### PR TITLE
Add variable backup-mysqlclient-options for configurable restore command

### DIFF
--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -1145,7 +1145,7 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string) error {
 	defer fz.Close()
 
 	cliParams := make([]string, 0)
-	cliParams = append(cliParams, `--host=`+misc.Unbracket(server.Host), `--port=`+server.Port, `--user=`+cluster.GetDbUser(), `--password=`+cluster.GetDbPass(), `--force`, `--batch`)
+	cliParams = append(cliParams, `--host=`+misc.Unbracket(server.Host), `--port=`+server.Port, `--user=`+cluster.GetDbUser(), `--password=`+cluster.GetDbPass())
 	cliParams = append(cliParams, strings.Split(server.GetSSLClientParam("client"), " ")...)
 	cliParams = append(cliParams, strings.Split(cluster.Conf.BackupMysqlclientOptions, " ")...)
 	clientCmd := exec.Command(cluster.GetMysqlclientPath(), misc.RemoveEmptyString(cliParams)...)
@@ -2651,8 +2651,9 @@ func (cluster *Cluster) JobRejoinMysqldumpFromSource(source *ServerMonitor, dest
 	stderrIn, _ := dumpCmd.StderrPipe()
 
 	cliParams := make([]string, 0)
-	cliParams = append(cliParams, `--defaults-file=`+file, `--host=`+misc.Unbracket(dest.Host), `--port=`+dest.Port, `--user=`+cluster.GetDbUser(), `--force`, `--batch`)
+	cliParams = append(cliParams, `--defaults-file=`+file, `--host=`+misc.Unbracket(dest.Host), `--port=`+dest.Port, `--user=`+cluster.GetDbUser())
 	cliParams = append(cliParams, strings.Split(dest.GetSSLClientParam("client"), " ")...)
+	cliParams = append(cliParams, strings.Split(cluster.Conf.BackupMysqlclientOptions, " ")...)
 
 	clientCmd := exec.Command(cluster.GetMysqlclientPath(), misc.RemoveEmptyString(cliParams)...)
 	stderrOut, _ := clientCmd.StderrPipe()

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -1138,15 +1138,16 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string) error {
 		return fmt.Errorf("[%s] Failed opening backup file in backup server for reseed:  %s ", server.URL, err)
 	}
 
-	fz, err := gzip.NewReaderN(gzfile, 8*1024*1024, 16)
+	fz, err := gzip.NewReaderN(gzfile, cluster.Conf.SSTSendBuffer, 16)
 	if err != nil {
 		return fmt.Errorf("[%s] Failed to unzip backup file in backup server for reseed:  %s ", server.URL, err)
 	}
 	defer fz.Close()
 
 	cliParams := make([]string, 0)
-	cliParams = append(cliParams, `--host=`+misc.Unbracket(server.Host), `--port=`+server.Port, `--user=`+cluster.GetDbUser(), `--password=`+cluster.GetDbPass(), `--force`, `--batch`, `--max-allowed-packet=128M`)
+	cliParams = append(cliParams, `--host=`+misc.Unbracket(server.Host), `--port=`+server.Port, `--user=`+cluster.GetDbUser(), `--password=`+cluster.GetDbPass(), `--force`, `--batch`)
 	cliParams = append(cliParams, strings.Split(server.GetSSLClientParam("client"), " ")...)
+	cliParams = append(cliParams, strings.Split(cluster.Conf.BackupMysqlclientOptions, " ")...)
 	clientCmd := exec.Command(cluster.GetMysqlclientPath(), misc.RemoveEmptyString(cliParams)...)
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s ", strings.Replace(clientCmd.String(), "="+cluster.GetDbPass(), "XXXX", -1))

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -1138,17 +1138,11 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string) error {
 		return fmt.Errorf("[%s] Failed opening backup file in backup server for reseed:  %s ", server.URL, err)
 	}
 
-	fz, err := gzip.NewReader(gzfile)
+	fz, err := gzip.NewReaderN(gzfile, 1024*1024, 16)
 	if err != nil {
 		return fmt.Errorf("[%s] Failed to unzip backup file in backup server for reseed:  %s ", server.URL, err)
 	}
 	defer fz.Close()
-
-	var buf bytes.Buffer
-	_, err = io.Copy(&buf, fz)
-	if err != nil {
-		return fmt.Errorf("[%s] Error happened when unzipping backup file in backup server for reseed:  %s ", server.URL, err)
-	}
 
 	cliParams := make([]string, 0)
 	cliParams = append(cliParams, `--host=`+misc.Unbracket(server.Host), `--port=`+server.Port, `--user=`+cluster.GetDbUser(), `--password=`+cluster.GetDbPass(), `--force`, `--batch`, `--verbose`)
