### PR TITLE
Adding validation for ignored slave. Will not purge ignored slave.

### DIFF
--- a/cluster/cluster_tgl.go
+++ b/cluster/cluster_tgl.go
@@ -575,6 +575,6 @@ func (cluster *Cluster) SwitchForceBinlogPurgeOnRestore() {
 	cluster.Conf.ForceBinlogPurgeOnRestore = !cluster.Conf.ForceBinlogPurgeOnRestore
 }
 
-func (cluster *Cluster) SwitchForceBinlogPurgeOnReplicas() {
-	cluster.Conf.ForceBinlogPurgeOnReplicas = !cluster.Conf.ForceBinlogPurgeOnReplicas
+func (cluster *Cluster) SwitchForceBinlogPurgeReplicas() {
+	cluster.Conf.ForceBinlogPurgeReplicas = !cluster.Conf.ForceBinlogPurgeReplicas
 }

--- a/cluster/cluster_tgl.go
+++ b/cluster/cluster_tgl.go
@@ -574,3 +574,7 @@ func (cluster *Cluster) SwitchForceBinlogPurge() {
 func (cluster *Cluster) SwitchForceBinlogPurgeOnRestore() {
 	cluster.Conf.ForceBinlogPurgeOnRestore = !cluster.Conf.ForceBinlogPurgeOnRestore
 }
+
+func (cluster *Cluster) SwitchForceBinlogPurgeOnReplicas() {
+	cluster.Conf.ForceBinlogPurgeOnReplicas = !cluster.Conf.ForceBinlogPurgeOnReplicas
+}

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -816,7 +816,9 @@ func (server *ServerMonitor) Refresh() error {
 					}
 				}
 			} else {
-				go server.CheckAndPurgeBinlogSlave()
+				if cluster.Conf.ForceBinlogPurgeOnReplicas && server.HaveBinlogSlaveUpdates && !server.IsIgnored() {
+					go server.CheckAndPurgeBinlogSlave()
+				}
 			}
 		}
 	}

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -816,7 +816,7 @@ func (server *ServerMonitor) Refresh() error {
 					}
 				}
 			} else {
-				if cluster.Conf.ForceBinlogPurgeOnReplicas && server.HaveBinlogSlaveUpdates && !server.IsIgnored() {
+				if cluster.Conf.ForceBinlogPurgeReplicas && server.HaveBinlogSlaveUpdates && !server.IsIgnored() {
 					go server.CheckAndPurgeBinlogSlave()
 				}
 			}

--- a/cluster/srv_binlog.go
+++ b/cluster/srv_binlog.go
@@ -384,7 +384,7 @@ func (server *ServerMonitor) JobBinlogPurgeSlave() {
 		}
 
 		if server.IsPurgingBinlog() {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, LvlErr, "Master is waiting for previous binlog purge to finish")
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, LvlErr, "Server is waiting for previous binlog purge to finish")
 			return
 		}
 
@@ -400,7 +400,11 @@ func (server *ServerMonitor) JobBinlogPurgeSlave() {
 			return
 		}
 
