### PR TITLE
Bootstrap staging from parent cluster backup

### DIFF
--- a/cluster/cluster_job.go
+++ b/cluster/cluster_job.go
@@ -7,9 +7,17 @@
 package cluster
 
 import (
+	"bufio"
+	"bytes"
 	"errors"
+	"fmt"
+	"os"
+	"regexp"
 	"sort"
+	"strconv"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/dbhelper"
@@ -99,4 +107,139 @@ func (cluster *Cluster) GetSlowLogTable() {
 
 		wg.Wait()
 	}
+}
+
+func (cluster *Cluster) JobMyLoaderParseMeta(dir string) (config.MyDumperMetaData, error) {
+	dir = strings.TrimSuffix(dir, "/")
+	if cluster.VersionsMap.Get("mydumper").GreaterEqual("0.14.1") {
+		return cluster.JobParseMyDumperMetaNew(dir)
+	} else {
+		return cluster.JobParseMyDumperMetaOld(dir)
+	}
+}
+
+func (cluster *Cluster) JobParseMyDumperMeta(meta *config.BackupMetadata) error {
+	var m config.MyDumperMetaData
+	var err error
+
+	m, err = cluster.JobMyLoaderParseMeta(meta.Dest)
+	if err != nil {
+		return err
+	}
+
+	meta.BinLogGtid = m.BinLogUuid
+	meta.BinLogFilePos = m.BinLogFilePos
+	meta.BinLogFileName = m.BinLogFileName
+
+	return nil
+}
+
+func (cluster *Cluster) JobParseMyDumperMetaNew(dir string) (config.MyDumperMetaData, error) {
+
+	var m config.MyDumperMetaData
+
+	meta := dir + "/metadata"
+	file, err := os.Open(meta)
+	if err != nil {
+		return m, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+
+	var binlogFile, position, gtidSet string
+
+	reFile := regexp.MustCompile(`^File\s*=\s*(.*)`)
+	rePos := regexp.MustCompile(`^Position\s*=\s*(\d+)`)
+	reGTID := regexp.MustCompile(`^Executed_Gtid_Set\s*=\s*(.*)`)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if binlogFile == "" {
+			if matches := reFile.FindStringSubmatch(line); matches != nil {
+				binlogFile = matches[1]
+			}
+		}
+
+		if position == "" {
+			if matches := rePos.FindStringSubmatch(line); matches != nil {
+				position = matches[1]
+			}
+		}
+
+		if gtidSet == "" {
+			if matches := reGTID.FindStringSubmatch(line); matches != nil {
+				gtidSet = matches[1]
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Println("Error reading file:", err)
+		return m, err
+	}
+
+	m.BinLogUuid = gtidSet
+	m.BinLogFilePos, _ = strconv.ParseUint(position, 10, 64)
+	m.BinLogFileName = binlogFile
+
+	return m, nil
+}
+
+func (cluster *Cluster) JobParseMyDumperMetaOld(dir string) (config.MyDumperMetaData, error) {
+
+	var m config.MyDumperMetaData
+	buf := new(bytes.Buffer)
+
+	// metadata file name.
+	meta := dir + "/metadata"
+
+	// open a file.
+	MetaFd, err := os.Open(meta)
+	if err != nil {
+		return m, err
+	}
+	defer MetaFd.Close()
+
+	MetaRd := bufio.NewReader(MetaFd)
+	for {
+		line, err := MetaRd.ReadBytes('\n')
+		if err != nil {
+			break
+		}
+
+		if len(line) > 2 {
+			newline := bytes.TrimLeft(line, "")
+			buf.Write(bytes.Trim(newline, "\n"))
+			line = []byte{}
+		}
+		if strings.Contains(string(buf.Bytes()), "Started") == true {
+			splitbuf := strings.Split(string(buf.Bytes()), ":")
+			m.StartTimestamp, _ = time.ParseInLocation("2006-01-02 15:04:05", strings.TrimLeft(strings.Join(splitbuf[1:], ":"), " "), time.Local)
+		}
+		if strings.Contains(string(buf.Bytes()), "Log") == true {
+			splitbuf := strings.Split(string(buf.Bytes()), ":")
+			m.BinLogFileName = strings.TrimLeft(strings.Join(splitbuf[1:], ":"), " ")
+		}
+		if strings.Contains(string(buf.Bytes()), "Pos") == true {
+			splitbuf := strings.Split(string(buf.Bytes()), ":")
+			pos, _ := strconv.Atoi(strings.TrimLeft(strings.Join(splitbuf[1:], ":"), " "))
+
+			m.BinLogFilePos = uint64(pos)
+		}
+
+		if strings.Contains(string(buf.Bytes()), "GTID") == true {
+			splitbuf := strings.Split(string(buf.Bytes()), ":")
+			m.BinLogUuid = strings.TrimLeft(strings.Join(splitbuf[1:], ":"), " ")
+		}
+		if strings.Contains(string(buf.Bytes()), "Finished") == true {
+			splitbuf := strings.Split(string(buf.Bytes()), ":")
+			m.EndTimestamp, _ = time.ParseInLocation("2006-01-02 15:04:05", strings.TrimLeft(strings.Join(splitbuf[1:], ":"), " "), time.Local)
+		}
+		buf.Reset()
+
+	}
+
+	return m, nil
 }

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -252,6 +252,8 @@ func (cluster *Cluster) RefreshStaging(source *Cluster) error {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "Reseed logical for refresh staging on %s failed: %s", STG.URL, err)
 				return err
 			}
+
+			STG.ChangeMasterTo(cluster.GetMaster(), "SLAVE_POS")
 		}
 
 		waitstart = time.Now()

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -514,7 +514,7 @@ func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster, target *ServerM
 					newGTID := target.SlaveGtid.Merge(*metaGTID)
 					masterGTIDList = newGTID.Sprint()
 				}
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Starting slave with mydumper metadata")
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Starting slave with mydumper metadata with GTID %s, meta %s", masterGTIDList, meta.BinLogUuid)
 				target.ExecQueryNoBinLog("SET GLOBAL gtid_slave_pos='"+masterGTIDList+"'", time.Second)
 			}
 		}

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -400,7 +400,7 @@ func (cluster *Cluster) GetStagingProxyHosts() []string {
 
 func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster, target *ServerMonitor, masterGTIDList string) (string, error) {
 	var err error
-	var logs, dest string
+	var logs, dest, masterCurrentGTID string
 
 	if parent == nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Parent cluster cannot be nil")
@@ -512,7 +512,9 @@ func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster, target *ServerM
 				if target.IsMaster() {
 					metaGTID := gtid.NewList(meta.BinLogUuid)
 					newGTID := target.SlaveGtid.Merge(*metaGTID)
+					newCurrentGTID := target.CurrentGtid.Merge(*metaGTID)
 					masterGTIDList = newGTID.Sprint()
+					masterCurrentGTID = newCurrentGTID.Sprint()
 				}
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Starting slave with mydumper metadata with GTID %s, meta %s", masterGTIDList, meta.BinLogUuid)
 				target.ExecQueryNoBinLog("SET GLOBAL gtid_slave_pos='"+masterGTIDList+"'", time.Second)
@@ -551,5 +553,5 @@ func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster, target *ServerM
 		return "", err
 	}
 
