### PR TITLE
 use GetVaultMonitorCredentials for db-servers-credential credentials

### DIFF
--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -668,7 +668,7 @@ func (cluster *Cluster) SetClusterMonitorCredentialsFromConfig() {
 			cluster.LogPrintf(LvlErr, "Unable to initialize AppRole auth method: %v", err)
 			return
 		}
-		user, pass, _ := cluster.GetVaultReplicationCredentials(client)
+		user, pass, _ := cluster.GetVaultMonitorCredentials(client)
 		var newSecret config.Secret
 		newSecret.OldValue = cluster.Conf.Secrets["db-servers-credential"].Value
 		newSecret.Value = user + ":" + pass


### PR DESCRIPTION
I try to fix https://github.com/signal18/replication-manager/issues/525

It works for me but I don't use password rollover so I cannot test