### PR TITLE
Link system V init script with systemd

### DIFF
--- a/service/replication-manager-arb-basedir.init.deb7
+++ b/service/replication-manager-arb-basedir.init.deb7
@@ -34,6 +34,7 @@ chown -R $MRMUSER:$MRMGROUP $MRMDATADIR
 CMD=$MRMBASEDIR/replication-manager-arb
 PIDFILE=$MRMDATADIR/mrm.pid
 
+. /lib/lsb/init-functions
 
 start()
 {

--- a/service/replication-manager-arb.init.deb7
+++ b/service/replication-manager-arb.init.deb7
@@ -34,6 +34,7 @@ chown -R $MRMUSER:$MRMGROUP $MRMDATADIR
 CMD=$MRMBASEDIR/replication-manager-arb
 PIDFILE=$MRMDATADIR/mrm.pid
 
+. /lib/lsb/init-functions
 
 start()
 {

--- a/service/replication-manager-osc-basedir.init.deb7
+++ b/service/replication-manager-osc-basedir.init.deb7
@@ -34,6 +34,7 @@ chown -R $MRMUSER:$MRMGROUP $MRMDATADIR
 CMD=$MRMBASEDIR/replication-manager-osc
 PIDFILE=$MRMDATADIR/mrm.pid
 
+. /lib/lsb/init-functions
 
 start()
 {

--- a/service/replication-manager-osc.init.deb7
+++ b/service/replication-manager-osc.init.deb7
@@ -34,6 +34,7 @@ chown -R $MRMUSER:$MRMGROUP $MRMDATADIR
 CMD=$MRMBASEDIR/replication-manager-osc
 PIDFILE=$MRMDATADIR/mrm.pid
 
+. /lib/lsb/init-functions
 
 start()
 {

--- a/service/replication-manager-pro.init.deb7
+++ b/service/replication-manager-pro.init.deb7
@@ -34,6 +34,7 @@ chown -R $MRMUSER:$MRMGROUP $MRMDATADIR
 CMD=$MRMBASEDIR/replication-manager-pro
 PIDFILE=$MRMDATADIR/mrm.pid
 
+. /lib/lsb/init-functions
 
 start()
 {

--- a/service/replication-manager-tst.init.deb7
+++ b/service/replication-manager-tst.init.deb7
@@ -34,6 +34,7 @@ chown -R $MRMUSER:$MRMGROUP $MRMDATADIR
 CMD=$MRMBASEDIR/replication-manager-tst
 PIDFILE=$MRMDATADIR/mrm.pid
 
+. /lib/lsb/init-functions
 
 start()
 {


### PR DESCRIPTION
Actually you can stop & start replication-manager on Debian8+ using either sysV init scripts or systemd :

```
# Using sysV
/etc/init.d/replication-manager start

# Using systemd
systemctl start replication-manager.service
```

But, If you start mrm with systemd and try to stop it with sysV init script, it fails:

```
root@myhost:~ # /etc/init.d/replication-manager stop
/etc/init.d/replication-manager: 57: kill: No such process
```
One way to solve this problem is to map init.d script with systemd. This can be achieved simply by adding /lib/lsb/init-functions to init.d script.

With this fix, example above should now display:
```
root@myhost:~ # /etc/init.d/replication-manager stop
[ ok ] Stopping replication-manager (via systemctl): replication-manager.service.
```
