### PR TITLE
Wait for maxadmin response before sending more commands

### DIFF
--- a/cluster/failover.go
+++ b/cluster/failover.go
@@ -465,41 +465,68 @@ func (cluster *Cluster) initMaxscale(oldmaster *ServerMonitor) {
 			if err != nil {
 				cluster.LogPrint("ERROR: MaxScale client could not shutdown monitor:%s", err)
 			}
+			m.Response()
+			if err != nil {
+				cluster.LogPrint("ERROR: MaxScale client could not shutdown monitor:%s", err)
+			}
 		} else {
 			cluster.LogPrint("INFO: MaxScale No running Monitor")
 		}
 	}
 
-	err = m.Command("set server " + cluster.master.MxsServerName + " master")
+	err = m.SetServer(cluster.master.MxsServerName, "master")
 	if err != nil {
 		cluster.LogPrint("ERROR: MaxScale client could not send command:%s", err)
 	}
-	err = m.Command("clear server " + cluster.master.MxsServerName + " slave")
+	err = m.ClearServer(cluster.master.MxsServerName, "slave")
 	if err != nil {
 		cluster.LogPrint("ERROR: MaxScale client could not send command:%s", err)
 	}
-	if err != nil {
-		cluster.LogPrint("ERROR: MaxScale client could not send command:%s", err)
-	}
+
 	if cluster.conf.MxsBinlogOn == false {
 		for _, s := range cluster.slaves {
-			err = m.Command("clear server " + s.MxsServerName + " master")
+			err = m.ClearServer(s.MxsServerName, "master")
 			if err != nil {
 				cluster.LogPrint("ERROR: MaxScale client could not send command:%s", err)
 			}
-			err = m.Command("set server " + s.MxsServerName + " slave")
-			if err != nil {
-				cluster.LogPrint("ERROR: MaxScale client could not send command:%s", err)
+
+			if s.State != stateSlave {
+				err = m.ClearServer(s.MxsServerName, "slave")
+				if err != nil {
+					cluster.LogPrint("ERROR: MaxScale client could not send command:%s", err)
+				}
+				err = m.ClearServer(s.MxsServerName, "running")
+				if err != nil {
+					cluster.LogPrint("ERROR: MaxScale client could not send command:%s", err)
+				}
+
+			} else {
+				err = m.SetServer(s.MxsServerName, "slave")
+				if err != nil {
+					cluster.LogPrint("ERROR: MaxScale client could not send command:%s", err)
+				}
 			}
 		}
 		if oldmaster != nil {
-			err = m.Command("clear server " + oldmaster.MxsServerName + " master")
+			err = m.ClearServer(oldmaster.MxsServerName, "master")
 			if err != nil {
 				cluster.LogPrint("ERROR: MaxScale client could not send command:%s", err)
 			}
-			err = m.Command("set server " + oldmaster.MxsServerName + " slave")
-			if err != nil {
-				cluster.LogPrint("ERROR: MaxScale client could not send command:%s", err)
+
+			if oldmaster.State != stateSlave {
+				err = m.ClearServer(oldmaster.MxsServerName, "slave")
+				if err != nil {
+					cluster.LogPrint("ERROR: MaxScale client could not send command:%s", err)
+				}
+				err = m.ClearServer(oldmaster.MxsServerName, "running")
+				if err != nil {
+					cluster.LogPrint("ERROR: MaxScale client could not send command:%s", err)
+				}
+			} else {
+				err = m.SetServer(oldmaster.MxsServerName, "slave")
+				if err != nil {
+					cluster.LogPrint("ERROR: MaxScale client could not send command:%s", err)
+				}
 			}
 		}
 

--- a/maxscale/maxscale.go
+++ b/maxscale/maxscale.go
@@ -351,6 +351,47 @@ func (m *MaxScale) Command(cmd string) error {
 	return err
 }
 
+func (m *MaxScale) Response() ([]string, error) {
+
+	reader := bufio.NewReader(m.Conn)
+	var response []byte
+	buf := make([]byte, 512)
+	for {
+		res, err := reader.Read(buf)
+		if err != nil {
+			return nil, errors.New("Failed to read result")
+		}
+		str := string(buf[0:res])
+		if strings.HasSuffix(str, "OK") {
+			response = append(response, buf[0:res-2]...)
+			break
+		}
+		response = append(response, buf[0:res]...)
+	}
+	list := strings.Split(string(response), "\n")
+	return list, nil
+}
+
+func (m *MaxScale) SetServer(server, status string) error {
+	err := m.Command("set server " + server + " " + status)
+
+	if err == nil {
+		_, err = m.Response()
+	}
+
+	return err
+}
+
+func (m *MaxScale) ClearServer(server, status string) error {
+	err := m.Command("clear server " + server + " " + status)
+
+	if err == nil {
+		_, err = m.Response()
+	}
+
+	return err
+}
+
 func (m *MaxScale) ShutdownMonitor(monitor string) error {
 	if m.Conn == nil {
 		return errors.New("Connection was close did you lost maxscale")


### PR DESCRIPTION
The MaxAdmin protocol always terminates the messages with a two byte `OK`
string. Before sending more commands the client should wait for a response
from MaxAdmin.