### PR TITLE
Reseed child cluster from parent via multisource

### DIFF
--- a/cluster/cluster_acl.go
+++ b/cluster/cluster_acl.go
@@ -855,6 +855,10 @@ func (cluster *Cluster) IsURLPassACL(strUser string, URL string, errorPrint bool
 		if strings.Contains(URL, "/api/clusters/"+cluster.Name+"/actions/staging-reload-script") {
 			return true
 		}
+
+		if strings.Contains(URL, "/api/clusters/"+cluster.Name+"/actions/staging-reseed-parent") {
+			return true
+		}
 	}
 
 	if cluster.APIUsers[strUser].Grants[config.GrantProvClusterUnprovision] {

--- a/cluster/cluster_acl.go
+++ b/cluster/cluster_acl.go
@@ -856,7 +856,7 @@ func (cluster *Cluster) IsURLPassACL(strUser string, URL string, errorPrint bool
 			return true
 		}
 
-		if strings.Contains(URL, "/api/clusters/"+cluster.Name+"/actions/staging-reseed-parent") {
+		if strings.Contains(URL, "/api/clusters/"+cluster.Name+"/actions/staging-reseed-from-parent") {
 			return true
 		}
 	}

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -209,6 +209,14 @@ func (cluster *Cluster) CheckBackupFreeSpace(backtype string, backup bool) error
 	}
 
 	parentDir := cluster.Conf.WorkingDir + "/" + config.ConstStreamingSubDir + "/" + cluster.Name
+	_, err := os.Stat(parentDir)
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(parentDir, os.ModePerm)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error creating directory %s: %s", parentDir, err)
+		}
+	}
+
 	diskstat, err := disk.Usage(parentDir)
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error getting disk usage: %s", err)

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -60,7 +60,7 @@ func (cluster *Cluster) GetShareDir() string {
 }
 
 // This will use installed mysqldump first
-func (cluster *Cluster) GetMysqlDumpOptions(server *ServerMonitor, usegtid, file string) []string {
+func (cluster *Cluster) GetMysqlDumpOptions(server *ServerMonitor, usegtid string) []string {
 	dumpver := cluster.VersionsMap.Get("client-dump")
 	events := ""
 	dumpslave := ""
@@ -77,7 +77,7 @@ func (cluster *Cluster) GetMysqlDumpOptions(server *ServerMonitor, usegtid, file
 		events = "--events=false"
 	}
 
-	dumpargs := strings.Split(strings.ReplaceAll("--defaults-file="+file+" "+cluster.getDumpParameter()+" "+dumpslave+" "+usegtid+" "+events, "  ", " "), " ")
+	dumpargs := strings.Split(strings.ReplaceAll(cluster.getDumpParameter()+" "+dumpslave+" "+usegtid+" "+events, "  ", " "), " ")
 
 	if server.IsMariaDB() && server.DBVersion.GreaterEqual("10.1") {
 		dumpargs = append(dumpargs, "--skip-log-queries")
@@ -87,9 +87,24 @@ func (cluster *Cluster) GetMysqlDumpOptions(server *ServerMonitor, usegtid, file
 		dumpargs = append(dumpargs, "--mysqld-long-query-time=10") // Prevent mysqldump from logging to slow_log
 	}
 
-	dumpargs = append(dumpargs, "--apply-slave-statements", "--host="+misc.Unbracket(server.Host), "--port="+server.Port, "--user="+cluster.GetDbUser(), "--ignore-table=replication_manager_schema.jobs")
-	dumpargs = append(dumpargs, strings.Split(server.GetSSLClientParam("client-dump"), " ")...)
+	dumpargs = append(dumpargs, cluster.GetDumpCredentials(server)...)
+	dumpargs = append(dumpargs, "--apply-slave-statements", "--ignore-table=replication_manager_schema.jobs")
+	if cluster.Conf.BackupSplitMysqlUser && !slices.Contains(dumpargs, "--ignore-table=mysql.user") {
+		// Ignore mysql.user table to avoid dump of password this is needed for staging
+		dumpargs = append(dumpargs, "--ignore-table=mysql.user")
+	}
+	dumpargs = append(dumpargs, server.GetSSLClientParam("client-dump")...)
 	return misc.RemoveEmptyString(dumpargs)
+}
+
+// This will use installed mysqldump first
+func (cluster *Cluster) GetDumpCredentials(server *ServerMonitor) []string {
+	return []string{"--host=" + misc.Unbracket(server.Host), "--port=" + server.Port, "--user=" + cluster.GetDbUser(), "--password=" + cluster.GetDbPass()}
+}
+
+// This will use installed mysqldump first
+func (cluster *Cluster) GetBinlogCredentials(server *ServerMonitor) []string {
+	return []string{"--host=" + misc.Unbracket(server.Host), "--port=" + server.Port, "--user=" + cluster.GetRplUser(), "--password=" + cluster.GetRplPass()}
 }
 
 // GetMySQLClientParams returns the parameters to connect to a MySQL server
@@ -98,7 +113,7 @@ func (cluster *Cluster) GetMysqlDumpOptions(server *ServerMonitor, usegtid, file
 //   - interactive: if true, the password will be prompted and not included in the command line
 func (cluster *Cluster) GetMySQLClientParams(server *ServerMonitor, roleType string, interactive bool) []string {
 	args := []string{"--host=" + server.Host, "--port=" + server.Port}
-	args = append(args, strings.Split(server.GetSSLClientParam("client"), " ")...)
+	args = append(args, server.GetSSLClientParam("client")...)
 	var passwd string
 	if slices.Contains([]string{config.RoleSysOps, config.RoleExtSysOps, "system"}, roleType) {
 		args = append(args, "--user="+cluster.GetDbUser())

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -385,7 +385,7 @@ func (cluster *Cluster) GetStagingProxyHosts() []string {
 	return strings.Split(cluster.Conf.StagingProxyHosts, ",")
 }
 
-func (cluster *Cluster) RefreshFromParentCluster(parent *Cluster) error {
+func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster) error {
 	var err error
 
 	if parent == nil {

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -480,9 +480,14 @@ func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster) error {
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Receive reseed logical backup %s request for server: %s", backtype, cmaster.URL)
 
 	if backtype == config.ConstBackupLogicalTypeMysqldump {
-		err = cmaster.JobReseedMysqldump(backupfile)
+		if pmaster.LastBackupMeta.Logical != nil && !pmaster.LastBackupMeta.Logical.SplitUser {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Reseed mysqldump with no split user is not supported")
+			cmaster.JobsUpdateState(task, "Reseed mysqldump with no split user is not supported", 5, 1)
+			return fmt.Errorf("Reseed mysqldump with no split user is not supported")
+		}
+		err = cmaster.JobReseedMysqldump(backupfile, false)
 	} else if backtype == config.ConstBackupLogicalTypeMydumper {
-		err = cmaster.JobReseedMyLoader(backupfile)
+		err = cmaster.JobReseedMyLoader(backupfile, false)
 	} else {
 		return fmt.Errorf("Unknown backup type %s", backtype)
 	}

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/share"
+	"github.com/signal18/replication-manager/utils/dbhelper"
 	"github.com/signal18/replication-manager/utils/misc"
 )
 
@@ -381,4 +383,120 @@ func (cluster *Cluster) GetStagingProxyHosts() []string {
 		return []string{}
 	}
 	return strings.Split(cluster.Conf.StagingProxyHosts, ",")
+}
+
+func (cluster *Cluster) RefreshFromParentCluster(parent *Cluster) error {
+	var err error
+
+	if parent == nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Parent cluster cannot be nil")
+		return fmt.Errorf("parent cluster cannot be nil")
+	}
+
+	backtype := parent.Conf.BackupLogicalType
+
+	cmaster := cluster.GetMaster()
+	if cmaster == nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "No master server found")
+		return fmt.Errorf("no master server found")
+	}
+
+	bcksrv := parent.GetBackupServer()
+	if bcksrv != nil && !bcksrv.HasBackupLogicalCookie() {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Parent cluster %s has no backup. Please run logical backup for refresh child cluster on %s", parent.Name, cluster.Name)
+		parent.LogModulePrintf(parent.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Parent cluster %s has no backup. Please run logical backup for refresh child cluster on %s", parent.Name, cluster.Name)
+		return err
+	}
+
+	pmaster := parent.GetMaster()
+	if pmaster == nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "No master server found")
+		return fmt.Errorf("no master server found")
+	}
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModExternalScript, config.LvlInfo, "Refresh data from parent cluster initiated")
+
+	var dest string
+	switch backtype {
+	case config.ConstBackupLogicalTypeMysqldump, "script":
+		dest = "mysqldump.sql.gz"
+	case config.ConstBackupLogicalTypeMydumper:
+		dest = "mydumper"
+	case config.ConstBackupLogicalTypeDumpling:
+		dest = "dumpling"
+	}
+
+	// Can't handle script validation, unknown logic
+	backupfile := bcksrv.GetMyBackupDirectory() + dest
+	if _, err := os.Stat(backupfile); err != nil {
+		//Remove false cookie
+		return fmt.Errorf("No backup file found on parent for %s", backtype)
+	}
+
+	if cmaster.HasAnyReseedingState() {
+		return fmt.Errorf("Server is in reseeding state by %s", cmaster.IsReseeding)
+	}
+
+	task := "reseed" + parent.Conf.BackupLogicalType
+	cmaster.SetInReseedBackup(task)
+	defer func() {
+		if cmaster.HasReseedingState(task) {
+			cmaster.SetInReseedBackup("")
+		}
+	}()
+
+	//Delete wait logical backup cookie
+	cmaster.DelWaitLogicalBackupCookie()
+
+	// Set replication master to current master if not PITR
+	logs, err := cmaster.StopSlaveChannel(parent.Conf.MasterConn)
+	if err != nil {
+		cluster.LogSQL(logs, err, cmaster.URL, "Rejoin", config.LvlErr, "Failed stop slave on server: %s %s", cmaster.URL, err)
+	}
+
+	changeOpt := dbhelper.ChangeMasterOpt{
+		Host:      pmaster.Host,
+		Port:      pmaster.Port,
+		User:      parent.GetRplUser(),
+		Password:  parent.GetRplPass(),
+		Retry:     strconv.Itoa(parent.Conf.ForceSlaveHeartbeatRetry),
+		Heartbeat: strconv.Itoa(parent.Conf.ForceSlaveHeartbeatTime),
+		Mode:      "SLAVE_POS",
+		SSL:       parent.Conf.ReplicationSSL,
+		Channel:   parent.Conf.MasterConn,
+	}
+
+	if cmaster.DBVersion.IsMySQLOrPercona() {
+		if cmaster.HasMySQLGTID() {
+			changeOpt.Mode = "MASTER_AUTO_POSITION"
+		} else {
+			changeOpt.Mode = "POSITIONAL"
+		}
+	}
+
+	dbhelper.ChangeMaster(cmaster.Conn, changeOpt, cmaster.DBVersion) // Ignore error
+
+	cmaster.JobsUpdateState(task, "processing", 1, 0)
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Receive reseed logical backup %s request for server: %s", backtype, cmaster.URL)
+
+	if backtype == config.ConstBackupLogicalTypeMysqldump {
+		err = cmaster.JobReseedMysqldump(backupfile)
+	} else if backtype == config.ConstBackupLogicalTypeMydumper {
+		err = cmaster.JobReseedMyLoader(backupfile)
+	} else {
+		return fmt.Errorf("Unknown backup type %s", backtype)
+	}
+
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error reseed %s on %s: %s", backtype, cmaster.URL, err.Error())
+		if e2 := cmaster.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
+		}
+	} else {
+		if e2 := cmaster.JobsUpdateState(task, "Reseed completed", 3, 1); e2 != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
+		}
+	}
+
+	return err
 }

--- a/cluster/prov_onpremise_prx.go
+++ b/cluster/prov_onpremise_prx.go
@@ -135,34 +135,35 @@ func (cluster *Cluster) OnPremiseUnprovisionProxyService(pri DatabaseProxy) erro
 }
 
 func (cluster *Cluster) OnPremiseStartProxyService(pri DatabaseProxy) error {
+	var err error
 	if prx, ok := pri.(*MariadbShardProxy); ok {
-		cluster.OnPremiseStartDatabaseService(prx.ShardProxy)
+		err = cluster.OnPremiseStartDatabaseService(prx.ShardProxy)
 	}
 
 	if prx, ok := pri.(*HaproxyProxy); ok {
-		cluster.OnPremiseStartHaProxyService(prx)
+		err = cluster.OnPremiseStartHaProxyService(prx)
 	}
 
 	if prx, ok := pri.(*ProxySQLProxy); ok {
-		cluster.OnPremiseStartProxySQLService(prx)
+		err = cluster.OnPremiseStartProxySQLService(prx)
 	}
 
-	cluster.errorChan <- nil
-	return nil
+	cluster.errorChan <- err
+	return err
 }
 
 func (cluster *Cluster) OnPremiseStopProxyService(pri DatabaseProxy) error {
-
+	var err error
 	if prx, ok := pri.(*MariadbShardProxy); ok {
-		prx.ShardProxy.Shutdown()
+		err = prx.ShardProxy.Shutdown()
 	}
 
 	if prx, ok := pri.(*HaproxyProxy); ok {
-		cluster.OnPremiseStopHaproxyService(prx)
+		err = cluster.OnPremiseStopHaproxyService(prx)
 	}
 	if prx, ok := pri.(*ProxySQLProxy); ok {
-		cluster.OnPremiseStopProxySQLService(prx)
+		err = cluster.OnPremiseStopProxySQLService(prx)
 	}
 
-	return nil
+	return err
 }

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1266,6 +1266,13 @@ func (server *ServerMonitor) StopSlave() (string, error) {
 	return dbhelper.StopSlave(server.Conn, cluster.Conf.MasterConn, server.DBVersion)
 }
 
