### PR TITLE
Add API error handling configuration and custom log adapter to suppress error

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -599,6 +599,10 @@ type Config struct {
 	APIBind                                   string                 `scope:"server" mapstructure:"api-bind" toml:"api-bind" json:"apiBind"`
 	APIPublicURL                              string                 `scope:"server" mapstructure:"api-public-url" toml:"api-public-url" json:"apiPublicUrl"`
 	APIHttpsBind                              bool                   `scope:"server" mapstructure:"api-https-bind" toml:"api-secure" json:"apiHttpsBind"`
+	APIErrorSuppress                          bool                   `scope:"server" mapstructure:"api-error-suppress" toml:"api-error-suppress" json:"apiErrorSuppress"`
+	APIErrorLimit                             int                    `scope:"server" mapstructure:"api-error-limit" toml:"api-error-limit" json:"apiErrorLimit"`
+	APIErrorLimitDuration                     int                    `scope:"server" mapstructure:"api-error-limit-duration" toml:"api-error-limit-duration" json:"apiErrorLimitDuration"`
+	APIErrorDisregardPort                     bool                   `scope:"server" mapstructure:"api-error-disregard-port" toml:"api-error-disregard-port" json:"apiErrorDisregardPort"`
 	AlertScript                               string                 `mapstructure:"alert-script" toml:"alert-script" json:"alertScript"`
 	ConfigFile                                string                 `mapstructure:"config" toml:"-" json:"-"`
 	MonitorScheduler                          bool                   `mapstructure:"monitoring-scheduler" toml:"monitoring-scheduler" json:"monitoringScheduler"`

--- a/server/api.go
+++ b/server/api.go
@@ -1507,11 +1507,12 @@ func (repman *ReplicationManager) RecoveryMiddleware(next http.Handler) http.Han
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if err := recover(); err != nil {
-				logrus.WithFields(logrus.Fields{
+				// Capture error and stack trace
+				repman.Logrus.WithFields(logrus.Fields{
 					"error":      err,
 					"stacktrace": string(debug.Stack()),
 					"url":        r.URL.String(),
-				}).Error("Recovered from panic")
+				}).Print("Recovered from panic")
 
 				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			}

--- a/server/http.go
+++ b/server/http.go
@@ -40,6 +40,8 @@ import (
 	"os"
 	"strconv"
 
+	basiclog "log"
+
 	"github.com/codegangsta/negroni"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
@@ -241,12 +243,18 @@ func (repman *ReplicationManager) httpserver() {
 
 	repman.IsHttpListenerReady = true
 
-	log.Fatal(http.ListenAndServe(repman.Conf.BindAddr+":"+repman.Conf.HttpPort, handlers.CORS(
-		handlers.AllowCredentials(),
-		handlers.AllowedHeaders([]string{"X-Requested-With", "Content-Type", "Authorization"}),
-		handlers.AllowedMethods([]string{"GET", "POST", "PUT", "HEAD", "OPTIONS"}),
-		handlers.AllowedOriginValidator(repman.handleOriginValidator),
-	)(router)))
+	server := &http.Server{
+		Addr: repman.Conf.BindAddr + ":" + repman.Conf.HttpPort,
+		Handler: handlers.CORS(
+			handlers.AllowCredentials(),
+			handlers.AllowedHeaders([]string{"X-Requested-With", "Content-Type", "Authorization"}),
+			handlers.AllowedMethods([]string{"GET", "POST", "PUT", "HEAD", "OPTIONS"}),
+			handlers.AllowedOriginValidator(repman.handleOriginValidator),
+		)(router),
+		ErrorLog: basiclog.New(repman.ApiLogAdapter, "", 0),
+	}
+
+	log.Fatal(server.ListenAndServe())
 }
 
 func (repman *ReplicationManager) handlerApp(w http.ResponseWriter, r *http.Request) {

--- a/server/repmanv3.go
+++ b/server/repmanv3.go
@@ -32,6 +32,8 @@ import (
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 
+	basiclog "log"
+
 	log "github.com/sirupsen/logrus"
 )
 
@@ -143,7 +145,7 @@ func (s *ReplicationManager) StartServerV3(debug bool, router *mux.Router) error
 			)(router),
 		),
 
-		// ErrorLog: zap.NewStdLog(s.log),
+		ErrorLog: basiclog.New(s.ApiLogAdapter, "", 0),
 	}
 
 	s.grpcWrapped = grpcweb.WrapServer(s.grpcServer, grpcweb.WithOriginFunc(func(origin string) bool {

--- a/server/server.go
+++ b/server/server.go
@@ -134,6 +134,7 @@ type ReplicationManager struct {
 	clog                                             *clog.Logger                      `json:"-"`
 	cApiLog                                          *clog.Logger                      `json:"-"`
 	Logrus                                           *log.Logger                       `json:"-"`
+	ApiLogAdapter                                    *ApiLogAdapter                    `json:"-"`
 	IsSavingConfig                                   bool                              `json:"isSavingConfig"`
 	HasSavingConfigQueue                             bool                              `json:"hasSavingConfigQueue"`
 	IsGitPull                                        bool                              `json:"isGitPull"`
@@ -526,6 +527,12 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.OAuthProvider, "api-oauth-provider-url", "https://gitlab.signal18.io", "API OAuth Provider URL")
 	flags.StringVar(&conf.OAuthClientID, "api-oauth-client-id", "", "API OAuth Client ID")
 	flags.StringVar(&conf.OAuthClientSecret, "api-oauth-client-secret", "", "API OAuth Client Secret")
+
+	// To prevent flooding of same error message in stderr
+	flags.BoolVar(&conf.APIErrorSuppress, "api-error-suppress", false, "Suppress same error message in API response beyond limit")
+	flags.IntVar(&conf.APIErrorLimit, "api-error-limit", 5, "Limit of same error message in API response")
+	flags.IntVar(&conf.APIErrorLimitDuration, "api-error-limit-duration", 1, "Time in minutes before reseting error limit")
+	flags.BoolVar(&conf.APIErrorDisregardPort, "api-error-disregard-port", true, "Use same hash for error message with or without port")
 
 	//vault
 	flags.StringVar(&conf.VaultServerAddr, "vault-server-addr", "", "Vault server address")
@@ -1809,6 +1816,7 @@ func (repman *ReplicationManager) Run() error {
 	repman.clog = clog.New()
 	repman.CheckSumConfig = make(map[string]hash.Hash)
 	repman.PeerBooked = make(map[string]string)
+	repman.ApiLogAdapter = NewApiLogAdapter(repman.Conf.APIErrorSuppress, repman.Conf.APIErrorLimit, repman.Conf.APIErrorLimitDuration, repman.Conf.APIErrorDisregardPort)
 
 	repman.LoadPeerJson()
 	repman.LoadPartnersJson()

--- a/server/server_log.go
+++ b/server/server_log.go
@@ -1,15 +1,19 @@
 package server
 
 import (
+	"crypto/md5"
 	"fmt"
 	"os"
 	"os/exec"
 	"os/user"
+	"regexp"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/s18log"
+	apilog "github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
@@ -161,4 +165,132 @@ func (repman *ReplicationManager) CheckAndRotateLog(logFile *lumberjack.Logger, 
 	} else {
 		fmt.Println("Log file is empty, no rotation performed.")
 	}
+}
+
+// ApiLogAdapter is a custom log adapter for http server using logrus
+// If suppress error enabled, it will suppress the log message if the hash is already written to the log more than MaxErrorWrite
+// The hash will be generated from the formatted message
+// The hash will be stored in the SuppressHashList
+// The hash will be reset after the ResetDuration
+type ApiLogAdapter struct {
+	logger           *apilog.Logger
+	SuppressError    bool                     // Suppress error after MaxErrorWrite
+	SuppressHashList map[string]*LogHashEntry // Suppress hash list
+	MaxErrorWrite    int                      // Maximum number of error write to log with same hash
+	ResetDuration    time.Duration            // Reset duration for hash list
+	DisregardPort    bool                     // Disregard port number, default is true
+}
+
+type LogHashEntry struct {
+	Hash      string
+	Printed   int
+	Timestamp time.Time
+}
+
+// NewApiLogAdapter creates a new ApiLogAdapter. Default setting is not to suppress error, with MaxErrorWrite of 5, and ResetDuration of 1 minute based on configuration
+// Default values:
+// SuppressError: false
+// MaxErrorWrite: 5
+// ResetDuration: 1 minutes
+// DisregardPort: true
+func NewApiLogAdapter(supress bool, limit, duration int, groupby bool) *ApiLogAdapter {
+	return &ApiLogAdapter{
+		logger:           apilog.New(),
+		SuppressError:    supress,
+		MaxErrorWrite:    limit,
+		SuppressHashList: make(map[string]*LogHashEntry),
+		ResetDuration:    time.Duration(duration) * time.Minute,
+		DisregardPort:    groupby,
+	}
+}
+
+func (la *ApiLogAdapter) SetOutput(w *os.File) {
+	la.logger.SetOutput(w)
+}
+
+func (la *ApiLogAdapter) SetFormatter(f apilog.Formatter) {
+	la.logger.SetFormatter(f)
+}
+
+func (la *ApiLogAdapter) SetLevel(l apilog.Level) {
+	la.logger.SetLevel(l)
+}
+
+func (la *ApiLogAdapter) SetSuppressError(b bool) {
+	la.SuppressError = b
+}
+
+func (la *ApiLogAdapter) SetMaxErrorWrite(n int) {
+	la.MaxErrorWrite = n
+}
+
+func (la *ApiLogAdapter) SetResetDuration(d time.Duration) {
+	la.ResetDuration = d
+}
+
+func (la *ApiLogAdapter) SetDisregardPort(b bool) {
+	la.DisregardPort = b
+}
+
+// stripPort checks if the message contains "error" and removes ports if found
+func stripPort(message string) string {
+
+	// Step 2: Remove ports from IP addresses and domain names
+	// Regex to match IPs or domains with ports
+	pattern := `\b((?:\d{1,3}\.){3}\d{1,3}|(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}):\d{1,5}\b`
+	re := regexp.MustCompile(pattern)
+
+	// Replace matched IPs/domains with ports removed
+	processedMessage := re.ReplaceAllString(message, "$1")
+
+	return processedMessage
+}
+
+// Write writes the log message to logger without any modification
+// If suppress error enabled, it will suppress the log message if the hash is already written to the log more than MaxErrorWrite
+// The hash will be generated from the formatted message
+// The hash will be stored in the SuppressHashList
+// The hash will be reset after the ResetDuration
+func (la *ApiLogAdapter) Write(p []byte) (n int, err error) {
+	message := string(p)
+
+	// Step 1: Check if the message contains "error" (case-insensitive)
+	if strings.Contains(strings.ToLower(message), "error") && la.SuppressError {
+		if la.DisregardPort {
+			message = stripPort(message)
+		}
+
+		md5hash := md5.New()
+		md5hash.Write([]byte(message))
+		md5sum := fmt.Sprintf("%x", md5hash.Sum(nil))
+
+		entry, ok := la.SuppressHashList[md5sum]
+		if ok {
+			n := entry.Printed
+
+			// Reset the counter if the duration is exceeded
+			if time.Since(entry.Timestamp) > la.ResetDuration {
+				entry.Printed = 0
+				entry.Timestamp = time.Now()
+			}
+
+			if n >= la.MaxErrorWrite {
+				return 0, nil
+			}
+		} else {
+			entry = &LogHashEntry{
+				Hash:      md5sum,
+				Printed:   0,
+				Timestamp: time.Now(),
+			}
+
+			la.SuppressHashList[md5sum] = entry
+		}
+
+		entry.Printed++
+	}
+
+	la.logger.Out.Write(p)
+
+	return len(p), nil
 }


### PR DESCRIPTION
This is to suppress error which flooding the stderr (this will flood journalctl)
TLS handshake error is common error log when the server restarted, since the certificate refreshed as well.

To suppress the error you need to set 
`api-error-suppress = true`

This will also address #536 