### PR TITLE
Enhance DBServers cleanup on unmount and improve cluster state handling in redux

### DIFF
--- a/share/dashboard_react/src/Pages/Dashboard/components/DBServers/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/DBServers/index.jsx
@@ -43,6 +43,12 @@ function DBServers({ selectedCluster, user }) {
         })
       )
     }
+
+    return () => {
+      setData([])
+      setHasMariadbGtid(false)
+      setHasMysqlGtid(false)
+    }
   }, [clusterServers, clusterStates, clusterMaster?.id])
 
   const showGridView = () => {

--- a/share/dashboard_react/src/Pages/Home/index.jsx
+++ b/share/dashboard_react/src/Pages/Home/index.jsx
@@ -20,7 +20,8 @@ import {
   setCluster,
   setRefreshInterval,
   pauseAutoReload,
-  getBackupStats
+  getBackupStats,
+  clearCluster
 } from '../../redux/clusterSlice'
 import { getClusters, getMonitoredData, getClusterPeers, getClusterForSale } from '../../redux/globalClustersSlice'
 import { AppSettings } from '../../AppSettings'
@@ -213,6 +214,9 @@ function Home() {
   const setDashboardTab = (cluster) => {
     selectedTabRef.current = 1
     isClusterOpenRef.current = true
+    if (selectedClusterNameRef.current !== cluster.name) {
+      dispatch(clearCluster({}))
+    }
     selectedClusterNameRef.current = cluster.name
     setSelectedTab(1)
   }

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -1448,8 +1448,10 @@ export const clusterSlice = createSlice({
           state.clusterMaster = action.payload.data
         } else if (action.type.includes('getClusterServers')) {
           state.isFetching.servers = false
-          state.clusterServers = action.payload.data
-          state.clusterStates = action.payload?.data?.map((server) => `${server.state}-${server.isVirtualMaster}`).join(',') || ''
+          if (action.payload?.data && action.meta.arg?.clusterName == state.clusterData?.name) {
+              state.clusterServers = action.payload.data
+              state.clusterStates = action.payload?.data?.map((server) => `${server.state}-${server.isVirtualMaster}`).join(',') || ''
+          }
         } else if (action.type.includes('getClusterProxies')) {
           state.isFetching.proxies = false
           state.clusterProxies = action.payload?.data


### PR DESCRIPTION
This pull request introduces improvements to state management and cleanup logic in the `Dashboard` and `Home` components, as well as the Redux slice for cluster data. Key changes include adding cleanup functions, refining state updates, and ensuring proper handling of cluster-specific data.

### State cleanup and management:

* [`share/dashboard_react/src/Pages/Dashboard/components/DBServers/index.jsx`](diffhunk://#diff-026292dfef904241521a5313f797e473bc7d9abdf5ed19169f24e4118b085775R46-R51): Added a cleanup function to reset component state (`setData`, `setHasMariadbGtid`, and `setHasMysqlGtid`) when the component unmounts. This prevents stale state issues.

* [`share/dashboard_react/src/Pages/Home/index.jsx`](diffhunk://#diff-64aa538ae37902cf9cc55ee965c82fa01e16a4a90e2401e121ce83bfb7d44007R217-R219): Updated the `setDashboardTab` function to clear cluster-specific data by dispatching the `clearCluster` action if the selected cluster changes. This ensures that the state is reset for the new cluster.

### Redux slice updates:

* [`share/dashboard_react/src/redux/clusterSlice.js`](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1451-R1454): Enhanced the `getClusterServers` action to only update `clusterServers` and `clusterStates` if the fetched data corresponds to the currently selected cluster. This avoids overwriting state with irrelevant data.

### Code organization:

* [`share/dashboard_react/src/Pages/Home/index.jsx`](diffhunk://#diff-64aa538ae37902cf9cc55ee965c82fa01e16a4a90e2401e121ce83bfb7d44007L23-R24): Added the `clearCluster` action to the list of imported actions from `clusterSlice`.