### PR TITLE
Fix RESTIC_CACHE_DIR environment variable assignment to use os.Getenv for HOME

### DIFF
--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -22,7 +22,7 @@ import (
 
 func (cluster *Cluster) ResticGetEnv() []string {
 	newEnv := append(os.Environ(), "RESTIC_PASSWORD="+cluster.Conf.GetDecryptedValue("backup-restic-password"))
-	newEnv = append(newEnv, "RESTIC_CACHE_DIR=$HOME/.cache/restic")
+	newEnv = append(newEnv, "RESTIC_CACHE_DIR="+os.Getenv("HOME")+"/.cache/restic")
 
 	if cluster.Conf.BackupResticAws {
 		newEnv = append(newEnv, "AWS_ACCESS_KEY_ID="+cluster.Conf.BackupResticAwsAccessKeyId)


### PR DESCRIPTION
Fix RESTIC_CACHE_DIR environment variable assignment to use os.Getenv for HOME