### PR TITLE
refactoring binlog functions

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -664,7 +664,7 @@ func (cluster *Cluster) Run() {
 							cluster.StateMachine.PreserveState("WARN0094")
 						}
 						if cluster.SlavesOldestMasterFile.Suffix == 0 {
-							cluster.CheckSlavesReplicationsPurge()
+							go cluster.CheckSlavesReplicationsPurge()
 						}
 						cluster.PrintDelayStat()
 					}
@@ -834,9 +834,8 @@ func (cluster *Cluster) Save() error {
 		return nil
 	}
 	_, file, no, ok := runtime.Caller(1)
-	// if ok && cluster.GetLogLevel() > 3 {
 	if ok {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModConfigLoad, config.LvlInfo, "Saved called from %s#%d\n", file, no)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModConfigLoad, config.LvlDbg, "Saved called from %s#%d\n", file, no)
 	}
 	type Save struct {
 		Servers    string      `json:"servers"`

--- a/cluster/cluster_bash.go
+++ b/cluster/cluster_bash.go
@@ -101,7 +101,7 @@ func (cluster *Cluster) BinlogRotationScript(srv *ServerMonitor) error {
 	if cluster.Conf.BinlogRotationScript != "" {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Calling binlog rotation script")
 		var out []byte
-		out, err := exec.Command(cluster.Conf.BinlogRotationScript, cluster.Name, srv.Host, srv.Port, srv.BinaryLogFile, srv.BinaryLogFilePrevious, srv.BinaryLogOldestFile).CombinedOutput()
+		out, err := exec.Command(cluster.Conf.BinlogRotationScript, cluster.Name, srv.Host, srv.Port, srv.BinaryLogFile, srv.BinaryLogFilePrevious, srv.BinaryLogFileOldest).CombinedOutput()
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "%s", err)
 		}

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"hash/crc64"
 	"os"
+	"os/exec"
 	"regexp"
 	"sort"
 	"strconv"
@@ -78,6 +79,11 @@ func (cluster *Cluster) GetMyLoaderPath() string {
 
 func (cluster *Cluster) GetMysqlBinlogPath() string {
 	if cluster.Conf.BackupMysqlbinlogPath == "" {
+		// Return installed mysqlbinlog on repman host instead of embedded if exists
+		if out, err := exec.Command("which", "mysqlbinlog").Output(); err == nil {
+			path := strings.Trim(string(out), "\r\n")
+			return path
+		}
 		return cluster.GetShareDir() + "/" + cluster.Conf.GoArch + "/" + cluster.Conf.GoOS + "/mysqlbinlog"
 	}
 	return cluster.Conf.BackupMysqlbinlogPath

--- a/cluster/srv_binlog.go
+++ b/cluster/srv_binlog.go
@@ -27,14 +27,15 @@ import (
 	"github.com/signal18/replication-manager/utils/state"
 )
 
-func (server *ServerMonitor) RefreshBinaryLogs() {
+func (server *ServerMonitor) RefreshBinaryLogs() error {
 	var logs string
 	var err error
 	cluster := server.ClusterGroup
 
 	//Don't check binlog of the ignored servers
 	if server.IsIgnored() {
-		return
+		err = errors.New("Server is ignored")
+		return err
 	}
 
 	server.BinaryLogFiles, logs, err = dbhelper.GetBinaryLogs(server.Conn, server.DBVersion)
@@ -43,7 +44,83 @@ func (server *ServerMonitor) RefreshBinaryLogs() {
 	}
 
 	if len(server.BinaryLogFiles) > 0 {
-		server.SetBinaryLogOldestFile()
+		server.SetBinaryLogFileOldest()
+	}
+
+	return err
+}
+
+func (server *ServerMonitor) CheckBinaryLogs() error {
+	cluster := server.ClusterGroup
+	var err error
+
+	//Don't check binlog of the ignored servers
+	if server.IsIgnored() {
+		err = errors.New("Server is ignored")
+		return err
+	}
+
+	if len(server.BinaryLogFiles) == 0 {
+		server.RefreshBinaryLogs()
+	}
+
+	if server.BinaryLogFilePrevious != "" && server.BinaryLogFilePrevious != server.BinaryLogFile {
+		// Always running, triggered by binlog rotation
+		if cluster.Conf.BinlogRotationScript != "" && server.IsMaster() {
+			cluster.BinlogRotationScript(server)
+		}
+
+		if cluster.Conf.BackupBinlogs {
+			//Set second parameter to false, not part of backupbinlogpurge
+			server.InitiateJobBackupBinlog(server.BinaryLogFilePrevious, false)
+			//Initiate purging backup binlog
+			go server.JobBackupBinlogPurge(server.BinaryLogFilePrevious)
+		}
+
+		server.RefreshBinaryLogs()
+	}
+
+	server.BinaryLogFilePrevious = server.BinaryLogFile
+
+	if cluster.Conf.ForceBinlogPurge && !server.DBVersion.IsPostgreSQL() {
+		if cluster.IsInFailover() {
+			err = errors.New("Cancel job purge slave binlog during failover")
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, err.Error())
+			return err
+		}
+
+		if server.IsBackingUpBinaryLog {
+			err = errors.New("Server is backing up binlogs")
+			return err
+		}
+		go server.ForcePurgeBinlogs()
+	}
+
+	return err
+}
+
+func (server *ServerMonitor) ForcePurgeBinlogs() {
+	cluster := server.ClusterGroup
+	isMaster := server.IsMaster()
+
+	if server.IsPurgingBinlog() {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Server is is waiting for previous binlog purge to finish")
+		return
+	}
+
+	if server.IsMariaDB() && server.DBVersion.GreaterEqual("11.4") { //Only MariaDB v.11.4 and up
+		err := server.SetMaxBinlogTotalSize()
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlWarn, err.Error())
+		}
+	} else if len(server.BinaryLogFiles) > 2 {
+		if isMaster {
+			go server.JobBinlogPurgeMaster()
+		}
+
+		if !isMaster && cluster.Conf.ForceBinlogPurgeReplicas && server.HaveBinlogSlaveUpdates && cluster.StateMachine.CurState.Search("WARN0107") == false && !server.IsIgnored() {
+			go server.JobBinlogPurgeSlave()
+		}
 	}
 }
 
@@ -105,7 +182,7 @@ func (server *ServerMonitor) SetBinlogOldestTimestamp(str string) error {
 		yy = yy - 100
 	}
 
-	server.OldestBinaryLogTimestamp = time.Date(yy, time.Month(mm), dd, hr, min, sec, 0, time.Local).Unix()
+	server.BinaryLogOldestTimestamp = time.Date(yy, time.Month(mm), dd, hr, min, sec, 0, time.Local).Unix()
 	return nil
 }
 
