### PR TITLE
Analyze Table Use PERSISTENT FOR

### DIFF
--- a/cluster/cluster_job.go
+++ b/cluster/cluster_job.go
@@ -48,10 +48,12 @@ func (cluster *Cluster) JobAnalyzeSQL() error {
 	defer func() {
 		cluster.inAnalyzeTables = false
 	}()
-	for _, t := range cluster.master.Tables {
 
+	// Preserve the old behavior of analyze tables, which is writing to the binlog
+	local := false
+	for _, t := range cluster.master.Tables {
 		//	for _, s := range cluster.slaves {
-		logs, err = dbhelper.AnalyzeTable(server.Conn, server.DBVersion, t.TableSchema+"."+t.TableName)
+		logs, err = dbhelper.AnalyzeTable(server.Conn, server.DBVersion, t.TableSchema+"."+t.TableName, local, cluster.Conf.AnalyzeUsePersistent, "ALL", "")
 		cluster.LogSQL(logs, err, server.URL, "Monitor", config.LvlDbg, "Could not get database variables %s %s", server.URL, err)
 
 		//	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral,LvlInfo, "Analyse table %s on %s", t, s.URL)

--- a/cluster/cluster_tgl.go
+++ b/cluster/cluster_tgl.go
@@ -469,6 +469,10 @@ func (cluster *Cluster) SwitchMonitoringScheduler() {
 	}
 }
 
+func (cluster *Cluster) SwitchAnalyzeUsePersistent() {
+	cluster.Conf.AnalyzeUsePersistent = !cluster.Conf.AnalyzeUsePersistent
+}
+
 func (cluster *Cluster) SwitchMonitoringQueries() {
 	cluster.Conf.MonitorQueries = !cluster.Conf.MonitorQueries
 }

--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -687,6 +687,9 @@ func (server *ServerMonitor) GetSlowLogTable(wg *sync.WaitGroup) error {
 }
 
 func (server *ServerMonitor) GetTables() []v3.Table {
+	if server.Tables == nil {
+		server.Tables = make([]v3.Table, 0)
+	}
 	return server.Tables
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -650,6 +650,7 @@ type Config struct {
 	SchedulerAlertDisableTime                 int                    `mapstructure:"scheduler-alert-disable-time" toml:"scheduler-alert-disable-time" json:"schedulerAlertDisableTime"`
 	OptimizeUseSQL                            bool                   `mapstructure:"optimize-use-sql" toml:"optimize-use-sql" json:"optimizeUseSql"`
 	AnalyzeUseSQL                             bool                   `mapstructure:"analyze-use-sql" toml:"analyze-use-sql" json:"analyzeUseSql"`
+	AnalyzeUsePersistent                      bool                   `mapstructure:"analyze-use-persistent" toml:"analyze-use-persistent" json:"analyzeUsePersistent"`
 	BackupLogicalCron                         string                 `mapstructure:"scheduler-db-servers-logical-backup-cron" toml:"scheduler-db-servers-logical-backup-cron" json:"schedulerDbServersLogicalBackupCron"`
 	BackupPhysicalCron                        string                 `mapstructure:"scheduler-db-servers-physical-backup-cron" toml:"scheduler-db-servers-physical-backup-cron" json:"schedulerDbServersPhysicalBackupCron"`
 	BackupDatabaseLogCron                     string                 `mapstructure:"scheduler-db-servers-logs-cron" toml:"scheduler-db-servers-logs-cron" json:"schedulerDbServersLogsCron"`

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -16470,6 +16470,9 @@ const docTemplate = `{
                 "alertTeamsUrl": {
                     "type": "string"
                 },
+                "analyzeUsePersistent": {
+                    "type": "boolean"
+                },
                 "analyzeUseSql": {
                     "type": "boolean"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -16459,6 +16459,9 @@
                 "alertTeamsUrl": {
                     "type": "string"
                 },
+                "analyzeUsePersistent": {
+                    "type": "boolean"
+                },
                 "analyzeUseSql": {
                     "type": "boolean"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1320,6 +1320,8 @@ definitions:
         type: string
       alertTeamsUrl:
         type: string
+      analyzeUsePersistent:
+        type: boolean
       analyzeUseSql:
         type: boolean
       apiBind:

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2393,6 +2393,8 @@ func (repman *ReplicationManager) switchClusterSettings(mycluster *cluster.Clust
 		}
 	case "topology-staging":
 		mycluster.SwitchTopologyStaging()
+	case "analyze-use-persistent":
+		mycluster.SwitchAnalyzeUsePersistent()
 	default:
 		return errors.New("Setting not found")
 	}
@@ -3550,6 +3552,8 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		mycluster.Conf.Cloud18OpenSysops = isactive
 	case "topology-staging":
 		mycluster.Conf.TopologyStaging = isactive
+	case "analyze-use-persistent":
+		mycluster.Conf.AnalyzeUsePersistent = isactive
 	default:
 		return errors.New("Setting not found")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -843,6 +843,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 
 	flags.BoolVar(&conf.OptimizeUseSQL, "optimize-use-sql", true, "Orchetrate optimize table via SQL not via database job using mysqlcheck")
 	flags.BoolVar(&conf.AnalyzeUseSQL, "analyze-use-sql", true, "Orchetrate analyze table via SQL not via database job using mysqlcheck")
+	flags.BoolVar(&conf.AnalyzeUsePersistent, "analyze-use-persistent", true, "Use 'PERSISTENT FOR' for analyze table")
 
 	flags.StringVar(&conf.ProvIops, "prov-db-disk-iops", "300", "Rnd IO/s in for micro service VM")
 	flags.StringVar(&conf.ProvIopsLatency, "prov-db-disk-iops-latency", "0.002", "IO latency in s")

--- a/share/dashboard_react/src/Pages/Settings/SchedulerSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/SchedulerSettings.jsx
@@ -49,6 +49,19 @@ function SchedulerSettings({ selectedCluster, user, openConfirmModal }) {
         />
       )
     },
+    {
+      key: 'Analyze Tables Use PERSISTENT',
+      value: (
+        <RMSwitch
+          confirmTitle={'Confirm switch settings for analyze-use-persistent?'}
+          onChange={() =>
+            dispatch(switchSetting({ clusterName: selectedCluster?.name, setting: 'analyze-use-persistent' }))
+          }
+          isDisabled={user?.grants['cluster-settings'] == false}
+          isChecked={selectedCluster?.config?.analyzeUsePersistent}
+        />
+      )
+    },
     ...(selectedCluster?.config?.monitoringScheduler
       ? [
           {

--- a/utils/dbhelper/dbhelper.go
+++ b/utils/dbhelper/dbhelper.go
@@ -3050,10 +3050,20 @@ func BenchCleanup(db *sqlx.DB) error {
 	return nil
 }
 
-func AnalyzeTable(db *sqlx.DB, myver *version.Version, table string) (string, error) {
-	query := "ANALYZE TABLE " + table
-	if myver.Greater("10.4.0") && myver.IsMariaDB() {
-		query += " PERSISTENT FOR ALL"
+// AnalyzeTable analyzes a table and optionally persists the analysis for all columns or specific columns and indexes.
+// The function returns the executed query and any error encountered.
+func AnalyzeTable(db *sqlx.DB, myver *version.Version, table string, nobinlog, persistent bool, columns string, indexes string) (string, error) {
+	query := "ANALYZE "
+	if nobinlog {
+		query += "LOCAL "
+	}
+	query += "TABLE " + table
+	if myver.Greater("10.4.0") && myver.IsMariaDB() && persistent {
+		if columns == "ALL" {
+			query += " PERSISTENT FOR ALL"
+		} else {
+			query += " PERSISTENT FOR COLUMNS (" + columns + ") INDEXES (" + indexes + ")"
+		}
 	}
 	_, err := db.Exec(query)
 	if err != nil {


### PR DESCRIPTION
This pull request introduces a new configuration option, `analyze-use-persistent`, to enhance the flexibility of table analysis in the system. The most significant changes include adding support for this feature across multiple layers of the application, such as configuration, API, database helper functions, and the frontend UI.

### Configuration and API Enhancements:
* Added `AnalyzeUsePersistent` as a new boolean field in the `Config` struct to allow toggling the use of persistent analysis for tables (`config/config.go`).
* Updated the API to support toggling and setting the `analyze-use-persistent` configuration via cluster settings (`server/api_cluster.go`). [[1]](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afR2396-R2397) [[2]](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afR3555-R3556)

### Backend Logic Updates:
* Enhanced the `AnalyzeTable` function to support persistent analysis for all columns or specific columns and indexes, with optional binlog suppression (`utils/dbhelper/dbhelper.go`).
* Modified `JobAnalyzeSQL` to pass the new `AnalyzeUsePersistent` flag when analyzing tables (`cluster/cluster_job.go`).

### Frontend Integration:
* Added a new toggle switch in the Scheduler Settings UI to enable or disable the `analyze-use-persistent` feature (`share/dashboard_react/src/Pages/Settings/SchedulerSettings.jsx`).

### Documentation Updates:
* Updated Swagger documentation (`docs/swagger.json`, `docs/swagger.yaml`) and internal API documentation (`docs/docs.go`) to include the `analyzeUsePersistent` field. [[1]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R16462-R16464) [[2]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R1323-R1324) [[3]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R16473-R16475)