### PR TITLE
Skip processing slow logs if the server is in a reseeding state

### DIFF
--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -580,6 +580,12 @@ func (server *ServerMonitor) GetSlowLogTable(wg *sync.WaitGroup) error {
 	if server.IsDown() {
 		return nil
 	}
+
+	// Skip if server is in reseeding (restore from backup) state
+	if server.HasAnyReseedingState() {
+		return nil
+	}
+
 	if !cluster.GetConf().MonitorQueries {
 		return nil
 	}


### PR DESCRIPTION
Skip processing slow logs from database table if the server is in a reseeding state to prevent deadlock