### PR TITLE
set Discovered state to true when topology is known and all DBs are up

### DIFF
--- a/cluster/cluster_has.go
+++ b/cluster/cluster_has.go
@@ -216,6 +216,10 @@ func (cluster *Cluster) HasAllDbUp() bool {
 
 		}
 	}
+
+	if cluster.GetTopology() != config.TopoUnknown {
+		cluster.GetStateMachine().Discovered = true
+	}
 	return true
 }
 


### PR DESCRIPTION
Proposal:
Set cluster as discovered when topology already known and all DBs are up.

Reason:
Cluster topology already discovered, and all db already found.

Note:
Need to check in all cluster.IsDiscovered(), to make sure the usage is correct