### PR TITLE
handle crash when rejoin master sync

### DIFF
--- a/cluster/srv_rejoin.go
+++ b/cluster/srv_rejoin.go
@@ -236,10 +236,18 @@ func (server *ServerMonitor) rejoinMasterSync(crash *Crash) error {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Found same or lower sequence %s , %s", server.BinaryLogFile, server.BinaryLogPos)
 	}
 	var err error
-	realmaster := cluster.master
+	realmaster := cluster.GetMaster()
 	if cluster.Conf.MxsBinlogOn || cluster.Conf.MultiTierSlave {
 		realmaster = cluster.GetRelayServer()
+		if realmaster == nil {
+			return fmt.Errorf("No relay for current cluster and Maxscale Binlog Server or multi tier slave is active")
+		}
 	}
+
+	if realmaster == nil {
+		return fmt.Errorf("No master found for rejoin GTID position")
+	}
+
 	if server.HasGTIDReplication() || (realmaster.MxsHaveGtid && realmaster.IsMaxscale) {
 		logs, err := server.SetReplicationGTIDCurrentPosFromServer(realmaster)
 		cluster.LogSQL(logs, err, server.URL, "Rejoin", config.LvlErr, "Failed in GTID rejoin old master in sync %s, %s", server.URL, err)


### PR DESCRIPTION
This pull request improves error handling and robustness in the `rejoinMasterSync` function within the `cluster/srv_rejoin.go` file. The most important changes involve replacing direct access to the `master` property with the `GetMaster` method and adding checks to handle cases where no master or relay server is found.

### Error handling improvements:
* Replaced the direct access of `cluster.master` with the `GetMaster()` method to ensure the master is retrieved dynamically, improving maintainability and encapsulation.
* Added error handling to check if `realmaster` is `nil`, returning specific error messages when no master or relay server is found. This prevents potential runtime issues and provides clearer debugging information.