@@ -1161,7 +1155,8 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string) error {
 	if server.DBVersion.IsMySQLOrPerconaGreater84() {
 		cmdstring = "RESET BINARY LOGS AND GTIDS;SET sql_log_bin=0;SET long_query_time=10;"
 	}
-	clientCmd.Stdin = io.MultiReader(bytes.NewBufferString(cmdstring), &buf)
+
+	clientCmd.Stdin = io.MultiReader(bytes.NewBufferString(cmdstring), fz)
 
 	stderr, _ := clientCmd.StdoutPipe()
 	clientCmd.Stderr = clientCmd.Stdout

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -1138,14 +1138,14 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string) error {
 		return fmt.Errorf("[%s] Failed opening backup file in backup server for reseed:  %s ", server.URL, err)
 	}
 
-	fz, err := gzip.NewReaderN(gzfile, 1024*1024, 16)
+	fz, err := gzip.NewReaderN(gzfile, 8*1024*1024, 16)
 	if err != nil {
 		return fmt.Errorf("[%s] Failed to unzip backup file in backup server for reseed:  %s ", server.URL, err)
 	}
 	defer fz.Close()
 
 	cliParams := make([]string, 0)
-	cliParams = append(cliParams, `--host=`+misc.Unbracket(server.Host), `--port=`+server.Port, `--user=`+cluster.GetDbUser(), `--password=`+cluster.GetDbPass(), `--force`, `--batch`, `--verbose`)
+	cliParams = append(cliParams, `--host=`+misc.Unbracket(server.Host), `--port=`+server.Port, `--user=`+cluster.GetDbUser(), `--password=`+cluster.GetDbPass(), `--force`, `--batch`, `--max-allowed-packet=128M`)
 	cliParams = append(cliParams, strings.Split(server.GetSSLClientParam("client"), " ")...)
 	clientCmd := exec.Command(cluster.GetMysqlclientPath(), misc.RemoveEmptyString(cliParams)...)
 
@@ -1165,9 +1165,15 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string) error {
 		return fmt.Errorf("Can't start mysql client:%s at %s", err, strings.ReplaceAll(clientCmd.String(), cluster.GetDbPass(), "XXXX"))
 	}
 
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
 	go func() {
-		server.copyTaskDebugLogs(stderr, config.ConstLogModBackupStream, "reseedmysqldump")
+		defer wg.Done()
+		server.copyLogs(stderr, config.ConstLogModBackupStream, config.LvlDbg)
 	}()
+
+	wg.Wait()
 
 	err = clientCmd.Wait()
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -704,6 +704,7 @@ type Config struct {
 	BackupMyDumperRegex                       string                 `mapstructure:"backup-mydumper-regex" toml:"backup-mydumper-regex" json:"backupMyDumperRegex"`
 	BackupMysqlbinlogPath                     string                 `mapstructure:"backup-mysqlbinlog-path" toml:"backup-mysqlbinlog-path" json:"backupMysqlbinlogPath"`
 	BackupMysqlclientPath                     string                 `mapstructure:"backup-mysqlclient-path" toml:"backup-mysqlclient-path" json:"backupMysqlclientgPath"`
+	BackupMysqlclientOptions                  string                 `mapstructure:"backup-mysqlclient-options" toml:"backup-mysqlclient-options" json:"backupMysqlclientOptions"`
 	BackupBinlogs                             bool                   `mapstructure:"backup-binlogs" toml:"backup-binlogs" json:"backupBinlogs"`
 	BackupBinlogsKeep                         int                    `mapstructure:"backup-binlogs-keep" toml:"backup-binlogs-keep" json:"backupBinlogsKeep"`
 	BinlogCopyMode                            string                 `mapstructure:"binlog-copy-mode" toml:"binlog-copy-mode" json:"binlogCopyMode"`

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2981,6 +2981,12 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 			return errors.New("Unable to decode")
 		}
 		mycluster.Conf.BackupMysqldumpOptions = string(val)
+	case "backup-mysqlclient-options":
+		val, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return errors.New("Unable to decode")
+		}
+		mycluster.Conf.BackupMysqlclientOptions = string(val)
 	case "cloud18-monthly-infra-cost":
 		val, _ := strconv.ParseFloat(value, 64)
 		mycluster.Conf.Cloud18MonthlyInfraCost = val

--- a/server/server.go
+++ b/server/server.go
@@ -808,7 +808,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.BackupMysqldumpOptions, "backup-mysqldump-options", "--hex-blob --single-transaction --verbose --all-databases --routines=true --triggers=true --system=all", "Extra options")
 	flags.StringVar(&conf.BackupMysqlbinlogPath, "backup-mysqlbinlog-path", "", "Path to mysqlbinlog binary")
 	flags.StringVar(&conf.BackupMysqlclientPath, "backup-mysqlclient-path", "", "Path to mysql client binary")
-	flags.StringVar(&conf.BackupMysqlclientOptions, "backup-mysqlclient-options", "--max-allowed-packet=128M", "Extra options")
+	flags.StringVar(&conf.BackupMysqlclientOptions, "backup-mysqlclient-options", "--force --batch --max-allowed-packet=128M", "Extra options")
 
 	flags.BoolVar(&conf.BackupBinlogs, "backup-binlogs", false, "Archive binlogs")
 	flags.IntVar(&conf.BackupBinlogsKeep, "backup-binlogs-keep", 10, "Number of master binlog to keep")

