### PR TITLE
add maintenance flag to cli topology

### DIFF
--- a/clients/client_topology.go
+++ b/clients/client_topology.go
@@ -40,7 +40,7 @@ func cliGetTopology() {
 		headstr += " |  Mode: Manual "
 	}
 
-	headstr += fmt.Sprintf("\n%19s %15s %6s %15s %10s %12s %20s %20s %30s %6s %3s", "Id", "Host", "Port", "Status", "Failures", "Using GTID", "Current GTID", "Slave GTID", "Replication Health", "Delay", "RO")
+	headstr += fmt.Sprintf("\n%19s %15s %6s %15s %10s %12s %20s %20s %30s %6s %3s %5s", "Id", "Host", "Port", "Status", "Failures", "Using GTID", "Current GTID", "Slave GTID", "Replication Health", "Delay", "RO", "MAINT")
 
 	for _, server := range cliServers {
 		var gtidCurr string
@@ -56,9 +56,16 @@ func cliGetTopology() {
 			gtidSlave = ""
 		}
 
-		headstr += fmt.Sprintf("\n%19s %15s %6s %15s %10d %12s %20s %20s %30s %6d %3s", server.Id, server.Host, server.Port, server.State, server.FailCount, server.GetReplicationUsingGtid(), gtidCurr, gtidSlave, "", server.GetReplicationDelay(), server.ReadOnly)
+		headstr += fmt.Sprintf("\n%19s %15s %6s %15s %10d %12s %20s %20s %30s %6d %3s %5s", server.Id, server.Host, server.Port, server.State, server.FailCount, server.GetReplicationUsingGtid(), gtidCurr, gtidSlave, "", server.GetReplicationDelay(), server.ReadOnly, boolToChar(server.IsMaintenance))
 
 	}
 	fmt.Printf(headstr)
 	fmt.Printf("\n")
+}
+
+func boolToChar(v bool) string {
+	if v {
+		return "Y"
+	}
+	return "N"
 }


### PR DESCRIPTION
This PR is adding maintenance column at the last position within cli topology

replication-manager-cli topology will resulting to:
```
./replication-manager-cli topology --cluster=fr
####
                 Id            Host   Port          Status   Failures   Using GTID         Current GTID           Slave GTID             Replication Health  Delay  RO MAINT
db8333316815677374852      172.17.0.2   3306          Master          0           No                0-1-5                                                          0 OFF     N
db3425150372194902490      172.17.0.3   3306          Failed       2159           No                0-1-5                0-1-5                                     0  ON     Y
db2995596438658588357      172.17.0.4   3306          Failed       2255           No                                                                               0         N
```
