### PR TITLE
Fix wrong backup type display and remove valid backup state when type is changed

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -645,6 +645,8 @@ func (cluster *Cluster) Run() {
 							cluster.StateMachine.PreserveState("WARN0084")
 							cluster.StateMachine.PreserveState("WARN0095")
 							cluster.StateMachine.PreserveState("WARN0101")
+							cluster.StateMachine.PreserveState("WARN0111")
+							cluster.StateMachine.PreserveState("WARN0112")
 							cluster.StateMachine.PreserveState("ERR00090")
 							cluster.StateMachine.PreserveState("WARN0102")
 						}
@@ -771,15 +773,35 @@ func (cluster *Cluster) StateProcessing() {
 				// 	go cluster.SSTRunSender(servertoreseed.GetMyBackupDirectory()+"mysqldump.sql.gz", servertoreseed, task)
 				// }
 			}
-			if s.ErrKey == "WARN0101" {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Cluster have backup")
+			/*
+				// Unused, will be split to logical and physical backup. For rejoin will still use the same ReseedMasterSST
+					if s.ErrKey == "WARN0101" {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Cluster have backup")
+						for _, srv := range cluster.Servers {
+							if srv.HasWaitBackupCookie() {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Server %s was waiting for backup", srv.URL)
+								go srv.ReseedMasterSST()
+							}
+						}
+					}
+			*/
+			if s.ErrKey == "WARN0111" {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Cluster have logical backup")
 				for _, srv := range cluster.Servers {
-					if srv.HasWaitBackupCookie() {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Server %s was waiting for backup", srv.URL)
-						go srv.ReseedMasterSST()
+					if srv.HasWaitLogicalBackupCookie() {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Server %s was waiting for logical backup", srv.URL)
+						go srv.JobReseedLogicalBackup()
 					}
 				}
-
+			}
+			if s.ErrKey == "WARN0112" {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Cluster have physical backup")
+				for _, srv := range cluster.Servers {
+					if srv.HasWaitLogicalBackupCookie() {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Server %s was waiting for physical backup", srv.URL)
+						go srv.JobReseedPhysicalBackup()
+					}
+				}
 			}
 
 			//		cluster.statecloseChan <- s

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -99,6 +99,11 @@ func (cluster *Cluster) GetMysqlBinlogPath() string {
 
 func (cluster *Cluster) GetMysqlclientPath() string {
 	if cluster.Conf.BackupMysqlclientPath == "" {
+		// Return installed mysql client on repman host instead of embedded if exists
+		if out, err := exec.Command("which", "mysql").Output(); err == nil {
+			path := strings.Trim(string(out), "\r\n")
+			return path
+		}
 		return cluster.GetShareDir() + "/" + cluster.Conf.GoArch + "/" + cluster.Conf.GoOS + "/mysql"
 	}
 	return cluster.Conf.BackupMysqlclientPath

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -803,11 +803,17 @@ func (cluster *Cluster) SetBackupKeepWeekly(keep string) error {
 }
 
 func (cluster *Cluster) SetBackupLogicalType(backup string) {
-	cluster.Conf.BackupLogicalType = backup
+	if cluster.Conf.BackupLogicalType != backup {
+		cluster.Conf.BackupLogicalType = backup
+		cluster.GetBackupServer().DelBackupLogicalCookie()
+	}
 }
 
 func (cluster *Cluster) SetBackupPhysicalType(backup string) {
-	cluster.Conf.BackupPhysicalType = backup
+	if cluster.Conf.BackupPhysicalType != backup {
+		cluster.Conf.BackupPhysicalType = backup
+		cluster.GetBackupServer().DelBackupPhysicalCookie()
+	}
 }
 
 func (cluster *Cluster) SetBackupBinlogType(backup string) {

--- a/cluster/cluster_sst.go
+++ b/cluster/cluster_sst.go
@@ -464,7 +464,7 @@ func (cluster *Cluster) SSTRunSender(backupfile string, sv *ServerMonitor, task 
 	defer sv.RunTaskCallback(task)
 
 	for {
-		if strings.Contains(backupfile, "gz") {
+		if strings.HasSuffix(backupfile, "gz") && !strings.Contains(task, "mysqldump") {
 			fz, err := gzip.NewReader(file)
 			if err != nil {
 				return

--- a/cluster/cluster_sst.go
+++ b/cluster/cluster_sst.go
@@ -464,7 +464,7 @@ func (cluster *Cluster) SSTRunSender(backupfile string, sv *ServerMonitor, task 
 	defer sv.RunTaskCallback(task)
 
 	for {
-		if strings.HasSuffix(backupfile, "gz") && !strings.Contains(task, "mysqldump") {
+		if strings.HasSuffix(backupfile, "gz") {
 			fz, err := gzip.NewReader(file)
 			if err != nil {
 				return

--- a/cluster/error.go
+++ b/cluster/error.go
@@ -169,4 +169,6 @@ var clusterError = map[string]string{
 	"WARN0108": "Default users still use default password. Please change the credentials for users: (%s)",
 	"WARN0109": "Error while checking master log file for purging in slave [%s] (%s) : %s\n",
 	"WARN0110": "Pending %s backup using %s for [%s] due to another job. Waiting...",
+	"WARN0111": "Cluster does not have logical backup",
+	"WARN0112": "Cluster does not have physical backup",
 }

--- a/cluster/srv_del.go
+++ b/cluster/srv_del.go
@@ -53,6 +53,14 @@ func (server *ServerMonitor) DelWaitBackupCookie() error {
 	return server.delCookie("cookie_waitbackup")
 }
 
+func (server *ServerMonitor) DelWaitLogicalBackupCookie() error {
+	return server.delCookie("cookie_waitlogicalbackup")
+}
+
+func (server *ServerMonitor) DelWaitPhysicalBackupCookie() error {
+	return server.delCookie("cookie_waitphysicalbackup")
+}
+
 func (server *ServerMonitor) DelBackupLogicalCookie() error {
 	return server.delCookie("cookie_logicalbackup")
 }

--- a/cluster/srv_has.go
+++ b/cluster/srv_has.go
@@ -129,6 +129,14 @@ func (server *ServerMonitor) HasWaitBackupCookie() bool {
 	return server.hasCookie("cookie_waitbackup")
 }
 
+func (server *ServerMonitor) HasWaitLogicalBackupCookie() bool {
+	return server.hasCookie("cookie_waitlogicalbackup")
+}
+
+func (server *ServerMonitor) HasWaitPhysicalBackupCookie() bool {
+	return server.hasCookie("cookie_waitphysicalbackup")
+}
+
 func (server *ServerMonitor) HasWaitStopCookie() bool {
 	return server.hasCookie("cookie_waitstop")
 }

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -871,9 +871,10 @@ func (server *ServerMonitor) JobBackupMyDumper() error {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Blocking DDL via BACKUP STAGE")
 	}
 
+	outputdir := server.GetMyBackupDirectory() + "mydumper"
 	threads := strconv.Itoa(cluster.Conf.BackupLogicalDumpThreads)
 	myargs := strings.Split(strings.ReplaceAll(cluster.Conf.BackupMyDumperOptions, "  ", " "), " ")
-	myargs = append(myargs, "--outputdir="+server.GetMyBackupDirectory(), "--threads="+threads, "--host="+misc.Unbracket(server.Host), "--port="+server.Port, "--user="+cluster.GetDbUser(), "--password="+cluster.GetDbPass())
+	myargs = append(myargs, "--outputdir="+outputdir, "--threads="+threads, "--host="+misc.Unbracket(server.Host), "--port="+server.Port, "--user="+cluster.GetDbUser(), "--password="+cluster.GetDbPass())
 	dumpCmd := exec.Command(cluster.GetMyDumperPath(), myargs...)
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "%s", strings.Replace(dumpCmd.String(), cluster.GetDbPass(), "XXXX", 1))

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -478,7 +478,7 @@ func (server *ServerMonitor) JobReseedMyLoader() {
 	server.Refresh()
 	if server.IsSlave {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Parsing mydumper metadata ")
-		meta, err := server.JobMyLoaderParseMeta(cluster.master.GetMasterBackupDirectory())
+		meta, err := server.JobMyLoaderParseMeta(backupdir)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "MyLoader metadata parsing: %s", err)
 		}

--- a/cluster/srv_set.go
+++ b/cluster/srv_set.go
@@ -390,6 +390,14 @@ func (server *ServerMonitor) SetWaitBackupCookie() error {
 	return server.createCookie("cookie_waitbackup")
 }
 
+func (server *ServerMonitor) SetWaitLogicalBackupCookie() error {
+	return server.createCookie("cookie_waitlogicalbackup")
+}
+
+func (server *ServerMonitor) SetWaitPhysicalBackupCookie() error {
+	return server.createCookie("cookie_waitphysicalbackup")
+}
+
 func (server *ServerMonitor) SetBackupPhysicalCookie() error {
 	return server.createCookie("cookie_physicalbackup")
 }

--- a/share/dashboard/app/dashboard.js
+++ b/share/dashboard/app/dashboard.js
@@ -1111,8 +1111,8 @@ app.controller('DashboardController', function (
   $scope.flushlogs = function (server) {
     if (confirm("Confirm flush logs for server-id: " + server)) httpGetWithoutResponse(getClusterUrl() + '/servers/' + server + '/actions/flush-logs');
   };
-  $scope.dbreseedmysqldump = function (server) {
-    if (confirm("Confirm reseed with mysqldump for server-id: " + server)) httpGetWithoutResponse(getClusterUrl() + '/servers/' + server + '/actions/reseed/logicalbackup');
+  $scope.dbreseedlogical = function (server) {
+    if (confirm("Confirm reseed with logical backup (" + $scope.selectedCluster.config.backupLogicalType + ") for server-id: " + server)) httpGetWithoutResponse(getClusterUrl() + '/servers/' + server + '/actions/reseed/logicalbackup');
   };
   $scope.dbreseedmysqldumpmaster = function (server) {
     if (confirm("Confirm reseed with mysqldump for server-id: " + server)) httpGetWithoutResponse(getClusterUrl() + '/servers/' + server + '/actions/reseed/logicalmaster');
@@ -1121,7 +1121,7 @@ app.controller('DashboardController', function (
     if (confirm("Confirm sending physical backup (" + $scope.selectedCluster.config.backupPhysicalType + " " + ($scope.selectedCluster.config.compressBackups ? 'compressed' : '') + ") for server-id: " + server)) httpGetWithoutResponse(getClusterUrl() + '/servers/' + server + '/actions/backup-physical');
   };
   $scope.dbdump = function (server) {
-    if (confirm("Confirm sending mysqldump for server-id: " + server)) httpGetWithoutResponse(getClusterUrl() + '/servers/' + server + '/actions/backup-logical');
+    if (confirm("Confirm sending logical backup (" + $scope.selectedCluster.config.backupLogicalType + ") for server-id: " + server)) httpGetWithoutResponse(getClusterUrl() + '/servers/' + server + '/actions/backup-logical');
   };
   $scope.dbskipreplicationevent = function (server) {
     if (confirm("Confirm skip replication event for server-id: " + server)) httpGetWithoutResponse(getClusterUrl() + '/servers/' + server + '/actions/skip-replication-event');

--- a/share/dashboard/static/menu-server.html
+++ b/share/dashboard/static/menu-server.html
@@ -67,7 +67,7 @@
                   Logical Backup
                </md-button>
             </md-menu-item>
-            <md-menu-item ng-if="server.id!=master.id" ng-click="dbreseedmysqldump(server.id)">
+            <md-menu-item ng-if="server.id!=master.id" ng-click="dbreseedlogical(server.id)">
                <md-button ng-disabled="selectedCluster.apiUsers[user].grants['db-restore']==false">
                   <md-icon md-menu-align-target class="fas fa-upload"></md-icon>
                   Reseed Logical From Backup


### PR DESCRIPTION
This should fix wrong logical backup type in mydumper, also changing the method of reseed mysqldump to execute from replication-manager to make it behave like direct dump.
It also remove the valid backup state, if the backup type is changed to different type
