### PR TITLE
set maintenance if status is "OFFLINE_SOFT" on refresh

### DIFF
--- a/cluster/prx_proxysql.go
+++ b/cluster/prx_proxysql.go
@@ -419,6 +419,12 @@ func (proxy *ProxySQLProxy) Refresh() error {
 			}
 		} //if bootstrap
 
+		//Set the GUI flag to maintenance if proxysql status is OFFLINE_SOFT
+		if (bke.PrxStatus == "OFFLINE_SOFT" || bkeread.PrxStatus == "OFFLINE_SOFT") && !s.IsMaintenance {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, LvlInfo, "Found DB server %s in OFFLINE_SOFT, flag as maintenance. ", s.Host+":"+s.Port)
+			s.SwitchMaintenance()
+		}
+
 		// load the grants
 		if s.IsMaster() && cluster.Conf.ProxysqlCopyGrants {
 			myprxusermap, _, err := dbhelper.GetProxySQLUsers(psql.Connection)
@@ -460,6 +466,7 @@ func (proxy *ProxySQLProxy) Refresh() error {
 				psql.SaveMySQLUsersToDisk()
 			}
 		}
+
 	} //end for each server
 
 	if updated {


### PR DESCRIPTION
When replication-manager start, db maintenance mode was false. If "OFFLINE_SOFT" was found, change to maintenance mode.

## Contributor Agreement

By submitting this pull request, I agree to the terms outlined in the [Contributor Agreement](CONTRIBUTING.md).
