### PR TITLE
Bump golang docker to 1.22

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 RUN mkdir -p /go/src/github.com/signal18/replication-manager
 WORKDIR /go/src/github.com/signal18/replication-manager

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.20-bullseye
+FROM golang:1.22-bullseye
 
 ENV PROXYSQL_VERSION=2.5.5
 

--- a/docker/Dockerfile.pro
+++ b/docker/Dockerfile.pro
@@ -1,4 +1,4 @@
-FROM golang:1.20-bullseye as builder
+FROM golang:1.22-bullseye as builder
 
 RUN mkdir -p /go/src/github.com/signal18/replication-manager
 WORKDIR /go/src/github.com/signal18/replication-manager


### PR DESCRIPTION
Bump dependencies needed after fixing k8s #608 

Before:
`
 => [ 4/17] COPY . .                                                                                                                                            1.9s
 => ERROR [ 5/17] RUN make pro cli                                                                                                                              0.7s
------
 > [ 5/17] RUN make pro cli:
0.624 env CGO_ENABLED=0 GOOS=linux GOARCH=amd64  go build -v --tags "server" --ldflags " -w -s -X 'github.com/signal18/replication-manager/server.Version=v2.3.30' -X 'github.com/signal18/replication-manager/server.FullVersion=v2.3.30-9-ga4c00a40' -X 'github.com/signal18/replication-manager/server.Build=2024-05-26T08:59:00+0000' -X github.com/signal18/replication-manager/server.WithOpenSVC=ON  "   -o build/binaries/replication-manager-pro
0.636 go: errors parsing go.mod:
0.636 /go/src/github.com/signal18/replication-manager/go.mod:3: invalid go version '1.22.0': must match format 1.23
0.636 /go/src/github.com/signal18/replication-manager/go.mod:5: unknown directive: toolchain
0.637 make: *** [Makefile:50: pro] Error 1
------
Dockerfile.dev:10
--------------------
   8 |     COPY . .
   9 |     
  10 | >>> RUN make pro cli
  11 |     
  12 |     RUN mkdir -p \
--------------------
ERROR: failed to solve: process "/bin/sh -c make pro cli" did not complete successfully: exit code: 2
`
