### PR TITLE
Add more wait time to prevent timeout too early

### DIFF
--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -106,7 +106,7 @@ func (cluster *Cluster) RefreshStaging() error {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Waiting for slave %s to stop replication", STG.URL)
 		waitstart := time.Now()
 		for STG.State == stateSlave {
-			if waitstart.Add(10 * time.Second).Before(time.Now()) {
+			if waitstart.Add(30 * time.Second).Before(time.Now()) {
 				err = fmt.Errorf("timeout waiting for slave %s to stop replication", STG.URL)
 				return err
 			}
@@ -138,7 +138,7 @@ func (cluster *Cluster) RefreshStaging() error {
 
 		waitstart = time.Now()
 		for STG.State != stateUnconn {
-			if waitstart.Add(10 * time.Second).Before(time.Now()) {
+			if waitstart.Add(30 * time.Second).Before(time.Now()) {
 				err = fmt.Errorf("timeout waiting for slave %s to be reset", STG.URL)
 				return err
 			}
@@ -178,7 +178,7 @@ func (cluster *Cluster) RefreshStaging() error {
 		// Wait until the slave is stopped
 		waitstart := time.Now()
 		for SL.State == stateSlave {
-			if waitstart.Add(10 * time.Second).Before(time.Now()) {
+			if waitstart.Add(30 * time.Second).Before(time.Now()) {
 				err = fmt.Errorf("timeout waiting for slave %s to stop replication", SL.URL)
 				return err
 			}
@@ -202,15 +202,19 @@ func (cluster *Cluster) RefreshStaging() error {
 			}
 		}
 
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Resetting master position on slave %s", SL.URL)
+		SL.StopSlave()
 		_, err = SL.ResetSlave()
 		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Error resetting slave: %s", err)
 			return err
 		}
 
 		waitstart = time.Now()
 		for SL.State != stateUnconn {
-			if waitstart.Add(10 * time.Second).Before(time.Now()) {
+			if waitstart.Add(30 * time.Second).Before(time.Now()) {
 				err = fmt.Errorf("timeout waiting for slave %s to be reset", SL.URL)
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Error resetting slave: %s", err)
 				return err
 			}
 
@@ -240,7 +244,7 @@ func (cluster *Cluster) RefreshStaging() error {
 
 		waitstart = time.Now()
 		for STG.State != stateSlave {
-			if waitstart.Add(10 * time.Second).Before(time.Now()) {
+			if waitstart.Add(30 * time.Second).Before(time.Now()) {
 				err = fmt.Errorf("timeout waiting for standalone %s to be reseeded", STG.URL)
 				return err
 			}

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -106,7 +106,7 @@ func (cluster *Cluster) RefreshStaging() error {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Waiting for slave %s to stop replication", STG.URL)
 		waitstart := time.Now()
 		for STG.State == stateSlave {
-			if waitstart.Add(30 * time.Second).Before(time.Now()) {
+			if waitstart.Add(60 * time.Second).Before(time.Now()) {
 				err = fmt.Errorf("timeout waiting for slave %s to stop replication", STG.URL)
 				return err
 			}
@@ -138,7 +138,7 @@ func (cluster *Cluster) RefreshStaging() error {
 
 		waitstart = time.Now()
 		for STG.State != stateUnconn {
-			if waitstart.Add(30 * time.Second).Before(time.Now()) {
+			if waitstart.Add(60 * time.Second).Before(time.Now()) {
 				err = fmt.Errorf("timeout waiting for slave %s to be reset", STG.URL)
 				return err
 			}
@@ -178,7 +178,7 @@ func (cluster *Cluster) RefreshStaging() error {
 		// Wait until the slave is stopped
 		waitstart := time.Now()
 		for SL.State == stateSlave {
-			if waitstart.Add(30 * time.Second).Before(time.Now()) {
+			if waitstart.Add(60 * time.Second).Before(time.Now()) {
 				err = fmt.Errorf("timeout waiting for slave %s to stop replication", SL.URL)
 				return err
 			}
@@ -212,7 +212,7 @@ func (cluster *Cluster) RefreshStaging() error {
 
 		waitstart = time.Now()
 		for SL.State != stateUnconn {
-			if waitstart.Add(30 * time.Second).Before(time.Now()) {
+			if waitstart.Add(60 * time.Second).Before(time.Now()) {
 				err = fmt.Errorf("timeout waiting for slave %s to be reset", SL.URL)
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Error resetting slave: %s", err)
 				return err
@@ -244,7 +244,7 @@ func (cluster *Cluster) RefreshStaging() error {
 
 		waitstart = time.Now()
 		for STG.State != stateSlave {
-			if waitstart.Add(30 * time.Second).Before(time.Now()) {
+			if waitstart.Add(60 * time.Second).Before(time.Now()) {
 				err = fmt.Errorf("timeout waiting for standalone %s to be reseeded", STG.URL)
 				return err
 			}


### PR DESCRIPTION
This pull request includes several changes to the `RefreshStaging` method in the `cluster/cluster_staging.go` file to improve the timeout handling and add additional logging.

Timeout handling improvements:
* Increased the timeout duration from 10 seconds to 60 seconds when waiting for the slave to stop replication, be reset, and be reseeded. [[1]](diffhunk://#diff-ec443a688a4298a59c849d13303c9c79f65eab2fdfda6f55916634131a6019e7L109-R109) [[2]](diffhunk://#diff-ec443a688a4298a59c849d13303c9c79f65eab2fdfda6f55916634131a6019e7L141-R141) [[3]](diffhunk://#diff-ec443a688a4298a59c849d13303c9c79f65eab2fdfda6f55916634131a6019e7L181-R181) [[4]](diffhunk://#diff-ec443a688a4298a59c849d13303c9c79f65eab2fdfda6f55916634131a6019e7L243-R247)

Additional logging:
* Added log statements to indicate when the master position is being reset on the slave and to log errors encountered during the reset process.## Contributor Agreement

By submitting this pull request, I agree to the terms outlined in the [Contributor Agreement](CONTRIBUTING.md).
