### PR TITLE
prevent too many message on error metadata lock and add identification for ShardProxy

### DIFF
--- a/cluster/prx_external.go
+++ b/cluster/prx_external.go
@@ -38,6 +38,10 @@ func NewExternalProxy(placement int, cluster *Cluster, proxyHost string) *Extern
 	}
 	// Source name will equal to cluster name
 	prx.ShardProxy, _ = cluster.newServerMonitor(prx.Host+":"+prx.Port, prx.User, prx.Pass, true, "", cluster.Name)
+	if prx.ShardProxy != nil {
+		//DB Version always exist due to nature of new
+		prx.ShardProxy.DBVersion.Suffix = "ShardProxy"
+	}
 	return prx
 }
 

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1050,9 +1050,11 @@ func (server *ServerMonitor) Refresh() error {
 			}
 			server.IsFull = false
 		}
-		if server.HaveMetaDataLocksLog {
-			server.MetaDataLocks, logs, err = dbhelper.GetMetaDataLock(server.Conn, server.DBVersion)
-			cluster.LogSQL(logs, err, server.URL, "Monitor", config.LvlDbg, "Could not get Metat data locks  %s %s", server.URL, err)
+		if server.DBVersion.Suffix != "ShardProxy" && server.HaveMetaDataLocksLog {
+			server.MetaDataLocks, _, err = dbhelper.GetMetaDataLock(server.Conn, server.DBVersion)
+			if err != nil {
+				cluster.SetState("WARN0122", state.State{ErrType: config.LvlWarn, ErrDesc: fmt.Sprintf(clusterError["WARN0122"], fmt.Sprintf("Could not get Metat data locks  %s %s", server.URL, err.Error())), ErrFrom: "SRV", ServerUrl: server.URL})
+			}
 		}
 	}
 	server.CheckMaxConnections()

--- a/config/error.go
+++ b/config/error.go
@@ -180,6 +180,7 @@ var ClusterError = map[string]string{
 	"WARN0119":  "Failed to get binlog client version on repman: %s",
 	"WARN0120":  "Failed to get mydumper version on repman: %s",
 	"WARN0121":  "Failed to get restic version on repman: %s",
+	"WARN0122":  "Metadata lock: %s",
 	"MDEV20821": "MariaDB version has replication issue https://jira.mariadb.org/browse/MDEV-20821",
 	"MDEV28310": "MariaDB version has replication issue for non row format https://jira.mariadb.org/browse/MDEV-28310",
 	"MDEV19577": "MariaDB version has replication issue for non row format https://jira.mariadb.org/browse/MDEV-19577",


### PR DESCRIPTION
This will prevent too many message on error metadata lock and add identification for ShardProxy