### PR TITLE
Add process management features with kill query and thread options

### DIFF
--- a/share/dashboard_react/src/Pages/ClusterDB/components/ClusterDBTabContent/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterDB/components/ClusterDBTabContent/index.jsx
@@ -50,7 +50,7 @@ function ClusterDBTabContent({ tab, dbId, clusterName, digestMode, toggleDigestM
         </HStack>
       </Flex>
       {currentTab === 'processlist' ? (
-        <ProcessList clusterName={clusterName} dbId={dbId} />
+        <ProcessList clusterName={clusterName} dbId={dbId} user={user}  />
       ) : currentTab === 'slowqueries' ? (
         <SlowQueries clusterName={clusterName} dbId={dbId} selectedDBServer={selectedDBServer} />
       ) : currentTab === 'digestqueries' ? (

--- a/share/dashboard_react/src/Pages/ClusterDB/components/ProcessList/ProcessMenu.jsx
+++ b/share/dashboard_react/src/Pages/ClusterDB/components/ProcessList/ProcessMenu.jsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react"
+import { useDispatch } from "react-redux"
+import MenuOptions from "../../../../components/MenuOptions"
+import { killQuery, killThread } from "../../../../redux/clusterSlice"
+import ConfirmModal from "../../../../components/Modals/ConfirmModal"
+
+function ProcessMenu({ clusterName, serverId, row, isDesktop, colorScheme, from = 'tableView', user }) {
+  const dispatch = useDispatch()
+  const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false)
+  const [confirmTitle, setConfirmTitle] = useState('')
+  const [confirmHandler, setConfirmHandler] = useState(null)
+
+  useEffect(() => {
+  }, [row, serverId])
+
+  const openConfirmModal = () => {
+    setIsConfirmModalOpen(true)
+  }
+
+  const closeConfirmModal = () => {
+    setIsConfirmModalOpen(false)
+    setConfirmHandler(null)
+    setConfirmTitle('')
+  }
+
+  return (
+    <>
+      <MenuOptions
+        colorScheme={colorScheme}
+        placement={from === 'tableView' ? 'right-end' : 'left-end'}
+        subMenuPlacement={isDesktop ? (from === 'tableView' ? 'right-end' : 'left-end') : 'bottom'}
+        options={[
+            ...(user?.grants['db-kill'] ? [{
+              name: 'Kill Connection',
+              onClick: () => {
+                openConfirmModal()
+                setConfirmTitle(`Confirm kill connection ${row.id}?`)
+                setConfirmHandler(() => () => dispatch(killThread({ clusterName, serverId, queryDigest: row.id })))
+              }
+            },
+            {
+              name: 'Kill Query',
+              onClick: () => {
+                openConfirmModal()
+                setConfirmTitle(`Confirm kill connection ${row.id}?`)
+                setConfirmHandler(() => () => dispatch(killQuery({ clusterName, serverId, queryDigest: row.id })))
+              }
+            }] : [])
+          ]}
+      />
+      {isConfirmModalOpen && (
+        <ConfirmModal
+          isOpen={isConfirmModalOpen}
+          closeModal={closeConfirmModal}
+          title={confirmTitle}
+          onConfirmClick={() => {
+            confirmHandler()
+            closeConfirmModal()
+          }}
+        />
+      )}
+    </>
+  )
+}
+
+export default ProcessMenu

--- a/share/dashboard_react/src/Pages/ClusterDB/components/ProcessList/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterDB/components/ProcessList/index.jsx
@@ -7,8 +7,9 @@ import { DataTable } from '../../../../components/DataTable'
 import { getReadableTime } from '../../../../utility/common'
 import DropdownSysbench from '../../../../components/DropdownSysbench'
 import { getDatabaseService } from '../../../../redux/clusterSlice'
+import ProcessMenu from './ProcessMenu'
 
-function ProcessList({ clusterName, dbId }) {
+function ProcessList({ clusterName, dbId, user }) {
   const dispatch = useDispatch()
   const [data, setData] = useState([])
 
@@ -82,6 +83,12 @@ function ProcessList({ clusterName, dbId }) {
 
   const columns = useMemo(
     () => [
+      columnHelper.accessor((row) => user?.grants['db-kill'] && <ProcessMenu clusterName={clusterName} serverId={dbId} row={row} user={user} />, {
+        cell: (info) => info.getValue(),
+        header: '#',
+        enableSorting: false,
+        width: '40px'
+      }),
       columnHelper.accessor((row) => row.id, {
         header: 'Id',
         enableSorting: false

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -865,6 +865,44 @@ export const toggleReadOnly = createAsyncThunk(
   }
 )
 
+export const killThread = createAsyncThunk(
+  'cluster/killThread',
+  async ({ clusterName, serverId, queryDigest }, thunkAPI) => {
+    try {
+      const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+      const { data, status } = await clusterService.killThread(clusterName, serverId, queryDigest, baseURL)
+      if (status === 200) {
+        showSuccessBanner('Thread killed successfully!', status, thunkAPI)
+      } else {
+        showErrorBanner('Thread kill failed!', status, thunkAPI)
+      }
+      return { data, status }
+    } catch (error) {
+      showErrorBanner('Thread kill failed!', error, thunkAPI)
+      handleError(error, thunkAPI)
+    }
+  }
+)
+
+export const killQuery = createAsyncThunk(
+  'cluster/killQuery',
+  async ({ clusterName, serverId, queryDigest }, thunkAPI) => {
+    try {
+      const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+      const { data, status } = await clusterService.killQuery(clusterName, serverId, queryDigest, baseURL)
+      if (status === 200) {
+        showSuccessBanner('Query killed successfully!', status, thunkAPI)
+      } else {
+        showErrorBanner('Query kill failed!', status, thunkAPI)
+      }
+      return { data, status }
+    } catch (error) {
+      showErrorBanner('Query kill failed!', error, thunkAPI)
+      handleError(error, thunkAPI)
+    }
+  }
+)
+
 export const resetMaster = createAsyncThunk('cluster/resetMaster', async ({ clusterName, serverId }, thunkAPI) => {
   try {
     const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
@@ -1547,6 +1585,8 @@ export const clusterSlice = createSlice({
         startProxy.pending,
         stopProxy.pending,
         refreshStaging.pending,
+        killThread.pending,
+        killQuery.pending
       ),
       (state, action) => {
         if (action.type.includes('switchOverCluster')) {
@@ -1615,6 +1655,8 @@ export const clusterSlice = createSlice({
         startProxy.fulfilled,
         stopProxy.fulfilled,
         refreshStaging.fulfilled,
+        killThread.fulfilled,
+        killQuery.fulfilled
       ),
       (state, action) => {
         if (action.type.includes('switchOverCluster')) {
@@ -1684,6 +1726,8 @@ export const clusterSlice = createSlice({
         startProxy.rejected,
         stopProxy.rejected,
         refreshStaging.rejected,
+        killThread.rejected,
+        killQuery.rejected
       ),
       (state, action) => {
         if (action.type.includes('switchOverCluster')) {

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -87,6 +87,8 @@ export const clusterService = {
   updateLongQueryTime,
   toggleDatabaseActions,
   checksumTable,
+  killThread,
+  killQuery,
 
   // Test run APIs
   runSysbench,
@@ -427,6 +429,14 @@ function updateLongQueryTime(clusterName, dbId, time, baseURL) {
 
 function toggleDatabaseActions(clusterName, serviceName, dbId, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/servers/${dbId}/actions/${serviceName}`)
+}
+
+function killThread(clusterName, dbId, queryDigest, baseURL) {
+  return getApi(baseURL).get(`clusters/${clusterName}/servers/${dbId}/queries/${queryDigest}/actions/kill-thread`)
+}
+
+function killQuery(clusterName, dbId, queryDigest, baseURL) {
+  return getApi(baseURL).get(`clusters/${clusterName}/servers/${dbId}/queries/${queryDigest}/actions/kill-query`)
 }
 
 function checksumTable(clusterName, schema, table, baseURL) {


### PR DESCRIPTION
This pull request introduces significant changes to the `ClusterDB` dashboard, focusing on user permissions and the ability to kill database threads and queries. The most important changes include adding user-based permissions for killing connections and queries, implementing new actions in the Redux slice, and updating the services to support these actions.

Enhancements to user permissions and actions:

* [`share/dashboard_react/src/Pages/ClusterDB/components/ClusterDBTabContent/index.jsx`](diffhunk://#diff-34fcc8c76e092d6b96e681cf12c30ce0cc7e7438647316f71dbc3b8292c8db52L53-R53): Added the `user` prop to the `ProcessList` component to pass user information for permission checks.
* [`share/dashboard_react/src/Pages/ClusterDB/components/ProcessList/ProcessMenu.jsx`](diffhunk://#diff-c9eec8d0be87141a4ef169ecf8a4d768b396876d18ff0eb0206355e76b4c7881R1-R66): Introduced the `ProcessMenu` component, which includes options to kill connections and queries based on user permissions.
* [`share/dashboard_react/src/Pages/ClusterDB/components/ProcessList/index.jsx`](diffhunk://#diff-6c1d0c5a79819335607528a08b76e38de799eca0a51b8c04fc05486789b34139R10-R12): Updated the `ProcessList` component to include the `ProcessMenu` and pass the `user` prop. [[1]](diffhunk://#diff-6c1d0c5a79819335607528a08b76e38de799eca0a51b8c04fc05486789b34139R10-R12) [[2]](diffhunk://#diff-6c1d0c5a79819335607528a08b76e38de799eca0a51b8c04fc05486789b34139R86-R91)

Redux slice updates:

* [`share/dashboard_react/src/redux/clusterSlice.js`](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R868-R905): Added `killThread` and `killQuery` actions to the Redux slice, including their pending, fulfilled, and rejected states. [[1]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R868-R905) [[2]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1588-R1589) [[3]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1658-R1659) [[4]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1729-R1730)

Service updates:

* [`share/dashboard_react/src/services/clusterService.js`](diffhunk://#diff-7bbc99751675465360b02f80d806f62b29109dd0a66e704ac6e8b47a480693fbR90-R91): Added `killThread` and `killQuery` functions to support the new actions for killing database threads and queries. [[1]](diffhunk://#diff-7bbc99751675465360b02f80d806f62b29109dd0a66e704ac6e8b47a480693fbR90-R91) [[2]](diffhunk://#diff-7bbc99751675465360b02f80d806f62b29109dd0a66e704ac6e8b47a480693fbR434-R441)