### PR TITLE
prevent job check when monitor scheduler is not active

### DIFF
--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -828,19 +828,18 @@ func (server *ServerMonitor) Refresh() error {
 		server.Users = config.FromNormalGrantsMap(server.Users, users)
 		cluster.LogSQL(logs, err, server.URL, "Monitor", config.LvlDbg, "Could not get database users %s %s", server.URL, err)
 
-		//Skip writing to db
-		if !cluster.IsInFailover() && !cluster.InRollingRestart {
-			// Job section
-			server.JobsCheckFinished()
-			server.JobsCheckErrors()
-			server.JobsCheckPending()
-		}
-
-		if server.NeedRefreshJobs {
-			server.JobsUpdateEntries()
-		}
-
 		if cluster.Conf.MonitorScheduler {
+
+			if !cluster.IsInFailover() && !cluster.InRollingRestart {
+				server.JobsCheckFinished()
+				server.JobsCheckErrors()
+				server.JobsCheckPending()
+			}
+
+			if server.NeedRefreshJobs {
+				server.JobsUpdateEntries()
+			}
+
 			server.JobsCheckRunning()
 		}
 

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -260,6 +260,7 @@ func (server *ServerMonitor) JobBackupPhysical() (int64, error) {
 	if server == nil {
 		return 0, nil
 	}
+
 	cluster := server.ClusterGroup
 
 	if cluster.IsInBackup() && cluster.Conf.BackupRestic {
@@ -1214,7 +1215,7 @@ func (server *ServerMonitor) JobsCheckPending() error {
 		return nil
 	}
 
-	server.ExecQueryNoBinLog("UPDATE replication_manager_schema.jobs SET state=5, result='Timeout waiting for job to start' where state=0 and start <= DATE_SUB(NOW(), interval 1 hour)")
+	server.ExecQueryNoBinLog("UPDATE replication_manager_schema.jobs SET state=5, result='Timeout waiting for job to start', done=1, end=now() where state=0 and start <= DATE_SUB(NOW(), interval 1 hour)")
 
 	//server.JobInsertTask("", "", "")
 	rows, err := Conn.Queryx("SELECT task ,count(*) as ct, max(id) as id FROM replication_manager_schema.jobs WHERE state=2 group by task ")
@@ -1230,7 +1231,7 @@ func (server *ServerMonitor) JobsCheckPending() error {
 		if task.ct > 0 {
 			if strings.HasPrefix(task.task, "reseed") || strings.HasPrefix(task.task, "flashback") {
 				res := "Replication-manager is down while preparing task, cancelling operation for data safety."
-				query := "UPDATE replication_manager_schema.jobs SET state=5, result='%s' where task = '%s'"
+				query := "UPDATE replication_manager_schema.jobs SET state=5, done=1, end=now(), result='%s' where task = '%s'"
 				server.ExecQueryNoBinLog(fmt.Sprintf(query, res, task.task))
 				server.SetNeedRefreshJobs(true)
 			}
@@ -1937,8 +1938,10 @@ func (server *ServerMonitor) JobBackupLogical() error {
 		}
 	} else {
 		task := cluster.Conf.BackupLogicalType
-		//Only for record
-		server.JobInsertTask(task, "0", cluster.Conf.MonitorAddress)
+		if cluster.Conf.MonitorScheduler {
+			//Only for record
+			server.JobInsertTask(task, "0", cluster.Conf.MonitorAddress)
+		}
 
 		//Change to switch since we only allow one type of backup (for now)
 		switch cluster.Conf.BackupLogicalType {

--- a/share/dashboard/static/dashboard/card-cluster-bottom.html
+++ b/share/dashboard/static/dashboard/card-cluster-bottom.html
@@ -1,4 +1,8 @@
-<div layout="column" layout-gt-xs="row">
+<div ng-if="selectedCluster.config.monitoringScheduler" layout="column" layout-gt-xs="row">
   <div flex-gt-xs="40" ng-include src="'static/card-cluster-test.html'"></div>
   <div flex-gt-xs="60" ng-include src="'static/card-cluster-jobs.html'"></div>
+</div>
+
+<div ng-if="!selectedCluster.config.monitoringScheduler" layout="column" layout-gt-xs="row">
+  <div flex-gt-xs="50" ng-include src="'static/card-cluster-test.html'"></div>
 </div>


### PR DESCRIPTION
This will prevent replication-manager to check jobs when monitoring-scheduler is disabled. See #814
