### PR TITLE
Improve log messages for replication bootstrap to include server URL

### DIFF
--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1829,7 +1829,7 @@ func (server *ServerMonitor) ChangeMasterTo(master *ServerMonitor, master_use_gi
 			SSL:         cluster.Conf.ReplicationSSL,
 			PostgressDB: server.PostgressDB,
 		}, server.DBVersion)
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Replication bootstrapped with %s as master", master.URL)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Replication bootstrapped on %s with %s as master", server.URL, master.URL)
 	} else if hasMyGTID && cluster.Conf.ForceSlaveNoGtid == false {
 		// MySQL GTID
 		logs, err = dbhelper.ChangeMaster(server.Conn, dbhelper.ChangeMasterOpt{
@@ -1846,7 +1846,7 @@ func (server *ServerMonitor) ChangeMasterTo(master *ServerMonitor, master_use_gi
 			Channel:     cluster.Conf.MasterConn,
 			PostgressDB: server.PostgressDB,
 		}, server.DBVersion)
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Replication bootstrapped with MySQL GTID replication style and %s as master", master.URL)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Replication bootstrapped on %s with MySQL GTID replication style and %s as master", server.URL, master.URL)
 
 	} else {
 		// Old Style file pos as default
@@ -1866,7 +1866,7 @@ func (server *ServerMonitor) ChangeMasterTo(master *ServerMonitor, master_use_gi
 			SSL:         cluster.Conf.ReplicationSSL,
 			PostgressDB: server.PostgressDB,
 		}, server.DBVersion)
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Replication bootstrapped with old replication style and %s as master", master.URL)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Replication bootstrapped on %s with old replication style and %s as master", server.URL, master.URL)
 
 	}
 	if err != nil {


### PR DESCRIPTION
This pull request updates log messages in the `ChangeMasterTo` function to include both the current server's URL and the master's URL, providing clearer context about which server is being bootstrapped during replication setup.

Logging improvements:

* Updated log messages in `cluster/srv.go` to include the current server's URL (`server.URL`) alongside the master's URL (`master.URL`) for all replication bootstrapping scenarios: standard, MySQL GTID, and old replication styles. [[1]](diffhunk://#diff-c5fffdb4a6a092160ddd24b95042ba54bfcb96dfb0e747bb200902aac778adb1L1832-R1832) [[2]](diffhunk://#diff-c5fffdb4a6a092160ddd24b95042ba54bfcb96dfb0e747bb200902aac778adb1L1849-R1849) [[3]](diffhunk://#diff-c5fffdb4a6a092160ddd24b95042ba54bfcb96dfb0e747bb200902aac778adb1L1869-R1869)
