### PR TITLE
fix goroutine leak when connection error

### DIFF
--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -229,7 +229,11 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 			err = fmt.Errorf("HTTP Response Code Error: %d", resp.StatusCode)
 		}
 	}
-
+	
+	if conn != nil {
+		defer conn.Close()
+	}
+	
 	// Handle failure cases here
 	if err != nil {
 		server.setDSN()
@@ -288,9 +292,7 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 
 		return
 	}
-	if conn != nil {
-		defer conn.Close()
-	}
+	
 	// from here we have connection
 	server.Refresh()
 

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -287,7 +287,8 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 		}
 
 		return
-	} else {
+	}
+	if conn != nil {
 		defer conn.Close()
 	}
 	// from here we have connection


### PR DESCRIPTION
when connection to mysql, if error is not nil, conn is not close, cause goroutine leak, because in database/sql, lauch two goroutine（connectionOpener, connectionReseter）, so goroutine unrenewable  cause memory leak.
I don't know whether agree with