### PR TITLE
Merge users from parent clusters with current users without changing credentials

### DIFF
--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -501,7 +501,8 @@ func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster, target *ServerM
 		}
 		err = target.JobReseedMysqldump(backupfile, false)
 	} else if backtype == config.ConstBackupLogicalTypeMydumper {
-		err = target.JobReseedMyLoader(backupfile, false)
+		restoreflag := pmaster.LastBackupMeta.Logical != nil && pmaster.LastBackupMeta.Logical.SplitUser && cluster.Conf.BackupRestoreMysqlUser
+		err = target.JobReseedMyLoader(backupfile, restoreflag)
 		meta, err2 := cluster.JobMyLoaderParseMeta(backupfile)
 		if err2 != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "MyLoader metadata parsing: %s", err2)

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -1025,20 +1025,55 @@ func (server *ServerMonitor) JobZFSSnapBack() (int64, error) {
 	return server.JobInsertTask("zfssnapback", "0", cluster.Conf.MonitorAddress)
 }
 
+func (server *ServerMonitor) JobReseedMysqldumpUser() error {
+	cluster := server.ClusterGroup
+	sql_log_bin := 0
+	resetmaster := "RESET MASTER;"
+	if server.DBVersion.IsMySQLOrPerconaGreater84() {
+		resetmaster = "RESET BINARY LOGS AND GTIDS;"
+	}
+
+	if server.URL == cluster.GetMaster().URL {
+		sql_log_bin = 1
+		resetmaster = ""
+	}
+
+	cmdstring := "%sSET sql_log_bin=%d;SET long_query_time=10;"
+	if server.DBVersion.IsMySQLOrPerconaGreater84() {
+		cmdstring = "%sSET sql_log_bin=%d;SET long_query_time=10;"
+	}
+	cmdstring = fmt.Sprintf(cmdstring, resetmaster, sql_log_bin)
+
+	usergzfile, err := server.ReadMysqldumpUser()
+	if err != nil {
+		return fmt.Errorf("Error opening mysql.user file %s", err)
+	}
+
+	cliParams := append(cluster.GetDumpCredentials(server), server.GetSSLClientParam("client")...)
+	cliParams = append(cliParams, strings.Split(cluster.Conf.BackupMysqlclientOptions, " ")...)
+	clientCmd := exec.Command(cluster.GetMysqlclientPath(), misc.RemoveEmptyString(cliParams)...)
+
+	clientCmd.Stdin = io.MultiReader(bytes.NewBufferString(cmdstring), usergzfile)
+	var out bytes.Buffer
+	clientCmd.Stdout = &out
+
+	if err := clientCmd.Run(); err != nil {
+		return fmt.Errorf("Error restoring users %s", err)
+	}
+
+	return nil
+}
+
 func (server *ServerMonitor) JobReseedMyLoader(backupdir string, restoreUser bool) error {
+	var err error
 	cluster := server.ClusterGroup
 	threads := strconv.Itoa(cluster.Conf.BackupLogicalLoadThreads)
 
 	if restoreUser {
-		//walk dir
-		files, err := os.ReadDir(backupdir)
-		if err == nil {
-			if len(files) > 0 {
-				for _, file := range files {
-					if strings.HasPrefix(file.Name(), "mysql.user") && strings.HasSuffix(file.Name(), ".sql.gz.skip") {
-						os.Rename(filepath.Join(backupdir, file.Name()), filepath.Join(backupdir, strings.TrimSuffix(file.Name(), ".skip")))
-					}
-				}
+		if server.LastBackupMeta.Logical != nil && server.LastBackupMeta.Logical.SplitUser {
+			err = server.JobReseedMysqldumpUser()
+			if err != nil {
+				return fmt.Errorf("Error restoring users %s", err)
 			}
 		}
 	} else {
@@ -1140,8 +1175,8 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string, restoreUser b
 	cmdstring = fmt.Sprintf(cmdstring, resetmaster, sql_log_bin)
 
 	var usergzfile io.Reader
-	if restoreUser {
-		usergzfile, err = server.ReadMysqldumpUser(backupfile)
+	if restoreUser && server.LastBackupMeta.Logical != nil && server.LastBackupMeta.Logical.SplitUser {
+		usergzfile, err = server.ReadMysqldumpUser()
 		if err != nil {
 			return fmt.Errorf("Error opening mysql.user file %s", err)
 		}
@@ -1176,11 +1211,11 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string, restoreUser b
 	return nil
 }
 
-func (server *ServerMonitor) ReadMysqldumpUser(backupfile string) (io.Reader, error) {
+func (server *ServerMonitor) ReadMysqldumpUser() (io.Reader, error) {
 	cluster := server.ClusterGroup
 	var err error
 
-	dir := filepath.Dir(backupfile)
+	dir := server.GetMyBackupDirectory()
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		return nil, fmt.Errorf("Directory %s does not exist", dir)
 	}
@@ -1192,7 +1227,7 @@ func (server *ServerMonitor) ReadMysqldumpUser(backupfile string) (io.Reader, er
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Opening mysql.user file %s", userpath)
 
-	gzfile, err := os.Open(backupfile)
+	gzfile, err := os.Open(userpath)
 	if err != nil {
 		return nil, fmt.Errorf("[%s] Failed opening backup file in backup server for reseed:  %s ", server.URL, err)
 	}
@@ -2163,9 +2198,10 @@ func (server *ServerMonitor) JobBackupLogical() error {
 	// Removing previous valid backup state and start
 	server.DelBackupLogicalCookie()
 
-	if cluster.Conf.BackupSplitMysqlUser {
+	// Always dump users for reusable backup for both mysqldump and mydumper
+	if server.IsMariaDB() && server.DBVersion.GreaterEqual("10.4") {
 		server.LastBackupMeta.Logical.SplitUser = true
-		err := server.JobBackupMysqldumpUser()
+		err = server.JobBackupMysqldumpUser()
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error mysqldump backup request: %s", err.Error())
 			return err

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -1025,7 +1025,7 @@ func (server *ServerMonitor) JobZFSSnapBack() (int64, error) {
 	return server.JobInsertTask("zfssnapback", "0", cluster.Conf.MonitorAddress)
 }
 
-func (server *ServerMonitor) JobReseedMysqldumpUser() error {
+func (server *ServerMonitor) JobReseedMysqldumpUser(dir string) error {
 	cluster := server.ClusterGroup
 	sql_log_bin := 0
 	resetmaster := "RESET MASTER;"
@@ -1044,7 +1044,7 @@ func (server *ServerMonitor) JobReseedMysqldumpUser() error {
 	}
 	cmdstring = fmt.Sprintf(cmdstring, resetmaster, sql_log_bin)
 
-	usergzfile, err := server.ReadMysqldumpUser()
+	usergzfile, err := server.ReadMysqldumpUser(dir)
 	if err != nil {
 		return fmt.Errorf("Error opening mysql.user file %s", err)
 	}
@@ -1071,7 +1071,7 @@ func (server *ServerMonitor) JobReseedMyLoader(backupdir string, restoreUser boo
 
 	if restoreUser {
 		if server.LastBackupMeta.Logical != nil && server.LastBackupMeta.Logical.SplitUser {
-			err = server.JobReseedMysqldumpUser()
+			err = server.JobReseedMysqldumpUser(filepath.Dir(backupdir))
 			if err != nil {
 				return fmt.Errorf("Error restoring users %s", err)
 			}
@@ -1176,7 +1176,7 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string, restoreUser b
 
 	var usergzfile io.Reader
 	if restoreUser && server.LastBackupMeta.Logical != nil && server.LastBackupMeta.Logical.SplitUser {
-		usergzfile, err = server.ReadMysqldumpUser()
+		usergzfile, err = server.ReadMysqldumpUser(filepath.Dir(backupfile))
 		if err != nil {
 			return fmt.Errorf("Error opening mysql.user file %s", err)
 		}
@@ -1211,11 +1211,10 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string, restoreUser b
 	return nil
 }
 
-func (server *ServerMonitor) ReadMysqldumpUser() (io.Reader, error) {
+func (server *ServerMonitor) ReadMysqldumpUser(dir string) (io.Reader, error) {
 	cluster := server.ClusterGroup
 	var err error
 
-	dir := server.GetMyBackupDirectory()
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		return nil, fmt.Errorf("Directory %s does not exist", dir)
 	}

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -1906,7 +1906,7 @@ func (server *ServerMonitor) JobBackupMysqldumpUser() error {
 	var err error
 
 	dir := server.GetMyBackupDirectory()
-	userpath := filepath.Join(dir, "mysql.users.sql.gz")
+	userpath := filepath.Join(dir, "mysql.user.sql.gz")
 
 	dumpargs := append(cluster.GetDumpCredentials(server), server.GetSSLClientParam("client-dump")...)
 	dumpargs = append(dumpargs, "--insert-ignore", "--system=user")

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -1236,7 +1236,21 @@ func (server *ServerMonitor) ReadMysqldumpUser(dir string) (io.Reader, error) {
 		return nil, fmt.Errorf("[%s] Failed to unzip backup file in backup server for reseed:  %s ", server.URL, err)
 	}
 
-	return fz, nil
+	pw := new(bytes.Buffer)
+	scanner := bufio.NewScanner(fz)
+	for scanner.Scan() {
+		line := scanner.Text()
+		cleaned := line
+		// REMOVE GRANT SUBSTRING FOR CONTAINING "IDENTIFIED BY" OR "IDENTIFIED WITH"
+		if strings.HasPrefix(line, "GRANT") && strings.Contains(line, "IDENTIFIED BY") || strings.Contains(line, "IDENTIFIED WITH") {
+			// Remove substring (IDENTIFIED .*) and exclude WITH
+			reIdentified := regexp.MustCompile(`(?i)\s+IDENTIFIED\s+(?:WITH\s+\S+(?:\s+(?:BY|AS)\s+'.*?')?|BY\s+(?:PASSWORD\s+)?'.*?')`)
+			cleaned = reIdentified.ReplaceAllString(line, "")
+		}
+		_, _ = pw.Write([]byte(cleaned + "\n"))
+	}
+
+	return pw, nil
 }
 
 // JobReseedBackupScript will execute the backup load script


### PR DESCRIPTION
This pull request introduces enhancements to the backup and restore functionality for MySQL/MariaDB clusters, focusing on user data handling during logical backups and reseeding. Key changes include the addition of a new method for restoring MySQL user data, updates to existing methods to handle user data more effectively, and improvements to ensure compatibility with specific database versions.

### Enhancements to Backup and Restore Functionality:
* **New Method for Restoring User Data**: Added `JobReseedMysqldumpUser` to handle the restoration of MySQL user data during reseeding. This method processes the `mysql.user` file, removes sensitive information (e.g., `IDENTIFIED BY` clauses), and applies the data to the target server (`cluster/srv_job.go`, [cluster/srv_job.goR1028-R1076](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fR1028-R1076)).

* **Improved Logical Backup Handling**:
  - Updated `JobBackupLogical` to always dump MySQL user data for reusable backups, ensuring compatibility with MariaDB 10.4+ (`cluster/srv_job.go`, [cluster/srv_job.goL2166-R2217](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fL2166-R2217)).
  - Renamed the output file for user data backups from `mysql.users.sql.gz` to `mysql.user.sql.gz` for consistency (`cluster/srv_job.go`, [cluster/srv_job.goL1875-R1923](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fL1875-R1923)).

### Modifications to Existing Methods:
* **Enhanced User Restoration in Reseeding**:
  - Updated `JobReseedMyLoader` to invoke `JobReseedMysqldumpUser` when restoring user data, simplifying the logic for handling `mysql.user` files (`cluster/srv_job.go`, [[1]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fR1028-R1076) [[2]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fL1143-R1179).
  - Adjusted `JobReseedMysqldump` to include additional checks for restoring user data based on metadata (`cluster/srv_job.go`, [cluster/srv_job.goL1143-R1179](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fL1143-R1179)).

* **Refactored `ReadMysqldumpUser`**:
  - Changed the parameter from `backupfile` to `dir` for better clarity and flexibility.
  - Enhanced the method to clean user data by removing sensitive details before processing (`cluster/srv_job.go`, [[1]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fL1179-L1183) [[2]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fL1195-R1229) [[3]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fL1205-R1253).

These changes improve the robustness and security of the backup and restore processes, particularly for user data, while ensuring compatibility with newer database versions.