### PR TITLE
Add /api/whoami endpoint to retrieve user information based on JWT token

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15568,6 +15568,48 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/whoami": {
+            "get": {
+                "description": "Returns information about the user making the request based on the provided JWT token.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Identify the user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User information",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Error retrieving user info from token\" or \"Error Marshal",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/cluster/{clusterName}/actions/dropserver/{host}/{port}": {
             "post": {
                 "description": "This endpoint allows dropping a server monitor or proxy monitor from a specified cluster.",
@@ -19261,6 +19303,9 @@ const docTemplate = `{
                 "backupEstimateSizePercentage": {
                     "type": "integer"
                 },
+                "backupGottyClientPath": {
+                    "type": "string"
+                },
                 "backupGrowthPercentage": {
                     "type": "integer"
                 },
@@ -19342,13 +19387,16 @@ const docTemplate = `{
                 "backupMysqlclientOptions": {
                     "type": "string"
                 },
-                "backupMysqlclientgPath": {
+                "backupMysqlclientPath": {
                     "type": "string"
                 },
                 "backupMysqldumpOptions": {
                     "type": "string"
                 },
                 "backupMysqldumpPath": {
+                    "type": "string"
+                },
+                "backupMytopPath": {
                     "type": "string"
                 },
                 "backupPhysicalType": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -15557,6 +15557,48 @@
                 }
             }
         },
+        "/api/whoami": {
+            "get": {
+                "description": "Returns information about the user making the request based on the provided JWT token.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Identify the user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User information",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Error retrieving user info from token\" or \"Error Marshal",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/cluster/{clusterName}/actions/dropserver/{host}/{port}": {
             "post": {
                 "description": "This endpoint allows dropping a server monitor or proxy monitor from a specified cluster.",
@@ -19250,6 +19292,9 @@
                 "backupEstimateSizePercentage": {
                     "type": "integer"
                 },
+                "backupGottyClientPath": {
+                    "type": "string"
+                },
                 "backupGrowthPercentage": {
                     "type": "integer"
                 },
@@ -19331,13 +19376,16 @@
                 "backupMysqlclientOptions": {
                     "type": "string"
                 },
-                "backupMysqlclientgPath": {
+                "backupMysqlclientPath": {
                     "type": "string"
                 },
                 "backupMysqldumpOptions": {
                     "type": "string"
                 },
                 "backupMysqldumpPath": {
+                    "type": "string"
+                },
+                "backupMytopPath": {
                     "type": "string"
                 },
                 "backupPhysicalType": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1716,6 +1716,8 @@ definitions:
         type: boolean
       backupEstimateSizePercentage:
         type: integer
+      backupGottyClientPath:
+        type: string
       backupGrowthPercentage:
         type: integer
       backupKeepDaily:
@@ -1770,11 +1772,13 @@ definitions:
         type: string
       backupMysqlclientOptions:
         type: string
-      backupMysqlclientgPath:
+      backupMysqlclientPath:
         type: string
       backupMysqldumpOptions:
         type: string
       backupMysqldumpPath:
+        type: string
+      backupMytopPath:
         type: string
       backupPhysicalType:
         type: string
@@ -14562,6 +14566,35 @@ paths:
       summary: Handles replication manager version requests
       tags:
       - Public
+  /api/whoami:
+    get:
+      consumes:
+      - application/json
+      description: Returns information about the user making the request based on
+        the provided JWT token.
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: User information
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Error retrieving user info from token" or "Error Marshal
+          schema:
+            type: string
+      summary: Identify the user
+      tags:
+      - User
   /cluster/{clusterName}/actions/dropserver/{host}/{port}:
     post:
       consumes:

--- a/server/api.go
+++ b/server/api.go
@@ -293,6 +293,11 @@ func (repman *ReplicationManager) apiserver() {
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxAuthCallback)),
 	))
 
+	router.Handle("/api/whoami", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxWhoAmI)),
+	))
+
 	router.Handle("/api/clusters", negroni.New(
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusters)),
 	))
