### PR TITLE
Fix BootstrapReplicationCleanup to ensure failover state is removed after failed cleanup to prevent stalled topology

### DIFF
--- a/cluster/prov.go
+++ b/cluster/prov.go
@@ -471,6 +471,7 @@ func (cluster *Cluster) BootstrapReplicationCleanup() error {
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Cleaning up replication on existing servers")
 	cluster.StateMachine.SetFailoverState()
+	defer cluster.StateMachine.RemoveFailoverState()
 	for _, server := range cluster.Servers {
 		err := server.Refresh()
 		if err != nil {
@@ -520,7 +521,6 @@ func (cluster *Cluster) BootstrapReplicationCleanup() error {
 	cluster.master = nil
 	cluster.vmaster = nil
 	cluster.slaves = nil
-	cluster.StateMachine.RemoveFailoverState()
 	return nil
 }
 


### PR DESCRIPTION
This pull request makes a small but important change to the replication cleanup process in the `Cluster` implementation. The main improvement ensures that the failover state is always cleaned up, even if an error occurs during the cleanup steps.

- Reliability improvement:
  * Added a `defer` statement to call `RemoveFailoverState()` at the beginning of `BootstrapReplicationCleanup`, ensuring the failover state is always removed regardless of whether an error is encountered. [[1]](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0R474) [[2]](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0L523)