### PR TITLE
Improve heartbeat check for slaves using goroutines for faster failover start

### DIFF
--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -8,6 +8,7 @@ package cluster
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +17,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/signal18/replication-manager/config"
@@ -205,39 +208,84 @@ func (cluster *Cluster) isBetweenFailoverTimeValid() bool {
 }
 
 func (cluster *Cluster) isOneSlaveHeartbeatIncreasing() bool {
-	if cluster.Conf.CheckFalsePositiveHeartbeat == false {
-		return false
-	}
-	if !cluster.isMasterFailed() {
+	if !cluster.Conf.CheckFalsePositiveHeartbeat || !cluster.isMasterFailed() {
 		return false
 	}
 
-	//cluster.LogModulePrintf(cluster.Conf.Verbose,config.ConstLogModGeneral,"CHECK: Failover Slaves heartbeats")
+	timeout := time.Duration(cluster.Conf.CheckFalsePositiveHeartbeatTimeout) * time.Second
+	// Total context timeout to cover all goroutines duration
+	ctx, cancel := context.WithTimeout(context.Background(), timeout*2)
+	defer cancel()
 
-	for _, s := range cluster.slaves {
-		relaycheck, _ := cluster.GetMasterFromReplication(s)
-		if relaycheck != nil {
-			if relaycheck.IsRelay == false {
-				status, logs, err := dbhelper.GetStatusAsInt(s.Conn, s.DBVersion)
-				cluster.LogSQL(logs, err, s.URL, "isOneSlaveHeartbeatIncreasing", config.LvlDbg, "Monitor")
-				saveheartbeats := status["SLAVE_RECEIVED_HEARTBEATS"]
-				// if cluster.Conf.LogLevel > 1 {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "SLAVE_RECEIVED_HEARTBEATS %d", saveheartbeats)
-				// }
-				time.Sleep(time.Duration(cluster.Conf.CheckFalsePositiveHeartbeatTimeout) * time.Second)
-				status2, logs, err := dbhelper.GetStatusAsInt(s.Conn, s.DBVersion)
-				cluster.LogSQL(logs, err, s.URL, "isOneSlaveHeartbeatIncreasing", config.LvlDbg, "Monitor")
-				// if cluster.Conf.LogLevel > 1 {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "SLAVE_RECEIVED_HEARTBEATS %d", status2["SLAVE_RECEIVED_HEARTBEATS"])
-				// }
-				if status2["SLAVE_RECEIVED_HEARTBEATS"] > saveheartbeats {
-					cluster.SetState("ERR00028", state.State{ErrType: config.LvlErr, ErrDesc: fmt.Sprintf(clusterError["ERR00028"], s.URL), ErrFrom: "CHECK"})
-					return true
+	var found int32
+	var wg sync.WaitGroup
+
+	for _, slave := range cluster.slaves {
+		relaycheck, _ := cluster.GetMasterFromReplication(slave)
+		// Skip if relaycheck is nil or it's a relay slave
+		if relaycheck == nil || relaycheck.IsRelay {
+			continue
+		}
+
+		wg.Add(1)
+		go func(slave *ServerMonitor) {
+			defer wg.Done()
+
+			// Check if already found an increasing heartbeat
+			if atomic.LoadInt32(&found) == 1 {
+				return
+			}
+
+			// First heartbeat status fetch
+			status1, logs, err := dbhelper.GetStatusAsInt(slave.Conn, slave.DBVersion)
+			cluster.LogSQL(logs, err, slave.URL, "isOneSlaveHeartbeatIncreasing", config.LvlDbg, "Monitor")
+			if err != nil || atomic.LoadInt32(&found) == 1 {
+				return
+			}
+
+			hb1 := status1["SLAVE_RECEIVED_HEARTBEATS"]
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg,
+				"SLAVE_RECEIVED_HEARTBEATS %d (first check)", hb1)
+
+			// Wait for timeout or cancellation before second check
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(timeout):
+				// continue after timeout
+			}
+
+			if atomic.LoadInt32(&found) == 1 {
+				return
+			}
+
+			// Second heartbeat status fetch
+			status2, logs, err := dbhelper.GetStatusAsInt(slave.Conn, slave.DBVersion)
+			cluster.LogSQL(logs, err, slave.URL, "isOneSlaveHeartbeatIncreasing", config.LvlDbg, "Monitor")
+			if err != nil {
+				return
+			}
+
+			hb2 := status2["SLAVE_RECEIVED_HEARTBEATS"]
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg,
+				"SLAVE_RECEIVED_HEARTBEATS %d (second check)", hb2)
+
+			// Check if heartbeat increased
+			if hb2 > hb1 {
+				cluster.SetState("ERR00028", state.State{
+					ErrType: config.LvlErr,
+					ErrDesc: fmt.Sprintf(clusterError["ERR00028"], slave.URL),
+					ErrFrom: "CHECK",
+				})
+				if atomic.CompareAndSwapInt32(&found, 0, 1) {
+					cancel() // cancel all other goroutines
 				}
 			}
-		}
+		}(slave)
 	}
-	return false
+
+	wg.Wait()
+	return atomic.LoadInt32(&found) == 1
 }
 
 func (cluster *Cluster) isMaxscaleSupectRunning() bool {

--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -214,7 +214,7 @@ func (cluster *Cluster) isOneSlaveHeartbeatIncreasing() bool {
 
 	timeout := time.Duration(cluster.Conf.CheckFalsePositiveHeartbeatTimeout) * time.Second
 	// Total context timeout to cover all goroutines duration
-	ctx, cancel := context.WithTimeout(context.Background(), timeout*2)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout*3)
 	defer cancel()
 
 	var found int32


### PR DESCRIPTION
This pull request refactors the `isOneSlaveHeartbeatIncreasing` function in `cluster/cluster_chk.go` to improve concurrency and reliability. It introduces context-based timeout management and atomic operations, ensuring efficient handling of slave heartbeat checks. Additionally, new imports for `context`, `sync`, and `sync/atomic` are added to support these changes.

### Functionality Improvements:
* **Enhanced concurrency in heartbeat checks**: The `isOneSlaveHeartbeatIncreasing` function now uses goroutines and a `sync.WaitGroup` to concurrently check heartbeat statuses for all slaves. This ensures faster execution and better scalability.
* **Context-based timeout management**: A `context.WithTimeout` mechanism has been introduced to manage the overall timeout for heartbeat checks, allowing for graceful cancellation of goroutines when the timeout is exceeded.
* **Atomic operations for thread safety**: The function uses `sync/atomic` operations to safely update and check the `found` variable across multiple goroutines, ensuring thread-safe execution.

### Code Maintenance:
* **Added necessary imports**: New imports for `context`, `sync`, and `sync/atomic` have been added to support the concurrency and timeout features. [[1]](diffhunk://#diff-a9c48f22ec1d87ff0d2873815cfa59dc52f9a82be452494ba540d4fe89a44774R11) [[2]](diffhunk://#diff-a9c48f22ec1d87ff0d2873815cfa59dc52f9a82be452494ba540d4fe89a44774R20-R21)