### PR TITLE
Update MS Teams Notification to Newer Package

### DIFF
--- a/cluster/cluster_log.go
+++ b/cluster/cluster_log.go
@@ -13,9 +13,13 @@ package cluster
 import (
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"time"
 
-	teams "github.com/dasrick/go-teams-notify/v2"
+	teams "github.com/atc0005/go-teams-notify/v2"
+	"github.com/atc0005/go-teams-notify/v2/messagecard"
+
 	"github.com/nsf/termbox-go"
 	"github.com/signal18/replication-manager/utils/s18log"
 	log "github.com/sirupsen/logrus"
@@ -236,14 +240,34 @@ func (cluster *Cluster) LogPrintf(level string, format string, args ...interface
 
 func (cluster *Cluster) sendMsTeams(level string, format string, args ...interface{}) error {
 	// init the client
-	mstClient := teams.NewClient()
+	mstClient := teams.NewTeamsClient()
 
 	// setup webhook url
 	webhookUrl := cluster.Conf.TeamsUrl
+	webhookProxyUrl := cluster.Conf.TeamsProxyUrl
+
+	proxyUrl, err := url.Parse(cluster.Conf.TeamsProxyUrl)
+
+	// Create a copy of the default mstClient.HTTPClient
+	httpClient := mstClient.HTTPClient()
+
+	if webhookProxyUrl != "" {
+		if err == nil {
+			httpClient.Transport = &http.Transport{Proxy: http.ProxyURL(proxyUrl)}
+		} else {
+			log.Printf(
+				"Failed to parse proxy URL %q: %v. Using the default HTTP client without a proxy.",
+				webhookProxyUrl,
+				err,
+			)
+		}
+	} else {
+		log.Printf("Proxy URL is empty. Using the default HTTP client without a proxy.")
+	}
 
 	// setup message card
-	msgCard := teams.NewMessageCard()
-	msgCard.Title = "Replication-Manager alert"
+	msgCard := messagecard.NewMessageCard()
+	msgCard.Title = "Replication-Manager alert. Monitor: " + cluster.Conf.MonitorAddress
 	switch level {
 	case "ERROR":
 		msgCard.ThemeColor = "#4169e1"
@@ -255,9 +279,11 @@ func (cluster *Cluster) sendMsTeams(level string, format string, args ...interfa
 
 	msgCard.Text = fmt.Sprintf(format, args...)
 	// send
-	err := mstClient.Send(webhookUrl, msgCard)
-	if err != nil {
-		log.Printf("sendMSTeams error send alert : %s", err)
+	if err := mstClient.Send(webhookUrl, msgCard); err != nil {
+		log.Printf(
+			"failed to send MSTeams alert message: %s",
+			err,
+		)
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -241,6 +241,7 @@ type Config struct {
 	PushoverAppToken                          string                 `mapstructure:"alert-pushover-app-token" toml:"alert-pushover-app-token" json:"alertPushoverAppToken"`
 	PushoverUserToken                         string                 `mapstructure:"alert-pushover-user-token" toml:"alert-pushover-user-token" json:"alertPushoverUserToken"`
 	TeamsUrl                                  string                 `mapstructure:"alert-teams-url" toml:"alert-teams-url" json:"alertTeamsUrl"`
+	TeamsProxyUrl                             string                 `mapstructure:"alert-teams-proxy-url" toml:"alert-teams-proxy-url" json:"alertTeamsProxyUrl"`
 	Heartbeat                                 bool                   `mapstructure:"heartbeat-table" toml:"heartbeat-table" json:"heartbeatTable"`
 	ExtProxyOn                                bool                   `mapstructure:"extproxy" toml:"extproxy" json:"extproxy"`
 	ExtProxyVIP                               string                 `mapstructure:"extproxy-address" toml:"extproxy-address" json:"extproxyAddress"`

--- a/config/config.go
+++ b/config/config.go
@@ -242,6 +242,7 @@ type Config struct {
 	PushoverUserToken                         string                 `mapstructure:"alert-pushover-user-token" toml:"alert-pushover-user-token" json:"alertPushoverUserToken"`
 	TeamsUrl                                  string                 `mapstructure:"alert-teams-url" toml:"alert-teams-url" json:"alertTeamsUrl"`
 	TeamsProxyUrl                             string                 `mapstructure:"alert-teams-proxy-url" toml:"alert-teams-proxy-url" json:"alertTeamsProxyUrl"`
+	TeamsAlertState                           string                 `mapstructure:"alert-teams-state" toml:"alert-teams-state" json:"alertTeamsState"`
 	Heartbeat                                 bool                   `mapstructure:"heartbeat-table" toml:"heartbeat-table" json:"heartbeatTable"`
 	ExtProxyOn                                bool                   `mapstructure:"extproxy" toml:"extproxy" json:"extproxy"`
 	ExtProxyVIP                               string                 `mapstructure:"extproxy-address" toml:"extproxy-address" json:"extproxyAddress"`

--- a/server/server_monitor.go
+++ b/server/server_monitor.go
@@ -196,6 +196,7 @@ func init() {
 
 	monitorCmd.Flags().StringVar(&conf.TeamsUrl, "alert-teams-url", "", "Teams url channel for alerts")
 	monitorCmd.Flags().StringVar(&conf.TeamsProxyUrl, "alert-teams-proxy-url", "", "Proxy url for Teams Webhook")
+	monitorCmd.Flags().StringVar(&conf.TeamsAlertState, "alert-teams-state", "", "State Code for Teams Alert : ERR|WARN|INFO")
 
 	conf.CheckType = "tcp"
 	monitorCmd.Flags().BoolVar(&conf.CheckReplFilter, "check-replication-filters", true, "Check that possible master have equal replication filters")

--- a/server/server_monitor.go
+++ b/server/server_monitor.go
@@ -195,6 +195,7 @@ func init() {
 	monitorCmd.Flags().StringVar(&conf.ProvOpensvcP12Secret, "opensvc-p12-secret", "", "OpenSVC Secret")
 
 	monitorCmd.Flags().StringVar(&conf.TeamsUrl, "alert-teams-url", "", "Teams url channel for alerts")
+	monitorCmd.Flags().StringVar(&conf.TeamsProxyUrl, "alert-teams-proxy-url", "", "Proxy url for Teams Webhook")
 
 	conf.CheckType = "tcp"
 	monitorCmd.Flags().BoolVar(&conf.CheckReplFilter, "check-replication-filters", true, "Check that possible master have equal replication filters")


### PR DESCRIPTION
Updating ms teams notification to active fork from dasrick to atc0005. 

Adding configuration for MS Teams:
- Adding proxy url (for isolated environment which only allow http traffic via proxy e.g. squid.
- Adding comma separated list configuration for capturing state based on code prefix ERR|WARN|INFO (default is none)