### PR TITLE
move fetch metadata to server scope

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -605,7 +605,6 @@ func (cluster *Cluster) Run() {
 					}
 					go cluster.initOrchetratorNodes()
 					go cluster.ResticFetchRepo()
-					go cluster.FetchLastBackupMetadata()
 					cluster.runOnceAfterTopology = false
 				} else {
 

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -240,9 +240,3 @@ func (cluster *Cluster) ResticFetchRepoStat() error {
 
 	return nil
 }
-
-func (cluster *Cluster) FetchLastBackupMetadata() {
-	for _, sv := range cluster.Servers {
-		sv.FetchLastBackupMetadata()
-	}
-}

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -367,6 +367,8 @@ func (cluster *Cluster) newServerMonitor(url string, user string, pass string, c
 	} else {
 		server.Conn, err = sqlx.Open("mysql", server.DSN)
 	}*/
+
+	go server.FetchLastBackupMetadata()
 	return server, err
 }
 


### PR DESCRIPTION
To prevent fetching metadata before server discovered for the first time, move fetch metadata to server scope