### PR TITLE
Refactor app drop functionality to use host and port instead of app ID

### DIFF
--- a/server/api_app.go
+++ b/server/api_app.go
@@ -59,10 +59,6 @@ func (repman *ReplicationManager) apiAppProtectedHandler(router *mux.Router) {
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxDropDeploymentFieldRow)),
 	))
-	router.Handle("/api/cluster/{clusterName}/apps/{appName}/actions/drop", negroni.New(
-		negroni.HandlerFunc(repman.validateTokenMiddleware),
-		negroni.Wrap(http.HandlerFunc(repman.handlerMuxAppDropByName)),
-	))
 	router.Handle("/api/clusters/{clusterName}/apps/{appName}/actions/unprovision", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxAppUnprovision)),
@@ -142,6 +138,10 @@ func (repman *ReplicationManager) apiAppProtectedHandler(router *mux.Router) {
 	router.Handle("/api/clusters/{clusterName}/apps/{appId}/git/{gitName}/actions/get-repo-tree", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxGitRepoTree)),
+	))
+	router.Handle("/api/cluster/{clusterName}/apps/{appHost}/{appPort}/actions/drop", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxAppDropByName)),
 	))
 }
 
@@ -2131,7 +2131,7 @@ func (repman *ReplicationManager) handlerMuxAppGetTemplateFromRepo(w http.Respon
 // @Success 200 {string} string "App monitor dropped successfully"
 // @Failure 403 {string} string "No valid ACL"
 // @Failure 500 {string} string "No app found with the provided app ID" or "Cluster Not Found"
-// @Router /api/clusters/{clusterName}/apps/{appName}/actions/drop [post]
+// @Router /api/clusters/{clusterName}/apps/{appHost}/{appPort}/actions/drop [post]
 func (repman *ReplicationManager) handlerMuxAppDropByName(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	vars := mux.Vars(r)
@@ -2142,19 +2142,13 @@ func (repman *ReplicationManager) handlerMuxAppDropByName(w http.ResponseWriter,
 			return
 		}
 
-		if vars["appName"] == "" {
-			http.Error(w, "No app ID provided", 400)
+		if vars["appHost"] == "" || vars["appPort"] == "" {
+			http.Error(w, "No app host or port provided", 400)
 			return
 		}
 
-		node := mycluster.GetAppFromName(vars["appName"])
-		if node == nil {
-			http.Error(w, "No server found with name "+vars["serverName"], 400)
-			return
-		}
-
-		mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Rest API receive drop app monitor %s", node.Name)
-		err := mycluster.RemoveAppMonitor(node.Host, node.Port)
+		mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Rest API receive drop app monitor for %s:%s", vars["appHost"], vars["appPort"])
+		err := mycluster.RemoveAppMonitor(vars["appHost"], vars["appPort"])
 		if err != nil {
 			http.Error(w, "Error dropping app monitor: "+err.Error(), 500)
 			return

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppMenu.jsx
@@ -2,7 +2,7 @@ import { useDispatch } from 'react-redux'
 import MenuOptions from '../../../../components/MenuOptions'
 import ConfirmModal from '../../../../components/Modals/ConfirmModal'
 import { useState, useEffect } from 'react'
-import { dropAppByName, provisionApp, startApp, stopApp, unprovisionApp } from '../../../../redux/clusterSlice'
+import { dropApp, provisionApp, startApp, stopApp, unprovisionApp } from '../../../../redux/clusterSlice'
 import { useNavigate } from 'react-router-dom'
 
 function AppMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView', user }) {
@@ -91,7 +91,7 @@ function AppMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView',
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm removing monitor for ${appName}?`)
-                  setConfirmHandler(() => () => dispatch(dropAppByName({ clusterName, appId: row.appId })))
+                  setConfirmHandler(() => () => dispatch(dropApp({ clusterName, host: row.server, port: row.port })))
                 }
               },
             ]

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -288,12 +288,12 @@ export const dropServerByName = createAsyncThunk(
   }
 )
 
-export const dropAppByName = createAsyncThunk(
-  'cluster/dropAppByName',
-  async ({ clusterName, appId }, thunkAPI) => {
+export const dropApp = createAsyncThunk(
+  'cluster/dropApp',
+  async ({ clusterName, host, port }, thunkAPI) => {
     try {
       const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
-      const { data, status } = await clusterService.dropAppByName(clusterName, appId, baseURL)
+      const { data, status } = await clusterService.dropApp(clusterName, host, port, baseURL)
       showSuccessBanner('New app dropped!', status, thunkAPI)
       return { data, status }
     } catch (error) {
@@ -1895,7 +1895,7 @@ export const clusterSlice = createSlice({
         resetSLA.pending,
         addServer.pending,
         dropServer.pending,
-        dropAppByName.pending,
+        dropApp.pending,
         toggleTraffic.pending,
         toggleTrafficStaging.pending,
         provisionCluster.pending,
@@ -1967,7 +1967,7 @@ export const clusterSlice = createSlice({
         resetSLA.fulfilled,
         addServer.fulfilled,
         dropServer.fulfilled,
-        dropAppByName.fulfilled,
+        dropApp.fulfilled,
         toggleTrafficStaging.fulfilled,
         provisionCluster.fulfilled,
         unProvisionCluster.fulfilled,
@@ -2038,7 +2038,7 @@ export const clusterSlice = createSlice({
         resetSLA.rejected,
         addServer.rejected,
         dropServer.rejected,
-        dropAppByName.rejected,
+        dropApp.rejected,
         toggleTraffic.rejected,
         toggleTrafficStaging.rejected,
         provisionCluster.rejected,

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -120,7 +120,7 @@ export const clusterService = {
   addClusterShard,
 
   // App management APIs
-  dropAppByName,
+  dropApp,
   getClusterApps,
   provisionApp,
   unprovisionApp,
@@ -246,8 +246,8 @@ function dropServerByName(clusterName, serverName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/actions/dropserver/${serverName}`)
 }
 
-function dropAppByName(clusterName, appId, baseURL) {
-  return getApi(baseURL).get(`clusters/${clusterName}/apps/${appId}/actions/drop`)
+function dropApp(clusterName, host, port, baseURL) {
+  return getApi(baseURL).get(`clusters/${clusterName}/apps/${host}/${port}/actions/drop`)
 }
 
 function provisionCluster(clusterName, baseURL) {


### PR DESCRIPTION
Refactor app drop functionality to use host and port instead of app ID