-	return masterGTIDList, nil
+	return masterCurrentGTID, nil
 }

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -50,7 +50,7 @@ func (cluster *Cluster) ReloadStagingScript() error {
 	return nil
 }
 
-func (cluster *Cluster) RefreshStaging() error {
+func (cluster *Cluster) RefreshStaging(source *Cluster) error {
 	var err error
 
 	if !cluster.Conf.TopologyStaging {
@@ -71,14 +71,16 @@ func (cluster *Cluster) RefreshStaging() error {
 		}
 	}
 
-	bcksrv := cluster.GetBackupServer()
-	if bcksrv != nil && !bcksrv.HasBackupLogicalCookie() {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Current master has no backup. Create logical backup for refresh staging on %s", bcksrv.URL)
+	bcksrv := source.GetBackupServer()
+	if cluster == source {
+		if bcksrv != nil && !bcksrv.HasBackupLogicalCookie() {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Current master has no backup. Create logical backup for refresh staging on %s", bcksrv.URL)
 
-		err = bcksrv.JobBackupLogical()
-		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "Create logical backup for refresh staging on %s failed: %s", bcksrv.URL, err)
-			return err
+			err = bcksrv.JobBackupLogical()
+			if err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "Create logical backup for refresh staging on %s failed: %s", bcksrv.URL, err)
+				return err
+			}
 		}
 	}
 
@@ -236,12 +238,20 @@ func (cluster *Cluster) RefreshStaging() error {
 			return err
 		}
 
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Reseed standalone %s", STG.URL)
-
-		err = STG.JobReseedLogicalBackup("default")
-		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "Reseed logical for refresh staging on %s failed: %s", STG.URL, err)
-			return err
+		if cluster == source {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Reseed standalone %s", STG.URL)
+			err = STG.JobReseedLogicalBackup("default")
+			if err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "Reseed logical for refresh staging on %s failed: %s", STG.URL, err)
+				return err
+			}
+		} else {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Reseed standalone %s from parent cluster %s backup", STG.URL, source.Name)
+			err = cluster.ReseedFromParentCluster(source, STG)
+			if err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "Reseed logical for refresh staging on %s failed: %s", STG.URL, err)
+				return err
+			}
 		}
 
 		waitstart = time.Now()
@@ -385,8 +395,9 @@ func (cluster *Cluster) GetStagingProxyHosts() []string {
 	return strings.Split(cluster.Conf.StagingProxyHosts, ",")
 }
 
-func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster) error {
+func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster, target *ServerMonitor) error {
 	var err error
+	var logs, dest string
 
 	if parent == nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Parent cluster cannot be nil")
@@ -395,10 +406,9 @@ func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster) error {
 
 	backtype := parent.Conf.BackupLogicalType
 
-	cmaster := cluster.GetMaster()
-	if cmaster == nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "No master server found")
-		return fmt.Errorf("no master server found")
+	if target == nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "No target server found")
+		return fmt.Errorf("no target server found")
 	}
 
 	bcksrv := parent.GetBackupServer()
@@ -416,7 +426,6 @@ func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster) error {
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModExternalScript, config.LvlInfo, "Refresh data from parent cluster initiated")
 
-	var dest string
 	switch backtype {
 	case config.ConstBackupLogicalTypeMysqldump, "script":
 		dest = "mysqldump.sql.gz"
@@ -433,84 +442,89 @@ func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster) error {
 		return fmt.Errorf("No backup file found on parent for %s", backtype)
 	}
 
