### PR TITLE
Fix app monitor removal handler to use correct appId

### DIFF
--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppMenu.jsx
@@ -91,7 +91,7 @@ function AppMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView',
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm removing monitor for ${appName}?`)
-                  setConfirmHandler(() => () => dispatch(dropAppByName({ clusterName, appId: row.id })))
+                  setConfirmHandler(() => () => dispatch(dropAppByName({ clusterName, appId: row.appId })))
                 }
               },
             ]


### PR DESCRIPTION
Fix app monitor removal handler to use correct appId