### PR TITLE
Add API Endpoints for getting attributes using dot notation

### DIFF
--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -249,6 +249,14 @@ func (cluster *Cluster) GetSlaves() serverList {
 	return cluster.slaves
 }
 
+func (cluster *Cluster) GetSlaveByIndex(idx int) *ServerMonitor {
+	if len(cluster.slaves) > idx {
+		return cluster.slaves[idx]
+	}
+
+	return nil
+}
+
 func (cluster *Cluster) GetProxies() proxyList {
 	return cluster.Proxies
 }

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -245,6 +245,34 @@ func (cluster *Cluster) GetServers() serverList {
 	return cluster.Servers
 }
 
+func (cluster *Cluster) GetStandaloneServers() serverList {
+	var standaloneServers serverList
+	for _, server := range cluster.Servers {
+		if server.IsStandAlone() {
+			standaloneServers = append(standaloneServers, server)
+		}
+	}
+	return standaloneServers
+}
+
+func (cluster *Cluster) GetStandaloneServerByIndex(idx int) (*ServerMonitor, error) {
+	counter := 0
+	for _, server := range cluster.Servers {
+		if server.IsStandAlone() {
+			if counter == idx {
+				return server, nil
+			}
+			counter++
+		}
+	}
+
+	if idx > counter {
+		return nil, errors.New("Invalid index")
+	}
+
+	return nil, errors.New("Server Not Found")
+}
+
 func (cluster *Cluster) GetSlaves() serverList {
 	return cluster.slaves
 }

