### PR TITLE
prevent missing grafana metrics when initialize with graphite-whitelist

### DIFF
--- a/cluster/cluster_graphite.go
+++ b/cluster/cluster_graphite.go
@@ -34,6 +34,19 @@ func (cluster *Cluster) NewClusterGraphite() {
 		UseBlacklist: cluster.Conf.GraphiteBlacklist,
 	}
 
+	/**
+	* Check if whitelist.conf not exists
+	* When not exists check if graphite embedded is already set
+	* If graphite embedded is immutable, set the default whitelist as grafana to prevent missing metrics
+	* The next process will be executed by ReloadGraphiteFilterList()
+	 */
+	if _, err := os.Stat(cluster.Conf.WorkingDir + "/" + cluster.Name + "/whitelist.conf"); errors.Is(err, os.ErrNotExist) {
+		//This will change the default to grafana
+		if _, ok := cluster.Conf.ImmuableFlagMap["graphite-embedded"]; ok {
+			cluster.Conf.GraphiteWhitelistTemplate = config.ConstGraphiteTemplateGrafana
+		}
+	}
+
 	cluster.ReloadGraphiteFilterList()
 }
 

--- a/cluster/cluster_graphite.go
+++ b/cluster/cluster_graphite.go
@@ -43,6 +43,7 @@ func (cluster *Cluster) NewClusterGraphite() {
 	if _, err := os.Stat(cluster.Conf.WorkingDir + "/" + cluster.Name + "/whitelist.conf"); errors.Is(err, os.ErrNotExist) {
 		//This will change the default to grafana
 		if _, ok := cluster.Conf.ImmuableFlagMap["graphite-embedded"]; ok {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGraphite, config.LvlWarn, "[Whitelist] failed to read file in cluster %s working dir, change template as grafana due to immutable graphite-embedded exists", cluster.Name)
 			cluster.Conf.GraphiteWhitelistTemplate = config.ConstGraphiteTemplateGrafana
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -565,7 +565,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 		flags.StringVar(&conf.GraphiteCarbonHost, "graphite-carbon-host", "127.0.0.1", "Graphite monitoring host")
 		flags.BoolVar(&conf.GraphiteMetrics, "graphite-metrics", false, "Enable Graphite monitoring")
 		flags.BoolVar(&conf.GraphiteEmbedded, "graphite-embedded", false, "Enable Internal Graphite Carbon Server")
-		flags.BoolVar(&conf.GraphiteWhitelist, "graphite-whitelist", false, "Enable Whitelist")
+		flags.BoolVar(&conf.GraphiteWhitelist, "graphite-whitelist", true, "Enable Whitelist")
 		flags.BoolVar(&conf.GraphiteBlacklist, "graphite-blacklist", false, "Enable Blacklist")
 		flags.StringVar(&conf.GraphiteWhitelistTemplate, "graphite-whitelist-template", "minimal", "Graphite default template for whitelist (none | minimal | grafana | all)")
 	}


### PR DESCRIPTION
This will prevent missing existing grafana metrics from graphite-embedded when initialize with graphite-whitelist as true