### PR TITLE
fix goroutine leak

### DIFF
--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -370,10 +370,10 @@ func (server *ServerMonitor) Refresh() error {
 		return errors.New("Connection is closed, server unreachable")
 	}
 	conn, err := sqlx.Connect("mysql", server.DSN)
+	defer conn.Close()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 	if server.ClusterGroup.conf.MxsBinlogOn {
 		mxsversion, _ := dbhelper.GetMaxscaleVersion(server.Conn)
 		if mxsversion != "" {

--- a/proxysql/proxysql.go
+++ b/proxysql/proxysql.go
@@ -31,6 +31,7 @@ func (psql *ProxySQL) Connect() error {
 	var err error
 	psql.Connection, err = sqlx.Connect("mysql", ProxysqlConfig.FormatDSN())
 	if err != nil {
+		defer psql.Connection.Close()
 		return fmt.Errorf("Could not connect to ProxySQL (%s)", err)
 	}
 	return nil

--- a/sphinx/sphinx.go
+++ b/sphinx/sphinx.go
@@ -30,6 +30,7 @@ func (sphinxql *SphinxSQL) Connect() error {
 	var err error
 	sphinxql.Connection, err = sqlx.Connect("mysql", SphinxConfig.FormatDSN())
 	if err != nil {
+		defer sphinxql.Connection.Close()
 		return fmt.Errorf("Could not connect to SphinxQL (%s)", err)
 	}
 	return nil


### PR DESCRIPTION
Similar last PR, loss close connection when connection error, cause goroutine leak, also can slove it by update sqlx version.