### PR TITLE
solve missing parameters within log sql

### DIFF
--- a/cluster/cluster_log.go
+++ b/cluster/cluster_log.go
@@ -174,7 +174,7 @@ func (cluster *Cluster) LogPrintf(level string, format string, args ...interface
 				cluster.LogSlack.WithFields(log.Fields{"cluster": cluster.Name, "type": "alert", "channel": "Slack"}).Errorf(cliformat, args...)
 			}
 			if cluster.Conf.TeamsUrl != "" {
-				go cluster.sendMsTeams(level, format, args)
+				go cluster.sendMsTeams(level, format, args...)
 			}
 		case "INFO":
 			log.WithField("cluster", cluster.Name).Infof(cliformat, args...)

--- a/cluster/cluster_log.go
+++ b/cluster/cluster_log.go
@@ -339,7 +339,7 @@ func (cluster *Cluster) LogModulePrintf(forcingLog bool, module int, level strin
 					cluster.LogSlack.WithFields(log.Fields{"cluster": cluster.Name, "type": "alert", "channel": "Slack"}).Errorf(cliformat, args...)
 				}
 				if cluster.Conf.TeamsUrl != "" {
-					go cluster.sendMsTeams(level, format, args)
+					go cluster.sendMsTeams(level, format, args...)
 				}
 			case "INFO":
 				log.WithField("cluster", cluster.Name).Infof(cliformat, args...)

--- a/cluster/cluster_log.go
+++ b/cluster/cluster_log.go
@@ -44,7 +44,7 @@ func (cluster *Cluster) display() {
 
 func (cluster *Cluster) LogSQL(logs string, err error, url string, from string, level string, format string, args ...interface{}) {
 	if err != nil && args != nil {
-		cluster.LogPrintf(level, format, args)
+		cluster.LogPrintf(level, format, args...)
 	}
 	if logs != "" {
 		if err != nil {


### PR DESCRIPTION
Currently there are misplaced values while logging SQL errors. This will solve that.

`Could not get database variables [{srv} {err}] %!s(MISSING)`
to
`Could not get database variables [ {srv} ] {err}`