### PR TITLE
Add apps grant for sponsors

### DIFF
--- a/cluster/cluster_acl.go
+++ b/cluster/cluster_acl.go
@@ -709,7 +709,7 @@ func (cluster *Cluster) IsURLPassACL(strUser string, URL string, errorPrint bool
 			return true
 		}
 	}
-	if cluster.APIUsers[strUser].Grants[config.GrantClusterCreateMonitor] {
+	if cluster.APIUsers[strUser].Grants[config.GrantClusterCreateMonitor] || cluster.APIUsers[strUser].Grants[config.GrantAppDeployment] {
 		if strings.Contains(URL, "/api/clusters/"+cluster.Name+"/actions/addserver") {
 			return true
 		}

--- a/cluster/cluster_acl.go
+++ b/cluster/cluster_acl.go
@@ -1010,6 +1010,9 @@ func (cluster *Cluster) IsURLPassAppsACL(strUser string, URL string) bool {
 		if strings.Contains(URL, "/actions/unprovision") {
 			return true
 		}
+		if strings.Contains(URL, "/actions/drop") {
+			return true
+		}
 	}
 	if cluster.APIUsers[strUser].Grants[config.GrantAppDeployment] {
 		if strings.Contains(URL, "/deployment/") {

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -59,6 +59,10 @@ func (repman *ReplicationManager) apiAppProtectedHandler(router *mux.Router) {
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxDropDeploymentFieldRow)),
 	))
+	router.Handle("/api/cluster/{clusterName}/apps/{appName}/actions/drop", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxAppDropByName)),
+	))
 	router.Handle("/api/clusters/{clusterName}/apps/{appName}/actions/unprovision", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxAppUnprovision)),
@@ -2114,4 +2118,50 @@ func (repman *ReplicationManager) handlerMuxAppGetTemplateFromRepo(w http.Respon
 		http.Error(w, "No cluster", 500)
 		return
 	}
+}
+
+// @Summary Drop App Monitor
+// @Description Drops the monitoring configuration for a specific app in a cluster.
+// @Tags Apps
+// @Accept json
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Param appId path string true "App ID"
+// @Success 200 {string} string "App monitor dropped successfully"
+// @Failure 403 {string} string "No valid ACL"
+// @Failure 500 {string} string "No app found with the provided app ID" or "Cluster Not Found"
+// @Router /api/clusters/{clusterName}/apps/{appName}/actions/drop [post]
+func (repman *ReplicationManager) handlerMuxAppDropByName(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster != nil {
+		if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+			http.Error(w, "No valid ACL", 403)
+			return
+		}
+
+		if vars["appName"] == "" {
+			http.Error(w, "No app ID provided", 400)
+			return
+		}
+
+		node := mycluster.GetAppFromName(vars["appName"])
+		if node == nil {
+			http.Error(w, "No server found with name "+vars["serverName"], 400)
+			return
+		}
+
+		mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Rest API receive drop app monitor %s", node.Name)
+		err := mycluster.RemoveAppMonitor(node.Host, node.Port)
+		if err != nil {
+			http.Error(w, "Error dropping app monitor: "+err.Error(), 500)
+			return
+		}
+	} else {
+		http.Error(w, "Cluster Not Found", 500)
+		return
+	}
+
 }

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppMenu.jsx
@@ -2,7 +2,7 @@ import { useDispatch } from 'react-redux'
 import MenuOptions from '../../../../components/MenuOptions'
 import ConfirmModal from '../../../../components/Modals/ConfirmModal'
 import { useState, useEffect } from 'react'
-import { dropServer, provisionApp, startApp, stopApp, unprovisionApp } from '../../../../redux/clusterSlice'
+import { dropAppByName, provisionApp, startApp, stopApp, unprovisionApp } from '../../../../redux/clusterSlice'
 import { useNavigate } from 'react-router-dom'
 
 function AppMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView', user }) {
