### PR TITLE
Enhance staging refresh and automate proxy backend detection. Use replication manager functions if no refresh script

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -684,7 +684,7 @@ func (cluster *Cluster) Run() {
 						if cluster.StateMachine.SchemaMonitorEndTime+60 < time.Now().Unix() && !cluster.StateMachine.IsInSchemaMonitor() {
 							go cluster.MonitorSchema()
 						}
-						if cluster.Conf.TestInjectTraffic || cluster.Conf.AutorejoinSlavePositionalHeartbeat || cluster.Conf.MonitorWriteHeartbeat {
+						if cluster.Conf.TestInjectTraffic || cluster.Conf.TestInjectTrafficStaging || cluster.Conf.AutorejoinSlavePositionalHeartbeat || cluster.Conf.MonitorWriteHeartbeat {
 							cluster.InjectProxiesTraffic()
 						}
 						if cluster.StateMachine.GetHeartbeats()%30 == 0 {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -117,6 +117,7 @@ type Cluster struct {
 	IsExportPush                  bool                   `json:"isExportPush"`
 	IsAlertDisable                bool                   `json:"isAlertDisable"`
 	IsRefreshStaging              bool                   `json:"isRefreshStaging"`
+	IsNeedStagingChange           bool                   `json:"isNeedStagingChange"`
 	Conf                          *config.Config         `json:"config"`
 	Confs                         *config.ConfVersion    `json:"-"`
 	CleanAll                      bool                   `json:"cleanReplication"` //used in testing

--- a/cluster/cluster_acl.go
+++ b/cluster/cluster_acl.go
@@ -573,6 +573,12 @@ func (cluster *Cluster) IsURLPassProxiesACL(strUser string, URL string) bool {
 			return true
 		}
 	}
+	if cluster.APIUsers[strUser].Grants[config.GrantClusterStaging] {
+		if strings.Contains(URL, "/actions/staging") {
+			return true
+		}
+	}
+
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "ACL proxy check failed for user %s : %s ", strUser, URL)
 
 	return false

--- a/cluster/cluster_bash.go
+++ b/cluster/cluster_bash.go
@@ -66,6 +66,7 @@ func (cluster *Cluster) BashScriptDbServersChangeState(srv *ServerMonitor, newSt
 
 		cluster.StagingServer = srv          // Set the new staging server as the new staging server
 		cluster.StagingServer.SetReadWrite() // Set the new staging server to read write for proxysql read-only checks
+		cluster.IsRefreshStaging = false
 
 		cluster.PostDetachStaging(srv.Host, srv.Port, newState, oldState)
 	}

--- a/cluster/cluster_bash.go
+++ b/cluster/cluster_bash.go
@@ -64,14 +64,17 @@ func (cluster *Cluster) BashScriptDbServersChangeState(srv *ServerMonitor, newSt
 	if cluster.IsRefreshStaging && cluster.IsNeedStagingChange && newState == stateUnconn && srv != cluster.StagingServer {
 
 		if cluster.Conf.TopologyStagingPostDetachScript != "" {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Calling staging post detach script")
 			cluster.PostDetachStaging(srv.Host, srv.Port, newState, oldState)
 		} else {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "No staging post detach script. Using default")
 			cluster.StagingServer.SetReadOnly() // Set the old staging server to read only
 
 			cluster.StagingServer = srv          // Set the new staging server as the new staging server
 			cluster.StagingServer.SetReadWrite() // Set the new staging server to read write for proxysql read-only checks
-			cluster.IsNeedStagingChange = false
 		}
+
+		cluster.IsNeedStagingChange = false // Reset the flag to avoid multiple calls
 	}
 
 	if cluster.Conf.DbServersChangeStateScript != "" {

--- a/cluster/cluster_bash.go
+++ b/cluster/cluster_bash.go
@@ -62,6 +62,11 @@ func (cluster *Cluster) BashScriptCloseSate(state state.State) error {
 
 func (cluster *Cluster) BashScriptDbServersChangeState(srv *ServerMonitor, newState string, oldState string) error {
 	if cluster.IsRefreshStaging && cluster.Conf.TopologyStagingPostDetachScript != "" && newState == stateUnconn && srv != cluster.StagingServer {
+		cluster.StagingServer.SetReadOnly() // Set the old staging server to read only
+
+		cluster.StagingServer = srv          // Set the new staging server as the new staging server
+		cluster.StagingServer.SetReadWrite() // Set the new staging server to read write for proxysql read-only checks
+
 		cluster.PostDetachStaging(srv.Host, srv.Port, newState, oldState)
 	}
 

--- a/cluster/cluster_bash.go
+++ b/cluster/cluster_bash.go
@@ -61,14 +61,17 @@ func (cluster *Cluster) BashScriptCloseSate(state state.State) error {
 }
 
 func (cluster *Cluster) BashScriptDbServersChangeState(srv *ServerMonitor, newState string, oldState string) error {
-	if cluster.IsRefreshStaging && cluster.Conf.TopologyStagingPostDetachScript != "" && newState == stateUnconn && srv != cluster.StagingServer {
-		cluster.StagingServer.SetReadOnly() // Set the old staging server to read only
+	if cluster.IsRefreshStaging && cluster.IsNeedStagingChange && newState == stateUnconn && srv != cluster.StagingServer {
 
-		cluster.StagingServer = srv          // Set the new staging server as the new staging server
-		cluster.StagingServer.SetReadWrite() // Set the new staging server to read write for proxysql read-only checks
-		cluster.IsRefreshStaging = false
+		if cluster.Conf.TopologyStagingPostDetachScript != "" {
+			cluster.PostDetachStaging(srv.Host, srv.Port, newState, oldState)
+		} else {
+			cluster.StagingServer.SetReadOnly() // Set the old staging server to read only
 
-		cluster.PostDetachStaging(srv.Host, srv.Port, newState, oldState)
+			cluster.StagingServer = srv          // Set the new staging server as the new staging server
+			cluster.StagingServer.SetReadWrite() // Set the new staging server to read write for proxysql read-only checks
+			cluster.IsNeedStagingChange = false
+		}
 	}
 
 	if cluster.Conf.DbServersChangeStateScript != "" {

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -271,6 +271,10 @@ func (cluster *Cluster) GetTraffic() bool {
 	return cluster.Conf.TestInjectTraffic
 }
 
+func (cluster *Cluster) GetTrafficStaging() bool {
+	return cluster.Conf.TestInjectTrafficStaging
+}
+
 func (cluster *Cluster) GetClusterName() string {
 	return cluster.Name
 }

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -556,6 +556,10 @@ func (cluster *Cluster) SetTraffic(traffic bool) {
 	cluster.Conf.TestInjectTraffic = traffic
 }
 
+func (cluster *Cluster) SetTrafficStaging(traffic bool) {
+	cluster.Conf.TestInjectTrafficStaging = traffic
+}
+
 func (cluster *Cluster) SetBenchMethod(m string) {
 	cluster.benchmarkType = m
 }

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -55,6 +55,10 @@ func (cluster *Cluster) RefreshStaging() error {
 		return nil
 	}
 
+	if cluster.IsRefreshStaging {
+		return nil
+	}
+
 	if cluster.StagingServer == nil {
 		for _, srv := range cluster.Servers {
 			if srv.State == stateUnconn {
@@ -64,6 +68,7 @@ func (cluster *Cluster) RefreshStaging() error {
 		}
 	}
 
+	cluster.IsNeedStagingChange = true
 	cluster.IsRefreshStaging = true
 	defer func() {
 		cluster.IsRefreshStaging = false
@@ -125,13 +130,6 @@ func (cluster *Cluster) RefreshStaging() error {
 	}
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModExternalScript, config.LvlInfo, "Refresh staging completed")
-
-	for _, srv := range cluster.Servers {
-		if srv.State == stateUnconn {
-			cluster.StagingServer = srv
-			break
-		}
-	}
 
 	return nil
 }

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -69,6 +69,17 @@ func (cluster *Cluster) RefreshStaging() error {
 		}
 	}
 
+	bcksrv := cluster.GetBackupServer()
+	if bcksrv != nil && !bcksrv.HasBackupLogicalCookie() {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Current master has no backup. Create logical backup for refresh staging on %s", bcksrv.URL)
+
+		err = bcksrv.JobBackupLogical()
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "Create logical backup for refresh staging on %s failed: %s", bcksrv.URL, err)
+			return err
+		}
+	}
+
 	cluster.IsNeedStagingChange = true
 	cluster.IsRefreshStaging = true
 	defer func() {

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -1,10 +1,13 @@
 package cluster
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/share"
@@ -46,9 +49,7 @@ func (cluster *Cluster) ReloadStagingScript() error {
 }
 
 func (cluster *Cluster) RefreshStaging() error {
-	var script string
-
-	filename := "staging_refresh.sh"
+	var err error
 
 	if !cluster.Conf.TopologyStaging {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModExternalScript, config.LvlInfo, "Refresh staging not enabled")
@@ -76,21 +77,186 @@ func (cluster *Cluster) RefreshStaging() error {
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModExternalScript, config.LvlInfo, "Refresh staging initiated")
 
-	script = cluster.Conf.TopologyStagingRefreshScript
-	if cluster.Conf.TopologyStagingRefreshScript == "" {
-		script = cluster.Conf.WorkingDir + "/" + cluster.Name + "/" + filename
+	if cluster.Conf.TopologyStagingRefreshScript != "" {
+		return cluster.RefreshStagingScript()
+	}
 
-		if _, err := os.Stat(script); os.IsNotExist(err) {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModExternalScript, config.LvlInfo, "Staging script not found, reloading")
-			err := cluster.ReloadStagingScript()
-			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModExternalScript, config.LvlErr, "Error reloading staging script. %s", err)
+	NB_SLAVES := len(cluster.GetSlaves())
+
+	if NB_SLAVES == 2 {
+		STG := cluster.GetSlaveByIndex(0)
+
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Refresh staging initiated")
+
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Stopping slave %s replication", STG.Name)
+		STG.StopSlave()
+
+		// Wait until the slave is stopped
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Waiting for slave %s to stop replication", STG.URL)
+		waitstart := time.Now()
+		for STG.State == stateSlave {
+			if waitstart.Add(10 * time.Second).Before(time.Now()) {
+				err = fmt.Errorf("timeout waiting for slave %s to stop replication", STG.URL)
 				return err
 			}
+
+			time.Sleep(1 * time.Second)
+		}
+
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Slave %s replication stopped", STG.URL)
+
+		fileio, err := os.OpenFile(STG.Datadir+"/replications.json", os.O_RDWR|os.O_CREATE, 0644)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Error opening replication info file: %s", err)
+		} else {
+			defer fileio.Close()
+			encoder := json.NewEncoder(fileio)
+			encoder.SetIndent("", "\t")
+			err = encoder.Encode(STG.Replications)
+			if err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Error encoding replication info: %s", err)
+			} else {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Replication info saved to %s", fileio.Name())
+			}
+		}
+
+		_, err = STG.ResetSlave()
+		if err != nil {
+			return err
+		}
+
+		waitstart = time.Now()
+		for STG.State != stateUnconn {
+			if waitstart.Add(10 * time.Second).Before(time.Now()) {
+				err = fmt.Errorf("timeout waiting for slave %s to be reset", STG.URL)
+				return err
+			}
+
+			time.Sleep(1 * time.Second)
+		}
+
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Slave %s is now STANDALONE", STG.URL)
+	} else if NB_SLAVES == 1 {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Picking a slave and standalone")
+
+		STG := cluster.StagingServer
+		if STG == nil {
+			STG, err = cluster.GetStandaloneServerByIndex(0)
+			if err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Error getting standalone server: %s", err)
+				return err
+			}
+		}
+
+		if STG == nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "No standalone server found")
+			return fmt.Errorf("no standalone server found")
+		}
+
+		SL := cluster.GetSlaveByIndex(0)
+		if SL == nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "No slave server found")
+			return fmt.Errorf("no slave server found")
+		}
+
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Switching staging from STANDALONE %s to SLAVE %s", STG.URL, SL.URL)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Stopping slave %s replication", SL.URL)
+
+		SL.StopSlave()
+
+		// Wait until the slave is stopped
+		waitstart := time.Now()
+		for SL.State == stateSlave {
+			if waitstart.Add(10 * time.Second).Before(time.Now()) {
+				err = fmt.Errorf("timeout waiting for slave %s to stop replication", SL.URL)
+				return err
+			}
+
+			time.Sleep(1 * time.Second)
+		}
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Slave %s replication stopped", SL.URL)
+
+		fileio, err := os.OpenFile(SL.Datadir+"/replications.json", os.O_RDWR|os.O_CREATE, 0644)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Error opening replication info file: %s", err)
+		} else {
+			defer fileio.Close()
+			encoder := json.NewEncoder(fileio)
+			encoder.SetIndent("", "\t")
+			err = encoder.Encode(SL.Replications)
+			if err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Error encoding replication info: %s", err)
+			} else {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Replication info saved to %s", fileio.Name())
+			}
+		}
+
+		_, err = SL.ResetSlave()
+		if err != nil {
+			return err
+		}
+
+		waitstart = time.Now()
+		for SL.State != stateUnconn {
+			if waitstart.Add(10 * time.Second).Before(time.Now()) {
+				err = fmt.Errorf("timeout waiting for slave %s to be reset", SL.URL)
+				return err
+			}
+
+			time.Sleep(1 * time.Second)
+		}
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Slave %s is now STANDALONE", SL.URL)
+
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Restoring STANDALONE %s as SLAVE", STG.URL)
+
+		// Set as read only
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Setting STANDALONE %s to read only", STG.URL)
+		STG.SetReadOnly()
+
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Resetting master position on standalone %s", STG.URL)
+		_, err = STG.ResetMaster()
+		if err != nil {
+			return err
+		}
+
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Reseed standalone %s", STG.URL)
+
+		err = STG.JobReseedLogicalBackup("default")
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "Reseed logical for refresh staging on %s failed: %s", STG.URL, err)
+			return err
+		}
+
+		waitstart = time.Now()
+		for STG.State != stateSlave {
+			if waitstart.Add(10 * time.Second).Before(time.Now()) {
+				err = fmt.Errorf("timeout waiting for standalone %s to be reseeded", STG.URL)
+				return err
+			}
+
+			time.Sleep(1 * time.Second)
+		}
+
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Standalone %s is now a slave", STG.URL)
+
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Refresh staging completed")
+	}
+
+	return nil
+}
+
+func (cluster *Cluster) RefreshStagingScript() error {
+	script := cluster.Conf.TopologyStagingRefreshScript
+
+	if _, err := os.Stat(script); os.IsNotExist(err) {
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModExternalScript, config.LvlErr, "Error checking script %s: %s", script, err)
+			return err
 		}
 	}
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModExternalScript, config.LvlInfo, "Run refresh staging script %s", script)
+
 	cmd := exec.Command(script)
 	cmd.Env = cluster.GetExecEnv()
 	stdoutIn, err := cmd.StdoutPipe()
@@ -129,7 +295,7 @@ func (cluster *Cluster) RefreshStaging() error {
 		return err
 	}
 
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModExternalScript, config.LvlInfo, "Refresh staging completed")
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModExternalScript, config.LvlInfo, "Refresh staging script completed")
 
 	return nil
 }

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -3,10 +3,12 @@ package cluster
 import (
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/share"
+	"github.com/signal18/replication-manager/utils/misc"
 )
 
 func (cluster *Cluster) ReloadStagingScript() error {
@@ -171,4 +173,42 @@ func (cluster *Cluster) PostDetachStaging(host, port, newstate, oldstate string)
 		}
 	}
 	return nil