+func (server *ServerMonitor) StopSlaveChannel(channel string) (string, error) {
+	if server.Conn == nil {
+		return "", errors.New("No database connection pool")
+	}
+	return dbhelper.StopSlave(server.Conn, channel, server.DBVersion)
+}
+
 func (server *ServerMonitor) StopAllSlaves() (string, error) {
 	if server.Conn == nil {
 		return "", errors.New("No database connection pool")
@@ -1310,6 +1317,13 @@ func (server *ServerMonitor) StartSlave() (string, error) {
 	cluster := server.ClusterGroup
 	return dbhelper.StartSlave(server.Conn, cluster.Conf.MasterConn, server.DBVersion)
 
+}
+
+func (server *ServerMonitor) StartSlaveChannel(channel string) (string, error) {
+	if server.Conn == nil {
+		return "", errors.New("No database connection")
+	}
+	return dbhelper.StartSlave(server.Conn, channel, server.DBVersion)
 }
 
 func (server *ServerMonitor) ResetMaster() (string, error) {

--- a/cluster/srv_binlog.go
+++ b/cluster/srv_binlog.go
@@ -166,10 +166,8 @@ func (server *ServerMonitor) RefreshBinlogMetaMySQL(meta *dbhelper.BinaryLogMeta
 		startpos := fmt.Sprintf("%d", ev.Pos)
 		endpos := fmt.Sprintf("%d", ev.End_log_pos)
 
-		binlogArgs := make([]string, 0)
-		binlogArgs = append(binlogArgs, "--read-from-remote-server", "--server-id="+binsrvid, "--user="+cluster.GetRplUser(), "--password="+cluster.GetRplPass(), "--host="+misc.Unbracket(server.Host), "--port="+server.Port, "--start-position="+startpos, "--stop-position="+endpos)
-		binlogArgs = append(binlogArgs, strings.Split(server.GetSSLClientParam("client-binlog"), " ")...)
-		binlogArgs = append(binlogArgs, meta.Filename)
+		binlogArgs := append(cluster.GetBinlogCredentials(server), server.GetSSLClientParam("client-binlog")...)
+		binlogArgs = append(binlogArgs, "--read-from-remote-server", "--server-id="+binsrvid, "--start-position="+startpos, "--stop-position="+endpos, meta.Filename)
 		mysqlbinlogcmd := exec.Command(cluster.GetMysqlBinlogPath(), misc.RemoveEmptyString(binlogArgs)...)
 
 		result, err := mysqlbinlogcmd.Output()
@@ -746,10 +744,8 @@ func (server *ServerMonitor) FindLogPositionForTimestamp(binlogFile string, time
 	}
 
 	timeString := timestamp.Format("2006-01-02 15:04:05")
-	binlogArgs := make([]string, 0)
-	binlogArgs = append(binlogArgs, "--read-from-remote-server", "--server-id="+binsrvid, "--user="+cluster.GetRplUser(), "--password="+cluster.GetRplPass(), "--host="+misc.Unbracket(server.Host), "--port="+server.Port, "--start-datetime", timeString, "--stop-datetime", timeString, "--base64-output=DECODE-ROWS", "--verbose")
-	binlogArgs = append(binlogArgs, strings.Split(server.GetSSLClientParam("client-binlog"), " ")...)
-	binlogArgs = append(binlogArgs, binlogFile)
+	binlogArgs := append(cluster.GetBinlogCredentials(server), server.GetSSLClientParam("client-binlog")...)
+	binlogArgs = append(binlogArgs, "--read-from-remote-server", "--server-id="+binsrvid, "--start-datetime", timeString, "--stop-datetime", timeString, "--base64-output=DECODE-ROWS", "--verbose", binlogFile)
 	cmd := exec.Command(cluster.GetMysqlBinlogPath(), misc.RemoveEmptyString(binlogArgs)...)
 	output, err := cmd.Output()
 	if err != nil {
@@ -788,10 +784,8 @@ func (server *ServerMonitor) FindNearestLogPosition(binlogFile string, timestamp
 		endTime := startTime.Add(1 * time.Minute)
 		endTimeString := endTime.Format("2006-01-02 15:04:05")
 
-		binlogArgs := make([]string, 0)
-		binlogArgs = append(binlogArgs, "--read-from-remote-server", "--server-id="+binsrvid, "--user="+cluster.GetRplUser(), "--password="+cluster.GetRplPass(), "--host="+misc.Unbracket(server.Host), "--port="+server.Port, "--start-datetime", startTimeString, "--stop-datetime", endTimeString, "--base64-output=DECODE-ROWS", "--verbose")
-		binlogArgs = append(binlogArgs, strings.Split(server.GetSSLClientParam("client-binlog"), " ")...)
-		binlogArgs = append(binlogArgs, binlogFile)
+		binlogArgs := append(cluster.GetBinlogCredentials(server), server.GetSSLClientParam("client-binlog")...)
+		binlogArgs = append(binlogArgs, "--read-from-remote-server", "--server-id="+binsrvid, "--start-datetime", startTimeString, "--stop-datetime", endTimeString, "--base64-output=DECODE-ROWS", "--verbose", binlogFile)
 		cmd := exec.Command(cluster.GetMysqlBinlogPath(), misc.RemoveEmptyString(binlogArgs)...)
 		output, err := cmd.Output()
 		if err != nil {
@@ -965,16 +959,15 @@ func (server *ServerMonitor) ReadAndApplyBinaryLogsWithinRange(start config.Read
 	}
 
 	// Binlog filename parameter
-	params = append(params, strings.Split(server.GetSSLClientParam("client-binlog"), " ")...)
+	params = append(params, server.GetSSLClientParam("client-binlog")...)
 	params = append(params, start.Filename)
 
 	binlogCmd := exec.Command(cluster.GetMysqlBinlogPath(), misc.RemoveEmptyString(params)...)
 	iodumpreader, _ := binlogCmd.StdoutPipe()
 	stderrIn, _ := binlogCmd.StderrPipe()
 
-	cliParams := make([]string, 0)
-	cliParams = append(cliParams, `--defaults-file=`+file, `--host=`+misc.Unbracket(dest.Host), `--port=`+dest.Port, `--user=`+cluster.GetDbUser(), `--force`, `--batch`, `--verbose`)
-	cliParams = append(cliParams, strings.Split(server.GetSSLClientParam("client"), " ")...)
+	cliParams := append(cluster.GetDumpCredentials(dest), server.GetSSLClientParam("client")...)
+	cliParams = append(cliParams, `--force`, `--batch`)
 	clientCmd := exec.Command(cluster.GetMysqlclientPath(), misc.RemoveEmptyString(cliParams)...)
 	cliErrPipe, _ := clientCmd.StderrPipe()
 	cliOutPipe, _ := clientCmd.StdoutPipe()

--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -816,7 +816,7 @@ func (server *ServerMonitor) GetCPUUsageFromThreadsPool() float64 {
 	return -1
 }
 
-func (server *ServerMonitor) GetSSLClientParam(tool string) string {
+func (server *ServerMonitor) GetSSLClientParam(tool string) []string {
 	var noSSLParams, skipVerify bool
 	var cacertfile, clicertfile, clikeyfile, path, sslMode string
 	cluster := server.ClusterGroup
@@ -870,39 +870,39 @@ func (server *ServerMonitor) GetSSLClientParam(tool string) string {
 					sslMode = "VERIFY_CA" // Only verify CA if no SSL mode is set
 				}
 
-				if server.DBVersion.IsMySQLOrPerconaGreater84() && ver.IsMySQLOrPerconaGreater84() { // Use --ssl-mode
+				if server.DBVersion.IsMySQLOrPerconaGreater84() && ver.IsMySQLOrPerconaGreater84() { // Use","--ssl-mode
 					switch sslMode {
 					case "DISABLED":
-						return "--ssl-mode=DISABLED"
+						return []string{"--ssl-mode=DISABLED"}
 					case "PREFERRED", "REQUIRED":
-						return "--ssl-mode=" + sslMode // No verify server cert
+						return []string{"--ssl-mode=" + sslMode} // No verify server cert
 					case "VERIFY_CA":
-						return "--ssl-mode=" + sslMode + " --ssl-ca=" + cacertfile
+						return []string{"--ssl-mode=" + sslMode, "--ssl-ca=" + cacertfile}
 					case "VERIFY_IDENTITY":
-						return "--ssl-mode=" + sslMode + " --ssl-ca=" + cacertfile + " --ssl-cert=" + clicertfile + " --ssl-key=" + clikeyfile
+						return []string{"--ssl-mode=" + sslMode, "--ssl-ca=" + cacertfile, "--ssl-cert=" + clicertfile, "--ssl-key=" + clikeyfile}
 					}
-				} else { // Use old --ssl equivalent
+				} else { // Use old","--ssl equivalent
 					switch sslMode {
 					case "DISABLED":
-						return "--skip-ssl"
+						return []string{"--skip-ssl"}
 					case "PREFERRED", "REQUIRED":
-						return "--ssl --ssl-verify-server-cert=false"
+						return []string{"--ssl", "--ssl-verify-server-cert=false"}
 					case "VERIFY_CA":
-						return "--ssl --ssl-verify-server-cert --ssl-ca=" + cacertfile
+						return []string{"--ssl", "--ssl-verify-server-cert", "--ssl-ca=" + cacertfile}
 					case "VERIFY_IDENTITY":
-						return "--ssl --ssl-verify-server-cert --ssl-ca=" + cacertfile + " --ssl-cert=" + clicertfile + " --ssl-key=" + clikeyfile
+						return []string{"--ssl", "--ssl-verify-server-cert", "--ssl-ca=" + cacertfile, "--ssl-cert=" + clicertfile, "--ssl-key=" + clikeyfile}
 					}
 				}
 			} else {
-				if server.DBVersion.IsMySQLOrPerconaGreater84() && ver.IsMySQLOrPerconaGreater84() { // Use --ssl-mode
-					return "--ssl-mode=" + sslMode // No verify server cert
-				} else { // Use old --ssl equivalent
+				if server.DBVersion.IsMySQLOrPerconaGreater84() && ver.IsMySQLOrPerconaGreater84() { // Use","--ssl-mode
+					return []string{"--ssl-mode=" + sslMode} // No verify server cert
+				} else { // Use old","--ssl equivalent
 					if sslMode == "DISABLED" {
-						return "--skip-ssl"
+						return []string{"--skip-ssl"}
 					}
 
 					// No verify server cert
-					return "--ssl --ssl-verify-server-cert=false"
+					return []string{"--ssl", "--ssl-verify-server-cert=false"}
 				}
 			}
 		}
@@ -911,18 +911,18 @@ func (server *ServerMonitor) GetSSLClientParam(tool string) string {
 	// Only add for client dist 11.3 onwards, and DB pre 11.3
 	if !server.DBVersion.IsMariaDBGreater113() && ver.IsMariaDBGreater113() {
 		if server.HasSSL() {
-			return "--ssl --ssl-verify-server-cert=false"
+			return []string{"--ssl", "--ssl-verify-server-cert=false"}
 		} else {
 			switch tool {
 			case "client":
-				return "--skip-ssl"
+				return []string{"--skip-ssl"}
 			case "client-dump", "client-binlog":
-				return "--ssl=FALSE"
+				return []string{"--ssl=FALSE"}
 			}
 		}
 	}
 
-	return ""
+	return []string{}
 }
 
 func (server *ServerMonitor) GetStatusDeltaValue(name string) int {

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -1052,10 +1052,11 @@ func (server *ServerMonitor) JobReseedMyLoader(backupdir string) error {
 		myargs = append(myargs, "--enable-binlog")
 	}
 
-	myargs = append(myargs, "--directory="+backupdir, "--threads="+threads, "--host="+misc.Unbracket(server.Host), "--port="+server.Port, "--user="+cluster.GetDbUser(), "--password="+cluster.GetDbPass())
+	myargs = append(myargs, cluster.GetDumpCredentials(server)...)
+	myargs = append(myargs, "--directory="+backupdir, "--threads="+threads)
 	dumpCmd := exec.Command(cluster.GetMyLoaderPath(), myargs...)
 
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s", strings.ReplaceAll(dumpCmd.String(), cluster.GetDbPass(), "XXXX"))
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s", strings.ReplaceAll(dumpCmd.String(), "="+cluster.GetDbPass(), "=XXXX"))
 
 	stdoutIn, _ := dumpCmd.StdoutPipe()
 	stderrIn, _ := dumpCmd.StderrPipe()
@@ -1106,13 +1107,11 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string) error {
 	}
 	defer fz.Close()
 
-	cliParams := make([]string, 0)
-	cliParams = append(cliParams, `--host=`+misc.Unbracket(server.Host), `--port=`+server.Port, `--user=`+cluster.GetDbUser(), `--password=`+cluster.GetDbPass())
-	cliParams = append(cliParams, strings.Split(server.GetSSLClientParam("client"), " ")...)
+	cliParams := append(cluster.GetDumpCredentials(server), server.GetSSLClientParam("client")...)
 	cliParams = append(cliParams, strings.Split(cluster.Conf.BackupMysqlclientOptions, " ")...)
 	clientCmd := exec.Command(cluster.GetMysqlclientPath(), misc.RemoveEmptyString(cliParams)...)
 
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s ", strings.Replace(clientCmd.String(), "="+cluster.GetDbPass(), "XXXX", -1))
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s ", strings.Replace(clientCmd.String(), "="+cluster.GetDbPass(), "=XXXX", -1))
 
 	sql_log_bin := 0
 	resetmaster := "RESET MASTER;"
@@ -1138,7 +1137,7 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string) error {
 	clientCmd.Stderr = clientCmd.Stdout
 
 	if err := clientCmd.Start(); err != nil {
-		return fmt.Errorf("Can't start mysql client:%s at %s", err, strings.ReplaceAll(clientCmd.String(), cluster.GetDbPass(), "XXXX"))
+		return fmt.Errorf("Can't start mysql client:%s at %s", err, strings.ReplaceAll(clientCmd.String(), "="+cluster.GetDbPass(), "=XXXX"))
 	}
 
 	wg := sync.WaitGroup{}
@@ -1174,7 +1173,7 @@ func (server *ServerMonitor) JobReseedBackupScript() {
 
 	cmd := exec.Command(cluster.Conf.BackupLoadScript, misc.Unbracket(server.Host), misc.Unbracket(cluster.master.Host), server.Port, server.GetCluster().GetMaster().Port, cluster.GetDbUser(), cluster.GetDbPass(), cluster.Name)
 
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command backup load script: %s", strings.Replace(cmd.String(), cluster.GetDbPass(), "XXXX", 1))
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command backup load script: %s", strings.Replace(cmd.String(), "="+cluster.GetDbPass(), "=XXXX", 1))
 
 	stdoutIn, _ := cmd.StdoutPipe()
 	stderrIn, _ := cmd.StderrPipe()
@@ -1624,7 +1623,7 @@ func (server *ServerMonitor) JobBackupScript() error {
 	defer cluster.SetInLogicalBackupState(false)
 
 	scriptCmd := exec.Command(cluster.Conf.BackupSaveScript, server.Host, server.GetCluster().GetMaster().Host, server.Port, server.GetCluster().GetMaster().Port, cluster.GetDbUser(), cluster.GetDbPass(), cluster.Name)
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s", strings.Replace(scriptCmd.String(), cluster.GetDbPass(), "XXXX", 1))
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s", strings.Replace(scriptCmd.String(), "="+cluster.GetDbPass(), "=XXXX", 1))
 	stdoutIn, _ := scriptCmd.StdoutPipe()
 	stderrIn, _ := scriptCmd.StderrPipe()
 	scriptCmd.Start()
@@ -1694,9 +1693,9 @@ func (server *ServerMonitor) JobBackupMysqldump(filename string) error {
 	}
 	defer os.Remove(file)
 
-	dumpCmd := exec.Command(cluster.GetMysqlDumpPath(), cluster.GetMysqlDumpOptions(server, server.JobGetDumpGtidParameter(), file)...)
+	dumpCmd := exec.Command(cluster.GetMysqlDumpPath(), cluster.GetMysqlDumpOptions(server, server.JobGetDumpGtidParameter())...)
 
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s ", strings.Replace(dumpCmd.String(), cluster.GetDbPass(), "XXXX", -1))
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s ", strings.Replace(dumpCmd.String(), "="+cluster.GetDbPass(), "=XXXX", -1))
 	// Get the stdout pipe from the command
 	stdout, err := dumpCmd.StdoutPipe()
 	if err != nil {
@@ -1882,7 +1881,7 @@ func (server *ServerMonitor) JobBackupMyDumper(outputdir string) error {
 
 	dumpCmd := exec.Command(cluster.GetMyDumperPath(), myargs...)
 
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "%s", strings.Replace(dumpCmd.String(), cluster.GetDbPass(), "XXXX", 1))
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "%s", strings.Replace(dumpCmd.String(), "="+cluster.GetDbPass(), "=XXXX", 1))
 	stdoutIn, _ := dumpCmd.StdoutPipe()
 	stderrIn, _ := dumpCmd.StderrPipe()
 	dumpCmd.Start()
@@ -2447,18 +2446,17 @@ func (server *ServerMonitor) JobBackupBinlog(binlogfile string, isPurge bool) er
 	server.SetBackingUpBinaryLog(true)
 	defer server.SetBackingUpBinaryLog(false)
 
-	var params []string = make([]string, 0)
-	params = append(params, "--read-from-remote-server", "--raw", "--server-id=10000", "--user="+cluster.GetRplUser(), "--password="+cluster.GetRplPass(), "--host="+misc.Unbracket(server.Host), "--port="+server.Port, "--result-file="+server.GetMyBackupDirectory())
-	params = append(params, strings.Split(server.GetSSLClientParam("client-binlog"), " ")...)
+	params := append(cluster.GetBinlogCredentials(server), "--read-from-remote-server", "--raw", "--server-id=10000", "--result-file="+server.GetMyBackupDirectory())
+	params = append(params, server.GetSSLClientParam("client-binlog")...)
 	params = append(params, binlogfile)
 	cmdrun := exec.Command(cluster.GetMysqlBinlogPath(), misc.RemoveEmptyString(params)...)
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "%s %s", cluster.GetMysqlBinlogPath(), strings.ReplaceAll(strings.Join(cmdrun.Args, " "), cluster.GetRplPass(), "XXXX"))
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "%s %s", cluster.GetMysqlBinlogPath(), strings.ReplaceAll(strings.Join(cmdrun.Args, " "), "="+cluster.GetRplPass(), "=XXXX"))
 
 	cmdErrPipe, _ := cmdrun.StderrPipe()
 	cmdOutPipe, _ := cmdrun.StdoutPipe()
 
 	if err := cmdrun.Start(); err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Failed mysqlbinlog command: %s at %s", err, strings.Replace(cmdrun.String(), cluster.GetDbPass(), "XXXX", -1))
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Failed mysqlbinlog command: %s at %s", err, strings.Replace(cmdrun.String(), "="+cluster.GetDbPass(), "=XXXX", -1))
 		return err
 	}
 
@@ -2479,7 +2477,7 @@ func (server *ServerMonitor) JobBackupBinlog(binlogfile string, isPurge bool) er
 
 	if err := cmdrun.Wait(); err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "Failed to backup binlogs of %s,%s", server.URL, err.Error())
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "%s %s", cluster.GetMysqlBinlogPath(), strings.ReplaceAll(strings.Join(cmdrun.Args, " "), cluster.GetRplPass(), "XXXX"))
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "%s %s", cluster.GetMysqlBinlogPath(), strings.ReplaceAll(strings.Join(cmdrun.Args, " "), "="+cluster.GetRplPass(), "=XXXX"))
 		return err
 	}
 
@@ -2619,18 +2617,16 @@ func (cluster *Cluster) JobRejoinMysqldumpFromSource(source *ServerMonitor, dest
 	defer os.Remove(file)
 
 	dest.StopSlave()
-	dumpCmd := exec.Command(cluster.GetMysqlDumpPath(), cluster.GetMysqlDumpOptions(source, dest.JobGetDumpGtidParameter(), file)...)
+	dumpCmd := exec.Command(cluster.GetMysqlDumpPath(), cluster.GetMysqlDumpOptions(source, dest.JobGetDumpGtidParameter())...)
 	stderrIn, _ := dumpCmd.StderrPipe()
 
-	cliParams := make([]string, 0)
-	cliParams = append(cliParams, `--defaults-file=`+file, `--host=`+misc.Unbracket(dest.Host), `--port=`+dest.Port, `--user=`+cluster.GetDbUser())
-	cliParams = append(cliParams, strings.Split(dest.GetSSLClientParam("client"), " ")...)
+	cliParams := append(cluster.GetDumpCredentials(dest), dest.GetSSLClientParam("client")...)
 	cliParams = append(cliParams, strings.Split(cluster.Conf.BackupMysqlclientOptions, " ")...)
 
 	clientCmd := exec.Command(cluster.GetMysqlclientPath(), misc.RemoveEmptyString(cliParams)...)
 	stderrOut, _ := clientCmd.StderrPipe()
 
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s ", strings.Replace(dumpCmd.String(), cluster.GetDbPass(), "XXXX", -1))
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s ", strings.Replace(dumpCmd.String(), "="+cluster.GetDbPass(), "=XXXX", -1))
 
 	iodumpreader, _ := dumpCmd.StdoutPipe()
 
@@ -2641,11 +2637,11 @@ func (cluster *Cluster) JobRejoinMysqldumpFromSource(source *ServerMonitor, dest
 	clientCmd.Stdin = io.MultiReader(bytes.NewBufferString(cmdstring), iodumpreader)
 
 	if err := dumpCmd.Start(); err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Failed mysqldump command: %s at %s", err, strings.Replace(dumpCmd.String(), cluster.GetDbPass(), "XXXX", -1))
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Failed mysqldump command: %s at %s", err, strings.Replace(dumpCmd.String(), "="+cluster.GetDbPass(), "=XXXX", -1))
 		return err
 	}
 	if err := clientCmd.Start(); err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Can't start mysql client:%s at %s", err, strings.Replace(clientCmd.String(), cluster.GetDbPass(), "XXXX", -1))
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Can't start mysql client:%s at %s", err, strings.Replace(clientCmd.String(), "="+cluster.GetDbPass(), "=XXXX", -1))
 		return err
 	}
 	var wg sync.WaitGroup

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -1114,10 +1114,17 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string) error {
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s ", strings.Replace(clientCmd.String(), "="+cluster.GetDbPass(), "XXXX", -1))
 
-	cmdstring := "RESET MASTER;SET sql_log_bin=0;SET long_query_time=10;"
-	if server.DBVersion.IsMySQLOrPerconaGreater84() {
-		cmdstring = "RESET BINARY LOGS AND GTIDS;SET sql_log_bin=0;SET long_query_time=10;"
+	sql_log_bin := 0
+	if server.URL == cluster.GetMaster().URL {
+		sql_log_bin = 1
 	}
+
+	cmdstring := "RESET MASTER;SET sql_log_bin=%d;SET long_query_time=10;"
+	if server.DBVersion.IsMySQLOrPerconaGreater84() {
+		cmdstring = "RESET BINARY LOGS AND GTIDS;SET sql_log_bin=%d;SET long_query_time=10;"
+	}
+
+	cmdstring = fmt.Sprintf(cmdstring, sql_log_bin)
 
 	clientCmd.Stdin = io.MultiReader(bytes.NewBufferString(cmdstring), fz)
 

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -574,7 +574,7 @@ func (server *ServerMonitor) JobReseedLogicalBackup(backtype string) error {
 	useMaster := true
 	var dest string
 	switch backtype {
-	case config.ConstBackupLogicalTypeMysqldump:
+	case config.ConstBackupLogicalTypeMysqldump, "script":
 		dest = "mysqldump.sql.gz"
 	case config.ConstBackupLogicalTypeMydumper:
 		dest = "mydumper"
@@ -582,28 +582,27 @@ func (server *ServerMonitor) JobReseedLogicalBackup(backtype string) error {
 		dest = "dumpling"
 	}
 
-	// Can't handle script validation, unknown logic
-	if backtype != "script" {
-		backupfile := master.GetMyBackupDirectory() + dest
+	backupfile := master.GetMyBackupDirectory() + dest
 
-		bckserver := cluster.GetBackupServer()
-		if bckserver != nil && bckserver.HasBackupTypeCookie(backtype) {
-			if _, err := os.Stat(bckserver.GetMyBackupDirectory() + dest); err == nil {
-				backupfile = bckserver.GetMyBackupDirectory() + dest
-				useMaster = false
-			} else {
-				//Remove false cookie
-				bckserver.DelBackupTypeCookie(backtype)
-			}
+	bckserver := cluster.GetBackupServer()
+	if bckserver != nil && bckserver.HasBackupTypeCookie(backtype) {
+		if _, err := os.Stat(bckserver.GetMyBackupDirectory() + dest); err == nil {
+			backupfile = bckserver.GetMyBackupDirectory() + dest
+			useMaster = false
+		} else {
+			//Remove false cookie
+			bckserver.DelBackupTypeCookie(backtype)
+		}
+	}
+
+	if useMaster {
+		if _, err := os.Stat(backupfile); err != nil {
+			//Remove false cookie
+			master.DelBackupTypeCookie(backtype)
+			return fmt.Errorf("No backup file found on master for %s", backtype)
 		}
 
-		if useMaster {
-			if _, err := os.Stat(backupfile); err != nil {
-				//Remove false cookie
-				master.DelBackupTypeCookie(backtype)
-				return fmt.Errorf("No backup file found on master for %s", backtype)
-			}
-		}
+		bckserver = master
 	}
 
 	if server.HasAnyReseedingState() {
@@ -678,81 +677,57 @@ func (server *ServerMonitor) JobReseedLogicalBackup(backtype string) error {
 	server.JobsUpdateState(task, "processing", 1, 0)
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Receive reseed logical backup %s request for server: %s", backtype, server.URL)
 	if backtype == config.ConstBackupLogicalTypeMysqldump {
-		go func() {
-			defer cluster.LogPanicToFile(task)
-
-			useMaster := true
-			file := "mysqldump.sql.gz"
-			backupfile := cluster.master.GetMyBackupDirectory() + file
-
-			bckserver := cluster.GetBackupServer()
-			if bckserver != nil && bckserver.HasBackupTypeCookie(config.ConstBackupLogicalTypeMysqldump) {
-				if _, err := os.Stat(bckserver.GetMyBackupDirectory() + file); err == nil {
-					backupfile = bckserver.GetMasterBackupDirectory() + file
-					useMaster = false
-				} else {
-					//Remove false cookie
-					bckserver.DelBackupTypeCookie(config.ConstBackupLogicalTypeMysqldump)
-				}
+		err = server.JobReseedMysqldump(backupfile)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error reseed %s on %s: %s", backtype, server.URL, err.Error())
+			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
+			}
+		} else {
+			if server.IsSlave && !server.PointInTimeMeta.IsInPITR {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Start slave after dump on %s", server.URL)
+				server.StartSlave()
 			}
 
-			if useMaster {
-				if _, err := os.Stat(backupfile); err != nil {
-					//Remove false cookie
-					cluster.master.DelBackupTypeCookie(config.ConstBackupLogicalTypeMysqldump)
-				}
+			if e2 := server.JobsUpdateState(task, "Reseed completed", 3, 1); e2 != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
 			}
-
-			err = server.JobReseedMysqldump(backupfile)
-			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error reseed %s on %s: %s", backtype, server.URL, err.Error())
-				if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-				}
-			} else {
-				if e2 := server.JobsUpdateState(task, "Reseed completed", 3, 1); e2 != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-				}
-			}
-		}()
+		}
 	} else if backtype == config.ConstBackupLogicalTypeMydumper {
-		go func() {
-			defer cluster.LogPanicToFile(task)
-
-			useMaster := true
-			dir := "mydumper"
-			backupdir := cluster.master.GetMyBackupDirectory() + dir
-
-			bckserver := cluster.GetBackupServer()
-			if bckserver != nil && bckserver.HasBackupTypeCookie(config.ConstBackupLogicalTypeMydumper) {
-				if _, err := os.Stat(bckserver.GetMyBackupDirectory() + dir); err == nil {
-					backupdir = bckserver.GetMasterBackupDirectory() + dir
-					useMaster = false
-				} else {
-					//Remove false cookie
-					bckserver.DelBackupTypeCookie(config.ConstBackupLogicalTypeMydumper)
-				}
+		err = server.JobReseedMyLoader(backupfile)
+		if err == nil && server.IsSlave && !server.PointInTimeMeta.IsInPITR {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Parsing mydumper metadata ")
+			meta, err2 := server.JobMyLoaderParseMeta(backupfile)
+			if err2 != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "MyLoader metadata parsing: %s", err2)
+				err = err2
 			}
 
-			if useMaster {
-				if _, err := os.Stat(backupdir); err != nil {
-					//Remove false cookie
-					cluster.master.DelBackupTypeCookie(config.ConstBackupLogicalTypeMydumper)
-				}
-			}
+			if server.IsMariaDB() && server.HaveMariaDBGTID {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Starting slave with mydumper metadata")
+				server.ExecQueryNoBinLog("SET GLOBAL gtid_slave_pos='"+meta.BinLogUuid+"'", time.Second)
 
-			err = server.JobReseedMyLoader(backupdir)
-			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error reseed %s on %s: %s", backtype, server.URL, err.Error())
-				if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
+				if server.IsMariaDB() && server.DBVersion.GreaterEqual("10") {
+					// Also reset GTID binlog state
+					_, err = server.ResetGTIDBinlogState(meta.BinLogUuid)
 				}
-			} else {
-				if e2 := server.JobsUpdateState(task, "Reseed completed", 3, 1); e2 != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
+
+				if err == nil {
+					server.StartSlave()
 				}
 			}
-		}()
+		}
+
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error reseed %s on %s: %s", backtype, server.URL, err.Error())
+			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
+			}
+		} else {
+			if e2 := server.JobsUpdateState(task, "Reseed completed", 3, 1); e2 != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
+			}
+		}
 	}
 	return err
 }
@@ -778,22 +753,35 @@ func (server *ServerMonitor) JobServerRestart() (int64, error) {
 }
 
 func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
-	cluster := server.ClusterGroup
-	task := "flashback" + cluster.Conf.BackupLogicalType
+	var dest, backupfile string
+	var err error
 
+	cluster := server.ClusterGroup
+	backtype := cluster.Conf.BackupLogicalType
+	task := "flashback" + backtype
+
+	// Ensure the cluster is discovered before proceeding
 	if !cluster.IsDiscovered() {
 		return errors.New("Cluster not discovered yet")
 	}
 
+	// Get the master node of the cluster
 	master := cluster.GetMaster()
 	if master == nil {
 		return errors.New("No master found. Cancel reseed logical backup")
 	}
 
+	// Check if the server is already reseeding
+	if server.HasAnyReseedingState() {
+		err := fmt.Errorf("Server is in reseeding state by %s", server.IsReseeding)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, err.Error())
+		return err
+	}
+
+	// Decide on backup filename depending on the backup type
 	useMaster := true
-	var dest string
-	switch cluster.Conf.BackupLogicalType {
-	case config.ConstBackupLogicalTypeMysqldump:
+	switch backtype {
+	case config.ConstBackupLogicalTypeMysqldump, "script":
 		dest = "mysqldump.sql.gz"
 	case config.ConstBackupLogicalTypeMydumper:
 		dest = "mydumper"
@@ -801,43 +789,48 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 		dest = "dumpling"
 	}
 
-	// Can't handle script validation, unknown logic
-	if cluster.Conf.BackupLogicalType != "script" {
-		backupfile := master.GetMyBackupDirectory() + dest
+	// Skip file lookup if using custom script
+	if backtype != "script" {
+		// Construct backup path on master
+		backupfile = master.GetMyBackupDirectory() + dest
 
+		// If a backup server has a valid backup for this type, use it instead
 		bckserver := cluster.GetBackupServer()
-		if bckserver != nil && bckserver.HasBackupTypeCookie(cluster.Conf.BackupLogicalType) {
+		if bckserver != nil && bckserver.HasBackupTypeCookie(backtype) {
 			if _, err := os.Stat(bckserver.GetMyBackupDirectory() + dest); err == nil {
 				backupfile = bckserver.GetMyBackupDirectory() + dest
 				useMaster = false
 			} else {
-				//Remove false cookie
-				bckserver.DelBackupTypeCookie(cluster.Conf.BackupLogicalType)
+				// Remove invalid cookie if file does not exist
+				bckserver.DelBackupTypeCookie(backtype)
 			}
 		}
 
+		// If no valid backup found, abort
 		if useMaster {
 			if _, err := os.Stat(backupfile); err != nil {
-				//Remove false cookie
 				master.DelBackupTypeCookie(cluster.Conf.BackupPhysicalType)
-				return fmt.Errorf("Cancelling reseed. No backup file found on master for %s", cluster.Conf.BackupLogicalType)
+				return fmt.Errorf("Cancelling reseed. No backup file found on master for %s", backtype)
 			}
 		}
 	}
 
-	if server.HasAnyReseedingState() {
-		err := fmt.Errorf("Server is in reseeding state by %s", server.IsReseeding)
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, err.Error())
-		return err
-	}
-
+	// Mark the server as in reseed for this task
 	server.SetInReseedBackup(task)
+	defer func() {
+		// Clear reseed state if task is still marked
+		if server.HasReseedingState(task) {
+			server.SetInReseedBackup("")
+		}
+	}()
 
+	// Attempt to stop slave replication on the server
 	logs, err := server.StopSlave()
 	if err != nil {
 		cluster.LogSQL(logs, err, server.URL, "Rejoin", config.LvlErr, "Failed stop slave on server: %s %s", server.URL, err)
 	}
 
+	// Reconfigure replication to point to master
 	logs, err = dbhelper.ChangeMaster(server.Conn, dbhelper.ChangeMasterOpt{
 		Host:      cluster.master.Host,
 		Port:      cluster.master.Port,
@@ -851,91 +844,78 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 	}, server.DBVersion)
 	if err != nil {
 		cluster.LogSQL(logs, err, server.URL, "Rejoin", config.LvlErr, "flashback can't changing master for logical backup %s request for server: %s %s", cluster.Conf.BackupLogicalType, server.URL, err)
-		if server.HasReseedingState(task) {
-			server.SetInReseedBackup("")
-		}
 		return err
 	}
 
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Receive flashback logical backup %s request for server: %s", cluster.Conf.BackupLogicalType, server.URL)
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Receive flashback logical backup %s request for server: %s", backtype, server.URL)
+
+	// If a custom script is configured, use it
 	if cluster.Conf.BackupLoadScript != "" {
-		server.SetInReseedBackup("script")
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Using script from backup-load-script on %s", server.URL)
-		go server.JobReseedBackupScript()
-	} else if cluster.Conf.BackupLogicalType == config.ConstBackupLogicalTypeMysqldump {
-		go func() {
-			defer cluster.LogPanicToFile(task)
+		server.JobReseedBackupScript()
 
-			useSelfBackup := true
-			file := "mysqldump.sql.gz"
-			backupfile := server.GetMyBackupDirectory() + file
-
-			bckserver := cluster.GetBackupServer()
-			if bckserver != nil && bckserver.HasBackupTypeCookie(config.ConstBackupLogicalTypeMysqldump) {
-				if _, err := os.Stat(bckserver.GetMyBackupDirectory() + file); err == nil {
-					backupfile = bckserver.GetMasterBackupDirectory() + file
-					useSelfBackup = false
-				} else {
-					//Remove false cookie
-					bckserver.DelBackupTypeCookie(config.ConstBackupLogicalTypeMysqldump)
-				}
+		// Handle mysqldump-based reseed
+	} else if backtype == config.ConstBackupLogicalTypeMysqldump {
+		err := server.JobReseedMysqldump(backupfile)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error flashback %s on %s: %s", backtype, server.URL, err.Error())
+			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
+			}
+		} else {
+			// Restart slave if needed
+			if server.IsSlave {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Start slave after dump on %s", server.URL)
+				server.StartSlave()
 			}
 
-			if useSelfBackup {
-				if _, err := os.Stat(backupfile); err != nil {
-					//Remove false cookie
-					server.DelBackupTypeCookie(config.ConstBackupLogicalTypeMysqldump)
-				}
+			if e2 := server.JobsUpdateState(task, "Flashback completed", 3, 1); e2 != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
 			}
-			err := server.JobReseedMysqldump(backupfile)
-			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error flashback %s on %s: %s", cluster.Conf.BackupLogicalType, server.URL, err.Error())
-				if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-				}
+		}
+
+		// Handle mydumper-based reseed
+	} else if backtype == config.ConstBackupLogicalTypeMydumper {
+		err := server.JobReseedMyLoader(backupfile)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error flashback %s on %s: %s", backtype, server.URL, err.Error())
+			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
+			}
+		} else {
+			// Parse metadata from mydumper
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Parsing mydumper metadata ")
+			meta, err2 := server.JobMyLoaderParseMeta(backupfile)
+			if err2 != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "MyLoader metadata parsing: %s", err2)
+				err = err2
 			} else {
-				if e2 := server.JobsUpdateState(task, "Flashback completed", 3, 1); e2 != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
+				// Set GTID position for MariaDB
+				if server.IsMariaDB() && server.HaveMariaDBGTID {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Starting slave with mydumper metadata")
+					server.ExecQueryNoBinLog("SET GLOBAL gtid_slave_pos='"+meta.BinLogUuid+"'", time.Second)
+
+					// Reset binlog state if supported
+					if server.IsMariaDB() && server.DBVersion.GreaterEqual("10") {
+						_, err = server.ResetGTIDBinlogState(meta.BinLogUuid)
+						if err != nil {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error flashback %s on %s: %s", backtype, server.URL, err.Error())
+							if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
+							}
+						}
+					}
 				}