--- a/server/server.go
+++ b/server/server.go
@@ -808,6 +808,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.BackupMysqldumpOptions, "backup-mysqldump-options", "--hex-blob --single-transaction --verbose --all-databases --routines=true --triggers=true --system=all", "Extra options")
 	flags.StringVar(&conf.BackupMysqlbinlogPath, "backup-mysqlbinlog-path", "", "Path to mysqlbinlog binary")
 	flags.StringVar(&conf.BackupMysqlclientPath, "backup-mysqlclient-path", "", "Path to mysql client binary")
+	flags.StringVar(&conf.BackupMysqlclientOptions, "backup-mysqlclient-options", "--max-allowed-packet=128M", "Extra options")
 
 	flags.BoolVar(&conf.BackupBinlogs, "backup-binlogs", false, "Archive binlogs")
 	flags.IntVar(&conf.BackupBinlogsKeep, "backup-binlogs-keep", 10, "Number of master binlog to keep")

--- a/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
@@ -19,17 +19,26 @@ import { DataTable } from '../../components/DataTable'
 import ResticPurgeStrategy from './ResticPurgeStrategy'
 import NumberInput from '../../components/NumberInput'
 
+const sizeGenerator = () => { 
+  const result = []
+  let i = 1024;
+  while( i <= 1024 * 1024 * 1024) {
+    result.push(i)
+    i = i * 2
+  }
+
+  return result.map((size) => {
+    return { name: formatBytes(size, 0), value: size }
+  })
+}
+
 function BackupSettings({ selectedCluster, user }) {
   const dispatch = useDispatch()
   const [logicalBackupOptions, setLogicalBackupOptions] = useState([])
   const [physicalBackupOptions, setPhysicalBackupOptions] = useState([])
   const [binlogBackupOptions, setBinlogBackupOptions] = useState([])
   const [binlogParseOptions, setBinlogParseOptions] = useState([])
-  const [sizeOptions, setSizeOptions] = useState(
-    [1024, 2048, 4096, 8192, 16384, 32768, 65536, 1048576].map((size) => {
-      return { name: formatBytes(size, 0), value: size }
-    })
-  )
+  const [sizeOptions, setSizeOptions] = useState(sizeGenerator())
   const [selectedBinlogBackupType, setselectedBinlogBackupType] = useState('')
   const [action, setAction] = useState({
     title: '',
@@ -173,6 +182,26 @@ The script will be executed with the following parameters:
             }}
           />
         </Flex>
+      )
+    },
+    {
+      key: 'DB Client options',
+      value: (
+        <TextForm
+          value={selectedCluster?.config?.backupMysqlclientOptions}
+          confirmTitle={`Confirm backup-mysqlclient-options to `}
+          maxLength={1024}
+          className={styles.textbox}
+          onSave={(value) =>
+            dispatch(
+              setSetting({
+                clusterName: selectedCluster?.name,
+                setting: 'backup-mysqlclient-options',
+                value: btoa(value)
+              })
+            )
+          }
+        />
       )
     },
     {
@@ -352,8 +381,7 @@ The script will be executed with the following parameters:
         </Flex>
       )
     },
-
-    {
+   {
       key: 'Use Compression',
       value: (
         <RMSwitch


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and configuration of the backup process in the `cluster` and `server` packages, as well as updates to the backup settings in the `share/dashboard_react` package. The most important changes include adding new configuration options for MySQL client, optimizing the reseed process, and enhancing the user interface for backup settings.

### Improvements to backup process and configuration:

* [`cluster/srv_job.go`](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fL1141-R1150): Enhanced the `JobReseedMysqldump` function by adding a new gzip reader with specific buffer size and removing the intermediate buffer for unzipping. This change improves the efficiency of the reseed process. [[1]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fL1141-R1150) [[2]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fL1164-R1160)
* [`config/config.go`](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R707): Added a new configuration option `BackupMysqlclientOptions` to allow specifying additional MySQL client options.
* [`server/api_cluster.go`](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afR2984-R2989): Updated the `setClusterSetting` function to handle the new `backup-mysqlclient-options` setting.
* [`server/server.go`](diffhunk://#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4R811): Added a flag for the new `backup-mysqlclient-options` configuration.

### Enhancements to backup settings UI:

* [`share/dashboard_react/src/Pages/Settings/BackupSettings.jsx`](diffhunk://#diff-ef0c47fa54ff21d2c74ce82a6e0f85fd2465bfa78a0137323d64627c8186248cR22-R41): Added a size generator function to dynamically create size options and included a new setting for `DB Client options` in the backup settings UI. [[1]](diffhunk://#diff-ef0c47fa54ff21d2c74ce82a6e0f85fd2465bfa78a0137323d64627c8186248cR22-R41) [[2]](diffhunk://#diff-ef0c47fa54ff21d2c74ce82a6e0f85fd2465bfa78a0137323d64627c8186248cR187-R206) [[3]](diffhunk://#diff-ef0c47fa54ff21d2c74ce82a6e0f85fd2465bfa78a0137323d64627c8186248cL355)