### PR TITLE
Set default port to 3306 for db and default monitor type when not specified in handlerMuxServerAdd

### DIFF
--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -4453,6 +4453,9 @@ func (repman *ReplicationManager) handlerMuxServerAdd(w http.ResponseWriter, r *
 		tag = vars["tag"]
 
 		if srvtype == "" {
+			if port == "0" || port == "" {
+				port = "3306"
+			}
 			err = mycluster.AddSeededServer(host + ":" + port)
 		} else if srvtype == "app" {
 			// Add app monitor
@@ -4543,6 +4546,10 @@ func (repman *ReplicationManager) handlerMuxServerAdd(w http.ResponseWriter, r *
 						mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Repository image with tag %s not found for database %s. Changing to the latest tag.", tag, srvtype)
 						repoimg = repopath + ":latest"
 					}
+				}
+
+				if port == "0" || port == "" {
+					port = "3306"
 				}
 
 				// update image


### PR DESCRIPTION
This pull request makes improvements to the server addition logic in the cluster API handler by ensuring that a default port value is set when none is provided. This change helps prevent issues when adding servers with missing or zero port values.

Improvements to server addition logic:

* When adding a seeded server, the code now sets the port to `"3306"` if the provided port is `"0"` or empty, ensuring a valid default is used. (`server/api_cluster.go`, [server/api_cluster.goR4456-R4458](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afR4456-R4458))
* Similarly, when adding a database monitor server, the port is set to `"3306"` if it is `"0"` or empty, standardizing the default port behavior. (`server/api_cluster.go`, [server/api_cluster.goR4551-R4554](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afR4551-R4554))