-		//Block multiple purge
+		//Only purge if slave not ignored
+		if server.IsIgnored() {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, LvlDbg, "Slave %s is in ignored list. Skipping", server.Host+":"+server.Port)
+			return
+		}
 
 		//Only purge if slave connected and status is slave or slave late
 		if server.State != stateSlave && server.State != stateSlaveLate {

--- a/cluster/srv_binlog.go
+++ b/cluster/srv_binlog.go
@@ -262,16 +262,16 @@ func (server *ServerMonitor) JobBinlogPurgeMaster() {
 				//Increment for purging use
 				oldestbinlog++
 
-				if oldestbinlog > 0 {
+				if oldestbinlog > 0 && oldestbinlog < cluster.SlavesOldestMasterFile.Suffix-1 {
 					filename := prefix + "." + fmt.Sprintf("%06d", oldestbinlog)
 					if _, ok := server.BinaryLogFiles[filename]; ok {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, LvlErr, "Purging binlog of %s: %s. ", server.URL, filename)
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, LvlInfo, "Purging binlog of %s: %s. ", server.URL, filename)
 						_, err := dbhelper.PurgeBinlogTo(server.Conn, filename)
 						if err != nil {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, LvlWarn, "Error purging binlog of %s,%s : %s", server.URL, filename, err.Error())
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, LvlErr, "Error purging binlog of %s,%s : %s", server.URL, filename, err.Error())
 						}
 					} else {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, LvlWarn, "Binlog filename not found on %s: %s", server.URL, filename)
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, LvlErr, "Binlog filename not found on %s: %s", server.URL, filename)
 					}
 				}
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -235,7 +235,7 @@ type Config struct {
 	ForceBinlogSlowqueries                    bool                   `mapstructure:"force-binlog-slowqueries" toml:"force-binlog-slowqueries" json:"forceBinlogSlowqueries"`
 	ForceBinlogChecksum                       bool                   `mapstructure:"force-binlog-checksum" toml:"force-binlog-checksum" json:"forceBinlogChecksum"`
 	ForceBinlogPurge                          bool                   `mapstructure:"force-binlog-purge" toml:"force-binlog-purge" json:"forceBinlogPurge"`
-	ForceBinlogPurgeOnReplicas                bool                   `mapstructure:"force-binlog-purge-replicas" toml:"force-binlog-purge-replicas" json:"forceBinlogPurgeOnReplicas"`
+	ForceBinlogPurgeReplicas                  bool                   `mapstructure:"force-binlog-purge-replicas" toml:"force-binlog-purge-replicas" json:"forceBinlogPurgeReplicas"`
 	ForceBinlogPurgeOnRestore                 bool                   `mapstructure:"force-binlog-purge-on-restore" toml:"force-binlog-purge-on-restore" json:"forceBinlogPurgeOnRestore"`
 	ForceBinlogPurgeTotalSize                 int                    `mapstructure:"force-binlog-purge-total-size" toml:"force-binlog-purge-total-size" json:"forceBinlogPurgeTotalSize"`
 	ForceBinlogPurgeMinReplica                int                    `mapstructure:"force-binlog-purge-min-replica" toml:"force-binlog-purge-min-replica" json:"forceBinlogPurgeMinReplica"`

--- a/config/config.go
+++ b/config/config.go
@@ -235,6 +235,7 @@ type Config struct {
 	ForceBinlogSlowqueries                    bool                   `mapstructure:"force-binlog-slowqueries" toml:"force-binlog-slowqueries" json:"forceBinlogSlowqueries"`
 	ForceBinlogChecksum                       bool                   `mapstructure:"force-binlog-checksum" toml:"force-binlog-checksum" json:"forceBinlogChecksum"`
 	ForceBinlogPurge                          bool                   `mapstructure:"force-binlog-purge" toml:"force-binlog-purge" json:"forceBinlogPurge"`
+	ForceBinlogPurgeOnReplicas                bool                   `mapstructure:"force-binlog-purge-replicas" toml:"force-binlog-purge-replicas" json:"forceBinlogPurgeOnReplicas"`
 	ForceBinlogPurgeOnRestore                 bool                   `mapstructure:"force-binlog-purge-on-restore" toml:"force-binlog-purge-on-restore" json:"forceBinlogPurgeOnRestore"`
 	ForceBinlogPurgeTotalSize                 int                    `mapstructure:"force-binlog-purge-total-size" toml:"force-binlog-purge-total-size" json:"forceBinlogPurgeTotalSize"`
 	ForceBinlogPurgeMinReplica                int                    `mapstructure:"force-binlog-purge-min-replica" toml:"force-binlog-purge-min-replica" json:"forceBinlogPurgeMinReplica"`

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -1185,6 +1185,8 @@ func (repman *ReplicationManager) switchSettings(mycluster *cluster.Cluster, set
 		mycluster.SwitchForceBinlogPurge()
 	case "force-binlog-purge-on-restore":
 		mycluster.SwitchForceBinlogPurgeOnRestore()
+	case "force-binlog-purge-on-replicas":
+		mycluster.SwitchForceBinlogPurgeOnReplicas()
 	}
 }
 

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -1185,8 +1185,8 @@ func (repman *ReplicationManager) switchSettings(mycluster *cluster.Cluster, set
 		mycluster.SwitchForceBinlogPurge()
 	case "force-binlog-purge-on-restore":
 		mycluster.SwitchForceBinlogPurgeOnRestore()
-	case "force-binlog-purge-on-replicas":
-		mycluster.SwitchForceBinlogPurgeOnReplicas()
+	case "force-binlog-purge-replicas":
+		mycluster.SwitchForceBinlogPurgeReplicas()
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -430,6 +430,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 		flags.BoolVar(&conf.ForceBinlogChecksum, "force-binlog-checksum", false, "Automatically force  binlog checksum")
 		flags.BoolVar(&conf.ForceBinlogCompress, "force-binlog-compress", false, "Automatically force binlog compression")
 		flags.BoolVar(&conf.ForceBinlogPurge, "force-binlog-purge", false, "Automatically force binlog purge")
+		flags.BoolVar(&conf.ForceBinlogPurgeOnReplicas, "force-binlog-purge-replicas", false, "Automatically force binlog purge replicas based on oldest master binlog when master purged")
 		flags.BoolVar(&conf.ForceBinlogPurgeOnRestore, "force-binlog-purge-on-restore", false, "Automatically force binlog purge on restore")
 		flags.IntVar(&conf.ForceBinlogPurgeTotalSize, "force-binlog-purge-total-size", 30, "Automatically force binlog purge more than total size")
 		flags.IntVar(&conf.ForceBinlogPurgeMinReplica, "force-binlog-purge-min-replica", 1, "Minimum of replica(s) needed for purging binary log")

--- a/server/server.go
+++ b/server/server.go
@@ -430,7 +430,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 		flags.BoolVar(&conf.ForceBinlogChecksum, "force-binlog-checksum", false, "Automatically force  binlog checksum")
 		flags.BoolVar(&conf.ForceBinlogCompress, "force-binlog-compress", false, "Automatically force binlog compression")
 		flags.BoolVar(&conf.ForceBinlogPurge, "force-binlog-purge", false, "Automatically force binlog purge")
-		flags.BoolVar(&conf.ForceBinlogPurgeOnReplicas, "force-binlog-purge-replicas", false, "Automatically force binlog purge replicas based on oldest master binlog when master purged")
+		flags.BoolVar(&conf.ForceBinlogPurgeReplicas, "force-binlog-purge-replicas", false, "Automatically force binlog purge replicas based on oldest master binlog when master purged")
 		flags.BoolVar(&conf.ForceBinlogPurgeOnRestore, "force-binlog-purge-on-restore", false, "Automatically force binlog purge on restore")
 		flags.IntVar(&conf.ForceBinlogPurgeTotalSize, "force-binlog-purge-total-size", 30, "Automatically force binlog purge more than total size")
 		flags.IntVar(&conf.ForceBinlogPurgeMinReplica, "force-binlog-purge-min-replica", 1, "Minimum of replica(s) needed for purging binary log")

--- a/share/dashboard/static/card-setting-binlog.html
+++ b/share/dashboard/static/card-setting-binlog.html
@@ -48,10 +48,10 @@
         </tr>
         <tr>
             <td>
-                <md-switch ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" ng-true-value="true" ng-false-value="false" ng-model="selectedCluster.config.forceBinlogPurgeOnReplicas"
-                           ng-click="switchsettings('force-binlog-purge-replicas')" aria-label="forceBinlogPurgeOnReplicas Mode Change">
-                    <span ng-if="selectedCluster.config.forceBinlogPurgeOnReplicas" class="label label-primary">On</span><span
-                        ng-if="!selectedCluster.config.forceBinlogPurgeOnReplicas" class="label label-warning">Off</span>
+                <md-switch ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" ng-true-value="true" ng-false-value="false" ng-model="selectedCluster.config.forceBinlogPurgeReplicas"
+                           ng-click="switchsettings('force-binlog-purge-replicas')" aria-label="forceBinlogPurgeReplicas Mode Change">
+                    <span ng-if="selectedCluster.config.forceBinlogPurgeReplicas" class="label label-primary">On</span><span
+                        ng-if="!selectedCluster.config.forceBinlogPurgeReplicas" class="label label-warning">Off</span>
 
             </md-switch>
             </td>

--- a/share/dashboard/static/card-setting-binlog.html
+++ b/share/dashboard/static/card-setting-binlog.html
@@ -43,5 +43,18 @@
             </md-switch>
             </td>
         </tr>
+        <tr>
+            <th>Enforce Binlog Purge On Replicas</th>
+        </tr>
+        <tr>
+            <td>
+                <md-switch ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" ng-true-value="true" ng-false-value="false" ng-model="selectedCluster.config.forceBinlogPurgeOnReplicas"
+                           ng-click="switchsettings('force-binlog-purge-replicas')" aria-label="forceBinlogPurgeOnReplicas Mode Change">
+                    <span ng-if="selectedCluster.config.forceBinlogPurgeOnReplicas" class="label label-primary">On</span><span
+                        ng-if="!selectedCluster.config.forceBinlogPurgeOnReplicas" class="label label-warning">Off</span>
+
+            </md-switch>
+            </td>
+        </tr>
     </table>
 </md-card>


### PR DESCRIPTION
To prevent unwanted purge on ignored slaves. Preventing child cluster's binary log getting purged by parent cluster

## Contributor Agreement

By submitting this pull request, I agree to the terms outlined in the [Contributor Agreement](CONTRIBUTING.md).
