### PR TITLE
add GUI flag for maintenance mode

### DIFF
--- a/share/dashboard/static/card-cluster-server-list-tab.html
+++ b/share/dashboard/static/card-cluster-server-list-tab.html
@@ -46,6 +46,7 @@
               <Table class="table fixed" style="border: 1px">
                 <tr>
                   <th class="tabicon">Status</th>
+                  <th class="tabicon">In Maintenance</th>
                   <th class="tabicon">Prefered/Ignored</th>
                   <th class="tabicon">Read Only</th>
                   <th class="tabicon">Ignore Read Only</th>
@@ -66,6 +67,8 @@
                     <span ng-switch-default class="label label-default">{{server.state}}
                       <label ng-if="server.isVirtualMaster==true">-VMaster</label></span>
                   </td>
+                  <td align="center" class="tabicon"><i ng-if="server.isMaintenance==true"
+                    class="fa fa-1x fa-cogs text-success"></i></td>
                   <td align="center" class="tabicon"><i ng-if="server.ignored==true"
                       class="fa fa-1x fa-thumbs-down text-danger"></i><i ng-if="server.prefered==true"
                       class="fa fa-1x fa-thumbs-up text-success"></i></td>

--- a/share/dashboard/static/card-cluster-server-list.html
+++ b/share/dashboard/static/card-cluster-server-list.html
@@ -8,6 +8,7 @@
         <th class="rowicon"><!-- Version --></th>
         <th class="servers">Database Servers</th>
         <th class="status">Status</th>
+        <th class="status">Is Mnt</th>
         <th>
             <span ng-if="servers[0].dbVersion.flavor=='MariaDB' && slaves[0].haveMariadbGtid==true">Using GTID</span>
             <span ng-if="servers[0].dbVersion.flavor!='MariaDB' && slaves[0].haveMysqlGtid==true">Executed GTID Set</span>
@@ -68,7 +69,8 @@
         <span ng-switch-default class="label label-default">{{server.state}}
             <label ng-if="server.isVirtualMaster==true">-VMaster</label></span>
     </td>
-
+    <td align="center" class="tabicon"><i ng-if="server.isMaintenance==true"
+        class="fa fa-1x fa-cogs text-success"></i></td>
 <td class="gtid"><span
         ng-if="server.dbVersion.flavor=='MariaDB' && slaves[0].haveMariadbGtid==true">{{server.replications[0].usingGtid.String}}</span>
 <span ng-if="server.dbVersion.flavor!='MariaDB' && slaves[0].haveMysqlGtid==true">{{server.gtidExecuted}}</span></td>


### PR DESCRIPTION
Adding information that server is in maintenance. Currently master status is always "master", even in maintenance mode. To make difference, I made a column indicating master is in maintenance mode (instead of changing state to maintenance).

## Contributor Agreement

By submitting this pull request, I agree to the terms outlined in the [Contributor Agreement](CONTRIBUTING.md).