-			}
-		}()
-	} else if cluster.Conf.BackupLogicalType == config.ConstBackupLogicalTypeMydumper {
-		go func() {
-			defer cluster.LogPanicToFile(task)
 
-			useSelfBackup := true
-			dir := "mydumper"
-			backupdir := server.GetMyBackupDirectory() + dir
-
-			bckserver := cluster.GetBackupServer()
-			if bckserver != nil && bckserver.HasBackupTypeCookie(config.ConstBackupLogicalTypeMydumper) {
-				if _, err := os.Stat(bckserver.GetMyBackupDirectory() + dir); err == nil {
-					backupdir = bckserver.GetMasterBackupDirectory() + dir
-					useSelfBackup = false
-				} else {
-					//Remove false cookie
-					bckserver.DelBackupTypeCookie(config.ConstBackupLogicalTypeMydumper)
+				if err == nil {
+					server.StartSlave()
 				}
 			}
 
-			if useSelfBackup {
-				if _, err := os.Stat(backupdir); err != nil {
-					//Remove false cookie
-					server.DelBackupTypeCookie(config.ConstBackupLogicalTypeMydumper)
-				}
+			if e2 := server.JobsUpdateState(task, "Flashback completed", 3, 1); e2 != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
 			}
-			err := server.JobReseedMyLoader(backupdir)
-			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error flashback %s on %s: %s", cluster.Conf.BackupLogicalType, server.URL, err.Error())
-				if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-				}
-			} else {
-				if e2 := server.JobsUpdateState(task, "Flashback completed", 3, 1); e2 != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-				}
-			}
-		}()
+		}
 	}
 
 	return nil
