### PR TITLE
Replaced hardcoded grant list in `AcceptSubscription` with a call to `config.GetDefaultGrants(config.RoleSponsor)`

### DIFF
--- a/server/server_cloud.go
+++ b/server/server_cloud.go
@@ -31,7 +31,7 @@ func (repman *ReplicationManager) AcceptSubscription(userform cluster.UserForm, 
 		return fmt.Errorf("User %s does not have 'pending' role", user)
 	}
 
-	grants := strings.Split("db show proxy grant extrole sales-unsubscribe", " ")
+	grants := strings.Split(config.GetDefaultGrants(config.RoleSponsor), " ")
 	roles := strings.Split("sponsor", " ")
 	for grant, v := range auser.Grants {
 		if v {


### PR DESCRIPTION
This pull request updates the default grants assigned to a sponsor during subscription acceptance in `server/server_cloud.go`. Instead of hardcoding the grants, it now uses the `config.GetDefaultGrants` function to dynamically fetch the appropriate grants for the sponsor role.

Configuration improvements:

* Replaced hardcoded grant list in `AcceptSubscription` with a call to `config.GetDefaultGrants(config.RoleSponsor)`, ensuring grants are consistent with configuration and easier to maintain.