### PR TITLE
Use a multi-stage Dockerfile to have slimmer image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,30 +1,24 @@
-FROM golang:1.9-alpine3.7
+FROM golang:1.9-alpine3.7 as builder
+
+RUN apk --no-cache --update add make git musl-dev
 
 RUN mkdir -p /go/src/github.com/signal18/replication-manager
 WORKDIR /go/src/github.com/signal18/replication-manager
-
-RUN mkdir -p \
-        /etc/replication-manager \
-        /usr/share/replication-manager/dashboard \
-        /var/lib/replication-manager 
-
-RUN \
-    apk --no-cache --update add make git musl-dev && \ 
-    rm -rf /var/cache/apk/*
 
 COPY . .
 
 RUN make osc cli
 
-COPY dashboard /usr/share/replication-manager/dashboard/
 
-RUN mv build/binaries/replication-manager-osc /go/bin/replication-manager \
-    && mv build/binaries/replication-manager-cli /go/bin/
+FROM alpine:3.7
 
-WORKDIR /go/bin
+RUN mkdir -p \
+        /etc/replication-manager \
+        /var/lib/replication-manager
 
-RUN rm -rf /go/src /go/pkg && apk --no-cache del make git musl-dev
-RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+COPY --from=builder /go/src/github.com/signal18/replication-manager/dashboard /usr/share/replication-manager/dashboard/
+COPY --from=builder /go/src/github.com/signal18/replication-manager/build/binaries/replication-manager-osc /usr/bin/replication-manager
+COPY --from=builder /go/src/github.com/signal18/replication-manager/build/binaries/replication-manager-cli /usr/bin/replication-manager-cli
 
-CMD ["replication-manager","monitor","--http-server"]
+CMD ["replication-manager", "monitor", "--http-server"]
 EXPOSE 10001


### PR DESCRIPTION
This PR improves the docker image by using a multistage Dockerfile. This allows to keep build-time dependencies in a dedicated container. 

The previous implementation just deleted the build tools, but due to docker's layering schema they were still hidden in lower layers, leading to a unnecessary big image (729MB).

The actual image of the final build stage is based on a plain alpine:3.7 and is only 36MB.