### PR TITLE
Fix flood for log writer election (previously log failed election)

### DIFF
--- a/cluster/cluster_fail.go
+++ b/cluster/cluster_fail.go
@@ -931,7 +931,7 @@ func (cluster *Cluster) electFailoverCandidate(l []*ServerMonitor, forcingLog bo
 	}
 	if forcingLog {
 		data, _ := json.MarshalIndent(trackposList, "", "\t")
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Election matrice: %s ", data)
+		cluster.LogModulePrintf(forcingLog, config.ConstLogModWriterElection, config.LvlInfo, "Election matrice: %s ", data)
 	}
 
 	if maxseq > 0 {
@@ -953,7 +953,7 @@ func (cluster *Cluster) electFailoverCandidate(l []*ServerMonitor, forcingLog bo
 		for _, p := range trackposList {
 			if p.Seq == maxseq && p.Ignoredrelay == false && p.Ignoredmultimaster == false && p.Ignoredreplication == false && p.Ignoredconf == true {
 				if forcingLog {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModWriterElection, config.LvlInfo, "Ignored server is the most up to date ")
+					cluster.LogModulePrintf(forcingLog, config.ConstLogModWriterElection, config.LvlInfo, "Ignored server is the most up to date ")
 				}
 				return p.Indice
 			}
@@ -1004,7 +1004,7 @@ func (cluster *Cluster) electFailoverCandidate(l []*ServerMonitor, forcingLog bo
 		for _, p := range trackposList {
 			if p.Pos == maxpos && p.Ignoredrelay == false && p.Ignoredmultimaster == false && p.Ignoredreplication == false && p.Ignoredconf == true {
 				if forcingLog {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModWriterElection, config.LvlInfo, "Ignored server is the most up to date ")
+					cluster.LogModulePrintf(forcingLog, config.ConstLogModWriterElection, config.LvlInfo, "Ignored server is the most up to date ")
 				}
 				return p.Indice
 			}

--- a/cluster/cluster_fail.go
+++ b/cluster/cluster_fail.go
@@ -960,10 +960,8 @@ func (cluster *Cluster) electFailoverCandidate(l []*ServerMonitor, forcingLog bo
 
 		}
 
-		if cluster.Conf.LogWriterElection {
-			data, _ := json.MarshalIndent(trackposList, "", "\t")
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModFailedElection, config.LvlInfo, "Election matrice maxseq >0: %s ", data)
-		}
+		data, _ := json.MarshalIndent(trackposList, "", "\t")
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModFailedElection, config.LvlDbg, "Election matrice maxseq >0: %s ", data)
 		return -1
 	}
 
@@ -1011,16 +1009,14 @@ func (cluster *Cluster) electFailoverCandidate(l []*ServerMonitor, forcingLog bo
 				return p.Indice
 			}
 		}
-		if cluster.Conf.LogWriterElection {
-			data, _ := json.MarshalIndent(trackposList, "", "\t")
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModFailedElection, config.LvlInfo, "Election matrice maxpos>0: %s ", data)
-		}
+
+		data, _ := json.MarshalIndent(trackposList, "", "\t")
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModFailedElection, config.LvlDbg, "Election matrice maxpos>0: %s ", data)
 		return -1
 	}
-	if cluster.Conf.LogWriterElection {
-		data, _ := json.MarshalIndent(trackposList, "", "\t")
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModFailedElection, config.LvlInfo, "Election matrice: %s ", data)
-	}
+
+	data, _ := json.MarshalIndent(trackposList, "", "\t")
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModFailedElection, config.LvlDbg, "Election matrice: %s ", data)
 	return -1
 }
 

--- a/cluster/cluster_fail.go
+++ b/cluster/cluster_fail.go
@@ -707,7 +707,7 @@ func (cluster *Cluster) electSwitchoverCandidate(l []*ServerMonitor, forcingLog 
 		if cluster.IsInPreferedHosts(sl) {
 			// if (cluster.Conf.LogLevel > 1 || forcingLog) && cluster.IsInFailover() {
 			if cluster.IsInFailover() {
-				cluster.LogModulePrintf(forcingLog, config.ConstLogModWriterElection, config.LvlDbg, "Election rig: %s elected as preferred master", sl.URL)
+				cluster.LogModulePrintf(forcingLog, config.ConstLogModWriterElection, config.LvlInfo, "Election rig: %s elected as preferred master", sl.URL)
 			}
 			return i
 		}

--- a/cluster/cluster_fail.go
+++ b/cluster/cluster_fail.go
@@ -960,7 +960,7 @@ func (cluster *Cluster) electFailoverCandidate(l []*ServerMonitor, forcingLog bo
 
 		}
 
-		if cluster.Conf.LogFailedElection {
+		if cluster.Conf.LogWriterElection {
 			data, _ := json.MarshalIndent(trackposList, "", "\t")
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModFailedElection, config.LvlInfo, "Election matrice maxseq >0: %s ", data)
 		}
@@ -1011,13 +1011,13 @@ func (cluster *Cluster) electFailoverCandidate(l []*ServerMonitor, forcingLog bo
 				return p.Indice
 			}
 		}