@@ -113,7 +190,9 @@ func (server *ServerMonitor) RefreshBinlogOldestTimestamp() error {
 	cluster := server.ClusterGroup
 	var err error
 
-	if server.BinaryLogOldestFile != "" {
+	defer server.SetInRefreshBinlog(false)
+
+	if server.BinaryLogFileOldest != "" {
 		if cluster.Conf.BinlogParseMode == "gomysql" {
 			port, _ := strconv.Atoi(server.Port)
 
@@ -128,7 +207,7 @@ func (server *ServerMonitor) RefreshBinlogOldestTimestamp() error {
 
 			syncer := replication.NewBinlogSyncer(cfg)
 
-			streamer, err := syncer.StartSync(mysql.Position{Name: server.BinaryLogOldestFile, Pos: 0})
+			streamer, err := syncer.StartSync(mysql.Position{Name: server.BinaryLogFileOldest, Pos: 0})
 			if err != nil {
 				return err
 			}
@@ -144,8 +223,8 @@ func (server *ServerMonitor) RefreshBinlogOldestTimestamp() error {
 				}
 
 				if ev.Header.EventType == replication.FORMAT_DESCRIPTION_EVENT {
-					server.OldestBinaryLogTimestamp = int64(ev.Header.Timestamp)
-					ts := time.Unix(server.OldestBinaryLogTimestamp, 0)
+					server.BinaryLogOldestTimestamp = int64(ev.Header.Timestamp)
+					ts := time.Unix(server.BinaryLogOldestTimestamp, 0)
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlInfo, "Refreshed oldest timestamp on %s. oldest: %s", server.Host+":"+server.Port, ts.String())
 					//Only update once for oldest binlog timestamp
 					break
@@ -156,9 +235,9 @@ func (server *ServerMonitor) RefreshBinlogOldestTimestamp() error {
 		} else {
 			binsrvid := strconv.Itoa(cluster.Conf.CheckBinServerId)
 
-			events, _, err := dbhelper.GetBinlogFormatDesc(server.Conn, server.BinaryLogOldestFile)
+			events, _, err := dbhelper.GetBinlogFormatDesc(server.Conn, server.BinaryLogFileOldest)
 			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Error while getting binlog events from oldest master binlog: %s. Err: %s", server.BinaryLogOldestFile, err.Error())
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Error while getting binlog events from oldest master binlog: %s. Err: %s", server.BinaryLogFileOldest, err.Error())
 				return err
 			}
 
@@ -170,17 +249,17 @@ func (server *ServerMonitor) RefreshBinlogOldestTimestamp() error {
 
 				result, err := mysqlbinlogcmd.Output()
 				if err != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Error while extracting timestamp from oldest master binlog: %s. Err: %s", server.BinaryLogOldestFile, err.Error())
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Error while extracting timestamp from oldest master binlog: %s. Err: %s", server.BinaryLogFileOldest, err.Error())
 					return err
 				}
 
 				err = server.SetBinlogOldestTimestamp(string(result))
 				if err != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "%s. Host: %s - %s", err.Error(), server.Host+":"+server.Port, server.BinaryLogOldestFile)
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "%s. Host: %s - %s", err.Error(), server.Host+":"+server.Port, server.BinaryLogFileOldest)
 					return err
 				}
 
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlInfo, "Refreshed binary logs on %s - %s. oldest timestamp: %s", server.Host+":"+server.Port, ev.Log_name, time.Unix(server.OldestBinaryLogTimestamp, 0).String())
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlInfo, "Refreshed binary logs on %s - %s. oldest timestamp: %s", server.Host+":"+server.Port, ev.Log_name, time.Unix(server.BinaryLogOldestTimestamp, 0).String())
 
 				return err
 			}