@@ -1097,28 +1077,6 @@ func (server *ServerMonitor) JobReseedMyLoader(backupdir string) error {
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Finish logical restaure %s for: %s", cluster.Conf.BackupLogicalType, server.URL)
 	server.Refresh()
 
-	// Prevent set slave when in PITR
-	if server.IsSlave && !server.PointInTimeMeta.IsInPITR {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Parsing mydumper metadata ")
-		meta, err := server.JobMyLoaderParseMeta(backupdir)
-		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "MyLoader metadata parsing: %s", err)
-		}
-		if server.IsMariaDB() && server.HaveMariaDBGTID {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Starting slave with mydumper metadata")
-			server.ExecQueryNoBinLog("SET GLOBAL gtid_slave_pos='"+meta.BinLogUuid+"'", time.Second)
-
-			if server.IsMariaDB() && server.DBVersion.GreaterEqual("10") {
-				// Also reset GTID binlog state
-				_, err = server.ResetGTIDBinlogState(meta.BinLogUuid)
-				if err != nil {
-					return err
-				}
-			}
-
-			server.StartSlave()
-		}
-	}
 	return nil
 }
 
@@ -1126,11 +1084,6 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string) error {
 	cluster := server.ClusterGroup
 	var err error
 	defer server.SetInReseedBackup("")
-
-	master := cluster.GetMaster()
-	if master == nil {
-		return fmt.Errorf("No master. Cancel backup reseeding %s", server.URL)
-	}
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Sending logical backup to reseed %s", server.URL)
 
@@ -1188,11 +1141,6 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string) error {
 	err = clientCmd.Wait()
 	if err != nil {
 		return fmt.Errorf("Error waiting reseed %s at %s", server.URL, err)
-	}
-
-	if server.IsSlave && !server.PointInTimeMeta.IsInPITR {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Start slave after dump on %s", server.URL)
-		server.StartSlave()
 	}
 
 	return nil

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -1115,16 +1115,22 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string) error {
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s ", strings.Replace(clientCmd.String(), "="+cluster.GetDbPass(), "XXXX", -1))
 
 	sql_log_bin := 0
+	resetmaster := "RESET MASTER;"
+	if server.DBVersion.IsMySQLOrPerconaGreater84() {
+		resetmaster = "RESET BINARY LOGS AND GTIDS;"
+	}
+
 	if server.URL == cluster.GetMaster().URL {
 		sql_log_bin = 1
+		resetmaster = ""
 	}
 
-	cmdstring := "RESET MASTER;SET sql_log_bin=%d;SET long_query_time=10;"
+	cmdstring := "%sSET sql_log_bin=%d;SET long_query_time=10;"
 	if server.DBVersion.IsMySQLOrPerconaGreater84() {
-		cmdstring = "RESET BINARY LOGS AND GTIDS;SET sql_log_bin=%d;SET long_query_time=10;"
+		cmdstring = "%sSET sql_log_bin=%d;SET long_query_time=10;"
 	}
 
-	cmdstring = fmt.Sprintf(cmdstring, sql_log_bin)
+	cmdstring = fmt.Sprintf(cmdstring, resetmaster, sql_log_bin)
 
 	clientCmd.Stdin = io.MultiReader(bytes.NewBufferString(cmdstring), fz)
 

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -1898,7 +1898,9 @@ func (server *ServerMonitor) JobBackupMysqldumpUser(filename string) error {
 	dir := filepath.Dir(filename)
 	userpath := filepath.Join(dir, "mysql.users.sql.gz")
 
-	dumpCmd := exec.Command(cluster.GetMysqlDumpPath(), append(cluster.GetMysqlDumpOptions(server, server.JobGetDumpGtidParameter()), server.GetSSLClientParam("client-dump")...)...)
+	dumpargs := append(cluster.GetDumpCredentials(server), server.GetSSLClientParam("client-dump")...)
+	dumpargs = append(dumpargs, "--insert-ignore", "--system=user", "mysql", "user")
+	dumpCmd := exec.Command(cluster.GetMysqlDumpPath(), dumpargs...)
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s ", strings.Replace(dumpCmd.String(), "="+cluster.GetDbPass(), "=XXXX", -1))
 

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -572,6 +572,7 @@ func (server *ServerMonitor) JobReseedLogicalBackup(backtype string) error {
 	}
 
 	useMaster := true
+	source := master
 	var dest string
 	switch backtype {
 	case config.ConstBackupLogicalTypeMysqldump, "script":
@@ -589,6 +590,7 @@ func (server *ServerMonitor) JobReseedLogicalBackup(backtype string) error {
 		if _, err := os.Stat(bckserver.GetMyBackupDirectory() + dest); err == nil {
 			backupfile = bckserver.GetMyBackupDirectory() + dest
 			useMaster = false
+			source = bckserver
 		} else {
 			//Remove false cookie
 			bckserver.DelBackupTypeCookie(backtype)
@@ -677,7 +679,7 @@ func (server *ServerMonitor) JobReseedLogicalBackup(backtype string) error {
 	server.JobsUpdateState(task, "processing", 1, 0)
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Receive reseed logical backup %s request for server: %s", backtype, server.URL)
 	if backtype == config.ConstBackupLogicalTypeMysqldump {
-		err = server.JobReseedMysqldump(backupfile)
+		err = server.JobReseedMysqldump(backupfile, cluster.Conf.BackupRestoreMysqlUser && source.LastBackupMeta.Logical != nil && source.LastBackupMeta.Logical.SplitUser)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error reseed %s on %s: %s", backtype, server.URL, err.Error())
 			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
@@ -694,7 +696,7 @@ func (server *ServerMonitor) JobReseedLogicalBackup(backtype string) error {
 			}
 		}
 	} else if backtype == config.ConstBackupLogicalTypeMydumper {
-		err = server.JobReseedMyLoader(backupfile)
+		err = server.JobReseedMyLoader(backupfile, cluster.Conf.BackupRestoreMysqlUser)
 		if err == nil && server.IsSlave && !server.PointInTimeMeta.IsInPITR {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Parsing mydumper metadata ")
 			meta, err2 := server.JobMyLoaderParseMeta(backupfile)
@@ -780,6 +782,7 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 
 	// Decide on backup filename depending on the backup type
 	useMaster := true
+	source := master
 	switch backtype {
 	case config.ConstBackupLogicalTypeMysqldump, "script":
 		dest = "mysqldump.sql.gz"
@@ -800,6 +803,7 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 			if _, err := os.Stat(bckserver.GetMyBackupDirectory() + dest); err == nil {
 				backupfile = bckserver.GetMyBackupDirectory() + dest
 				useMaster = false
+				source = bckserver
 			} else {
 				// Remove invalid cookie if file does not exist
 				bckserver.DelBackupTypeCookie(backtype)
@@ -856,7 +860,7 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 
 		// Handle mysqldump-based reseed
 	} else if backtype == config.ConstBackupLogicalTypeMysqldump {
-		err := server.JobReseedMysqldump(backupfile)
+		err := server.JobReseedMysqldump(backupfile, cluster.Conf.BackupRestoreMysqlUser && source.LastBackupMeta.Logical != nil && source.LastBackupMeta.Logical.SplitUser)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error flashback %s on %s: %s", backtype, server.URL, err.Error())
 			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
@@ -876,7 +880,7 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 
 		// Handle mydumper-based reseed
 	} else if backtype == config.ConstBackupLogicalTypeMydumper {
-		err := server.JobReseedMyLoader(backupfile)
+		err := server.JobReseedMyLoader(backupfile, cluster.Conf.BackupRestoreMysqlUser)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error flashback %s on %s: %s", backtype, server.URL, err.Error())
 			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
@@ -1036,9 +1040,35 @@ func (server *ServerMonitor) JobZFSSnapBack() (int64, error) {
 	return server.JobInsertTask("zfssnapback", "0", cluster.Conf.MonitorAddress)
 }
 
-func (server *ServerMonitor) JobReseedMyLoader(backupdir string) error {
+func (server *ServerMonitor) JobReseedMyLoader(backupdir string, restoreUser bool) error {
 	cluster := server.ClusterGroup
 	threads := strconv.Itoa(cluster.Conf.BackupLogicalLoadThreads)
+
+	if restoreUser {
+		//walk dir
+		files, err := os.ReadDir(backupdir)
+		if err == nil {
+			if len(files) > 0 {
+				for _, file := range files {
+					if strings.HasPrefix(file.Name(), "mysql.user") && strings.HasSuffix(file.Name(), ".sql.gz.skip") {
+						os.Rename(filepath.Join(backupdir, file.Name()), filepath.Join(backupdir, strings.TrimSuffix(file.Name(), ".skip")))
+					}
+				}
+			}
+		}
+	} else {
+		//walk dir
+		files, err := os.ReadDir(backupdir)
+		if err == nil {
+			if len(files) > 0 {
+				for _, file := range files {
+					if strings.HasPrefix(file.Name(), "mysql.user") && strings.HasSuffix(file.Name(), ".sql.gz") {
+						os.Rename(filepath.Join(backupdir, file.Name()), filepath.Join(backupdir, file.Name()+".skip"))
+					}
+				}
+			}
+		}
+	}
 
 	defer server.SetInReseedBackup("")
 
@@ -1081,7 +1111,7 @@ func (server *ServerMonitor) JobReseedMyLoader(backupdir string) error {
 	return nil
 }
 
-func (server *ServerMonitor) JobReseedMysqldump(backupfile string) error {
+func (server *ServerMonitor) JobReseedMysqldump(backupfile string, restoreUser bool) error {
 	cluster := server.ClusterGroup
 	var err error
 	defer server.SetInReseedBackup("")
@@ -1089,12 +1119,6 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string) error {
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Sending logical backup to reseed %s", server.URL)
 
 	server.StopSlave()
-
-	file, err := cluster.CreateTmpClientConfFile()
-	if err != nil {
-		return fmt.Errorf("[%s] Failed creating tmp connection file:  %s ", server.URL, err)
-	}
-	defer os.Remove(file)
 
 	gzfile, err := os.Open(backupfile)
 	if err != nil {
@@ -1128,10 +1152,19 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string) error {
 	if server.DBVersion.IsMySQLOrPerconaGreater84() {
 		cmdstring = "%sSET sql_log_bin=%d;SET long_query_time=10;"
 	}
-
 	cmdstring = fmt.Sprintf(cmdstring, resetmaster, sql_log_bin)
 
-	clientCmd.Stdin = io.MultiReader(bytes.NewBufferString(cmdstring), fz)
+	var usergzfile io.Reader
+	if restoreUser {
+		usergzfile, err = server.ReadMysqldumpUser(backupfile)
+		if err != nil {
+			return fmt.Errorf("Error opening mysql.user file %s", err)
+		}
+
+		clientCmd.Stdin = io.MultiReader(bytes.NewBufferString(cmdstring), usergzfile, fz) //Append mysql.user
+	} else {
+		clientCmd.Stdin = io.MultiReader(bytes.NewBufferString(cmdstring), fz)
+	}
 
 	stderr, _ := clientCmd.StdoutPipe()
 	clientCmd.Stderr = clientCmd.Stdout
@@ -1156,6 +1189,35 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string) error {
 	}
 
 	return nil
+}
+
+func (server *ServerMonitor) ReadMysqldumpUser(backupfile string) (io.Reader, error) {
+	cluster := server.ClusterGroup
+	var err error
+
+	dir := filepath.Dir(backupfile)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return nil, fmt.Errorf("Directory %s does not exist", dir)
+	}
+
+	userpath := filepath.Join(dir, "mysql.user.sql.gz")
+	if _, err := os.Stat(userpath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("File %s does not exist", userpath)
+	}
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Opening mysql.user file %s", userpath)
+
+	gzfile, err := os.Open(backupfile)
+	if err != nil {
+		return nil, fmt.Errorf("[%s] Failed opening backup file in backup server for reseed:  %s ", server.URL, err)
+	}
+
+	fz, err := gzip.NewReaderN(gzfile, cluster.Conf.SSTSendBuffer, 16)
+	if err != nil {
+		return nil, fmt.Errorf("[%s] Failed to unzip backup file in backup server for reseed:  %s ", server.URL, err)
+	}
+
+	return fz, nil
 }
 
 // JobReseedBackupScript will execute the backup load script
@@ -1684,14 +1746,17 @@ func (server *ServerMonitor) JobBackupMysqldump(filename string) error {
 		gtidRegex = regexp.MustCompile(`GTID_PURGED\s*=(\/\*!.+\*\/)?\s*'(.+)'`)
 	}
 
+	if cluster.Conf.BackupSplitMysqlUser {
+		server.LastBackupMeta.Logical.SplitUser = true
+		err := server.JobBackupMysqldumpUser(filename)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error mysqldump backup request: %s", err.Error())
+			return err
+		}
+	}
+
 	var bfile, bgtid string
 	var bpos uint64
-
-	file, err2 := cluster.CreateTmpClientConfFile()
-	if err2 != nil {
-		return err2
-	}
-	defer os.Remove(file)
 
 	dumpCmd := exec.Command(cluster.GetMysqlDumpPath(), cluster.GetMysqlDumpOptions(server, server.JobGetDumpGtidParameter())...)
 
@@ -1826,10 +1891,71 @@ func (server *ServerMonitor) JobBackupMysqldump(filename string) error {
 	return err
 }
 
+func (server *ServerMonitor) JobBackupMysqldumpUser(filename string) error {
+	cluster := server.ClusterGroup
+	var err error
+
+	dir := filepath.Dir(filename)
+	userpath := filepath.Join(dir, "mysql.users.sql.gz")
+
+	dumpCmd := exec.Command(cluster.GetMysqlDumpPath(), append(cluster.GetMysqlDumpOptions(server, server.JobGetDumpGtidParameter()), server.GetSSLClientParam("client-dump")...)...)
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s ", strings.Replace(dumpCmd.String(), "="+cluster.GetDbPass(), "=XXXX", -1))
+
+	f, err := os.Create(userpath)
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error mysqldump user backup request: %s", err.Error())
+		return err
+	}
+
+	gw := gzip.NewWriter(f)
+
+	// Buffer before gzip to improve compression
+	bw := bufio.NewWriterSize(gw, 64*1024) // 64KB buffer
+	defer func() {
+		if err := bw.Flush(); err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error flushing buffer: %s", err.Error())
+		}
+		if err := gw.Close(); err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error closing gzip: %s", err.Error())
+		}
+		f.Close()
+	}()
+
+	dumpCmd.Stdout = gw
+	stderrIn, _ := dumpCmd.StderrPipe()
+
+	err = dumpCmd.Start()
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error backup request: %s", err)
+		return err
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		server.copyLogs(stderrIn, config.ConstLogModBackupStream, config.LvlDbg)
+	}()
+
+	// Wait for print log to finish
+	wg.Wait()
+
+	err = dumpCmd.Wait()
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "mysqldump: %s", err)
+	}
+
+	return err
+}
+
 func (server *ServerMonitor) JobBackupMyDumper(outputdir string) error {
 	cluster := server.ClusterGroup
 	var err error
 	var bckConn *sqlx.DB
+
+	// Mydumper is fine with split user since we can
+	server.LastBackupMeta.Logical.SplitUser = true
 
 	defer cluster.SetInLogicalBackupState(false)
 
@@ -2609,12 +2735,6 @@ func (cluster *Cluster) CreateTmpClientConfFile() (string, error) {
 func (cluster *Cluster) JobRejoinMysqldumpFromSource(source *ServerMonitor, dest *ServerMonitor) error {
 	defer dest.SetInReseedBackup("")
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Rejoining from direct mysqldump from %s", source.URL)
-
-	file, err := cluster.CreateTmpClientConfFile()
-	if err != nil {
-		return err
-	}
-	defer os.Remove(file)
 
 	dest.StopSlave()
 	dumpCmd := exec.Command(cluster.GetMysqlDumpPath(), cluster.GetMysqlDumpOptions(source, dest.JobGetDumpGtidParameter())...)

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -2010,6 +2010,8 @@ func (server *ServerMonitor) JobBackupLogical() error {
 	}
 
 	cluster.SetInLogicalBackupState(true)
+	defer cluster.SetInLogicalBackupState(false)
+
 	start := time.Now()
 	var prevId int64
 	prev := cluster.BackupMetaMap.GetPreviousBackup(cluster.Conf.BackupLogicalType, server.URL)

--- a/cluster/srv_rejoin.go
+++ b/cluster/srv_rejoin.go
@@ -314,7 +314,7 @@ func (server *ServerMonitor) rejoinMasterFlashBack(crash *Crash) error {
 
 	cliParams := make([]string, 0)
 	cliParams = append(cliParams, "--host="+misc.Unbracket(server.Host), "--port="+server.Port, "--user="+cluster.GetDbUser(), "--password="+cluster.GetDbPass())
-	cliParams = append(cliParams, strings.Split(server.GetSSLClientParam("client"), " ")...)
+	cliParams = append(cliParams, server.GetSSLClientParam("client")...)
 	clientCmd := exec.Command(cluster.GetMysqlclientPath(), misc.RemoveEmptyString(cliParams)...)
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "FlashBack: %s %s", cluster.GetMysqlBinlogPath(), strings.Replace(strings.Join(binlogCmd.Args, " "), cluster.GetRplPass(), "XXXX", -1))
@@ -726,7 +726,7 @@ func (server *ServerMonitor) backupBinlog(crash *Crash) error {
 
 	var params []string = make([]string, 0)
 	params = append(params, "--read-from-remote-server", "--raw", "--stop-never-slave-server-id=10000", "--user="+cluster.GetRplUser(), "--password="+cluster.GetRplPass(), "--host="+misc.Unbracket(server.Host), "--port="+server.Port, "--result-file="+cluster.Conf.WorkingDir+"/"+cluster.Name+"-server"+strconv.FormatUint(uint64(server.ServerID), 10)+"-", "--start-position="+crash.FailoverMasterLogPos)
-	params = append(params, strings.Split(server.GetSSLClientParam("client-binlog"), " ")...)
+	params = append(params, server.GetSSLClientParam("client-binlog")...)
 	params = append(params, crash.FailoverMasterLogFile)
 	cmdrun = exec.Command(cluster.GetMysqlBinlogPath(), misc.RemoveEmptyString(params)...)
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Backup %s %s", cluster.GetMysqlBinlogPath(), strings.ReplaceAll(strings.Join(cmdrun.Args, " "), cluster.GetRplPass(), "XXXX"))

--- a/config/backup.go
+++ b/config/backup.go
@@ -41,6 +41,7 @@ type BackupMetadata struct {
 	BinLogFilePos  uint64         `json:"binLogFilePos"`
 	BinLogGtid     string         `json:"binLogUuid"`
 	Completed      bool           `json:"completed"`
+	SplitUser      bool           `json:"splitUser"`
 	Previous       int64          `json:"previous"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -707,11 +707,11 @@ type Config struct {
 	BackupMysqlclientOptions                  string                 `mapstructure:"backup-mysqlclient-options" toml:"backup-mysqlclient-options" json:"backupMysqlclientOptions"`
 	BackupBinlogs                             bool                   `mapstructure:"backup-binlogs" toml:"backup-binlogs" json:"backupBinlogs"`
 	BackupBinlogsKeep                         int                    `mapstructure:"backup-binlogs-keep" toml:"backup-binlogs-keep" json:"backupBinlogsKeep"`
+	BackupLockDDL                             bool                   `mapstructure:"backup-lockddl" toml:"backup-lockddl" json:"backupLockDDL"`
 	BinlogCopyMode                            string                 `mapstructure:"binlog-copy-mode" toml:"binlog-copy-mode" json:"binlogCopyMode"`
 	BinlogCopyScript                          string                 `mapstructure:"binlog-copy-script" toml:"binlog-copy-script" json:"binlogCopyScript"`
 	BinlogRotationScript                      string                 `mapstructure:"binlog-rotation-script" toml:"binlog-rotation-script" json:"binlogRotationScript"`
 	BinlogParseMode                           string                 `mapstructure:"binlog-parse-mode" toml:"binlog-parse-mode" json:"binlogParseMode"`
-	BackupLockDDL                             bool                   `mapstructure:"backup-lockddl" toml:"backup-lockddl" json:"backupLockDDL"`
 	ClusterConfigPath                         string                 `mapstructure:"cluster-config-file" toml:"-" json:"-"`
 	VaultServerAddr                           string                 `mapstructure:"vault-server-addr" toml:"vault-server-addr" json:"vaultServerAddr"`
 	VaultRoleId                               string                 `mapstructure:"vault-role-id" toml:"vault-role-id" json:"vaultRoleId"`

--- a/config/config.go
+++ b/config/config.go
@@ -645,6 +645,8 @@ type Config struct {
 	BackupSaveScript                          string                 `mapstructure:"backup-save-script" toml:"backup-save-script" json:"backupSaveScript"`
 	BackupLoadScript                          string                 `mapstructure:"backup-load-script" toml:"backup-load-script" json:"backupLoadScript"`
 	CompressBackups                           bool                   `mapstructure:"compress-backups" toml:"compress-backups" json:"compressBackups"`
+	BackupSplitMysqlUser                      bool                   `mapstructure:"backup-split-mysql-user" toml:"backup-split-mysql-user" json:"backupSplitMysqlUser"`
+	BackupRestoreMysqlUser                    bool                   `mapstructure:"backup-restore-mysql-user" toml:"backup-restore-mysql-user" json:"backupRestoreMysqlUser"`
 	BackupCheckFreeSpace                      bool                   `mapstructure:"backup-check-free-space" toml:"backup-check-free-space" json:"backupCheckFreeSpace"`
 	BackupDiskTresholdWarn                    int                    `mapstructure:"backup-disk-treshold-warn" toml:"backup-disk-treshold-warn" json:"backupDiskTresholdWarn"`
 	BackupDiskTresholdCrit                    int                    `mapstructure:"backup-disk-treshold-crit" toml:"backup-disk-treshold-crit" json:"backupDiskTresholdCrit"`

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1314,6 +1314,55 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/clusters/{clusterName}/actions/reseed-from-parent": {
+            "post": {
+                "description": "Reseed the specified cluster from its parent cluster.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterReplication"
+                ],
+                "summary": "Reseed from Parent Cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Reseed from parent queued",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "No cluster",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/actions/reset-failover-control": {
             "post": {
                 "description": "This endpoint resets the failover control for the specified cluster.",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15437,6 +15437,9 @@ const docTemplate = `{
         "dbhelper.SlaveStatus": {
             "type": "object",
             "properties": {
+                "autoPosition": {
+                    "type": "integer"
+                },
                 "channelName": {
                     "$ref": "#/definitions/sql.NullString"
                 },
@@ -15812,6 +15815,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "backupMysqlbinlogPath": {
+                    "type": "string"
+                },
+                "backupMysqlclientOptions": {
                     "type": "string"
                 },
                 "backupMysqlclientgPath": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -15426,6 +15426,9 @@
         "dbhelper.SlaveStatus": {
             "type": "object",
             "properties": {
+                "autoPosition": {
+                    "type": "integer"
+                },
                 "channelName": {
                     "$ref": "#/definitions/sql.NullString"
                 },
@@ -15801,6 +15804,9 @@
                     "type": "string"
                 },
                 "backupMysqlbinlogPath": {
+                    "type": "string"
+                },
+                "backupMysqlclientOptions": {
                     "type": "string"
                 },
                 "backupMysqlclientgPath": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1303,6 +1303,55 @@
                 }
             }
         },
+        "/api/clusters/{clusterName}/actions/reseed-from-parent": {
+            "post": {
+                "description": "Reseed the specified cluster from its parent cluster.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterReplication"
+                ],
+                "summary": "Reseed from Parent Cluster",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Reseed from parent queued",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "No cluster",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/actions/reset-failover-control": {
             "post": {
                 "description": "This endpoint resets the failover control for the specified cluster.",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4044,6 +4044,39 @@ paths:
       summary: Cleanup replication bootstrap for a specific cluster
       tags:
       - ClusterReplication
+  /api/clusters/{clusterName}/actions/reseed-from-parent:
+    post:
+      description: Reseed the specified cluster from its parent cluster.
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Reseed from parent queued
+          schema:
+            type: string
+        "403":
+          description: No valid ACL
+          schema:
+            type: string
+        "500":
+          description: No cluster
+          schema:
+            type: string
+      summary: Reseed from Parent Cluster
+      tags:
+      - ClusterReplication
   /api/clusters/{clusterName}/actions/reset-failover-control:
     post:
       consumes:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1204,6 +1204,8 @@ definitions:
     type: object
   dbhelper.SlaveStatus:
     properties:
+      autoPosition:
+        type: integer
       channelName:
         $ref: '#/definitions/sql.NullString'
       connectionName:
@@ -1454,6 +1456,8 @@ definitions:
       backupMyloaderPath:
         type: string
       backupMysqlbinlogPath:
+        type: string
+      backupMysqlclientOptions:
         type: string
       backupMysqlclientgPath:
         type: string

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -6508,6 +6508,17 @@ func (repman *ReplicationManager) handlerMuxClusterHealth(w http.ResponseWriter,
 	}
 }
 
+// handlerMuxReseedFromParent handles the HTTP request to reseed a cluster from its parent cluster.
+// @Summary Reseed from Parent Cluster
+// @Description Reseed the specified cluster from its parent cluster.
+// @Tags ClusterReplication
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Success 200 {string} string "Reseed from parent queued"
+// @Failure 403 {string} string "No valid ACL"
+// @Failure 500 {string} string "No cluster"
+// @Router /api/clusters/{clusterName}/actions/reseed-from-parent [post]
 func (repman *ReplicationManager) handlerMuxReseedFromParent(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	var strUser string

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -566,7 +566,7 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxRejectSubscription)),
 	))
 
-	router.Handle("/api/clusters/{clusterName}/actions/staging-reseed-parent", negroni.New(
+	router.Handle("/api/clusters/{clusterName}/actions/staging-reseed-from-parent", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxReseedFromParent)),
 	))

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -565,6 +565,11 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxRejectSubscription)),
 	))
+
+	router.Handle("/api/clusters/{clusterName}/actions/staging-reseed-parent", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxReseedFromParent)),
+	))
 }
 
 // @Summary Retrieve servers for a specific cluster
