### PR TITLE
Restrict PFS query to non-null digests

### DIFF
--- a/dbhelper/dbhelper.go
+++ b/dbhelper/dbhelper.go
@@ -765,7 +765,7 @@ func GetQueries(db *sqlx.DB) (map[string]string, error) {
 	vars := make(map[string]string)
 	query := "set session group_concat_max_len=2048"
 	db.Exec(query)
-	query = "select digest_text as digest, round(sum_timer_wait/1000000000000, 6) as value from performance_schema.events_statements_summary_by_digest order by sum_timer_wait desc limit 20"
+	query = "select digest_text as digest, round(sum_timer_wait/1000000000000, 6) as value from performance_schema.events_statements_summary_by_digest where digest_text is not null order by sum_timer_wait desc limit 20"
 
 	rows, err := db.Queryx(query)
 	defer rows.Close();


### PR DESCRIPTION
Followup to #275, this PR modifies the query to the performance_schema to prevent null values from appearing in the results set. 

While #275 fixed the leaking connection in the event the row scanner failed, here we sanitize the data passed to the scanner to prevent the scanner from failing in the first place. This also fixes spamming "Could not get PFS queries" in the log file if there is a null value in the performance_schema. 