@@ -214,18 +293,27 @@ func (server *ServerMonitor) SetMaxBinlogTotalSize() error {
 	return nil
 }
 
-func (server *ServerMonitor) SetBinaryLogOldestFile() {
+func (server *ServerMonitor) SetBinaryLogFileOldest() {
 	cluster := server.ClusterGroup
 	files := len(server.BinaryLogFiles)
+
+	if server.IsRefreshingBinlog {
+		return
+	}
+
+	server.SetInRefreshBinlog(true)
+
 	if files > 0 {
 		//If no other binlog is exist
-		if files == 1 && server.BinaryLogOldestFile != server.BinaryLogFile {
-			if server.BinaryLogOldestFile != server.BinaryLogFile {
-				server.BinaryLogOldestFile = server.BinaryLogFile
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Refreshed binary logs on %s. oldest: %s", server.Host+":"+server.Port, server.BinaryLogOldestFile)
+		if files == 1 && server.BinaryLogFileOldest != server.BinaryLogFile {
+			if server.BinaryLogFileOldest != server.BinaryLogFile {
+				server.BinaryLogFileOldest = server.BinaryLogFile
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Refreshed binary logs on %s. oldest: %s", server.Host+":"+server.Port, server.BinaryLogFileOldest)
 				//Only get timestamp when needed
 				if cluster.Conf.ForceBinlogPurge {
-					server.RefreshBinlogOldestTimestamp()
+					go server.RefreshBinlogOldestTimestamp()
+				} else {
+					server.SetInRefreshBinlog(false)
 				}
 			}
 			return
@@ -239,13 +327,15 @@ func (server *ServerMonitor) SetBinaryLogOldestFile() {
 		oldestbinlog := latestbinlog - len(server.BinaryLogFiles) + 1
 		oldest := prefix + "." + fmt.Sprintf("%06d", oldestbinlog)
 
-		if _, ok := server.BinaryLogFiles[oldest]; ok && server.BinaryLogOldestFile != server.BinaryLogFile {
-			if server.BinaryLogOldestFile != oldest {
-				server.BinaryLogOldestFile = oldest
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Refreshed binary logs on %s. oldest: %s", server.Host+":"+server.Port, server.BinaryLogOldestFile)
+		if _, ok := server.BinaryLogFiles[oldest]; ok && server.BinaryLogFileOldest != server.BinaryLogFile {
+			if server.BinaryLogFileOldest != oldest {
+				server.BinaryLogFileOldest = oldest
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Refreshed binary logs on %s. oldest: %s", server.Host+":"+server.Port, server.BinaryLogFileOldest)
 				//Only get timestamp when needed
 				if cluster.Conf.ForceBinlogPurge {
-					server.RefreshBinlogOldestTimestamp()
+					go server.RefreshBinlogOldestTimestamp()
+				} else {
+					server.SetInRefreshBinlog(false)
 				}
 			}
 			return
@@ -297,10 +387,39 @@ func (server *ServerMonitor) JobBinlogPurgeMaster() {
 	last := len(parts) - 1
 	prefix := strings.Join(parts[:last], ".")
 
-	latestbinlog, _ := strconv.Atoi(parts[last])
-	oldestbinlog := latestbinlog + 1 - len(server.BinaryLogFiles)
+	suffix, _ := strconv.Atoi(parts[last])
+	oldestbinlog := suffix + 1 - len(server.BinaryLogFiles)
 
-	// If force purge binlog total size is set (default 30)
+	if cluster.SlavesOldestMasterFile.Prefix != prefix {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Purge cancelled, master binlog file has different prefix")
+		return
+	}
+
+	if suffix < cluster.SlavesOldestMasterFile.Suffix {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Purge cancelled because of inconsistency, slaves master filename is bigger than master binlog")
+		return
+	}
+
+	//Purge binlog on restore
+	if cluster.Conf.ForceBinlogPurgeOnRestore {
+
+		//Only purge if oldest master binlog has more than 2 files
+		prevbinlog := cluster.SlavesOldestMasterFile.Suffix - 1
+
+		if oldestbinlog > 0 && oldestbinlog < prevbinlog {
+			//Purge binlog to will retain the file
+			filename := cluster.SlavesOldestMasterFile.Prefix + "." + fmt.Sprintf("%06d", prevbinlog)
+			server.PurgeBinlogTo(filename)
+			server.RefreshBinaryLogs()
+
+		}
+		//Not needed to continue, since this only retain last two binlogs
+		return
+	}
+
+	/**
+	* This will run when force purge binlog total size is set (default 30)
+	 **/
 	if cluster.Conf.ForceBinlogPurgeTotalSize > 0 {
 		// cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "server:%s start:%s stop:%s list: %s", server.URL, fmt.Sprintf("%06d", latestbinlog), fmt.Sprintf("%06d", oldestbinlog))
 		var totalSize uint
@@ -308,15 +427,15 @@ func (server *ServerMonitor) JobBinlogPurgeMaster() {
 		lastfile := 0
 
 		//Accumulating newest binlog size and shifting to oldest
-		for latestbinlog > 0 && totalSize < uint(cluster.Conf.ForceBinlogPurgeTotalSize*(1024*1024*1024)) {
-			filename := prefix + "." + fmt.Sprintf("%06d", latestbinlog)
+		for suffix > 0 && totalSize < uint(cluster.Conf.ForceBinlogPurgeTotalSize*(1024*1024*1024)) {
+			filename := prefix + "." + fmt.Sprintf("%06d", suffix)
 			if size, ok := server.BinaryLogFiles[filename]; ok {
 				//accumulating size
 				totalSize += size
-				lastfile = latestbinlog //last file based on total size
+				lastfile = suffix //last file based on total size
 			}
 			//Descending
-			latestbinlog--
+			suffix--
 		}
 
 		// Purging binlog if more than total size
@@ -352,108 +471,29 @@ func (server *ServerMonitor) JobBinlogPurgeMaster() {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Cancel job purge due to no total size")
 	}
 
-	return
 }
 
-func (server *ServerMonitor) JobBinlogPurgeMasterOnRestore() {
-	cluster := server.GetCluster()
-
-	if server.DBVersion.IsPostgreSQL() {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Force Binlog Purge On Restore not available in PostgreSQL")
-		return
-	}
-
-	//Refresh slaves replication positions
-	cluster.CheckSlavesReplicationsPurge()
-
-	if cluster.SlavesConnected <= cluster.Conf.ForceBinlogPurgeMinReplica {
-		if cluster.StateMachine.CurState.Search("WARN0106") == false {
-			cluster.StateMachine.AddState("WARN0106", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0106"], cluster.Conf.ForceBinlogPurgeMinReplica), ErrFrom: "PURGE", ServerUrl: server.URL})
-		}
-		return
-	}
-
-	if len(server.BinaryLogFiles) == 0 {
-		server.RefreshBinaryLogs()
-	}
-
-	//Block multiple purge
-	if server.IsPurgingBinlog() {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Master is waiting for previous binlog purge to finish")
-		return
-	}
-
-	server.SetIsPurgingBinlog(true)
-	defer server.SetIsPurgingBinlog(false)
-
-	if cluster.IsInFailover() {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Cancel job purge binlog during failover")
-		return
-	}
-	if !cluster.Conf.ForceBinlogPurge {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Purge binlog not enabled")
-		return
-	}
-
-	if !server.IsMaster() {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Purge only master binlog")
-		return
-	}
-
-	if !cluster.Conf.ForceBinlogPurgeOnRestore {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Purge binlog on restore is not enabled")
-		return
-	}
-
-	parts := strings.Split(server.BinaryLogFile, ".")
-	last := len(parts) - 1
-	prefix := strings.Join(parts[:last], ".")
-	suffix, _ := strconv.Atoi(parts[last])
-	oldestbinlog := suffix + 1 - len(server.BinaryLogFiles)
-
-	if cluster.SlavesOldestMasterFile.Prefix != prefix {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Purge cancelled, master binlog file has different prefix")
-		return
-	}
-
-	if suffix < cluster.SlavesOldestMasterFile.Suffix {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Purge cancelled because of inconsistency, slaves master filename is bigger than master binlog")
-		return
-	}
-
-	//Only purge if oldest master binlog has more than 2 files
-	if oldestbinlog > 0 && oldestbinlog < cluster.SlavesOldestMasterFile.Suffix-1 {
-
-		//Retain previous binlog
-		filename := cluster.SlavesOldestMasterFile.Prefix + "." + fmt.Sprintf("%06d", cluster.SlavesOldestMasterFile.Suffix-1)
-
-		//Check if file exists
-		if _, ok := server.BinaryLogFiles[filename]; ok {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlInfo, "Purging binlog of %s: %s. ", server.URL, filename)
-			_, err := dbhelper.PurgeBinlogTo(server.Conn, filename)
-			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Error purging binlog of %s,%s : %s", server.URL, filename, err.Error())
-			}
+func (server *ServerMonitor) PurgeBinlogTo(filename string) {
+	cluster := server.ClusterGroup
+	//Check if file exists
+	if _, ok := server.BinaryLogFiles[filename]; ok {
+		_, err := dbhelper.PurgeBinlogTo(server.Conn, filename)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlWarn, "Error purging binlog of %s,%s : %s", server.URL, filename, err.Error())
 		} else {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Binlog filename not found on %s: %s", server.URL, filename)
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlInfo, "[%s] Executed PURGE BINLOG TO %s", server.URL, filename)
 		}
-
-		server.RefreshBinaryLogs()
+	} else {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Binlog filename not found on %s: %s", server.URL, filename)
 	}
-
-	return
 }
 
 func (server *ServerMonitor) JobBinlogPurgeSlave() {
 	cluster := server.GetCluster()
 	master := cluster.GetMaster()
 
-	if master != nil {
-		//Block multiple purge
-		if len(server.BinaryLogFiles) == 0 {
-			server.RefreshBinaryLogs()
-		}
-
+	//Only purge when master is valid
+	if master != nil && master.Host == server.GetReplicationMasterHost() {
 		if server.IsPurgingBinlog() {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Server is waiting for previous binlog purge to finish")
 			return
@@ -462,108 +502,23 @@ func (server *ServerMonitor) JobBinlogPurgeSlave() {
 		server.SetIsPurgingBinlog(true)
 		defer server.SetIsPurgingBinlog(false)
 
-		if cluster.IsInFailover() {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Cancel job purge slave binlog during failover")
-			return
-		}
-		if !cluster.Conf.ForceBinlogPurge {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Purge binlog not enabled")
-			return
-		}
-
-		//Only purge if slave not ignored
-		if server.IsIgnored() {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Slave %s is in ignored list. Skipping", server.Host+":"+server.Port)
-			return
-		}
-
 		//Only purge if slave connected and status is slave or slave late
 		if server.State != stateSlave && server.State != stateSlaveLate {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Can not purge. Only connected slave is allowed to purge binlog")
 			return
 		}
 
-		//Purge slaves to oldest master binlog timestamp and skip if slave only has 1 binary logs file left
-		if server.OldestBinaryLogTimestamp > 0 && master.OldestBinaryLogTimestamp > server.OldestBinaryLogTimestamp && len(server.BinaryLogFiles) > 1 {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlInfo, "Purging slave binlog of %s from %s until oldest timestamp on master: %s", server.URL, time.Unix(server.OldestBinaryLogTimestamp, 0).String(), time.Unix(master.OldestBinaryLogTimestamp, 0).String())
-			q, err := dbhelper.PurgeBinlogBefore(server.Conn, master.OldestBinaryLogTimestamp)
+		//Purge slaves to oldest master binlog timestamp and skip if slave only has 2 binary logs file left (Current Binlog and Prev Binlog)
+		if server.BinaryLogOldestTimestamp > 0 && master.BinaryLogOldestTimestamp > server.BinaryLogPurgeBefore && len(server.BinaryLogFiles) > 2 {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlInfo, "Purging slave binlog of %s from %s until oldest timestamp on master: %s", server.URL, time.Unix(server.BinaryLogOldestTimestamp, 0).String(), time.Unix(master.BinaryLogOldestTimestamp, 0).String())
+			q, err := dbhelper.PurgeBinlogBefore(server.Conn, master.BinaryLogOldestTimestamp)
 			if err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Error purging binlog of %s : %s", server.URL, err.Error())
 			} else {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Executed query: %s", q)
 			}
-
+			server.BinaryLogPurgeBefore = master.BinaryLogOldestTimestamp
 			server.RefreshBinaryLogs()
-		}
-	}
-
-	return
-}
-
-// Check And Purge Binlogs check mariadb binlog
-func (server *ServerMonitor) CheckAndPurgeBinlogMaster() {
-	cluster := server.ClusterGroup
-	if cluster.IsInFailover() {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Cancel job purge binlog during failover")
-		return
-	}
-	if !cluster.Conf.ForceBinlogPurge {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Purge binlog not enabled")
-		return
-	}
-
-	if !server.DBVersion.IsPostgreSQL() { // Only work if ForceBinlogPurge is on and MySQL/Percona/MariaDB
-
-		if server.IsMariaDB() && server.DBVersion.GreaterEqual("11.4") { //Only MariaDB v.11 and up
-			err := server.SetMaxBinlogTotalSize()
-			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlInfo, err.Error())
-			}
-		} else {
-			// cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Purging check")
-			if !server.IsPurgingBinlog() && len(server.BinaryLogFiles) > 1 {
-				// cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "[PURGE] MariaDB Version is not compatible for max_binlog_total_size, using manual purging")
-				go server.JobBinlogPurgeMaster()
-			}
-		}
-	}
-}
-
-// Check And Purge Binlogs check mariadb binlog
-func (server *ServerMonitor) CheckAndPurgeBinlogMasterOnRestore() {
-	cluster := server.ClusterGroup
-	if cluster.Conf.ForceBinlogPurge && !server.DBVersion.IsPostgreSQL() { // Only work if ForceBinlogPurge is on and MySQL/Percona/MariaDB
-		if !server.IsPurgingBinlog() {
-			go server.JobBinlogPurgeMasterOnRestore()
-		}
-	}
-}
-
-// Check And Purge Binlogs check mariadb binlog
-func (server *ServerMonitor) CheckAndPurgeBinlogSlave() {
-	cluster := server.ClusterGroup
-	if cluster.IsInFailover() {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Cancel job purge binlog during failover")
-		return
-	}
-	if !cluster.Conf.ForceBinlogPurge {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "Purge binlog not enabled")
-		return
-	}
-
-	if !server.DBVersion.IsPostgreSQL() { // Only work if ForceBinlogPurge is on and MySQL/Percona/MariaDB
-		if server.IsMariaDB() && server.DBVersion.GreaterEqual("11.4") { //Only MariaDB v.11.4 and up
-			err := server.SetMaxBinlogTotalSize()
-			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlInfo, err.Error())
-			}
-		} else {
-			if !server.IsPurgingBinlog() && len(server.BinaryLogFiles) > 1 {
-				// cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "[PURGE] MariaDB Version is not compatible for max_binlog_total_size, using manual purging")
-				if cluster.StateMachine.CurState.Search("WARN0107") == false {
-					go server.JobBinlogPurgeSlave()
-				}
-			}
 		}
 	}
 }

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -1180,14 +1180,22 @@ func (server *ServerMonitor) JobRunViaSSH() error {
 
 func (server *ServerMonitor) JobBackupBinlog(binlogfile string, isPurge bool) error {
 	cluster := server.ClusterGroup
+	var err error
+
 	if !server.IsMaster() {
-		return errors.New("Copy only master binlog")
+		err = errors.New("Cancelling backup because server is not master")
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "%s", err.Error())
+		return err
 	}
 	if cluster.IsInFailover() {
-		return errors.New("Cancel job copy binlog during failover")
+		err = errors.New("Cancel job copy binlog during failover")
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "%s", err.Error())
+		return err
 	}
 	if !cluster.Conf.BackupBinlogs {
-		return errors.New("Copy binlog not enable")
+		err = errors.New("Copy binlog not enable")
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg, "%s", err.Error())
+		return err
 	}
 
 	//Skip setting in backup state due to batch purging
@@ -1207,7 +1215,7 @@ func (server *ServerMonitor) JobBackupBinlog(binlogfile string, isPurge bool) er
 	defer server.SetBackingUpBinaryLog(false)
 
 	cmdrun := exec.Command(cluster.GetMysqlBinlogPath(), "--read-from-remote-server", "--raw", "--server-id=10000", "--user="+cluster.GetRplUser(), "--password="+cluster.GetRplPass(), "--host="+misc.Unbracket(server.Host), "--port="+server.Port, "--result-file="+server.GetMyBackupDirectory(), binlogfile)
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "%s", strings.Replace(cmdrun.String(), cluster.GetRplPass(), "XXXX", 1))
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "%s", strings.ReplaceAll(cmdrun.String(), cluster.GetRplPass(), "XXXX"))
 
 	var outrun bytes.Buffer
 	cmdrun.Stdout = &outrun
@@ -1500,6 +1508,10 @@ func (server *ServerMonitor) InitiateJobBackupBinlog(binlogfile string, isPurge 
 		binlogpath := strings.Join(parts[:len(parts)-1], "/")
 
 		server.SetBinaryLogDir(binlogpath)
+	}
+
+	if !isPurge {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Initiating backup binlog for %s", binlogfile)
 	}
 
 	switch cluster.Conf.BinlogCopyMode {

--- a/cluster/srv_set.go
+++ b/cluster/srv_set.go
@@ -429,3 +429,7 @@ func (server *ServerMonitor) SetBinaryLogDir(value string) {
 func (server *ServerMonitor) SetInCaptureMode(value bool) {
 	server.InCaptureMode = value
 }
+
+func (server *ServerMonitor) SetInRefreshBinlog(value bool) {
+	server.IsRefreshingBinlog = value
+}

--- a/share/dashboard/static/card-cluster-server-list-tab.html
+++ b/share/dashboard/static/card-cluster-server-list-tab.html
@@ -94,6 +94,18 @@
             <td class="rowicon">Fail Cnt</td>
             <td>{{server.failCount}}/{{server.failSuspectHeartbeat}}</td>
           </tr>
+          <tr>
+            <td class="rowicon">Binary Log</td>
+            <td>{{server.binaryLogFile}}</td>
+          </tr>
+          <tr>
+            <td class="rowicon">Binary Log Oldest</td>
+            <td>{{server.binaryLogFileOldest}}</td>
+          </tr>
+          <tr>
+            <td class="rowicon">Binary Log Oldest Timestamp </td>
+            <td><span ng-if="server.binaryLogOldestTimestamp > 0">{{ (server.binaryLogOldestTimestamp * 1000) | date:'yyyy-MM-dd HH:mm:ss' }}</span></td>
+          </tr>
         </table>
         <div ng-repeat="replication in server.replications">
           <table style="width: 100%;" class="table table-condensed fixed" border=0>


### PR DESCRIPTION
Fix binary log operations for purging and timestamp
Refactoring function for readability and efficiency
Fixing locking from binary log purging and checking
Fixing bug from using embedded mysqlbinlog as default, using installed mysqlbinlog instead