@@ -6499,4 +6504,46 @@ func (repman *ReplicationManager) handlerMuxClusterHealth(w http.ResponseWriter,
 		w.WriteHeader(http.StatusBadRequest)
 		io.WriteString(w, "No cluster found:"+vars["clusterName"])
 	}
+}
+
+func (repman *ReplicationManager) handlerMuxReseedFromParent(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	var strUser string
+	var valid bool
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster != nil {
+		if valid, strUser = repman.IsValidClusterACL(r, mycluster); !valid {
+			http.Error(w, "No valid ACL", 403)
+			return
+		}
+
+		if mycluster.Conf.ReplicationMultisourceHeadClusters == "" {
+			http.Error(w, "No multisource cluster", 500)
+			return
+		}
+
+		pcluster := repman.GetParentClusterFromReplicationSource(mycluster.Conf.ReplicationMultisourceHeadClusters)
+		if pcluster == nil {
+			http.Error(w, "No parent cluster", 500)
+			return
+		}
+
+		if !pcluster.IsURLPassACL(strUser, strings.Replace(r.URL.Path, "/"+mycluster.Name+"/", "/"+pcluster.Name+"/", 1), true) {
+			http.Error(w, "No valid ACL in parent cluster", 403)
+			return
+		}
+
+		go mycluster.ReseedFromParentCluster(pcluster)
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Reseed from parent queued"))
+
+	} else {
+		http.Error(w, "No cluster", 500)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("Reseed from parent queued"))
 }

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -3066,6 +3066,8 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		mycluster.Conf.TopologyStagingRefreshScript = value
 	case "topology-staging-post-detach-script":
 		mycluster.Conf.TopologyStagingPostDetachScript = value