--- a/config/config.go
+++ b/config/config.go
@@ -360,6 +360,9 @@ type Config struct {
 	HaproxyBinaryPath                         string                 `mapstructure:"haproxy-binary-path" toml:"haproxy-binary-path" json:"haproxyBinaryPath"`
 	HaproxyAPIReadBackend                     string                 `mapstructure:"haproxy-api-read-backend"  toml:"haproxy-api-read-backend" json:"haproxyAPIReadBackend"`
 	HaproxyAPIWriteBackend                    string                 `mapstructure:"haproxy-api-write-backend"  toml:"haproxy-api-write-backend" json:"haproxyAPIWriteBackend"`
+	HaproxyStagingPort                        string                 `mapstructure:"haproxy-staging-port"  toml:"haproxy-staging-port" json:"haproxyStagingPort"`
+	HaproxyStagingBind                        string                 `mapstructure:"haproxy-staging-bind" toml:"haproxy-staging-bind" json:"haproxyStagingBind"`
+	HaproxyStagingBackend                     string                 `mapstructure:"haproxy-staging-backend" toml:"haproxy-staging-backend" json:"haproxyStagingBackend"`
 	ProxysqlOn                                bool                   `mapstructure:"proxysql" toml:"proxysql" json:"proxysql"`
 	ProxysqlDebug                             bool                   `mapstructure:"proxysql-debug" toml:"proxysql-debug" json:"proxysqlDebug"`
 	ProxysqlLogLevel                          int                    `mapstructure:"proxysql-log-level" toml:"proxysql-log-level" json:"proxysqlLogLevel"`
@@ -380,6 +383,8 @@ type Config struct {
 	ProxysqlBootstrapQueryRules               bool                   `mapstructure:"proxysql-bootstrap-query-rules" toml:"proxysql-bootstrap-query-rules" json:"proxysqlBootstrapQueryRules"`
 	ProxysqlMultiplexing                      bool                   `mapstructure:"proxysql-multiplexing" toml:"proxysql-multiplexing" json:"proxysqlMultiplexing"`
 	ProxysqlBinaryPath                        string                 `mapstructure:"proxysql-binary-path" toml:"proxysql-binary-path" json:"proxysqlBinaryPath"`
+	ProxysqlWriteTrackState                   string                 `mapstructure:"proxysql-write-track-state" toml:"proxysql-write-track-state" json:"proxysqlWriteTrackState"`
+	ProxysqlreadTrackState                    string                 `mapstructure:"proxysql-read-track-state" toml:"proxysql-read-track-state" json:"proxysqlReadTrackState"`
 	ProxyJanitorDebug                         bool                   `mapstructure:"proxyjanitor-debug" toml:"proxyjanitor-debug" json:"proxyjanitorDebug"`
 	ProxyJanitorLogLevel                      int                    `mapstructure:"proxyjanitor-log-level" toml:"proxyjanitor-log-level" json:"proxyjanitorLogLevel"`
 	ProxyJanitorHosts                         string                 `mapstructure:"proxyjanitor-servers" toml:"proxyjanitor-servers" json:"proxyjanitorServers"`
@@ -419,6 +424,9 @@ type Config struct {
 	KeyPath                                   string                 `mapstructure:"keypath" toml:"-" json:"-"`
 	Topology                                  string                 `mapstructure:"topology" toml:"-" json:"-"` // use by bootstrap
 	TopologyTarget                            string                 `mapstructure:"topology-target" toml:"topology-target" json:"topologyTarget"`
+	TopologyStaging                           bool                   `mapstructure:"topology-staging" toml:"topology-staging" json:"topologyStaging"`
+	TopologyStagingRefreshScript              string                 `mapstructure:"staging-refresh-script" toml:"staging-refresh-script" json:"stagingRefreshScript"`
+	TopologyStagingPostDetachScript           string                 `mapstructure:"staging-post-detach-script" toml:"staging-refresh-script" json:"stagingPostDetachScript"`
 	GraphiteMetrics                           bool                   `scope:"server" mapstructure:"graphite-metrics" toml:"graphite-metrics" json:"graphiteMetrics"`
 	GraphiteEmbedded                          bool                   `scope:"server" mapstructure:"graphite-embedded" toml:"graphite-embedded" json:"graphiteEmbedded"`
 	GraphiteWhitelist                         bool                   `scope:"server" mapstructure:"graphite-whitelist" toml:"graphite-whitelist" json:"graphiteWhitelist"`

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -9497,6 +9497,46 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/clusters/{clusterName}/topology/servers/count": {
+            "get": {
+                "description": "Return number of servers for that specific named cluster",
+                "tags": [
+                    "ClusterTopology"
+                ],
+                "summary": "Return number of servers for that specific named cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Number of servers",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/topology/slaves": {
             "get": {
                 "description": "Shows the slaves for that specific named cluster",
@@ -9717,6 +9757,46 @@ const docTemplate = `{
                             "items": {
                                 "$ref": "#/definitions/cluster.ServerMonitor"
                             }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/topology/standalones/count": {
+            "get": {
+                "description": "Return number of servers for that specific named cluster",
+                "tags": [
+                    "ClusterTopology"
+                ],
+                "summary": "Return number of servers for that specific named cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Number of servers",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     "500": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -5338,6 +5338,63 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/clusters/{clusterName}/servers/{serverName}/attr/{attrName}": {
+            "get": {
+                "description": "Retrieves the details of a specified server within a cluster.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Database"
+                ],
+                "summary": "Get server details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Server Name",
+                        "name": "serverName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Attribute Name (using json path notation split by dot)",
+                        "name": "attrName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Server Attribute (partial based on attrName)",
+                        "schema": {
+                            "$ref": "#/definitions/cluster.ServerMonitor"
+                        }
+                    },
+                    "500": {
+                        "description": "No cluster\" or \"Server Not Found\" or \"Attribute not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/servers/{serverName}/digest-statements-pfs": {
             "get": {
                 "description": "Retrieves the PFS statements of a specified server within a cluster.",
@@ -9394,6 +9451,147 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/clusters/{clusterName}/topology/slaves/count": {
+            "get": {
+                "description": "Return number of slaves for that specific named cluster",
+                "tags": [
+                    "ClusterTopology"
+                ],
+                "summary": "Return number of slaves for that specific named cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Number of slaves",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/topology/slaves/index/{slaveIndex}": {
+            "get": {
+                "description": "Shows the slaves for that specific named cluster",
+                "tags": [
+                    "ClusterTopology"
+                ],
+                "summary": "Shows the slaves for that specific named cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Slave Index (start from 0)",
+                        "name": "slaveIndex",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Slave Data",
+                        "schema": {
+                            "$ref": "#/definitions/cluster.ServerMonitor"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/topology/slaves/index/{slaveIndex}/attr/{attrName}": {
+            "get": {
+                "description": "Shows the slaves for that specific named cluster",
+                "tags": [
+                    "ClusterTopology"
+                ],
+                "summary": "Shows the slaves for that specific named cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Slave Index (start from 0)",
+                        "name": "slaveIndex",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Attribute Name (using json path notation split by dot)",
+                        "name": "attrName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Slave Attribute (partial based on attrName)",
+                        "schema": {
+                            "$ref": "#/definitions/cluster.ServerMonitor"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/users/add": {
             "post": {
                 "description": "Adds a new user to the specified cluster if the request is valid and the user has the necessary permissions.",
@@ -11461,9 +11659,6 @@ const docTemplate = `{
                 "dbopsEmail": {
                     "type": "string"
                 },
-                "domains": {
-                    "type": "string"
-                },
                 "id": {
                     "type": "integer"
                 },
@@ -12773,6 +12968,15 @@ const docTemplate = `{
                 "haproxyServers-ipv6": {
                     "type": "string"
                 },
+                "haproxyStagingBackend": {
+                    "type": "string"
+                },
+                "haproxyStagingBind": {
+                    "type": "string"
+                },
+                "haproxyStagingPort": {
+                    "type": "string"
+                },
                 "haproxyStatPort": {
                     "type": "integer"
                 },
@@ -13645,6 +13849,9 @@ const docTemplate = `{
                 "proxysqlPort": {
                     "type": "string"
                 },
+                "proxysqlReadTrackState": {
+                    "type": "string"
+                },
                 "proxysqlReaderHostgroup": {
                     "type": "string"
                 },
@@ -13658,6 +13865,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "proxysqlUser": {
+                    "type": "string"
+                },
+                "proxysqlWriteTrackState": {
                     "type": "string"
                 },
                 "proxysqlWriterHostgroup": {
@@ -13915,6 +14125,12 @@ const docTemplate = `{
                 "sstSendBuffer": {
                     "type": "integer"
                 },
+                "stagingPostDetachScript": {
+                    "type": "string"
+                },
+                "stagingRefreshScript": {
+                    "type": "string"
+                },
                 "switchoverAtEqualGtid": {
                     "type": "boolean"
                 },
@@ -13973,6 +14189,9 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "testInjectTraffic": {
+                    "type": "boolean"
+                },
+                "topologyStaging": {
                     "type": "boolean"
                 },
                 "topologyTarget": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -5704,6 +5704,48 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/clusters/{clusterName}/servers/{serverName}/is-slave-Stop": {
+            "get": {
+                "description": "Checks if a specified server within a cluster is in a slave Stop state.",
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "Database"
+                ],
+                "summary": "Check if a server is in slave Stop state",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Server Name",
+                        "name": "serverName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "200 -Server is in Slave Stop state!",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "500 -Server is not in Slave Stop state!\" or \"500 -No valid server!\" or \"500 -No cluster!",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/servers/{serverName}/is-slave-error": {
             "get": {
                 "description": "Checks if a specified server within a cluster is in a slave error state.",
@@ -7183,6 +7225,54 @@ const docTemplate = `{
                     },
                     "503": {
                         "description": "503 -Not a Valid Slave!",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/servers/{serverName}/{serverPort}/is-slave-Stop": {
+            "get": {
+                "description": "Checks if a specified server within a cluster is in a slave Stop state.",
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "Database"
+                ],
+                "summary": "Check if a server is in slave Stop state",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Server Name",
+                        "name": "serverName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Server Port",
+                        "name": "serverPort",
+                        "in": "path"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "200 -Server is in Slave Stop state!",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "500 -Server is not in Slave Stop state!\" or \"500 -No valid server!\" or \"500 -No cluster!",
                         "schema": {
                             "type": "string"
                         }
@@ -9579,6 +9669,159 @@ const docTemplate = `{
                 "responses": {
                     "200": {
                         "description": "Slave Attribute (partial based on attrName)",
+                        "schema": {
+                            "$ref": "#/definitions/cluster.ServerMonitor"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/topology/standalones": {
+            "get": {
+                "description": "This endpoint retrieves the servers for the specified cluster.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterTopology"
+                ],
+                "summary": "Retrieve all standalone server for a specific cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Standalone Server",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/cluster.ServerMonitor"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/topology/standalones/index/{index}": {
+            "get": {
+                "description": "This endpoint retrieves the servers for the specified cluster.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterTopology"
+                ],
+                "summary": "Retrieve first standalone server for a specific cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Index",
+                        "name": "index",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Standalone Server",
+                        "schema": {
+                            "$ref": "#/definitions/cluster.ServerMonitor"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/topology/standalones/index/{index}/attr/{attrName}": {
+            "get": {
+                "description": "This endpoint retrieves the servers for the specified cluster.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterTopology"
+                ],
+                "summary": "Retrieve first standalone server for a specific cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Index",
+                        "name": "index",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Attribute Name with dot notation",
+                        "name": "attrName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Standalone Server (partial based on attrName)",
                         "schema": {
                             "$ref": "#/definitions/cluster.ServerMonitor"
                         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -9486,6 +9486,46 @@
                 }
             }
         },
+        "/api/clusters/{clusterName}/topology/servers/count": {
+            "get": {
+                "description": "Return number of servers for that specific named cluster",
+                "tags": [
+                    "ClusterTopology"
+                ],
+                "summary": "Return number of servers for that specific named cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Number of servers",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/topology/slaves": {
             "get": {
                 "description": "Shows the slaves for that specific named cluster",
@@ -9706,6 +9746,46 @@
                             "items": {
                                 "$ref": "#/definitions/cluster.ServerMonitor"
                             }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/topology/standalones/count": {
+            "get": {
+                "description": "Return number of servers for that specific named cluster",
+                "tags": [
+                    "ClusterTopology"
+                ],
+                "summary": "Return number of servers for that specific named cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Number of servers",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     "500": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5693,6 +5693,48 @@
                 }
             }
         },
+        "/api/clusters/{clusterName}/servers/{serverName}/is-slave-Stop": {
+            "get": {
+                "description": "Checks if a specified server within a cluster is in a slave Stop state.",
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "Database"
+                ],
+                "summary": "Check if a server is in slave Stop state",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Server Name",
+                        "name": "serverName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "200 -Server is in Slave Stop state!",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "500 -Server is not in Slave Stop state!\" or \"500 -No valid server!\" or \"500 -No cluster!",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/servers/{serverName}/is-slave-error": {
             "get": {
                 "description": "Checks if a specified server within a cluster is in a slave error state.",
@@ -7172,6 +7214,54 @@
                     },
                     "503": {
                         "description": "503 -Not a Valid Slave!",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/servers/{serverName}/{serverPort}/is-slave-Stop": {
+            "get": {
+                "description": "Checks if a specified server within a cluster is in a slave Stop state.",
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "Database"
+                ],
+                "summary": "Check if a server is in slave Stop state",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Server Name",
+                        "name": "serverName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Server Port",
+                        "name": "serverPort",
+                        "in": "path"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "200 -Server is in Slave Stop state!",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "500 -Server is not in Slave Stop state!\" or \"500 -No valid server!\" or \"500 -No cluster!",
                         "schema": {
                             "type": "string"
                         }
@@ -9568,6 +9658,159 @@
                 "responses": {
                     "200": {
                         "description": "Slave Attribute (partial based on attrName)",
+                        "schema": {
+                            "$ref": "#/definitions/cluster.ServerMonitor"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/topology/standalones": {
+            "get": {
+                "description": "This endpoint retrieves the servers for the specified cluster.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterTopology"
+                ],
+                "summary": "Retrieve all standalone server for a specific cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Standalone Server",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/cluster.ServerMonitor"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/topology/standalones/index/{index}": {
+            "get": {
+                "description": "This endpoint retrieves the servers for the specified cluster.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterTopology"
+                ],
+                "summary": "Retrieve first standalone server for a specific cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Index",
+                        "name": "index",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Standalone Server",
+                        "schema": {
+                            "$ref": "#/definitions/cluster.ServerMonitor"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/topology/standalones/index/{index}/attr/{attrName}": {
+            "get": {
+                "description": "This endpoint retrieves the servers for the specified cluster.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterTopology"
+                ],
+                "summary": "Retrieve first standalone server for a specific cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Index",
+                        "name": "index",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Attribute Name with dot notation",
+                        "name": "attrName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Standalone Server (partial based on attrName)",
                         "schema": {
                             "$ref": "#/definitions/cluster.ServerMonitor"
                         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5327,6 +5327,63 @@
                 }
             }
         },
+        "/api/clusters/{clusterName}/servers/{serverName}/attr/{attrName}": {
+            "get": {
+                "description": "Retrieves the details of a specified server within a cluster.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Database"
+                ],
+                "summary": "Get server details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Server Name",
+                        "name": "serverName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Attribute Name (using json path notation split by dot)",
+                        "name": "attrName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Server Attribute (partial based on attrName)",
+                        "schema": {
+                            "$ref": "#/definitions/cluster.ServerMonitor"
+                        }
+                    },
+                    "500": {
+                        "description": "No cluster\" or \"Server Not Found\" or \"Attribute not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/servers/{serverName}/digest-statements-pfs": {
             "get": {
                 "description": "Retrieves the PFS statements of a specified server within a cluster.",
@@ -9383,6 +9440,147 @@
                 }
             }
         },
+        "/api/clusters/{clusterName}/topology/slaves/count": {
+            "get": {
+                "description": "Return number of slaves for that specific named cluster",
+                "tags": [
+                    "ClusterTopology"
+                ],
+                "summary": "Return number of slaves for that specific named cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Number of slaves",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/topology/slaves/index/{slaveIndex}": {
+            "get": {
+                "description": "Shows the slaves for that specific named cluster",
+                "tags": [
+                    "ClusterTopology"
+                ],
+                "summary": "Shows the slaves for that specific named cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Slave Index (start from 0)",
+                        "name": "slaveIndex",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Slave Data",
+                        "schema": {
+                            "$ref": "#/definitions/cluster.ServerMonitor"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/topology/slaves/index/{slaveIndex}/attr/{attrName}": {
+            "get": {
+                "description": "Shows the slaves for that specific named cluster",
+                "tags": [
+                    "ClusterTopology"
+                ],
+                "summary": "Shows the slaves for that specific named cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Slave Index (start from 0)",
+                        "name": "slaveIndex",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Attribute Name (using json path notation split by dot)",
+                        "name": "attrName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Slave Attribute (partial based on attrName)",
+                        "schema": {
+                            "$ref": "#/definitions/cluster.ServerMonitor"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/users/add": {
             "post": {
                 "description": "Adds a new user to the specified cluster if the request is valid and the user has the necessary permissions.",
@@ -11450,9 +11648,6 @@
                 "dbopsEmail": {
                     "type": "string"
                 },
-                "domains": {
-                    "type": "string"
-                },
                 "id": {
                     "type": "integer"
                 },
@@ -12762,6 +12957,15 @@
                 "haproxyServers-ipv6": {
                     "type": "string"
                 },
+                "haproxyStagingBackend": {
+                    "type": "string"
+                },
+                "haproxyStagingBind": {
+                    "type": "string"
+                },
+                "haproxyStagingPort": {
+                    "type": "string"
+                },
                 "haproxyStatPort": {
                     "type": "integer"
                 },
@@ -13634,6 +13838,9 @@
                 "proxysqlPort": {
                     "type": "string"
                 },
+                "proxysqlReadTrackState": {
+                    "type": "string"
+                },
                 "proxysqlReaderHostgroup": {
                     "type": "string"
                 },
@@ -13647,6 +13854,9 @@
                     "type": "string"
                 },
                 "proxysqlUser": {
+                    "type": "string"
+                },
+                "proxysqlWriteTrackState": {
                     "type": "string"
                 },
                 "proxysqlWriterHostgroup": {
@@ -13904,6 +14114,12 @@
                 "sstSendBuffer": {
                     "type": "integer"
                 },
+                "stagingPostDetachScript": {
+                    "type": "string"
+                },
+                "stagingRefreshScript": {
+                    "type": "string"
+                },
                 "switchoverAtEqualGtid": {
                     "type": "boolean"
                 },
@@ -13962,6 +14178,9 @@
                     "type": "boolean"
                 },
                 "testInjectTraffic": {
+                    "type": "boolean"
+                },
+                "topologyStaging": {
                     "type": "boolean"
                 },
                 "topologyTarget": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -5080,6 +5080,40 @@ paths:
       summary: Check if a server port is a slave
       tags:
       - Database
+  /api/clusters/{clusterName}/servers/{serverName}/{serverPort}/is-slave-Stop:
+    get:
+      description: Checks if a specified server within a cluster is in a slave Stop
+        state.
+      parameters:
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      - description: Server Name
+        in: path
+        name: serverName
+        required: true
+        type: string
+      - description: Server Port
+        in: path
+        name: serverPort
+        type: string
+      produces:
+      - text/plain
+      responses:
+        "200":
+          description: 200 -Server is in Slave Stop state!
+          schema:
+            type: string
+        "500":
+          description: 500 -Server is not in Slave Stop state!" or "500 -No valid
+            server!" or "500 -No cluster!
+          schema:
+            type: string
+      summary: Check if a server is in slave Stop state
+      tags:
+      - Database
   /api/clusters/{clusterName}/servers/{serverName}/{serverPort}/is-slave-error:
     get:
       description: Checks if a specified server within a cluster is in a slave error
@@ -7255,6 +7289,36 @@ paths:
       summary: Check if a server is a slave
       tags:
       - Database
+  /api/clusters/{clusterName}/servers/{serverName}/is-slave-Stop:
+    get:
+      description: Checks if a specified server within a cluster is in a slave Stop
+        state.
+      parameters:
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      - description: Server Name
+        in: path
+        name: serverName
+        required: true
+        type: string
+      produces:
+      - text/plain
+      responses:
+        "200":
+          description: 200 -Server is in Slave Stop state!
+          schema:
+            type: string
+        "500":
+          description: 500 -Server is not in Slave Stop state!" or "500 -No valid
+            server!" or "500 -No cluster!
+          schema:
+            type: string
+      summary: Check if a server is in slave Stop state
+      tags:
+      - Database
   /api/clusters/{clusterName}/servers/{serverName}/is-slave-error:
     get:
       description: Checks if a specified server within a cluster is in a slave error
@@ -9358,6 +9422,110 @@ paths:
           schema:
             type: string
       summary: Shows the slaves for that specific named cluster
+      tags:
+      - ClusterTopology
+  /api/clusters/{clusterName}/topology/standalones:
+    get:
+      description: This endpoint retrieves the servers for the specified cluster.
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Standalone Server
+          schema:
+            items:
+              $ref: '#/definitions/cluster.ServerMonitor'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Retrieve all standalone server for a specific cluster
+      tags:
+      - ClusterTopology
+  /api/clusters/{clusterName}/topology/standalones/index/{index}:
+    get:
+      description: This endpoint retrieves the servers for the specified cluster.
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      - description: Index
+        in: path
+        name: index
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Standalone Server
+          schema:
+            $ref: '#/definitions/cluster.ServerMonitor'
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Retrieve first standalone server for a specific cluster
+      tags:
+      - ClusterTopology
+  /api/clusters/{clusterName}/topology/standalones/index/{index}/attr/{attrName}:
+    get:
+      description: This endpoint retrieves the servers for the specified cluster.
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      - description: Index
+        in: path
+        name: index
+        required: true
+        type: string
+      - description: Attribute Name with dot notation
+        in: path
+        name: attrName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Standalone Server (partial based on attrName)
+          schema:
+            $ref: '#/definitions/cluster.ServerMonitor'
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Retrieve first standalone server for a specific cluster
       tags:
       - ClusterTopology
   /api/clusters/{clusterName}/users/add:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -897,8 +897,6 @@ definitions:
     properties:
       dbopsEmail:
         type: string
-      domains:
-        type: string
       id:
         type: integer
       isDbops:
@@ -1781,6 +1779,12 @@ definitions:
         type: string
       haproxyServers-ipv6:
         type: string
+      haproxyStagingBackend:
+        type: string
+      haproxyStagingBind:
+        type: string
+      haproxyStagingPort:
+        type: string
       haproxyStatPort:
         type: integer
       haproxyWritePort:
@@ -2363,6 +2367,8 @@ definitions:
         type: string
       proxysqlPort:
         type: string
+      proxysqlReadTrackState:
+        type: string
       proxysqlReaderHostgroup:
         type: string
       proxysqlSaveToDisk:
@@ -2372,6 +2378,8 @@ definitions:
       proxysqlServersIpv6:
         type: string
       proxysqlUser:
+        type: string
+      proxysqlWriteTrackState:
         type: string
       proxysqlWriterHostgroup:
         type: string
@@ -2543,6 +2551,10 @@ definitions:
         type: string
       sstSendBuffer:
         type: integer
+      stagingPostDetachScript:
+        type: string
+      stagingRefreshScript:
+        type: string
       switchoverAtEqualGtid:
         type: boolean
       switchoverAtSync:
@@ -2582,6 +2594,8 @@ definitions:
       test:
         type: boolean
       testInjectTraffic:
+        type: boolean
+      topologyStaging:
         type: boolean
       topologyTarget:
         type: string
@@ -6991,6 +7005,45 @@ paths:
       summary: Get status of all slaves of a server
       tags:
       - Database
+  /api/clusters/{clusterName}/servers/{serverName}/attr/{attrName}:
+    get:
+      description: Retrieves the details of a specified server within a cluster.
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      - description: Server Name
+        in: path
+        name: serverName
+        required: true
+        type: string
+      - description: Attribute Name (using json path notation split by dot)
+        in: path
+        name: attrName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Server Attribute (partial based on attrName)
+          schema:
+            $ref: '#/definitions/cluster.ServerMonitor'
+        "500":
+          description: No cluster" or "Server Not Found" or "Attribute not found
+          schema:
+            type: string
+      summary: Get server details
+      tags:
+      - Database
   /api/clusters/{clusterName}/servers/{serverName}/digest-statements-pfs:
     get:
       description: Retrieves the PFS statements of a specified server within a cluster.
@@ -9204,6 +9257,102 @@ paths:
               additionalProperties: true
               type: object
             type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Shows the slaves for that specific named cluster
+      tags:
+      - ClusterTopology
+  /api/clusters/{clusterName}/topology/slaves/count:
+    get:
+      description: Return number of slaves for that specific named cluster
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      responses:
+        "200":
+          description: Number of slaves
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Return number of slaves for that specific named cluster
+      tags:
+      - ClusterTopology
+  /api/clusters/{clusterName}/topology/slaves/index/{slaveIndex}:
+    get:
+      description: Shows the slaves for that specific named cluster
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      - description: Slave Index (start from 0)
+        in: path
+        name: slaveIndex
+        required: true
+        type: string
+      responses:
+        "200":
+          description: Slave Data
+          schema:
+            $ref: '#/definitions/cluster.ServerMonitor'
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Shows the slaves for that specific named cluster
+      tags:
+      - ClusterTopology
+  /api/clusters/{clusterName}/topology/slaves/index/{slaveIndex}/attr/{attrName}:
+    get:
+      description: Shows the slaves for that specific named cluster
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      - description: Slave Index (start from 0)
+        in: path
+        name: slaveIndex
+        required: true
+        type: string
+      - description: Attribute Name (using json path notation split by dot)
+        in: path
+        name: attrName
+        required: true
+        type: string
+      responses:
+        "200":
+          description: Slave Attribute (partial based on attrName)
+          schema:
+            $ref: '#/definitions/cluster.ServerMonitor'
         "500":
           description: Internal Server Error
           schema:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -9298,6 +9298,33 @@ paths:
       summary: Retrieve servers for a specific cluster
       tags:
       - ClusterTopology
+  /api/clusters/{clusterName}/topology/servers/count:
+    get:
+      description: Return number of servers for that specific named cluster
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      responses:
+        "200":
+          description: Number of servers
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Return number of servers for that specific named cluster
+      tags:
+      - ClusterTopology
   /api/clusters/{clusterName}/topology/slaves:
     get:
       description: Shows the slaves for that specific named cluster
@@ -9453,6 +9480,33 @@ paths:
           schema:
             type: string
       summary: Retrieve all standalone server for a specific cluster
+      tags:
+      - ClusterTopology
+  /api/clusters/{clusterName}/topology/standalones/count:
+    get:
+      description: Return number of servers for that specific named cluster
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      responses:
+        "200":
+          description: Number of servers
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Return number of servers for that specific named cluster
       tags:
       - ClusterTopology
   /api/clusters/{clusterName}/topology/standalones/index/{index}:

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -328,6 +328,18 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxSlaves)),
 	))
+	router.Handle("/api/clusters/{clusterName}/topology/slaves/count", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxSlavesCount)),
+	))
+	router.Handle("/api/clusters/{clusterName}/topology/slaves/index/{slaveIndex}", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxSlaveIndex)),
+	))
+	router.Handle("/api/clusters/{clusterName}/topology/slaves/index/{slaveIndex}/attr/{attrName}", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxSlaveAttributeByIndex)),
+	))
 	router.Handle("/api/clusters/{clusterName}/topology/logs", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxLog)),
@@ -500,6 +512,151 @@ func (repman *ReplicationManager) handlerMuxSlaves(w http.ResponseWriter, r *htt
 		}
 	} else {
 
+		http.Error(w, "No cluster", 500)
+		return
+	}
+}
+
+// @Summary Return number of slaves for that specific named cluster
+// @Description Return number of slaves for that specific named cluster
+// @Tags ClusterTopology
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Success 200 {string} string "Number of slaves"
+// @Failure 500 {string} string "Internal Server Error"
+// @Router /api/clusters/{clusterName}/topology/slaves/count [get]
+func (repman *ReplicationManager) handlerMuxSlavesCount(w http.ResponseWriter, r *http.Request) {
+	//marshal unmarchal for ofuscation deep copy of struc
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster != nil {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(strconv.Itoa(len(mycluster.GetSlaves()))))
+	} else {
+		http.Error(w, "No cluster", 500)
+		return
+	}
+}
+
+// @Summary Shows the slaves for that specific named cluster
+// @Description Shows the slaves for that specific named cluster
+// @Tags ClusterTopology
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Param slaveIndex path string true "Slave Index (start from 0)"
+// @Success 200 {object} cluster.ServerMonitor "Slave Data"
+// @Failure 500 {string} string "Internal Server Error"
+// @Router /api/clusters/{clusterName}/topology/slaves/index/{slaveIndex} [get]
+func (repman *ReplicationManager) handlerMuxSlaveIndex(w http.ResponseWriter, r *http.Request) {
+	//marshal unmarchal for ofuscation deep copy of struc
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster != nil {
+		uname := repman.GetUserFromRequest(r)
+		if _, ok := mycluster.APIUsers[uname]; !ok {
+			http.Error(w, "No Valid ACL", 500)
+			return
+		}
+
+		index, err := strconv.Atoi(vars["slaveIndex"])
+		if err != nil {
+			http.Error(w, "Invalid index", 500)
+			return
+		}
+
+		slave := mycluster.GetSlaveByIndex(index)
+		if slave == nil {
+			http.Error(w, "Slave not found", 500)
+			return
+		}
+
+		data, _ := json.Marshal(slave)
+		var srv cluster.ServerMonitor
+
+		err = json.Unmarshal(data, &srv)
+		if err != nil {
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "API Error encoding JSON: ", err)
+			http.Error(w, "Encoding error", 500)
+			return
+		}
+
+		srv.Pass = "XXXXXXXX"
+		e := json.NewEncoder(w)
+		e.SetIndent("", "\t")
+		err = e.Encode(srv)
+		if err != nil {
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "API Error encoding JSON: ", err)
+			http.Error(w, "Encoding error", 500)
+			return
+		}
+	} else {
+		http.Error(w, "No cluster", 500)
+		return
+	}
+}
+
+// @Summary Shows the slaves for that specific named cluster
+// @Description Shows the slaves for that specific named cluster
+// @Tags ClusterTopology
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Param slaveIndex path string true "Slave Index (start from 0)"
+// @Param attrName path string true "Attribute Name (using json path notation split by dot)"
+// @Success 200 {object} cluster.ServerMonitor "Slave Attribute (partial based on attrName)"
+// @Failure 500 {string} string "Internal Server Error"
+// @Router /api/clusters/{clusterName}/topology/slaves/index/{slaveIndex}/attr/{attrName} [get]
+func (repman *ReplicationManager) handlerMuxSlaveAttributeByIndex(w http.ResponseWriter, r *http.Request) {
+	//marshal unmarchal for ofuscation deep copy of struc
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster != nil {
+		uname := repman.GetUserFromRequest(r)
+		if _, ok := mycluster.APIUsers[uname]; !ok {
+			http.Error(w, "No Valid ACL", 500)
+			return
+		}
+
+		index, err := strconv.Atoi(vars["slaveIndex"])
+		if err != nil {
+			http.Error(w, "Invalid index", 500)
+			return
+		}
+
+		slave := mycluster.GetSlaveByIndex(index)
+		if slave == nil {
+			http.Error(w, "Slave not found", 500)
+			return
+		}
+
+		var data, value []byte
+		var valtype jsonparser.ValueType
+		// get the value from the json path
+		// if the attribute is binaryLogFiles, we need to convert the map to json
+		// if the attribute is binaryLogFiles.*, we need to convert the map to json and get the value from the json path
+		// otherwise, we just get the value from the json path
+		if vars["attrName"] == "binaryLogFiles" {
+			value, _ = json.Marshal(slave.BinaryLogFiles.ToNewMap())
+		} else if strings.HasPrefix(vars["attrName"], "binaryLogFiles.") {
+			data, _ = json.Marshal(slave.BinaryLogFiles.ToNewMap())
+			value, valtype, _, _ = jsonparser.Get(data, strings.Split(vars["attrName"], ".")[1:]...)
+		} else {
+			data, _ = json.Marshal(slave)
+			value, valtype, _, _ = jsonparser.Get(data, strings.Split(vars["attrName"], ".")...)
+		}
+
+		// if the value is not found, return an error
+		if valtype == jsonparser.NotExist {
+			http.Error(w, "Attribute not found", 500)
+			return
+		}
+
+		// Write the value to the response
+		w.WriteHeader(http.StatusOK)
+		w.Write(value)
+	} else {
 		http.Error(w, "No cluster", 500)
 		return
 	}


### PR DESCRIPTION
Add API routes for getting server by index
/api/clusters/{clusterName}/topology/slaves/index/{slaveIndex}

Add API routes for getting attribute by name
/api/clusters/{clusterName}/servers/{serverName}/attr/{attrName}
/api/clusters/{clusterName}/topology/slaves/index/{slaveIndex}/attr/{attrName}