### PR TITLE
Don't add SSL parameters for Mariadb Server without SSL configurator tag

### DIFF
--- a/cluster/cluster_key.go
+++ b/cluster/cluster_key.go
@@ -118,7 +118,7 @@ func (cluster *Cluster) createKeys() error {
 	// start generate key
 	var notBefore time.Time
 	notBefore = time.Now()
-	notAfter := notBefore.Add(365 * 24 * time.Hour * 2)
+	notAfter := notBefore.Add(365 * 24 * time.Hour * 100)
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {

--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -800,7 +800,7 @@ func (server *ServerMonitor) GetSSLClientParam(tool string) string {
 	cluster := server.ClusterGroup
 	ver := cluster.VersionsMap.Get(tool)
 
-	if server.HasSSL() && !server.DBVersion.IsMariaDBGreater114() {
+	if server.HasSSL() && !server.DBVersion.IsMariaDBGreater113() {
 		cacertfile := cluster.Conf.HostsTLSCA
 		clicertfile := cluster.Conf.HostsTlsCliCert
 		clikeyfile := cluster.Conf.HostsTlsCliKey

--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -800,7 +800,7 @@ func (server *ServerMonitor) GetSSLClientParam(tool string) string {
 	cluster := server.ClusterGroup
 	ver := cluster.VersionsMap.Get(tool)
 
-	if server.HasSSL() && !server.DBVersion.IsMariaDBGreater113() {
+	if server.HasSSL() && cluster.Configurator.HaveDBTag("ssl") {
 		cacertfile := cluster.Conf.HostsTLSCA
 		clicertfile := cluster.Conf.HostsTlsCliCert
 		clikeyfile := cluster.Conf.HostsTlsCliKey

--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -800,7 +800,7 @@ func (server *ServerMonitor) GetSSLClientParam(tool string) string {
 	cluster := server.ClusterGroup
 	ver := cluster.VersionsMap.Get(tool)
 
-	if server.HasSSL() {
+	if server.HasSSL() && !server.DBVersion.IsMariaDBGreater114() {
 		cacertfile := cluster.Conf.HostsTLSCA
 		clicertfile := cluster.Conf.HostsTlsCliCert
 		clikeyfile := cluster.Conf.HostsTlsCliKey

--- a/utils/version/version.go
+++ b/utils/version/version.go
@@ -308,11 +308,11 @@ func (mv *Version) IsMySQLOrPerconaGreater84() bool {
 	return (mv.Flavor == "MySQL" || mv.Flavor == "Percona") && ((mv.Major == 8 && mv.Minor >= 4) || mv.Major > 8)
 }
 
-// IsMariaDBZeroConfigSSL checks if the version is MariaDB 11.4 or greater
-func (mv *Version) IsMariaDBGreater114() bool {
+// IsMariaDBGreater113 checks if the version is MariaDB 11.3 or greater which introduce breaking changes in SSL
+func (mv *Version) IsMariaDBGreater113() bool {
 	if mv == nil {
 		return false
 	}
 
-	return mv.Flavor == "MariaDB" && ((mv.Major == 11 && mv.Minor >= 4) || mv.Major > 11)
+	return mv.Flavor == "MariaDB" && ((mv.Major == 11 && mv.Minor >= 3) || mv.Major > 11)
 }

--- a/utils/version/version.go
+++ b/utils/version/version.go
@@ -290,6 +290,7 @@ func (mv *Version) IsMySQL57() bool {
 	return mv.Flavor == "MySQL" && mv.Major == 5 && mv.Minor > 6
 }
 
+// IsMySQLGreater57 checks if the version is MySQL or Percona 5.7 or greater
 func (mv *Version) IsMySQLOrPerconaGreater57() bool {
 	if mv == nil {
 		return false
@@ -298,10 +299,20 @@ func (mv *Version) IsMySQLOrPerconaGreater57() bool {
 	return (mv.Flavor == "MySQL" || mv.Flavor == "Percona") && ((mv.Major == 5 && mv.Minor > 6) || mv.Major > 5)
 }
 
+// IsMySQLOrPerconaGreater84 checks if the version is MySQL or Percona 8.4 or greater
 func (mv *Version) IsMySQLOrPerconaGreater84() bool {
 	if mv == nil {
 		return false
 	}
 
-	return (mv.Flavor == "MySQL" || mv.Flavor == "Percona") && ((mv.Major == 8 && mv.Minor > 4) || mv.Major > 8)
+	return (mv.Flavor == "MySQL" || mv.Flavor == "Percona") && ((mv.Major == 8 && mv.Minor >= 4) || mv.Major > 8)
+}
+
+// IsMariaDBZeroConfigSSL checks if the version is MariaDB 11.4 or greater
+func (mv *Version) IsMariaDBGreater114() bool {
+	if mv == nil {
+		return false
+	}
+
+	return mv.Flavor == "MariaDB" && ((mv.Major == 11 && mv.Minor >= 4) || mv.Major > 11)
 }


### PR DESCRIPTION
Don't add SSL parameters for Mariadb Server 11.3 and greater due to Zero Config SSL 