-		if cluster.Conf.LogFailedElection {
+		if cluster.Conf.LogWriterElection {
 			data, _ := json.MarshalIndent(trackposList, "", "\t")
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModFailedElection, config.LvlInfo, "Election matrice maxpos>0: %s ", data)
 		}
 		return -1
 	}
-	if cluster.Conf.LogFailedElection {
+	if cluster.Conf.LogWriterElection {
 		data, _ := json.MarshalIndent(trackposList, "", "\t")
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModFailedElection, config.LvlInfo, "Election matrice: %s ", data)
 	}

--- a/cluster/cluster_fail.go
+++ b/cluster/cluster_fail.go
@@ -707,7 +707,7 @@ func (cluster *Cluster) electSwitchoverCandidate(l []*ServerMonitor, forcingLog 
 		if cluster.IsInPreferedHosts(sl) {
 			// if (cluster.Conf.LogLevel > 1 || forcingLog) && cluster.IsInFailover() {
 			if cluster.IsInFailover() {
-				cluster.LogModulePrintf(forcingLog, config.ConstLogModFailedElection, config.LvlDbg, "Election rig: %s elected as preferred master", sl.URL)
+				cluster.LogModulePrintf(forcingLog, config.ConstLogModWriterElection, config.LvlDbg, "Election rig: %s elected as preferred master", sl.URL)
 			}
 			return i
 		}
@@ -953,7 +953,7 @@ func (cluster *Cluster) electFailoverCandidate(l []*ServerMonitor, forcingLog bo
 		for _, p := range trackposList {
 			if p.Seq == maxseq && p.Ignoredrelay == false && p.Ignoredmultimaster == false && p.Ignoredreplication == false && p.Ignoredconf == true {
 				if forcingLog {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModFailedElection, config.LvlInfo, "Ignored server is the most up to date ")
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModWriterElection, config.LvlInfo, "Ignored server is the most up to date ")
 				}
 				return p.Indice
 			}
@@ -961,7 +961,7 @@ func (cluster *Cluster) electFailoverCandidate(l []*ServerMonitor, forcingLog bo
 		}
 
 		data, _ := json.MarshalIndent(trackposList, "", "\t")
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModFailedElection, config.LvlDbg, "Election matrice maxseq >0: %s ", data)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModWriterElection, config.LvlDbg, "Election matrice maxseq >0: %s ", data)
 		return -1
 	}
 
