### PR TITLE
Fix the path of binary within tty and use ssl-mode since mysql 8.0

### DIFF
--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -219,6 +219,30 @@ func (cluster *Cluster) GetMysqlclientPath() string {
 	return cluster.Conf.BackupMysqlclientPath
 }
 
+func (cluster *Cluster) GetMytopPath() string {
+	if cluster.Conf.BackupMytopPath == "" {
+		// Return installed mysql client on repman host instead of embedded if exists
+		if out, err := exec.Command("which", "mytop").Output(); err == nil {
+			path := strings.Trim(string(out), "\r\n")
+			return path
+		}
+		return cluster.GetShareDir() + "/" + cluster.Conf.GoArch + "/" + cluster.Conf.GoOS + "/mytop"
+	}
+	return cluster.Conf.BackupMytopPath
+}
+
+func (cluster *Cluster) GetGottyClientPath() string {
+	if cluster.Conf.BackupGottyClientPath == "" {
+		// Return installed mysql client on repman host instead of embedded if exists
+		if out, err := exec.Command("which", "gotty-client").Output(); err == nil {
+			path := strings.Trim(string(out), "\r\n")
+			return path
+		}
+		return cluster.GetShareDir() + "/" + cluster.Conf.GoArch + "/" + cluster.Conf.GoOS + "/gotty-client"
+	}
+	return cluster.Conf.BackupGottyClientPath
+}
+
 func (cluster *Cluster) GetMysqlServerBinaryPath() string {
 	if cluster.Conf.BackupMysqlclientPath == "" {
 		// Return installed mysql client on repman host instead of embedded if exists

--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -887,7 +887,7 @@ func (server *ServerMonitor) GetSSLClientParam(tool string) []string {
 					sslMode = "VERIFY_CA" // Only verify CA if no SSL mode is set
 				}
 
-				if server.DBVersion.IsMySQLOrPerconaGreater84() && ver.IsMySQLOrPerconaGreater84() { // Use","--ssl-mode
+				if server.DBVersion.IsMySQLOrPerconaGreater8() && ver.IsMySQLOrPerconaGreater8() { // Use","--ssl-mode
 					switch sslMode {
 					case "DISABLED":
 						return []string{"--ssl-mode=DISABLED"}
@@ -911,7 +911,7 @@ func (server *ServerMonitor) GetSSLClientParam(tool string) []string {
 					}
 				}
 			} else {
-				if server.DBVersion.IsMySQLOrPerconaGreater84() && ver.IsMySQLOrPerconaGreater84() { // Use","--ssl-mode
+				if server.DBVersion.IsMySQLOrPerconaGreater8() && ver.IsMySQLOrPerconaGreater8() { // Use","--ssl-mode
 					return []string{"--ssl-mode=" + sslMode} // No verify server cert
 				} else { // Use old","--ssl equivalent
 					if sslMode == "DISABLED" {

--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -912,7 +912,11 @@ func (server *ServerMonitor) GetSSLClientParam(tool string) []string {
 				}
 			} else {
 				if server.DBVersion.IsMySQLOrPerconaGreater8() && ver.IsMySQLOrPerconaGreater8() { // Use","--ssl-mode
-					return []string{"--ssl-mode=" + sslMode} // No verify server cert
+					if sslMode != "" {
+						return []string{"--ssl-mode=" + sslMode} // No verify server cert
+					} else {
+						return []string{"--ssl-mode=PREFERRED"} // No verify server cert
+					}
 				} else { // Use old","--ssl equivalent
 					if sslMode == "DISABLED" {
 						return []string{"--skip-ssl"}

--- a/config/config.go
+++ b/config/config.go
@@ -719,8 +719,10 @@ type Config struct {
 	BackupMyDumperOptions                     string                 `mapstructure:"backup-mydumper-options" toml:"backup-mydumper-options" json:"backupMyDumperOptions"`
 	BackupMyDumperRegex                       string                 `mapstructure:"backup-mydumper-regex" toml:"backup-mydumper-regex" json:"backupMyDumperRegex"`
 	BackupMysqlbinlogPath                     string                 `mapstructure:"backup-mysqlbinlog-path" toml:"backup-mysqlbinlog-path" json:"backupMysqlbinlogPath"`
-	BackupMysqlclientPath                     string                 `mapstructure:"backup-mysqlclient-path" toml:"backup-mysqlclient-path" json:"backupMysqlclientgPath"`
+	BackupMysqlclientPath                     string                 `mapstructure:"backup-mysqlclient-path" toml:"backup-mysqlclient-path" json:"backupMysqlclientPath"`
 	BackupMysqlclientOptions                  string                 `mapstructure:"backup-mysqlclient-options" toml:"backup-mysqlclient-options" json:"backupMysqlclientOptions"`
+	BackupMytopPath                           string                 `mapstructure:"backup-mytop-path" toml:"backup-mytop-path" json:"backupMytopPath"`
+	BackupGottyClientPath                     string                 `mapstructure:"backup-gotty-client-path" toml:"backup-gotty-client-path" json:"backupGottyClientPath"`
 	BackupBinlogs                             bool                   `mapstructure:"backup-binlogs" toml:"backup-binlogs" json:"backupBinlogs"`
 	BackupBinlogsKeep                         int                    `mapstructure:"backup-binlogs-keep" toml:"backup-binlogs-keep" json:"backupBinlogsKeep"`
 	BackupLockDDL                             bool                   `mapstructure:"backup-lockddl" toml:"backup-lockddl" json:"backupLockDDL"`

--- a/server/api.go
+++ b/server/api.go
@@ -275,7 +275,7 @@ func (repman *ReplicationManager) apiserver() {
 			http.Redirect(w, r, "/", http.StatusFound)
 		}
 	})
-	
+
 	router.Handle("/api/terminal/list", negroni.New(
 		negroni.Wrap(http.HandlerFunc(repman.handlerGetTerminalSessionList)),
 	))
@@ -1981,14 +1981,17 @@ func (repman *ReplicationManager) handlerTerminal(w http.ResponseWriter, r *http
 				session.Arguments = append(session.Arguments, session.ServiceGottyUrl)
 
 				session.CmdType = tty.TerminalGottyClient
+				session.Command = mycluster.GetGottyClientPath()
 				session, err = repman.SessionManager.RunSession(session)
 			} else {
 				session, err = repman.SessionManager.RunSSHSession(session)
 			}
 		} else if session.CmdType == tty.TerminalMySQL {
+			session.Command = mycluster.GetMysqlclientPath()
 			session.Arguments = append(session.Arguments, "-p")
 			session, err = repman.SessionManager.RunSession(session)
 		} else if session.CmdType == tty.TerminalMyTop {
+			session.Command = mycluster.GetMytopPath()
 			session.Arguments = append(session.Arguments, "--prompt")
 			session, err = repman.SessionManager.RunSession(session)
 		} else {

--- a/server/server.go
+++ b/server/server.go
@@ -822,6 +822,8 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.BackupMysqlbinlogPath, "backup-mysqlbinlog-path", "", "Path to mysqlbinlog binary")
 	flags.StringVar(&conf.BackupMysqlclientPath, "backup-mysqlclient-path", "", "Path to mysql client binary")
 	flags.StringVar(&conf.BackupMysqlclientOptions, "backup-mysqlclient-options", "--force --batch", "Extra options")
+	flags.StringVar(&conf.BackupMytopPath, "backup-mytop-path", "", "Path to mytop binary")
+	flags.StringVar(&conf.BackupGottyClientPath, "backup-gotty-client-path", "", "Path to gotty client binary")
 
 	flags.BoolVar(&conf.BackupBinlogs, "backup-binlogs", false, "Archive binlogs")
 	flags.IntVar(&conf.BackupBinlogsKeep, "backup-binlogs-keep", 10, "Number of master binlog to keep")

--- a/utils/tty/tty.go
+++ b/utils/tty/tty.go
@@ -88,6 +88,7 @@ type Session struct {
 	SSHClient            *ssh.Client         `json:"-"`
 	SSHSession           *ssh.Session        `json:"-"`
 	Cmd                  *exec.Cmd           `json:"-"`
+	Command              string              `json:"-"`
 	Arguments            []string            `json:"-"`
 	CmdType              TerminalCommandType `json:"-"`
 	PTY                  *os.File            `json:"-"`
@@ -258,12 +259,8 @@ func (sm *SessionManager) RunSession(session *Session) (*Session, error) {
 	session.SafeWriteMessage(websocket.TextMessage, []byte("Starting new session...\n"))
 
 	var cmd *exec.Cmd
-	if session.CmdType == TerminalMySQL {
-		cmd = exec.Command("mysql", session.Arguments...)
-	} else if session.CmdType == TerminalMyTop {
-		cmd = exec.Command("mytop", session.Arguments...)
-	} else if session.CmdType == TerminalGottyClient {
-		cmd = exec.Command("gotty-client", session.Arguments...)
+	if session.CmdType == TerminalMySQL || session.CmdType == TerminalMyTop || session.CmdType == TerminalGottyClient {
+		cmd = exec.Command(session.Command, session.Arguments...)
 	} else {
 		if session.AllowResume && session.TerminalMgr != nil {
 			cmd, err = session.TerminalMgr.LaunchTerminal(session.ID)

--- a/utils/version/version.go
+++ b/utils/version/version.go
@@ -308,6 +308,15 @@ func (mv *Version) IsMySQLOrPerconaGreater84() bool {
 	return (mv.Flavor == "MySQL" || mv.Flavor == "Percona") && ((mv.Major == 8 && mv.Minor >= 4) || mv.Major > 8)
 }
 
+// IsMySQLOrPerconaGreater84 checks if the version is MySQL or Percona 8.4 or greater
+func (mv *Version) IsMySQLOrPerconaGreater8() bool {
+	if mv == nil {
+		return false
+	}
+
+	return (mv.Flavor == "MySQL" || mv.Flavor == "Percona") && (mv.Major >= 8)
+}
+
 // IsMariaDBGreater113 checks if the version is MariaDB 11.3 or greater which introduce breaking changes in SSL
 func (mv *Version) IsMariaDBGreater113() bool {
 	if mv == nil {


### PR DESCRIPTION
This pull request adds support for specifying custom binary paths for `mytop` and `gotty-client`, improves how these binaries are located and executed, and refines version checks for MySQL/Percona SSL parameters. It also fixes a typo in the configuration struct and ensures that command execution uses the correct binary paths based on configuration or system availability.

**Binary path configuration and execution:**
- Added new configuration options `BackupMytopPath` and `BackupGottyClientPath` to allow specifying custom paths for the `mytop` and `gotty-client` binaries (`config/config.go`, `server/server.go`). [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L722-R725) [[2]](diffhunk://#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4R825-R826)
- Implemented `GetMytopPath` and `GetGottyClientPath` methods in the `Cluster` struct to resolve the correct binary path, preferring system-installed binaries if available, and falling back to embedded paths or configuration values (`cluster/cluster_get.go`).
- Updated session handling to use the resolved binary paths for `mysql`, `mytop`, and `gotty-client` commands, ensuring the correct binary is executed during terminal sessions (`server/api.go`, `utils/tty/tty.go`). [[1]](diffhunk://#diff-3fb3d4184590bc6f747661f3062676031e837b0dd5f2b18640f439be7a2235f6R1984-R1994) [[2]](diffhunk://#diff-8325b645db524a9fd2d590394f3543f040a3fe49d1f1e1bf4471f7c3f516a2f4L261-R263) [[3]](diffhunk://#diff-8325b645db524a9fd2d590394f3543f040a3fe49d1f1e1bf4471f7c3f516a2f4R91)

**MySQL/Percona version check improvements:**
- Added a new method `IsMySQLOrPerconaGreater8` for version checks and updated SSL parameter logic to use this method, ensuring compatibility with MySQL/Percona 8.x and above (`utils/version/version.go`, `cluster/srv_get.go`). [[1]](diffhunk://#diff-6190a4bad4a6f7cb61dcedcf512daf14f1758c8a211cb28e1961fe94bd64584cR311-R319) [[2]](diffhunk://#diff-1f102cb4f0681169e52bd5cbd3b82ade67edf8c28f57cc0d9bb8500e72de97acL890-R890) [[3]](diffhunk://#diff-1f102cb4f0681169e52bd5cbd3b82ade67edf8c28f57cc0d9bb8500e72de97acL914-R919)

**Bug fix:**
- Fixed a typo in the `BackupMysqlclientPath` JSON field name in the configuration struct (`config/config.go`).