### PR TITLE
Improve BootstrapReplication and BootstrapTopology methods

### DIFF
--- a/cluster/prov.go
+++ b/cluster/prov.go
@@ -537,6 +537,7 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 		err := cluster.BootstrapReplicationCleanup()
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cleanup error %s", err)
+			return err
 		}
 	}
 	for _, server := range cluster.Servers {
@@ -554,10 +555,21 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 	err = cluster.TopologyDiscover(wg)
 	wg.Wait()
 	if err == nil {
-		return errors.New("Environment already has an existing master/slave setup")
+		newErr := errors.New("Environment already has an existing master/slave setup")
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn, "%s", newErr)
+		return newErr
 	}
 
 	cluster.StateMachine.SetFailoverState()
+	defer cluster.StateMachine.RemoveFailoverState()
+
+	if clean {
+		// Remove old master if any
+		cluster.master = nil
+		cluster.vmaster = nil
+		cluster.slaves = nil
+	}
+
 	masterKey := 0
 	if cluster.Conf.PrefMaster != "" {
 		masterKey = func() int {
@@ -567,11 +579,9 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 					continue
 				}
 				if server.IsPrefered() {
-					cluster.StateMachine.RemoveFailoverState()
 					return k
 				}
 			}
-			cluster.StateMachine.RemoveFailoverState()
 			return -1
 		}()
 	}
@@ -627,11 +637,18 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 			}
 
 		}
+		if cluster.master == nil {
+			cluster.master = cluster.Servers[masterKey]
+			cluster.master.SetMaster()
+		}
 	}
+
 	// Slave Relay
 	if cluster.Conf.MultiTierSlave == true {
-		masterKey = 0
 		relaykey := 1
+		if masterKey == 1 {
+			relaykey = 0
+		}
 		for key, server := range cluster.Servers {
 			if server.State == stateFailed {
 				continue
@@ -664,14 +681,12 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 				if relaykey == key {
 					err = server.ChangeMasterTo(cluster.Servers[masterKey], "CURRENT_POS")
 					if err != nil {
-						cluster.StateMachine.RemoveFailoverState()
 						return err
 					}
 
 				} else {
 					err = server.ChangeMasterTo(cluster.Servers[relaykey], "CURRENT_POS")
 					if err != nil {
-						cluster.StateMachine.RemoveFailoverState()
 						return err
 					}
 				}
@@ -683,6 +698,7 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 		}
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Environment bootstrapped with %s as master", cluster.Servers[masterKey].URL)
 	}
+
 	// Multi Master
 	if cluster.Conf.MultiMaster == true {
 		for _, server := range cluster.Servers {
@@ -706,7 +722,6 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 			if key == 0 {
 				err = server.ChangeMasterTo(cluster.Servers[1], "CURRENT_POS")
 				if err != nil {
-					cluster.StateMachine.RemoveFailoverState()
 					return err
 				}
 				if !server.ClusterGroup.IsInIgnoredReadonly(server) {
@@ -716,7 +731,6 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 			if key == 1 {
 				err = server.ChangeMasterTo(cluster.Servers[0], "CURRENT_POS")
 				if err != nil {
-					cluster.StateMachine.RemoveFailoverState()
 					return err
 				}
 			}
@@ -758,7 +772,6 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 			i := (len(cluster.Servers) + key - 1) % len(cluster.Servers)
 			err = server.ChangeMasterTo(cluster.Servers[i], "SLAVE_POS")
 			if err != nil {
-				cluster.StateMachine.RemoveFailoverState()
 				return err
 			}
 
@@ -766,7 +779,7 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 
 		}
 	}
-	cluster.StateMachine.RemoveFailoverState()
+
 	// speed up topology discovery
 	wg.Add(1)
 	cluster.TopologyDiscover(wg)

--- a/cluster/prov.go
+++ b/cluster/prov.go
@@ -530,13 +530,13 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 	var err error
 
 	if cluster.Conf.MultiMasterWsrep {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Galera cluster ignoring replication setup")
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Galera cluster ignoring replication setup")
 		return nil
 	}
 	if clean {
 		err := cluster.BootstrapReplicationCleanup()
 		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cleanup error %s", err)
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Cleanup error %s", err)
 			return err
 		}
 	}
@@ -556,7 +556,7 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 	wg.Wait()
 	if err == nil {
 		newErr := errors.New("Environment already has an existing master/slave setup")
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn, "%s", newErr)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "%s", newErr)
 		return newErr
 	}
 

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -1441,9 +1441,13 @@ func (repman *ReplicationManager) handlerMuxBootstrapReplication(w http.Response
 			return
 		}
 
-		mycluster.BootstrapTopology(vars["topology"])
-		err := mycluster.BootstrapReplication(true)
-		if err != nil {
+		if err := mycluster.BootstrapTopology(vars["topology"]); err != nil {
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "Error bootstraping topology %s", err)
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		if err := mycluster.BootstrapReplication(true); err != nil {
 			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "Error bootstraping replication %s", err)
 			http.Error(w, err.Error(), 500)
 			return


### PR DESCRIPTION
This pull request improves error handling and state management in the cluster replication bootstrap process, making the code more robust and maintainable. The key changes include enhanced logging, better cleanup and failover state handling, and improved error propagation to the API layer.

**Error handling and logging improvements:**
* Added immediate error return and logging when `BootstrapReplicationCleanup` fails, ensuring issues are surfaced early in the process (`cluster/prov.go`).
* When an existing master/slave setup is detected, now logs a warning before returning the error, providing better observability of cluster state issues (`cluster/prov.go`).

**State management and cleanup:**
* Replaced multiple scattered calls to `RemoveFailoverState` with a single deferred call, ensuring the failover state is always cleaned up, even on early returns or errors (`cluster/prov.go`) [[1]](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0L557-R572) [[2]](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0L570-L574) [[3]](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0L667-L674) [[4]](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0L709) [[5]](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0L719) [[6]](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0L761-R782).
* When the `clean` flag is set, the cluster's master, virtual master, and slaves are reset to prevent stale state from affecting the bootstrap process (`cluster/prov.go`).

**API error propagation:**
* Improved error handling in the HTTP handler by logging and returning errors from both `BootstrapTopology` and `BootstrapReplication` to the client, ensuring that failures are clearly communicated and not silently ignored (`server/api_cluster.go`).

**Replication role assignment fixes:**
* Ensured that the master server is always set if not already assigned, and improved logic for determining relay and master keys in multi-tier slave setups (`cluster/prov.go`).

These changes collectively make the cluster bootstrap process more reliable and easier to debug.