+	case "replication-multisource-head-clusters":
+		mycluster.Conf.ReplicationMultisourceHeadClusters = value
 	case "db-servers-tls-ssl-mode":
 		mycluster.Conf.HostsTlsSslMode = value
 

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -3073,6 +3073,8 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		mycluster.Conf.TopologyStagingPostDetachScript = value
 	case "replication-multisource-head-clusters":
 		mycluster.Conf.ReplicationMultisourceHeadClusters = value
+	case "replication-source-name":
+		mycluster.Conf.MasterConn = value
 	case "db-servers-tls-ssl-mode":
 		mycluster.Conf.HostsTlsSslMode = value
 

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2235,6 +2235,10 @@ func (repman *ReplicationManager) switchClusterSettings(mycluster *cluster.Clust
 		mycluster.SwitchBackupBinlogs()
 	case "compress-backups":
 		mycluster.SwitchCompressBackups()
+	case "backup-split-mysql-user":
+		mycluster.Conf.BackupSplitMysqlUser = !mycluster.Conf.BackupSplitMysqlUser
+	case "backup-restore-mysql-user":
+		mycluster.Conf.BackupRestoreMysqlUser = !mycluster.Conf.BackupRestoreMysqlUser
 	case "backup-check-free-space":
 		mycluster.Conf.BackupCheckFreeSpace = !mycluster.Conf.BackupCheckFreeSpace
 	case "backup-estimate-size":
@@ -3248,6 +3252,10 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		}
 	case "compress-backups":
 		mycluster.Conf.CompressBackups = isactive
