### PR TITLE
Add base64 encoding for alert and backup script settings

### DIFF
--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2917,7 +2917,11 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 	case "alert-pushover-user-token":
 		mycluster.SetAlertPushoverUserToken(value)
 	case "alert-script":
-		mycluster.SetAlertScript(value)
+		val, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return errors.New("Unable to decode")
+		}
+		mycluster.SetAlertScript(string(val))
 	case "alert-slack-channel":
 		mycluster.SetAlertSlackChannel(value)
 	case "alert-slack-url":
@@ -3149,13 +3153,29 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 			mycluster.Conf.Cloud18DbOps = value
 		}
 	case "backup-save-script":
-		mycluster.Conf.BackupSaveScript = value
+		val, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return errors.New("Unable to decode")
+		}
+		mycluster.Conf.BackupSaveScript = string(val)
 	case "backup-load-script":
-		mycluster.Conf.BackupLoadScript = value
+		val, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return errors.New("Unable to decode")
+		}
+		mycluster.Conf.BackupLoadScript = string(val)
 	case "topology-staging-refresh-script":
-		mycluster.Conf.TopologyStagingRefreshScript = value
+		val, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return errors.New("Unable to decode")
+		}
+		mycluster.Conf.TopologyStagingRefreshScript = string(val)
 	case "topology-staging-post-detach-script":
-		mycluster.Conf.TopologyStagingPostDetachScript = value
+		val, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return errors.New("Unable to decode")
+		}
+		mycluster.Conf.TopologyStagingPostDetachScript = string(val)
 	case "replication-multisource-head-clusters":
 		mycluster.Conf.ReplicationMultisourceHeadClusters = value
 	case "replication-source-name":

--- a/share/dashboard_react/src/Pages/Settings/AlertSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/AlertSettings.jsx
@@ -173,7 +173,7 @@ function AlertSettings({ selectedCluster, user, openConfirmModal }) {
               setSetting({
                 clusterName: selectedCluster?.name,
                 setting: 'alert-script',
-                value: value
+                value: btoa(value)
               })
             )
           }

--- a/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
@@ -125,7 +125,7 @@ The script will be executed with the following parameters:
                 setSetting({
                   clusterName: selectedCluster?.name,
                   setting: 'backup-save-script',
-                  value: value
+                  value: btoa(value)
                 })
               )
             }
@@ -152,7 +152,7 @@ The script will be executed with the following parameters:
                 setSetting({
                   clusterName: selectedCluster?.name,
                   setting: 'backup-load-script',
-                  value: value
+                  value: btoa(value)
                 })
               )
             }

--- a/share/dashboard_react/src/Pages/Settings/StagingSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/StagingSettings.jsx
@@ -42,7 +42,7 @@ function StagingSettings({ selectedCluster, user, openConfirmModal, monitor }) {
           value={selectedCluster?.config?.topologyStagingRefreshScript}
           confirmTitle={`Confirm staging refresh script to `}
           onSave={(value) => {
-            dispatch(setSetting({ clusterName: selectedCluster?.name, setting: 'topology-staging-refresh-script', value }))
+            dispatch(setSetting({ clusterName: selectedCluster?.name, setting: 'topology-staging-refresh-script', value: btoa(value) }))
           }}
         />
       )
@@ -54,7 +54,7 @@ function StagingSettings({ selectedCluster, user, openConfirmModal, monitor }) {
           value={selectedCluster?.config?.topologyStagingPostDetachScript}
           confirmTitle={`Confirm staging post-detach script to `}
           onSave={(value) => {
-            dispatch(setSetting({ clusterName: selectedCluster?.name, setting: 'topology-staging-post-detach-script', value }))
+            dispatch(setSetting({ clusterName: selectedCluster?.name, setting: 'topology-staging-post-detach-script', value: btoa(value) }))
           }}
         />
       )


### PR DESCRIPTION
This pull request introduces changes to ensure that script-based cluster settings are securely encoded and decoded using Base64. The updates span both the backend logic and the frontend components responsible for managing these settings. This will prevent user from missing root path (/)

### Backend Updates: Base64 Decoding for Script Settings

* [`server/api_cluster.go`](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afL2920-R2924): Added Base64 decoding logic for script-based settings (`alert-script`, `backup-save-script`, `backup-load-script`, `topology-staging-refresh-script`, and `topology-staging-post-detach-script`) to ensure the values are properly decoded before being stored or processed. Errors during decoding are now handled gracefully with error messages. [[1]](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afL2920-R2924) [[2]](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afL3152-R3178)

### Frontend Updates: Base64 Encoding for Script Settings

* [`share/dashboard_react/src/Pages/Settings/AlertSettings.jsx`](diffhunk://#diff-5d307b94d2a5b1855b99470d218e7fa81ef09f5a20477aa116039f8fc5707590L176-R176): Updated the `alert-script` setting to encode the value using Base64 (`btoa`) before sending it to the backend.
* [`share/dashboard_react/src/Pages/Settings/BackupSettings.jsx`](diffhunk://#diff-ef0c47fa54ff21d2c74ce82a6e0f85fd2465bfa78a0137323d64627c8186248cL128-R128): Applied Base64 encoding (`btoa`) for `backup-save-script` and `backup-load-script` settings before dispatching updates. [[1]](diffhunk://#diff-ef0c47fa54ff21d2c74ce82a6e0f85fd2465bfa78a0137323d64627c8186248cL128-R128) [[2]](diffhunk://#diff-ef0c47fa54ff21d2c74ce82a6e0f85fd2465bfa78a0137323d64627c8186248cL155-R155)
* [`share/dashboard_react/src/Pages/Settings/StagingSettings.jsx`](diffhunk://#diff-a9890b6db26618572dbd5bb28809208651f3ca41b5681d7a3bf4ba55dcc91b96L45-R45): Incorporated Base64 encoding (`btoa`) for `topology-staging-refresh-script` and `topology-staging-post-detach-script` settings to align with backend requirements. [[1]](diffhunk://#diff-a9890b6db26618572dbd5bb28809208651f3ca41b5681d7a3bf4ba55dcc91b96L45-R45) [[2]](diffhunk://#diff-a9890b6db26618572dbd5bb28809208651f3ca41b5681d7a3bf4ba55dcc91b96L57-R57)