### PR TITLE
Prevent unwanted version change when adding new monitor

### DIFF
--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -309,6 +309,11 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxServerAdd)),
 	))
 
+	router.Handle("/api/clusters/{clusterName}/actions/addserver/{host}/{port}/{type}/{tag}", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxServerAdd)),
+	))
+
 	router.Handle("/api/clusters/{clusterName}/actions/dropserver/{host}/{port}", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxServerDrop)),
@@ -4072,14 +4077,18 @@ func (repman *ReplicationManager) handlerMuxSettingsReload(w http.ResponseWriter
 // @Param host path string true "Host"
 // @Param port path string true "Port"
 // @Param type path string false "Type"
+// @Param tag path string false "Tag"
 // @Success 200 {string} string "Monitor added"
 // @Failure 403 {string} string "No valid ACL"
 // @Failure 409 {string} string "Error adding new monitor"
 // @Failure 500 {string} string "Cluster Not Found"
+// @Router /api/clusters/{clusterName}/actions/addserver/{host}/{port}/{type}/{tag} [post]
 // @Router /api/clusters/{clusterName}/actions/addserver/{host}/{port}/{type} [post]
 // @Router /api/clusters/{clusterName}/actions/addserver/{host}/{port} [post]
 func (repman *ReplicationManager) handlerMuxServerAdd(w http.ResponseWriter, r *http.Request) {
 	var err error
+	var updateImg bool
+	var repopath, repoimg string
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Content-Type", "application/json")
 	vars := mux.Vars(r)
@@ -4094,16 +4103,74 @@ func (repman *ReplicationManager) handlerMuxServerAdd(w http.ResponseWriter, r *
 		if vars["type"] == "" {
 			err = mycluster.AddSeededServer(vars["host"] + ":" + vars["port"])
 		} else {
-			if mycluster.MonitorType[vars["type"]] == "proxy" {
+			repopath = repman.GetDockerRepoPath(vars["type"])
+
+			if repman.MonitorType[vars["type"]] == "proxy" {
+				// update image if tag is not empty
+				if vars["tag"] != "" {
+					updateImg = true
+
+					// check if repository list is exists
+					repoimg = repman.GetDockerRepoImage(vars["type"], vars["tag"])
+
+					if repoimg == "" && repopath == "" {
+						mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Repository path not found for proxy %s. Skipping proxy image update", vars["type"])
+						updateImg = false
+					} else if repopath != "" {
+						mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Repository image with tag %s not found for proxy %s. Changing to the latest tag.", vars["tag"], vars["type"])
+						repoimg = repopath + ":latest"
+					}
+
+					// update image
+					if updateImg {
+						switch vars["type"] {
+						case config.ConstProxyHaproxy:
+							mycluster.Conf.ProvProxHaproxyImg = repoimg
+						case config.ConstProxySqlproxy:
+							mycluster.Conf.ProvProxProxysqlImg = repoimg
+						case config.ConstProxyMaxscale:
+							mycluster.Conf.ProvProxMaxscaleImg = repoimg
+						case config.ConstProxySphinx:
+							mycluster.Conf.ProvSphinxImg = repoimg
+						}
+					}
+				}
 				err = mycluster.AddSeededProxy(vars["type"], vars["host"], vars["port"], "", "")
-			} else if mycluster.MonitorType[vars["type"]] == "database" {
-				switch vars["type"] {
-				case "mariadb":
-					mycluster.Conf.ProvDbImg = "mariadb:latest"
-				case "percona":
-					mycluster.Conf.ProvDbImg = "percona:latest"
-				case "mysql":
-					mycluster.Conf.ProvDbImg = "mysql:latest"
+			} else if repman.MonitorType[vars["type"]] == "database" {
+				// Check if new database repo is different with current repo
+				oldrepopath := strings.Split(mycluster.Conf.ProvDbImg, ":")[0]
+				if oldrepopath != repopath {
+					updateImg = true
+
+					// if no tag, use the latest version
+					if vars["tag"] == "" {
+						vars["tag"] = "latest"
+					}
+				}
+
+				if vars["tag"] != "" {
+					updateImg = true
+					repoimg = repman.GetDockerRepoImage(vars["type"], vars["tag"])
+
+					if repoimg == "" && repopath == "" {
+						mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Repository path not found for database %s. Skipping database image update", vars["type"])
+						updateImg = false
+					} else if repopath != "" {
+						mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Repository image with tag %s not found for database %s. Changing to the latest tag.", vars["tag"], vars["type"])
+						repoimg = repopath + ":latest"
+					}
+				}
+
+				// update image
+				if updateImg {
+					switch vars["type"] {
+					case "mariadb":
+						mycluster.Conf.ProvDbImg = repoimg
+					case "percona":
+						mycluster.Conf.ProvDbImg = repoimg
+					case "mysql":
+						mycluster.Conf.ProvDbImg = repoimg
+					}
 				}
 				err = mycluster.AddSeededServer(vars["host"] + ":" + vars["port"])
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -99,6 +99,7 @@ type ReplicationManager struct {
 	CommandLineFlag                                  []string                    `json:"-"`
 	ConfigPathList                                   []string                    `json:"-"`
 	Logs                                             s18log.HttpLog              `json:"logs"`
+	MonitorType                                      map[string]string           `json:"monitorType"`
 	ServicePlans                                     []config.ServicePlan        `json:"servicePlans"`
 	ServiceOrchestrators                             []config.ConfigVariableType `json:"serviceOrchestrators"`
 	ServiceAcl                                       []config.Grant              `json:"serviceAcl"`
@@ -1953,6 +1954,7 @@ func (repman *ReplicationManager) Run() error {
 	repman.InitGrants()
 	repman.InitRoles()
 	repman.ReloadTerms()
+	repman.MonitorType = config.GetMonitorType()
 	repman.ServiceRepos, err = repman.Conf.GetDockerRepos(repman.Conf.ShareDir+"/repo/repos.json", repman.Conf.Test)
 	if err != nil {
 		repman.Logrus.WithError(err).Errorf("Initialization docker repo failed: %s %s", repman.Conf.ShareDir+"/repo/repos.json", err)

--- a/server/server_get.go
+++ b/server/server_get.go
@@ -18,6 +18,30 @@ func (repman *ReplicationManager) getClusterByName(clname string) *cluster.Clust
 	return c
 }
 
+func (repman *ReplicationManager) GetDockerRepoPath(reponame string) string {
+	for _, c := range repman.ServiceRepos {
+		if c.Name == reponame {
+			return c.Image
+		}
+	}
+
+	return ""
+}
+
+func (repman *ReplicationManager) GetDockerRepoImage(reponame string, version string) string {
+	for _, c := range repman.ServiceRepos {
+		if c.Name == reponame {
+			for _, v := range c.Tags.Results {
+				if v.Name == version {
+					return c.Image + ":" + v.Name
+				}
+			}
+		}
+	}
+
+	return ""
+}
+
 // func (repman *ReplicationManager) GenerateKey(conf *config.Config) error {
 // 	var err error
 // 	_, err = os.Stat(conf.MonitoringKeyPath)

--- a/share/dashboard_react/src/components/Modals/NewServerModal.jsx
+++ b/share/dashboard_react/src/components/Modals/NewServerModal.jsx
@@ -12,8 +12,8 @@ import {
   ModalOverlay,
   Stack
 } from '@chakra-ui/react'
-import React, { useState } from 'react'
-import { useDispatch } from 'react-redux'
+import React, { useEffect, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import { addServer } from '../../redux/clusterSlice'
 import Dropdown from '../Dropdown'
 import RMButton from '../RMButton'
@@ -23,12 +23,42 @@ import parentStyles from './styles.module.scss'
 function NewServerModal({ clusterName, isOpen, closeModal }) {
   const dispatch = useDispatch()
   const { theme } = useTheme()
+  const { globalClusters: { monitor } } = useSelector((state) => state)
   const [host, setHost] = useState('')
   const [port, setPort] = useState(0)
   const [monitorType, setMonitorType] = useState('')
+  const [tag, setTag] = useState('')
+  const [serviceRepos, setServiceRepos] = useState([])
+  const [tagOptions, setTagOptions] = useState([])
   const [hostError, setHostError] = useState('')
   const [portError, setPortError] = useState('')
-  const [monitorTypeError, setMonitorTypeError] = useState('')
+
+  useEffect(() => {
+    if (monitor?.serviceRepos?.length > 0) {
+      const repos = monitor?.serviceRepos.map(entry => ({
+        name: entry.name,
+        image: entry.image,
+        options: entry.tags?.results?.map(tag => ({
+          name: tag.name,
+          value: `${entry.image}:${tag.name}`
+        }))
+      }))
+
+      setServiceRepos(repos)
+    }
+  }, [monitor?.serviceRepos])
+
+  const fillVersionDropdown = (selectedType) => {
+    setMonitorType(selectedType)
+    setTag('')
+    
+    let repolist = selectedType
+    if (repolist === 'shardproxy') {
+      repolist = 'mariadb'
+    }
+    const repo = serviceRepos.find((r) => r.name === repolist)
+    setTagOptions(repo?.options || [])
+  }
 
   const handleCreateNewServer = () => {
     setHostError('')
@@ -44,12 +74,7 @@ function NewServerModal({ clusterName, isOpen, closeModal }) {
       return
     }
 
-    if (!monitorType) {
-      setMonitorTypeError('Monitor type is required')
-      return
-    }
-
-    dispatch(addServer({ clusterName, host, port, monitorType }))
+    dispatch(addServer({ clusterName, host, port, monitorType, tag }))
     closeModal()
   }
 
@@ -71,13 +96,13 @@ function NewServerModal({ clusterName, isOpen, closeModal }) {
               <Input id='port' type='number' isRequired={true} value={port} onChange={(e) => setPort(e.target.value)} />
               <FormErrorMessage>{portError}</FormErrorMessage>
             </FormControl>
-            <FormControl isInvalid={monitorTypeError}>
+            <FormControl>
               <FormLabel htmlFor='monitorType'>Monitor type</FormLabel>
               <Dropdown
                 id='monitorType'
                 isMenuPortalTarget={false}
                 onChange={(option) => {
-                  setMonitorType(option.value)
+                  fillVersionDropdown(option.value)
                 }}
                 options={[
                   { name: 'MariaDB', value: 'mariadb' },
@@ -91,7 +116,17 @@ function NewServerModal({ clusterName, isOpen, closeModal }) {
                   { name: 'VIP', value: 'extvip' }
                 ]}
               />
-              <FormErrorMessage>{monitorTypeError}</FormErrorMessage>
+            </FormControl>
+            <FormControl >
+              <FormLabel htmlFor='tag'>Docker Version</FormLabel>
+              <Dropdown
+                id='tag'
+                isMenuPortalTarget={false}
+                onChange={(option) => {
+                  setTag(option.value)
+                }}
+                options={tagOptions}
+              />
             </FormControl>
           </Stack>
         </ModalBody>

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -225,10 +225,10 @@ export const toggleTraffic = createAsyncThunk('cluster/toggleTraffic', async ({ 
 
 export const addServer = createAsyncThunk(
   'cluster/addServer',
-  async ({ clusterName, host, port, monitorType }, thunkAPI) => {
+  async ({ clusterName, host, port, monitorType, tag }, thunkAPI) => {
     try {
       const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
-      const { data, status } = await clusterService.addServer(clusterName, host, port, monitorType, baseURL)
+      const { data, status } = await clusterService.addServer(clusterName, host, port, monitorType, tag, baseURL)
       showSuccessBanner('New server added!', status, thunkAPI)
       return { data, status }
     } catch (error) {

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -182,8 +182,14 @@ function toggleTraffic(clusterName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/settings/actions/switch/database-heartbeat`)
 }
 
-function addServer(clusterName, host, port, monitorType, baseURL) {
-  return getApi(baseURL).get(`clusters/${clusterName}/actions/addserver/${host}/${port}/${monitorType}`)
+function addServer(clusterName, host, port, monitorType, tag, baseURL) {
+  if (!monitorType) {
+    return getApi(baseURL).get(`clusters/${clusterName}/actions/addserver/${host}/${port}`)
+  } else if (!tag) {
+    return getApi(baseURL).get(`clusters/${clusterName}/actions/addserver/${host}/${port}/${monitorType}`)
+  } else {
+    return getApi(baseURL).get(`clusters/${clusterName}/actions/addserver/${host}/${port}/${monitorType}/${tag}`)
+  }
 }
 
 function dropServer(clusterName, host, port, baseURL) {
@@ -426,60 +432,60 @@ function runRegressionTests(clusterName, testName, baseURL) {
 
 //#region User management APIs
 function addUser(clusterName, username, grants, roles, baseURL) {
-  return getApi(baseURL).post(`clusters/${clusterName}/users/add`, {username, grants, roles})
+  return getApi(baseURL).post(`clusters/${clusterName}/users/add`, { username, grants, roles })
 }
 
 function updateGrants(clusterName, username, grants, roles, baseURL) {
-  return getApi(baseURL).post(`clusters/${clusterName}/users/update`, {username, grants, roles})
+  return getApi(baseURL).post(`clusters/${clusterName}/users/update`, { username, grants, roles })
 }
 
 function dropUser(clusterName, username, baseURL) {
-  return getApi(baseURL).post(`clusters/${clusterName}/users/drop`, {username})
+  return getApi(baseURL).post(`clusters/${clusterName}/users/drop`, { username })
 }
 
 function sendCredentials(clusterName, username, type, baseURL) {
-  return getApi(baseURL).post(`clusters/${clusterName}/users/send-credentials`,{username, type})
+  return getApi(baseURL).post(`clusters/${clusterName}/users/send-credentials`, { username, type })
 }
 
 //#Peer subscription APIs
 function clusterSubscribe(username, password, clusterName, baseURL) {
-  return getApi(baseURL).post(`clusters/${clusterName}/subscribe`,{username, password})
+  return getApi(baseURL).post(`clusters/${clusterName}/subscribe`, { username, password })
 }
 
 function clusterUnsubscribe(username, clusterName, baseURL) {
-  return getApi(baseURL).post(`clusters/${clusterName}/unsubscribe`,{username})
+  return getApi(baseURL).post(`clusters/${clusterName}/unsubscribe`, { username })
 }
 
 function acceptSubscription(clusterName, username, baseURL) {
-  return getApi(baseURL).post(`clusters/${clusterName}/sales/accept-subscription`,{username})
+  return getApi(baseURL).post(`clusters/${clusterName}/sales/accept-subscription`, { username })
 }
 
 function rejectSubscription(clusterName, username, baseURL) {
-  return getApi(baseURL).post(`clusters/${clusterName}/sales/refuse-subscription`,{username})
+  return getApi(baseURL).post(`clusters/${clusterName}/sales/refuse-subscription`, { username })
 }
 
 function endSubscription(clusterName, username, baseURL) {
-  return getApi(baseURL).post(`clusters/${clusterName}/sales/end-subscription`,{username})
+  return getApi(baseURL).post(`clusters/${clusterName}/sales/end-subscription`, { username })
 }
 
 function subscribeExternalRole(clusterName, username, roles, baseURL) {
-  return getApi(baseURL).post(`clusters/${clusterName}/ext-role/subscribe`, {username, roles})
+  return getApi(baseURL).post(`clusters/${clusterName}/ext-role/subscribe`, { username, roles })
 }
 
 function quoteExternalRole(clusterName, username, roles, cost, baseURL) {
-  return getApi(baseURL).post(`clusters/${clusterName}/ext-role/quote`, {username, roles, cost})
+  return getApi(baseURL).post(`clusters/${clusterName}/ext-role/quote`, { username, roles, cost })
 }
 
 function acceptExternalRole(clusterName, username, roles, baseURL) {
-  return getApi(baseURL).post(`clusters/${clusterName}/ext-role/accept`, {username, roles})
+  return getApi(baseURL).post(`clusters/${clusterName}/ext-role/accept`, { username, roles })
 }
 
 function refuseExternalRole(clusterName, username, roles, reason, baseURL) {
-  return getApi(baseURL).post(`clusters/${clusterName}/ext-role/refuse`, {username, roles, reason})
+  return getApi(baseURL).post(`clusters/${clusterName}/ext-role/refuse`, { username, roles, reason })
 }
 
 function endExternalRole(clusterName, username, roles, reason, baseURL) {
-  return getApi(baseURL).post(`clusters/${clusterName}/ext-role/end`, {username, roles, reason})
+  return getApi(baseURL).post(`clusters/${clusterName}/ext-role/end`, { username, roles, reason })
 }
 
 //#endregion User management APIs


### PR DESCRIPTION
Previously new server monitor will auto change to latest docker when added. This might lead to wrong version when initiate provision.

By skipping config change if no tag change, it will retain the correct version.

Additionally if tag is selected, we can use the selected tag as the new version (since we do not record separate provisioning config for docker version each db node)