### PR TITLE
categorize logs into two

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -111,6 +111,7 @@ type Cluster struct {
 	WorkLoad                      WorkLoad              `json:"workLoad"`
 	LogPushover                   *log.Logger           `json:"-"`
 	Log                           s18log.HttpLog        `json:"log"`
+	LogTask                       s18log.HttpLog        `json:"logTask"`
 	LogSlack                      *log.Logger           `json:"-"`
 	JobResults                    map[string]*JobResult `json:"jobResults"`
 	Grants                        map[string]string     `json:"-"`
@@ -363,6 +364,7 @@ func (cluster *Cluster) InitFromConf() {
 	}
 	cluster.benchmarkType = "sysbench"
 	cluster.Log = s18log.NewHttpLog(200)
+	cluster.LogTask = s18log.NewHttpLog(200)
 
 	cluster.MonitorType = cluster.Conf.GetMonitorType()
 	cluster.TopologyType = cluster.Conf.GetTopologyType()

--- a/cluster/cluster_log.go
+++ b/cluster/cluster_log.go
@@ -161,6 +161,7 @@ func (cluster *Cluster) LogPrintf(level string, format string, args ...interface
 				Text:      fmt.Sprintf(cliformat, args...),
 			}
 			line = cluster.htlog.Add(msg)
+
 			cluster.Log.Add(msg)
 		}
 	}
@@ -332,7 +333,12 @@ func (cluster *Cluster) LogModulePrintf(forcingLog bool, module int, level strin
 				Text:      fmt.Sprintf(cliformat, args...),
 			}
 			line = cluster.htlog.Add(msg)
-			cluster.Log.Add(msg)
+			switch module {
+			case config.ConstLogModTask, config.ConstLogModSST, config.ConstLogModBackupStream:
+				cluster.LogTask.Add(msg)
+			default:
+				cluster.Log.Add(msg)
+			}
 		}
 
 		if cluster.Conf.Daemon {

--- a/share/dashboard/app/dashboard.js
+++ b/share/dashboard/app/dashboard.js
@@ -63,6 +63,17 @@ app.controller('DashboardController', function (
   $scope.promise = undefined;
 
   $scope.showTable = false
+  $scope.showLog = true
+  $scope.showLogTask = false
+
+  $scope.toggleLog = function(panel){
+    if(panel == "log") {
+      $scope.showLog = !$scope.showLog
+    }
+    if(panel == "task") {
+      $scope.showLogTask = !$scope.showLogTask
+    }
+  }
 
   $scope.user = undefined;
 

--- a/share/dashboard/static/card-cluster-log.html
+++ b/share/dashboard/static/card-cluster-log.html
@@ -1,24 +1,60 @@
 <md-card>
-    <table ng-if="servers" class="table">
+    <table ng-if="servers" class="table" style="margin-bottom: 0px;">
         <tr>
-            <th>Cluster Logs</th>
+            <th>
+                Cluster Logs 
+                <span class="pull-right">
+                    <button ng-click="toggleLog('log')">
+                        <span ng-show="showLog">Hide</span>
+                        <span ng-show="!showLog">Show</span>
+                    </button>
+                </span>
+            </th>
         </tr>
     </table>
-<md-card-content ng-if="selectedCluster" style="height: 600px; overflow-y: auto">
-
-<table style="table-layout: fixed;width: 100%;" class="log">
-<tr ng-repeat="logline in selectedCluster.log.buffer" ng-if="logline.timestamp">
-<td width="150px" class="stamp">{{ logline.timestamp }}</td>
-<td width="70px" ng-switch="logline.level">
-<span ng-switch-when="INFO" class="label label-info">{{ logline.level }}</span>
-<span ng-switch-when="WARN" class="label label-warning">{{ logline.level }}</span>
-<span ng-switch-when="ERROR" class="label label-danger">{{ logline.level }}</span>
-<span ng-switch-when="DEBUG" class="label label-primary">{{ logline.level }}</span>
-<span ng-switch-default class="label label-default">{{ logline.level }}</span>
-<td class="text" style="word-wrap:break-word;white-space: normal;">{{ logline.text }}</td>
-</tr>
-</table>
-    </md-pre>
-</md-card-content>
-
+    <md-card-content ng-if="selectedCluster && showLog" style="min-height: 0px; max-height: 400px; overflow-y: auto">
+        <table style="table-layout: fixed;width: 100%;" class="log">
+            <tr ng-repeat="logline in selectedCluster.log.buffer" ng-if="logline.timestamp">
+                <td width="150px" class="stamp">{{ logline.timestamp }}</td>
+                <td width="70px" ng-switch="logline.level">
+                    <span ng-switch-when="INFO" class="label label-info">{{ logline.level }}</span>
+                    <span ng-switch-when="WARN" class="label label-warning">{{ logline.level }}</span>
+                    <span ng-switch-when="ERROR" class="label label-danger">{{ logline.level }}</span>
+                    <span ng-switch-when="DEBUG" class="label label-primary">{{ logline.level }}</span>
+                    <span ng-switch-default class="label label-default">{{ logline.level }}</span>
+                <td class="text" style="word-wrap:break-word;white-space: normal;">{{ logline.text }}</td>
+            </tr>
+        </table>
+        </md-pre>
+    </md-card-content>
+</md-card>
+<md-card>
+    <table ng-if="servers" class="table" style="margin-bottom: 0px;">
+        <tr>
+            <th>
+                Job Logs 
+                <span class="pull-right">
+                    <button ng-click="toggleLog('task')">
+                        <span ng-show="showLogTask">Hide</span>
+                        <span ng-show="!showLogTask">Show</span>
+                    </button>
+                </span>
+            </th>
+        </tr>
+    </table>
+    <md-card-content ng-if="selectedCluster && showLogTask" style="min-height: 0px; max-height: 300px; overflow-y: auto">
+        <table style="table-layout: fixed;width: 100%;" class="log">
+            <tr ng-repeat="logline in selectedCluster.logTask.buffer" ng-if="logline.timestamp">
+                <td width="150px" class="stamp">{{ logline.timestamp }}</td>
+                <td width="70px" ng-switch="logline.level">
+                    <span ng-switch-when="INFO" class="label label-info">{{ logline.level }}</span>
+                    <span ng-switch-when="WARN" class="label label-warning">{{ logline.level }}</span>
+                    <span ng-switch-when="ERROR" class="label label-danger">{{ logline.level }}</span>
+                    <span ng-switch-when="DEBUG" class="label label-primary">{{ logline.level }}</span>
+                    <span ng-switch-default class="label label-default">{{ logline.level }}</span>
+                <td class="text" style="word-wrap:break-word;white-space: normal;">{{ logline.text }}</td>
+            </tr>
+        </table>
+        </md-pre>
+    </md-card-content>
 </md-card>


### PR DESCRIPTION
For better readability, split logs into two containers. This might fix #685
