### PR TITLE
Add "FOR CHANNEL" to the start slave command when boostrapping

### DIFF
--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1460,7 +1460,7 @@ func (server *ServerMonitor) ChangeMasterTo(master *ServerMonitor, master_use_gi
 	if err != nil {
 		server.ClusterGroup.LogSQL(logs, err, server.URL, "BootstrapReplication", LvlErr, "Replication can't be bootstrap for server %s with %s as master: %s ", server.URL, master.URL, err)
 	}
-	_, err = server.Conn.Exec("START SLAVE")
+	_, err = server.Conn.Exec("START SLAVE FOR CHANNEL '" + server.ClusterGroup.Conf.MasterConn + "'")
 	if err != nil {
 		err = errors.New(fmt.Sprintln("Can't start slave: ", err))
 	}

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1460,7 +1460,7 @@ func (server *ServerMonitor) ChangeMasterTo(master *ServerMonitor, master_use_gi
 	if err != nil {
 		server.ClusterGroup.LogSQL(logs, err, server.URL, "BootstrapReplication", LvlErr, "Replication can't be bootstrap for server %s with %s as master: %s ", server.URL, master.URL, err)
 	}
-	_, err = server.Conn.Exec("START SLAVE '" + server.ClusterGroup.Conf.MasterConn + "'")
+	_, err = server.Conn.Exec("START SLAVE")
 	if err != nil {
 		err = errors.New(fmt.Sprintln("Can't start slave: ", err))
 	}


### PR DESCRIPTION
Hi,

Currently, the bootstrap operation leads to a syntax error on MySQL 5.7. This causes bootstrapping to fail (and not start the slave).

This is a small quality of life change that enables this functionality.

TIA