-	if cmaster.HasAnyReseedingState() {
-		return fmt.Errorf("Server is in reseeding state by %s", cmaster.IsReseeding)
+	if target.HasAnyReseedingState() {
+		return fmt.Errorf("Server is in reseeding state by %s", target.IsReseeding)
 	}
 
 	task := "reseed" + parent.Conf.BackupLogicalType
-	cmaster.SetInReseedBackup(task)
+	target.SetInReseedBackup(task)
 	defer func() {
-		if cmaster.HasReseedingState(task) {
-			cmaster.SetInReseedBackup("")
+		if target.HasReseedingState(task) {
+			target.SetInReseedBackup("")
 		}
 	}()
 
 	//Delete wait logical backup cookie
-	cmaster.DelWaitLogicalBackupCookie()
+	target.DelWaitLogicalBackupCookie()
 
-	// Set replication master to current master if not PITR
-	logs, err := cmaster.StopSlaveChannel(parent.Conf.MasterConn)
-	if err != nil {
-		cluster.LogSQL(logs, err, cmaster.URL, "Rejoin", config.LvlErr, "Failed stop slave on server: %s %s", cmaster.URL, err)
-	}
-
-	changeOpt := dbhelper.ChangeMasterOpt{
-		Host:      pmaster.Host,
-		Port:      pmaster.Port,
-		User:      parent.GetRplUser(),
-		Password:  parent.GetRplPass(),
-		Retry:     strconv.Itoa(parent.Conf.ForceSlaveHeartbeatRetry),
-		Heartbeat: strconv.Itoa(parent.Conf.ForceSlaveHeartbeatTime),
-		Mode:      "SLAVE_POS",
-		SSL:       parent.Conf.ReplicationSSL,
-		Channel:   parent.Conf.MasterConn,
-	}
-
-	if cmaster.DBVersion.IsMySQLOrPercona() {
-		if cmaster.HasMySQLGTID() {
-			changeOpt.Mode = "MASTER_AUTO_POSITION"
-		} else {
-			changeOpt.Mode = "POSITIONAL"
+	if target.IsMaster() {
+		// Set replication master to current master if not PITR
+		logs, err = target.StopSlaveChannel(parent.Conf.MasterConn)
+		if err != nil {
+			cluster.LogSQL(logs, err, target.URL, "Rejoin", config.LvlErr, "Failed stop slave on server: %s %s", target.URL, err)
 		}
+
+		changeOpt := dbhelper.ChangeMasterOpt{
+			Host:      pmaster.Host,
+			Port:      pmaster.Port,
+			User:      parent.GetRplUser(),
+			Password:  parent.GetRplPass(),
+			Retry:     strconv.Itoa(parent.Conf.ForceSlaveHeartbeatRetry),
+			Heartbeat: strconv.Itoa(parent.Conf.ForceSlaveHeartbeatTime),
+			Mode:      "SLAVE_POS",
+			SSL:       parent.Conf.ReplicationSSL,
+			Channel:   parent.Conf.MasterConn,
+		}
+
+		if target.DBVersion.IsMySQLOrPercona() {
+			if target.HasMySQLGTID() {
+				changeOpt.Mode = "MASTER_AUTO_POSITION"
+			} else {
+				changeOpt.Mode = "POSITIONAL"
+			}
+		}
+
+		dbhelper.ChangeMaster(target.Conn, changeOpt, target.DBVersion) // Ignore error
 	}
 
-	dbhelper.ChangeMaster(cmaster.Conn, changeOpt, cmaster.DBVersion) // Ignore error
-
-	cmaster.JobsUpdateState(task, "processing", 1, 0)
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Receive reseed logical backup %s request for server: %s", backtype, cmaster.URL)
+	target.JobsUpdateState(task, "processing", 1, 0)
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Receive reseed logical backup %s request for server: %s", backtype, target.URL)
 
 	if backtype == config.ConstBackupLogicalTypeMysqldump {
 		if pmaster.LastBackupMeta.Logical != nil && !pmaster.LastBackupMeta.Logical.SplitUser {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Reseed mysqldump with no split user is not supported")
-			cmaster.JobsUpdateState(task, "Reseed mysqldump with no split user is not supported", 5, 1)
+			target.JobsUpdateState(task, "Reseed mysqldump with no split user is not supported", 5, 1)
 			return fmt.Errorf("Reseed mysqldump with no split user is not supported")
 		}
-		err = cmaster.JobReseedMysqldump(backupfile, false)
+		err = target.JobReseedMysqldump(backupfile, false)
 	} else if backtype == config.ConstBackupLogicalTypeMydumper {
-		err = cmaster.JobReseedMyLoader(backupfile, false)
+		err = target.JobReseedMyLoader(backupfile, false)
 	} else {
 		return fmt.Errorf("Unknown backup type %s", backtype)
 	}
 
 	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error reseed %s on %s: %s", backtype, cmaster.URL, err.Error())
-		if e2 := cmaster.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error reseed %s on %s: %s", backtype, target.URL, err.Error())
+		if e2 := target.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
 		}
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Reseed logical backup %s from parent cluster failed on %s", backtype, cmaster.URL)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Reseed logical backup %s from parent cluster failed on %s", backtype, target.URL)
 
 	} else {
-		if e2 := cmaster.JobsUpdateState(task, "Reseed completed", 3, 1); e2 != nil {
+		if e2 := target.JobsUpdateState(task, "Reseed completed", 3, 1); e2 != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
 		}
 
-		_, err2 := cmaster.StartSlaveChannel(parent.Conf.MasterConn)
-		if err2 != nil {
-			cluster.LogSQL(logs, err, cmaster.URL, "Rejoin", config.LvlErr, "Failed start slave on server: %s %s", cmaster.URL, err)
-		} else {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Start slave on %s", cmaster.URL)
+		if target.IsMaster() {
+			_, err2 := target.StartSlaveChannel(parent.Conf.MasterConn)
+			if err2 != nil {
+				cluster.LogSQL(logs, err, target.URL, "Rejoin", config.LvlErr, "Failed start slave on server: %s %s", target.URL, err)
+			} else {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Start slave on %s", target.URL)
+			}
 		}
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Reseed logical backup %s from parent cluster completed on %s", backtype, cmaster.URL)
+
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Reseed logical backup %s from parent cluster completed on %s", backtype, target.URL)
 
 	}
 

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -508,7 +508,7 @@ func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster, target *ServerM
 			err = err2
 		} else {
 			// Set GTID position for MariaDB
-			if target.IsMariaDB() && (target.HaveMariaDBGTID || (target.IsMaster() && target.SlaveGtid.Sprint() != "")) {
+			if target.IsMariaDB() && (target.HaveMariaDBGTID || (target.IsMaster() && target.SlaveGtid != nil && target.SlaveGtid.Sprint() != "")) {
 				if target.IsMaster() {
 					metaGTID := gtid.NewList(meta.BinLogUuid)
 					newGTID := target.SlaveGtid.Merge(*metaGTID)

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -13,6 +13,7 @@ import (
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/share"
 	"github.com/signal18/replication-manager/utils/dbhelper"
+	"github.com/signal18/replication-manager/utils/gtid"
 	"github.com/signal18/replication-manager/utils/misc"
 )
 
@@ -50,7 +51,7 @@ func (cluster *Cluster) ReloadStagingScript() error {
 	return nil
 }
 
-func (cluster *Cluster) RefreshStaging(source *Cluster) error {
+func (cluster *Cluster) RefreshStaging(source *Cluster, masterGTIDList string) error {
 	var err error
 
 	if !cluster.Conf.TopologyStaging {
@@ -247,7 +248,7 @@ func (cluster *Cluster) RefreshStaging(source *Cluster) error {
 			}
 		} else {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Reseed standalone %s from parent cluster %s backup", STG.URL, source.Name)
-			err = cluster.ReseedFromParentCluster(source, STG)
+			_, err = cluster.ReseedFromParentCluster(source, STG, masterGTIDList) // Sync GTID with cluster master
 			if err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "Reseed logical for refresh staging on %s failed: %s", STG.URL, err)
 				return err
@@ -397,33 +398,33 @@ func (cluster *Cluster) GetStagingProxyHosts() []string {
 	return strings.Split(cluster.Conf.StagingProxyHosts, ",")
 }
 
-func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster, target *ServerMonitor) error {
+func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster, target *ServerMonitor, masterGTIDList string) (string, error) {
 	var err error
 	var logs, dest string
 
 	if parent == nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Parent cluster cannot be nil")
-		return fmt.Errorf("parent cluster cannot be nil")
+		return "", fmt.Errorf("parent cluster cannot be nil")
 	}
 
 	backtype := parent.Conf.BackupLogicalType
 
 	if target == nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "No target server found")
-		return fmt.Errorf("no target server found")
+		return "", fmt.Errorf("no target server found")
 	}
 
 	bcksrv := parent.GetBackupServer()
 	if bcksrv != nil && !bcksrv.HasBackupLogicalCookie() {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Parent cluster %s has no backup. Please run logical backup for refresh child cluster on %s", parent.Name, cluster.Name)
 		parent.LogModulePrintf(parent.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Parent cluster %s has no backup. Please run logical backup for refresh child cluster on %s", parent.Name, cluster.Name)
-		return err
+		return "", err
 	}
 
 	pmaster := parent.GetMaster()
 	if pmaster == nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "No master server found")
-		return fmt.Errorf("no master server found")
+		return "", fmt.Errorf("no master server found")
 	}
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModExternalScript, config.LvlInfo, "Refresh data from parent cluster initiated")
@@ -441,11 +442,11 @@ func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster, target *ServerM
 	backupfile := bcksrv.GetMyBackupDirectory() + dest
 	if _, err := os.Stat(backupfile); err != nil {
 		//Remove false cookie
-		return fmt.Errorf("No backup file found on parent for %s", backtype)
+		return "", fmt.Errorf("No backup file found on parent for %s", backtype)
 	}
 
 	if target.HasAnyReseedingState() {
-		return fmt.Errorf("Server is in reseeding state by %s", target.IsReseeding)
+		return "", fmt.Errorf("Server is in reseeding state by %s", target.IsReseeding)
 	}
 
 	task := "reseed" + parent.Conf.BackupLogicalType
@@ -496,13 +497,29 @@ func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster, target *ServerM
 		if pmaster.LastBackupMeta.Logical != nil && !pmaster.LastBackupMeta.Logical.SplitUser {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Reseed mysqldump with no split user is not supported")
 			target.JobsUpdateState(task, "Reseed mysqldump with no split user is not supported", 5, 1)
-			return fmt.Errorf("Reseed mysqldump with no split user is not supported")
+			return "", fmt.Errorf("Reseed mysqldump with no split user is not supported")
 		}
 		err = target.JobReseedMysqldump(backupfile, false)
 	} else if backtype == config.ConstBackupLogicalTypeMydumper {
 		err = target.JobReseedMyLoader(backupfile, false)
+		meta, err2 := cluster.JobMyLoaderParseMeta(backupfile)
+		if err2 != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "MyLoader metadata parsing: %s", err2)
+			err = err2
+		} else {
+			// Set GTID position for MariaDB
+			if target.IsMariaDB() && target.HaveMariaDBGTID {
+				if target.IsMaster() {
+					metaGTID := gtid.NewList(meta.BinLogUuid)
+					newGTID := target.SlaveGtid.Merge(*metaGTID)
+					masterGTIDList = newGTID.Sprint()
+				}
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Starting slave with mydumper metadata")
+				target.ExecQueryNoBinLog("SET GLOBAL gtid_slave_pos='"+masterGTIDList+"'", time.Second)
+			}
+		}
 	} else {
-		return fmt.Errorf("Unknown backup type %s", backtype)
+		return "", fmt.Errorf("Unknown backup type %s", backtype)
 	}
 
 	if err != nil {
@@ -530,5 +547,9 @@ func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster, target *ServerM
 
 	}
 