@@ -474,8 +479,10 @@ func (repman *ReplicationManager) GetUserInfoMap(token *jwt.Token) (map[string]s
 	userinfo := claims["CustomUserInfo"]
 	mycutinfo := userinfo.(map[string]interface{})
 	UserInfoMap := make(map[string]string)
+	UserInfoMap["Name"] = mycutinfo["Name"].(string)
 	UserInfoMap["Password"] = mycutinfo["Password"].(string)
 	UserInfoMap["Role"] = mycutinfo["Role"].(string)
+	UserInfoMap["Email"] = ""
 	_, ok := mycutinfo["profile"]
 	if ok {
 		profile := mycutinfo["profile"].(string)
@@ -485,6 +492,7 @@ func (repman *ReplicationManager) GetUserInfoMap(token *jwt.Token) (map[string]s
 		}
 		if strings.Contains(profile, repman.Conf.OAuthProvider) {
 			UserInfoMap["User"] = mycutinfo["email"].(string)
+			UserInfoMap["Email"] = mycutinfo["email"].(string)
 			UserInfoMap["profile"] = profile
 			return UserInfoMap, nil
 		}
@@ -598,12 +606,12 @@ func (repman *ReplicationManager) loginHandler(w http.ResponseWriter, r *http.Re
 			email, err := githelper.GetGitLabUserEmail(tok, true)
 			if email != "" {
 				repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModSupport, config.LvlInfo, "Switch from gitlab user to email  : %s", email)
-				user.Username = email
+				meetUser = email
 			} else {
 				repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModSupport, config.LvlErr, "Error retrieving email from gitlab: %e", err)
+				meetUser = user.Username
 			}
 
-			meetUser = user.Username
 			meetPassword = user.Password
 
 			//to get meet token and create a client while login
@@ -623,7 +631,7 @@ func (repman *ReplicationManager) loginHandler(w http.ResponseWriter, r *http.Re
 				Email      string `json:"email"`
 				Profile    string `json:"profile"`
 				MeetUserID string `json:"meet_user_id"`
-			}{user.Username, "Member", repman.Conf.GetEncryptedString(user.Password), user.Username, repman.Conf.OAuthProvider, meetUserID}
+			}{user.Username, "Member", repman.Conf.GetEncryptedString(user.Password), email, repman.Conf.OAuthProvider, meetUserID}
 
 		} else {
 
@@ -909,6 +917,40 @@ func (repman *ReplicationManager) handlerVersion(w http.ResponseWriter, r *http.
 func (repman *ReplicationManager) handlerMuxTerms(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Write(repman.Terms)
+}
+
+// handlerMuxWhoAmI handles the HTTP request to identify the user making the request.
+// @Summary Identify the user
+// @Description Returns information about the user making the request based on the provided JWT token.
+// @Tags User
+// @Accept json
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Success 200 {object} map[string]string "User information"
+// @Failure 500 {string} string "Error retrieving user info from token" or "Error Marshal"
+// @Router /api/whoami [get]
+func (repman *ReplicationManager) handlerMuxWhoAmI(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	user, err := repman.GetJWTClaims(r)
+	if err != nil {
+		http.Error(w, "Error retrieving user info from token: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	res, err := json.Marshal(user)
+	if err != nil {
+		http.Error(w, "Error Marshal", 500)
+		return
+	}
+
+	res, err = sjson.SetBytes(res, "Password", "*****")
+	if err != nil {
+		http.Error(w, "Encoding error", 500)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(res)
 }
 
 // handlerMuxAddClusterUser handles the addition of a new user to a cluster.

--- a/server/http.go
+++ b/server/http.go
@@ -167,6 +167,11 @@ func (repman *ReplicationManager) httpserver() {
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxAuthCallback)),
 	))
 
+	router.Handle("/api/whoami", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxWhoAmI)),
+	))
+
 	router.Handle("/api/prometheus", negroni.New(
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxPrometheus)),
 	))

--- a/share/dashboard_react/src/Pages/Mattermost/index.jsx
+++ b/share/dashboard_react/src/Pages/Mattermost/index.jsx
@@ -10,9 +10,6 @@ import MessageRender from '../../components/MessageRender';
 import Picker from "@emoji-mart/react";
 import data from "@emoji-mart/data";
 
