### PR TITLE
Disable interactive mode when in daemon mode

### DIFF
--- a/repmgr.go
+++ b/repmgr.go
@@ -308,6 +308,7 @@ Interactive console and HTTP dashboards are available for control`,
 		sme.Init()
 
 		if daemon {
+			interactive = false
 			termlength = 40
 			logprintf("INFO : replication-manager version %s started in daemon mode", repmgrVersion)
 		} else {


### PR DESCRIPTION
Implicitly disabling interactive mode in daemon mode makes sense as there's no way to manually initiate the failover without the graphical interface.