+	case "backup-split-mysql-user":
+		mycluster.Conf.BackupSplitMysqlUser = isactive
+	case "backup-restore-mysql-user":
+		mycluster.Conf.BackupRestoreMysqlUser = isactive
 	case "backup-check-free-space":
 		mycluster.Conf.BackupCheckFreeSpace = isactive
 	case "backup-estimate-size":

--- a/server/server.go
+++ b/server/server.go
@@ -792,6 +792,8 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.BackupSaveScript, "backup-save-script", "", "Customized backup save script")
 	flags.StringVar(&conf.BackupLoadScript, "backup-load-script", "", "Customized backup load script")
 	flags.BoolVar(&conf.CompressBackups, "compress-backups", false, "To compress backups")
+	flags.BoolVar(&conf.BackupSplitMysqlUser, "backup-split-mysql-user", false, "To split mysql user in backup")
+	flags.BoolVar(&conf.BackupRestoreMysqlUser, "backup-restore-mysql-user", true, "Restore mysql user alongside with backup")
 	flags.BoolVar(&conf.BackupCheckFreeSpace, "backup-check-size", true, "To check free space before processing backup")
 	flags.IntVar(&conf.BackupDiskTresholdWarn, "backup-disk-treshold-warn", 85, "Warning threshold for used disk in percentage")
 	flags.IntVar(&conf.BackupDiskTresholdCrit, "backup-disk-treshold-crit", 95, "Critical threshold for used space in percentage. If disk usage is above this value, backup will be skipped")
@@ -1039,7 +1041,6 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 				crcTable := crc64.MakeTable(crc64.ECMA)
 				conf.ProvCodeApp = "ns" + strconv.FormatUint(crc64.Checksum([]byte(dbConfig.Get("email").(string)), crcTable), 10)
 			}
-
 		}
 	}
 

--- a/server/server_get.go
+++ b/server/server_get.go
@@ -18,6 +18,19 @@ func (repman *ReplicationManager) getClusterByName(clname string) *cluster.Clust
 	return c
 }
 