-	return err
+	if err != nil {
+		return "", err
+	}
+
+	return masterGTIDList, nil
 }

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -508,7 +508,7 @@ func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster, target *ServerM
 			err = err2
 		} else {
 			// Set GTID position for MariaDB
-			if target.IsMariaDB() && target.HaveMariaDBGTID {
+			if target.IsMariaDB() && (target.HaveMariaDBGTID || (target.IsMaster() && target.SlaveGtid.Sprint() != "")) {
 				if target.IsMaster() {
 					metaGTID := gtid.NewList(meta.BinLogUuid)
 					newGTID := target.SlaveGtid.Merge(*metaGTID)

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1334,37 +1334,6 @@ func (server *ServerMonitor) ResetMaster() (string, error) {
 	return dbhelper.ResetMaster(server.Conn, cluster.Conf.MasterConn, server.DBVersion)
 }
 
-func (server *ServerMonitor) ResetGTIDBinlogState(gtid_pos string) (string, error) {
-	if server.Conn == nil {
-		return "", errors.New("No database connection pool")
-	}
-
-	prefix := strings.Split(gtid_pos, "-")[0]
-
-	binlogstate := server.Variables.Get("GTID_BINLOG_STATE")
-
-	// replace the GTID_BINLOG_STATE with the new GTID_BINLOG_POS
-	found := false
-	newstate := []string{}
-	for _, gtid := range strings.Split(binlogstate, ",") {
-		if strings.HasPrefix(gtid, prefix) {
-			found = true
-			if gtid > gtid_pos {
-				server.ResetMaster()
-				newstate = append(newstate, gtid_pos)
-			}
-		} else {
-			newstate = append(newstate, gtid)
-		}
-	}
-
-	if !found {
-		newstate = append(newstate, gtid_pos)
-	}
-
-	return dbhelper.SetGTIDBinlogState(server.Conn, strings.Join(newstate, ","))
-}
-
 func (server *ServerMonitor) ResetPFSQueries() error {
 	return server.ExecQueryNoBinLog("truncate performance_schema.events_statements_summary_by_digest", 5*time.Second)
 }

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -699,7 +699,7 @@ func (server *ServerMonitor) JobReseedLogicalBackup(backtype string) error {
 		err = server.JobReseedMyLoader(backupfile, cluster.Conf.BackupRestoreMysqlUser)
 		if err == nil && server.IsSlave && !server.PointInTimeMeta.IsInPITR {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Parsing mydumper metadata ")
-			meta, err2 := server.JobMyLoaderParseMeta(backupfile)
+			meta, err2 := cluster.JobMyLoaderParseMeta(backupfile)
 			if err2 != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "MyLoader metadata parsing: %s", err2)
 				err = err2
@@ -885,7 +885,7 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 		} else {
 			// Parse metadata from mydumper
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Parsing mydumper metadata ")
-			meta, err2 := server.JobMyLoaderParseMeta(backupfile)
+			meta, err2 := cluster.JobMyLoaderParseMeta(backupfile)
 			if err2 != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "MyLoader metadata parsing: %s", err2)
 				err = err2
@@ -2016,7 +2016,7 @@ func (server *ServerMonitor) JobBackupMyDumper(outputdir string) error {
 		return err
 	}
 
-	if e2 := server.JobParseMyDumperMeta(); e2 != nil {
+	if e2 := cluster.JobParseMyDumperMeta(server.LastBackupMeta.Logical); e2 != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error parsing mydumper metadata: %s", err.Error())
 	}
 
@@ -3272,142 +3272,6 @@ func (server *ServerMonitor) JobsUpdateState(task, result string, state, done in
 
 	server.SetNeedRefreshJobs(true)
 	return err
-}
-
-func (server *ServerMonitor) JobMyLoaderParseMeta(dir string) (config.MyDumperMetaData, error) {
-	cluster := server.ClusterGroup
-	dir = strings.TrimSuffix(dir, "/")
-	if cluster.VersionsMap.Get("mydumper").GreaterEqual("0.14.1") {
-		return server.JobParseMyDumperMetaNew(dir)
-	} else {
-		return server.JobParseMyDumperMetaOld(dir)
-	}
-}
-
-func (server *ServerMonitor) JobParseMyDumperMeta() error {
-	var m config.MyDumperMetaData
-	var err error
-
-	m, err = server.JobMyLoaderParseMeta(server.LastBackupMeta.Logical.Dest)
-	if err != nil {
-		return err
-	}
-
-	server.LastBackupMeta.Logical.BinLogGtid = m.BinLogUuid
-	server.LastBackupMeta.Logical.BinLogFilePos = m.BinLogFilePos
-	server.LastBackupMeta.Logical.BinLogFileName = m.BinLogFileName
-
-	return nil
-}
-
-func (server *ServerMonitor) JobParseMyDumperMetaNew(dir string) (config.MyDumperMetaData, error) {
-
-	var m config.MyDumperMetaData
-
-	meta := dir + "/metadata"
-	file, err := os.Open(meta)
-	if err != nil {
-		return m, err
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-
-	var binlogFile, position, gtidSet string
-
-	reFile := regexp.MustCompile(`^File\s*=\s*(.*)`)
-	rePos := regexp.MustCompile(`^Position\s*=\s*(\d+)`)
-	reGTID := regexp.MustCompile(`^Executed_Gtid_Set\s*=\s*(.*)`)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		if binlogFile == "" {
-			if matches := reFile.FindStringSubmatch(line); matches != nil {
-				binlogFile = matches[1]
-			}
-		}
-
-		if position == "" {
-			if matches := rePos.FindStringSubmatch(line); matches != nil {
-				position = matches[1]
-			}
-		}
-
-		if gtidSet == "" {
-			if matches := reGTID.FindStringSubmatch(line); matches != nil {
-				gtidSet = matches[1]
-			}
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		fmt.Println("Error reading file:", err)
-		return m, err
-	}
-
-	m.BinLogUuid = gtidSet
-	m.BinLogFilePos, _ = strconv.ParseUint(position, 10, 64)
-	m.BinLogFileName = binlogFile
-
-	return m, nil
-}
-
-func (server *ServerMonitor) JobParseMyDumperMetaOld(dir string) (config.MyDumperMetaData, error) {
-
-	var m config.MyDumperMetaData
-	buf := new(bytes.Buffer)
-
-	// metadata file name.
-	meta := dir + "/metadata"
-
-	// open a file.
-	MetaFd, err := os.Open(meta)
-	if err != nil {
-		return m, err
-	}
-	defer MetaFd.Close()
-
-	MetaRd := bufio.NewReader(MetaFd)
-	for {
-		line, err := MetaRd.ReadBytes('\n')
-		if err != nil {
-			break
-		}
-
-		if len(line) > 2 {
-			newline := bytes.TrimLeft(line, "")
-			buf.Write(bytes.Trim(newline, "\n"))
-			line = []byte{}
-		}
-		if strings.Contains(string(buf.Bytes()), "Started") == true {
-			splitbuf := strings.Split(string(buf.Bytes()), ":")
-			m.StartTimestamp, _ = time.ParseInLocation("2006-01-02 15:04:05", strings.TrimLeft(strings.Join(splitbuf[1:], ":"), " "), time.Local)
-		}
-		if strings.Contains(string(buf.Bytes()), "Log") == true {
-			splitbuf := strings.Split(string(buf.Bytes()), ":")
-			m.BinLogFileName = strings.TrimLeft(strings.Join(splitbuf[1:], ":"), " ")
-		}
-		if strings.Contains(string(buf.Bytes()), "Pos") == true {
-			splitbuf := strings.Split(string(buf.Bytes()), ":")
-			pos, _ := strconv.Atoi(strings.TrimLeft(strings.Join(splitbuf[1:], ":"), " "))
-
-			m.BinLogFilePos = uint64(pos)
-		}
-
-		if strings.Contains(string(buf.Bytes()), "GTID") == true {
-			splitbuf := strings.Split(string(buf.Bytes()), ":")
-			m.BinLogUuid = strings.TrimLeft(strings.Join(splitbuf[1:], ":"), " ")
-		}
-		if strings.Contains(string(buf.Bytes()), "Finished") == true {
-			splitbuf := strings.Split(string(buf.Bytes()), ":")
-			m.EndTimestamp, _ = time.ParseInLocation("2006-01-02 15:04:05", strings.TrimLeft(strings.Join(splitbuf[1:], ":"), " "), time.Local)
-		}
-		buf.Reset()
-
-	}
-
-	return m, nil
 }
 
 func (server *ServerMonitor) JobFinishReceiveFile(task string) error {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/buger/jsonparser"
 	"github.com/codegangsta/negroni"
@@ -5648,7 +5649,7 @@ func (repman *ReplicationManager) handlerMuxRefreshStagingCluster(w http.Respons
 			http.Error(w, "No valid ACL", 403)
 			return
 		}
-		go mycluster.RefreshStaging()
+		go mycluster.RefreshStaging(mycluster)
 	} else {
 		http.Error(w, "No cluster", 500)
 		return
@@ -6556,10 +6557,41 @@ func (repman *ReplicationManager) handlerMuxReseedFromParent(w http.ResponseWrit
 		}
 
 		go func() {
-			err := mycluster.ReseedFromParentCluster(pcluster)
+			cmaster := mycluster.GetMaster()
+			if cmaster == nil {
+				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Cancel reseed from parent cluster. No master found", mycluster.Name)
+				return
+			}
+
+			err := mycluster.ReseedFromParentCluster(pcluster, cmaster)
 			if err == nil {
 				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Reseed from parent cluster %s done. Refreshing staging", pcluster.Name)
-				mycluster.RefreshStaging()
+
+				slave := mycluster.GetSlaveByIndex(0)
+				if slave == nil {
+					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Cancel refresh staging. No slave found for standalone candidate", mycluster.Name)
+					return
+				}
+				starttime := time.Now()
+				if slave.State == "SlaveLate" {
+					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Waiting for slave to sync replication")
+					for slave.State == "SlaveLate" && time.Since(starttime) < 2*time.Minute {
+						time.Sleep(1 * time.Second)
+					}
+
+					if slave.State == "SlaveLate" {
+						mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Cancel refresh staging. Slave is still late after 2 minutes. Please refresh staging later or check the replication status")
+						return
+					}
+				}
+
+				if slave.State != "Slave" {
+					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Cancel refresh staging. Slave is not OK. Please check the replication status")
+					return
+				}
+
+				mycluster.RefreshStaging(pcluster)
+
 			} else {
 				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Cancel refresh staging. Error reseeding from parent cluster: %s", err)
 			}

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -6590,7 +6590,15 @@ func (repman *ReplicationManager) handlerMuxReseedFromParent(w http.ResponseWrit
 					return
 				}
 
-				mycluster.RefreshStaging(pcluster, masterGTIDList) // refresh staging and sync the GTID list from current master
+				err := mycluster.RefreshStaging(pcluster, masterGTIDList) // refresh staging and sync the GTID list from current master
+				if err == nil {
+					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Reseed from parent cluster %s done", pcluster.Name)
+					// Refresh staging is done. Now we can start the backup
+					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Starting backup for cluster %s", mycluster.Name)
+					go cmaster.JobBackupLogical()
+				} else {
+					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Refresh standalone failed: %s", err)
+				}
 
 			} else {
 				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Cancel refresh staging. Error reseeding from parent cluster: %s", err)

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -5649,7 +5649,7 @@ func (repman *ReplicationManager) handlerMuxRefreshStagingCluster(w http.Respons
 			http.Error(w, "No valid ACL", 403)
 			return
 		}
-		go mycluster.RefreshStaging(mycluster)
+		go mycluster.RefreshStaging(mycluster, "") // "" means no GTID sync needed since restore from same cluster
 	} else {
 		http.Error(w, "No cluster", 500)
 		return
@@ -6563,7 +6563,7 @@ func (repman *ReplicationManager) handlerMuxReseedFromParent(w http.ResponseWrit
 				return
 			}
 
-			err := mycluster.ReseedFromParentCluster(pcluster, cmaster)
+			masterGTIDList, err := mycluster.ReseedFromParentCluster(pcluster, cmaster, "") // master will combine it's GTID list with the one from the parent cluster automatically
 			if err == nil {
 				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Reseed from parent cluster %s done. Refreshing staging", pcluster.Name)
 
@@ -6590,7 +6590,7 @@ func (repman *ReplicationManager) handlerMuxReseedFromParent(w http.ResponseWrit
 					return
 				}
 
-				mycluster.RefreshStaging(pcluster)
+				mycluster.RefreshStaging(pcluster, masterGTIDList) // refresh staging and sync the GTID list from current master
 
 			} else {
 				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Cancel refresh staging. Error reseeding from parent cluster: %s", err)

--- a/server/server_get.go
+++ b/server/server_get.go
@@ -23,7 +23,7 @@ func (repman *ReplicationManager) GetParentClusterFromReplicationSource(source s
 	defer repman.Unlock()
 
 	for _, c := range repman.Clusters {
-		if c.Conf.MasterConn == source {
+		if c.Name == source {
 			return c
 		}
 	}

--- a/share/dashboard_react/src/Pages/Home/index.jsx
+++ b/share/dashboard_react/src/Pages/Home/index.jsx
@@ -254,7 +254,7 @@ function Home() {
             ...(isClusterOpenRef.current
               ? [
                 <Dashboard user={user} selectedCluster={selectedCluster} />,
-                <Settings user={user} selectedCluster={selectedCluster} onTabChange={handleTabChange} />,
+                <Settings user={user} selectedCluster={selectedCluster} onTabChange={handleTabChange} monitor={monitor}/>,
                 <Configs user={user} selectedCluster={selectedCluster} />,
                 ...(selectedCluster?.config?.graphiteMetrics && user?.grants['cluster-show-graphs']
                   ? [<Graphs />]

--- a/share/dashboard_react/src/Pages/Settings/StagingSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/StagingSettings.jsx
@@ -9,9 +9,17 @@ import RMSwitch from '../../components/RMSwitch'
 import RMIconButton from '../../components/RMIconButton'
 import { TbDatabaseExport, TbDatabaseImport, TbReload } from 'react-icons/tb'
 import { refreshStaging, reseedStagingFromParent } from '../../redux/clusterSlice'
+import Dropdown from '../../components/Dropdown'
 
-function StagingSettings({ selectedCluster, user, openConfirmModal }) {
+function StagingSettings({ selectedCluster, user, openConfirmModal, monitor }) {
   const dispatch = useDispatch()
+  const [clusters, setClusters] = useState([])
+
+  useEffect(() => {
+    if (monitor?.clusters) {
+      setClusters(monitor?.clusters?.filter((cl) => cl != selectedCluster.name).map((cluster) => ({ name: cluster, value: cluster })))
+    }
+  },[monitor?.clusters?.join(',')])
 
   const dataObject = [
     {
@@ -55,13 +63,16 @@ function StagingSettings({ selectedCluster, user, openConfirmModal }) {
       {
         key: 'Staging multisource head cluster',
         value: (
-          <TextForm
-            value={selectedCluster?.config?.replicationMultisourceHeadClusters}
-            confirmTitle={`Confirm staging replication-multisource-head-clusters to `}
-            onSave={(value) => {
-              dispatch(setSetting({ clusterName: selectedCluster?.name, setting: 'replication-multisource-head-clusters', value }))
-            }}
-          />
+          <Dropdown
+                id='replication-multisource-head-clusters'
+                confirmTitle={`Confirm staging replication-multisource-head-clusters to `}
+                onChange={(value) => {
+                  dispatch(setSetting({ clusterName: selectedCluster?.name, setting: 'replication-multisource-head-clusters', value }))
+                }}
+                selectedValue={selectedCluster?.config?.replicationMultisourceHeadClusters}
+                options={clusters}
+                className={styles.fullWidth}
+              />
         )
       },
       {
@@ -77,10 +88,10 @@ function StagingSettings({ selectedCluster, user, openConfirmModal }) {
         )
       },
       {
-        key: 'Reseed Staging From Parent',
+        key: 'Bootstrap Staging From Parent',
         value: (
           <RMIconButton icon={TbDatabaseImport} onClick={() => {
-            openConfirmModal(`Confirm reseed staging from parent? All cluster will be overwritten!`, () => () => {
+            openConfirmModal(`Confirm bootstrap staging from parent? Data will be overwritten by parent cluster!`, () => () => {
               dispatch(
                 reseedStagingFromParent({ clusterName: selectedCluster?.name })
               )

--- a/share/dashboard_react/src/Pages/Settings/index.jsx
+++ b/share/dashboard_react/src/Pages/Settings/index.jsx
@@ -16,7 +16,7 @@ import RepConfigSettings from './RepConfigSettings'
 import AlertSettings from './AlertSettings'
 import StagingSettings from './StagingSettings'
 
-function Settings({ selectedCluster, user, onTabChange }) {
+function Settings({ selectedCluster, user, onTabChange, monitor }) {
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false)
   const [confirmHandler, setConfirmHandler] = useState(null)
   const [confirmTitle, setConfirmTitle] = useState('')
@@ -191,7 +191,7 @@ function Settings({ selectedCluster, user, onTabChange }) {
         isOpen={isStagingOpen}
         headerClassName={styles.accordionHeader}
         panelClassName={styles.accordionPanel}
-        body={<StagingSettings selectedCluster={selectedCluster} user={user} openConfirmModal={openConfirmModal} />}
+        body={<StagingSettings selectedCluster={selectedCluster} user={user} openConfirmModal={openConfirmModal} monitor={monitor} />}
       />
 
       {isConfirmModalOpen && (

--- a/utils/gtid/gtid.go
+++ b/utils/gtid/gtid.go
@@ -230,29 +230,21 @@ func (gl List) Equal(glcomp *List) bool {
 	return false
 }
 
-func (gl List) MergeGTID(g Gtid) (Gtid, int) {
-	for i, g1 := range gl {
-		if g1.DomainID == g.DomainID {
-			if g1.SeqNo > g.SeqNo {
-				return g1, i
-			} else if g1.SeqNo < g.SeqNo {
-				return g, i
-			}
-		}
-	}
-	return g, -1
-}
-
-// Merge merges two GTID lists
 func (gl List) Merge(glcomp List) List {
+	distinct := make(map[uint64]Gtid)
+	for _, g := range gl {
+		distinct[g.DomainID] = g
+	}
+
 	for _, g := range glcomp {
-		newg, i := gl.MergeGTID(g)
-		if i == -1 {
-			gl = append(gl, newg)
-		} else {
-			gl[i] = newg
+		if existing, ok := distinct[g.DomainID]; !ok || g.SeqNo > existing.SeqNo {
+			distinct[g.DomainID] = g
 		}
 	}
 
-	return gl
+	result := make(List, 0, len(distinct))
+	for _, g := range distinct {
+		result = append(result, g)
+	}
+	return result
 }

--- a/utils/gtid/gtid.go
+++ b/utils/gtid/gtid.go
@@ -245,12 +245,12 @@ func (gl List) MergeGTID(g Gtid) (Gtid, int) {
 
 // Merge merges two GTID lists
 func (gl List) Merge(glcomp List) List {
-	for j, g := range glcomp {
+	for _, g := range glcomp {
 		newg, i := gl.MergeGTID(g)
 		if i == -1 {
 			gl = append(gl, newg)
 		} else {
-			gl[j] = newg
+			gl[i] = newg
 		}
 	}
 

--- a/utils/gtid/gtid.go
+++ b/utils/gtid/gtid.go
@@ -229,3 +229,30 @@ func (gl List) Equal(glcomp *List) bool {
 	}
 	return false
 }
+
+func (gl List) MergeGTID(g Gtid) (Gtid, int) {
+	for i, g1 := range gl {
+		if g1.DomainID == g.DomainID {
+			if g1.SeqNo > g.SeqNo {
+				return g1, i
+			} else if g1.SeqNo < g.SeqNo {
+				return g, i
+			}
+		}
+	}
+	return g, -1
+}
+
+// Merge merges two GTID lists
+func (gl List) Merge(glcomp List) List {
+	for j, g := range glcomp {
+		newg, i := gl.MergeGTID(g)
+		if i == -1 {
+			gl = append(gl, newg)
+		} else {
+			gl[j] = newg
+		}
+	}
+
+	return gl
+}


### PR DESCRIPTION
This pull request introduces significant changes to the `cluster` package, focusing on improving metadata parsing for MyDumper backups, enhancing staging cluster operations, and removing unused methods. Below are the most important changes grouped by theme:

### Metadata Parsing for MyDumper Backups

* Added new methods in `cluster/cluster_job.go` for parsing MyDumper metadata (`JobMyLoaderParseMeta`, `JobParseMyDumperMeta`, `JobParseMyDumperMetaNew`, and `JobParseMyDumperMetaOld`). These methods handle metadata parsing for both new and old MyDumper versions, extracting binlog details and GTID information.
* Updated `JobBackupMyDumper`, `JobReseedLogicalBackup`, and `JobFlashbackLogicalBackup` in `cluster/srv_job.go` to use the new `JobParseMyDumperMeta` method for consistent metadata parsing. [[1]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fL2019-R2019) [[2]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fL702-R702) [[3]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fL888-R888)

### Staging Cluster Enhancements

* Modified `RefreshStaging` in `cluster/cluster_staging.go` to support reseeding from a parent cluster with GTID synchronization. This includes changes to handle backups, logical reseeding, and GTID-based replication setup. [[1]](diffhunk://#diff-ec443a688a4298a59c849d13303c9c79f65eab2fdfda6f55916634131a6019e7L53-R54) [[2]](diffhunk://#diff-ec443a688a4298a59c849d13303c9c79f65eab2fdfda6f55916634131a6019e7R242-R258)
* Updated `ReseedFromParentCluster` to support a target server parameter and GTID synchronization. This ensures better handling of reseeding operations across clusters. [[1]](diffhunk://#diff-ec443a688a4298a59c849d13303c9c79f65eab2fdfda6f55916634131a6019e7L388-L419) [[2]](diffhunk://#diff-ec443a688a4298a59c849d13303c9c79f65eab2fdfda6f55916634131a6019e7L469-R556)

### Code Cleanup

* Removed the unused `ResetGTIDBinlogState` method from `cluster/srv.go`, simplifying the codebase and removing redundant logic.

### Dependency Updates

* Added new imports (`bufio`, `bytes`, `regexp`, `strconv`, `strings`, and `time`) in `cluster/cluster_job.go` to support metadata parsing functionality.
* Included the `gtid` utility in `cluster/cluster_staging.go` for GTID-related operations.