### PR TITLE
Remove master assignment in BootstrapReplication function

### DIFF
--- a/cluster/prov.go
+++ b/cluster/prov.go
@@ -635,11 +635,6 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 					server.SetReadOnly()
 				}
 			}
-
-		}
-		if cluster.master == nil {
-			cluster.master = cluster.Servers[masterKey]
-			cluster.master.SetMaster()
 		}
 	}
 


### PR DESCRIPTION
Remove master assignment in bootstrap replication and let the topology discover the master