### PR TITLE
Resolves #385

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/signal18/replication-manager
 
 go 1.12
 
-replace github.com/jacobsa/fuse => github.com/kahing/fusego v0.0.0-20190829004836-cb66eea2377f
-
 replace github.com/kahing/goofys => github.com/georgyo/goofys v0.21.0
 
 require (
@@ -73,7 +71,7 @@ require (
 	github.com/hydrogen18/stalecucumber v0.0.0-20161215203336-0a94983f3e27
 	github.com/inconshreveable/mousetrap v1.0.0
 	github.com/iu0v1/gelada v1.2.2
-	github.com/jacobsa/fuse v0.0.0-20180417054321-cd3959611bcb
+	github.com/jacobsa/fuse v0.0.0-20211125163655-ffd6c474e806
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/jordan-wright/email v0.0.0-20160301001728-a62870b0c368
 	github.com/juju/errors v0.0.0-20170703010042-c7d06af17c68
@@ -124,8 +122,8 @@ require (
 	github.com/wangjohn/quickselect v0.0.0-20161129230411-ed8402a42d5f
 	github.com/xwb1989/sqlparser v0.0.0-20171128062118-da747e0c62c4
 	golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529
-	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
-	golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f
+	golang.org/x/net v0.0.0-20200301022130-244492dfa37a
+	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527
 	golang.org/x/text v0.3.2
 	google.golang.org/appengine v1.5.0
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,7 @@ github.com/davecgh/go-spew v0.0.0-20180203072859-87df7c60d582/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/detailyang/go-fallocate v0.0.0-20180908115635-432fa640bd2e/go.mod h1:3ZQK6DMPSz/QZ73jlWxBtUhNA8xZx7LzUFSq/OfP8vk=
 github.com/dgrijalva/jwt-go v0.0.0-20160705203006-01aeca54ebda/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.1.0+incompatible h1:FFziAwDQQ2dz1XClWMkwvukur3evtZx7x/wMHKM1i20=
 github.com/dgrijalva/jwt-go v3.1.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -255,6 +256,14 @@ github.com/jacobsa/fuse v0.0.0-20180417054321-cd3959611bcb h1:TRAjtOoio6kvnrIMLe
 github.com/jacobsa/fuse v0.0.0-20180417054321-cd3959611bcb/go.mod h1:9Aml1MG17JVeXrN4D2mtJvYHtHklJH5bESjCKNzVjFU=
 github.com/jacobsa/fuse v0.0.0-20200311085126-7d791d27a25d h1:4gaMlb9FOx56oj4XJaISZjPpVYWWk7+qkZ8gN4bWwXQ=
 github.com/jacobsa/fuse v0.0.0-20200311085126-7d791d27a25d/go.mod h1:9Aml1MG17JVeXrN4D2mtJvYHtHklJH5bESjCKNzVjFU=
+github.com/jacobsa/fuse v0.0.0-20211125163655-ffd6c474e806 h1:DiUk5AzBZMGRMljnsHBvI4uc+rm4UCfgv5nTpAvFLi8=
+github.com/jacobsa/fuse v0.0.0-20211125163655-ffd6c474e806/go.mod h1:xtZnnLxHY6QniCrfIpTwr5h8mH8zr+jsOFj0y9cfyp4=
+github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd/go.mod h1:TlmyIZDpGmwRoTWiakdr+HA1Tukze6C6XbRVidYq02M=
+github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff/go.mod h1:gJWba/XXGl0UoOmBQKRWCJdHrr3nE0T65t6ioaj3mLI=
+github.com/jacobsa/ogletest v0.0.0-20170503003838-80d50a735a11/go.mod h1:+DBdDyfoO2McrOyDemRBq0q9CMEByef7sYl7JH5Q3BI=
+github.com/jacobsa/reqtrace v0.0.0-20150505043853-245c9e0234cb/go.mod h1:ivcmUvxXWjb27NsPEaiYK7AidlZXS7oQ5PowUS9z3I4=
+github.com/jacobsa/syncutil v0.0.0-20180201203307-228ac8e5a6c3/go.mod h1:mPvulh9VKXvo+yOlrD4VYOOYuLdZJ36wa/5QIrtXvWs=
+github.com/jacobsa/timeutil v0.0.0-20170205232429-577e5acbbcf6/go.mod h1:JEWKD6V8xETMW+DEv+IQVz++f8Cn8O/X0HPeDY3qNis=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmoiron/sqlx v0.0.0-20180124204410-05cef0741ade h1:ryslCsfLTV4Cm/9NXqCJirlbYodWqFiTH454IaSn/fY=
@@ -291,6 +300,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lestrrat/go-file-rotatelogs v0.0.0-20171229092148-f984502973a0 h1:iVr3oVautdZxVynLvbUBipvk4EnAe+joJMoS+nIdqMo=
 github.com/lestrrat/go-file-rotatelogs v0.0.0-20171229092148-f984502973a0/go.mod h1:UGmTpUd3rjbtfIpwAPrcfmGf/Z1HS95TATB+m57TPB8=
 github.com/lestrrat/go-strftime v0.0.0-20170113112000-04ef93e28531 h1:qA9RB9NobSxHKYfJrOcqHFL8uanRWCG3+rN4CibuNPc=
@@ -519,6 +529,8 @@ golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc h1:gkKoSkUmnU6bpS/VhkuO27bzQ
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a h1:tImsplftrFpALCYumobsd0K86vlAs/eXGFms2txfJfA=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -544,6 +556,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f h1:25KHgbfyiSm6vwQLbM3zZIe1v9p/3ea4Rz+nnM5K/i4=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20180208041248-4e4a3210bb54 h1:a5WocgxWTnjG0C4hZblDx+yonFbQMMbv8yJGhHMz/nY=
 golang.org/x/text v0.0.0-20180208041248-4e4a3210bb54/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/goofys/api/common/panic_logger.go
+++ b/goofys/api/common/panic_logger.go
@@ -145,6 +145,11 @@ func (fs FusePanicLogger) SetXattr(ctx context.Context, op *fuseops.SetXattrOp) 
 	return fs.Fs.SetXattr(ctx, op)
 }
 
+func (fs FusePanicLogger) Fallocate(ctx context.Context, op *fuseops.FallocateOp) (err error) {
+	defer LogPanic(&err)
+	return fs.Fs.Fallocate(ctx, op)
+}
+
 func (fs FusePanicLogger) Destroy() {
 	fs.Fs.Destroy()
 }

--- a/goofys/internal/dir.go
+++ b/goofys/internal/dir.go
@@ -786,7 +786,7 @@ func (parent *Inode) Unlink(name string) (err error) {
 }
 
 func (parent *Inode) Create(
-	name string, metadata fuseops.OpMetadata) (inode *Inode, fh *FileHandle) {
+	name string, metadata fuseops.OpContext) (inode *Inode, fh *FileHandle) {
 
 	parent.logFuse("Create", name)
 

--- a/goofys/internal/file.go
+++ b/goofys/internal/file.go
@@ -67,7 +67,7 @@ const READAHEAD_CHUNK = uint32(20 * 1024 * 1024)
 
 // NewFileHandle returns a new file handle for the given `inode` triggered by fuse
 // operation with the given `opMetadata`
-func NewFileHandle(inode *Inode, opMetadata fuseops.OpMetadata) *FileHandle {
+func NewFileHandle(inode *Inode, opMetadata fuseops.OpContext) *FileHandle {
 	tgid, err := GetTgid(opMetadata.Pid)
 	if err != nil {
 		log.Debugf(

--- a/goofys/internal/goofys.go
+++ b/goofys/internal/goofys.go
@@ -838,7 +838,7 @@ func (fs *Goofys) OpenFile(
 	in := fs.getInodeOrDie(op.Inode)
 	fs.mu.RUnlock()
 
-	fh, err := in.OpenFile(op.Metadata)
+	fh, err := in.OpenFile(op.OpContext)
 	if err != nil {
 		return
 	}
@@ -892,10 +892,10 @@ func (fs *Goofys) FlushFile(
 	// This check helps us with scenarios like https://github.com/signal18/replication-manager/goofys/issues/273
 	// Also see goofys_test.go:TestClientForkExec.
 	if fh.Tgid != nil {
-		tgid, err := GetTgid(op.Metadata.Pid)
+		tgid, err := GetTgid(op.OpContext.Pid)
 		if err != nil {
 			fh.inode.logFuse("<-- FlushFile",
-				fmt.Sprintf("Failed to retrieve tgid from op.Metadata.Pid. FlushFileOp:%#v, err:%v",
+				fmt.Sprintf("Failed to retrieve tgid from op.OpContext.Pid. FlushFileOp:%#v, err:%v",
 					op, err))
 			return fuse.EIO
 		}
@@ -952,7 +952,7 @@ func (fs *Goofys) CreateFile(
 	parent := fs.getInodeOrDie(op.Parent)
 	fs.mu.RUnlock()
 
-	inode, fh := parent.Create(op.Name, op.Metadata)
+	inode, fh := parent.Create(op.Name, op.OpContext)
 
 	parent.mu.Lock()
 

--- a/goofys/internal/goofys_test.go
+++ b/goofys/internal/goofys_test.go
@@ -722,7 +722,7 @@ func (s *GoofysTest) TestReadFiles(t *C) {
 			in, err := parent.LookUp(en.Name)
 			t.Assert(err, IsNil)
 
-			fh, err := in.OpenFile(fuseops.OpMetadata{uint32(os.Getpid())})
+			fh, err := in.OpenFile(fuseops.OpContext{uint32(os.Getpid())})
 			t.Assert(err, IsNil)
 
 			buf := make([]byte, 4096)
@@ -748,7 +748,7 @@ func (s *GoofysTest) TestReadOffset(t *C) {
 	in, err := root.LookUp(f)
 	t.Assert(err, IsNil)
 
-	fh, err := in.OpenFile(fuseops.OpMetadata{uint32(os.Getpid())})
+	fh, err := in.OpenFile(fuseops.OpContext{uint32(os.Getpid())})
 	t.Assert(err, IsNil)
 
 	buf := make([]byte, 4096)
@@ -772,7 +772,7 @@ func (s *GoofysTest) TestReadOffset(t *C) {
 func (s *GoofysTest) TestCreateFiles(t *C) {
 	fileName := "testCreateFile"
 
-	_, fh := s.getRoot(t).Create(fileName, fuseops.OpMetadata{uint32(os.Getpid())})
+	_, fh := s.getRoot(t).Create(fileName, fuseops.OpContext{uint32(os.Getpid())})
 
 	err := fh.FlushFile()
 	t.Assert(err, IsNil)
@@ -791,7 +791,7 @@ func (s *GoofysTest) TestCreateFiles(t *C) {
 	inode, err := s.getRoot(t).LookUp(fileName)
 	t.Assert(err, IsNil)
 
-	fh, err = inode.OpenFile(fuseops.OpMetadata{uint32(os.Getpid())})
+	fh, err = inode.OpenFile(fuseops.OpContext{uint32(os.Getpid())})
 	t.Assert(err, IsNil)
 
 	err = fh.FlushFile()
@@ -870,7 +870,7 @@ func (s *GoofysTest) testWriteFileAt(t *C, fileName string, offset int64, size i
 		}
 	} else {
 		in := s.fs.inodes[lookup.Entry.Child]
-		fh, err = in.OpenFile(fuseops.OpMetadata{uint32(os.Getpid())})
+		fh, err = in.OpenFile(fuseops.OpContext{uint32(os.Getpid())})
 		t.Assert(err, IsNil)
 	}
 
@@ -954,7 +954,7 @@ func (s *GoofysTest) TestReadRandom(t *C) {
 	in, err := s.LookUpInode(t, "testLargeFile")
 	t.Assert(err, IsNil)
 
-	fh, err := in.OpenFile(fuseops.OpMetadata{uint32(os.Getpid())})
+	fh, err := in.OpenFile(fuseops.OpContext{uint32(os.Getpid())})
 	t.Assert(err, IsNil)
 	fr := &FileHandleReader{s.fs, fh, 0}
 
@@ -986,7 +986,7 @@ func (s *GoofysTest) TestMkDir(t *C) {
 	t.Assert(err, IsNil)
 
 	fileName := "file"
-	_, fh := inode.Create(fileName, fuseops.OpMetadata{uint32(os.Getpid())})
+	_, fh := inode.Create(fileName, fuseops.OpContext{uint32(os.Getpid())})
 
 	err = fh.FlushFile()
 	t.Assert(err, IsNil)
@@ -2450,7 +2450,7 @@ func (s *GoofysTest) TestDirMtimeCreate(t *C) {
 	m1 := attr.Mtime
 	time.Sleep(time.Second)
 
-	_, _ = root.Create("foo", fuseops.OpMetadata{uint32(os.Getpid())})
+	_, _ = root.Create("foo", fuseops.OpContext{uint32(os.Getpid())})
 	attr2, _ := root.GetAttributes()
 	m2 := attr2.Mtime
 
@@ -2513,7 +2513,7 @@ func (s *GoofysTest) TestRead403(t *C) {
 	in, err := s.LookUpInode(t, "file1")
 	t.Assert(err, IsNil)
 
-	fh, err := in.OpenFile(fuseops.OpMetadata{uint32(os.Getpid())})
+	fh, err := in.OpenFile(fuseops.OpContext{uint32(os.Getpid())})
 	t.Assert(err, IsNil)
 
 	s3.awsConfig.Credentials = credentials.AnonymousCredentials
@@ -2971,7 +2971,7 @@ func (s *GoofysTest) TestVFS(t *C) {
 	_, err = in.LookUp("file5")
 	t.Assert(err, Equals, fuse.ENOENT)
 
-	_, fh := in.Create("testfile", fuseops.OpMetadata{uint32(os.Getpid())})
+	_, fh := in.Create("testfile", fuseops.OpContext{uint32(os.Getpid())})
 	err = fh.FlushFile()
 	t.Assert(err, IsNil)
 
@@ -3006,7 +3006,7 @@ func (s *GoofysTest) TestVFS(t *C) {
 
 	// create another file inside subdir to make sure that our
 	// mount check is correct for dir inside the root
-	_, fh = subdir.Create("testfile2", fuseops.OpMetadata{uint32(os.Getpid())})
+	_, fh = subdir.Create("testfile2", fuseops.OpContext{uint32(os.Getpid())})
 	err = fh.FlushFile()
 	t.Assert(err, IsNil)
 
@@ -3262,7 +3262,7 @@ func (s *GoofysTest) testMountsNested(t *C, cloud StorageBackend,
 	t.Assert(*dir_dir.Name, Equals, "dir")
 	t.Assert(dir_dir.dir.cloud == cloud, Equals, true)
 
-	_, fh := dir_in.Create("testfile", fuseops.OpMetadata{uint32(os.Getpid())})
+	_, fh := dir_in.Create("testfile", fuseops.OpContext{uint32(os.Getpid())})
 	err = fh.FlushFile()
 	t.Assert(err, IsNil)
 
@@ -3270,7 +3270,7 @@ func (s *GoofysTest) testMountsNested(t *C, cloud StorageBackend,
 	t.Assert(err, IsNil)
 	defer resp.Body.Close()
 
-	_, fh = dir_dir.Create("testfile", fuseops.OpMetadata{uint32(os.Getpid())})
+	_, fh = dir_dir.Create("testfile", fuseops.OpContext{uint32(os.Getpid())})
 	err = fh.FlushFile()
 	t.Assert(err, IsNil)
 

--- a/goofys/internal/handles.go
+++ b/goofys/internal/handles.go
@@ -471,7 +471,7 @@ func (inode *Inode) ListXattr() ([]string, error) {
 	return xattrs, nil
 }
 
-func (inode *Inode) OpenFile(metadata fuseops.OpMetadata) (fh *FileHandle, err error) {
+func (inode *Inode) OpenFile(metadata fuseops.OpContext) (fh *FileHandle, err error) {
 	inode.logFuse("OpenFile")
 
 	inode.mu.Lock()


### PR DESCRIPTION
Removes the go.mod replace for jacobsa/fuse to kahing/fusego back to
the upstream jacobsa/fuse. Updated the version.

Implemented the new required Fallocate for the fuseutil.FileSystem

Upstream had a different struct name for OpsMetadata, has been changed
in our code.