@@ -1004,33 +1004,33 @@ func (cluster *Cluster) electFailoverCandidate(l []*ServerMonitor, forcingLog bo
 		for _, p := range trackposList {
 			if p.Pos == maxpos && p.Ignoredrelay == false && p.Ignoredmultimaster == false && p.Ignoredreplication == false && p.Ignoredconf == true {
 				if forcingLog {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModFailedElection, config.LvlInfo, "Ignored server is the most up to date ")
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModWriterElection, config.LvlInfo, "Ignored server is the most up to date ")
 				}
 				return p.Indice
 			}
 		}
 
 		data, _ := json.MarshalIndent(trackposList, "", "\t")
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModFailedElection, config.LvlDbg, "Election matrice maxpos>0: %s ", data)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModWriterElection, config.LvlDbg, "Election matrice maxpos>0: %s ", data)
 		return -1
 	}
 
 	data, _ := json.MarshalIndent(trackposList, "", "\t")
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModFailedElection, config.LvlDbg, "Election matrice: %s ", data)
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModWriterElection, config.LvlDbg, "Election matrice: %s ", data)
 	return -1
 }
 
 func (cluster *Cluster) isSlaveElectable(sl *ServerMonitor, forcingLog bool) bool {
 	ss, err := sl.GetSlaveStatus(sl.ReplicationSourceName)
 	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModFailedElection, config.LvlWarn, "Error in getting slave status in testing slave electable %s: %s  ", sl.URL, err)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModWriterElection, config.LvlWarn, "Error in getting slave status in testing slave electable %s: %s  ", sl.URL, err)
 		return false
 	}
 	//if master is alived and IO Thread stops then not a good candidate and not forced
 	if ss.SlaveIORunning.String == "No" && cluster.Conf.RplChecks && !cluster.IsMasterFailed() {
 		cluster.StateMachine.AddState("ERR00087", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00087"], sl.URL), ErrFrom: "CHECK", ServerUrl: sl.URL})
 		// if cluster.Conf.LogLevel > 1 || forcingLog {
-		cluster.LogModulePrintf(forcingLog, config.ConstLogModFailedElection, config.LvlWarn, "Unsafe failover condition. Slave %s IO Thread is stopped %s. Skipping", sl.URL, ss.LastIOError.String)
+		cluster.LogModulePrintf(forcingLog, config.ConstLogModWriterElection, config.LvlWarn, "Unsafe failover condition. Slave %s IO Thread is stopped %s. Skipping", sl.URL, ss.LastIOError.String)
 		// }
 		return false
 	}
@@ -1039,14 +1039,14 @@ func (cluster *Cluster) isSlaveElectable(sl *ServerMonitor, forcingLog bool) boo
 	if dbhelper.CheckSlavePrerequisites(sl.Conn, sl.Host, sl.DBVersion) == false {
 		cluster.StateMachine.AddState("ERR00040", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00040"], sl.URL), ErrFrom: "CHECK", ServerUrl: sl.URL})
 		// if cluster.Conf.LogLevel > 1 || forcingLog {
-		cluster.LogModulePrintf(forcingLog, config.ConstLogModFailedElection, config.LvlWarn, "Slave %s does not ping or has no binlogs. Skipping", sl.URL)
+		cluster.LogModulePrintf(forcingLog, config.ConstLogModWriterElection, config.LvlWarn, "Slave %s does not ping or has no binlogs. Skipping", sl.URL)
 		// }
 		return false
 	}
 	if sl.IsMaintenance {
 		cluster.StateMachine.AddState("ERR00047", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00047"], sl.URL), ErrFrom: "CHECK", ServerUrl: sl.URL})
 		// if cluster.Conf.LogLevel > 1 || forcingLog {
-		cluster.LogModulePrintf(forcingLog, config.ConstLogModFailedElection, config.LvlWarn, "Slave %s is in maintenance. Skipping", sl.URL)
+		cluster.LogModulePrintf(forcingLog, config.ConstLogModWriterElection, config.LvlWarn, "Slave %s is in maintenance. Skipping", sl.URL)
 		// }
 		return false
 	}
@@ -1054,7 +1054,7 @@ func (cluster *Cluster) isSlaveElectable(sl *ServerMonitor, forcingLog bool) boo
 	if ss.SecondsBehindMaster.Int64 > cluster.Conf.FailMaxDelay && cluster.Conf.FailMaxDelay != -1 && cluster.Conf.RplChecks == true {
 		cluster.StateMachine.AddState("ERR00041", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00041"]+" Sql: "+sl.GetProcessListReplicationLongQuery(), sl.URL, cluster.Conf.FailMaxDelay, ss.SecondsBehindMaster.Int64), ErrFrom: "CHECK", ServerUrl: sl.URL})
 		// if cluster.Conf.LogLevel > 1 || forcingLog {
-		cluster.LogModulePrintf(forcingLog, config.ConstLogModFailedElection, config.LvlWarn, "Unsafe failover condition. Slave %s has more than failover-max-delay %d seconds with replication delay %d. Skipping", sl.URL, cluster.Conf.FailMaxDelay, ss.SecondsBehindMaster.Int64)
+		cluster.LogModulePrintf(forcingLog, config.ConstLogModWriterElection, config.LvlWarn, "Unsafe failover condition. Slave %s has more than failover-max-delay %d seconds with replication delay %d. Skipping", sl.URL, cluster.Conf.FailMaxDelay, ss.SecondsBehindMaster.Int64)
 		// }
 
 		return false
@@ -1063,14 +1063,14 @@ func (cluster *Cluster) isSlaveElectable(sl *ServerMonitor, forcingLog bool) boo
 	if ss.SlaveSQLRunning.String == "No" && cluster.Conf.RplChecks {
 		cluster.StateMachine.AddState("ERR00042", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00042"], sl.URL), ErrFrom: "CHECK", ServerUrl: sl.URL})
 		// if cluster.Conf.LogLevel > 1 || forcingLog {
-		cluster.LogModulePrintf(forcingLog, config.ConstLogModFailedElection, config.LvlWarn, "Unsafe failover condition. Slave %s SQL Thread is stopped. Skipping", sl.URL)
+		cluster.LogModulePrintf(forcingLog, config.ConstLogModWriterElection, config.LvlWarn, "Unsafe failover condition. Slave %s SQL Thread is stopped. Skipping", sl.URL)
 		// }
 		return false
 	}
 
 	//if master is alived and connection issues, we have to refetch password from vault
 	if ss.SlaveIORunning.String == "Connecting" && !cluster.IsMasterFailed() {
-		cluster.LogModulePrintf(forcingLog, config.ConstLogModFailedElection, config.LvlDbg, "isSlaveElect lastIOErrno: %s", ss.LastIOErrno.String)
+		cluster.LogModulePrintf(forcingLog, config.ConstLogModWriterElection, config.LvlDbg, "isSlaveElect lastIOErrno: %s", ss.LastIOErrno.String)
 		if ss.LastIOErrno.String == "1045" {
 			cluster.StateMachine.AddState("ERR00088", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00088"], sl.URL), ErrFrom: "CHECK", ServerUrl: sl.URL})
 			sl.SetReplicationCredentialsRotation(ss)
@@ -1080,13 +1080,13 @@ func (cluster *Cluster) isSlaveElectable(sl *ServerMonitor, forcingLog bool) boo
 	if sl.HaveSemiSync && sl.SemiSyncSlaveStatus == false && cluster.Conf.FailSync && cluster.Conf.RplChecks {
 		cluster.StateMachine.AddState("ERR00043", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00043"], sl.URL), ErrFrom: "CHECK", ServerUrl: sl.URL})
 		// if cluster.Conf.LogLevel > 1 || forcingLog {
-		cluster.LogModulePrintf(forcingLog, config.ConstLogModFailedElection, config.LvlWarn, "Semi-sync slave %s is out of sync. Skipping", sl.URL)
+		cluster.LogModulePrintf(forcingLog, config.ConstLogModWriterElection, config.LvlWarn, "Semi-sync slave %s is out of sync. Skipping", sl.URL)
 		// }
 		return false
 	}
 	if sl.IsIgnored() {
 		// if cluster.Conf.LogLevel > 1 || forcingLog {
-		cluster.LogModulePrintf(forcingLog, config.ConstLogModFailedElection, config.LvlWarn, "Slave is in ignored list %s", sl.URL)
+		cluster.LogModulePrintf(forcingLog, config.ConstLogModWriterElection, config.LvlWarn, "Slave is in ignored list %s", sl.URL)
 		// }
 		return false
 	}
@@ -1096,14 +1096,14 @@ func (cluster *Cluster) isSlaveElectable(sl *ServerMonitor, forcingLog bool) boo
 func (cluster *Cluster) isSlaveValidReader(sl *ServerMonitor, forcingLog bool) bool {
 	ss, err := sl.GetSlaveStatus(sl.ReplicationSourceName)
 	if err != nil {
-		cluster.LogModulePrintf(forcingLog, config.ConstLogModFailedElection, config.LvlWarn, "Error in getting slave status in testing slave electable %s: %s  ", sl.URL, err)
+		cluster.LogModulePrintf(forcingLog, config.ConstLogModWriterElection, config.LvlWarn, "Error in getting slave status in testing slave electable %s: %s  ", sl.URL, err)
 		return false
 	}
 
 	if sl.IsMaintenance {
 		cluster.StateMachine.AddState("ERR00047", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00047"], sl.URL), ErrFrom: "CHECK", ServerUrl: sl.URL})
 		// if cluster.Conf.LogLevel > 1 || forcingLog {
-		cluster.LogModulePrintf(forcingLog, config.ConstLogModFailedElection, config.LvlWarn, "Slave %s is in maintenance. Skipping", sl.URL)
+		cluster.LogModulePrintf(forcingLog, config.ConstLogModWriterElection, config.LvlWarn, "Slave %s is in maintenance. Skipping", sl.URL)
 		// }
 		return false
 	}
@@ -1127,13 +1127,13 @@ func (cluster *Cluster) isSlaveValidReader(sl *ServerMonitor, forcingLog bool) b
 	if ss.SlaveSQLRunning.String == "No" {
 		cluster.StateMachine.AddState("ERR00042", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00042"], sl.URL), ErrFrom: "CHECK", ServerUrl: sl.URL})
 		// if cluster.Conf.LogLevel > 1 || forcingLog {
-		cluster.LogModulePrintf(forcingLog, config.ConstLogModFailedElection, config.LvlWarn, "Unsafe failover condition. Slave %s SQL Thread is stopped. Skipping", sl.URL)
+		cluster.LogModulePrintf(forcingLog, config.ConstLogModWriterElection, config.LvlWarn, "Unsafe failover condition. Slave %s SQL Thread is stopped. Skipping", sl.URL)
 		// }
 		return false
 	}
 	if sl.IsIgnored() {
 		// if cluster.Conf.LogLevel > 1 || forcingLog {
-		cluster.LogModulePrintf(forcingLog, config.ConstLogModFailedElection, config.LvlWarn, "Slave is in ignored list %s", sl.URL)
+		cluster.LogModulePrintf(forcingLog, config.ConstLogModWriterElection, config.LvlWarn, "Slave is in ignored list %s", sl.URL)
 		// }
 		return false
 	}

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -1537,12 +1537,12 @@ func (cluster *Cluster) SetPrintDelayStatInterval(keep string) error {
 	return nil
 }
 
-func (cluster *Cluster) SetLogFailedElectionLevel(value int) {
-	cluster.Conf.LogFailedElectionLevel = value
+func (cluster *Cluster) SetLogWriterElectionLevel(value int) {
+	cluster.Conf.LogWriterElectionLevel = value
 	if value > 0 {
-		cluster.Conf.LogFailedElection = true
+		cluster.Conf.LogWriterElection = true
 	} else {
-		cluster.Conf.LogFailedElection = false
+		cluster.Conf.LogWriterElection = false
 	}
 }
 func (cluster *Cluster) SetLogSSTLevel(value int) {

--- a/cluster/cluster_tgl.go
+++ b/cluster/cluster_tgl.go
@@ -460,13 +460,13 @@ func (cluster *Cluster) SwitchLogSQLInMonitoring() {
 	cluster.Conf.LogSQLInMonitoring = !cluster.Conf.LogSQLInMonitoring
 }
 
-func (cluster *Cluster) SwitchLogFailedElection() {
-	if cluster.Conf.LogFailedElection {
-		cluster.Conf.LogFailedElectionLevel = 0
+func (cluster *Cluster) SwitchLogWriterElection() {
+	if cluster.Conf.LogWriterElection {
+		cluster.Conf.LogWriterElectionLevel = 0
 	} else {
-		cluster.Conf.LogFailedElectionLevel = 1
+		cluster.Conf.LogWriterElectionLevel = 1
 	}
-	cluster.Conf.LogFailedElection = !cluster.Conf.LogFailedElection
+	cluster.Conf.LogWriterElection = !cluster.Conf.LogWriterElection
 }
 
 func (cluster *Cluster) SwitchLogSST() {

--- a/config/config.go
+++ b/config/config.go
@@ -941,7 +941,7 @@ This is the list of modules to be used in LogModulePrintF
 */
 const (
 	ConstLogNameGeneral        string = "log-general"
-	ConstLogNameFailedElection string = "log-writer-election"
+	ConstLogNameWriterelection string = "log-writer-election"
 	ConstLogNameSST            string = "log-sst"
 	ConstLogNameHeartBeat      string = "log-heartbeat"
 	ConstLogNameConfigLoad     string = "log-config-load"
@@ -2088,7 +2088,7 @@ func GetIndexFromModuleName(module string) int {
 	switch module {
 	case ConstLogNameGeneral:
 		return ConstLogModGeneral
-	case ConstLogNameFailedElection:
+	case ConstLogNameWriterelection:
 		return ConstLogModWriterElection
 	case ConstLogNameSST:
 		return ConstLogModSST

--- a/config/config.go
+++ b/config/config.go
@@ -917,7 +917,7 @@ This is the list of modules to be used in LogModulePrintF
 */
 const (
 	ConstLogModGeneral        = 0
-	ConstLogModFailedElection = 1
+	ConstLogModWriterElection = 1
 	ConstLogModSST            = 2
 	ConstLogModHeartBeat      = 3
 	ConstLogModConfigLoad     = 4
@@ -1931,7 +1931,7 @@ func (conf *Config) IsEligibleForPrinting(module int, level string) bool {
 		switch {
 		case module == ConstLogModGeneral:
 			return conf.LogLevel >= lvl
-		case module == ConstLogModFailedElection:
+		case module == ConstLogModWriterElection:
 			if conf.LogWriterElection {
 				return conf.LogWriterElectionLevel >= lvl
 			}
@@ -2052,7 +2052,7 @@ func GetTagsForLog(module int) string {
 	switch module {
 	case ConstLogModGeneral:
 		return "general"
-	case ConstLogModFailedElection:
+	case ConstLogModWriterElection:
 		return "fail"
 	case ConstLogModSST:
 		return "sst"
@@ -2106,7 +2106,7 @@ func GetIndexFromModuleName(module string) int {
 	case ConstLogNameGeneral:
 		return ConstLogModGeneral
 	case ConstLogNameFailedElection:
-		return ConstLogModFailedElection
+		return ConstLogModWriterElection
 	case ConstLogNameSST:
 		return ConstLogModSST
 	case ConstLogNameHeartBeat:

--- a/config/config.go
+++ b/config/config.go
@@ -107,8 +107,8 @@ type Config struct {
 	LogHeartbeat                              bool                   `mapstructure:"log-heartbeat" toml:"log-heartbeat" json:"logHeartbeat"`
 	LogHeartbeatLevel                         int                    `mapstructure:"log-heartbeat-level" toml:"log-heartbeat-level" json:"logHeartbeatLevel"`
 	LogSQLInMonitoring                        bool                   `mapstructure:"log-sql-in-monitoring"  toml:"log-sql-in-monitoring" json:"logSqlInMonitoring"`
-	LogFailedElection                         bool                   `mapstructure:"log-failed-election"  toml:"log-failed-election" json:"logFailedElection"`
-	LogFailedElectionLevel                    int                    `mapstructure:"log-failed-election-level"  toml:"log-failed-election-level" json:"logFailedElectionLevel"`
+	LogWriterElection                         bool                   `mapstructure:"log-writer-election"  toml:"log-writer-election" json:"logWriterElection"`
+	LogWriterElectionLevel                    int                    `mapstructure:"log-writer-election-level"  toml:"log-writer-election-level" json:"logWriterElectionLevel"`
 	LogGit                                    bool                   `mapstructure:"log-git" toml:"log-git" json:"logGit"`
 	LogGitLevel                               int                    `mapstructure:"log-git-level" toml:"log-git-level" json:"logGitLevel"`
 	LogConfigLoad                             bool                   `mapstructure:"log-config-load" toml:"log-config-load" json:"logConfigLoad"`
@@ -941,7 +941,7 @@ This is the list of modules to be used in LogModulePrintF
 */
 const (
 	ConstLogNameGeneral        string = "log-general"
-	ConstLogNameFailedElection string = "log-failed-election"
+	ConstLogNameFailedElection string = "log-writer-election"
 	ConstLogNameSST            string = "log-sst"
 	ConstLogNameHeartBeat      string = "log-heartbeat"
 	ConstLogNameConfigLoad     string = "log-config-load"
@@ -1932,8 +1932,8 @@ func (conf *Config) IsEligibleForPrinting(module int, level string) bool {
 		case module == ConstLogModGeneral:
 			return conf.LogLevel >= lvl
 		case module == ConstLogModFailedElection:
-			if conf.LogFailedElection {
-				return conf.LogFailedElectionLevel >= lvl
+			if conf.LogWriterElection {
+				return conf.LogWriterElectionLevel >= lvl
 			}
 			break
 		case module == ConstLogModSST:

--- a/config/config.go
+++ b/config/config.go
@@ -1935,87 +1935,70 @@ func (conf *Config) IsEligibleForPrinting(module int, level string) bool {
 			if conf.LogWriterElection {
 				return conf.LogWriterElectionLevel >= lvl
 			}
-			break
 		case module == ConstLogModSST:
 			if conf.LogSST {
 				return conf.LogSSTLevel >= lvl
 			}
-			break
 		case module == ConstLogModHeartBeat:
 			if conf.LogHeartbeat {
 				return conf.LogHeartbeatLevel >= lvl
 			}
-			break
 		case module == ConstLogModConfigLoad:
 			if conf.LogConfigLoad {
 				return conf.LogConfigLoadLevel >= lvl
 			}
-			break
 		case module == ConstLogModGit:
 			if conf.LogGit {
 				return conf.LogGitLevel >= lvl
 			}
-			break
 		case module == ConstLogModBackupStream:
 			if conf.LogBackupStream {
 				return conf.LogBackupStreamLevel >= lvl
 			}
-			break
 		case module == ConstLogModOrchestrator:
 			if conf.LogOrchestrator {
 				return conf.LogOrchestratorLevel >= lvl
 			}
-			break
 		case module == ConstLogModVault:
 			if conf.LogVault {
 				return conf.LogVaultLevel >= lvl
 			}
-			break
 		case module == ConstLogModTopology:
 			if conf.LogTopology {
 				return conf.LogTopologyLevel >= lvl
 			}
-			break
 		case module == ConstLogModProxy:
 			if conf.LogProxy {
 				return conf.LogProxyLevel >= lvl
 			}
-			break
 		case module == ConstLogModProxySQL:
 			if conf.ProxysqlDebug {
 				return conf.ProxysqlLogLevel >= lvl
 			}
-			break
 		case module == ConstLogModHAProxy:
 			if conf.HaproxyDebug {
 				return conf.HaproxyLogLevel >= lvl
 			}
-			break
 		case module == ConstLogModProxyJanitor:
 			if conf.ProxyJanitorDebug {
 				return conf.ProxyJanitorLogLevel >= lvl
 			}
-			break
 		case module == ConstLogModMaxscale:
 			if conf.MxsDebug {
 				return conf.MxsLogLevel >= lvl
 			}
-			break
 		case module == ConstLogModGraphite:
 			if conf.LogGraphite {
 				return conf.LogGraphiteLevel >= lvl
 			}
-			break
 		case module == ConstLogModPurge:
 			if conf.LogBinlogPurge {
 				return conf.LogBinlogPurgeLevel >= lvl
 			}
-			break
 		case module == ConstLogModTask:
 			if conf.LogTask {
 				return conf.LogTaskLevel >= lvl
 			}
-			break
 		}
 	}
 
@@ -2053,7 +2036,7 @@ func GetTagsForLog(module int) string {
 	case ConstLogModGeneral:
 		return "general"
 	case ConstLogModWriterElection:
-		return "fail"
+		return "election"
 	case ConstLogModSST:
 		return "sst"
 	case ConstLogModHeartBeat:

--- a/etc/cluster.d/cluster1.toml.sample
+++ b/etc/cluster.d/cluster1.toml.sample
@@ -47,7 +47,7 @@ replication-credential = "root:mariadb"
 ##  CLUSTER LOGS  ##
 ####################
 
-# log-failed-election  = true
+# log-writer-election  = true
 # log-level = 3
 # log-rotate-max-age = 7
 # log-rotate-max-backup = 7
@@ -60,8 +60,8 @@ replication-credential = "root:mariadb"
 # log-binlog-purge-level = 1
 # log-config-load = true
 # log-config-load-level= 2
-# log-failed-election = true
-# log-failed-election-level 1
+# log-writer-election = true
+# log-writer-election-level 1
 # log-git = true
 # log-git-level = 1
 # log-graphite = true

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -1193,8 +1193,8 @@ func (repman *ReplicationManager) switchSettings(mycluster *cluster.Cluster, set
 		mycluster.SwitchForceBinlogSlowqueries()
 	case "log-sql-in-monitoring":
 		mycluster.SwitchLogSQLInMonitoring()
-	case "log-failed-election":
-		mycluster.SwitchLogFailedElection()
+	case "log-writer-election":
+		mycluster.SwitchLogWriterElection()
 	case "log-sst":
 		mycluster.SwitchLogSST()
 	case "log-heartbeat":
@@ -1406,9 +1406,9 @@ func (repman *ReplicationManager) setSetting(mycluster *cluster.Cluster, name st
 	case "log-level":
 		val, _ := strconv.Atoi(value)
 		mycluster.SetLogLevel(val)
-	case "log-failed-election-level":
+	case "log-writer-election-level":
 		val, _ := strconv.Atoi(value)
-		mycluster.SetLogFailedElectionLevel(val)
+		mycluster.SetLogWriterElectionLevel(val)
 	case "log-sst-level":
 		val, _ := strconv.Atoi(value)
 		mycluster.SetLogSSTLevel(val)

--- a/server/server.go
+++ b/server/server.go
@@ -281,7 +281,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.IntVar(&conf.LogHeartbeatLevel, "log-heartbeat-level", 1, "Log Heartbeat Level")
 
 	flags.BoolVar(&conf.LogWriterElection, "log-writer-election", true, "Log writer election")
-	flags.IntVar(&conf.LogWriterElectionLevel, "log-writer-election-level", 2, "Log writer election Level")
+	flags.IntVar(&conf.LogWriterElectionLevel, "log-writer-election-level", 1, "Log writer election Level")
 
 	flags.BoolVar(&conf.LogBinlogPurge, "log-binlog-purge", false, "Log Binlog Purge")
 	flags.IntVar(&conf.LogBinlogPurgeLevel, "log-binlog-purge-level", 1, "Log Binlog Purge Level")

--- a/server/server.go
+++ b/server/server.go
@@ -280,8 +280,8 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.BoolVar(&conf.LogHeartbeat, "log-heartbeat", false, "Log Heartbeat")
 	flags.IntVar(&conf.LogHeartbeatLevel, "log-heartbeat-level", 1, "Log Heartbeat Level")
 
-	flags.BoolVar(&conf.LogFailedElection, "log-failed-election", true, "Log failed election")
-	flags.IntVar(&conf.LogFailedElectionLevel, "log-failed-election-level", 3, "Log failed election Level")
+	flags.BoolVar(&conf.LogWriterElection, "log-writer-election", true, "Log writer election")
+	flags.IntVar(&conf.LogWriterElectionLevel, "log-writer-election-level", 2, "Log writer election Level")
 
 	flags.BoolVar(&conf.LogBinlogPurge, "log-binlog-purge", false, "Log Binlog Purge")
 	flags.IntVar(&conf.LogBinlogPurgeLevel, "log-binlog-purge-level", 1, "Log Binlog Purge Level")

--- a/share/dashboard/static/card-setting-logs.html
+++ b/share/dashboard/static/card-setting-logs.html
@@ -80,7 +80,7 @@
             <td><md-slider ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" md-discrete
                     flex ng-model="selectedCluster.config.logTaskLevel"
                     ng-change="setsettings('log-task-level',selectedCluster.config.logTaskLevel)"
-                    step="1" min="0" max="4" round="0" aria-label="Log Failed Election Level"></md-slider></td>
+                    step="1" min="0" max="4" round="0" aria-label="Log writer election Level"></md-slider></td>
         </tr>
         <tr>
             <td>
@@ -97,25 +97,25 @@
             </td>
         </tr>
         <tr>
-            <td>Log Failed Election</td>
+            <td>Log writer election</td>
         </tr>
         <tr>
             <td><md-slider ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" md-discrete
-                    flex ng-model="selectedCluster.config.logFailedElectionLevel"
-                    ng-change="setsettings('log-failed-election-level',selectedCluster.config.logFailedElectionLevel)"
-                    step="1" min="0" max="4" round="0" aria-label="Log Failed Election Level"></md-slider></td>
+                    flex ng-model="selectedCluster.config.logWriterElectionLevel"
+                    ng-change="setsettings('log-writer-election-level',selectedCluster.config.logWriterElectionLevel)"
+                    step="1" min="0" max="4" round="0" aria-label="Log writer election Level"></md-slider></td>
         </tr>
         <tr>
             <td>
-                <span ng-if="selectedCluster.config.logFailedElectionLevel == 0" class="label label-default"> NO LOGGING
+                <span ng-if="selectedCluster.config.logWriterElectionLevel == 0" class="label label-default"> NO LOGGING
                 </span>
-                <span ng-if="selectedCluster.config.logFailedElectionLevel >= 1" class="label label-danger"> ERROR
+                <span ng-if="selectedCluster.config.logWriterElectionLevel >= 1" class="label label-danger"> ERROR
                 </span> &nbsp; &nbsp;
-                <span ng-if="selectedCluster.config.logFailedElectionLevel >= 2" class="label label-warning"> WARNING
+                <span ng-if="selectedCluster.config.logWriterElectionLevel >= 2" class="label label-warning"> WARNING
                 </span> &nbsp; &nbsp;
-                <span ng-if="selectedCluster.config.logFailedElectionLevel >= 3" class="label label-info"> INFO </span>
+                <span ng-if="selectedCluster.config.logWriterElectionLevel >= 3" class="label label-info"> INFO </span>
                 &nbsp; &nbsp;
-                <span ng-if="selectedCluster.config.logFailedElectionLevel >= 4" class="label label-primary"> DEBUG
+                <span ng-if="selectedCluster.config.logWriterElectionLevel >= 4" class="label label-primary"> DEBUG
                 </span>
             </td>
         </tr>
@@ -126,7 +126,7 @@
             <td><md-slider ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" md-discrete
                     flex ng-model="selectedCluster.config.logSstLevel"
                     ng-change="setsettings('log-sst-level',selectedCluster.config.logSstLevel)" step="1" min="0" max="4"
-                    round="0" aria-label="Log Failed Election Level"></md-slider></td>
+                    round="0" aria-label="Log writer election Level"></md-slider></td>
         </tr>
         <tr>
             <td>
@@ -147,7 +147,7 @@
             <td><md-slider ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" md-discrete
                     flex ng-model="selectedCluster.config.logHeartbeatLevel"
                     ng-change="setsettings('log-heartbeat-level',selectedCluster.config.logHeartbeatLevel)" step="1"
-                    min="0" max="4" round="0" aria-label="Log Failed Election Level"></md-slider></td>
+                    min="0" max="4" round="0" aria-label="Log writer election Level"></md-slider></td>
         </tr>
         <tr>
             <td>
@@ -191,7 +191,7 @@
             <td><md-slider ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" md-discrete
                     flex ng-model="selectedCluster.config.logGitLevel"
                     ng-change="setsettings('log-git-level',selectedCluster.config.logGitLevel)" step="1" min="0" max="4"
-                    round="0" aria-label="Log Failed Election Level"></md-slider></td>
+                    round="0" aria-label="Log writer election Level"></md-slider></td>
         </tr>
         <tr>
             <td>
@@ -212,7 +212,7 @@
             <td><md-slider ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" md-discrete
                     flex ng-model="selectedCluster.config.logBackupStreamLevel"
                     ng-change="setsettings('log-backup-stream-level',selectedCluster.config.logBackupStreamLevel)"
-                    step="1" min="1" max="4" round="0" aria-label="Log Failed Election Level"></md-slider></td>
+                    step="1" min="1" max="4" round="0" aria-label="Log writer election Level"></md-slider></td>
         </tr>
         <tr>
             <td>
@@ -235,7 +235,7 @@
             <td><md-slider ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" md-discrete
                     flex ng-model="selectedCluster.config.logOrchestratorLevel"
                     ng-change="setsettings('log-orchestrator-level',selectedCluster.config.logOrchestratorLevel)"
-                    step="1" min="1" max="4" round="0" aria-label="Log Failed Election Level"></md-slider></td>
+                    step="1" min="1" max="4" round="0" aria-label="Log writer election Level"></md-slider></td>
         </tr>
         <tr>
             <td>
@@ -258,7 +258,7 @@
             <td><md-slider ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" md-discrete
                     flex ng-model="selectedCluster.config.logVaultLevel"
                     ng-change="setsettings('log-vault-level',selectedCluster.config.logVaultLevel)" step="1" min="0"
-                    max="4" round="0" aria-label="Log Failed Election Level"></md-slider></td>
+                    max="4" round="0" aria-label="Log writer election Level"></md-slider></td>
         </tr>
         <tr>
             <td>
@@ -279,7 +279,7 @@
             <td><md-slider ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" md-discrete
                     flex ng-model="selectedCluster.config.logTopologyLevel"
                     ng-change="setsettings('log-topology-level',selectedCluster.config.logTopologyLevel)" step="1"
-                    min="0" max="4" round="0" aria-label="Log Failed Election Level"></md-slider></td>
+                    min="0" max="4" round="0" aria-label="Log writer election Level"></md-slider></td>
         </tr>
         <tr>
             <td>
@@ -349,7 +349,7 @@
             <td><md-slider ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" md-discrete
                     flex ng-model="selectedCluster.config.logProxyLevel"
                     ng-change="setsettings('log-proxy-level',selectedCluster.config.logProxyLevel)" step="1" min="0"
-                    max="4" round="0" aria-label="Log Failed Election Level"></md-slider></td>
+                    max="4" round="0" aria-label="Log writer election Level"></md-slider></td>
         </tr>
         <tr>
             <td>
@@ -370,7 +370,7 @@
             <td><md-slider ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" md-discrete
                     flex ng-model="selectedCluster.config.haproxyLogLevel"
                     ng-change="setsettings('haproxy-log-level',selectedCluster.config.haproxyLogLevel)" step="1" min="0"
-                    max="4" round="0" aria-label="Log Failed Election Level"></md-slider></td>
+                    max="4" round="0" aria-label="Log writer election Level"></md-slider></td>
         </tr>
         <tr>
             <td>
@@ -392,7 +392,7 @@
             <td><md-slider ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" md-discrete
                     flex ng-model="selectedCluster.config.proxysqlLogLevel"
                     ng-change="setsettings('proxysql-log-level',selectedCluster.config.proxysqlLogLevel)" step="1"
-                    min="0" max="4" round="0" aria-label="Log Failed Election Level"></md-slider></td>
+                    min="0" max="4" round="0" aria-label="Log writer election Level"></md-slider></td>
         </tr>
         <tr>
             <td>
@@ -414,7 +414,7 @@
             <td><md-slider ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" md-discrete
                     flex ng-model="selectedCluster.config.proxyjanitorLogLevel"
                     ng-change="setsettings('proxyjanitor-log-level',selectedCluster.config.proxyjanitorLogLevel)"
-                    step="1" min="1" max="4" round="0" aria-label="Log Failed Election Level"></md-slider></td>
+                    step="1" min="1" max="4" round="0" aria-label="Log writer election Level"></md-slider></td>
         </tr>
         <tr>
             <td>
@@ -437,7 +437,7 @@
             <td><md-slider ng-disabled="selectedCluster.apiUsers[user].grants['cluster-settings']==false" md-discrete
                     flex ng-model="selectedCluster.config.maxscaleLogLevel"
                     ng-change="setsettings('maxscale-log-level',selectedCluster.config.maxscaleLogLevel)" step="1"
-                    min="0" max="4" round="0" aria-label="Log Failed Election Level"></md-slider></td>
+                    min="0" max="4" round="0" aria-label="Log writer election Level"></md-slider></td>
         </tr>
         <tr>
             <td>

--- a/share/dashboard/swagger.json
+++ b/share/dashboard/swagger.json
@@ -1418,9 +1418,9 @@
           "type": "string",
           "x-go-name": "KubeConfig"
         },
-        "logFailedElection": {
+        "logWriterElection": {
           "type": "boolean",
-          "x-go-name": "LogFailedElection"
+          "x-go-name": "LogWriterElection"
         },
         "logFile": {
           "type": "string",


### PR DESCRIPTION
This PR will fix #705.
It contains changing the default to error only level
Apply forcing logs instead of verbose in forced areas
Change the log modules tag to election