+func (repman *ReplicationManager) GetParentClusterFromReplicationSource(source string) *cluster.Cluster {
+	repman.Lock()
+	defer repman.Unlock()
+
+	for _, c := range repman.Clusters {
+		if c.Conf.MasterConn == source {
+			return c
+		}
+	}
+
+	return nil
+}
+
 func (repman *ReplicationManager) GetDockerRepoPath(reponame string) string {
 	for _, c := range repman.ServiceRepos {
 		if c.Name == reponame {

--- a/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
@@ -34,11 +34,13 @@ import NewServerModal from '../../../components/Modals/NewServerModal'
 import parentStyles from '../styles.module.scss'
 import CopyTextModal from '../../../components/Modals/CopyTextModal'
 import SetCredentialsModal from '../../../components/Modals/SetCredentialsModal'
+import NewClusterModal from '../../../components/Modals/NewClusterModal'
 
 function ClusterDetail({ selectedCluster }) {
   const dispatch = useDispatch()
   const {
     common: { isDesktop },
+    globalClusters: { monitor },
     cluster: {
       clusterMaster,
       clusterServers,
@@ -49,6 +51,7 @@ function ClusterDetail({ selectedCluster }) {
 
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false)
   const [isNewServerModalOpen, setIsNewServerModalOpen] = useState(false)
+  const [isNewClusterModalOpen, setIsNewClusterModalOpen] = useState(false)
   const [isCredentialModalOpen, setIsCredentialModalOpen] = useState(false)
   const [isClipboardModalOpen, setIsClipboardModalOpen] = useState(false)
   const [clipboardText, setClipboardText] = useState('')
@@ -96,7 +99,7 @@ function ClusterDetail({ selectedCluster }) {
             setConfirmHandler(() => () => dispatch(toggleTraffic({ clusterName: selectedCluster?.name })))
           }
         },
-        ...( selectedCluster.config.topologyStaging ? [{
+        ...(selectedCluster.config.topologyStaging ? [{
           name: 'Toggle Traffic Staging',
           onClick: () => {
             openConfirmModal()
@@ -106,32 +109,38 @@ function ClusterDetail({ selectedCluster }) {
         }] : []),
         ...(clusterMaster?.state === 'Failed'
           ? [
-              {
-                name: 'Failover',
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle('Confirm failover?')
-                  setConfirmHandler(() => () => dispatch(failOverCluster({ clusterName: selectedCluster?.name })))
-                }
+            {
+              name: 'Failover',
+              onClick: () => {
+                openConfirmModal()
+                setConfirmTitle('Confirm failover?')
+                setConfirmHandler(() => () => dispatch(failOverCluster({ clusterName: selectedCluster?.name })))
               }
-            ]
+            }
+          ]
           : [
-              {
-                name: 'Switchover',
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle('Confirm switchover?')
-                  setConfirmHandler(
-                    () => () => dispatch(switchOverCluster({ clusterName: selectedCluster?.name }))
-                  )
-                }
+            {
+              name: 'Switchover',
+              onClick: () => {
+                openConfirmModal()
+                setConfirmTitle('Confirm switchover?')
+                setConfirmHandler(
+                  () => () => dispatch(switchOverCluster({ clusterName: selectedCluster?.name }))
+                )
               }
-            ])
+            }
+          ])
       ]
     },
     {
       name: 'Provision',
       subMenu: [
+        {
+          name: 'New Cluster Shard',
+          onClick: () => {
+            setIsNewClusterModalOpen(true)
+          }
+        },
         {
           name: 'New Monitor',
           onClick: () => {
@@ -462,6 +471,16 @@ function ClusterDetail({ selectedCluster }) {
           title={confirmTitle}
           showPrettyJsonCheckbox={true}
         />
+      )}
+
+      {isNewClusterModalOpen && (
+        <NewClusterModal 
+        plans={monitor?.servicePlans} 
+        orchestrators={monitor?.serviceOrchestrators} 
+        defaultOrchestrator={monitor?.config.provOrchestrator} 
+        isOpen={isNewClusterModalOpen} 
+        clusterHead={selectedCluster?.name}
+        closeModal={() => setIsNewClusterModalOpen(false)} />
       )}
 
       {isNewServerModalOpen && (

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyMenu.jsx
@@ -78,8 +78,7 @@ function ProxyMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView
                 }
               ]
             : []),
-          ...(user?.grants['proxy-start'] && isMenuOptionsVisible
-            ? [
+          ...(user?.grants['proxy-start'] ? [
                 {
                   name: 'Start Proxy',
                   onClick: () => {
@@ -90,8 +89,7 @@ function ProxyMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView
                 }
               ]
             : []),
-          ...(user?.grants['proxy-stop'] && isMenuOptionsVisible
-            ? [
+          ...(user?.grants['proxy-stop'] ? [
                 {
                   name: 'Stop Proxy',
                   onClick: () => {

--- a/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
@@ -285,6 +285,28 @@ The script will be executed with the following parameters:
       )
     },
     {
+      key: 'Split Logical Dump with DB Credentials',
+      value: (
+        <RMSwitch
+          isChecked={selectedCluster?.config?.backupSplitMysqlUser}
+          isDisabled={user?.grants['cluster-settings'] == false}
+          confirmTitle={'Confirm switch settings for backup-split-mysql-user?'}
+          onChange={() => dispatch(switchSetting({ clusterName: selectedCluster?.name, setting: 'backup-split-mysql-user' }))}
+        />
+      )
+    },
+    {
+      key: 'Restore User When Reseed',
+      value: (
+        <RMSwitch
+          isChecked={selectedCluster?.config?.backupRestoreMysqlUser}
+          isDisabled={user?.grants['cluster-settings'] == false}
+          confirmTitle={'Confirm switch settings for backup-restore-mysql-user?'}
+          onChange={() => dispatch(switchSetting({ clusterName: selectedCluster?.name, setting: 'backup-restore-mysql-user' }))}
+        />
+      )
+    },
+    {
       key: 'Physical Backup',
       value: (
         <Flex className={styles.dropdownContainer}>

--- a/share/dashboard_react/src/Pages/Settings/RepConfigSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/RepConfigSettings.jsx
@@ -5,12 +5,24 @@ import { useDispatch } from 'react-redux'
 import TableType2 from '../../components/TableType2'
 import { setSetting, switchSetting } from '../../redux/settingsSlice'
 import RMSwitch from '../../components/RMSwitch'
-import RMSlider from '../../components/Sliders/RMSlider'
+import TextForm from '../../components/TextForm'
 
 function RepConfigSettings({ selectedCluster, user, openConfirmModal, closeConfirmModal }) {
   const dispatch = useDispatch()
 
   const dataObject = [
+    {
+      key: 'Replication channel',
+      value: (
+        <TextForm
+          value={selectedCluster?.config?.replicationSourceName}
+          confirmTitle={`Confirm staging replication-source-name to `}
+          onSave={(value) => {
+            dispatch(setSetting({ clusterName: selectedCluster?.name, setting: 'replication-source-name', value }))
+          }}
+        />
+      )
+    },
     {
       key: 'Enforce read only on replicas',
       value: (

--- a/share/dashboard_react/src/Pages/Settings/StagingSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/StagingSettings.jsx
@@ -8,7 +8,7 @@ import TextForm from '../../components/TextForm'
 import RMSwitch from '../../components/RMSwitch'
 import RMIconButton from '../../components/RMIconButton'
 import { TbDatabaseExport, TbDatabaseImport, TbReload } from 'react-icons/tb'
-import { refreshStaging, reloadStagingScript } from '../../redux/clusterSlice'
+import { refreshStaging, stagingReseedFromParent } from '../../redux/clusterSlice'
 
 function StagingSettings({ selectedCluster, user, openConfirmModal }) {
   const dispatch = useDispatch()
@@ -82,7 +82,7 @@ function StagingSettings({ selectedCluster, user, openConfirmModal }) {
           <RMIconButton icon={TbDatabaseImport} onClick={() => {
             openConfirmModal(`Confirm reseed staging from parent? All cluster will be overwritten!`, () => () => {
               dispatch(
-                reloadStagingScript({ clusterName: selectedCluster?.name })
+                stagingReseedFromParent({ clusterName: selectedCluster?.name })
               )
             })
           }} />

--- a/share/dashboard_react/src/Pages/Settings/StagingSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/StagingSettings.jsx
@@ -8,7 +8,7 @@ import TextForm from '../../components/TextForm'
 import RMSwitch from '../../components/RMSwitch'
 import RMIconButton from '../../components/RMIconButton'
 import { TbDatabaseExport, TbDatabaseImport, TbReload } from 'react-icons/tb'
-import { refreshStaging, stagingReseedFromParent } from '../../redux/clusterSlice'
+import { refreshStaging, reseedStagingFromParent } from '../../redux/clusterSlice'
 
 function StagingSettings({ selectedCluster, user, openConfirmModal }) {
   const dispatch = useDispatch()
@@ -82,7 +82,7 @@ function StagingSettings({ selectedCluster, user, openConfirmModal }) {
           <RMIconButton icon={TbDatabaseImport} onClick={() => {
             openConfirmModal(`Confirm reseed staging from parent? All cluster will be overwritten!`, () => () => {
               dispatch(
-                stagingReseedFromParent({ clusterName: selectedCluster?.name })
+                reseedStagingFromParent({ clusterName: selectedCluster?.name })
               )
             })
           }} />

--- a/share/dashboard_react/src/Pages/Settings/StagingSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/StagingSettings.jsx
@@ -7,7 +7,7 @@ import { setSetting, switchSetting } from '../../redux/settingsSlice'
 import TextForm from '../../components/TextForm'
 import RMSwitch from '../../components/RMSwitch'
 import RMIconButton from '../../components/RMIconButton'
-import { TbDatabaseExport, TbReload } from 'react-icons/tb'
+import { TbDatabaseExport, TbDatabaseImport, TbReload } from 'react-icons/tb'
 import { refreshStaging, reloadStagingScript } from '../../redux/clusterSlice'
 
 function StagingSettings({ selectedCluster, user, openConfirmModal }) {
@@ -53,7 +53,7 @@ function StagingSettings({ selectedCluster, user, openConfirmModal }) {
     },
     ...(selectedCluster?.config?.topologyStaging ? [
       {
-        key: 'Staging head cluster',
+        key: 'Staging multisource head cluster',
         value: (
           <TextForm
             value={selectedCluster?.config?.replicationMultisourceHeadClusters}
@@ -77,10 +77,10 @@ function StagingSettings({ selectedCluster, user, openConfirmModal }) {
         )
       },
       {
-        key: 'Reload Staging Script Template',
+        key: 'Reseed Staging From Parent',
         value: (
-          <RMIconButton icon={TbReload} onClick={() => {
-            openConfirmModal(`Confirm reload staging script template? Current template will be overwritten!`, () => () => {
+          <RMIconButton icon={TbDatabaseImport} onClick={() => {
+            openConfirmModal(`Confirm reseed staging from parent? All cluster will be overwritten!`, () => () => {
               dispatch(
                 reloadStagingScript({ clusterName: selectedCluster?.name })
               )

--- a/share/dashboard_react/src/Pages/Settings/StagingSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/StagingSettings.jsx
@@ -53,6 +53,18 @@ function StagingSettings({ selectedCluster, user, openConfirmModal }) {
     },
     ...(selectedCluster?.config?.topologyStaging ? [
       {
+        key: 'Staging head cluster',
+        value: (
+          <TextForm
+            value={selectedCluster?.config?.replicationMultisourceHeadClusters}
+            confirmTitle={`Confirm staging replication-multisource-head-clusters to `}
+            onSave={(value) => {
+              dispatch(setSetting({ clusterName: selectedCluster?.name, setting: 'replication-multisource-head-clusters', value }))
+            }}
+          />
+        )
+      },
+      {
         key: 'Refresh Staging',
         value: (
           <RMIconButton icon={TbDatabaseExport} onClick={() => {

--- a/share/dashboard_react/src/components/Modals/NewClusterModal.jsx
+++ b/share/dashboard_react/src/components/Modals/NewClusterModal.jsx
@@ -20,8 +20,9 @@ import RMButton from '../RMButton'
 import { useTheme } from '../../ThemeProvider'
 import parentStyles from './styles.module.scss'
 import TableType2 from '../TableType2'
+import { addClusterShard } from '../../redux/clusterSlice'
 
-function NewClusterModal({ plans, orchestrators, defaultOrchestrator, isOpen, closeModal }) {
+function NewClusterModal({ plans, orchestrators, defaultOrchestrator, isOpen, closeModal, clusterHead = '' }) {
   const dispatch = useDispatch()
   const { theme } = useTheme()
   const [orchestratorOptions, setOrchestratorOptions] = useState([])
@@ -48,7 +49,11 @@ function NewClusterModal({ plans, orchestrators, defaultOrchestrator, isOpen, cl
       return
     }
 
-    dispatch(addCluster({ clusterName, formdata: { orchestrator, plan } }))
+    if (clusterHead != "") {
+      dispatch(addClusterShard({ clusterHead, clusterShard: clusterName, formdata: { orchestrator, plan } }))
+    } else {
+      dispatch(addCluster({ clusterName, formdata: { orchestrator, plan } }))
+    }
     closeModal()
   }
 

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -1221,12 +1221,12 @@ export const refreshStaging = createAsyncThunk(
   }
 )
 
-export const reloadStagingScript = createAsyncThunk(
-  'cluster/reloadStagingScript',
+export const reseedStagingFromParent = createAsyncThunk(
+  'cluster/reseedStagingFromParent',
   async ({ clusterName }, thunkAPI) => {
     try {
       const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
-      const { data, status } = await clusterService.reloadStagingScript(clusterName, baseURL)
+      const { data, status } = await clusterService.reseedStagingFromParent(clusterName, baseURL)
       showSuccessBanner(`Staging script reloaded successfully!`, status, thunkAPI)
       return { data, status }
     } catch (error) {

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -1332,6 +1332,21 @@ export const endExternalRole = createAsyncThunk(
   }
 )
 
+export const addClusterShard = createAsyncThunk('cluster/addClusterShard', async ({ clusterName, clusterShard, formdata }, thunkAPI) => {
+  try {
+    const { data, status } = await clusterService.addClusterShard(clusterName, clusterShard, formdata)
+    if (status === 200) {
+      showSuccessBanner("Add cluster '" + clusterName + "' is successful!", status, thunkAPI)
+      return { data, status }
+    } else {
+      throw new Error(data)
+    }
+  } catch (error) {
+    showErrorBanner("Add cluster '" + clusterName + "' is failed!", error, thunkAPI)
+    handleError(error, thunkAPI)
+  }
+})
+
 const initialState = {
   loading: false,
   isFetching: {

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -45,7 +45,7 @@ export const clusterService = {
   configDiscoverDB,
   configDynamic,
   refreshStaging,
-  reloadStagingScript,
+  reseedStagingFromParent,
 
   // Server management APIs
   setMaintenanceMode,
@@ -287,8 +287,8 @@ function refreshStaging(clusterName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/actions/staging-refresh`)
 }
 
-function reloadStagingScript(clusterName, baseURL) {
-  return getApi(baseURL).get(`clusters/${clusterName}/actions/staging-reload-script`)
+function reseedStagingFromParent(clusterName, baseURL) {
+  return getApi(baseURL).get(`clusters/${clusterName}/actions/staging-reseed-from-parent`)
 }
 //#endregion Cluster management APIs
 

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -110,6 +110,8 @@ export const clusterService = {
   acceptExternalRole,
   refuseExternalRole,
   endExternalRole,
+
+  addClusterShard,
 }
 
 //#region Cluster data APIs
@@ -511,6 +513,10 @@ function refuseExternalRole(clusterName, username, roles, reason, baseURL) {
 
 function endExternalRole(clusterName, username, roles, reason, baseURL) {
   return getApi(baseURL).post(`clusters/${clusterName}/ext-role/end`, { username, roles, reason })
+}
+
+function addClusterShard(clusterName, shardClusterName, formdata, baseURL) {
+  return getApi(baseURL).post(`clusters/${clusterName}/actions/add/${shardClusterName}`, formdata)
 }
 
 //#endregion User management APIs

--- a/share/opensvc/moduleset_mariadb.svc.mrm.db.json
+++ b/share/opensvc/moduleset_mariadb.svc.mrm.db.json
@@ -3444,7 +3444,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_rep_binlog.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"@ mariadb_command: EXECURE IMMEDIATE IF(@@log_bin=0,\\\"SELECT 'Unchanged log_bin'\\\",  \\\"SET GLOBAL log_bin=0\\\");\\n@ mariadb_default: EXECURE IMMEDIATE IF(@@log_bin=1,\\\"SELECT 'Unchanged log_bin'\\\",  \\\"SET GLOBAL log_bin=1\\\");\\n\\n@ mysql_command: SET GLOBAL log_bin=0;\\n@ mysql_default: SET GLOBAL log_bin=1;\\n\\n[mysqld]\\nskip-log-bin\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_rep_binlog.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"@ mariadb_command: EXECUTE IMMEDIATE IF(@@log_bin=0,\\\"SELECT 'Unchanged log_bin'\\\",  \\\"SET GLOBAL log_bin=0\\\");\\n@ mariadb_default: EXECUTE IMMEDIATE IF(@@log_bin=1,\\\"SELECT 'Unchanged log_bin'\\\",  \\\"SET GLOBAL log_bin=1\\\");\\n\\n@ mysql_command: SET GLOBAL log_bin=0;\\n@ mysql_default: SET GLOBAL log_bin=1;\\n\\n[mysqld]\\nskip-log-bin\"}",
                     "var_updated": "2024-07-29 19:09:19",
                     "var_name": "db_cnf_rep_no_binlog",
                     "id": 6114


### PR DESCRIPTION
This pull request introduces several enhancements and bug fixes across multiple files, primarily focusing on improving cluster management functionality, ensuring better handling of database operations, and enhancing code maintainability. Key changes include the addition of new methods for managing database credentials, improvements to error handling, and the introduction of a new reseeding feature for child clusters.

### Enhancements to Cluster Management:
* Added a new method `ReseedFromParentCluster` in `cluster/cluster_staging.go` to enable reseeding child clusters from a parent cluster, including validation for backup availability and reseeding state.
* Introduced handling for a new URL pattern in `IsURLPassACL` to support reseeding actions via API.

### Improvements to Database Operations:
* Added methods `GetDumpCredentials` and `GetBinlogCredentials` in `cluster/cluster_get.go` to centralize and simplify the generation of database connection parameters for dump and binlog operations.
* Updated `GetSSLClientParam` in `cluster/srv_get.go` to return SSL parameters as a slice of strings instead of a single string, improving flexibility and compatibility. [[1]](diffhunk://#diff-1f102cb4f0681169e52bd5cbd3b82ade67edf8c28f57cc0d9bb8500e72de97acL819-R819) [[2]](diffhunk://#diff-1f102cb4f0681169e52bd5cbd3b82ade67edf8c28f57cc0d9bb8500e72de97acL873-R905) [[3]](diffhunk://#diff-1f102cb4f0681169e52bd5cbd3b82ade67edf8c28f57cc0d9bb8500e72de97acL914-R925)

### Enhanced Error Handling:
* Improved error propagation in `OnPremiseStartProxyService` and `OnPremiseStopProxyService` methods in `cluster/prov_onpremise_prx.go` by returning errors from underlying service calls.
* Added directory creation logic in `CheckBackupFreeSpace` in `cluster/cluster_bck.go` to handle cases where the parent directory does not exist.

### Refactoring and Code Simplification:
* Refactored binlog-related methods in `cluster/srv_binlog.go` to use the new `GetBinlogCredentials` method, reducing code duplication. [[1]](diffhunk://#diff-0b775f117728e711b4137e4baa258badcc3d4712f01829731c05a05adce5d9c3L169-R170) [[2]](diffhunk://#diff-0b775f117728e711b4137e4baa258badcc3d4712f01829731c05a05adce5d9c3L749-R748) [[3]](diffhunk://#diff-0b775f117728e711b4137e4baa258badcc3d4712f01829731c05a05adce5d9c3L791-R788) [[4]](diffhunk://#diff-0b775f117728e711b4137e4baa258badcc3d4712f01829731c05a05adce5d9c3L968-R970)
* Removed redundant `--defaults-file` argument in `GetMysqlDumpOptions` in `cluster/cluster_get.go` to streamline dump command arguments.

### Additional Changes:
* Added a new import for `dbhelper` in `cluster/cluster_staging.go` to support database operation utilities.
* Introduced methods `StopSlaveChannel` and `StartSlaveChannel` in `cluster/srv.go` to manage replication channels more granularly. [[1]](diffhunk://#diff-c5fffdb4a6a092160ddd24b95042ba54bfcb96dfb0e747bb200902aac778adb1R1269-R1275) [[2]](diffhunk://#diff-c5fffdb4a6a092160ddd24b95042ba54bfcb96dfb0e747bb200902aac778adb1R1322-R1328)