### PR TITLE
Enhance BootstrapTopology function to return error for unknown topology

### DIFF
--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -669,7 +669,7 @@ func (cluster *Cluster) CheckSlavesReplicationsPurge() {
 	}
 }
 
-func (cluster *Cluster) BootstrapTopology(topology string) {
+func (cluster *Cluster) BootstrapTopology(topology string) error {
 	switch topology {
 	case "master-slave":
 		cluster.SetMultiMasterRing(false)
@@ -738,9 +738,10 @@ func (cluster *Cluster) BootstrapTopology(topology string) {
 		cluster.SetMultiMasterWsrep(false)
 		cluster.SetMultiMasterGroupRep(true)
 	default:
-		return
+		return errors.New("Unknown topology: " + topology)
 	}
 	cluster.SetTopologyTarget(topology)
+	return nil
 }
 
 func (cluster *Cluster) GetReplicationMasterServerID() uint64 {


### PR DESCRIPTION
This pull request updates the `BootstrapTopology` method in `cluster/cluster_topo.go` to improve error handling and make its interface more robust. The method now returns an error if an unknown topology is provided, rather than silently returning.

Error handling improvements:

* Changed the signature of `BootstrapTopology` to return an `error` instead of `void`, allowing callers to handle failures explicitly.
* Added a return of an error with a descriptive message when an unknown topology is passed, instead of simply returning without feedback.