### PR TITLE
Fix leaked connections when PFS queries contain null digests

### DIFF
--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -513,8 +513,14 @@ func (server *ServerMonitor) Refresh() error {
 	if server.ClusterGroup.conf.GraphiteEmbedded {
 		// SHOW ENGINE INNODB STATUS
 		server.EngineInnoDB, err = dbhelper.GetEngineInnoDB(server.Conn)
+		if err != nil {
+			server.ClusterGroup.LogPrintf("WARNING", "Could not get engine")
+		}
 		// GET PFS query digest
 		server.Queries, err = dbhelper.GetQueries(server.Conn)
+		if err != nil {
+			server.ClusterGroup.LogPrintf("WARNING", "Could not get PFS queries")
+		}
 	}
 	// SHOW SLAVE STATUS
 	err = server.SetReplicationChannel(server.ClusterGroup.conf.MasterConn)

--- a/dbhelper/dbhelper.go
+++ b/dbhelper/dbhelper.go
@@ -768,6 +768,7 @@ func GetQueries(db *sqlx.DB) (map[string]string, error) {
 	query = "select digest_text as digest, round(sum_timer_wait/1000000000000, 6) as value from performance_schema.events_statements_summary_by_digest order by sum_timer_wait desc limit 20"
 
 	rows, err := db.Queryx(query)
+	defer rows.Close();
 	if err != nil {
 		return nil, errors.New("Could not get queries")
 	}


### PR DESCRIPTION
When the events_statements_summary_by_digest table in the performance schema
reaches the performance_schema_digests_size, it will aggregate all rows in a
row will a null digest. (See https://mariadb.com/kb/en/library/performance-schema-events_statements_summary_by_digest-table/)

When this null value is returned and parsed by `rows.Scan()`, an error occurs,
and the method returns early. Since `rows` was never fully iterated, it does
not automatically close itself as it usually does.

This patch adds a `defer rows.Close()` statement to prevent this issue, and
adds some additional logging when it occurs.