### PR TITLE
revert the defer for the replication bootstrap to prevent deadlock

### DIFF
--- a/cluster/prov.go
+++ b/cluster/prov.go
@@ -471,11 +471,11 @@ func (cluster *Cluster) BootstrapReplicationCleanup() error {
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Cleaning up replication on existing servers")
 	cluster.StateMachine.SetFailoverState()
-	defer cluster.StateMachine.RemoveFailoverState()
 	for _, server := range cluster.Servers {
 		err := server.Refresh()
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Refresh failed in Cleanup on server %s %s", server.URL, err)
+			cluster.StateMachine.RemoveFailoverState()
 			return err
 		}
 		if cluster.Conf.Verbose {
@@ -521,6 +521,7 @@ func (cluster *Cluster) BootstrapReplicationCleanup() error {
 	cluster.master = nil
 	cluster.vmaster = nil
 	cluster.slaves = nil
+	cluster.StateMachine.RemoveFailoverState()
 	return nil
 }
 
@@ -531,14 +532,13 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 	oldMaster := cluster.GetMaster()
 
 	if cluster.Conf.MultiMasterWsrep {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Galera cluster ignoring replication setup")
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Galera cluster ignoring replication setup")
 		return nil
 	}
 	if clean {
 		err := cluster.BootstrapReplicationCleanup()
 		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Cleanup error %s", err)
-			return err
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cleanup error %s", err)
 		}
 	}
 	for _, server := range cluster.Servers {
@@ -556,60 +556,36 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 	err = cluster.TopologyDiscover(wg)
 	wg.Wait()
 	if err == nil {
-		newErr := errors.New("Environment already has an existing master/slave setup")
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "%s", newErr)
-		return newErr
+		return errors.New("Environment already has an existing master/slave setup")
 	}
 
-	err = cluster.BoostrapProcess(clean, oldMaster)
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "BoostrapProcess error %s", err)
-		return err
-	}
-
-	// speed up topology discovery
-	wg.Add(1)
-	cluster.TopologyDiscover(wg)
-	wg.Wait()
-
-	//bootstrapChan <- true
-	return nil
-}
-
-func (cluster *Cluster) BoostrapProcess(clean bool, oldMaster *ServerMonitor) error {
 	cluster.StateMachine.SetFailoverState()
-	defer cluster.StateMachine.RemoveFailoverState()
+	masterKey := 0
 
-	var err error
-	// reset cluster state
-	if clean {
-		// Remove old master if any
-		cluster.master = nil
-		cluster.vmaster = nil
-	}
-
-	masterKey := func() int {
+	masterKey = func() int {
 		for k, server := range cluster.Servers {
 			// Skip child cluster
 			if server.SourceClusterName != cluster.Name {
 				continue
 			}
 			if oldMaster != nil {
-				if server.URL == oldMaster.URL {
+				if server == oldMaster {
+					cluster.StateMachine.RemoveFailoverState()
 					return k
 				}
 			} else if cluster.Conf.PrefMaster != "" {
 				if server.IsPrefered() {
+					cluster.StateMachine.RemoveFailoverState()
 					return k
 				}
 			}
 		}
-
+		cluster.StateMachine.RemoveFailoverState()
 		if cluster.Conf.PrefMaster != "" {
 			return -1
 		}
 
-		return 0 // default to first node
+		return 0
 	}()
 
 	if masterKey == -1 {
@@ -662,9 +638,9 @@ func (cluster *Cluster) BoostrapProcess(clean bool, oldMaster *ServerMonitor) er
 					server.SetReadOnly()
 				}
 			}
+
 		}
 	}
-
 	// Slave Relay
 	if cluster.Conf.MultiTierSlave == true {
 		relaykey := 1
@@ -703,12 +679,14 @@ func (cluster *Cluster) BoostrapProcess(clean bool, oldMaster *ServerMonitor) er
 				if relaykey == key {
 					err = server.ChangeMasterTo(cluster.Servers[masterKey], "CURRENT_POS")
 					if err != nil {
+						cluster.StateMachine.RemoveFailoverState()
 						return err
 					}
 
 				} else {
 					err = server.ChangeMasterTo(cluster.Servers[relaykey], "CURRENT_POS")
 					if err != nil {
+						cluster.StateMachine.RemoveFailoverState()
 						return err
 					}
 				}
@@ -720,7 +698,6 @@ func (cluster *Cluster) BoostrapProcess(clean bool, oldMaster *ServerMonitor) er
 		}
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Environment bootstrapped with %s as master", cluster.Servers[masterKey].URL)
 	}
-
 	// Multi Master
 	if cluster.Conf.MultiMaster == true {
 		for _, server := range cluster.Servers {
@@ -744,6 +721,7 @@ func (cluster *Cluster) BoostrapProcess(clean bool, oldMaster *ServerMonitor) er
 			if key == 0 {
 				err = server.ChangeMasterTo(cluster.Servers[1], "CURRENT_POS")
 				if err != nil {
+					cluster.StateMachine.RemoveFailoverState()
 					return err
 				}
 				if !server.ClusterGroup.IsInIgnoredReadonly(server) {
@@ -753,6 +731,7 @@ func (cluster *Cluster) BoostrapProcess(clean bool, oldMaster *ServerMonitor) er
 			if key == 1 {
 				err = server.ChangeMasterTo(cluster.Servers[0], "CURRENT_POS")
 				if err != nil {
+					cluster.StateMachine.RemoveFailoverState()
 					return err
 				}
 			}
@@ -794,6 +773,7 @@ func (cluster *Cluster) BoostrapProcess(clean bool, oldMaster *ServerMonitor) er
 			i := (len(cluster.Servers) + key - 1) % len(cluster.Servers)
 			err = server.ChangeMasterTo(cluster.Servers[i], "SLAVE_POS")
 			if err != nil {
+				cluster.StateMachine.RemoveFailoverState()
 				return err
 			}
 
@@ -801,7 +781,13 @@ func (cluster *Cluster) BoostrapProcess(clean bool, oldMaster *ServerMonitor) er
 
 		}
 	}
+	cluster.StateMachine.RemoveFailoverState()
+	// speed up topology discovery
+	wg.Add(1)
+	cluster.TopologyDiscover(wg)
+	wg.Wait()
 
+	//bootstrapChan <- true
 	return nil
 }
 


### PR DESCRIPTION
revert the defer of cluster.StateMachine.RemoveFailoverState() to prevent stalled topology