### PR TITLE
Refactor SSL mode checks to use IsMySQLOrPerconaSSLMode function

### DIFF
--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -887,7 +887,7 @@ func (server *ServerMonitor) GetSSLClientParam(tool string) []string {
 					sslMode = "VERIFY_CA" // Only verify CA if no SSL mode is set
 				}
 
-				if server.DBVersion.IsMySQLOrPerconaGreater8() && ver.IsMySQLOrPerconaGreater8() { // Use","--ssl-mode
+				if server.DBVersion.IsMySQLOrPerconaSSLMode() && ver.IsMySQLOrPerconaSSLMode() { // Use","--ssl-mode
 					switch sslMode {
 					case "DISABLED":
 						return []string{"--ssl-mode=DISABLED"}
@@ -911,7 +911,7 @@ func (server *ServerMonitor) GetSSLClientParam(tool string) []string {
 					}
 				}
 			} else {
-				if server.DBVersion.IsMySQLOrPerconaGreater8() && ver.IsMySQLOrPerconaGreater8() { // Use","--ssl-mode
+				if server.DBVersion.IsMySQLOrPerconaSSLMode() && ver.IsMySQLOrPerconaSSLMode() { // Use","--ssl-mode
 					if sslMode != "" {
 						return []string{"--ssl-mode=" + sslMode} // No verify server cert
 					} else {

--- a/utils/version/version.go
+++ b/utils/version/version.go
@@ -323,7 +323,7 @@ func (mv *Version) IsMySQLOrPerconaSSLMode() bool {
 		return false
 	}
 
-	return (mv.Flavor == "MySQL" || mv.Flavor == "Percona") && ((mv.Major == 8 && mv.Minor >= 0 && mv.Release >= 26) || (mv.Major > 8))
+	return (mv.Flavor == "MySQL" || mv.Flavor == "Percona") && mv.GreaterEqual("8.0.26")
 }
 
 // IsMariaDBGreater113 checks if the version is MariaDB 11.3 or greater which introduce breaking changes in SSL

--- a/utils/version/version.go
+++ b/utils/version/version.go
@@ -317,6 +317,15 @@ func (mv *Version) IsMySQLOrPerconaGreater8() bool {
 	return (mv.Flavor == "MySQL" || mv.Flavor == "Percona") && (mv.Major >= 8)
 }
 
+// IsMySQLOrPerconaGreater84 checks if the version is MySQL or Percona 8.4 or greater
+func (mv *Version) IsMySQLOrPerconaSSLMode() bool {
+	if mv == nil {
+		return false
+	}
+
+	return (mv.Flavor == "MySQL" || mv.Flavor == "Percona") && ((mv.Major == 8 && mv.Minor >= 0 && mv.Release >= 26) || (mv.Major > 8))
+}
+
 // IsMariaDBGreater113 checks if the version is MariaDB 11.3 or greater which introduce breaking changes in SSL
 func (mv *Version) IsMariaDBGreater113() bool {
 	if mv == nil {


### PR DESCRIPTION
This pull request updates how the code determines when to use the `--ssl-mode` parameter for MySQL and Percona servers, introducing a more precise version check. The main change is the addition of a new helper method to identify MySQL or Percona versions that support the `--ssl-mode` flag, and updating the logic that generates SSL client parameters to use this new check.

**Version handling improvements:**

* Added a new method `IsMySQLOrPerconaSSLMode` to the `Version` struct in `version.go`, which checks if the version is MySQL or Percona 8.0.26 or greater (including all 8.x versions from 8.0.26 and up, and all versions above 8) as these support the `--ssl-mode` parameter.

**SSL client parameter logic:**

* Updated the logic in `ServerMonitor.GetSSLClientParam` in `srv_get.go` to use the new `IsMySQLOrPerconaSSLMode` method instead of the previous `IsMySQLOrPerconaGreater8` check, ensuring the `--ssl-mode` parameter is only used for supported server versions. [[1]](diffhunk://#diff-1f102cb4f0681169e52bd5cbd3b82ade67edf8c28f57cc0d9bb8500e72de97acL890-R890) [[2]](diffhunk://#diff-1f102cb4f0681169e52bd5cbd3b82ade67edf8c28f57cc0d9bb8500e72de97acL914-R914)