### PR TITLE
Get proxysql information when using master-master topology

### DIFF
--- a/cluster/cluster_fail.go
+++ b/cluster/cluster_fail.go
@@ -387,7 +387,7 @@ func (cluster *Cluster) MasterFailover(fail bool) bool {
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Switching other slaves to the new master")
 	for _, sl := range cluster.slaves {
 		// Don't switch if slave was the old master or is in a multiple master setup or with relay server.
-		if sl.URL == cluster.oldMaster.URL || sl.State == stateMaster || (sl.IsRelay == false && cluster.Conf.MxsBinlogOn == true) {
+		if (!cluster.Conf.MultiMaster && !cluster.Conf.MultiMasterGrouprep) || sl.URL == cluster.oldMaster.URL || sl.State == stateMaster || (sl.IsRelay == false && cluster.Conf.MxsBinlogOn == true) {
 			continue
 		}
 		// maxscale is in the list of slave

--- a/cluster/cluster_fail.go
+++ b/cluster/cluster_fail.go
@@ -223,7 +223,7 @@ func (cluster *Cluster) MasterFailover(fail bool) bool {
 	// Phase 3: Prepare new master
 	if !cluster.Conf.MultiMaster && !cluster.Conf.MultiMasterGrouprep {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Stopping slave threads on new master")
-		if cluster.master.DBVersion.IsMariaDB() || (cluster.master.DBVersion.IsMariaDB() == false && cluster.master.DBVersion.Minor < 7) {
+		if cluster.master.DBVersion.IsMariaDB() || cluster.master.DBVersion.Minor < 7 {
 			logs, err := cluster.master.StopSlave()
 			cluster.LogSQL(logs, err, cluster.master.URL, "MasterFailover", config.LvlErr, "Failed stopping slave on new master %s %s", cluster.master.URL, err)
 		}

--- a/cluster/cluster_fail.go
+++ b/cluster/cluster_fail.go
@@ -356,7 +356,12 @@ func (cluster *Cluster) MasterFailover(fail bool) bool {
 				logs, err = cluster.oldMaster.SetReadWrite()
 				cluster.LogSQL(logs, err, cluster.oldMaster.URL, "MasterFailover", config.LvlErr, "Could not set old master as read-write, %s", err)
 			*/
+		} else if cluster.Conf.MultiMaster {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "topology multi-master, remove read_only on old master")
+			err = cluster.oldMaster.SetReadWrite()
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Could not set old master as read-write, %s", err)
 		}
+
 		if cluster.Conf.SwitchDecreaseMaxConn {
 
 			logs, err := dbhelper.SetMaxConnections(cluster.oldMaster.Conn, cluster.oldMaster.maxConn, cluster.oldMaster.DBVersion)

--- a/etc/local/multimaster/proxysql/config.toml
+++ b/etc/local/multimaster/proxysql/config.toml
@@ -1,0 +1,39 @@
+## config.toml
+## Example replication-manager configuration file
+
+## change the service file  in /etc/systemd/system/replication-manager.service to looks like :
+## replication-manager-osc  --config=./etc/config.toml.sample  --cluster=Cluster01,Cluster_Test_2_Nodes monitor
+
+[MultiMasterProxysql]
+title = "MultiMasterProxysql"
+
+prov-orchestrator = "local"
+db-servers-hosts = "127.0.0.1:3313,127.0.0.1:3314"
+db-servers-prefered-master = "127.0.0.1:3313"
+db-servers-credential = "root:mariadb"
+db-servers-connect-timeout = 1
+
+replication-credential = "root:mariadb"
+replication-multi-master = true
+
+failover-readonly-state = false
+force-slave-readonly = false
+
+proxy-servers-read-on-master = true
+
+proxysql = true
+proxysql-servers = "127.0.0.1"
+proxysql-user = "admin"
+proxysql-password = "admin"
+proxysql-port = "3306"
+proxysql-admin-port = "6032"
+
+
+proxysql-bootstrap = true
+proxysql-bootstrap-query-rules = true
+proxysql-bootstrap-users = true
+proxysql-bootstrap-variables = true
+proxysql-bootstrap-hostgroups = false
+proxysql-save-to-disk = true
+
+

--- a/router/proxysql/proxysql.go
+++ b/router/proxysql/proxysql.go
@@ -249,24 +249,20 @@ func (psql *ProxySQL) CopyReaderToWriter(host string, port string) error {
 }
 
 func (psql *ProxySQL) ReplaceWriter(host string, port string, oldhost string, oldport string, masterasreader bool) error {
-
+    var err error
 	if masterasreader {
-		err := psql.DeleteAllWriters()
-		if err != nil {
+		if err = psql.DeleteAllWriters(); err != nil {
 			return err
 		}
 		err = psql.CopyReaderToWriter(host, port)
-		return err
 	} else {
-		err := psql.SetReader(oldhost, oldport)
-		if err != nil {
+		if err := psql.SetReader(oldhost, oldport); err != nil {
 			return err
 		}
 		err = psql.SetWriter(host, port)
-		return err
 	}
 	//sql := fmt.Sprintf("UPDATE mysql_servers SET status='ONLINE' ,  hostgroup_id='%s', hostname='%s',  port='%s' WHERE  hostname='%s' and  port='%s' ", psql.WriterHG, host, port, oldhost, oldport)
-	return nil
+	return err
 }
 
 func (psql *ProxySQL) GetStatsForHostRead(host string, port string) (string, string, int, int, int, int, error) {
@@ -278,7 +274,7 @@ func (psql *ProxySQL) GetStatsForHostRead(host string, port string) (string, str
 		bytein    int
 		latency   int
 	)
-	sql := fmt.Sprintf("SELECT hostgroup, status, ConnUsed, Bytes_data_sent , Bytes_data_recv , Latency_us FROM stats.stats_mysql_connection_pool INNER JOIN mysql_replication_hostgroups ON mysql_replication_hostgroups.reader_hostgroup=hostgroup  WHERE srv_host='%s' AND srv_port='%s'", host, port)
+	sql := fmt.Sprintf("SELECT hostgroup, status, ConnUsed, Bytes_data_sent , Bytes_data_recv , Latency_us FROM stats.stats_mysql_connection_pool WHERE hostgroup='%s' AND srv_host='%s' AND srv_port='%s'", psql.ReaderHG, host, port)
 	row := psql.Connection.QueryRow(sql)
 	err := row.Scan(&hostgroup, &status, &connused, &byteout, &bytein, &latency)
 	return hostgroup, status, connused, byteout, bytein, latency, err
@@ -293,7 +289,7 @@ func (psql *ProxySQL) GetStatsForHostWrite(host string, port string) (string, st
 		bytein    int
 		latency   int
 	)
-	sql := fmt.Sprintf("SELECT hostgroup, status, ConnUsed, Bytes_data_sent , Bytes_data_recv , Latency_us FROM stats.stats_mysql_connection_pool INNER JOIN mysql_replication_hostgroups ON mysql_replication_hostgroups.writer_hostgroup=hostgroup  WHERE srv_host='%s' AND srv_port='%s'", host, port)
+	sql := fmt.Sprintf("SELECT hostgroup, status, ConnUsed, Bytes_data_sent , Bytes_data_recv , Latency_us FROM stats.stats_mysql_connection_pool WHERE hostgroup='%s' AND srv_host='%s' AND srv_port='%s'", psql.WriterHG, host, port)
 	row := psql.Connection.QueryRow(sql)
 	err := row.Scan(&hostgroup, &status, &connused, &byteout, &bytein, &latency)
 	return hostgroup, status, connused, byteout, bytein, latency, err


### PR DESCRIPTION
When in multi master topology to avoid proxysql to set any read_only=0 server to the write host group you need to drop record from mysql_replication_hostgroup. But it causes issues to repman with regard to retrieving proxy information.

as hostgroup is configured in repman at cluster level I suggest using this information instead of discovering HG config through proxysql.