### PR TITLE
Fix selecting non existant time_ms in mysql version

### DIFF
--- a/utils/dbhelper/dbhelper.go
+++ b/utils/dbhelper/dbhelper.go
@@ -569,13 +569,13 @@ func GetProcesslistTable(db *sqlx.DB, version *version.Version, inactive_queryin
 		filter_order_limit = " WHERE " + filter_user + " AND  a.command='query' "
 	}
 	if order_by_trx_time {
-		if version.IsMySQLOrPercona() && version.Lower("8.0") {
+		if version.IsMySQL() || (version.IsPercona() && version.Lower("8.0")) {
 			filter_order_limit += " ORDER BY IF(a.Command='Query',a.TIME, b.trx_started) DESC LIMIT " + limit
 		} else {
 			filter_order_limit += " ORDER BY IF(a.Command='Query',a.TIME_MS, b.trx_started) DESC LIMIT " + limit
 		}
 	} else {
-		if version.IsMySQLOrPercona() && version.Lower("8.0") {
+		if version.IsMySQL() || (version.IsPercona() && version.Lower("8.0")) {
 			filter_order_limit += " ORDER BY a.TIME DESC LIMIT " + limit
 		} else {
 			filter_order_limit += " ORDER BY a.TIME_MS DESC LIMIT " + limit

--- a/utils/dbhelper/dbhelper.go
+++ b/utils/dbhelper/dbhelper.go
@@ -558,7 +558,7 @@ func GetProcesslistTable(db *sqlx.DB, version *version.Version, inactive_queryin
 	filter_user := "1=1"
 
 	if user != "" {
-		filter_user = "  User='+" + user + "' "
+		filter_user = "  User='" + user + "' "
 	}
 	if inactive_querying || order_by_trx_time {
 		filter_order_limit = " WHERE " + filter_user

--- a/utils/dbhelper/dbhelper.go
+++ b/utils/dbhelper/dbhelper.go
@@ -569,16 +569,16 @@ func GetProcesslistTable(db *sqlx.DB, version *version.Version, inactive_queryin
 		filter_order_limit = " WHERE " + filter_user + " AND  a.command='query' "
 	}
 	if order_by_trx_time {
-		if version.IsMySQL() || (version.IsPercona() && version.Lower("8.0")) {
-			filter_order_limit += " ORDER BY IF(a.Command='Query',a.TIME, b.trx_started) DESC LIMIT " + limit
-		} else {
+		if version.IsMariaDB() || (version.IsPercona() && version.GreaterEqual("8.0")) {
 			filter_order_limit += " ORDER BY IF(a.Command='Query',a.TIME_MS, b.trx_started) DESC LIMIT " + limit
+		} else {
+			filter_order_limit += " ORDER BY IF(a.Command='Query',a.TIME, b.trx_started) DESC LIMIT " + limit
 		}
 	} else {
-		if version.IsMySQL() || (version.IsPercona() && version.Lower("8.0")) {
-			filter_order_limit += " ORDER BY a.TIME DESC LIMIT " + limit
-		} else {
+		if version.IsMariaDB() || (version.IsPercona() && version.GreaterEqual("8.0")) {
 			filter_order_limit += " ORDER BY a.TIME_MS DESC LIMIT " + limit
+		} else {
+			filter_order_limit += " ORDER BY a.TIME DESC LIMIT " + limit
 		}
 	}
 	if version.IsMariaDB() {
@@ -591,7 +591,7 @@ func GetProcesslistTable(db *sqlx.DB, version *version.Version, inactive_queryin
 		//MySQL
 
 		stmt = "SELECT a.Id, a.User, a.Host, a.`Db` AS `db`,IF(a.Command='Sleep' AND b.trx_isolation_level IS NOT NULL ,'Trx sleep',a.Command) as Command, a.Time as Time, a.State, SUBSTRING(COALESCE(a.INFO,''),1,1000) as Info ,0 as Progress,  COALESCE(TIMESTAMPDIFF(SECOND,b.trx_started , now()),0) as trx_time, COALESCE(b.trx_isolation_level,'') as trx_isolation_level, COALESCE(b.trx_tables_in_use,0) as trx_tables_in_use, COALESCE(b.trx_tables_locked,0) as trx_tables_locked, COALESCE(b.trx_lock_structs,0) as trx_lock_structs, COALESCE(b.trx_lock_memory_bytes,0) as trx_lock_memory_bytes, COALESCE(b.trx_rows_locked,0) as trx_rows_locked, COALESCE(b.trx_rows_modified,0) as trx_rows_modified, COALESCE(b.trx_is_read_only,0) as trx_is_read_only  FROM INFORMATION_SCHEMA.PROCESSLIST a LEFT JOIN INFORMATION_SCHEMA.INNODB_TRX b ON b.trx_mysql_thread_id=a.id " + filter_order_limit
-		if version.GreaterEqual("8.0") {
+		if version.IsPercona() && version.GreaterEqual("8.0") {
 			stmt = "SELECT a.Id, a.User, a.Host, a.`Db` AS `db`,IF(a.Command='Sleep' AND b.trx_isolation_level IS NOT NULL ,'Trx sleep',a.Command) as Command, a.Time_ms as Time, a.State, SUBSTRING(COALESCE(a.INFO,''),1,1000) as Info ,0 as Progress , COALESCE(TIMESTAMPDIFF(SECOND,b.trx_started , now()),0) as trx_time, COALESCE(b.trx_isolation_level,'') as trx_isolation_level, COALESCE(b.trx_tables_in_use,0) as trx_tables_in_use, COALESCE(b.trx_tables_locked,0) as trx_tables_locked, COALESCE(b.trx_lock_structs,0) as trx_lock_structs, COALESCE(b.trx_lock_memory_bytes,0) as trx_lock_memory_bytes, COALESCE(b.trx_rows_locked,0) as trx_rows_locked, COALESCE(b.trx_rows_modified,0) as trx_rows_modified, COALESCE(b.trx_is_read_only,0) as trx_is_read_only  FROM INFORMATION_SCHEMA.PROCESSLIST a LEFT JOIN INFORMATION_SCHEMA.INNODB_TRX b ON b.trx_mysql_thread_id=a.id  " + filter_order_limit
 		}
 		if !full_process_is {


### PR DESCRIPTION
This pull request updates the logic in the `GetProcesslistTable` function in `utils/dbhelper/dbhelper.go` to improve compatibility and correctness when handling different MySQL, Percona, and MariaDB versions. The main focus is on refining version checks and query construction for process list retrieval.

Key changes include:

**Version-specific query handling:**

* Updated the ordering and limit logic to distinguish more accurately between MariaDB, Percona 8.0+, and other MySQL versions, ensuring the correct use of `TIME_MS` and `TIME` fields depending on the database type and version.
* Changed the SQL statement selection for Percona 8.0+ to use `Time_ms` instead of `Time`, preventing incorrect data retrieval for these versions.

**Bug fix:**

* Fixed a typo in the user filter string construction to correctly quote the username in the SQL query.