### PR TITLE
disable check errant transaction when master state is failed

### DIFF
--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -764,7 +764,7 @@ func (cluster *Cluster) IsSameWsrepUUID() bool {
 }
 
 func (cluster *Cluster) IsNotHavingMySQLErrantTransaction() bool {
-	if cluster.GetMaster() == nil {
+	if cluster.GetMaster() == nil || cluster.GetMaster().State == stateFailed {
 		// disable check if master is crashed as the slave can get more GTID events and so slave GTID is not ubset of masetr GTID
 		return true
 	}


### PR DESCRIPTION
## Contributor Agreement

By submitting this pull request, I agree to the terms outlined in the [Contributor Agreement](CONTRIBUTING.md).


The main fix addresses the issue where, if a failover is triggered while the database GTID is changing rapidly, the GTID of the slave node may become greater than that of the master node. In the current code, only the existence of the check object data in memory is verified, which prevents detecting the fact that the master has crashed. Therefore, an additional state check has been added to the check object data to determine whether the master has already failed.