### PR TITLE
Reseed set gtid binlog state

### DIFF
--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1334,7 +1334,10 @@ func (server *ServerMonitor) ResetGTIDBinlogState(gtid_pos string) (string, erro
 	for _, gtid := range strings.Split(binlogstate, ",") {
 		if strings.HasPrefix(gtid, prefix) {
 			found = true
-			newstate = append(newstate, gtid_pos)
+			if gtid > gtid_pos {
+				server.ResetMaster()
+				newstate = append(newstate, gtid_pos)
+			}
 		} else {
 			newstate = append(newstate, gtid)
 		}

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1319,6 +1319,34 @@ func (server *ServerMonitor) ResetMaster() (string, error) {
 	return dbhelper.ResetMaster(server.Conn, cluster.Conf.MasterConn, server.DBVersion)
 }
 
+func (server *ServerMonitor) ResetGTIDBinlogState(gtid_pos string) (string, error) {
+	if server.Conn == nil {
+		return "", errors.New("No database connection pool")
+	}
+
+	prefix := strings.Split(gtid_pos, "-")[0]
+
+	binlogstate := server.Variables.Get("GTID_BINLOG_STATE")
+
+	// replace the GTID_BINLOG_STATE with the new GTID_BINLOG_POS
+	found := false
+	newstate := []string{}
+	for _, gtid := range strings.Split(binlogstate, ",") {
+		if strings.HasPrefix(gtid, prefix) {
+			found = true
+			newstate = append(newstate, gtid_pos)
+		} else {
+			newstate = append(newstate, gtid)
+		}
+	}
+
+	if !found {
+		newstate = append(newstate, gtid_pos)
+	}
+
+	return dbhelper.SetGTIDBinlogState(server.Conn, strings.Join(newstate, ","))
+}
+
 func (server *ServerMonitor) ResetPFSQueries() error {
 	return server.ExecQueryNoBinLog("truncate performance_schema.events_statements_summary_by_digest", 5*time.Second)
 }

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -1107,6 +1107,15 @@ func (server *ServerMonitor) JobReseedMyLoader(backupdir string) error {
 		if server.IsMariaDB() && server.HaveMariaDBGTID {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Starting slave with mydumper metadata")
 			server.ExecQueryNoBinLog("SET GLOBAL gtid_slave_pos='"+meta.BinLogUuid+"'", time.Second)
+
+			if server.IsMariaDB() && server.DBVersion.GreaterEqual("10") {
+				// Also reset GTID binlog state
+				_, err = server.ResetGTIDBinlogState(meta.BinLogUuid)
+				if err != nil {
+					return err
+				}
+			}
+
 			server.StartSlave()
 		}
 	}

--- a/utils/dbhelper/dbhelper.go
+++ b/utils/dbhelper/dbhelper.go
@@ -2064,12 +2064,8 @@ func GetUsers(db *sqlx.DB, myver *version.Version) (map[string]*Grant, string, e
 	query := "SELECT user, host, password, CONV(LEFT(MD5(concat(user,host)), 16), 16, 10)    FROM mysql.user where host<>'localhost' "
 	if myver.IsPostgreSQL() {
 		query = "SELECT usename as user , '%' as host , 'unknow'  as password, 0 FROM pg_catalog.pg_user"
-	} else if (myver.IsMySQL() || myver.IsPercona()) && (myver.Major > 7 || (myver.Major == 5 && myver.Minor >= 7)) {
-		if myver.Major > 7 {
-			query = "SELECT user, host, authentication_string as password, CONV(LEFT(MD5(concat(user,host)), 16), 16, 10)  FROM mysql.user"
-		} else {
-			query = "SELECT user, host, '****' as password, CONV(LEFT(MD5(concat(user,host)), 16), 16, 10)    FROM mysql.user"
-		}
+	} else if myver.IsMySQLOrPercona() && myver.GreaterEqual("5.7.6") {
+		query = "SELECT user, host, authentication_string as password, CONV(LEFT(MD5(concat(user,host)), 16), 16, 10)  FROM mysql.user"
 	}
 
 	rows, err := db.Queryx(query)
@@ -2530,6 +2526,13 @@ func ResetMaster(db *sqlx.DB, Channel string, myver *version.Version) (string, e
 	} else {
 		stmt += "RESET MASTER"
 	}
+	_, err := db.Exec(stmt)
+
+	return stmt, err
+}
+
+func SetGTIDBinlogState(db *sqlx.DB, binlogstate string) (string, error) {
+	stmt := "SET GLOBAL gtid_binlog_state = '" + binlogstate + "'"
 	_, err := db.Exec(stmt)
 
 	return stmt, err


### PR DESCRIPTION
This pull request introduces several new functionalities and improvements to the `ServerMonitor` and `dbhelper` components, primarily focusing on GTID binlog state management and MySQL version handling. The most important changes include the addition of a method to reset the GTID binlog state, modifications to MySQL user query handling, and integration of the new GTID reset functionality within the server's job reseed process.

### GTID Binlog State Management:

* [`cluster/srv.go`](diffhunk://#diff-c5fffdb4a6a092160ddd24b95042ba54bfcb96dfb0e747bb200902aac778adb1R1322-R1352): Added a new method `ResetGTIDBinlogState` to reset the GTID binlog state based on a given GTID position. This method updates the `GTID_BINLOG_STATE` variable and ensures the new state is set correctly.

* [`utils/dbhelper/dbhelper.go`](diffhunk://#diff-e9e0167b5c5254cf7532586841c5126202e3eecc885ba66aa23747877ccb6398R2534-R2540): Added a new function `SetGTIDBinlogState` to execute the SQL statement for setting the GTID binlog state. This function constructs and executes the appropriate SQL command.

### Job Reseed Process:

* [`cluster/srv_job.go`](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fR1110-R1118): Integrated the `ResetGTIDBinlogState` method into the `JobReseedMyLoader` function to ensure that the GTID binlog state is reset when reseeding a MariaDB server with a version greater than or equal to 10.

### MySQL Version Handling:

* [`utils/dbhelper/dbhelper.go`](diffhunk://#diff-e9e0167b5c5254cf7532586841c5126202e3eecc885ba66aa23747877ccb6398L2067-L2072): Simplified the user query logic by using the `GreaterEqual` method for MySQL version comparison. This change ensures that the correct query is used for MySQL versions 5.7.6 and above.
