### PR TITLE
Fix: force slave semi sync errors with Percona 8.0.36

### DIFF
--- a/cluster/srv_chk.go
+++ b/cluster/srv_chk.go
@@ -165,7 +165,7 @@ func (server *ServerMonitor) CheckSlaveSettings() {
 	cluster := server.ClusterGroup
 	if cluster.Conf.ForceSlaveSemisync && sl.HaveSemiSync == false && cluster.GetTopology() != topoMultiMasterWsrep {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "DEBUG", "Enforce semisync on slave %s", sl.URL)
-		dbhelper.InstallSemiSync(sl.Conn)
+		dbhelper.InstallSemiSync(sl.Conn, server.DBVersion)
 	} else if sl.IsIgnored() == false && sl.HaveSemiSync == false && cluster.GetTopology() != topoMultiMasterWsrep {
 		cluster.StateMachine.AddState("WARN0048", state.State{ErrType: LvlWarn, ErrDesc: fmt.Sprintf(clusterError["WARN0048"], sl.URL), ErrFrom: "TOPO", ServerUrl: sl.URL})
 	}
@@ -280,7 +280,7 @@ func (server *ServerMonitor) CheckMasterSettings() {
 	cluster := server.ClusterGroup
 	if cluster.Conf.ForceSlaveSemisync && server.HaveSemiSync == false {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Enforce semisync on Master %s", server.URL)
-		dbhelper.InstallSemiSync(server.Conn)
+		dbhelper.InstallSemiSync(server.Conn, server.DBVersion)
 	} else if server.HaveSemiSync == false && cluster.GetTopology() != topoMultiMasterWsrep && cluster.GetTopology() != topoMultiMasterGrouprep {
 		cluster.StateMachine.AddState("WARN0060", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0060"], server.URL), ErrFrom: "TOPO", ServerUrl: server.URL})
 	}

--- a/utils/dbhelper/dbhelper.go
+++ b/utils/dbhelper/dbhelper.go
@@ -1194,7 +1194,7 @@ func SetMultiSourceRepl(db *sqlx.DB, master_host string, master_port string, mas
 	return logs, err
 }
 
-func InstallSemiSync(db *sqlx.DB) (string, error) {
+func InstallSemiSync(db *sqlx.DB, myver *MySQLVersion) (string, error) {
 	stmt := "INSTALL PLUGIN rpl_semi_sync_slave SONAME 'semisync_slave.so'"
 	logs := stmt
 	_, err := db.Exec(stmt)
@@ -2172,16 +2172,16 @@ func SetMaxConnections(db *sqlx.DB, connections string, myver *MySQLVersion) (st
 func SetSemiSyncSlave(db *sqlx.DB, myver *MySQLVersion) (string, error) {
 
 	query := "SET GLOBAL rpl-semi-sync-slave-enabled=1"
-	if myver.IsMySQL() && ((myver.Major >= 8 && myver.Minor > 0) || (myver.Major >= 8 && myver.Minor == 0 && myver.Release >= 26)) {
-		query = "SET GLOBAL rpl_semi_sync_replica_enabled=1"
+	if myver.IsMySQLOrPercona() && ((myver.Major >= 8 && myver.Minor > 0) || (myver.Major >= 8 && myver.Minor == 0 && myver.Release >= 26)) {
+		query = "SET GLOBAL rpl_semi_sync_replica_enabled=ON"
 	}
 	_, err := db.Exec(query)
 	if err != nil {
 		return query, err
 	}
 	query = "SET GLOBAL rpl-semi-sync-master-enabled=0"
-	if myver.IsMySQL() && ((myver.Major >= 8 && myver.Minor > 0) || (myver.Major >= 8 && myver.Minor == 0 && myver.Release >= 26)) {
-		query = "SET GLOBAL rpl_semi_sync_source_enabled=0"
+	if myver.IsMySQLOrPercona() && ((myver.Major >= 8 && myver.Minor > 0) || (myver.Major >= 8 && myver.Minor == 0 && myver.Release >= 26)) {
+		query = "SET GLOBAL rpl_semi_sync_source_enabled=OFF"
 	}
 	_, err = db.Exec(query)
 	return query, err
@@ -2190,16 +2190,16 @@ func SetSemiSyncSlave(db *sqlx.DB, myver *MySQLVersion) (string, error) {
 func SetSemiSyncMaster(db *sqlx.DB, myver *MySQLVersion) (string, error) {
 
 	query := "SET GLOBAL rpl-semi-sync-master-enabled=1"
-	if myver.IsMySQL() && ((myver.Major >= 8 && myver.Minor > 0) || (myver.Major >= 8 && myver.Minor == 0 && myver.Release >= 26)) {
-		query = "SET GLOBAL rpl_semi_sync_source_enabled=1"
+	if myver.IsMySQLOrPercona() && ((myver.Major >= 8 && myver.Minor > 0) || (myver.Major >= 8 && myver.Minor == 0 && myver.Release >= 26)) {
+		query = "SET GLOBAL rpl_semi_sync_source_enabled=ON"
 	}
 	_, err := db.Exec(query)
 	if err != nil {
 		return query, err
 	}
 	query = "SET GLOBAL rpl-semi-sync-slave-enabled=0"
-	if myver.IsMySQL() && ((myver.Major >= 8 && myver.Minor > 0) || (myver.Major >= 8 && myver.Minor == 0 && myver.Release >= 26)) {
-		query = "SET GLOBAL rpl_semi_sync_replica_enabled=0"
+	if myver.IsMySQLOrPercona() && ((myver.Major >= 8 && myver.Minor > 0) || (myver.Major >= 8 && myver.Minor == 0 && myver.Release >= 26)) {
+		query = "SET GLOBAL rpl_semi_sync_replica_enabled=OFF"
 	}
 	_, err = db.Exec(query)
 	return query, err


### PR DESCRIPTION
When using Percona Server 8.0.36 semi-sync changes are failing, the condition should be MySQL or Percona.
When installing semi-sync we need to check the version 8.0.26+ MySQL or Percona

-----

## Contributor Agreement

By submitting this pull request, I agree to the terms outlined in the [Contributor Agreement](CONTRIBUTING.md).
