### PR TITLE
Delay average statistic

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1253,6 +1253,10 @@ func (cluster *Cluster) Close() {
 func (cluster *Cluster) ResetFailoverCtr() {
 	cluster.FailoverCtr = 0
 	cluster.FailoverTs = 0
+
+	for _, server := range cluster.Servers {
+		server.ResetDelayStat()
+	}
 }
 
 func (cluster *Cluster) agentFlagCheck() {

--- a/cluster/cluster_fail.go
+++ b/cluster/cluster_fail.go
@@ -845,7 +845,7 @@ func (cluster *Cluster) electFailoverCandidate(l []*ServerMonitor, forcingLog bo
 		trackposList[i].Prefered = sl.IsPrefered()
 		trackposList[i].Ignoredconf = sl.IsIgnored()
 		trackposList[i].Ignoredrelay = sl.IsRelay
-		trackposList[i].DelayStat = sl.TotalDelayStat
+		trackposList[i].DelayStat = sl.DelayStat.Total
 
 		//Need comment//
 		if sl.IsRelay {

--- a/cluster/cluster_fail.go
+++ b/cluster/cluster_fail.go
@@ -830,6 +830,7 @@ func (cluster *Cluster) electFailoverCandidate(l []*ServerMonitor, forcingLog bo
 		Ignoredmultimaster bool
 		Ignoredreplication bool
 		Weight             uint
+		DelayStat          DelayStat
 	}
 
 	// HaveOneValidReader is used to state that at least one replicat is available for reading via proxies
@@ -844,6 +845,7 @@ func (cluster *Cluster) electFailoverCandidate(l []*ServerMonitor, forcingLog bo
 		trackposList[i].Prefered = sl.IsPrefered()
 		trackposList[i].Ignoredconf = sl.IsIgnored()
 		trackposList[i].Ignoredrelay = sl.IsRelay
+		trackposList[i].DelayStat = sl.TotalDelayStat
 
 		//Need comment//
 		if sl.IsRelay {
@@ -940,10 +942,27 @@ func (cluster *Cluster) electFailoverCandidate(l []*ServerMonitor, forcingLog bo
 		cluster.StateMachine.AddState("ERR00085", state.State{ErrType: LvlWarn, ErrDesc: fmt.Sprintf(clusterError["ERR00085"]), ErrFrom: "CHECK"})
 	}
 
-	sort.Slice(trackposList[:], func(i, j int) bool {
-		return trackposList[i].Seq > trackposList[j].Seq
-	})
-
+	if !cluster.Conf.FailoverCheckDelayStat {
+		sort.Slice(trackposList[:], func(i, j int) bool {
+			return trackposList[i].Seq > trackposList[j].Seq
+		})
+	} else {
+		sort.Slice(trackposList[:], func(i, j int) bool {
+			if trackposList[i].Seq != trackposList[j].Seq {
+				return trackposList[i].Seq > trackposList[j].Seq
+			}
+			if trackposList[i].DelayStat.SlaveErrCount != trackposList[j].DelayStat.SlaveErrCount {
+				return trackposList[i].DelayStat.SlaveErrCount < trackposList[j].DelayStat.SlaveErrCount
+			}
+			if trackposList[i].DelayStat.DelayCount != trackposList[j].DelayStat.DelayCount {
+				return trackposList[i].DelayStat.DelayCount < trackposList[j].DelayStat.DelayCount
+			}
+			if trackposList[i].DelayStat.DelayAvg != trackposList[j].DelayStat.DelayAvg {
+				return trackposList[i].DelayStat.DelayAvg < trackposList[j].DelayStat.DelayAvg
+			}
+			return trackposList[i].DelayStat.Counter > trackposList[j].DelayStat.Counter
+		})
+	}
 	if forcingLog {
 		data, _ := json.MarshalIndent(trackposList, "", "\t")
 		cluster.LogPrintf(LvlInfo, "Election matrice: %s ", data)
@@ -981,9 +1000,29 @@ func (cluster *Cluster) electFailoverCandidate(l []*ServerMonitor, forcingLog bo
 		}
 		return -1
 	}
-	sort.Slice(trackposList[:], func(i, j int) bool {
-		return trackposList[i].Pos > trackposList[j].Pos
-	})
+
+	if !cluster.Conf.FailoverCheckDelayStat {
+		sort.Slice(trackposList[:], func(i, j int) bool {
+			return trackposList[i].Pos > trackposList[j].Pos
+		})
+	} else {
+		sort.Slice(trackposList[:], func(i, j int) bool {
+			if trackposList[i].Pos != trackposList[j].Pos {
+				return trackposList[i].Pos > trackposList[j].Pos
+			}
+			if trackposList[i].DelayStat.SlaveErrCount != trackposList[j].DelayStat.SlaveErrCount {
+				return trackposList[i].DelayStat.SlaveErrCount < trackposList[j].DelayStat.SlaveErrCount
+			}
+			if trackposList[i].DelayStat.DelayCount != trackposList[j].DelayStat.DelayCount {
+				return trackposList[i].DelayStat.DelayCount < trackposList[j].DelayStat.DelayCount
+			}
+			if trackposList[i].DelayStat.DelayAvg != trackposList[j].DelayStat.DelayAvg {
+				return trackposList[i].DelayStat.DelayAvg < trackposList[j].DelayStat.DelayAvg
+			}
+			return trackposList[i].DelayStat.Counter > trackposList[j].DelayStat.Counter
+		})
+	}
+
 	if maxpos > 0 {
 		/* Return key of slave with the highest pos. */
 		for _, p := range trackposList {

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -1466,3 +1466,17 @@ func (cluster *Cluster) SetSecretsToVault() {
 		}
 	}
 }
+
+func (cluster *Cluster) SetDelayStatRotate(keep string) error {
+	numkeep, err := strconv.Atoi(keep)
+	if err != nil {
+		return err
+	}
+	if numkeep > 72 {
+		cluster.LogPrintf(LvlErr, "Cannot set delaystat more than 72 hours (3 days). Adjusting value from %s to 72 hours", keep)
+		numkeep = 72
+	}
+	cluster.LogPrintf(LvlInfo, "Delay Stat Rotate set to %s", strconv.Itoa(numkeep))
+	cluster.Conf.DelayStatRotate = numkeep
+	return nil
+}

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -1480,3 +1480,13 @@ func (cluster *Cluster) SetDelayStatRotate(keep string) error {
 	cluster.Conf.DelayStatRotate = numkeep
 	return nil
 }
+
+func (cluster *Cluster) SetPrintDelayStatInterval(keep string) error {
+	numkeep, err := strconv.Atoi(keep)
+	if err != nil {
+		return err
+	}
+	cluster.LogPrintf(LvlInfo, "Print delay statistic interval set to %s", strconv.Itoa(numkeep))
+	cluster.Conf.PrintDelayStatInterval = numkeep
+	return nil
+}

--- a/cluster/cluster_stat.go
+++ b/cluster/cluster_stat.go
@@ -1,0 +1,190 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// Authors: Guillaume Lefranc <guillaume@signal18.io>
+//          Stephane Varoqui  <svaroqui@gmail.com>
+// This source code is licensed under the GNU General Public License, version 3.
+
+package cluster
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Logging Replication Delay Stat
+type DelayStat struct {
+	DelayAvg      float64 `json:"delay"`         // Average Seconds of Delay
+	DelayCount    int32   `json:"delayCount"`    // Number of Delay Occurred
+	SlaveErrCount int32   `json:"slaveErrCount"` // Number of Slave Err Occurred
+	Counter       int32   `json:"counter"`       // Increment
+}
+
+type DelayStatHistory struct {
+	DelayStat DelayStat `json:"delayStat"`
+	Datetime  time.Time `json:"delayDT"`
+}
+
+type DelayHistoryList []DelayStatHistory
+
+type ServerDelayStat struct {
+	Total        DelayStat        `json:"total"` // Total Delay Average since SRM started
+	Rotated      DelayStat        `json:"rotated"`
+	Current      DelayStat        `json:"current"`
+	CurrentDT    time.Time        `json:"currentDT"`
+	DelayHistory DelayHistoryList `json:"delayHistory"`
+}
+
+// Get Current Datetime in hourly format
+func (sds *ServerDelayStat) CurrentDelayDatetime(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, t.Location())
+}
+
+func (sds *ServerDelayStat) ResetCurrentStat() {
+	sds.Current = DelayStat{DelayAvg: 0, DelayCount: 0, SlaveErrCount: 0, Counter: 0}
+	sds.CurrentDT = sds.CurrentDelayDatetime(time.Now())
+}
+
+func (sds *ServerDelayStat) ResetDelayStat() {
+	sds.ResetCurrentStat()
+	sds.Total = sds.Current
+	sds.Rotated = sds.Current
+	sds.DelayHistory = []DelayStatHistory{{sds.Current, sds.CurrentDT}}
+}
+
+func (sds *ServerDelayStat) UpdateCurrentDelayStat(s int64) {
+	if s > 0 {
+		sds.Current.DelayCount = sds.Current.DelayCount + 1
+	}
+
+	sds.Current.DelayAvg = ((sds.Current.DelayAvg*float64(sds.Current.Counter) + float64(s)) / (float64(sds.Current.Counter + 1)))
+	sds.Current.Counter = sds.Current.Counter + 1
+}
+
+// Update Delay with Rotating Stats
+func (sds *ServerDelayStat) UpdateDelayWithRotate(s int64, limit int) {
+	sds.Rotated = sds.DelayHistory[0].DelayStat
+
+	//Rotate Stat if exceed limit
+	if len(sds.DelayHistory) == limit {
+		sds.DelayHistory = sds.DelayHistory[1:]
+	}
+
+	sds.ResetCurrentStat() //Reset Current Stat
+	sds.UpdateCurrentDelayStat(s)
+	sds.DelayHistory = append(sds.DelayHistory, DelayStatHistory{sds.Current, sds.CurrentDT})
+
+	//Updating Total
+	sds.Total.DelayAvg = (sds.Total.DelayAvg*float64(sds.Total.Counter) - (sds.Rotated.DelayAvg * float64(sds.Rotated.Counter)) + float64(s)) / float64(sds.Total.Counter+1-sds.Rotated.Counter)
+	sds.Total.Counter = sds.Total.Counter + 1 - sds.Rotated.Counter
+
+	if s > 0 {
+		sds.Total.DelayCount = sds.Total.DelayCount + 1 - sds.Rotated.DelayCount
+	} else {
+		sds.Total.DelayCount = sds.Total.DelayCount - sds.Rotated.DelayCount
+	}
+
+}
+
+// Update Delay without Rotating Stats
+func (sds *ServerDelayStat) UpdateDelayWithoutRotate(s int64) {
+	sds.UpdateCurrentDelayStat(s)
+	sds.DelayHistory[len(sds.DelayHistory)-1].DelayStat = sds.Current
+
+	//Updating Total
+	sds.Total.DelayAvg = (sds.Total.DelayAvg*float64(sds.Total.Counter) + float64(s)) / float64(sds.Total.Counter+1)
+	sds.Total.Counter = sds.Total.Counter + 1
+
+	if s > 0 {
+		sds.Total.DelayCount = sds.Total.DelayCount + 1
+	}
+}
+
+func (sds *ServerDelayStat) UpdateDelayStat(s int64, limit int) {
+	curTime := sds.CurrentDelayDatetime(time.Now())
+
+	if curTime != sds.CurrentDT {
+		sds.UpdateDelayWithRotate(s, limit)
+	} else {
+		sds.UpdateDelayWithoutRotate(s)
+	}
+}
+
+func (sds *ServerDelayStat) UpdateTotalSlaveErrStat() {
+
+}
+
+func (sds *ServerDelayStat) UpdateSlaveErrorWithRotate(limit int) {
+	sds.Rotated = sds.DelayHistory[0].DelayStat
+
+	//Rotate Stat if reach limit
+	if len(sds.DelayHistory) == limit {
+		sds.DelayHistory = sds.DelayHistory[1:]
+	}
+	sds.ResetCurrentStat() //Reset Current Stat
+
+	sds.Current.SlaveErrCount = sds.Current.SlaveErrCount + 1
+	sds.Current.Counter = sds.Current.Counter + 1
+	sds.DelayHistory = append(sds.DelayHistory, DelayStatHistory{sds.Current, sds.CurrentDT})
+
+	sds.Total.Counter = sds.Total.Counter + 1 - sds.Rotated.Counter
+	sds.Total.SlaveErrCount = sds.Total.SlaveErrCount + 1 - sds.Rotated.SlaveErrCount
+}
+
+func (sds *ServerDelayStat) UpdateSlaveErrorWithoutRotate() {
+	sds.Current.SlaveErrCount = sds.Current.SlaveErrCount + 1
+	sds.Current.Counter = sds.Current.Counter + 1
+	sds.DelayHistory[len(sds.DelayHistory)-1].DelayStat = sds.Current
+
+	sds.Total.SlaveErrCount = sds.Total.SlaveErrCount + 1
+	sds.Total.Counter = sds.Total.Counter + 1
+}
+
+func (sds *ServerDelayStat) UpdateSlaveErrorStat(limit int) {
+	curTime := sds.CurrentDelayDatetime(time.Now())
+
+	if curTime != sds.CurrentDT {
+		sds.UpdateSlaveErrorWithRotate(limit)
+	} else {
+		sds.UpdateSlaveErrorWithoutRotate()
+	}
+}
+
+func (cluster *Cluster) PrintTotalDelayStat() {
+	var allStat map[string]DelayStat = make(map[string]DelayStat)
+	for _, sl := range cluster.slaves {
+		allStat[sl.URL] = sl.DelayStat.Total
+	}
+
+	jtext, err := json.MarshalIndent(allStat, " ", "\t")
+	if err != nil {
+		cluster.LogPrintf(LvlErr, "Average delay for cluster %s : %s", cluster.Name, err)
+		return
+	}
+	cluster.LogPrintf(LvlInfo, "Average delay for cluster %s : %s", cluster.Name, jtext)
+}
+
+func (cluster *Cluster) PrintDelayStatHistory() {
+	var allStat map[string]DelayHistoryList = make(map[string]DelayHistoryList)
+	for _, sl := range cluster.slaves {
+		allStat[sl.URL] = sl.DelayStat.DelayHistory
+	}
+
+	jtext, err := json.MarshalIndent(allStat, " ", "\t")
+	if err != nil {
+		cluster.LogPrintf(LvlErr, "Delay history for cluster %s : %s", cluster.Name, err)
+		return
+	}
+	cluster.LogPrintf(LvlInfo, "Delay history for cluster %s : %s", cluster.Name, jtext)
+}
+
+func (cluster *Cluster) PrintDelayStat() {
+	if cluster.Conf.PrintDelayStat {
+		if cluster.LastDelayStatPrint.IsZero() || !time.Now().Before(cluster.LastDelayStatPrint.Add(time.Minute*time.Duration(cluster.Conf.PrintDelayStatInterval))) {
+			cluster.LastDelayStatPrint = time.Now()
+			cluster.PrintTotalDelayStat()
+			if cluster.Conf.PrintDelayStatHistory {
+				cluster.PrintDelayStatHistory()
+			}
+		}
+	}
+}

--- a/cluster/cluster_tgl.go
+++ b/cluster/cluster_tgl.go
@@ -417,6 +417,19 @@ func (cluster *Cluster) SwitchTraffic() {
 
 func (cluster *Cluster) SwitchDelayStatCapture() {
 	cluster.Conf.DelayStatCapture = !cluster.Conf.DelayStatCapture
+	if !cluster.Conf.DelayStatCapture {
+		cluster.Conf.FailoverCheckDelayStat = false
+		cluster.Conf.PrintDelayStat = false
+		cluster.Conf.PrintDelayStatHistory = false
+	}
+}
+
+func (cluster *Cluster) SwitchPrintDelayStat() {
+	cluster.Conf.PrintDelayStat = !cluster.Conf.PrintDelayStat
+}
+
+func (cluster *Cluster) SwitchPrintDelayStatHistory() {
+	cluster.Conf.PrintDelayStatHistory = !cluster.Conf.PrintDelayStatHistory
 }
 
 func (cluster *Cluster) SwitchFailoverCheckDelayStat() {

--- a/cluster/cluster_tgl.go
+++ b/cluster/cluster_tgl.go
@@ -414,3 +414,7 @@ func (cluster *Cluster) SwitchTestMode() {
 func (cluster *Cluster) SwitchTraffic() {
 	cluster.SetTraffic(!cluster.GetTraffic())
 }
+
+func (cluster *Cluster) SwitchFailoverCheckDelayStat() {
+	cluster.Conf.FailoverCheckDelayStat = !cluster.Conf.FailoverCheckDelayStat
+}

--- a/cluster/cluster_tgl.go
+++ b/cluster/cluster_tgl.go
@@ -415,6 +415,10 @@ func (cluster *Cluster) SwitchTraffic() {
 	cluster.SetTraffic(!cluster.GetTraffic())
 }
 
+func (cluster *Cluster) SwitchDelayStatCapture() {
+	cluster.Conf.DelayStatCapture = !cluster.Conf.DelayStatCapture
+}
+
 func (cluster *Cluster) SwitchFailoverCheckDelayStat() {
 	cluster.Conf.FailoverCheckDelayStat = !cluster.Conf.FailoverCheckDelayStat
 }

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -39,6 +39,19 @@ import (
 	"github.com/signal18/replication-manager/utils/state"
 )
 
+// Logging Replication Delay Stat
+type DelayStat struct {
+	DelayAvg      float64 `json:"delay"`         // Average Seconds of Delay
+	DelayCount    int32   `json:"delayCount"`    // Number of Delay Occurred
+	SlaveErrCount int32   `json:"slaveErrCount"` // Number of Slave Err Occurred
+	Counter       int32   `json:"counter"`       // Increment
+}
+
+type DelayStatHistory struct {
+	DelayStat DelayStat `json:"delayStat"`
+	Datetime  time.Time `json:"delayDT"`
+}
+
 // ServerMonitor defines a server to monitor.
 type ServerMonitor struct {
 	Id                          string                       `json:"id"` //Unique name given by cluster & crc64(URL) used by test to provision
@@ -181,6 +194,11 @@ type ServerMonitor struct {
 	BinaryLogFiles              map[string]uint              `json:"binaryLogFiles"`
 	MaxSlowQueryTimestamp       int64                        `json:"maxSlowQueryTimestamp"`
 	WorkLoad                    map[string]WorkLoad          `json:"workLoad"`
+	TotalDelayStat              DelayStat                    `json:"totalDelayStat"` // Total Delay Average since SRM started
+	PrevDelayStat               DelayStat                    `json:"prevDelayStat"`  // Total Delay Average until previous hour
+	CurrentDelayStat            DelayStatHistory             `json:"currDelayStat"`  // Delay Average for current hour
+	DelayHistory                []DelayStatHistory           `json:"delayHistory"`
+	LastDelayStatPrint          map[string]time.Time         `json:"prevDelayStatPrintTime"`
 	IsInSlowQueryCapture        bool
 	IsInPFSQueryCapture         bool
 }
@@ -300,6 +318,7 @@ func (cluster *Cluster) newServerMonitor(url string, user string, pass string, c
 	server.SetPreferedBackup(cluster.IsInPreferedBackupHosts(server))
 	server.SetPrefered(cluster.IsInPreferedHosts(server))
 	server.ReloadSaveInfosVariables()
+	server.ResetDelayStat()
 
 	server.WorkLoad = make(map[string]WorkLoad)
 	server.CurrentWorkLoad()
@@ -1665,5 +1684,166 @@ func (server *ServerMonitor) CpuFromStatWorkLoad(start_time time.Time) time.Time
 		current_workLoad.BusyTime, _ = server.GetBusyTimeFromStats()
 		server.WorkLoad["current"] = current_workLoad
 		return time.Now()
+	}
+}
+
+// Get Current Datetime in hourly format
+func (server *ServerMonitor) CurrentDelayDatetime(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, t.Location())
+}
+
+func (server *ServerMonitor) ResetCurrentDelayStat() {
+	t := time.Now()
+	server.CurrentDelayStat = DelayStatHistory{DelayStat: DelayStat{DelayAvg: 0, DelayCount: 0, SlaveErrCount: 0, Counter: 0}, Datetime: server.CurrentDelayDatetime(t)}
+}
+
+func (server *ServerMonitor) AppendNewCurrentDelayStat() {
+	server.ResetCurrentDelayStat()
+	server.DelayHistory = append(server.DelayHistory, server.CurrentDelayStat)
+}
+
+func (server *ServerMonitor) ResetDelayStat() {
+	server.ResetCurrentDelayStat()
+	server.TotalDelayStat = server.CurrentDelayStat.DelayStat
+	server.PrevDelayStat = server.CurrentDelayStat.DelayStat
+	server.DelayHistory = []DelayStatHistory{server.CurrentDelayStat}
+	if server.LastDelayStatPrint == nil {
+		server.LastDelayStatPrint = make(map[string]time.Time)
+	}
+}
+
+func (server *ServerMonitor) UpdateTotalDelayStat(s int64) {
+	server.TotalDelayStat.DelayAvg = (server.TotalDelayStat.DelayAvg*float64(server.TotalDelayStat.Counter) + float64(s)) / float64(server.TotalDelayStat.Counter+1)
+	server.TotalDelayStat.Counter = server.TotalDelayStat.Counter + 1
+
+	if s > 0 {
+		server.TotalDelayStat.DelayCount = server.TotalDelayStat.DelayCount + 1
+	}
+}
+
+func (server *ServerMonitor) UpdateTotalSlaveErrStat() {
+	server.TotalDelayStat.SlaveErrCount = server.TotalDelayStat.SlaveErrCount + 1
+	server.TotalDelayStat.Counter = server.TotalDelayStat.Counter + 1
+}
+
+func (server *ServerMonitor) UpdateandRotateTotalDelayStat(s int64) {
+	rotated := server.DelayHistory[0]
+	server.TotalDelayStat.DelayAvg = (server.TotalDelayStat.DelayAvg*float64(server.TotalDelayStat.Counter) - (rotated.DelayStat.DelayAvg * float64(rotated.DelayStat.Counter)) + float64(s)) / float64(server.TotalDelayStat.Counter+1-rotated.DelayStat.Counter)
+	server.TotalDelayStat.Counter = server.TotalDelayStat.Counter + 1 - rotated.DelayStat.Counter
+
+	if s > 0 {
+		server.TotalDelayStat.DelayCount = server.TotalDelayStat.DelayCount + 1 - rotated.DelayStat.DelayCount
+	} else {
+		server.TotalDelayStat.DelayCount = server.TotalDelayStat.DelayCount - rotated.DelayStat.DelayCount
+	}
+
+}
+
+func (server *ServerMonitor) UpdateandRotateTotalSlaveErrStat() {
+	rotated := server.DelayHistory[0]
+	server.TotalDelayStat.Counter = server.TotalDelayStat.Counter + 1 - rotated.DelayStat.Counter
+	server.TotalDelayStat.SlaveErrCount = server.TotalDelayStat.SlaveErrCount + 1 - rotated.DelayStat.SlaveErrCount
+}
+
+func (server *ServerMonitor) PrintDelayStat(key string) {
+	switch key {
+	case "avg":
+		jtext, err := json.MarshalIndent(server.TotalDelayStat, " ", "\t")
+		if err != nil {
+			server.ClusterGroup.LogPrintf(LvlErr, "Average delay for slave %s : %s", server.URL, err)
+			return
+		}
+		server.ClusterGroup.LogPrintf(LvlInfo, "Average delay for slave %s : %s", server.URL, jtext)
+	case "hourly":
+		jtext, err := json.MarshalIndent(server.DelayHistory, " ", "\t")
+		if err != nil {
+			server.ClusterGroup.LogPrintf(LvlErr, "Hourly Delay History for slave %s : %s", server.URL, err)
+			return
+		}
+		server.ClusterGroup.LogPrintf(LvlInfo, "Hourly Delay History for slave %s : %s", server.URL, jtext)
+	}
+
+}
+
+func (server *ServerMonitor) UpdateDelayStat(s int64) {
+	t := time.Now()
+	curTime := server.CurrentDelayDatetime(t)
+
+	if curTime != server.CurrentDelayStat.Datetime {
+		server.PrevDelayStat = server.TotalDelayStat
+		server.AppendNewCurrentDelayStat()
+	}
+
+	if s > 0 {
+		server.CurrentDelayStat.DelayStat.DelayCount = server.CurrentDelayStat.DelayStat.DelayCount + 1
+	}
+
+	server.CurrentDelayStat.DelayStat.DelayAvg = ((server.CurrentDelayStat.DelayStat.DelayAvg*float64(server.CurrentDelayStat.DelayStat.Counter) + float64(s)) / (float64(server.CurrentDelayStat.DelayStat.Counter + 1)))
+	server.CurrentDelayStat.DelayStat.Counter = server.CurrentDelayStat.DelayStat.Counter + 1
+
+	server.DelayHistory[len(server.DelayHistory)-1] = server.CurrentDelayStat
+
+	if curTime != server.CurrentDelayStat.Datetime {
+		server.UpdateandRotateTotalDelayStat(s)
+	} else {
+		server.UpdateTotalDelayStat(s)
+	}
+
+	if ld, ok := server.LastDelayStatPrint["avg"]; ok {
+		if t.After(ld.Add(2 * time.Minute)) {
+			server.PrintDelayStat("avg")
+			server.LastDelayStatPrint["avg"] = t
+		}
+	} else {
+		server.PrintDelayStat("avg")
+		server.LastDelayStatPrint["avg"] = t
+	}
+
+	if ld, ok := server.LastDelayStatPrint["hourly"]; ok {
+		if t.After(ld.Add(4 * time.Minute)) {
+			server.PrintDelayStat("hourly")
+			server.LastDelayStatPrint["hourly"] = t
+		}
+	} else {
+		server.PrintDelayStat("hourly")
+		server.LastDelayStatPrint["hourly"] = t
+	}
+}
+
+func (server *ServerMonitor) UpdateSlaveErrorStat() {
+	t := time.Now()
+	curTime := server.CurrentDelayDatetime(t)
+
+	if curTime != server.CurrentDelayStat.Datetime {
+		server.PrevDelayStat = server.TotalDelayStat
+		server.AppendNewCurrentDelayStat()
+	}
+
+	server.CurrentDelayStat.DelayStat.SlaveErrCount = server.CurrentDelayStat.DelayStat.SlaveErrCount + 1
+
+	if curTime != server.CurrentDelayStat.Datetime {
+		server.UpdateandRotateTotalSlaveErrStat()
+	} else {
+		server.UpdateTotalSlaveErrStat()
+	}
+
+	if ld, ok := server.LastDelayStatPrint["avg"]; ok {
+		if t.After(ld.Add(2 * time.Minute)) {
+			server.PrintDelayStat("avg")
+			server.LastDelayStatPrint["avg"] = t
+		}
+	} else {
+		server.PrintDelayStat("avg")
+		server.LastDelayStatPrint["avg"] = t
+	}
+
+	if ld, ok := server.LastDelayStatPrint["hourly"]; ok {
+		if t.After(ld.Add(4 * time.Minute)) {
+			server.PrintDelayStat("hourly")
+			server.LastDelayStatPrint["hourly"] = t
+		}
+	} else {
+		server.PrintDelayStat("hourly")
+		server.LastDelayStatPrint["hourly"] = t
 	}
 }

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1754,6 +1754,7 @@ func (server *ServerMonitor) PrintDelayStat(key string) {
 			return
 		}
 		server.ClusterGroup.LogPrintf(LvlInfo, "Average delay for slave %s : %s", server.URL, jtext)
+		return
 	case "hourly":
 		jtext, err := json.MarshalIndent(server.DelayHistory, " ", "\t")
 		if err != nil {
@@ -1761,6 +1762,7 @@ func (server *ServerMonitor) PrintDelayStat(key string) {
 			return
 		}
 		server.ClusterGroup.LogPrintf(LvlInfo, "Hourly Delay History for slave %s : %s", server.URL, jtext)
+		return
 	}
 
 }
@@ -1821,6 +1823,8 @@ func (server *ServerMonitor) UpdateSlaveErrorStat() {
 
 	server.CurrentDelayStat.DelayStat.SlaveErrCount = server.CurrentDelayStat.DelayStat.SlaveErrCount + 1
 
+	server.DelayHistory[len(server.DelayHistory)-1] = server.CurrentDelayStat
+
 	if curTime != server.CurrentDelayStat.Datetime {
 		server.UpdateandRotateTotalSlaveErrStat()
 	} else {
@@ -1828,7 +1832,7 @@ func (server *ServerMonitor) UpdateSlaveErrorStat() {
 	}
 
 	if ld, ok := server.LastDelayStatPrint["avg"]; ok {
-		if t.After(ld.Add(2 * time.Minute)) {
+		if t.After(ld.Add(time.Minute)) {
 			server.PrintDelayStat("avg")
 			server.LastDelayStatPrint["avg"] = t
 		}
@@ -1838,7 +1842,7 @@ func (server *ServerMonitor) UpdateSlaveErrorStat() {
 	}
 
 	if ld, ok := server.LastDelayStatPrint["hourly"]; ok {
-		if t.After(ld.Add(4 * time.Minute)) {
+		if t.After(ld.Add(time.Minute)) {
 			server.PrintDelayStat("hourly")
 			server.LastDelayStatPrint["hourly"] = t
 		}

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -899,6 +899,14 @@ func (server *ServerMonitor) Refresh() error {
 
 	server.ReplicationHealth = server.CheckReplication()
 
+	if server.IsSlave == true {
+		if server.ClusterGroup.Conf.DelayStatCapture {
+			if server.State == stateFailed || server.State == stateSlaveErr {
+				server.UpdateSlaveErrorStat()
+			}
+		}
+	}
+
 	if len(server.PrevStatus) > 0 {
 		qps, _ := strconv.ParseInt(server.Status["QUERIES"], 10, 64)
 		prevqps, _ := strconv.ParseInt(server.PrevStatus["QUERIES"], 10, 64)
@@ -1822,6 +1830,7 @@ func (server *ServerMonitor) UpdateSlaveErrorStat() {
 	}
 
 	server.CurrentDelayStat.DelayStat.SlaveErrCount = server.CurrentDelayStat.DelayStat.SlaveErrCount + 1
+	server.CurrentDelayStat.DelayStat.Counter = server.CurrentDelayStat.DelayStat.Counter + 1
 
 	server.DelayHistory[len(server.DelayHistory)-1] = server.CurrentDelayStat
 

--- a/cluster/srv_chk.go
+++ b/cluster/srv_chk.go
@@ -65,9 +65,6 @@ func (server *ServerMonitor) CheckReplication() string {
 		return "In Failover"
 	}
 	if (server.IsDown()) && server.IsSlave == false {
-		if server.ClusterGroup.Conf.DelayStatCapture {
-			server.UpdateSlaveErrorStat() //Capture stat as Slave Error due to server down
-		}
 		return "Master OK"
 	}
 
@@ -94,20 +91,12 @@ func (server *ServerMonitor) CheckReplication() string {
 			} else if server.IsRelay {
 				server.SetState(stateRelayErr)
 			}
-
-			if server.ClusterGroup.Conf.DelayStatCapture {
-				server.UpdateSlaveErrorStat()
-			}
 			return fmt.Sprintf("NOT OK, IO Stopped (%s)", ss.LastIOErrno.String)
 		} else if ss.SlaveSQLRunning.String == "No" && ss.SlaveIORunning.String == "Yes" {
 			if server.IsRelay == false && server.IsMaxscale == false {
 				server.SetState(stateSlaveErr)
 			} else if server.IsRelay {
 				server.SetState(stateRelayErr)
-			}
-
-			if server.ClusterGroup.Conf.DelayStatCapture {
-				server.UpdateSlaveErrorStat()
 			}
 			return fmt.Sprintf("NOT OK, SQL Stopped (%s)", ss.LastSQLErrno.String)
 		} else if ss.SlaveSQLRunning.String == "No" && ss.SlaveIORunning.String == "No" {
@@ -116,20 +105,12 @@ func (server *ServerMonitor) CheckReplication() string {
 			} else if server.IsRelay {
 				server.SetState(stateRelayErr)
 			}
-
-			if server.ClusterGroup.Conf.DelayStatCapture {
-				server.UpdateSlaveErrorStat()
-			}
 			return "NOT OK, ALL Stopped"
 		} else if ss.SlaveSQLRunning.String == "Connecting" {
 			if server.IsRelay == false && server.IsMaxscale == false {
 				server.SetState(stateSlave)
 			} else if server.IsRelay {
 				server.SetState(stateRelay)
-			}
-
-			if server.ClusterGroup.Conf.DelayStatCapture {
-				server.UpdateSlaveErrorStat()
 			}
 			return "NOT OK, IO Connecting"
 		}

--- a/cluster/srv_chk.go
+++ b/cluster/srv_chk.go
@@ -120,10 +120,6 @@ func (server *ServerMonitor) CheckReplication() string {
 		} else if server.IsRelay {
 			server.SetState(stateRelay)
 		}
-
-		if server.ClusterGroup.Conf.DelayStatCapture {
-			server.UpdateSlaveErrorStat() //Capture stat with value of slave error due to replication still connecting
-		}
 		return "Running OK"
 	}
 
@@ -144,7 +140,7 @@ func (server *ServerMonitor) CheckReplication() string {
 		}
 
 		if server.ClusterGroup.Conf.DelayStatCapture {
-			server.UpdateDelayStat(ss.SecondsBehindMaster.Int64) // Capture Delay Stat
+			server.DelayStat.UpdateDelayStat(ss.SecondsBehindMaster.Int64, server.ClusterGroup.Conf.DelayStatRotate) // Capture Delay Stat
 		}
 		return "Behind master"
 	}
@@ -155,7 +151,7 @@ func (server *ServerMonitor) CheckReplication() string {
 	}
 
 	if server.ClusterGroup.Conf.DelayStatCapture {
-		server.UpdateDelayStat(ss.SecondsBehindMaster.Int64) // Capture Delay Stat with 0 seconds behind master
+		server.DelayStat.UpdateDelayStat(ss.SecondsBehindMaster.Int64, server.ClusterGroup.Conf.DelayStatRotate) // Capture Delay Stat with 0 seconds behind master
 	}
 	return "Running OK"
 }

--- a/cluster/srv_chk.go
+++ b/cluster/srv_chk.go
@@ -91,6 +91,7 @@ func (server *ServerMonitor) CheckReplication() string {
 			} else if server.IsRelay {
 				server.SetState(stateRelayErr)
 			}
+			server.UpdateSlaveErrorStat()
 			return fmt.Sprintf("NOT OK, IO Stopped (%s)", ss.LastIOErrno.String)
 		} else if ss.SlaveSQLRunning.String == "No" && ss.SlaveIORunning.String == "Yes" {
 			if server.IsRelay == false && server.IsMaxscale == false {
@@ -98,6 +99,7 @@ func (server *ServerMonitor) CheckReplication() string {
 			} else if server.IsRelay {
 				server.SetState(stateRelayErr)
 			}
+			server.UpdateSlaveErrorStat()
 			return fmt.Sprintf("NOT OK, SQL Stopped (%s)", ss.LastSQLErrno.String)
 		} else if ss.SlaveSQLRunning.String == "No" && ss.SlaveIORunning.String == "No" {
 			if server.IsRelay == false && server.IsMaxscale == false {
@@ -105,6 +107,7 @@ func (server *ServerMonitor) CheckReplication() string {
 			} else if server.IsRelay {
 				server.SetState(stateRelayErr)
 			}
+			server.UpdateSlaveErrorStat()
 			return "NOT OK, ALL Stopped"
 		} else if ss.SlaveSQLRunning.String == "Connecting" {
 			if server.IsRelay == false && server.IsMaxscale == false {
@@ -112,6 +115,7 @@ func (server *ServerMonitor) CheckReplication() string {
 			} else if server.IsRelay {
 				server.SetState(stateRelay)
 			}
+			server.UpdateSlaveErrorStat()
 			return "NOT OK, IO Connecting"
 		}
 
@@ -138,6 +142,8 @@ func (server *ServerMonitor) CheckReplication() string {
 				server.SetState(stateRelay)
 			}
 		}
+
+		server.UpdateDelayStat(ss.SecondsBehindMaster.Int64)
 		return "Behind master"
 	}
 	if server.IsRelay == false && server.IsMaxscale == false {
@@ -145,6 +151,8 @@ func (server *ServerMonitor) CheckReplication() string {
 	} else if server.IsRelay {
 		server.SetState(stateRelayLate)
 	}
+
+	server.UpdateDelayStat(ss.SecondsBehindMaster.Int64)
 	return "Running OK"
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -180,6 +180,9 @@ type Config struct {
 	FailoverLogFileKeep                       int                    `mapstructure:"failover-log-file-keep" toml:"failover-log-file-keep" json:"failoverLogFileKeep"`
 	FailoverSwitchToPrefered                  bool                   `mapstructure:"failover-switch-to-prefered" toml:"failover-switch-to-prefered" json:"failoverSwithToPrefered"`
 	DelayStatCapture                          bool                   `mapstructure:"delay-stat-capture" toml:"delay-stat-capture" json:"delayStatCapture"`
+	PrintDelayStat                            bool                   `mapstructure:"print-delay-stat" toml:"print-delay-stat" json:"printDelayStat"`
+	PrintDelayStatHistory                     bool                   `mapstructure:"print-delay-stat-history" toml:"print-delay-stat-history" json:"printDelayStatHistory"`
+	PrintDelayStatInterval                    int                    `mapstructure:"print-delay-stat-interval" toml:"print-delay-stat-interval" json:"printDelayStatInterval"`
 	DelayStatRotate                           int                    `mapstructure:"delay-stat-rotate" toml:"delay-stat-rotate" json:"delayStatRotate"`
 	FailoverCheckDelayStat                    bool                   `mapstructure:"failover-check-delay-stat" toml:"failover-check-delay-stat" json:"failoverCheckDelayStat"`
 	Autorejoin                                bool                   `mapstructure:"autorejoin" toml:"autorejoin" json:"autorejoin"`

--- a/config/config.go
+++ b/config/config.go
@@ -179,6 +179,8 @@ type Config struct {
 	CheckFalsePositiveExternalPort            int                    `mapstructure:"failover-falsepositive-external-port" toml:"failover-falsepositive-external-port" json:"failoverFalsePositiveExternalPort"`
 	FailoverLogFileKeep                       int                    `mapstructure:"failover-log-file-keep" toml:"failover-log-file-keep" json:"failoverLogFileKeep"`
 	FailoverSwitchToPrefered                  bool                   `mapstructure:"failover-switch-to-prefered" toml:"failover-switch-to-prefered" json:"failoverSwithToPrefered"`
+	FailoverCheckDelayStat                    bool                   `mapstructure:"failover-check-delay-stat" toml:"failover-check-delay-stat" json:"failoverCheckDelayStat"`
+	DelayStatRotate                           int                    `mapstructure:"delay-stat-rotate" toml:"delay-stat-rotate" json:"delayStatRotate"`
 	Autorejoin                                bool                   `mapstructure:"autorejoin" toml:"autorejoin" json:"autorejoin"`
 	Autoseed                                  bool                   `mapstructure:"autoseed" toml:"autoseed" json:"autoseed"`
 	AutorejoinForceRestore                    bool                   `mapstructure:"autorejoin-force-restore" toml:"autorejoin-force-restore" json:"autorejoinForceRestore"`

--- a/config/config.go
+++ b/config/config.go
@@ -179,8 +179,9 @@ type Config struct {
 	CheckFalsePositiveExternalPort            int                    `mapstructure:"failover-falsepositive-external-port" toml:"failover-falsepositive-external-port" json:"failoverFalsePositiveExternalPort"`
 	FailoverLogFileKeep                       int                    `mapstructure:"failover-log-file-keep" toml:"failover-log-file-keep" json:"failoverLogFileKeep"`
 	FailoverSwitchToPrefered                  bool                   `mapstructure:"failover-switch-to-prefered" toml:"failover-switch-to-prefered" json:"failoverSwithToPrefered"`
-	FailoverCheckDelayStat                    bool                   `mapstructure:"failover-check-delay-stat" toml:"failover-check-delay-stat" json:"failoverCheckDelayStat"`
+	DelayStatCapture                          bool                   `mapstructure:"delay-stat-capture" toml:"delay-stat-capture" json:"delayStatCapture"`
 	DelayStatRotate                           int                    `mapstructure:"delay-stat-rotate" toml:"delay-stat-rotate" json:"delayStatRotate"`
+	FailoverCheckDelayStat                    bool                   `mapstructure:"failover-check-delay-stat" toml:"failover-check-delay-stat" json:"failoverCheckDelayStat"`
 	Autorejoin                                bool                   `mapstructure:"autorejoin" toml:"autorejoin" json:"autorejoin"`
 	Autoseed                                  bool                   `mapstructure:"autoseed" toml:"autoseed" json:"autoseed"`
 	AutorejoinForceRestore                    bool                   `mapstructure:"autorejoin-force-restore" toml:"autorejoin-force-restore" json:"autorejoinForceRestore"`

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -1001,6 +1001,9 @@ func (repman *ReplicationManager) switchSettings(mycluster *cluster.Cluster, set
 		mycluster.SwitchFailoverEventStatus()
 	case "failover-event-scheduler":
 		mycluster.SwitchFailoverEventScheduler()
+	case "delay-stat-capture":
+		mycluster.SwitchDelayStatCapture()
+
 	case "failover-check-delay-stat":
 		mycluster.SwitchFailoverCheckDelayStat()
 	case "autorejoin":

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -1003,7 +1003,10 @@ func (repman *ReplicationManager) switchSettings(mycluster *cluster.Cluster, set
 		mycluster.SwitchFailoverEventScheduler()
 	case "delay-stat-capture":
 		mycluster.SwitchDelayStatCapture()
-
+	case "print-delay-stat":
+		mycluster.SwitchPrintDelayStat()
+	case "print-delay-stat-history":
+		mycluster.SwitchPrintDelayStatHistory()
 	case "failover-check-delay-stat":
 		mycluster.SwitchFailoverCheckDelayStat()
 	case "autorejoin":
@@ -1313,6 +1316,8 @@ func (repman *ReplicationManager) setSetting(mycluster *cluster.Cluster, name st
 		mycluster.SetBackupBinlogsKeep(value)
 	case "delay-stat-rotate":
 		mycluster.SetDelayStatRotate(value)
+	case "print-delay-stat-interval":
+		mycluster.SetPrintDelayStatInterval(value)
 	}
 }
 

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -1001,6 +1001,8 @@ func (repman *ReplicationManager) switchSettings(mycluster *cluster.Cluster, set
 		mycluster.SwitchFailoverEventStatus()
 	case "failover-event-scheduler":
 		mycluster.SwitchFailoverEventScheduler()
+	case "failover-check-delay-stat":
+		mycluster.SwitchFailoverCheckDelayStat()
 	case "autorejoin":
 		mycluster.SwitchRejoin()
 	case "autoseed":
@@ -1306,6 +1308,8 @@ func (repman *ReplicationManager) setSetting(mycluster *cluster.Cluster, name st
 		mycluster.SetSchedulerAlertDisableCron(value)
 	case "backup-binlogs-keep":
 		mycluster.SetBackupBinlogsKeep(value)
+	case "delay-stat-rotate":
+		mycluster.SetDelayStatRotate(value)
 	}
 }
 

--- a/server/server_monitor.go
+++ b/server/server_monitor.go
@@ -170,6 +170,9 @@ func init() {
 	monitorCmd.Flags().IntVar(&conf.CheckFalsePositiveExternalPort, "failover-falsepositive-external-port", 80, "Failover checks external port")
 	monitorCmd.Flags().IntVar(&conf.MaxFail, "failover-falsepositive-ping-counter", 5, "Failover after this number of ping failures (interval 1s)")
 	monitorCmd.Flags().IntVar(&conf.FailoverLogFileKeep, "failover-log-file-keep", 5, "Purge log files taken during failover")
+	monitorCmd.Flags().BoolVar(&conf.FailoverCheckDelayStat, "failover-check-delay-stat", false, "Purge log files taken during failover")
+	monitorCmd.Flags().IntVar(&conf.DelayStatRotate, "delay-stat-rotate", 72, "Number of hours before rotating the delay stat")
+
 	monitorCmd.Flags().BoolVar(&conf.Autoseed, "autoseed", false, "Automatic join a standalone node")
 	monitorCmd.Flags().BoolVar(&conf.Autorejoin, "autorejoin", true, "Automatic rejoin a failed master")
 	monitorCmd.Flags().BoolVar(&conf.AutorejoinBackupBinlog, "autorejoin-backup-binlog", true, "backup ahead binlogs events when old master rejoin")

--- a/server/server_monitor.go
+++ b/server/server_monitor.go
@@ -170,8 +170,9 @@ func init() {
 	monitorCmd.Flags().IntVar(&conf.CheckFalsePositiveExternalPort, "failover-falsepositive-external-port", 80, "Failover checks external port")
 	monitorCmd.Flags().IntVar(&conf.MaxFail, "failover-falsepositive-ping-counter", 5, "Failover after this number of ping failures (interval 1s)")
 	monitorCmd.Flags().IntVar(&conf.FailoverLogFileKeep, "failover-log-file-keep", 5, "Purge log files taken during failover")
-	monitorCmd.Flags().BoolVar(&conf.FailoverCheckDelayStat, "failover-check-delay-stat", false, "Purge log files taken during failover")
+	monitorCmd.Flags().BoolVar(&conf.DelayStatCapture, "delay-stat-capture", false, "Capture hourly statistic for delay average")
 	monitorCmd.Flags().IntVar(&conf.DelayStatRotate, "delay-stat-rotate", 72, "Number of hours before rotating the delay stat")
+	monitorCmd.Flags().BoolVar(&conf.FailoverCheckDelayStat, "failover-check-delay-stat", false, "Use delay avg statistic for failover decision")
 
 	monitorCmd.Flags().BoolVar(&conf.Autoseed, "autoseed", false, "Automatic join a standalone node")
 	monitorCmd.Flags().BoolVar(&conf.Autorejoin, "autorejoin", true, "Automatic rejoin a failed master")

--- a/server/server_monitor.go
+++ b/server/server_monitor.go
@@ -171,9 +171,11 @@ func init() {
 	monitorCmd.Flags().IntVar(&conf.MaxFail, "failover-falsepositive-ping-counter", 5, "Failover after this number of ping failures (interval 1s)")
 	monitorCmd.Flags().IntVar(&conf.FailoverLogFileKeep, "failover-log-file-keep", 5, "Purge log files taken during failover")
 	monitorCmd.Flags().BoolVar(&conf.DelayStatCapture, "delay-stat-capture", false, "Capture hourly statistic for delay average")
+	monitorCmd.Flags().BoolVar(&conf.PrintDelayStat, "print-delay-stat", false, "Print captured delay statistic")
+	monitorCmd.Flags().BoolVar(&conf.PrintDelayStatHistory, "print-delay-stat-history", false, "Print captured delay statistic history")
+	monitorCmd.Flags().IntVar(&conf.PrintDelayStatInterval, "print-delay-stat-interval", 1, "Interval for printing delay stat (in minutes)")
 	monitorCmd.Flags().IntVar(&conf.DelayStatRotate, "delay-stat-rotate", 72, "Number of hours before rotating the delay stat")
 	monitorCmd.Flags().BoolVar(&conf.FailoverCheckDelayStat, "failover-check-delay-stat", false, "Use delay avg statistic for failover decision")
-
 	monitorCmd.Flags().BoolVar(&conf.Autoseed, "autoseed", false, "Automatic join a standalone node")
 	monitorCmd.Flags().BoolVar(&conf.Autorejoin, "autorejoin", true, "Automatic rejoin a failed master")
 	monitorCmd.Flags().BoolVar(&conf.AutorejoinBackupBinlog, "autorejoin-backup-binlog", true, "backup ahead binlogs events when old master rejoin")

--- a/share/dashboard/app/dashboard.js
+++ b/share/dashboard/app/dashboard.js
@@ -1614,8 +1614,11 @@ function (
       $scope.changeswitchoverwaitroutechange = function (delay) {
           if (confirm("Confirm change wait change route detection "+delay.toString()))   httpGetWithoutResponse(getClusterUrl() + '/settings/actions/set/switchover-wait-route-change/' + delay);
       };
-      $scope.changedelaystatrorate = function (rotate) {
+      $scope.changedelaystatrotate = function (rotate) {
         if (confirm("Confirm change delay stat rotate value to "+rotate.toString()))   httpGetWithoutResponse(getClusterUrl() + '/settings/actions/set/delay-stat-rotate/' + rotate);
+      };
+      $scope.changeprintdelaystatinterval = function (intv) {
+        if (confirm("Confirm change delay stat rotate value to "+intv.toString()))   httpGetWithoutResponse(getClusterUrl() + '/settings/actions/set/print-delay-stat-interval/' + intv);
       };
 
       $scope.setsettings = function (setting, value) {

--- a/share/dashboard/app/dashboard.js
+++ b/share/dashboard/app/dashboard.js
@@ -1614,6 +1614,9 @@ function (
       $scope.changeswitchoverwaitroutechange = function (delay) {
           if (confirm("Confirm change wait change route detection "+delay.toString()))   httpGetWithoutResponse(getClusterUrl() + '/settings/actions/set/switchover-wait-route-change/' + delay);
       };
+      $scope.changedelaystatrorate = function (rotate) {
+        if (confirm("Confirm change delay stat rotate value to "+rotate.toString()))   httpGetWithoutResponse(getClusterUrl() + '/settings/actions/set/delay-stat-rotate/' + rotate);
+      };
 
       $scope.setsettings = function (setting, value) {
         httpGetWithoutResponse(getClusterUrl() + '/settings/actions/set/' + setting + '/' + value);

--- a/share/dashboard/static/card-setting-replication.html
+++ b/share/dashboard/static/card-setting-replication.html
@@ -100,7 +100,7 @@
         </tr>
         <tr>
             <td>
-                <md-switch  ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" ng-true-value="true" ng-false-value="false"
+                <md-switch  ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false || !selectedCluster.config.delayStatCapture" ng-true-value="true" ng-false-value="false"
                            ng-model="selectedCluster.config.failoverCheckDelayStat"
                            ng-click="switchsettings('failover-check-delay-stat')"
                            aria-label="Failover check delay statistics">
@@ -112,7 +112,7 @@
             </td>
         </tr>
         <tr>
-            <th>Backup Binlogs Keep files</th>
+            <th>Delay Statistic Rotate Hours</th>
         </tr>
         <tr>
             <td>
@@ -121,6 +121,51 @@
                 </md-slider>
     
                 <span class="label label-primary">{{selectedCluster.config.delayStatRotate}}</span>
+    
+            </td>
+        </tr>
+        <tr>
+            <th>Print delay statistic</th>
+        </tr>
+        <tr>
+            <td>
+                <md-switch  ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false || !selectedCluster.config.delayStatCapture" ng-true-value="true" ng-false-value="false"
+                           ng-model="selectedCluster.config.printDelayStat"
+                           ng-click="switchsettings('print-delay-stat')"
+                           aria-label="print delay statistics">
+                    <span ng-if="selectedCluster.config.printDelayStat"
+                          class="label label-primary">On</span><span
+                        ng-if="!selectedCluster.config.printDelayStat" class="label label-warning">Off</span>
+
+            </md-switch>
+            </td>
+        </tr>
+        <tr>
+            <th>Print delay statistic history</th>
+        </tr>
+        <tr>
+            <td>
+                <md-switch  ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false || !selectedCluster.config.delayStatCapture" ng-true-value="true" ng-false-value="false"
+                           ng-model="selectedCluster.config.printDelayStatHistory"
+                           ng-click="switchsettings('print-delay-stat-history')"
+                           aria-label="print delay statistics history">
+                    <span ng-if="selectedCluster.config.printDelayStatHistory"
+                          class="label label-primary">On</span><span
+                        ng-if="!selectedCluster.config.printDelayStatHistory" class="label label-warning">Off</span>
+
+            </md-switch>
+            </td>
+        </tr>
+        <tr>
+            <th>Delay Statistic Print Interval</th>
+        </tr>
+        <tr>
+            <td>
+                <md-slider ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" ng-value="selectedCluster.config.printDelayStatInterval" md-discrete flex
+                           ng-model="selectedPrintDelayStatInterval" ng-change="changeprintdelaystatinterval(selectedPrintDelayStatInterval)" step="1" min="0" max="60" aria-label="<!-- WARNING:  -->ait">
+                </md-slider>
+    
+                <span class="label label-primary">{{selectedCluster.config.printDelayStatInterval}}</span>
     
             </td>
         </tr>

--- a/share/dashboard/static/card-setting-replication.html
+++ b/share/dashboard/static/card-setting-replication.html
@@ -79,6 +79,35 @@
             </md-switch>
             </td>
         </tr>
+        <tr>
+            <th>Failover check delay statistics</th>
+        </tr>
+        <tr>
+            <td>
+                <md-switch  ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" ng-true-value="true" ng-false-value="false"
+                           ng-model="selectedCluster.config.failoverCheckDelayStat"
+                           ng-click="switchsettings('failover-check-delay-stat')"
+                           aria-label="Failover check delay statistics">
+                    <span ng-if="selectedCluster.config.failoverCheckDelayStat"
+                          class="label label-primary">On</span><span
+                        ng-if="!selectedCluster.config.failoverCheckDelayStat" class="label label-warning">Off</span>
+
+            </md-switch>
+            </td>
+        </tr>
+        <tr>
+            <th>Backup Binlogs Keep files</th>
+        </tr>
+        <tr>
+            <td>
+                <md-slider ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" ng-value="selectedCluster.config.delayStatRotate" md-discrete flex
+                           ng-model="selectedDelayStatRotate" ng-change="changedelaystatrotate(selectedDelayStatRotate)" step="1" min="0" max="72" aria-label="<!-- WARNING:  -->ait">
+                </md-slider>
+    
+                <span class="label label-primary">{{selectedCluster.config.delayStatRotate}}</span>
+    
+            </td>
+        </tr>
         </table>
       </md-card>
       <BR>

--- a/share/dashboard/static/card-setting-replication.html
+++ b/share/dashboard/static/card-setting-replication.html
@@ -80,6 +80,22 @@
             </td>
         </tr>
         <tr>
+            <th>Capture statistic for hourly delay average</th>
+        </tr>
+        <tr>
+            <td>
+                <md-switch  ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" ng-true-value="true" ng-false-value="false"
+                           ng-model="selectedCluster.config.delayStatCapture"
+                           ng-click="switchsettings('delay-stat-capture')"
+                           aria-label="capture delay statistics">
+                    <span ng-if="selectedCluster.config.delayStatCapture"
+                          class="label label-primary">On</span><span
+                        ng-if="!selectedCluster.config.delayStatCapture" class="label label-warning">Off</span>
+
+            </md-switch>
+            </td>
+        </tr>
+        <tr>
             <th>Failover check delay statistics</th>
         </tr>
         <tr>


### PR DESCRIPTION
Adding delay average statistics for failover weighting. Already got the statistic, but still waiting for the weighting calculation. Kindly suggest the weighting algorithm.
values:
delay: average delay
delayCount: counter of lag more than 0 seconds occured
slaveErrCount: counter of slave error
counter: total counter

if we want to see percentage of delay count we can do delayCount / counter and so does with slave err percentage slaveErrCount
based on the logic we should pick the lowest value available.