### PR TITLE
Add automatic daemon example to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,12 @@ The http server is accessible on http://localhost:10001 by default, and looks li
 
 The http dashboard is an experimental angularjs application, please don't use it in production as it has no protected access for now (or use creativity to restrict access to it).
 
+Start replication-manager in automatic daemon mode:
+
+`replication-manager monitor --hosts=db1:3306,db2:3306,db2:3306 --user=root:pass --rpluser=repl:pass --daemon --interactive=false`
+
+This mode is similar to the normal console mode with the exception of automated master failovers. With this mode, it is possible to run the replication-manager as a daemon process that manages a database cluster. Note that the `--interactive=false` option is required with the `--daemon` option to make the failovers automatic. Without it, the daemon only passively monitors the cluster.
+
 ## Available commands
 
 ```


### PR DESCRIPTION
The README should mention that the replication-manager can be run as an
automatic daemon that manages a cluster without the need for human
interaction.
