### PR TITLE
Skip adding Default cluster to cluster list to prevent stalled loop

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1530,6 +1530,9 @@ func (repman *ReplicationManager) InitConfig(conf config.Config, init_git bool) 
 	//add config from cluster to the config map
 	for _, cl := range repman.ClusterList {
 		//vipersave := backupvipersave
+		if len(repman.ClusterList) > 1 && cl == "Default" {
+			continue
+		}
 		confs[cl] = repman.GetClusterConfig(fistRead, ImmuableMap, DynamicMap, cl, conf)
 		cfgGroupIndex++
 	}


### PR DESCRIPTION
This pull request introduces a minor improvement to the cluster configuration initialization logic in the `ReplicationManager`. Specifically, it ensures that when there are multiple clusters, the default cluster (`"Default"`) is skipped during configuration setup. This helps prevent unnecessary or redundant configuration loading for the default cluster in multi-cluster environments.

* Skip adding configuration for the `"Default"` cluster when there are multiple clusters in `ReplicationManager.InitConfig` (`server/server.go`).