### PR TITLE
Fix the stalled discovery by wrapping the bootstrap process to a function

### DIFF
--- a/cluster/prov.go
+++ b/cluster/prov.go
@@ -561,14 +561,31 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 		return newErr
 	}
 
+	err = cluster.BoostrapProcess(clean, oldMaster)
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "BoostrapProcess error %s", err)
+		return err
+	}
+
+	// speed up topology discovery
+	wg.Add(1)
+	cluster.TopologyDiscover(wg)
+	wg.Wait()
+
+	//bootstrapChan <- true
+	return nil
+}
+
+func (cluster *Cluster) BoostrapProcess(clean bool, oldMaster *ServerMonitor) error {
 	cluster.StateMachine.SetFailoverState()
 	defer cluster.StateMachine.RemoveFailoverState()
 
+	var err error
+	// reset cluster state
 	if clean {
 		// Remove old master if any
 		cluster.master = nil
 		cluster.vmaster = nil
-		cluster.slaves = nil
 	}
 
 	masterKey := func() int {
@@ -785,12 +802,6 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 		}
 	}
 
-	// speed up topology discovery
-	wg.Add(1)
-	cluster.TopologyDiscover(wg)
-	wg.Wait()
-
-	//bootstrapChan <- true
 	return nil
 }
 


### PR DESCRIPTION
Fix the stalled discovery from 07d4925276eff138ff912f1c26ce8b2fead793b9
This pull request refactors the cluster bootstrapping logic to improve modularity and maintainability. The main change is the extraction of the replication bootstrapping process into a new `BoostrapProcess` method, which helps separate concerns and simplifies the main `BootstrapReplication` method.

Refactoring and modularization:

* Extracted the core replication bootstrapping logic from `BootstrapReplication` into a new method `BoostrapProcess`, improving code organization and reusability. (`cluster/prov.go`, [cluster/prov.goR564-L571](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0R564-L571))
* Updated `BootstrapReplication` to call the new `BoostrapProcess` method and handle its errors appropriately, with improved error logging. (`cluster/prov.go`, [cluster/prov.goR564-L571](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0R564-L571))

Code cleanup:

* Removed redundant code in `BootstrapReplication` related to topology discovery and commented-out channel signaling, as these are now handled more cleanly after the refactor. (`cluster/prov.go`, [cluster/prov.goL788-L793](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0L788-L793))