### PR TITLE
Fix API route for app drop action to use plural 'clusters'

### DIFF
--- a/server/api_app.go
+++ b/server/api_app.go
@@ -139,7 +139,7 @@ func (repman *ReplicationManager) apiAppProtectedHandler(router *mux.Router) {
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxGitRepoTree)),
 	))
-	router.Handle("/api/cluster/{clusterName}/apps/{appHost}/{appPort}/actions/drop", negroni.New(
+	router.Handle("/api/clusters/{clusterName}/apps/{appHost}/{appPort}/actions/drop", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxAppDropByName)),
 	))


### PR DESCRIPTION
Fix API route for app drop action to use plural 'clusters'