### PR TITLE
Prevent changing config within topology discovery by using cluster.Topology for all checks

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -568,6 +568,8 @@ func (cluster *Cluster) InitFromConf() {
 	cluster.CheckDefaultUser(true)
 	cluster.SetToolVersions()
 	cluster.StartResticRepo()
+
+	cluster.Conf.TopologyTarget = cluster.GetTopologyFromConf()
 }
 
 func (cluster *Cluster) initOrchetratorNodes() {
@@ -634,7 +636,7 @@ func (cluster *Cluster) Run() {
 	}
 
 	cluster.Lock()
-	cluster.Topology = cluster.GetTopologyFromConf()
+	cluster.Topology = config.TopoUnknown
 	cluster.Unlock()
 
 	for cluster.exit == false {
@@ -725,10 +727,6 @@ func (cluster *Cluster) Run() {
 						if !cluster.CanConnectVault {
 							cluster.SetState("ERR00089", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00089"], cluster.errorConnectVault), ErrFrom: "OPENSVC"})
 						}
-						if cluster.Topology != cluster.Conf.TopologyTarget {
-							cluster.SetState("ERR00092", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00092"], cluster.Name, cluster.Topology, cluster.Conf.TopologyTarget), ErrFrom: "TOPO"})
-						}
-
 						if cluster.StateMachine.GetHeartbeats()%36000 == 0 {
 							// Set in parallel since it will wait for fetch to finish
 							go cluster.ResticPurgeRepo()
@@ -742,8 +740,14 @@ func (cluster *Cluster) Run() {
 						}
 						cluster.PrintDelayStat()
 					}
+
 					wg.Wait()
 				}
+
+				if cluster.HasDiscoverTopologyMismatchTarget() {
+					cluster.SetState("ERR00092", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00092"], cluster.Name, cluster.Topology, cluster.Conf.TopologyTarget), ErrFrom: "TOPO"})
+				}
+
 				// AddChildServers can't be done before TopologyDiscover but need a refresh aquiring more fresh gtid vs current cluster so elelection win but server is ignored see electFailoverCandidate
 				err := cluster.AddChildServers()
 

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -902,41 +902,35 @@ func (cluster *Cluster) GetProxyServerIdList() []string {
 
 func (cluster *Cluster) GetTopologyFromConf() string {
 
-	cluster.Conf.Topology = config.TopoUnknown
+	targetTopology := config.TopoMasterSlave
 	if cluster.Conf.MultiMaster {
-		cluster.Conf.Topology = config.TopoMultiMaster
+		targetTopology = config.TopoMultiMaster
 	} else if cluster.Conf.MultiMasterRing {
-		cluster.Conf.Topology = config.TopoMultiMasterRing
+		targetTopology = config.TopoMultiMasterRing
 	} else if cluster.Conf.MultiMasterWsrep {
-		cluster.Conf.Topology = config.TopoMultiMasterWsrep
+		targetTopology = config.TopoMultiMasterWsrep
 	} else if cluster.Conf.MultiMasterGrouprep {
-		cluster.Conf.Topology = config.TopoMultiMasterGrouprep
+		targetTopology = config.TopoMultiMasterGrouprep
 	} else if cluster.Conf.MxsBinlogOn {
-		cluster.Conf.Topology = config.TopoBinlogServer
+		targetTopology = config.TopoBinlogServer
 	} else if cluster.Conf.MultiTierSlave {
-		cluster.Conf.Topology = config.TopoMultiTierSlave
+		targetTopology = config.TopoMultiTierSlave
 	} else if cluster.Conf.MasterSlavePgStream {
-		cluster.Conf.Topology = config.TopoMasterSlavePgStream
+		targetTopology = config.TopoMasterSlavePgStream
 		cluster.IsPostgres = true
 	} else if cluster.Conf.MasterSlavePgLogical {
-		cluster.Conf.Topology = config.TopoMasterSlavePgLog
+		targetTopology = config.TopoMasterSlavePgLog
 		cluster.IsPostgres = true
 	} else if cluster.Conf.ActivePassive {
-		cluster.Conf.Topology = config.TopoActivePassive
+		targetTopology = config.TopoActivePassive
 	} else {
 		relay := cluster.GetRelayServer()
 		if relay != nil && cluster.Conf.ReplicationNoRelay == false {
-			cluster.Conf.Topology = config.TopoMultiTierSlave
-		} else if cluster.master != nil {
-			cluster.Conf.Topology = config.TopoMasterSlave
+			targetTopology = config.TopoMultiTierSlave
 		}
 	}
 
-	if cluster.Conf.TopologyTarget == "" || cluster.Conf.TopologyTarget == config.TopoUnknown {
-		cluster.SetTopologyTarget(cluster.Conf.Topology)
-	}
-
-	return cluster.Conf.Topology
+	return targetTopology
 }
 
 func (cluster *Cluster) GetTopology() string {

--- a/cluster/cluster_has.go
+++ b/cluster/cluster_has.go
@@ -565,3 +565,15 @@ func (cluster *Cluster) HasWaitSponsorCredCookie() bool {
 	}
 	return false
 }
+
+func (cluster *Cluster) HasDiscoverTopologyMismatchTarget() bool {
+	return cluster.Topology != cluster.Conf.TopologyTarget
+}
+
+func (cluster *Cluster) HasDiscoverTopologyReachTarget() bool {
+	return cluster.Topology == cluster.Conf.TopologyTarget
+}
+
+func (cluster *Cluster) IsTopologyTargetEqual(target string) bool {
+	return cluster.Conf.TopologyTarget == target
+}

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -168,13 +168,10 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 	// if only one server
 	if len(cluster.Servers) == 1 {
 		cluster.Topology = config.TopoActivePassive
-		cluster.Conf.ActivePassive = true
 		for _, sv := range cluster.Servers {
 			cluster.master = sv
 		}
 		return nil
-	} else {
-		cluster.Conf.ActivePassive = false
 	}
 
 	// Check topology Cluster is down
@@ -187,6 +184,8 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 	if cluster.Conf.Spider == true {
 		cluster.SpiderShardsDiscovery()
 	}
+
+	// Reset slaves list
 	cluster.slaves = nil
 	for k, sv := range cluster.Servers {
 		// Failed Do not ignore suspect or topology will change to fast
@@ -206,14 +205,14 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 				cluster.LogSlaveServers = append(cluster.LogSlaveServers, sv.URL)
 			}
 		}
-		// count wsrep node as  slaves
+
+		// if server is a slave or wsrep primary or group replication slave
 		if sv.IsSlave || sv.IsWsrepPrimary || sv.IsGroupReplicationSlave {
-			// if cluster.Conf.LogLevel > 2 {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTopology, config.LvlDbg, "Server %s is configured as a slave", sv.URL)
-			// }
 			cluster.slaves = append(cluster.slaves, sv)
 		} else { // not slave
 			if sv.IsGroupReplicationMaster {
+				// If server is group replication master
 				cluster.master = cluster.Servers[k]
 				cluster.vmaster = cluster.Servers[k]
 				cluster.master.SetMaster()
@@ -222,23 +221,22 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTopology, config.LvlInfo, "Group replication server %s disable read only ", cluster.master.URL)
 				}
 			} else if sv.BinlogDumpThreads == 0 && sv.State != stateMaster {
-				//sv.State = stateUnconn
-				//transition to standalone may happen despite server have never connect successfully when default to suspect
-				// if cluster.Conf.LogLevel > 2 {
+				// No slave and no binlog dump threads
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTopology, config.LvlDbg, "Server %s has no slaves ", sv.URL)
-				// }
 			} else {
+				// Server has binlog dump threads or is master
 				master := cluster.GetMaster()
+
+				// If master-slave topology and server is not the master (split brain)
 				if cluster.IsActive() && master != nil && cluster.GetTopology() == config.TopoMasterSlave && cluster.Servers[k].URL != master.URL {
 					//Extra master in master slave topology rejoin it after split brain
 					cluster.SetState("ERR00063", state.State{ErrType: "ERROR", ErrDesc: fmt.Sprintf(clusterError["ERR00063"]), ErrFrom: "TOPO"})
 					//	cluster.Servers[k].RejoinMaster() /* remove for rolling restart , wrongly rejoin server as master before just after swithover while the server is just stopping */
 				} else {
-					// if cluster.Conf.LogLevel > 2 {
+					// Either no other master or multi-master topology
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTopology, config.LvlInfo, "Server %s was set master as last non slave", sv.URL)
-					// }
 					if len(cluster.Servers) == 1 {
-						cluster.Conf.ActivePassive = true
+						cluster.Topology = config.TopoActivePassive
 					}
 
 					cluster.master = cluster.Servers[k]
@@ -264,15 +262,17 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 		cluster.SetState("ERR00010", state.State{ErrType: "ERROR", ErrDesc: fmt.Sprintf(clusterError["ERR00010"]), ErrFrom: "TOPO"})
 	} else {
 		for k, sv := range cluster.Servers {
-			//Already checked topology once
+			// If there is no master, and all slaves are replicating from the same host, set this host as master
 			if !cluster.runOnceAfterTopology && cluster.GetMaster() == nil && len(cluster.slaves) > 0 && cluster.Conf.TopologyTarget == config.TopoMasterSlave {
 				numSlaves := 0
 				for _, sl := range cluster.slaves {
+					// if the slave is replicating from this server
 					if sl.GetReplicationMasterHost() == sv.Host && sl.GetReplicationMasterPort() == sv.Port {
 						numSlaves++
 					}
 				}
 
+				// If all slaves are replicating from this server, set it as master
 				if numSlaves == len(cluster.slaves) {
 					cluster.master = cluster.Servers[k]
 					cluster.master.SetMaster()
@@ -297,22 +297,18 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 				sl.CheckSlaveSameMasterGrants()
 				if sl.HasCycling() {
 					hasCycling = true
-					if cluster.Conf.MultiMaster == false && len(cluster.Servers) == 2 {
+					if len(cluster.Servers) == 2 {
 						cluster.SetState("ERR00011", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00011"]), ErrFrom: "TOPO", ServerUrl: sl.URL})
-						// if cluster.Conf.DynamicTopology {
-						cluster.Conf.MultiMaster = true
 						cluster.Topology = config.TopoMultiMaster
-						// }
-					}
-					if cluster.Conf.MultiMasterRing == false && len(cluster.Servers) > 2 {
+					} else if len(cluster.Servers) > 2 {
 						// Prevent Multi Master Ring for unsafe environment
-						// if cluster.Conf.DynamicTopology && (len(cluster.LogSlaveServers) > 1 || cluster.Conf.MultiMasterRingUnsafe) {
 						if len(cluster.LogSlaveServers) > 1 || cluster.Conf.MultiMasterRingUnsafe {
-							cluster.Conf.MultiMasterRing = true
+							cluster.Topology = config.TopoMultiMasterRing
 						}
-					}
-					if cluster.Conf.MultiMasterRing == true && cluster.GetMaster() == nil {
-						cluster.vmaster = sl
+
+						if cluster.Conf.MultiMasterRing == true && cluster.GetMaster() == nil {
+							cluster.vmaster = sl
+						}
 					}
 
 					//broken replication ring
@@ -321,8 +317,8 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 					cluster.SetState("ERR00048", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00048"]), ErrFrom: "TOPO"})
 					cluster.master = cluster.GetFailedServer()
 				}
-
 			}
+
 			if cluster.Conf.MultiMaster == false && sl.IsMaxscale == false {
 				if sl.IsSlave == true && sl.HasSlaves(cluster.slaves) == true {
 					if sl.IsRelay == false {
@@ -341,11 +337,11 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 	}
 
 	// If no relay and master-slave is preferred
-	if !hasRelay && !hasCycling && cluster.Conf.TopologyTarget == config.TopoMasterSlave {
-		cluster.BootstrapTopology(config.TopoMasterSlave)
+	if !hasRelay && !hasCycling {
+		cluster.Topology = config.TopoMasterSlave
 	}
 
-	if cluster.Conf.MultiMaster == true || cluster.GetTopology() == config.TopoMultiMasterWsrep || cluster.GetTopology() == config.TopoMultiMasterGrouprep {
+	if cluster.GetTopology() == config.TopoMultiMaster || cluster.GetTopology() == config.TopoMultiMasterWsrep || cluster.GetTopology() == config.TopoMultiMasterGrouprep {
 		srw := 0
 		for _, s := range cluster.Servers {
 			if s.IsReadWrite() {
@@ -354,10 +350,12 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 
 			_, err := s.GetSlaveStatus(s.ReplicationSourceName)
 			if err != nil {
-				cluster.Conf.MultiMaster = false
+				if cluster.Topology == config.TopoMultiMaster {
+					cluster.Topology = config.TopoMasterSlave
+				}
 			}
 		}
-		if srw > 1 && cluster.Conf.MultiMaster {
+		if srw > 1 && cluster.Topology == config.TopoMultiMaster {
 			cluster.SetState("WARN0003", state.State{ErrType: "WARNING", ErrDesc: "RW server count > 1 in multi-master mode. set read_only=1 in cnf is a must have, choosing prefered master", ErrFrom: "TOPO"})
 		}
 		sro := 0
@@ -399,15 +397,14 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 			found := cluster.FindMasterByReplicationServerID(sid)
 
 			// If master is not found and topology is multi-master, find it in the list of servers
-			if found == false && (cluster.Conf.MultiMaster == true || cluster.GetTopology() == config.TopoMultiMasterWsrep || cluster.GetTopology() == config.TopoMultiMasterGrouprep) {
+			if !found && (cluster.Topology == config.TopoMultiMaster || cluster.GetTopology() == config.TopoMultiMasterWsrep || cluster.GetTopology() == config.TopoMultiMasterGrouprep) {
 				for k, s := range cluster.Servers {
 					if s.IsIgnored() {
 						continue
 					}
 
 					if !cluster.Servers[k].IsDown() && s.IsReadWrite() {
-
-						if cluster.Conf.MultiMaster == true {
+						if cluster.Topology == config.TopoMultiMaster {
 							cluster.master = cluster.Servers[k]
 							cluster.master.SetMaster()
 							found = true
@@ -448,9 +445,8 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 			cluster.master.CheckMasterSettings()
 		}
 		// Replication checks
-		if cluster.Conf.MultiMaster == false {
+		if cluster.Topology != config.TopoMultiMaster {
 			for _, sl := range cluster.slaves {
-
 				if sl.IsRelay == false {
 					// if cluster.Conf.LogLevel > 2 {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTopology, config.LvlDbg, "Checking if server %s is a slave of server %s", sl.Host, cluster.master.Host)
@@ -486,9 +482,15 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 
 	}
 
-	// if cluster.Conf.DynamicTopology || cluster.Topology == config.TopoUnknown {
-	cluster.Topology = cluster.GetTopologyFromConf()
-	// }
+	if cluster.Topology == config.TopoUnknown {
+		cluster.Topology = cluster.GetTopologyFromConf()
+	}
+
+	// Check if topology match target and don't allow failover if not matching
+	// This will prevent unwanted failover in case of missconfiguration
+	if cluster.HasDiscoverTopologyMismatchTarget() {
+		cluster.SetState("ERR00092", state.State{ErrType: "ERROR", ErrDesc: fmt.Sprintf(clusterError["ERR00092"], cluster.Name, cluster.Topology, cluster.Conf.TopologyTarget), ErrFrom: "TOPO"})
+	}
 
 	// Remove master or vmaster read only if not in maintenance
 	mst := cluster.GetMaster()
@@ -669,7 +671,7 @@ func (cluster *Cluster) CheckSlavesReplicationsPurge() {
 	}
 }
 
-func (cluster *Cluster) BootstrapTopology(topology string) {
+func (cluster *Cluster) BootstrapTopology(topology string) error {
 	switch topology {
 	case "master-slave":
 		cluster.SetMultiMasterRing(false)
@@ -738,9 +740,10 @@ func (cluster *Cluster) BootstrapTopology(topology string) {
 		cluster.SetMultiMasterWsrep(false)
 		cluster.SetMultiMasterGroupRep(true)
 	default:
-		return
+		return errors.New("Invalid topology type, supported types are: master-slave, master-slave-no-gtid, multi-master, multi-tier-slave, maxscale-binlog, multi-master-ring, multi-master-wsrep, multi-master-grprep")
 	}
 	cluster.SetTopologyTarget(topology)
+	return nil
 }
 
 func (cluster *Cluster) GetReplicationMasterServerID() uint64 {

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -672,7 +672,6 @@ func (cluster *Cluster) CheckSlavesReplicationsPurge() {
 }
 
 func (cluster *Cluster) BootstrapTopology(topology string) error {
-func (cluster *Cluster) BootstrapTopology(topology string) error {
 	switch topology {
 	case "master-slave":
 		cluster.SetMultiMasterRing(false)

--- a/server/server.go
+++ b/server/server.go
@@ -459,13 +459,13 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.BoolVar(&conf.MultiMasterWsrep, "replication-multi-master-wsrep", false, "Enable Galera wsrep multi-master")
 	flags.StringVar(&conf.MultiMasterWsrepSSTMethod, "replication-multi-master-wsrep-sst-method", "mariabackup", "mariabackup|xtrabackup-v2|rsync|mysqldump")
 	flags.IntVar(&conf.MultiMasterWsrepPort, "replication-multi-master-wsrep-port", 4567, "wsrep network port")
-	flags.StringVar(&conf.TopologyTarget, "topology-target", "", "Target topology for current cluster. Default 'master-slave'")
+	flags.StringVar(&conf.TopologyTarget, "topology-target", "master-slave", "Target topology for current cluster. Default 'master-slave'")
 	flags.BoolVar(&conf.DynamicTopology, "replication-dynamic-topology", true, "Auto discover topology when changed") //Set to true to keep same behavior
 	flags.BoolVar(&conf.MultiMasterRing, "replication-multi-master-ring", false, "Multi-master ring topology")
 	flags.BoolVar(&conf.MultiMasterRingUnsafe, "replication-multi-master-ring-unsafe", true, "Allow multi-master ring topology without log slave updates") //Set to true to keep same behavior
 	flags.BoolVar(&conf.MultiTierSlave, "replication-multi-tier-slave", false, "Relay slaves topology")
 	flags.BoolVar(&conf.MasterSlavePgStream, "replication-master-slave-pg-stream", false, "Postgres streaming replication")
-	flags.BoolVar(&conf.MasterSlavePgLogical, "replication-master-slave-pg-locgical", false, "Postgres logical replication")
+	flags.BoolVar(&conf.MasterSlavePgLogical, "replication-master-slave-pg-logical", false, "Postgres logical replication")
 	flags.BoolVar(&conf.ReplicationNoRelay, "replication-master-slave-never-relay", true, "Do not allow relay server MSS MXS XXM RSM")
 	flags.StringVar(&conf.ReplicationErrorScript, "replication-error-script", "", "Replication error script")
 	flags.StringVar(&conf.ReplicationRestartOnSQLErrorMatch, "replication-restart-on-sqlerror-match", "", "Auto restart replication on SQL Error regexep")


### PR DESCRIPTION
This pull request refactors and improves the cluster topology detection and management logic. The main focus is to decouple configuration flags from runtime topology state, ensure consistent handling of topology targets, and improve error reporting when the detected topology does not match the expected target. Several helper methods are introduced for clarity, and the code now defaults to a "master-slave" topology target if not specified.

**Topology detection and configuration improvements:**

* `GetTopologyFromConf` now determines the target topology based on configuration flags and returns it, instead of mutating configuration state. The default topology target is set to "master-slave" if not specified. [[1]](diffhunk://#diff-ebe18c11af755e19a8493b229fe8b73799087472ad6bc067ea4e2b69df70b6f7L905-R933) [[2]](diffhunk://#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4L462-R468)
* The cluster's `InitFromConf` method now sets `TopologyTarget` using the result of `GetTopologyFromConf`, ensuring the target is always initialized from configuration.
* In the cluster's `Run` method, the runtime `Topology` is explicitly set to `TopoUnknown` at start, decoupling it from the configuration-derived target.

**Topology mismatch detection and error handling:**

* Introduced new helper methods: `HasDiscoverTopologyMismatchTarget`, `HasDiscoverTopologyReachTarget`, and `IsTopologyTargetEqual` for clearer checks on topology state.
* The system now consistently checks for mismatches between discovered and target topology in both the main loop and after topology discovery, setting an error state if a mismatch is found. [[1]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R743-R750) [[2]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2L489-R493)

**Refactoring of topology discovery logic:**

* Topology detection logic in `TopologyDiscover` is refactored to use runtime state (e.g., `cluster.Topology`) instead of configuration flags (e.g., `cluster.Conf.MultiMaster`), improving clarity and correctness. [[1]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2L209-R215) [[2]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2L300-R321) [[3]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2L344-R344) [[4]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2L357-R358) [[5]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2L402-R407) [[6]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2L451-L453)
* The code now avoids mutating configuration flags during discovery, focusing on updating runtime state only. [[1]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2L225-R239) [[2]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2L300-R321)

**Other improvements and fixes:**

* Improved error message for invalid topology types in `BootstrapTopology`.
* Fixed a typo in the configuration flag for Postgres logical replication.
* Minor code comments and log message clarifications to make the code easier to follow. [[1]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2R187-R188) [[2]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2L267-R275)

These changes make the topology management more robust, predictable, and easier to maintain.