@@ -91,7 +91,7 @@ function AppMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView',
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm removing monitor for ${appName}?`)
-                  setConfirmHandler(() => () => dispatch(dropServer({ clusterName, host: row.host, port: row.port, type: 'app' })))
+                  setConfirmHandler(() => () => dispatch(dropAppByName({ clusterName, appId: row.id })))
                 }
               },
             ]

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -288,6 +288,21 @@ export const dropServerByName = createAsyncThunk(
   }
 )
 
+export const dropAppByName = createAsyncThunk(
+  'cluster/dropAppByName',
+  async ({ clusterName, appId }, thunkAPI) => {
+    try {
+      const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+      const { data, status } = await clusterService.dropAppByName(clusterName, appId, baseURL)
+      showSuccessBanner('New app dropped!', status, thunkAPI)
+      return { data, status }
+    } catch (error) {
+      showErrorBanner('Error while dropping a new app', error, thunkAPI)
+      handleError(error, thunkAPI)
+    }
+  }
+)
+
 export const provisionCluster = createAsyncThunk('cluster/provisionCluster', async ({ clusterName }, thunkAPI) => {
   try {
     const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
@@ -1880,6 +1895,7 @@ export const clusterSlice = createSlice({
         resetSLA.pending,
         addServer.pending,
         dropServer.pending,
+        dropAppByName.pending,
         toggleTraffic.pending,
         toggleTrafficStaging.pending,
         provisionCluster.pending,
@@ -1951,6 +1967,7 @@ export const clusterSlice = createSlice({
         resetSLA.fulfilled,
         addServer.fulfilled,
         dropServer.fulfilled,
+        dropAppByName.fulfilled,
         toggleTrafficStaging.fulfilled,
         provisionCluster.fulfilled,
         unProvisionCluster.fulfilled,
@@ -2021,6 +2038,7 @@ export const clusterSlice = createSlice({
         resetSLA.rejected,
         addServer.rejected,
         dropServer.rejected,
+        dropAppByName.rejected,
         toggleTraffic.rejected,
         toggleTrafficStaging.rejected,
         provisionCluster.rejected,

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -119,6 +119,8 @@ export const clusterService = {
 
   addClusterShard,
 
+  // App management APIs
+  dropAppByName,
   getClusterApps,
   provisionApp,
   unprovisionApp,
@@ -221,7 +223,7 @@ function toggleTrafficStaging(clusterName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/settings/actions/switch/database-heartbeat-staging`)
 }
 
-function addServer(clusterName, host, port, monitorType, tag,  dockerRegistry = {}, baseURL) {
+function addServer(clusterName, host, port, monitorType, tag, dockerRegistry = {}, baseURL) {
   if (monitorType === 'app') {
     return getApi(baseURL).post(`clusters/${clusterName}/actions/addserver/${host}/${port}/${monitorType}/${tag}`, { ...dockerRegistry })
   } else if (!monitorType) {
@@ -242,6 +244,10 @@ function dropServer(clusterName, host, port, type, baseURL) {
 
 function dropServerByName(clusterName, serverName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/actions/dropserver/${serverName}`)
+}
+
+function dropAppByName(clusterName, appId, baseURL) {
+  return getApi(baseURL).get(`clusters/${clusterName}/apps/${appId}/actions/drop`)
 }
 
 function provisionCluster(clusterName, baseURL) {
@@ -601,7 +607,7 @@ function getAppService(clusterName, serviceName, appId, baseURL) {
 }
 
 function resolveTemplateVariables(clusterName, appId, rawValue, baseURL) {
-  return getApi(baseURL).post(`clusters/${clusterName}/apps/${appId}/resolve-template`, {data: rawValue})
+  return getApi(baseURL).post(`clusters/${clusterName}/apps/${appId}/resolve-template`, { data: rawValue })
 }
 
 function addDeployment(clusterName, appId, deployment, baseURL) {


### PR DESCRIPTION
This pull request introduces a new feature to allow dropping (removing) app monitors from clusters via both backend API and frontend UI. The changes span backend access control, API endpoints, and frontend Redux and service integration to support this operation.

**Backend API and Access Control**

* Added a new backend API endpoint `POST /api/clusters/{clusterName}/apps/{appName}/actions/drop` to remove an app monitor, including implementation and OpenAPI documentation.
* Updated cluster ACL logic to allow users with either `GrantClusterCreateMonitor` or `GrantAppDeployment` permissions to access the new drop app monitor endpoint.
* Extended the ACL check for app actions to permit `/actions/drop` for users with monitor privileges.

**Frontend Integration**

* Added a new Redux thunk `dropAppByName` and corresponding service method to call the backend API for dropping app monitors. [[1]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R291-R305) [[2]](diffhunk://#diff-7bbc99751675465360b02f80d806f62b29109dd0a66e704ac6e8b47a480693fbR249-R252)
* Updated the app menu UI to use the new `dropAppByName` action, replacing the previous server drop logic for apps. [[1]](diffhunk://#diff-fff90a811cec8dd5ad15b43391c4a4a1367b381419d3e07b79f44f31c693bda8L5-R5) [[2]](diffhunk://#diff-fff90a811cec8dd5ad15b43391c4a4a1367b381419d3e07b79f44f31c693bda8L94-R94)
* Integrated `dropAppByName` into the Redux slice for pending, fulfilled, and rejected states. [[1]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1898) [[2]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1970) [[3]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R2041)
* Registered the new service method in the cluster service API object.