-
-
-
 // eslint-disable-next-line react/display-name, react/prop-types
 const MattermostIntegration = memo(({ isOpen, setIsChatOpen, onClose, cloud18 }) => {
     const dispatch = useDispatch();
@@ -43,7 +40,7 @@ const MattermostIntegration = memo(({ isOpen, setIsChatOpen, onClose, cloud18 })
                 if (messagesContainerRef.current) {
                     messagesContainerRef.current.scrollTop = messagesContainerRef.current.scrollHeight;
                 }
-            }, 100);
+            }, 1000);
         }
     }, []);
 
@@ -81,7 +78,7 @@ const MattermostIntegration = memo(({ isOpen, setIsChatOpen, onClose, cloud18 })
                     }
                     dispatch(getMeetInfo());
                 }
-            }, 500);
+            }, 2000);
         return () => clearInterval(interval);
     }, [dispatch, selectedChannel, isLogged, cloud18]);
 

--- a/share/dashboard_react/src/redux/authSlice.js
+++ b/share/dashboard_react/src/redux/authSlice.js
@@ -33,6 +33,22 @@ export const peerLogin = createAsyncThunk('auth/peerLogin', async ({  password, 
   }
 })
 
+export const whoami = createAsyncThunk('auth/whoami', async ({  baseURL }, thunkAPI) => {
+  try {
+    const response = await authService.whoami(baseURL)
+    if (response.status == 200){
+      return response
+    } else {
+      return thunkAPI.rejectWithValue({ errorMessage: response.data || "Request failed", errorStatus: response.status || 500 })
+    }
+  } catch (error) {
+    const errorMessage = error.message || 'Request failed'
+    const errorStatus = error.errorStatus || 500 // Default error status if not provided
+    // Handle errors (including custom errorStatus)
+    return thunkAPI.rejectWithValue({ errorMessage, errorStatus }) // Pass the entire Error object to the rejected action
+  }
+})
+
 export const authSlice = createSlice({
   name: 'auth',
   initialState: { 
@@ -55,7 +71,10 @@ export const authSlice = createSlice({
     setUserData: (state, action) => {
       const username = localStorage.getItem('username')
       state.isLogged = localStorage.getItem('user_token') ? true : false
-      state.user = {
+      state.user = state.user ? {
+        ...state.user,
+        username: username
+      } : {
         username: username
       }
     },
@@ -108,6 +127,20 @@ export const authSlice = createSlice({
         state.loadingPeerLogin = false
         state.isPeerLogged = false 
       } 
+      state.error = action?.payload?.errorMessage
+    })
+    builder.addMatcher(isAnyOf(whoami.fulfilled), (state, action) => {
+      const { payload } = action
+      const { data } = payload
+      state.user = {
+        ...state.user,
+        ...data
+      }
+      state.isLogged = true
+    })
+    builder.addMatcher(isAnyOf(whoami.rejected), (state, action) => {
+      state.user = null
+      state.isLogged = false
       state.error = action?.payload?.errorMessage
     })
   }

--- a/share/dashboard_react/src/redux/meetSlice.js
+++ b/share/dashboard_react/src/redux/meetSlice.js
@@ -274,7 +274,6 @@ const meetSlice = createSlice({
         state.isFetchingInfo = true;
       })
       .addCase(getMeetInfo.fulfilled, (state, action) => {
-        state.isFetchingInfo = false;
         state.meetInfo = action.payload.data;
         //localStorage.setItem('userID', state.meetInfo?.user_id);
         state.unreadMessagesByChannel = action.payload.data.unread_messages_by_channel || {};
@@ -284,14 +283,19 @@ const meetSlice = createSlice({
           ...Object.entries(action.payload.data?.channel_ids_private || {}).map(([name, id]) => ({ name, id, type: 'P' })),
           ...Object.entries(action.payload.data?.channel_ids_direct || {}).map(([name, id]) => ({ name, id, type: 'D' })),
         ]
+        state.isFetchingInfo = false;
       })
       .addCase(logoutFromMeet.pending, (state) => {
         state.loading = true;
       })
       .addCase(getMeetInfo.rejected, (state, action) => {
-        state.isFetchingInfo = false;
         state.meetError = true;
         state.meetInfo = null;
+
+        // sleep for 5 seconds to prevent too many requests in case of error
+        setTimeout(() => {
+          state.isFetchingInfo = false;
+        }, 5000);
       })
       .addCase(logoutFromMeet.fulfilled, (state, action) => {
         state.loading = false;


### PR DESCRIPTION
This pull request introduces a new API endpoint for user identification, updates API documentation, and improves user-related state management in the frontend. Additionally, it refines backup configuration fields and adjusts timing and state handling in the React dashboard. The most important changes are grouped below:

**API Enhancements & Documentation:**

* Added a new `/api/whoami` endpoint to both the HTTP and API servers, allowing clients to retrieve user information based on the JWT token. This includes a new handler `handlerMuxWhoAmI` and updates to OpenAPI documentation (`docs.go`, `swagger.yaml`, `swagger.json`). [[1]](diffhunk://#diff-3fb3d4184590bc6f747661f3062676031e837b0dd5f2b18640f439be7a2235f6R296-R300) [[2]](diffhunk://#diff-9dc8ed5b73297cf3c3d1d32cb36520c8f982a0194fad1e7b3fc521c5799e2023R170-R174) [[3]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R15571-R15612) [[4]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R15560-R15601) [[5]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R14569-R14597)
* Improved the `GetUserInfoMap` function to include the user's name and email in the returned map, ensuring more complete user data in responses. [[1]](diffhunk://#diff-3fb3d4184590bc6f747661f3062676031e837b0dd5f2b18640f439be7a2235f6R482-R485) [[2]](diffhunk://#diff-3fb3d4184590bc6f747661f3062676031e837b0dd5f2b18640f439be7a2235f6R495)
* Updated login handler logic to correctly set the `meetUser` and include the email in user info, ensuring consistency between authentication and user data. [[1]](diffhunk://#diff-3fb3d4184590bc6f747661f3062676031e837b0dd5f2b18640f439be7a2235f6L601-L606) [[2]](diffhunk://#diff-3fb3d4184590bc6f747661f3062676031e837b0dd5f2b18640f439be7a2235f6L626-R634)

**Backup Configuration Updates:**

* Added new fields for backup configuration: `backupGottyClientPath` and `backupMytopPath`, and corrected a typo from `backupMysqlclientgPath` to `backupMysqlclientPath` in API documentation and OpenAPI specs. [[1]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R1719-R1720) [[2]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583L1773-R1782) [[3]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R19306-R19308) [[4]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4L19345-R19390) [[5]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R19399-R19401) [[6]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R19295-R19297) [[7]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524L19334-R19379) [[8]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R19388-R19390)

**Frontend User State Management:**

* Added a new Redux thunk `whoami` to fetch user info from the new API endpoint and updated the `authSlice` to handle this data, improving login state reliability and error handling. [[1]](diffhunk://#diff-02a453886e98c92458352b41fa96aa4398bba20e337ea26b99f42c0dcf2baedbR36-R51) [[2]](diffhunk://#diff-02a453886e98c92458352b41fa96aa4398bba20e337ea26b99f42c0dcf2baedbR132-R145)
* Improved logic in `setUserData` reducer to merge username with existing user state, ensuring user info is consistently updated.

**React Dashboard Timing and State Fixes:**

* Increased timeouts for chat UI updates in Mattermost integration to improve user experience and reduce UI glitches. [[1]](diffhunk://#diff-99ddc44e5c56238c451cfcd465284ed2d7234fa1b6e88637c8748b06e7062660L46-R43) [[2]](diffhunk://#diff-99ddc44e5c56238c451cfcd465284ed2d7234fa1b6e88637c8748b06e7062660L84-R81)
* Adjusted meet info fetching logic to ensure `isFetchingInfo` is set correctly after data is loaded or on error, including adding a delay after errors to prevent excessive requests. [[1]](diffhunk://#diff-b09b6a85847cfb44629066757af8adaf7c8272cf45dee5b6f76649701675ba23L277) [[2]](diffhunk://#diff-b09b6a85847cfb44629066757af8adaf7c8272cf45dee5b6f76649701675ba23R286-R298)
