### PR TITLE
Enhance BootstrapReplication to consider previous master when determining preferred master

### DIFF
--- a/cluster/prov.go
+++ b/cluster/prov.go
@@ -528,6 +528,7 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 
 	// default to master slave
 	var err error
+	oldMaster := cluster.GetMaster()
 
 	if cluster.Conf.MultiMasterWsrep {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Galera cluster ignoring replication setup")
@@ -570,21 +571,30 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 		cluster.slaves = nil
 	}
 
-	masterKey := 0
-	if cluster.Conf.PrefMaster != "" {
-		masterKey = func() int {
-			for k, server := range cluster.Servers {
-				// Skip child cluster
-				if server.SourceClusterName != cluster.Name {
-					continue
+	masterKey := func() int {
+		for k, server := range cluster.Servers {
+			// Skip child cluster
+			if server.SourceClusterName != cluster.Name {
+				continue
+			}
+			if oldMaster != nil {
+				if server.URL == oldMaster.URL {
+					return k
 				}
+			} else if cluster.Conf.PrefMaster != "" {
 				if server.IsPrefered() {
 					return k
 				}
 			}
+		}
+
+		if cluster.Conf.PrefMaster != "" {
 			return -1
-		}()
-	}
+		}
+
+		return 0 // default to first node
+	}()
+
 	if masterKey == -1 {
 		return errors.New("Preferred master could not be found in existing servers")
 	}


### PR DESCRIPTION
This pull request refactors the logic for selecting the master server during replication bootstrap in the `Cluster` struct. The main improvement is to prioritize retaining the previous master if possible, and to simplify the selection logic for the preferred master.

Master server selection logic improvements:

* Refactored the master selection logic in `BootstrapReplication` to first attempt to keep the old master (`oldMaster`) as the new master if it still exists; otherwise, it falls back to the preferred master or defaults to the first node. This improves cluster stability by avoiding unnecessary master switches. [[1]](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0R531) [[2]](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0L573-R597)