+}
+
+func (cluster *Cluster) AddProxyToStagingHosts(prx DatabaseProxy) {
+	prx.SetStaging(true)
+
+	if cluster.Conf.StagingProxyHosts == "" {
+		cluster.Conf.StagingProxyHosts = prx.GetName()
+	} else {
+		cluster.Conf.StagingProxyHosts = cluster.Conf.StagingProxyHosts + "," + prx.GetName()
+	}
+}
+
+func (cluster *Cluster) DelProxyFromStagingHosts(prx DatabaseProxy) {
+	prx.SetStaging(false)
+
+	// Remove from staging hosts
+	cluster.Conf.StagingProxyHosts = misc.RemoveFromList(cluster.Conf.StagingProxyHosts, prx.GetName())
+}
+
+func (cluster *Cluster) GetStagingProxyHosts() []string {
+	if cluster.Conf.StagingProxyHosts == "" {
+		return []string{}
+	}
+	return strings.Split(cluster.Conf.StagingProxyHosts, ",")
+}
+
+func (cluster *Cluster) IsProxyInStagingList(proxyHost string) bool {
+	if cluster.Conf.StagingProxyHosts == "" {
+		return false
+	}
+
+	for _, host := range strings.Split(cluster.Conf.StagingProxyHosts, ",") {
+		if proxyHost == host {
+			return true
+		}
+	}
+
+	return false
 }

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -176,6 +176,10 @@ func (cluster *Cluster) PostDetachStaging(host, port, newstate, oldstate string)
 }
 
 func (cluster *Cluster) AddProxyToStagingHosts(prx DatabaseProxy) {
+	if prx == nil {
+		return
+	}
+
 	prx.SetStaging(true)
 
 	if cluster.Conf.StagingProxyHosts == "" {
@@ -197,18 +201,4 @@ func (cluster *Cluster) GetStagingProxyHosts() []string {
 		return []string{}
 	}
 	return strings.Split(cluster.Conf.StagingProxyHosts, ",")
-}
-
-func (cluster *Cluster) IsProxyInStagingList(proxyHost string) bool {
-	if cluster.Conf.StagingProxyHosts == "" {
-		return false
-	}
-
-	for _, host := range strings.Split(cluster.Conf.StagingProxyHosts, ",") {
-		if proxyHost == host {
-			return true
-		}
-	}
-
-	return false
 }

--- a/cluster/cluster_tgl.go
+++ b/cluster/cluster_tgl.go
@@ -453,6 +453,10 @@ func (cluster *Cluster) SwitchTraffic() {
 	cluster.SetTraffic(!cluster.GetTraffic())
 }
 
+func (cluster *Cluster) SwitchTrafficStaging() {
+	cluster.SetTrafficStaging(!cluster.GetTrafficStaging())
+}
+
 func (cluster *Cluster) SwitchDelayStatCapture() {
 	cluster.Conf.DelayStatCapture = !cluster.Conf.DelayStatCapture
 	if !cluster.Conf.DelayStatCapture {

--- a/cluster/prx.go
+++ b/cluster/prx.go
@@ -137,6 +137,7 @@ type DatabaseProxy interface {
 	SetDataDir()
 	SetServiceName(namespace string)
 	SetStaging(staging bool)
+	IsInStaging() bool
 
 	SetProvisionCookie() error
 	SetUnprovisionCookie() error
@@ -258,9 +259,36 @@ func (cluster *Cluster) newProxyList() error {
 func (cluster *Cluster) InjectProxiesTraffic() {
 	var definer string
 	// Found server from ServerId
-	if cluster.GetMaster() != nil {
+	if cluster.Conf.TopologyStaging && cluster.Conf.TestInjectTrafficStaging {
 		for _, pr := range cluster.Proxies {
-			if pr.GetType() == config.ConstProxySphinx || pr.GetType() == config.ConstProxyMyProxy {
+			if pr.GetType() == config.ConstProxySphinx || pr.GetType() == config.ConstProxyMyProxy || !pr.IsInStaging() { // Traffic for staging only
+				// Does not yet understand CREATE OR REPLACE VIEW
+				continue
+			}
+			db, err := pr.GetClusterConnection()
+			if err != nil {
+				cluster.SetState("ERR00050", state.State{ErrType: "ERROR", ErrDesc: fmt.Sprintf(clusterError["ERR00050"], err), ErrFrom: "TOPO"})
+			} else {
+				if pr.GetType() == config.ConstProxyMyProxy {
+					definer = "DEFINER = root@localhost"
+				} else {
+					definer = ""
+				}
+				_, err := db.Exec("CREATE OR REPLACE " + definer + " VIEW replication_manager_schema.pseudo_gtid_v as select '" + misc.GetUUID() + "' from dual")
+
+				if err != nil {
+					cluster.SetState("ERR00050", state.State{ErrType: "ERROR", ErrDesc: fmt.Sprintf(clusterError["ERR00050"], err), ErrFrom: "TOPO"})
+					db.Exec("CREATE DATABASE IF NOT EXISTS replication_manager_schema")
+
+				}
+				db.Close()
+			}
+		}
+	}
+
+	if cluster.GetMaster() != nil && (cluster.Conf.TestInjectTraffic || cluster.Conf.AutorejoinSlavePositionalHeartbeat || cluster.Conf.MonitorWriteHeartbeat) {
+		for _, pr := range cluster.Proxies {
+			if pr.GetType() == config.ConstProxySphinx || pr.GetType() == config.ConstProxyMyProxy || (cluster.Conf.TopologyStaging && pr.IsInStaging()) { // skip staging proxy
 				// Does not yet understand CREATE OR REPLACE VIEW
 				continue
 			}

--- a/cluster/prx.go
+++ b/cluster/prx.go
@@ -65,6 +65,7 @@ type Proxy struct {
 	ServiceName     string               `json:"serviceName"`
 	Agent           string               `json:"agent"`
 	Weight          string               `json:"weight"`
+	IsStaging       bool                 `json:"isStaging"`
 	Lock            sync.Mutex
 }
 
@@ -134,6 +135,7 @@ type DatabaseProxy interface {
 	SetID()
 	SetDataDir()
 	SetServiceName(namespace string)
+	SetStaging(staging bool)
 
 	SetProvisionCookie() error
 	SetUnprovisionCookie() error
@@ -238,6 +240,10 @@ func (cluster *Cluster) newProxyList() error {
 	if cluster.Conf.RegistryConsul {
 		prx := NewConsulProxy(0, cluster, "")
 		cluster.AddProxy(prx)
+	}
+
+	for _, pr := range cluster.Proxies {
+		pr.SetStaging(cluster.IsProxyInStagingList(pr.GetName()))
 	}
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlInfo, "Loaded %d proxies", len(cluster.Proxies))

--- a/cluster/prx.go
+++ b/cluster/prx.go
@@ -13,6 +13,7 @@ package cluster
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -242,8 +243,11 @@ func (cluster *Cluster) newProxyList() error {
 		cluster.AddProxy(prx)
 	}
 
+	stagingList := strings.Split(cluster.Conf.StagingProxyHosts, ",")
 	for _, pr := range cluster.Proxies {
-		pr.SetStaging(cluster.IsProxyInStagingList(pr.GetName()))
+		if pr != nil && slices.Contains(stagingList, pr.GetName()) {
+			pr.SetStaging(true)
+		}
 	}
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlInfo, "Loaded %d proxies", len(cluster.Proxies))

--- a/cluster/prx_haproxy.go
+++ b/cluster/prx_haproxy.go
@@ -135,8 +135,19 @@ func (proxy *HaproxyProxy) Init() {
 		// log.Printf("Found exiting leader removing")
 	}
 
-	if cluster.GetMaster() != nil {
+	stagingsrv := cluster.StagingServer
+	if stagingsrv == nil {
+		stagingsrv, _ = cluster.GetStandaloneServerByIndex(0)
+		cluster.StagingServer = stagingsrv
+	}
 
+	if cluster.Conf.TopologyStaging && proxy.IsStaging && stagingsrv != nil {
+		p, _ := strconv.Atoi(stagingsrv.Port)
+		s := haproxy.ServerDetail{Name: "leader", Host: stagingsrv.Host, Port: p, Weight: 100, MaxConn: 2000, Check: true, CheckInterval: 1000}
+		if err = haConfig.AddServer(cluster.Conf.HaproxyAPIWriteBackend, &s); err != nil {
+			//	log.Printf("Failed to add server to service_write ")
+		}
+	} else if cluster.GetMaster() != nil {
 		p, _ := strconv.Atoi(cluster.GetMaster().Port)
 		s := haproxy.ServerDetail{Name: "leader", Host: cluster.GetMaster().Host, Port: p, Weight: 100, MaxConn: 2000, Check: true, CheckInterval: 1000}
 		if err = haConfig.AddServer(cluster.Conf.HaproxyAPIWriteBackend, &s); err != nil {
@@ -148,6 +159,7 @@ func (proxy *HaproxyProxy) Init() {
 			//	log.Printf("Failed to add server to service_write ")
 		}
 	}
+
 	fer := haproxy.Frontend{Name: "my_read_frontend", Mode: "tcp", DefaultBackend: cluster.Conf.HaproxyAPIReadBackend, BindPort: cluster.Conf.HaproxyReadPort, BindIp: cluster.Conf.HaproxyReadBindIp}
 	if err := haConfig.AddFrontend(&fer); err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "HAProxy failed to add frontend read")
@@ -199,7 +211,11 @@ func (proxy *HaproxyProxy) Init() {
 
 func (proxy *HaproxyProxy) Refresh() error {
 	cluster := proxy.ClusterGroup
-	stagingsrv, _ := cluster.GetStandaloneServerByIndex(0)
+	stagingsrv := cluster.StagingServer
+	if stagingsrv == nil {
+		stagingsrv, _ = cluster.GetStandaloneServerByIndex(0)
+		cluster.StagingServer = stagingsrv
+	}
 	// if proxy.ClusterGroup.Conf.HaproxyStatHttp {
 
 	/*
@@ -350,7 +366,11 @@ func (proxy *HaproxyProxy) Refresh() error {
 
 					if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
 						if !srv.IsStandAlone() {
-							stagingsrv, _ = cluster.GetStandaloneServerByIndex(0)
+							if stagingsrv == nil {
+								stagingsrv, _ = cluster.GetStandaloneServerByIndex(0)
+								cluster.StagingServer = stagingsrv
+							}
+
 							if stagingsrv != nil {
 								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "[Staging] Detecting wrong master server in haproxy %s fixing it to standalone %s %s", proxy.Host+":"+proxy.Port, stagingsrv.Host, stagingsrv.Port)
 								msg, err := haRuntime.SetMaster(stagingsrv.Host, stagingsrv.Port)
@@ -489,7 +509,11 @@ func (proxy *HaproxyProxy) Refresh() error {
 	}
 	if !foundMasterInStat {
 		if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
-			stagingsrv, _ = cluster.GetStandaloneServerByIndex(0)
+			if stagingsrv == nil {
+				stagingsrv, _ = cluster.GetStandaloneServerByIndex(0)
+				cluster.StagingServer = stagingsrv
+			}
+
 			if stagingsrv != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "[Staging] HAProxy has standalone in cluster but not in haproxy %s fixing it to standalone %s %s", proxy.Host+":"+proxy.Port, stagingsrv.Host, stagingsrv.Port)
 				msg, err := haRuntime.SetMaster(stagingsrv.Host, stagingsrv.Port)

--- a/cluster/prx_haproxy.go
+++ b/cluster/prx_haproxy.go
@@ -199,6 +199,7 @@ func (proxy *HaproxyProxy) Init() {
 
 func (proxy *HaproxyProxy) Refresh() error {
 	cluster := proxy.ClusterGroup
+	stagingsrv, _ := cluster.GetStandaloneServerByIndex(0)
 	// if proxy.ClusterGroup.Conf.HaproxyStatHttp {
 
 	/*
@@ -346,15 +347,31 @@ func (proxy *HaproxyProxy) Refresh() error {
 
 				if bkw.PrxName != "" {
 					proxy.BackendsWrite = append(proxy.BackendsWrite, bkw)
-					if !srv.IsMaster() {
-						master := cluster.GetMaster()
-						if master != nil {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "Detecting wrong master server in haproxy %s fixing it to master %s %s", proxy.Host+":"+proxy.Port, master.Host, master.Port)
-							msg, err := haRuntime.SetMaster(master.Host, master.Port)
-							if err != nil {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
-							} else {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
+
+					if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
+						if !srv.IsStandAlone() {
+							stagingsrv, _ = cluster.GetStandaloneServerByIndex(0)
+							if stagingsrv != nil {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "[Staging] Detecting wrong master server in haproxy %s fixing it to standalone %s %s", proxy.Host+":"+proxy.Port, stagingsrv.Host, stagingsrv.Port)
+								msg, err := haRuntime.SetMaster(stagingsrv.Host, stagingsrv.Port)
+								if err != nil {
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
+								} else {
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
+								}
+							}
+						}
+					} else {
+						if !srv.IsMaster() {
+							master := cluster.GetMaster()
+							if master != nil {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "Detecting wrong master server in haproxy %s fixing it to master %s %s", proxy.Host+":"+proxy.Port, master.Host, master.Port)
+								msg, err := haRuntime.SetMaster(master.Host, master.Port)
+								if err != nil {
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
+								} else {
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
+								}
 							}
 						}
 					}
@@ -393,36 +410,42 @@ func (proxy *HaproxyProxy) Refresh() error {
 
 				if bkr.PrxName != "" {
 					proxy.BackendsRead = append(proxy.BackendsRead, bkr)
-					if (srv.State == stateSlaveErr || srv.State == stateRelayErr || srv.State == stateSlaveLate || srv.State == stateRelayLate || srv.IsIgnored()) && line[17] == "UP" || srv.State == stateWsrepLate || srv.State == stateWsrepDonor {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy detecting broken replication and UP state in haproxy %s drain  server %s", proxy.Host+":"+proxy.Port, srv.URL)
-						msg, err := haRuntime.SetDrain(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
-						if err != nil {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
-						} else {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlInfo, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+					if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
+						if stagingsrv != nil {
+							if srv.Id == stagingsrv.Id { // Only activate staging server for read
+								if line[17] == "DRAIN" {
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy staging is DRAIN in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
+									msg, err := haRuntime.SetReady(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
+									if err != nil {
+										cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+									} else {
+										cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+									}
+								}
+							} else { // Deactivate other servers
+								if line[17] == "UP" {
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy non-staging backend state is UP in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
+									msg, err := haRuntime.SetDrain(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
+									if err != nil {
+										cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+									} else {
+										cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+									}
+								}
+							}
 						}
-					}
-					if (srv.State == stateSlave || srv.State == stateRelay || (srv.State == stateWsrep && !srv.IsLeader())) && line[17] == "DRAIN" && !srv.IsIgnored() {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy valid replication and DRAIN state in haproxy %s enable traffic on server %s", proxy.Host+":"+proxy.Port, srv.URL)
-						msg, err := haRuntime.SetReady(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
-						if err != nil {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
-						} else {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
-						}
-					}
-					if srv.IsMaster() {
-						if !cluster.Configurator.HasProxyReadLeader() && line[17] == "UP" {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy master is not configured as reader but state is UP in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
+					} else {
+						if (srv.State == stateSlaveErr || srv.State == stateRelayErr || srv.State == stateSlaveLate || srv.State == stateRelayLate || srv.IsIgnored()) && line[17] == "UP" || srv.State == stateWsrepLate || srv.State == stateWsrepDonor {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy detecting broken replication and UP state in haproxy %s drain  server %s", proxy.Host+":"+proxy.Port, srv.URL)
 							msg, err := haRuntime.SetDrain(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
 							if err != nil {
 								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 							} else {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlInfo, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 							}
 						}
-						if cluster.Configurator.HasProxyReadLeader() && line[17] == "DRAIN" {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy master is configured as reader but state is DRAIN in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
+						if (srv.State == stateSlave || srv.State == stateRelay || (srv.State == stateWsrep && !srv.IsLeader())) && line[17] == "DRAIN" && !srv.IsIgnored() {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy valid replication and DRAIN state in haproxy %s enable traffic on server %s", proxy.Host+":"+proxy.Port, srv.URL)
 							msg, err := haRuntime.SetReady(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
 							if err != nil {
 								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
@@ -430,8 +453,28 @@ func (proxy *HaproxyProxy) Refresh() error {
 								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 							}
 						}
-
+						if srv.IsMaster() {
+							if !cluster.Configurator.HasProxyReadLeader() && line[17] == "UP" {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy master is not configured as reader but state is UP in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
+								msg, err := haRuntime.SetDrain(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
+								if err != nil {
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+								} else {
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+								}
+							}
+							if cluster.Configurator.HasProxyReadLeader() && line[17] == "DRAIN" {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy master is configured as reader but state is DRAIN in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
+								msg, err := haRuntime.SetReady(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
+								if err != nil {
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+								} else {
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+								}
+							}
+						}
 					}
+
 					if srv.IsMaintenance && line[17] == "UP" {
 						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy detecting server %s in maintenance but proxy %s reports UP  ", srv.URL, proxy.Host+":"+proxy.Port)
 						proxy.SetMaintenance(srv)
@@ -445,14 +488,28 @@ func (proxy *HaproxyProxy) Refresh() error {
 		}
 	}
 	if !foundMasterInStat {
-		master := cluster.GetMaster()
-		if master != nil && master.IsLeader() {
-			res, err := haRuntime.SetMaster(master.Host, master.Port)
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy has leader in cluster but not in %s fixing it to master %s return %s", proxy.Host+":"+proxy.Port, master.URL, res)
-			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "HAProxy cannot add leader %s in cluster but not in %s : %s", master.URL, proxy.Host+":"+proxy.Port, err)
+		if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
+			stagingsrv, _ = cluster.GetStandaloneServerByIndex(0)
+			if stagingsrv != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "[Staging] HAProxy has standalone in cluster but not in haproxy %s fixing it to standalone %s %s", proxy.Host+":"+proxy.Port, stagingsrv.Host, stagingsrv.Port)
+				msg, err := haRuntime.SetMaster(stagingsrv.Host, stagingsrv.Port)
+				if err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
+				} else {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
+				}
+			}
+		} else {
+			master := cluster.GetMaster()
+			if master != nil && master.IsLeader() {
+				res, err := haRuntime.SetMaster(master.Host, master.Port)
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy has leader in cluster but not in %s fixing it to master %s return %s", proxy.Host+":"+proxy.Port, master.URL, res)
+				if err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "HAProxy cannot add leader %s in cluster but not in %s : %s", master.URL, proxy.Host+":"+proxy.Port, err)
+				}
 			}
 		}
+
 	}
 	return nil
 }

--- a/cluster/prx_has.go
+++ b/cluster/prx_has.go
@@ -74,3 +74,7 @@ func (proxy *Proxy) HasDNS() bool {
 	}
 	return false
 }
+
+func (proxy *Proxy) IsInStaging() bool {
+	return proxy.IsStaging
+}

--- a/cluster/prx_proxysql.go
+++ b/cluster/prx_proxysql.go
@@ -152,6 +152,8 @@ func (proxy *ProxySQLProxy) Init() {
 	for _, s := range cluster.Servers {
 		if cluster.Conf.TopologyStaging && proxy.IsStaging {
 			if s.State == stateUnconn {
+				psql.SetMonitorIsAlsoWriter(true)
+
 				err = psql.AddServerAsWriter(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
 				if err != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add writer %s (%s) ", s.URL, err)
@@ -242,6 +244,8 @@ func (proxy *ProxySQLProxy) Failover() {
 	for _, s := range cluster.Servers {
 		if cluster.Conf.TopologyStaging && proxy.IsStaging {
 			if s.State == stateUnconn {
+				psql.SetMonitorIsAlsoWriter(true)
+
 				err = psql.DeleteAllWriters()
 				if err != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not delete old writer (%s)", err)
@@ -361,6 +365,8 @@ func (proxy *ProxySQLProxy) Refresh() error {
 		if cluster.Conf.TopologyStaging && proxy.IsStaging {
 			if cluster.IsDiscovered() {
 				if s == stagingsrv {
+					psql.SetMonitorIsAlsoWriter(true)
+
 					if !isBackendWriter {
 						err = psql.DeleteAllWriters()
 						if err != nil {
@@ -371,8 +377,6 @@ func (proxy *ProxySQLProxy) Refresh() error {
 						if err != nil {
 							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add writer %s (%s) ", s.URL, err)
 						}
-
-						psql.SetMonitorIsAlsoWriter(true)
 						updated = true
 					}
 

--- a/cluster/prx_proxysql.go
+++ b/cluster/prx_proxysql.go
@@ -358,66 +358,69 @@ func (proxy *ProxySQLProxy) Refresh() error {
 			IsBackendReader = false
 		}
 
-		if cluster.Conf.TopologyStaging && cluster.IsDiscovered() && proxy.IsStaging {
-			if s == stagingsrv {
-				if !isBackendWriter {
-					err = psql.DeleteAllWriters()
-					if err != nil {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not delete old writer (%s)", err)
+		if cluster.Conf.TopologyStaging && proxy.IsStaging {
+			if cluster.IsDiscovered() {
+				if s == stagingsrv {
+					if !isBackendWriter {
+						err = psql.DeleteAllWriters()
+						if err != nil {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not delete old writer (%s)", err)
+						}
+
+						err = psql.AddServerAsWriter(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
+						if err != nil {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add writer %s (%s) ", s.URL, err)
+						}
+
+						psql.SetMonitorIsAlsoWriter(true)
+						updated = true
 					}
 
-					err = psql.AddServerAsWriter(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
-					if err != nil {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add writer %s (%s) ", s.URL, err)
-					}
-					updated = true
-				}
-
-				if !IsBackendReader {
-					// Add  leader in reader group if not found and setup
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL add leader in reader group in %s", s.URL)
-					err = psql.AddServerAsReader(misc.Unbracket(s.Host), s.Port, "1", "0", strconv.Itoa(s.ClusterGroup.Conf.PRXServersBackendMaxConnections), strconv.Itoa(misc.Bool2Int(s.ClusterGroup.Conf.PRXServersBackendCompression)), proxy.UseSSL())
-					if err != nil {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add reader %s (%s)", s.URL, err)
-					}
-					updated = true
-				}
-
-				// Set staging server as writer
-				if ((isBackendWriter && bke.PrxStatus == "OFFLINE_SOFT") || (IsBackendReader && bkeread.PrxStatus == "OFFLINE_SOFT")) && !s.IsMaintenance {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL setting staging server %s as writer", s.URL)
-					err = psql.SetOnlineSoft(misc.Unbracket(s.Host), s.Port)
-					if err != nil {
-						cluster.SetState("ERR00068", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00068"], s.URL, err), ErrFrom: "PRX", ServerUrl: proxy.Name})
-					}
-					updated = true
-				}
-
-			} else {
-				if isBackendWriter { // if not staging server
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL drop non staging in writer group from %s", s.URL)
-					err = psql.DropWriter(misc.Unbracket(s.Host), s.Port)
-					if err != nil {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not drop non staging in writer in %s (%s)", s.URL, err)
-					}
-					updated = true
-				}
-
-				if IsBackendReader {
-					// Drop slave from writer HG if exists
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL drop non staging in reader group from %s", s.URL)
-					err = psql.DropReader(misc.Unbracket(s.Host), s.Port)
-					if err != nil {
-						cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
+					if !IsBackendReader {
+						// Add  leader in reader group if not found and setup
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL add leader in reader group in %s", s.URL)
+						err = psql.AddServerAsReader(misc.Unbracket(s.Host), s.Port, "1", "0", strconv.Itoa(s.ClusterGroup.Conf.PRXServersBackendMaxConnections), strconv.Itoa(misc.Bool2Int(s.ClusterGroup.Conf.PRXServersBackendCompression)), proxy.UseSSL())
+						if err != nil {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add reader %s (%s)", s.URL, err)
+						}
+						updated = true
 					}
 
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL add backend %s as offline (%s)", s.URL, err)
-					err = psql.AddOfflineServer(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
-					if err != nil {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add backend %s as offline (%s)", s.URL, err)
+					// Set staging server as writer
+					if ((isBackendWriter && bke.PrxStatus == "OFFLINE_SOFT") || (IsBackendReader && bkeread.PrxStatus == "OFFLINE_SOFT")) && !s.IsMaintenance {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL setting staging server %s as writer", s.URL)
+						err = psql.SetOnlineSoft(misc.Unbracket(s.Host), s.Port)
+						if err != nil {
+							cluster.SetState("ERR00068", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00068"], s.URL, err), ErrFrom: "PRX", ServerUrl: proxy.Name})
+						}
+						updated = true
+					}
+				} else {
+					if isBackendWriter { // if not staging server
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL drop non staging in writer group from %s", s.URL)
+						err = psql.DropWriter(misc.Unbracket(s.Host), s.Port)
+						if err != nil {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not drop non staging in writer in %s (%s)", s.URL, err)
+						}
+						updated = true
 					}
 
-					updated = true
+					if IsBackendReader {
+						// Drop slave from writer HG if exists
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL drop non staging in reader group from %s", s.URL)
+						err = psql.DropReader(misc.Unbracket(s.Host), s.Port)
+						if err != nil {
+							cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
+						}
+
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL add backend %s as offline (%s)", s.URL, err)
+						err = psql.AddOfflineServer(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
+						if err != nil {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add backend %s as offline (%s)", s.URL, err)
+						}
+
+						updated = true
+					}
 				}
 			}
 		} else if cluster.Conf.ProxysqlBootstrap && cluster.IsDiscovered() { // nothing should be done if no bootstrap

--- a/cluster/prx_proxysql.go
+++ b/cluster/prx_proxysql.go
@@ -163,7 +163,7 @@ func (proxy *ProxySQLProxy) Init() {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add reader %s (%s)", s.URL, err)
 				}
 			} else {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL add backend %s as offline (%s)", s.URL, err)
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlInfo, "ProxySQL add backend %s as offline", s.URL)
 				err = psql.AddOfflineServer(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
 				if err != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add backend %s as offline (%s)", s.URL, err)

--- a/cluster/prx_proxysql.go
+++ b/cluster/prx_proxysql.go
@@ -150,38 +150,56 @@ func (proxy *ProxySQLProxy) Init() {
 	//	proxy.Refresh()
 	//	return
 	for _, s := range cluster.Servers {
-
-		if s.State == stateUnconn || s.IsIgnored() {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL add backend %s as offline (%s)", s.URL, err)
-			err = psql.AddOfflineServer(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
-			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add backend %s as offline (%s)", s.URL, err)
-			}
-		} else {
-			//weight string, max_replication_lag string, max_connections string, compression string
-
-			if s.IsLeader() {
+		if cluster.Conf.TopologyStaging && proxy.IsStaging {
+			if s.State == stateUnconn {
 				err = psql.AddServerAsWriter(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
 				if err != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add writer %s (%s) ", s.URL, err)
 				}
-				if cluster.Configurator.HasProxyReadLeader() {
+				err = psql.AddServerAsReader(misc.Unbracket(s.Host), s.Port, "1", strconv.Itoa(s.ClusterGroup.Conf.PRXServersBackendMaxReplicationLag), strconv.Itoa(s.ClusterGroup.Conf.PRXServersBackendMaxConnections), strconv.Itoa(misc.Bool2Int(s.ClusterGroup.Conf.PRXServersBackendCompression)), proxy.UseSSL())
+				if err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add reader %s (%s)", s.URL, err)
+				}
+			} else {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL add backend %s as offline (%s)", s.URL, err)
+				err = psql.AddOfflineServer(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
+				if err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add backend %s as offline (%s)", s.URL, err)
+				}
+			}
+		} else {
+			if s.State == stateUnconn || s.IsIgnored() {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL add backend %s as offline (%s)", s.URL, err)
+				err = psql.AddOfflineServer(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
+				if err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add backend %s as offline (%s)", s.URL, err)
+				}
+			} else {
+				//weight string, max_replication_lag string, max_connections string, compression string
+				if s.IsLeader() {
+					err = psql.AddServerAsWriter(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
+					if err != nil {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add writer %s (%s) ", s.URL, err)
+					}
+					if cluster.Configurator.HasProxyReadLeader() {
+						err = psql.AddServerAsReader(misc.Unbracket(s.Host), s.Port, "1", strconv.Itoa(s.ClusterGroup.Conf.PRXServersBackendMaxReplicationLag), strconv.Itoa(s.ClusterGroup.Conf.PRXServersBackendMaxConnections), strconv.Itoa(misc.Bool2Int(s.ClusterGroup.Conf.PRXServersBackendCompression)), proxy.UseSSL())
+						if err != nil {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add reader %s (%s)", s.URL, err)
+						}
+					}
+				} else if s.State == stateSlave {
 					err = psql.AddServerAsReader(misc.Unbracket(s.Host), s.Port, "1", strconv.Itoa(s.ClusterGroup.Conf.PRXServersBackendMaxReplicationLag), strconv.Itoa(s.ClusterGroup.Conf.PRXServersBackendMaxConnections), strconv.Itoa(misc.Bool2Int(s.ClusterGroup.Conf.PRXServersBackendCompression)), proxy.UseSSL())
 					if err != nil {
 						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add reader %s (%s)", s.URL, err)
 					}
 				}
-			} else if s.State == stateSlave {
-				err = psql.AddServerAsReader(misc.Unbracket(s.Host), s.Port, "1", strconv.Itoa(s.ClusterGroup.Conf.PRXServersBackendMaxReplicationLag), strconv.Itoa(s.ClusterGroup.Conf.PRXServersBackendMaxConnections), strconv.Itoa(misc.Bool2Int(s.ClusterGroup.Conf.PRXServersBackendCompression)), proxy.UseSSL())
-				if err != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add reader %s (%s)", s.URL, err)
-				}
-			}
-			// if cluster.Conf.LogLevel > 2 || cluster.Conf.ProxysqlDebug {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlWarn, "ProxySQL init backend  %s with state %s ", s.URL, s.State)
-			// }
+				// if cluster.Conf.LogLevel > 2 || cluster.Conf.ProxysqlDebug {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlWarn, "ProxySQL init backend  %s with state %s ", s.URL, s.State)
+				// }
 
+			}
 		}
+
 	}
 	err = psql.LoadServersToRuntime()
 	if err != nil {
@@ -222,20 +240,37 @@ func (proxy *ProxySQLProxy) Failover() {
 
 	defer psql.Connection.Close()
 	for _, s := range cluster.Servers {
-		if (s.State == stateUnconn && !cluster.Conf.TopologyStaging && !proxy.IsStaging) || s.IsIgnored() {
-			err = psql.SetOffline(misc.Unbracket(s.Host), s.Port)
-			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "Failover ProxySQL could not set server %s offline (%s)", s.URL, err)
-			} else {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlInfo, "Failover ProxySQL set server %s offline", s.URL)
+		if cluster.Conf.TopologyStaging && proxy.IsStaging {
+			if s.State == stateUnconn {
+				err = psql.DeleteAllWriters()
+				if err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not delete old writer (%s)", err)
+				}
+				err = psql.AddServerAsWriter(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
+				if err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add writer %s (%s) ", s.URL, err)
+				}
+				err = psql.AddServerAsReader(misc.Unbracket(s.Host), s.Port, "1", strconv.Itoa(s.ClusterGroup.Conf.PRXServersBackendMaxReplicationLag), strconv.Itoa(s.ClusterGroup.Conf.PRXServersBackendMaxConnections), strconv.Itoa(misc.Bool2Int(s.ClusterGroup.Conf.PRXServersBackendCompression)), proxy.UseSSL())
+				if err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add reader %s (%s)", s.URL, err)
+				}
 			}
-		}
-		if (s.IsMaster() && !cluster.Conf.TopologyStaging && !proxy.IsStaging) && !s.IsRelay && cluster.oldMaster != nil {
-			err = psql.ReplaceWriter(misc.Unbracket(s.Host), s.Port, misc.Unbracket(cluster.oldMaster.Host), cluster.oldMaster.Port, cluster.Configurator.HasProxyReadLeader())
-			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "Failover ProxySQL could not set server %s Master (%s)", s.URL, err)
-			} else {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlInfo, "Failover ProxySQL set server %s master", s.URL)
+		} else {
+			if s.State == stateUnconn || s.IsIgnored() {
+				err = psql.SetOffline(misc.Unbracket(s.Host), s.Port)
+				if err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "Failover ProxySQL could not set server %s offline (%s)", s.URL, err)
+				} else {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlInfo, "Failover ProxySQL set server %s offline", s.URL)
+				}
+			}
+			if s.IsMaster() && !s.IsRelay && cluster.oldMaster != nil {
+				err = psql.ReplaceWriter(misc.Unbracket(s.Host), s.Port, misc.Unbracket(cluster.oldMaster.Host), cluster.oldMaster.Port, cluster.Configurator.HasProxyReadLeader())
+				if err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "Failover ProxySQL could not set server %s Master (%s)", s.URL, err)
+				} else {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlInfo, "Failover ProxySQL set server %s master", s.URL)
+				}
 			}
 		}
 	}
@@ -326,16 +361,14 @@ func (proxy *ProxySQLProxy) Refresh() error {
 		if cluster.Conf.TopologyStaging && cluster.IsDiscovered() && proxy.IsStaging {
 			if s == stagingsrv {
 				if !isBackendWriter {
-					if psql.ExistAsWriterOrOffline(misc.Unbracket(s.Host), s.Port) {
-						err = psql.SetOnline(misc.Unbracket(s.Host), s.Port)
-						if err != nil {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "Monitor ProxySQL setting online failed server %s: %s", s.URL, err.Error())
-						}
-					} else {
-						err = psql.AddServerAsWriter(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
-						if err != nil {
-							cluster.SetState("ERR00071", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00071"], proxy.Name, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
-						}
+					err = psql.DeleteAllWriters()
+					if err != nil {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not delete old writer (%s)", err)
+					}
+
+					err = psql.AddServerAsWriter(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
+					if err != nil {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add writer %s (%s) ", s.URL, err)
 					}
 					updated = true
 				}
@@ -361,7 +394,6 @@ func (proxy *ProxySQLProxy) Refresh() error {
 				}
 
 			} else {
-
 				if isBackendWriter { // if not staging server
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL drop non staging in writer group from %s", s.URL)
 					err = psql.DropWriter(misc.Unbracket(s.Host), s.Port)
@@ -378,6 +410,13 @@ func (proxy *ProxySQLProxy) Refresh() error {
 					if err != nil {
 						cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
 					}
+
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL add backend %s as offline (%s)", s.URL, err)
+					err = psql.AddOfflineServer(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
+					if err != nil {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add backend %s as offline (%s)", s.URL, err)
+					}
+
 					updated = true
 				}
 			}

--- a/cluster/prx_proxysql.go
+++ b/cluster/prx_proxysql.go
@@ -313,7 +313,10 @@ func (proxy *ProxySQLProxy) Refresh() error {
 	bkWriters := make([]Backend, 0)
 	bkReaders := make([]Backend, 0)
 
-	stagingsrv, _ := cluster.GetStandaloneServerByIndex(0)
+	stagingsrv := cluster.StagingServer
+	if stagingsrv == nil {
+		stagingsrv, _ = cluster.GetStandaloneServerByIndex(0)
+	}
 
 	for _, s := range cluster.Servers {
 		isBackendWriter := true

--- a/cluster/prx_proxysql.go
+++ b/cluster/prx_proxysql.go
@@ -468,8 +468,8 @@ func (proxy *ProxySQLProxy) Refresh() error {
 					if err != nil {
 						cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
 					}
-					updated = true
 				}
+				updated = true
 			} else if s.State == stateUnconn && bkeread.PrxStatus == "ONLINE" && IsBackendReader {
 				if cluster.Conf.TopologyStaging { // Need to be dropped since standalone should not be writing in staging topology
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor Non Staging ProxySQL: drop standalone in reader group from %s", s.URL)
@@ -484,8 +484,8 @@ func (proxy *ProxySQLProxy) Refresh() error {
 					if err != nil {
 						cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
 					}
-					updated = true
 				}
+				updated = true
 			} else if s.IsLeader() && (s.PrevState == stateUnconn || s.PrevState == stateFailed || (len(proxy.BackendsWrite) == 0 || !isBackendWriter)) {
 				// if the master comes back from a previously failed or standalone state, reintroduce it in
 				// the appropriate HostGroup

--- a/cluster/prx_proxysql.go
+++ b/cluster/prx_proxysql.go
@@ -222,7 +222,7 @@ func (proxy *ProxySQLProxy) Failover() {
 
 	defer psql.Connection.Close()
 	for _, s := range cluster.Servers {
-		if s.State == stateUnconn || s.IsIgnored() {
+		if (s.State == stateUnconn && !cluster.Conf.TopologyStaging && !proxy.IsStaging) || s.IsIgnored() {
 			err = psql.SetOffline(misc.Unbracket(s.Host), s.Port)
 			if err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "Failover ProxySQL could not set server %s offline (%s)", s.URL, err)
@@ -230,7 +230,7 @@ func (proxy *ProxySQLProxy) Failover() {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlInfo, "Failover ProxySQL set server %s offline", s.URL)
 			}
 		}
-		if s.IsMaster() && !s.IsRelay && cluster.oldMaster != nil {
+		if (s.IsMaster() && !cluster.Conf.TopologyStaging && !proxy.IsStaging) && !s.IsRelay && cluster.oldMaster != nil {
 			err = psql.ReplaceWriter(misc.Unbracket(s.Host), s.Port, misc.Unbracket(cluster.oldMaster.Host), cluster.oldMaster.Port, cluster.Configurator.HasProxyReadLeader())
 			if err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "Failover ProxySQL could not set server %s Master (%s)", s.URL, err)
@@ -324,44 +324,57 @@ func (proxy *ProxySQLProxy) Refresh() error {
 		}
 
 		if cluster.Conf.TopologyStaging && cluster.IsDiscovered() && proxy.IsStaging {
-			if isBackendWriter && s != stagingsrv { // if not staging server
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL drop non staging in writer group from %s", s.URL)
-				err = psql.DropWriter(misc.Unbracket(s.Host), s.Port)
-				if err != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not drop non staging in writer in %s (%s)", s.URL, err)
-				}
-				updated = true
-			} else {
-				if s == stagingsrv {
-					// Set staging server as writer
-					if bke.PrxStatus != "ONLINE" && bke.PrxStatus != "OFFLINE_SOFT" && !s.IsMaintenance {
-						if psql.ExistAsWriterOrOffline(misc.Unbracket(s.Host), s.Port) {
-							err = psql.SetOnline(misc.Unbracket(s.Host), s.Port)
-							if err != nil {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "Monitor ProxySQL setting online failed server %s: %s", s.URL, err.Error())
-							}
-						} else {
-							//scenario restart with failed leader
-							err = psql.AddServerAsWriter(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
-							if err != nil {
-								cluster.SetState("ERR00071", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00071"], proxy.Name, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
-							}
-						}
-					}
-
-					if !IsBackendReader {
-						// Add  leader in reader group if not found and setup
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL add leader in reader group in %s", s.URL)
-						err = psql.AddServerAsReader(misc.Unbracket(s.Host), s.Port, "1", "0", strconv.Itoa(s.ClusterGroup.Conf.PRXServersBackendMaxConnections), strconv.Itoa(misc.Bool2Int(s.ClusterGroup.Conf.PRXServersBackendCompression)), proxy.UseSSL())
+			if s == stagingsrv {
+				if !isBackendWriter {
+					if psql.ExistAsWriterOrOffline(misc.Unbracket(s.Host), s.Port) {
+						err = psql.SetOnline(misc.Unbracket(s.Host), s.Port)
 						if err != nil {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add reader %s (%s)", s.URL, err)
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "Monitor ProxySQL setting online failed server %s: %s", s.URL, err.Error())
 						}
-						updated = true
+					} else {
+						err = psql.AddServerAsWriter(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
+						if err != nil {
+							cluster.SetState("ERR00071", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00071"], proxy.Name, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
+						}
 					}
-				} else if bkeread.PrxStatus != "OFFLINE_SOFT" || bke.PrxStatus != "OFFLINE_HARD" {
-					// Drop slave from writer HG if exists
+					updated = true
+				}
+
+				if !IsBackendReader {
+					// Add  leader in reader group if not found and setup
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL add leader in reader group in %s", s.URL)
+					err = psql.AddServerAsReader(misc.Unbracket(s.Host), s.Port, "1", "0", strconv.Itoa(s.ClusterGroup.Conf.PRXServersBackendMaxConnections), strconv.Itoa(misc.Bool2Int(s.ClusterGroup.Conf.PRXServersBackendCompression)), proxy.UseSSL())
+					if err != nil {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add reader %s (%s)", s.URL, err)
+					}
+					updated = true
+				}
+
+				// Set staging server as writer
+				if ((isBackendWriter && bke.PrxStatus == "OFFLINE_SOFT") || (IsBackendReader && bkeread.PrxStatus == "OFFLINE_SOFT")) && !s.IsMaintenance {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL setting staging server %s as writer", s.URL)
+					err = psql.SetOnlineSoft(misc.Unbracket(s.Host), s.Port)
+					if err != nil {
+						cluster.SetState("ERR00068", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00068"], s.URL, err), ErrFrom: "PRX", ServerUrl: proxy.Name})
+					}
+					updated = true
+				}
+
+			} else {
+
+				if isBackendWriter { // if not staging server
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL drop non staging in writer group from %s", s.URL)
-					err = psql.SetOfflineSoft(misc.Unbracket(s.Host), s.Port)
+					err = psql.DropWriter(misc.Unbracket(s.Host), s.Port)
+					if err != nil {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not drop non staging in writer in %s (%s)", s.URL, err)
+					}
+					updated = true
+				}
+
+				if IsBackendReader {
+					// Drop slave from writer HG if exists
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL drop non staging in reader group from %s", s.URL)
+					err = psql.DropReader(misc.Unbracket(s.Host), s.Port)
 					if err != nil {
 						cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
 					}

--- a/cluster/prx_proxysql.go
+++ b/cluster/prx_proxysql.go
@@ -455,37 +455,42 @@ func (proxy *ProxySQLProxy) Refresh() error {
 					cluster.SetState("ERR00094", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00094"], proxy.GetURL(), s.URL, err), ErrFrom: "PRX", ServerUrl: proxy.Name})
 				}
 				updated = true
-			} else if s.State == stateUnconn && bke.PrxStatus == "ONLINE" {
-				if cluster.Conf.TopologyStaging { // Need to be dropped since standalone should not be writing in staging topology
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor Non Staging ProxySQL: drop standalone in writer group from %s", s.URL)
-					err = psql.DropWriter(misc.Unbracket(s.Host), s.Port)
-					if err != nil {
-						cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
+			} else if s.State == stateUnconn {
+				if bke.PrxStatus == "ONLINE" && isBackendWriter {
+					if cluster.Conf.TopologyStaging { // Need to be dropped since standalone should not be writing in staging topology
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor Non Staging ProxySQL: drop standalone in writer group from %s", s.URL)
+						err = psql.DropWriter(misc.Unbracket(s.Host), s.Port)
+						if err != nil {
+							cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
+						}
+					} else {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL setting writer offline standalone server %s", s.URL)
+						err = psql.SetOffline(misc.Unbracket(s.Host), s.Port)
+						if err != nil {
+							cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
+						}
 					}
-				} else {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL setting writer offline standalone server %s", s.URL)
-					err = psql.SetOffline(misc.Unbracket(s.Host), s.Port)
-					if err != nil {
-						cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
-					}
+					updated = true
 				}
-				updated = true
-			} else if s.State == stateUnconn && bkeread.PrxStatus == "ONLINE" && IsBackendReader {
-				if cluster.Conf.TopologyStaging { // Need to be dropped since standalone should not be writing in staging topology
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor Non Staging ProxySQL: drop standalone in reader group from %s", s.URL)
-					err = psql.DropReader(misc.Unbracket(s.Host), s.Port)
-					if err != nil {
-						cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
+
+				if bkeread.PrxStatus == "ONLINE" && IsBackendReader {
+					if cluster.Conf.TopologyStaging { // Need to be dropped since standalone should not be writing in staging topology
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor Non Staging ProxySQL: drop standalone in reader group from %s", s.URL)
+						err = psql.DropReader(misc.Unbracket(s.Host), s.Port)
+						if err != nil {
+							cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
+						}
+					} else {
+						// if server is Standalone, and reader shunned it in ProxySQL
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlInfo, "Monitor ProxySQL setting reader offline standalone server %s", s.URL)
+						err = psql.SetOfflineSoft(misc.Unbracket(s.Host), s.Port)
+						if err != nil {
+							cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
+						}
 					}
-				} else {
-					// if server is Standalone, and reader shunned it in ProxySQL
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlInfo, "Monitor ProxySQL setting reader offline standalone server %s", s.URL)
-					err = psql.SetOfflineSoft(misc.Unbracket(s.Host), s.Port)
-					if err != nil {
-						cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
-					}
+					updated = true
 				}
-				updated = true
+
 			} else if s.IsLeader() && (s.PrevState == stateUnconn || s.PrevState == stateFailed || (len(proxy.BackendsWrite) == 0 || !isBackendWriter)) {
 				// if the master comes back from a previously failed or standalone state, reintroduce it in
 				// the appropriate HostGroup

--- a/cluster/prx_proxysql.go
+++ b/cluster/prx_proxysql.go
@@ -464,14 +464,21 @@ func (proxy *ProxySQLProxy) Refresh() error {
 				updated = true
 
 			} else if s.State == stateUnconn && bkeread.PrxStatus == "ONLINE" && IsBackendReader {
-				// if server is Standalone, and reader shunned it in ProxySQL
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlInfo, "Monitor ProxySQL setting reader offline standalone server %s", s.URL)
-				err = psql.SetOfflineSoft(misc.Unbracket(s.Host), s.Port)
-				if err != nil {
-					cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
+				if cluster.Conf.TopologyStaging { // Need to be dropped since standalone should not be writing in staging topology
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor Non Staging ProxySQL: drop standalone in reader group from %s", s.URL)
+					err = psql.DropReader(misc.Unbracket(s.Host), s.Port)
+					if err != nil {
+						cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
+					}
+				} else {
+					// if server is Standalone, and reader shunned it in ProxySQL
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlInfo, "Monitor ProxySQL setting reader offline standalone server %s", s.URL)
+					err = psql.SetOfflineSoft(misc.Unbracket(s.Host), s.Port)
+					if err != nil {
+						cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
+					}
+					updated = true
 				}
-				updated = true
-
 			} else if s.IsLeader() && (s.PrevState == stateUnconn || s.PrevState == stateFailed || (len(proxy.BackendsWrite) == 0 || !isBackendWriter)) {
 				// if the master comes back from a previously failed or standalone state, reintroduce it in
 				// the appropriate HostGroup

--- a/cluster/prx_proxysql.go
+++ b/cluster/prx_proxysql.go
@@ -274,6 +274,8 @@ func (proxy *ProxySQLProxy) Refresh() error {
 	bkWriters := make([]Backend, 0)
 	bkReaders := make([]Backend, 0)
 
+	stagingsrv, _ := cluster.GetStandaloneServerByIndex(0)
+
 	for _, s := range cluster.Servers {
 		isBackendWriter := true
 		proxysqlHostgroup, proxysqlServerStatus, proxysqlServerConnections, proxysqlByteOut, proxysqlByteIn, proxysqlLatency, err := psql.GetStatsForHostWrite(misc.Unbracket(s.Host), s.Port)
@@ -321,8 +323,52 @@ func (proxy *ProxySQLProxy) Refresh() error {
 			IsBackendReader = false
 		}
 
-		// nothing should be done if no bootstrap
-		if cluster.Conf.ProxysqlBootstrap && cluster.IsDiscovered() {
+		if cluster.Conf.TopologyStaging && cluster.IsDiscovered() && proxy.IsStaging {
+			if isBackendWriter && s != stagingsrv { // if not staging server
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL drop non staging in writer group from %s", s.URL)
+				err = psql.DropWriter(misc.Unbracket(s.Host), s.Port)
+				if err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not drop non staging in writer in %s (%s)", s.URL, err)
+				}
+				updated = true
+			} else {
+				if s == stagingsrv {
+					// Set staging server as writer
+					if bke.PrxStatus != "ONLINE" && bke.PrxStatus != "OFFLINE_SOFT" && !s.IsMaintenance {
+						if psql.ExistAsWriterOrOffline(misc.Unbracket(s.Host), s.Port) {
+							err = psql.SetOnline(misc.Unbracket(s.Host), s.Port)
+							if err != nil {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "Monitor ProxySQL setting online failed server %s: %s", s.URL, err.Error())
+							}
+						} else {
+							//scenario restart with failed leader
+							err = psql.AddServerAsWriter(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
+							if err != nil {
+								cluster.SetState("ERR00071", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00071"], proxy.Name, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
+							}
+						}
+					}
+
+					if !IsBackendReader {
+						// Add  leader in reader group if not found and setup
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL add leader in reader group in %s", s.URL)
+						err = psql.AddServerAsReader(misc.Unbracket(s.Host), s.Port, "1", "0", strconv.Itoa(s.ClusterGroup.Conf.PRXServersBackendMaxConnections), strconv.Itoa(misc.Bool2Int(s.ClusterGroup.Conf.PRXServersBackendCompression)), proxy.UseSSL())
+						if err != nil {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "ProxySQL could not add reader %s (%s)", s.URL, err)
+						}
+						updated = true
+					}
+				} else if bkeread.PrxStatus != "OFFLINE_SOFT" || bke.PrxStatus != "OFFLINE_HARD" {
+					// Drop slave from writer HG if exists
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL drop non staging in writer group from %s", s.URL)
+					err = psql.SetOfflineSoft(misc.Unbracket(s.Host), s.Port)
+					if err != nil {
+						cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
+					}
+					updated = true
+				}
+			}
+		} else if cluster.Conf.ProxysqlBootstrap && cluster.IsDiscovered() { // nothing should be done if no bootstrap
 			// if ProxySQL and replication-manager states differ, resolve the conflict
 			if bke.PrxStatus == "OFFLINE_HARD" && s.State == stateSlave && !s.IsIgnored() {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL setting online as reader rejoining server %s", s.URL)
@@ -447,8 +493,13 @@ func (proxy *ProxySQLProxy) Refresh() error {
 			cluster.SetState("ERR00093", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00093"], proxy.Name), ErrFrom: "PRX", ServerUrl: proxy.Name})
 		}
 
+		leader := s.IsMaster()
+		if cluster.Conf.TopologyStaging && proxy.IsStaging {
+			leader = stagingsrv == s
+		}
+
 		// load the grants
-		if s.IsMaster() && cluster.Conf.ProxysqlCopyGrants {
+		if leader && cluster.Conf.ProxysqlCopyGrants {
 			myprxusermap, _, err := dbhelper.GetProxySQLUsers(psql.Connection)
 			if err != nil {
 				cluster.SetState("ERR00053", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00053"], err), ErrFrom: "MON", ServerUrl: proxy.Name})

--- a/cluster/prx_proxysql.go
+++ b/cluster/prx_proxysql.go
@@ -335,7 +335,7 @@ func (proxy *ProxySQLProxy) Refresh() error {
 		s.ProxysqlHostgroup = proxysqlHostgroup
 		s.MxsServerStatus = proxysqlServerStatus
 
-		if err == nil {
+		if err == nil && proxysqlHostgroup != "" {
 			bkWriters = append(bkWriters, bke)
 		} else {
 			isBackendWriter = false
@@ -356,7 +356,7 @@ func (proxy *ProxySQLProxy) Refresh() error {
 			PrxLatency:     strconv.Itoa(rproxysqlLatency),
 			PrxHostgroup:   rproxysqlHostgroup,
 		}
-		if err == nil {
+		if err == nil && rproxysqlHostgroup != "" {
 			bkReaders = append(bkReaders, bkeread)
 		} else {
 			IsBackendReader = false

--- a/cluster/prx_proxysql.go
+++ b/cluster/prx_proxysql.go
@@ -456,13 +456,20 @@ func (proxy *ProxySQLProxy) Refresh() error {
 				}
 				updated = true
 			} else if s.State == stateUnconn && bke.PrxStatus == "ONLINE" {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL setting writer offline standalone server %s", s.URL)
-				err = psql.SetOffline(misc.Unbracket(s.Host), s.Port)
-				if err != nil {
-					cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
+				if cluster.Conf.TopologyStaging { // Need to be dropped since standalone should not be writing in staging topology
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor Non Staging ProxySQL: drop standalone in writer group from %s", s.URL)
+					err = psql.DropWriter(misc.Unbracket(s.Host), s.Port)
+					if err != nil {
+						cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
+					}
+				} else {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL setting writer offline standalone server %s", s.URL)
+					err = psql.SetOffline(misc.Unbracket(s.Host), s.Port)
+					if err != nil {
+						cluster.SetState("ERR00070", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00070"], err, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
+					}
+					updated = true
 				}
-				updated = true
-
 			} else if s.State == stateUnconn && bkeread.PrxStatus == "ONLINE" && IsBackendReader {
 				if cluster.Conf.TopologyStaging { // Need to be dropped since standalone should not be writing in staging topology
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor Non Staging ProxySQL: drop standalone in reader group from %s", s.URL)

--- a/cluster/prx_set.go
+++ b/cluster/prx_set.go
@@ -36,6 +36,10 @@ func (proxy *Proxy) SetServiceName(namespace string) {
 	proxy.ServiceName = namespace + "/svc/" + proxy.Name
 }
 
+func (proxy *Proxy) SetInStaging(staging bool) {
+	proxy.IsStaging = staging
+}
+
 func (proxy *Proxy) SetPlacement(k int, ProvAgents string, SlapOSDBPartitions string, ProxysqlHostsIPV6 string, Weights string) {
 	slapospartitions := strings.Split(SlapOSDBPartitions, ",")
 	agents := strings.Split(ProvAgents, ",")

--- a/cluster/prx_set.go
+++ b/cluster/prx_set.go
@@ -36,7 +36,7 @@ func (proxy *Proxy) SetServiceName(namespace string) {
 	proxy.ServiceName = namespace + "/svc/" + proxy.Name
 }
 
-func (proxy *Proxy) SetInStaging(staging bool) {
+func (proxy *Proxy) SetStaging(staging bool) {
 	proxy.IsStaging = staging
 }
 

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -611,6 +611,11 @@ func (server *ServerMonitor) JobReseedLogicalBackup(backtype string) error {
 	}
 
 	server.SetInReseedBackup(task)
+	defer func() {
+		if server.HasReseedingState(task) {
+			server.SetInReseedBackup("")
+		}
+	}()
 
 	//Delete wait logical backup cookie
 	server.DelWaitLogicalBackupCookie()
@@ -667,13 +672,7 @@ func (server *ServerMonitor) JobReseedLogicalBackup(backtype string) error {
 			}
 		}
 
-		logs, err = dbhelper.ChangeMaster(server.Conn, changeOpt, server.DBVersion)
-		if err != nil {
-			if server.HasReseedingState(task) {
-				server.SetInReseedBackup("")
-			}
-			return err
-		}
+		dbhelper.ChangeMaster(server.Conn, changeOpt, server.DBVersion) // Ignore error
 	}
 
 	server.JobsUpdateState(task, "processing", 1, 0)

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -1391,6 +1391,15 @@ func (server *ServerMonitor) JobsCancelTasks(force bool, tasks ...string) error 
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Failed to cancel tasks. No rows found or tasks already started", server.URL)
 	}
 
+	if !cluster.Conf.MonitorScheduler {
+		for _, task := range tasks {
+			server.JobsUpdateState(task, "cancelled by user", 5, 1)
+			if server.HasReseedingState(task) {
+				server.SetInReseedBackup("")
+			}
+		}
+	}
+
 	if server.IsDown() {
 		if canCancel || force {
 			server.SetInReseedBackup("")

--- a/cluster/srv_rejoin.go
+++ b/cluster/srv_rejoin.go
@@ -214,7 +214,9 @@ func (server *ServerMonitor) ReseedMasterSST() error {
 			server.JobReseedBackupScript()
 		} else if cluster.Conf.AutorejoinLogicalBackup {
 			err := server.JobReseedLogicalBackup("default")
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "Reseed logical for rejoin on %s failed: %s", server.URL, err)
+			if err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "Reseed logical for rejoin on %s failed: %s", server.URL, err)
+			}
 		} else if cluster.Conf.AutorejoinPhysicalBackup {
 			server.JobReseedPhysicalBackup("default")
 		} else {

--- a/config/config.go
+++ b/config/config.go
@@ -472,6 +472,7 @@ type Config struct {
 	SwitchoverCopyOldLeaderGtid               bool                   `toml:"-" json:"-"` //suspicious code
 	Test                                      bool                   `mapstructure:"test" toml:"test" json:"test"`
 	TestInjectTraffic                         bool                   `mapstructure:"test-inject-traffic" toml:"test-inject-traffic" json:"testInjectTraffic"`
+	TestInjectTrafficStaging                  bool                   `mapstructure:"test-inject-traffic-staging" toml:"test-inject-traffic-staging" json:"testInjectTrafficStaging"`
 	Enterprise                                bool                   `toml:"enterprise" json:"enterprise"` //used to talk to opensvc collector
 	KubeConfig                                string                 `mapstructure:"kube-config" toml:"kube-config" json:"kubeConfig"`
 	SlapOSConfig                              string                 `mapstructure:"slapos-config" toml:"slapos-config" json:"slaposConfig"`

--- a/config/config.go
+++ b/config/config.go
@@ -440,6 +440,7 @@ type Config struct {
 	TopologyStaging                           bool                   `mapstructure:"topology-staging" toml:"topology-staging" json:"topologyStaging"`
 	TopologyStagingRefreshScript              string                 `mapstructure:"topology-staging-refresh-script" toml:"topology-staging-refresh-script" json:"topologyStagingRefreshScript"`
 	TopologyStagingPostDetachScript           string                 `mapstructure:"topology-staging-post-detach-script" toml:"topology-staging-post-detach-script" json:"topologyStagingPostDetachScript"`
+	StagingProxyHosts                         string                 `mapstructure:"staging-proxy-hosts" toml:"staging-proxy-hosts" json:"stagingProxyHosts"`
 	GraphiteMetrics                           bool                   `scope:"server" mapstructure:"graphite-metrics" toml:"graphite-metrics" json:"graphiteMetrics"`
 	GraphiteEmbedded                          bool                   `scope:"server" mapstructure:"graphite-embedded" toml:"graphite-embedded" json:"graphiteEmbedded"`
 	GraphiteWhitelist                         bool                   `scope:"server" mapstructure:"graphite-whitelist" toml:"graphite-whitelist" json:"graphiteWhitelist"`

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -769,6 +769,90 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/clusters/{clusterName}/actions/addserver/{host}/{port}/{type}/{tag}": {
+            "post": {
+                "description": "This endpoint adds a server to the specified cluster.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterMonitor"
+                ],
+                "summary": "Add a server to a specific cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Host",
+                        "name": "host",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Port",
+                        "name": "port",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Type",
+                        "name": "type",
+                        "in": "path"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Tag",
+                        "name": "tag",
+                        "in": "path"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Monitor added",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "409": {
+                        "description": "Error adding new monitor",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Cluster Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/actions/cancel-rolling-reprov": {
             "post": {
                 "description": "This endpoint cancels the rolling reprovision for the specified cluster.",
@@ -1714,7 +1798,111 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/clusters/{clusterName}/actions/start-traffic-staging": {
+            "post": {
+                "description": "This endpoint starts traffic for the specified cluster.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterTraffics"
+                ],
+                "summary": "Start traffic for a specific cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully started traffic",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "No cluster",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/actions/stop-traffic": {
+            "post": {
+                "description": "This endpoint stops traffic for the specified cluster.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterTraffics"
+                ],
+                "summary": "Stop traffic for a specific cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully stopped traffic",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "No cluster",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/actions/stop-traffic-staging": {
             "post": {
                 "description": "This endpoint stops traffic for the specified cluster.",
                 "consumes": [
@@ -3288,6 +3476,78 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Cluster Not Found\" \"Server Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/proxies/{proxyName}/actions/staging/{isStaging}": {
+            "post": {
+                "description": "Set the proxy service for a given cluster and proxy to staging",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Proxies"
+                ],
+                "summary": "Set Staging",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Proxy Name",
+                        "name": "proxyName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Is Staging",
+                        "name": "isStaging",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Proxy Service Set to Staging",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Cluster Not Found\" \"Server Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "503": {
+                        "description": "Not a Valid Server!",
                         "schema": {
                             "type": "string"
                         }
@@ -12394,6 +12654,65 @@ const docTemplate = `{
                 }
             }
         },
+        "/cluster/{clusterName}/actions/dropserver/{serverName}": {
+            "post": {
+                "description": "This endpoint allows dropping a server monitor or proxy monitor from a specified cluster.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterMonitor"
+                ],
+                "summary": "Drop a server monitor from a cluster by name",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Monitor Server ID",
+                        "name": "serverName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Monitor dropped successfully",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Cluster Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/meet/add/{channelId}/{userId}": {
             "get": {
                 "description": "Adds a user to a specific channel",
@@ -13597,6 +13916,9 @@ const docTemplate = `{
                         "$ref": "#/definitions/cluster.VariableDiff"
                     }
                 },
+                "diskStat": {
+                    "$ref": "#/definitions/misc.DiskStatManager"
+                },
                 "diskType": {
                     "type": "object",
                     "additionalProperties": {
@@ -13615,6 +13937,12 @@ const docTemplate = `{
                 },
                 "failoverLastTime": {
                     "type": "integer"
+                },
+                "falsePositiveChecks": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "boolean"
+                    }
                 },
                 "fsType": {
                     "type": "object",
@@ -13700,10 +14028,13 @@ const docTemplate = `{
                 "isNeedProxiesConfigChange": {
                     "type": "boolean"
                 },
+                "isNeedProxiesReprov": {
+                    "type": "boolean"
+                },
                 "isNeedProxiesRestart": {
                     "type": "boolean"
                 },
-                "isNeedProxyRestart": {
+                "isNeedStagingChange": {
                     "type": "boolean"
                 },
                 "isNotMonitoring": {
@@ -13713,6 +14044,9 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "isProvision": {
+                    "type": "boolean"
+                },
+                "isRefreshStaging": {
                     "type": "boolean"
                 },
                 "isSplitBrain": {
@@ -13987,6 +14321,9 @@ const docTemplate = `{
                 },
                 "internalProxy": {
                     "$ref": "#/definitions/myproxy.Server"
+                },
+                "isStaging": {
+                    "type": "boolean"
                 },
                 "lock": {
                     "$ref": "#/definitions/sync.Mutex"
@@ -14413,6 +14750,10 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/dbhelper.SlaveStatus"
                     }
+                },
+                "lastTLSConfig": {
+                    "description": "used to track last working TLS config",
+                    "type": "string"
                 },
                 "logOutput": {
                     "type": "string"
@@ -15209,6 +15550,9 @@ const docTemplate = `{
         "github_com_signal18_replication-manager_config.Config": {
             "type": "object",
             "properties": {
+                "ExternalScript": {
+                    "type": "boolean"
+                },
                 "alertPushoverAppToken": {
                     "type": "string"
                 },
@@ -15375,6 +15719,24 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "backupBinlogsKeep": {
+                    "type": "integer"
+                },
+                "backupCheckFreeSpace": {
+                    "type": "boolean"
+                },
+                "backupDiskTresholdCrit": {
+                    "type": "integer"
+                },
+                "backupDiskTresholdWarn": {
+                    "type": "integer"
+                },
+                "backupEstimateSize": {
+                    "type": "boolean"
+                },
+                "backupEstimateSizePercentage": {
+                    "type": "integer"
+                },
+                "backupGrowthPercentage": {
                     "type": "integer"
                 },
                 "backupKeepDaily": {
@@ -15728,6 +16090,9 @@ const docTemplate = `{
                 "dbServersTlsServerKey": {
                     "type": "string"
                 },
+                "dbServersTlsSslMode": {
+                    "type": "string"
+                },
                 "dbServersUseGeneratedCert": {
                     "type": "boolean"
                 },
@@ -15912,12 +16277,6 @@ const docTemplate = `{
                 "fullVersion": {
                     "type": "string"
                 },
-                "gitMaxWorker": {
-                    "type": "integer"
-                },
-                "gitMinWorker": {
-                    "type": "integer"
-                },
                 "gitMonitoringTicker": {
                     "type": "integer"
                 },
@@ -16095,6 +16454,9 @@ const docTemplate = `{
                 "logConfigLoadLevel": {
                     "type": "integer"
                 },
+                "logExternalScriptLevel": {
+                    "type": "integer"
+                },
                 "logFile": {
                     "type": "string"
                 },
@@ -16155,6 +16517,9 @@ const docTemplate = `{
                 },
                 "logSstLevel": {
                     "description": "internal replication-manager sst",
+                    "type": "integer"
+                },
+                "logStatsLevel": {
                     "type": "integer"
                 },
                 "logSupport": {
@@ -17216,6 +17581,9 @@ const docTemplate = `{
                 "sstSendBuffer": {
                     "type": "integer"
                 },
+                "stagingProxyHosts": {
+                    "type": "string"
+                },
                 "switchoverAtEqualGtid": {
                     "type": "boolean"
                 },
@@ -17228,11 +17596,17 @@ const docTemplate = `{
                 "switchoverDecreaseMaxConnValue": {
                     "type": "integer"
                 },
+                "switchoverLockUserOnFreeze": {
+                    "type": "boolean"
+                },
                 "switchoverLowerRelease": {
                     "type": "boolean"
                 },
                 "switchoverMaxSlaveDelay": {
                     "type": "integer"
+                },
+                "switchoverRedirectOnFreeze": {
+                    "type": "boolean"
                 },
                 "switchoverSlaveWaitCatch": {
                     "type": "boolean"
@@ -17283,6 +17657,9 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "testInjectTraffic": {
+                    "type": "boolean"
+                },
+                "testInjectTrafficStaging": {
                     "type": "boolean"
                 },
                 "topologyStaging": {
@@ -17539,6 +17916,58 @@ const docTemplate = `{
                 "text": {
                     "type": "string"
                 }
+            }
+        },
+        "misc.DiskStatManager": {
+            "type": "object",
+            "properties": {
+                "stats": {
+                    "$ref": "#/definitions/misc.DiskUsageStatMap"
+                }
+            }
+        },
+        "misc.DiskUsageStat": {
+            "type": "object",
+            "properties": {
+                "free": {
+                    "type": "integer"
+                },
+                "fstype": {
+                    "type": "string"
+                },
+                "inodesFree": {
+                    "type": "integer"
+                },
+                "inodesTotal": {
+                    "type": "integer"
+                },
+                "inodesUsed": {
+                    "type": "integer"
+                },
+                "inodesUsedPercent": {
+                    "type": "number"
+                },
+                "last_update": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "total": {
+                    "type": "integer"
+                },
+                "used": {
+                    "type": "integer"
+                },
+                "usedPercent": {
+                    "type": "number"
+                }
+            }
+        },
+        "misc.DiskUsageStatMap": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/misc.DiskUsageStat"
             }
         },
         "myproxy.Server": {
@@ -18111,6 +18540,12 @@ const docTemplate = `{
                 "memprofile": {
                     "type": "string"
                 },
+                "monitorType": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "os": {
                     "type": "string"
                 },
@@ -18172,6 +18607,12 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/config.Role"
+                    }
+                },
+                "serviceSslMode": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "boolean"
                     }
                 },
                 "serviceTarballs": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -758,6 +758,90 @@
                 }
             }
         },
+        "/api/clusters/{clusterName}/actions/addserver/{host}/{port}/{type}/{tag}": {
+            "post": {
+                "description": "This endpoint adds a server to the specified cluster.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterMonitor"
+                ],
+                "summary": "Add a server to a specific cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Host",
+                        "name": "host",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Port",
+                        "name": "port",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Type",
+                        "name": "type",
+                        "in": "path"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Tag",
+                        "name": "tag",
+                        "in": "path"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Monitor added",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "409": {
+                        "description": "Error adding new monitor",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Cluster Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/actions/cancel-rolling-reprov": {
             "post": {
                 "description": "This endpoint cancels the rolling reprovision for the specified cluster.",
@@ -1703,7 +1787,111 @@
                 }
             }
         },
+        "/api/clusters/{clusterName}/actions/start-traffic-staging": {
+            "post": {
+                "description": "This endpoint starts traffic for the specified cluster.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterTraffics"
+                ],
+                "summary": "Start traffic for a specific cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully started traffic",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "No cluster",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/actions/stop-traffic": {
+            "post": {
+                "description": "This endpoint stops traffic for the specified cluster.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterTraffics"
+                ],
+                "summary": "Stop traffic for a specific cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully stopped traffic",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "No cluster",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/actions/stop-traffic-staging": {
             "post": {
                 "description": "This endpoint stops traffic for the specified cluster.",
                 "consumes": [
@@ -3277,6 +3465,78 @@
                     },
                     "500": {
                         "description": "Cluster Not Found\" \"Server Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/proxies/{proxyName}/actions/staging/{isStaging}": {
+            "post": {
+                "description": "Set the proxy service for a given cluster and proxy to staging",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Proxies"
+                ],
+                "summary": "Set Staging",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Proxy Name",
+                        "name": "proxyName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Is Staging",
+                        "name": "isStaging",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Proxy Service Set to Staging",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Cluster Not Found\" \"Server Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "503": {
+                        "description": "Not a Valid Server!",
                         "schema": {
                             "type": "string"
                         }
@@ -12383,6 +12643,65 @@
                 }
             }
         },
+        "/cluster/{clusterName}/actions/dropserver/{serverName}": {
+            "post": {
+                "description": "This endpoint allows dropping a server monitor or proxy monitor from a specified cluster.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterMonitor"
+                ],
+                "summary": "Drop a server monitor from a cluster by name",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Monitor Server ID",
+                        "name": "serverName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Monitor dropped successfully",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Cluster Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/meet/add/{channelId}/{userId}": {
             "get": {
                 "description": "Adds a user to a specific channel",
@@ -13586,6 +13905,9 @@
                         "$ref": "#/definitions/cluster.VariableDiff"
                     }
                 },
+                "diskStat": {
+                    "$ref": "#/definitions/misc.DiskStatManager"
+                },
                 "diskType": {
                     "type": "object",
                     "additionalProperties": {
@@ -13604,6 +13926,12 @@
                 },
                 "failoverLastTime": {
                     "type": "integer"
+                },
+                "falsePositiveChecks": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "boolean"
+                    }
                 },
                 "fsType": {
                     "type": "object",
@@ -13689,10 +14017,13 @@
                 "isNeedProxiesConfigChange": {
                     "type": "boolean"
                 },
+                "isNeedProxiesReprov": {
+                    "type": "boolean"
+                },
                 "isNeedProxiesRestart": {
                     "type": "boolean"
                 },
-                "isNeedProxyRestart": {
+                "isNeedStagingChange": {
                     "type": "boolean"
                 },
                 "isNotMonitoring": {
@@ -13702,6 +14033,9 @@
                     "type": "boolean"
                 },
                 "isProvision": {
+                    "type": "boolean"
+                },
+                "isRefreshStaging": {
                     "type": "boolean"
                 },
                 "isSplitBrain": {
@@ -13976,6 +14310,9 @@
                 },
                 "internalProxy": {
                     "$ref": "#/definitions/myproxy.Server"
+                },
+                "isStaging": {
+                    "type": "boolean"
                 },
                 "lock": {
                     "$ref": "#/definitions/sync.Mutex"
@@ -14402,6 +14739,10 @@
                     "items": {
                         "$ref": "#/definitions/dbhelper.SlaveStatus"
                     }
+                },
+                "lastTLSConfig": {
+                    "description": "used to track last working TLS config",
+                    "type": "string"
                 },
                 "logOutput": {
                     "type": "string"
@@ -15198,6 +15539,9 @@
         "github_com_signal18_replication-manager_config.Config": {
             "type": "object",
             "properties": {
+                "ExternalScript": {
+                    "type": "boolean"
+                },
                 "alertPushoverAppToken": {
                     "type": "string"
                 },
@@ -15364,6 +15708,24 @@
                     "type": "boolean"
                 },
                 "backupBinlogsKeep": {
+                    "type": "integer"
+                },
+                "backupCheckFreeSpace": {
+                    "type": "boolean"
+                },
+                "backupDiskTresholdCrit": {
+                    "type": "integer"
+                },
+                "backupDiskTresholdWarn": {
+                    "type": "integer"
+                },
+                "backupEstimateSize": {
+                    "type": "boolean"
+                },
+                "backupEstimateSizePercentage": {
+                    "type": "integer"
+                },
+                "backupGrowthPercentage": {
                     "type": "integer"
                 },
                 "backupKeepDaily": {
@@ -15717,6 +16079,9 @@
                 "dbServersTlsServerKey": {
                     "type": "string"
                 },
+                "dbServersTlsSslMode": {
+                    "type": "string"
+                },
                 "dbServersUseGeneratedCert": {
                     "type": "boolean"
                 },
@@ -15901,12 +16266,6 @@
                 "fullVersion": {
                     "type": "string"
                 },
-                "gitMaxWorker": {
-                    "type": "integer"
-                },
-                "gitMinWorker": {
-                    "type": "integer"
-                },
                 "gitMonitoringTicker": {
                     "type": "integer"
                 },
@@ -16084,6 +16443,9 @@
                 "logConfigLoadLevel": {
                     "type": "integer"
                 },
+                "logExternalScriptLevel": {
+                    "type": "integer"
+                },
                 "logFile": {
                     "type": "string"
                 },
@@ -16144,6 +16506,9 @@
                 },
                 "logSstLevel": {
                     "description": "internal replication-manager sst",
+                    "type": "integer"
+                },
+                "logStatsLevel": {
                     "type": "integer"
                 },
                 "logSupport": {
@@ -17205,6 +17570,9 @@
                 "sstSendBuffer": {
                     "type": "integer"
                 },
+                "stagingProxyHosts": {
+                    "type": "string"
+                },
                 "switchoverAtEqualGtid": {
                     "type": "boolean"
                 },
@@ -17217,11 +17585,17 @@
                 "switchoverDecreaseMaxConnValue": {
                     "type": "integer"
                 },
+                "switchoverLockUserOnFreeze": {
+                    "type": "boolean"
+                },
                 "switchoverLowerRelease": {
                     "type": "boolean"
                 },
                 "switchoverMaxSlaveDelay": {
                     "type": "integer"
+                },
+                "switchoverRedirectOnFreeze": {
+                    "type": "boolean"
                 },
                 "switchoverSlaveWaitCatch": {
                     "type": "boolean"
@@ -17272,6 +17646,9 @@
                     "type": "boolean"
                 },
                 "testInjectTraffic": {
+                    "type": "boolean"
+                },
+                "testInjectTrafficStaging": {
                     "type": "boolean"
                 },
                 "topologyStaging": {
@@ -17528,6 +17905,58 @@
                 "text": {
                     "type": "string"
                 }
+            }
+        },
+        "misc.DiskStatManager": {
+            "type": "object",
+            "properties": {
+                "stats": {
+                    "$ref": "#/definitions/misc.DiskUsageStatMap"
+                }
+            }
+        },
+        "misc.DiskUsageStat": {
+            "type": "object",
+            "properties": {
+                "free": {
+                    "type": "integer"
+                },
+                "fstype": {
+                    "type": "string"
+                },
+                "inodesFree": {
+                    "type": "integer"
+                },
+                "inodesTotal": {
+                    "type": "integer"
+                },
+                "inodesUsed": {
+                    "type": "integer"
+                },
+                "inodesUsedPercent": {
+                    "type": "number"
+                },
+                "last_update": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "total": {
+                    "type": "integer"
+                },
+                "used": {
+                    "type": "integer"
+                },
+                "usedPercent": {
+                    "type": "number"
+                }
+            }
+        },
+        "misc.DiskUsageStatMap": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/misc.DiskUsageStat"
             }
         },
         "myproxy.Server": {
@@ -18100,6 +18529,12 @@
                 "memprofile": {
                     "type": "string"
                 },
+                "monitorType": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "os": {
                     "type": "string"
                 },
@@ -18161,6 +18596,12 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/config.Role"
+                    }
+                },
+                "serviceSslMode": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "boolean"
                     }
                 },
                 "serviceTarballs": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -182,6 +182,8 @@ definitions:
         items:
           $ref: '#/definitions/cluster.VariableDiff'
         type: array
+      diskStat:
+        $ref: '#/definitions/misc.DiskStatManager'
       diskType:
         additionalProperties:
           type: string
@@ -195,6 +197,10 @@ definitions:
         type: array
       failoverLastTime:
         type: integer
+      falsePositiveChecks:
+        additionalProperties:
+          type: boolean
+        type: object
       fsType:
         additionalProperties:
           type: boolean
@@ -251,15 +257,19 @@ definitions:
         type: boolean
       isNeedProxiesConfigChange:
         type: boolean
+      isNeedProxiesReprov:
+        type: boolean
       isNeedProxiesRestart:
         type: boolean
-      isNeedProxyRestart:
+      isNeedStagingChange:
         type: boolean
       isNotMonitoring:
         type: boolean
       isPostgres:
         type: boolean
       isProvision:
+        type: boolean
+      isRefreshStaging:
         type: boolean
       isSplitBrain:
         type: boolean
@@ -449,6 +459,8 @@ definitions:
         type: string
       internalProxy:
         $ref: '#/definitions/myproxy.Server'
+      isStaging:
+        type: boolean
       lock:
         $ref: '#/definitions/sync.Mutex'
       name:
@@ -732,6 +744,9 @@ definitions:
         items:
           $ref: '#/definitions/dbhelper.SlaveStatus'
         type: array
+      lastTLSConfig:
+        description: used to track last working TLS config
+        type: string
       logOutput:
         type: string
       longQueryTime:
@@ -1264,6 +1279,8 @@ definitions:
     type: object
   github_com_signal18_replication-manager_config.Config:
     properties:
+      ExternalScript:
+        type: boolean
       alertPushoverAppToken:
         type: string
       alertPushoverUserToken:
@@ -1375,6 +1392,18 @@ definitions:
       backupBinlogs:
         type: boolean
       backupBinlogsKeep:
+        type: integer
+      backupCheckFreeSpace:
+        type: boolean
+      backupDiskTresholdCrit:
+        type: integer
+      backupDiskTresholdWarn:
+        type: integer
+      backupEstimateSize:
+        type: boolean
+      backupEstimateSizePercentage:
+        type: integer
+      backupGrowthPercentage:
         type: integer
       backupKeepDaily:
         type: integer
@@ -1610,6 +1639,8 @@ definitions:
         type: string
       dbServersTlsServerKey:
         type: string
+      dbServersTlsSslMode:
+        type: string
       dbServersUseGeneratedCert:
         type: boolean
       delayStatCapture:
@@ -1733,10 +1764,6 @@ definitions:
         type: boolean
       fullVersion:
         type: string
-      gitMaxWorker:
-        type: integer
-      gitMinWorker:
-        type: integer
       gitMonitoringTicker:
         type: integer
       gitUrl:
@@ -1855,6 +1882,8 @@ definitions:
         type: boolean
       logConfigLoadLevel:
         type: integer
+      logExternalScriptLevel:
+        type: integer
       logFile:
         type: string
       logFileLevel:
@@ -1896,6 +1925,8 @@ definitions:
         type: boolean
       logSstLevel:
         description: internal replication-manager sst
+        type: integer
+      logStatsLevel:
         type: integer
       logSupport:
         type: boolean
@@ -2603,6 +2634,8 @@ definitions:
         type: string
       sstSendBuffer:
         type: integer
+      stagingProxyHosts:
+        type: string
       switchoverAtEqualGtid:
         type: boolean
       switchoverAtSync:
@@ -2611,10 +2644,14 @@ definitions:
         type: boolean
       switchoverDecreaseMaxConnValue:
         type: integer
+      switchoverLockUserOnFreeze:
+        type: boolean
       switchoverLowerRelease:
         type: boolean
       switchoverMaxSlaveDelay:
         type: integer
+      switchoverRedirectOnFreeze:
+        type: boolean
       switchoverSlaveWaitCatch:
         type: boolean
       switchoverWaitKill:
@@ -2648,6 +2685,8 @@ definitions:
       test:
         type: boolean
       testInjectTraffic:
+        type: boolean
+      testInjectTrafficStaging:
         type: boolean
       topologyStaging:
         type: boolean
@@ -2816,6 +2855,40 @@ definitions:
         type: string
       text:
         type: string
+    type: object
+  misc.DiskStatManager:
+    properties:
+      stats:
+        $ref: '#/definitions/misc.DiskUsageStatMap'
+    type: object
+  misc.DiskUsageStat:
+    properties:
+      free:
+        type: integer
+      fstype:
+        type: string
+      inodesFree:
+        type: integer
+      inodesTotal:
+        type: integer
+      inodesUsed:
+        type: integer
+      inodesUsedPercent:
+        type: number
+      last_update:
+        type: string
+      path:
+        type: string
+      total:
+        type: integer
+      used:
+        type: integer
+      usedPercent:
+        type: number
+    type: object
+  misc.DiskUsageStatMap:
+    additionalProperties:
+      $ref: '#/definitions/misc.DiskUsageStat'
     type: object
   myproxy.Server:
     type: object
@@ -3197,6 +3270,10 @@ definitions:
         $ref: '#/definitions/s18log.HttpLog'
       memprofile:
         type: string
+      monitorType:
+        additionalProperties:
+          type: string
+        type: object
       os:
         type: string
       osUser:
@@ -3239,6 +3316,10 @@ definitions:
         items:
           $ref: '#/definitions/config.Role'
         type: array
+      serviceSslMode:
+        additionalProperties:
+          type: boolean
+        type: object
       serviceTarballs:
         items:
           $ref: '#/definitions/config.Tarball'
@@ -3563,6 +3644,63 @@ paths:
       - description: Type
         in: path
         name: type
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Monitor added
+          schema:
+            type: string
+        "403":
+          description: No valid ACL
+          schema:
+            type: string
+        "409":
+          description: Error adding new monitor
+          schema:
+            type: string
+        "500":
+          description: Cluster Not Found
+          schema:
+            type: string
+      summary: Add a server to a specific cluster
+      tags:
+      - ClusterMonitor
+  /api/clusters/{clusterName}/actions/addserver/{host}/{port}/{type}/{tag}:
+    post:
+      consumes:
+      - application/json
+      description: This endpoint adds a server to the specified cluster.
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      - description: Host
+        in: path
+        name: host
+        required: true
+        type: string
+      - description: Port
+        in: path
+        name: port
+        required: true
+        type: string
+      - description: Type
+        in: path
+        name: type
+        type: string
+      - description: Tag
+        in: path
+        name: tag
         type: string
       produces:
       - application/json
@@ -4230,7 +4368,77 @@ paths:
       summary: Start traffic for a specific cluster
       tags:
       - ClusterTraffics
+  /api/clusters/{clusterName}/actions/start-traffic-staging:
+    post:
+      consumes:
+      - application/json
+      description: This endpoint starts traffic for the specified cluster.
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully started traffic
+          schema:
+            type: string
+        "403":
+          description: No valid ACL
+          schema:
+            type: string
+        "500":
+          description: No cluster
+          schema:
+            type: string
+      summary: Start traffic for a specific cluster
+      tags:
+      - ClusterTraffics
   /api/clusters/{clusterName}/actions/stop-traffic:
+    post:
+      consumes:
+      - application/json
+      description: This endpoint stops traffic for the specified cluster.
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully stopped traffic
+          schema:
+            type: string
+        "403":
+          description: No valid ACL
+          schema:
+            type: string
+        "500":
+          description: No cluster
+          schema:
+            type: string
+      summary: Stop traffic for a specific cluster
+      tags:
+      - ClusterTraffics
+  /api/clusters/{clusterName}/actions/stop-traffic-staging:
     post:
       consumes:
       - application/json
@@ -5300,6 +5508,55 @@ paths:
           schema:
             type: string
       summary: Provision Proxy Service
+      tags:
+      - Proxies
+  /api/clusters/{clusterName}/proxies/{proxyName}/actions/staging/{isStaging}:
+    post:
+      consumes:
+      - application/json
+      description: Set the proxy service for a given cluster and proxy to staging
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      - description: Proxy Name
+        in: path
+        name: proxyName
+        required: true
+        type: string
+      - description: Is Staging
+        in: path
+        name: isStaging
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Proxy Service Set to Staging
+          schema:
+            type: string
+        "403":
+          description: No valid ACL
+          schema:
+            type: string
+        "500":
+          description: Cluster Not Found" "Server Not Found
+          schema:
+            type: string
+        "503":
+          description: Not a Valid Server!
+          schema:
+            type: string
+      summary: Set Staging
       tags:
       - Proxies
   /api/clusters/{clusterName}/proxies/{proxyName}/actions/start:
@@ -11831,6 +12088,47 @@ paths:
           schema:
             type: string
       summary: Drop a server monitor from a cluster
+      tags:
+      - ClusterMonitor
+  /cluster/{clusterName}/actions/dropserver/{serverName}:
+    post:
+      consumes:
+      - application/json
+      description: This endpoint allows dropping a server monitor or proxy monitor
+        from a specified cluster.
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      - description: Monitor Server ID
+        in: path
+        name: serverName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Monitor dropped successfully
+          schema:
+            type: string
+        "403":
+          description: No valid ACL
+          schema:
+            type: string
+        "500":
+          description: Cluster Not Found
+          schema:
+            type: string
+      summary: Drop a server monitor from a cluster by name
       tags:
       - ClusterMonitor
   /meet/add/{channelId}/{userId}:

--- a/router/proxysql/proxysql.go
+++ b/router/proxysql/proxysql.go
@@ -249,7 +249,7 @@ func (psql *ProxySQL) CopyReaderToWriter(host string, port string) error {
 }
 
 func (psql *ProxySQL) ReplaceWriter(host string, port string, oldhost string, oldport string, masterasreader bool) error {
-    var err error
+	var err error
 	if masterasreader {
 		if err = psql.DeleteAllWriters(); err != nil {
 			return err

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -284,6 +284,16 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxStartTraffic)),
 	))
 
+	router.Handle("/api/clusters/{clusterName}/actions/stop-traffic-staging", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxStopTrafficStaging)),
+	))
+
+	router.Handle("/api/clusters/{clusterName}/actions/start-traffic-staging", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxStartTrafficStaging)),
+	))
+
 	router.Handle("/api/clusters/{clusterName}/actions/optimize", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterOptimize)),
@@ -1283,6 +1293,66 @@ func (repman *ReplicationManager) handlerMuxStopTraffic(w http.ResponseWriter, r
 	return
 }
 
+// handlerMuxStartTraffic handles the start traffic process for a given cluster.
+// @Summary Start traffic for a specific cluster
+// @Description This endpoint starts traffic for the specified cluster.
+// @Tags ClusterTraffics
+// @Accept json
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Success 200 {string} string "Successfully started traffic"
+// @Failure 403 {string} string "No valid ACL"
+// @Failure 500 {string} string "No cluster"
+// @Router /api/clusters/{clusterName}/actions/start-traffic-staging [post]
+func (repman *ReplicationManager) handlerMuxStartTrafficStaging(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster != nil {
+		if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+			http.Error(w, "No valid ACL", 403)
+			return
+		}
+		mycluster.SetTrafficStaging(true)
+	} else {
+
+		http.Error(w, "No cluster", 500)
+		return
+	}
+	return
+}
+
+// handlerMuxStopTraffic handles the stop traffic process for a given cluster.
+// @Summary Stop traffic for a specific cluster
+// @Description This endpoint stops traffic for the specified cluster.
+// @Tags ClusterTraffics
+// @Accept json
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Success 200 {string} string "Successfully stopped traffic"
+// @Failure 403 {string} string "No valid ACL"
+// @Failure 500 {string} string "No cluster"
+// @Router /api/clusters/{clusterName}/actions/stop-traffic-staging [post]
+func (repman *ReplicationManager) handlerMuxStopTrafficStaging(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster != nil {
+		if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+			http.Error(w, "No valid ACL", 403)
+			return
+		}
+		mycluster.SetTrafficStaging(false)
+	} else {
+
+		http.Error(w, "No cluster", 500)
+		return
+	}
+	return
+}
+
 // handlerMuxBootstrapReplicationCleanup handles the cleanup process for replication bootstrap.
 // @Summary Cleanup replication bootstrap for a specific cluster
 // @Description This endpoint triggers the cleanup process for replication bootstrap for the specified cluster.
@@ -2142,6 +2212,8 @@ func (repman *ReplicationManager) switchClusterSettings(mycluster *cluster.Clust
 		mycluster.SwitchProxyServersBackendCompression()
 	case "database-heartbeat":
 		mycluster.SwitchTraffic()
+	case "database-heartbeat-staging":
+		mycluster.SwitchTrafficStaging()
 	case "test":
 		mycluster.SwitchTestMode()
 	case "prov-net-cni":
@@ -3133,6 +3205,8 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		mycluster.Conf.PRXServersBackendCompression = isactive
 	case "database-heartbeat":
 		mycluster.Conf.TestInjectTraffic = isactive
+	case "database-heartbeat-staging":
+		mycluster.Conf.TestInjectTrafficStaging = isactive
 	case "test":
 		mycluster.Conf.Test = isactive
 	case "prov-net-cni":

--- a/server/api_proxy.go
+++ b/server/api_proxy.go
@@ -47,6 +47,10 @@ func (repman *ReplicationManager) apiProxyProtectedHandler(router *mux.Router) {
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxProxyNeedReprov)),
 	))
+	router.Handle("/api/clusters/{clusterName}/proxies/{proxyName}/actions/staging/{isStaging}", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxProxySetStaging)),
+	))
 	router.Handle("/api/terminal/connect/clusters/{clusterName}/proxies/{serverName}", negroni.New(
 		negroni.Wrap(http.HandlerFunc(repman.handlerTerminal)),
 	))
@@ -351,6 +355,49 @@ func (repman *ReplicationManager) handlerMuxProxyNeedReprov(w http.ResponseWrite
 		}
 	} else {
 		http.Error(w, "No cluster", 500)
+		return
+	}
+}
+
+// @Summary Set Staging
+// @Description Set the proxy service for a given cluster and proxy to staging
+// @Tags Proxies
+// @Accept json
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Param proxyName path string true "Proxy Name"
+// @Param isStaging path string true "Is Staging"
+// @Success 200 {string} string "Proxy Service Set to Staging"
+// @Failure 403 {string} string "No valid ACL"
+// @Failure 500 {string} string "Cluster Not Found" "Server Not Found"
+// @Failure 503 {string} string "Not a Valid Server!"
+// @Router /api/clusters/{clusterName}/proxies/{proxyName}/actions/staging/{isStaging} [post]
+func (repman *ReplicationManager) handlerMuxProxySetStaging(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster != nil {
+		if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+			http.Error(w, "No valid ACL", 403)
+			return
+		}
+		node := mycluster.GetProxyFromName(vars["proxyName"])
+		if node != nil {
+			if vars["isStaging"] == "true" {
+				mycluster.AddProxyToStagingHosts(node)
+			} else if vars["isStaging"] == "false" {
+				mycluster.DelProxyFromStagingHosts(node)
+			} else {
+				http.Error(w, "Invalid staging value", 500)
+				return
+			}
+		} else {
+			http.Error(w, "Server Not Found", 500)
+			return
+		}
+	} else {
+		http.Error(w, "Cluster Not Found", 500)
 		return
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -857,6 +857,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 
 	flags.BoolVar(&conf.Test, "test", false, "Enable non regression tests")
 	flags.BoolVar(&conf.TestInjectTraffic, "test-inject-traffic", false, "Inject some database traffic via proxy")
+	flags.BoolVar(&conf.TestInjectTrafficStaging, "test-inject-traffic-staging", false, "Inject some database traffic via proxy to staging")
 	flags.IntVar(&conf.SysbenchTime, "sysbench-time", 100, "Time to run benchmark")
 	flags.IntVar(&conf.SysbenchThreads, "sysbench-threads", 4, "Number of threads to run benchmark")
 	flags.StringVar(&conf.SysbenchTest, "sysbench-test", "oltp_read_write", "oltp_read_write|tpcc|oltp_read_only|oltp_update_index|oltp_update_non_index")

--- a/server/server.go
+++ b/server/server.go
@@ -462,6 +462,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.BoolVar(&conf.TopologyStaging, "topology-staging", false, "Use topology staging")
 	flags.StringVar(&conf.TopologyStagingRefreshScript, "topology-staging-refresh-script", "", "Topology staging refresh script path. Empty will use copy of embedded template in working directory")
 	flags.StringVar(&conf.TopologyStagingPostDetachScript, "topology-staging-post-detach-script", "", "Topology staging post detach script path. Empty will not execute anything")
+	flags.StringVar(&conf.StagingProxyHosts, "staging-proxy-hosts", "", "Staging proxy hosts list to monitor separated by commas")
 
 	flags.StringVar(&conf.PreScript, "failover-pre-script", "", "Path of pre-failover script")
 	flags.StringVar(&conf.PostScript, "failover-post-script", "", "Path of post-failover script")

--- a/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
@@ -27,6 +27,7 @@ import {
   rotateDBCredential,
   switchOverCluster,
   toggleTraffic,
+  toggleTrafficStaging,
   unProvisionCluster
 } from '../../../redux/clusterSlice'
 import NewServerModal from '../../../components/Modals/NewServerModal'
@@ -95,6 +96,14 @@ function ClusterDetail({ selectedCluster }) {
             setConfirmHandler(() => () => dispatch(toggleTraffic({ clusterName: selectedCluster?.name })))
           }
         },
+        ...( selectedCluster.config.topologyStaging ? [{
+          name: 'Toggle Traffic Staging',
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Toggle traffic?')
+            setConfirmHandler(() => () => dispatch(toggleTrafficStaging({ clusterName: selectedCluster?.name })))
+          }
+        }] : []),
         ...(clusterMaster?.state === 'Failed'
           ? [
               {

--- a/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
@@ -386,6 +386,7 @@ function ClusterDetail({ selectedCluster }) {
           {
             <>
               {selectedCluster?.config?.testInjectTraffic && <TagPill type='success' text='PrxTraffic' />}
+              {selectedCluster?.config?.testInjectTrafficStaging && <TagPill type='success' text='PrxTrafficStaging' />}
               {selectedCluster?.config?.monitoringPause && (
                 <TagPill colorScheme='red' isBlinking={true} text='NotMonitored' />
               )}

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyGrid/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyGrid/index.jsx
@@ -12,7 +12,7 @@ import RMIconButton from '../../../../../components/RMIconButton'
 import styles from './styles.module.scss'
 import ServerName from '../../../../../components/ServerName'
 
-function ProxyGrid({ proxies = [], clusterName, showTableView, user, isDesktop, isMenuOptionsVisible, showTerminal }) {
+function ProxyGrid({ proxies = [], clusterName, showTableView, user, isDesktop, isMenuOptionsVisible, showTerminal, topoStaging }) {
   return (
     <SimpleGrid columns={{ base: 1, sm: 1, md: 2, lg: 3 }} spacing={2} spacingY={6} spacingX={6} marginTop='4px'>
       {proxies?.length > 0 &&
@@ -54,7 +54,8 @@ function ProxyGrid({ proxies = [], clusterName, showTableView, user, isDesktop, 
                   isDesktop={isDesktop}
                   user={user}
                   isMenuOptionsVisible={isMenuOptionsVisible}
-                  showTerminal
+                  showTerminal={showTerminal}
+                  topoStaging={topoStaging}
                 />
               </Flex>
 

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyMenu.jsx
@@ -2,10 +2,10 @@ import { useDispatch } from 'react-redux'
 import MenuOptions from '../../../../components/MenuOptions'
 import ConfirmModal from '../../../../components/Modals/ConfirmModal'
 import { useState, useEffect } from 'react'
-import { dropServerByName, provisionProxy, startProxy, stopProxy, unprovisionProxy } from '../../../../redux/clusterSlice'
+import { dropServerByName, provisionProxy, stagingProxy, startProxy, stopProxy, unprovisionProxy } from '../../../../redux/clusterSlice'
 import { useNavigate } from 'react-router-dom'
 
-function ProxyMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView', user, isMenuOptionsVisible = false, showTerminal }) {
+function ProxyMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView', user, isMenuOptionsVisible = false, showTerminal, topoStaging }) {
   const dispatch = useDispatch()
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false)
   const [confirmTitle, setConfirmTitle] = useState('')
@@ -35,6 +35,25 @@ function ProxyMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView
         placement={from === 'tableView' ? 'right-end' : 'left-end'}
         subMenuPlacement={isDesktop ? (from === 'tableView' ? 'right-end' : 'left-end') : 'bottom'}
         options={[
+          ...(user?.grants['cluster-staging'] && topoStaging ? row.isStaging ? [
+            {
+              name: 'Set As Normal Proxy',
+              onClick: () => {
+                openConfirmModal()
+                setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
+                setConfirmHandler(() => () => dispatch(stagingProxy({ clusterName, proxyId: row.proxyId, staging: false })))
+              }
+            }
+          ] : [
+            {
+              name: 'Set As Staging Proxy',
+              onClick: () => {
+                openConfirmModal()
+                setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
+                setConfirmHandler(() => () => dispatch(stagingProxy({ clusterName, proxyId: row.proxyId, staging: true })))
+              }
+            }
+          ] : []),
           ...(user?.grants['prov-proxy-provision'] && isMenuOptionsVisible
             ? [
                 {

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyTable/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyTable/index.jsx
@@ -12,7 +12,7 @@ import RMIconButton from '../../../../../components/RMIconButton'
 import styles from './styles.module.scss'
 import ServerName from '../../../../../components/ServerName'
 
-function ProxyTable({ proxies = [], isDesktop, clusterName, showGridView, user, isMenuOptionsVisible, showTerminal}) {
+function ProxyTable({ proxies = [], isDesktop, clusterName, showGridView, user, isMenuOptionsVisible, showTerminal, topoStaging}) {
   const [tableData, setTableData] = useState([])
   useEffect(() => {
     if (proxies?.length > 0) {
@@ -64,7 +64,7 @@ function ProxyTable({ proxies = [], isDesktop, clusterName, showGridView, user, 
   const columns = useMemo(
     () => [
       columnHelper.accessor(
-        (row) => row.showMenu && <ProxyMenu row={row} isDesktop={isDesktop} clusterName={clusterName} user={user} isMenuOptionsVisible={isMenuOptionsVisible} showTerminal={showTerminal}/>,
+        (row) => row.showMenu && <ProxyMenu row={row} isDesktop={isDesktop} clusterName={clusterName} user={user} isMenuOptionsVisible={isMenuOptionsVisible} showTerminal={showTerminal} topoStaging={topoStaging}/>,
         {
           cell: (info) => info.getValue(),
           id: 'options',

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyTable/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyTable/index.jsx
@@ -30,6 +30,7 @@ function ProxyTable({ proxies = [], isDesktop, clusterName, showGridView, user, 
         if (!proxy.backendsRead && !proxy.backendsWrite) {
           data.push({
             logo: <ProxyLogo proxyName={proxy.type} />,
+            isStaging: proxy.isStaging,
             proxyId: proxy.id,
             showMenu: true, // to show the menu icon
             server: `${proxy.host}:${proxy.port}`,
@@ -45,6 +46,7 @@ function ProxyTable({ proxies = [], isDesktop, clusterName, showGridView, user, 
     return {
       logo: isNewProxy && <ProxyLogo proxyName={proxy.type} />,
       proxyId: proxy.id,
+      isStaging: proxy.isStaging,
       showMenu: isNewProxy,
       server: `${proxy.host}:${data.port}`,
       status: <ProxyStatus status={proxy.state} />,

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import ProxyTable from './ProxyTable'
 import ProxyGrid from './ProxyGrid'
@@ -6,7 +6,7 @@ import ProxyGrid from './ProxyGrid'
 function Proxies({ selectedCluster, user }) {
   const {
     common: { isDesktop },
-    cluster: { clusterProxies }
+    cluster: { clusterProxies, clusterProxiesStaging }
   } = useSelector((state) => state)
 
   const [viewType, setViewType] = useState('table')
@@ -17,6 +17,9 @@ function Proxies({ selectedCluster, user }) {
   const showTableView = () => {
     setViewType('table')
   }
+
+  useEffect(() => {
+  }, [clusterProxiesStaging])
 
   return clusterProxies ? (
     viewType === 'table' ? (

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/index.jsx
@@ -27,6 +27,7 @@ function Proxies({ selectedCluster, user }) {
         showGridView={showGridView}
         isMenuOptionsVisible={selectedCluster?.config?.provOrchestrator !== 'onpremise'}
         showTerminal={selectedCluster?.config?.terminalSessionEnabled}
+        topoStaging={selectedCluster?.config?.topologyStaging}
         user={user}
       />
     ) : (
@@ -37,6 +38,7 @@ function Proxies({ selectedCluster, user }) {
         showTableView={showTableView}
         isMenuOptionsVisible={selectedCluster?.config?.provOrchestrator !== 'onpremise'}
         showTerminal={selectedCluster?.config?.terminalSessionEnabled}
+        topoStaging={selectedCluster?.config?.topologyStaging}
         user={user}
       />
     )

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -943,6 +943,18 @@ export const stopProxy = createAsyncThunk('cluster/stopProxy', async ({ clusterN
   }
 })
 
+export const stagingProxy = createAsyncThunk('cluster/stagingProxy', async ({ clusterName, proxyId, staging }, thunkAPI) => {
+  try {
+    const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+    const { data, status } = await clusterService.stagingProxy(clusterName, proxyId, staging, baseURL)
+    showSuccessBanner('Staging proxy successful!', status, thunkAPI)
+    return { data, status }
+  } catch (error) {
+    showErrorBanner('Staging proxy failed!', error, thunkAPI)
+    handleError(error, thunkAPI)
+  }
+})
+
 export const runSysBench = createAsyncThunk('cluster/runSysBench', async ({ clusterName, thread }, thunkAPI) => {
   try {
     const baseURL = thunkAPI.getState()?.auth?.baseURL || ''

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -223,6 +223,18 @@ export const toggleTraffic = createAsyncThunk('cluster/toggleTraffic', async ({ 
   }
 })
 
+export const toggleTrafficStaging = createAsyncThunk('cluster/toggleTrafficStaging', async ({ clusterName }, thunkAPI) => {
+  try {
+    const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+    const { data, status } = await clusterService.toggleTrafficStaging(clusterName, baseURL)
+    showSuccessBanner('Traffic staging toggle done!', status, thunkAPI)
+    return { data, status }
+  } catch (error) {
+    showErrorBanner('Traffic staging toggle failed!', error, thunkAPI)
+    handleError(error, thunkAPI)
+  }
+})
+
 export const addServer = createAsyncThunk(
   'cluster/addServer',
   async ({ clusterName, host, port, monitorType, tag }, thunkAPI) => {
@@ -1484,6 +1496,7 @@ export const clusterSlice = createSlice({
         addServer.pending,
         dropServer.pending,
         toggleTraffic.pending,
+        toggleTrafficStaging.pending,
         provisionCluster.pending,
         unProvisionCluster.pending,
         sendCredentials.pending,
@@ -1551,7 +1564,7 @@ export const clusterSlice = createSlice({
         resetSLA.fulfilled,
         addServer.fulfilled,
         dropServer.fulfilled,
-        toggleTraffic.fulfilled,
+        toggleTrafficStaging.fulfilled,
         provisionCluster.fulfilled,
         unProvisionCluster.fulfilled,
         sendCredentials.fulfilled,
@@ -1620,6 +1633,7 @@ export const clusterSlice = createSlice({
         addServer.rejected,
         dropServer.rejected,
         toggleTraffic.rejected,
+        toggleTrafficStaging.rejected,
         provisionCluster.rejected,
         unProvisionCluster.rejected,
         sendCredentials.rejected,

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -1310,6 +1310,7 @@ const initialState = {
   clusterMaster: null,
   clusterServers: null,
   clusterProxies: null,
+  clusterProxiesStaging: null,
   clusterCertificates: null,
   clusterStates: null,
   backups: {
@@ -1398,7 +1399,8 @@ export const clusterSlice = createSlice({
           state.clusterStates = action.payload?.data?.map((server) => `${server.state}-${server.isVirtualMaster}`).join(',') || ''
         } else if (action.type.includes('getClusterProxies')) {
           state.isFetching.proxies = false
-          state.clusterProxies = action.payload.data
+          state.clusterProxies = action.payload?.data
+          state.clusterProxiesStaging = action.payload?.data?.filter((proxy) => proxy.isStaging).map((proxy) => proxy.name).join(',') || ''
         } else if (action.type.includes('getClusterCertificates')) {
           state.clusterCertificates = action.payload.data
         } else if (action.type.includes('getTopProcess')) {

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -79,6 +79,7 @@ export const clusterService = {
   unprovisionProxy,
   startProxy,
   stopProxy,
+  stagingProxy,
 
   // Database service APIs
   getDatabaseService,
@@ -403,6 +404,10 @@ function startProxy(clusterName, proxyId, baseURL) {
 
 function stopProxy(clusterName, proxyId, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/proxies/${proxyId}/actions/stop`)
+}
+
+function stagingProxy(clusterName, proxyId, isStaging, baseURL) {
+  return getApi(baseURL).get(`clusters/${clusterName}/proxies/${proxyId}/actions/staging/${isStaging}`)
 }
 //#endregion Proxy management APIs
 

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -22,6 +22,7 @@ export const clusterService = {
   resetFailOverCounter,
   resetSLA,
   toggleTraffic,
+  toggleTrafficStaging,
   addServer,
   dropServer,
   dropServerByName,
@@ -182,6 +183,10 @@ function resetSLA(clusterName, baseURL) {
 
 function toggleTraffic(clusterName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/settings/actions/switch/database-heartbeat`)
+}
+
+function toggleTrafficStaging(clusterName, baseURL) {
+  return getApi(baseURL).get(`clusters/${clusterName}/settings/actions/switch/database-heartbeat-staging`)
 }
 
 function addServer(clusterName, host, port, monitorType, tag, baseURL) {


### PR DESCRIPTION
This pull request introduces several changes to the `cluster` package, primarily focusing on enhancing the staging functionality. The main updates include adding new methods and properties to handle staging traffic and proxies, as well as updating existing methods to incorporate these new features.

Enhancements to staging functionality:

* [`cluster/cluster.go`](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R120): Added a new boolean property `IsNeedStagingChange` to the `Cluster` struct to track if a staging change is needed.
* [`cluster/cluster_staging.go`](diffhunk://#diff-ec443a688a4298a59c849d13303c9c79f65eab2fdfda6f55916634131a6019e7R4-R14): Introduced new methods `AddProxyToStagingHosts`, `DelProxyFromStagingHosts`, and `GetStagingProxyHosts` to manage staging proxies. Added extensive logic to the `RefreshStaging` method to handle staging refresh operations, including backup creation and slave management. [[1]](diffhunk://#diff-ec443a688a4298a59c849d13303c9c79f65eab2fdfda6f55916634131a6019e7R4-R14) [[2]](diffhunk://#diff-ec443a688a4298a59c849d13303c9c79f65eab2fdfda6f55916634131a6019e7L47-R62) [[3]](diffhunk://#diff-ec443a688a4298a59c849d13303c9c79f65eab2fdfda6f55916634131a6019e7R72-R270) [[4]](diffhunk://#diff-ec443a688a4298a59c849d13303c9c79f65eab2fdfda6f55916634131a6019e7L125-R309) [[5]](diffhunk://#diff-ec443a688a4298a59c849d13303c9c79f65eab2fdfda6f55916634131a6019e7R352-R379)
* [`cluster/cluster_acl.go`](diffhunk://#diff-a731c27675af8adff750e3acd4db4260f02693f0d35ec87b67fe23eb0bc2e08cR576-R581): Updated the `IsURLPassProxiesACL` method to include checks for staging-related actions.

Handling staging traffic:

* [`cluster/cluster.go`](diffhunk://#diff-ebe18c11af755e19a8493b229fe8b73799087472ad6bc067ea4e2b69df70b6f7R274-R277): Added new methods `GetTrafficStaging` and `SetTrafficStaging` to manage staging traffic configurations. [[1]](diffhunk://#diff-ebe18c11af755e19a8493b229fe8b73799087472ad6bc067ea4e2b69df70b6f7R274-R277) [[2]](diffhunk://#diff-d5872677c3cc5c2ea2a32bdf57af1e39a3e2d5e5eb735fc8bbba65b445132846R559-R562)
* [`cluster/cluster_tgl.go`](diffhunk://#diff-aec793cc6784c84a2f2e247c5f69a9e86dacca03bd6e9b80a54b0f92b2bc92a4R456-R459): Introduced the `SwitchTrafficStaging` method to toggle staging traffic.

Updates to proxy management:

* [`cluster/prx.go`](diffhunk://#diff-a1c4554e1b8f361bf9e6d5a29900403ccee9c45fd57c773806c064fc53ca4bcaR16): Added a new boolean property `IsStaging` to the `Proxy` struct and updated the `DatabaseProxy` interface with `SetStaging` and `IsInStaging` methods. Modified the `newProxyList` method to initialize staging proxies based on configuration. [[1]](diffhunk://#diff-a1c4554e1b8f361bf9e6d5a29900403ccee9c45fd57c773806c064fc53ca4bcaR16) [[2]](diffhunk://#diff-a1c4554e1b8f361bf9e6d5a29900403ccee9c45fd57c773806c064fc53ca4bcaR69) [[3]](diffhunk://#diff-a1c4554e1b8f361bf9e6d5a29900403ccee9c45fd57c773806c064fc53ca4bcaR139-R140) [[4]](diffhunk://#diff-a1c4554e1b8f361bf9e6d5a29900403ccee9c45fd57c773806c064fc53ca4bcaR247-R253) [[5]](diffhunk://#diff-a1c4554e1b8f361bf9e6d5a29900403ccee9c45fd57c773806c064fc53ca4bcaL251-R291)
* [`cluster/prx_haproxy.go`](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL138-R150): Updated the `Init` and `Refresh` methods of the `HaproxyProxy` struct to handle staging proxies appropriately. [[1]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL138-R150) [[2]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aR162) [[3]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aR214-R218)

Configuration:

staging-proxy-hosts="prx1,prx2"  
test-inject-traffic-staging = true

These changes improve the handling of staging environments and traffic within the cluster, providing more robust and flexible staging management capabilities.
