### PR TITLE
Fix display when using non email username via Gitlab SSO

### DIFF
--- a/share/dashboard_react/src/Pages/ClusterApp/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/index.jsx
@@ -10,7 +10,7 @@ import { HiArrowNarrowLeft } from 'react-icons/hi'
 import { useDispatch, useSelector } from 'react-redux'
 import { getClusterData, getClusterApps, setRefreshInterval, getAppService } from '../../redux/clusterSlice'
 
-function ClusterApp({}) {
+function ClusterApp({ }) {
   const params = useParams()
   const dispatch = useDispatch()
   const navigate = useNavigate()
@@ -22,6 +22,7 @@ function ClusterApp({}) {
   const [appId, setAppId] = useState(params.appname)
   const tabs = useRef([])
 
+  const loggedUser = useSelector((state) => state.auth.user)
   const refreshInterval = useSelector((state) => state.cluster.refreshInterval)
   const clusterApps = useSelector((state) => state.cluster.clusterApps)
   const clusterData = useSelector((state) => state.cluster.clusterData)
@@ -77,25 +78,24 @@ function ClusterApp({}) {
       const app = clusterApps.find((x) => x.id === appId)
       setSelectedApp(app)
     }
-    if (clusterData?.apiUsers) {
-      const loggedUser = localStorage.getItem('username')
-      if (loggedUser && clusterData?.apiUsers[loggedUser]) {
-        const apiUser = clusterData.apiUsers[loggedUser]
-        const authorizedTabs = [
-          <>
-            <CustomIcon icon={HiArrowNarrowLeft} /> Dashboard
-          </>
-        ]
-        authorizedTabs.push('App Overview')
-        authorizedTabs.push('Storages')
-        authorizedTabs.push('Service OpenSVC')
-        tabs.current = authorizedTabs
-        setUser(apiUser)
-      }
+    if (clusterData?.apiUsers && loggedUser) {
+        const apiUser = clusterData?.apiUsers[loggedUser.User] || clusterData?.apiUsers[loggedUser.Email]
+        if (apiUser) {
+          const authorizedTabs = [
+            <>
+              <CustomIcon icon={HiArrowNarrowLeft} /> Dashboard
+            </>
+          ]
+          authorizedTabs.push('App Overview')
+          authorizedTabs.push('Storages')
+          authorizedTabs.push('Service OpenSVC')
+          tabs.current = authorizedTabs
+          setUser(apiUser)
+        }
     }
-  }, [appId, clusterApps])
+  }, [appId, clusterApps, loggedUser])
 
-  
+
   const handleTabChange = (tabIndex) => {
     selectedTabRef.current = tabIndex
     setSelectedTab(tabIndex)
@@ -104,7 +104,7 @@ function ClusterApp({}) {
     }
   }
 
-  if (clusterApps?.length === 0 || !selectedApp) { 
+  if (clusterApps?.length === 0 || !selectedApp) {
     return (
       <PageContainer>
         <Box className={styles.container}>

--- a/share/dashboard_react/src/Pages/ClusterDB/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterDB/index.jsx
@@ -24,9 +24,11 @@ function ClusterDB(props) {
   const [dbId, setDbId] = useState(params.dbname)
   const tabs = useRef([])
 
-  const {
-    cluster: { refreshInterval, clusterServers, clusterData }
-  } = useSelector((state) => state)
+  const refreshInterval = useSelector((state) => state.cluster.refreshInterval)
+  const clusterServers = useSelector((state) => state.cluster.clusterServers)
+  const clusterData = useSelector((state) => state.cluster.clusterData)
+  const loggedUser = useSelector((state) => state.auth.user)
+
   useEffect(() => {
     let intervalId = 0
     let interval = localStorage.getItem('refresh_interval')
@@ -53,10 +55,12 @@ function ClusterDB(props) {
       const server = clusterServers.find((x) => x.id === dbId)
       setSelectedDBServer(server)
     }
-    if (clusterData?.apiUsers) {
-      const loggedUser = localStorage.getItem('username')
-      if (loggedUser && clusterData?.apiUsers[loggedUser]) {
-        const apiUser = clusterData.apiUsers[loggedUser]
+  }, [dbId, clusterServers])
+
+  useEffect(() => {
+    if (clusterData?.apiUsers && loggedUser) {
+      const apiUser = clusterData.apiUsers[loggedUser.User] ? clusterData.apiUsers[loggedUser.User] : clusterData.apiUsers[loggedUser.Email]
+      if (apiUser) {
         const authorizedTabs = [
           <>
             <CustomIcon icon={HiArrowNarrowLeft} /> Dashboard
@@ -88,7 +92,7 @@ function ClusterDB(props) {
         setUser(apiUser)
       }
     }
-  }, [dbId, clusterServers])
+  }, [dbId, loggedUser, clusterData])
 
   const callServices = () => {
     dispatch(getClusterServers({ clusterName }))

--- a/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
@@ -95,7 +95,7 @@ function ClusterDetail({ selectedCluster }) {
             setConfirmHandler(() => () => dispatch(toggleTraffic({ clusterName: selectedCluster?.name })))
           }
         },
-        ...(selectedCluster.config.topologyStaging ? [{
+        ...(selectedCluster.config?.topologyStaging ? [{
           name: 'Toggle Traffic Staging',
           onClick: () => {
             openConfirmModal()

--- a/share/dashboard_react/src/Pages/Home/index.jsx
+++ b/share/dashboard_react/src/Pages/Home/index.jsx
@@ -63,6 +63,7 @@ function Home() {
 
   const terminalURL = useHref('/terminal/')
 
+  const loggedUser = useSelector((state) => state.auth.user)
   const refreshInterval = useSelector((state) => state.cluster.refreshInterval)
   const clusterData = useSelector((state) => state.cluster.clusterData)
   const monitor = useSelector((state) => state.globalClusters.monitor)
@@ -89,38 +90,37 @@ function Home() {
   useEffect(() => {
     if (clusterData) {
       setSelectedCluster(clusterData)
-      if (clusterData.apiUsers) {
-        const loggedUser = localStorage.getItem('username')
-        if (loggedUser && clusterData?.apiUsers[loggedUser]) {
-          const apiUser = clusterData.apiUsers[loggedUser]
-          setUser(apiUser)
-          const authorizedTabs = ['Dashboard', 'Settings', 'Configs']
-          if (clusterData.config.graphiteMetrics && apiUser.grants['cluster-show-graphs']) {
-            authorizedTabs.push('Graphs')
+      if (clusterData.apiUsers && loggedUser) {
+          const apiUser = clusterData.apiUsers[loggedUser.User] ? clusterData.apiUsers[loggedUser.User] : clusterData.apiUsers[loggedUser.Email]
+          if (apiUser) {
+            setUser(apiUser)
+            const authorizedTabs = ['Dashboard', 'Settings', 'Configs']
+            if (clusterData.config.graphiteMetrics && apiUser.grants['cluster-show-graphs']) {
+              authorizedTabs.push('Graphs')
+            }
+            if (apiUser.grants['cluster-show-agents']) {
+              authorizedTabs.push('Agents')
+            }
+            if (apiUser.grants['cluster-show-backups']) {
+              authorizedTabs.push('Maintenance')
+            }
+            if (apiUser.grants['db-show-process']) {
+              authorizedTabs.push('Tops')
+            }
+            if (clusterData.config.proxysql && apiUser.grants['cluster-show-agents']) {
+              authorizedTabs.push('Query Rules')
+            }
+            if (apiUser.grants['db-show-schema']) {
+              authorizedTabs.push('Shards')
+            }
+            if (apiUser.grants['cluster-grant']) {
+              authorizedTabs.push('Users')
+            }
+            dashboardTabsRef.current = authorizedTabs
           }
-          if (apiUser.grants['cluster-show-agents']) {
-            authorizedTabs.push('Agents')
-          }
-          if (apiUser.grants['cluster-show-backups']) {
-            authorizedTabs.push('Maintenance')
-          }
-          if (apiUser.grants['db-show-process']) {
-            authorizedTabs.push('Tops')
-          }
-          if (clusterData.config.proxysql && apiUser.grants['cluster-show-agents']) {
-            authorizedTabs.push('Query Rules')
-          }
-          if (apiUser.grants['db-show-schema']) {
-            authorizedTabs.push('Shards')
-          }
-          if (apiUser.grants['cluster-grant']) {
-            authorizedTabs.push('Users')
-          }
-          dashboardTabsRef.current = authorizedTabs
         }
       }
-    }
-  }, [clusterData])
+  }, [clusterData, loggedUser])
 
   useEffect(() => {
     let intervalId = 0
@@ -252,14 +252,14 @@ function Home() {
               ? [renderClusterListTabWithArrow(), ...dashboardTabsRef.current]
               : globalTabsRef.current
           }
-          tabPrefix={[...(selectedClusterNameRef.current == '' ? [<div onClick={openNewClusterModal} className={styles.tabSelected}><CustomIcon icon={FaPlus}/></div>]: [])]}
-          tabSuffix={[...(selectedClusterNameRef.current == '' && localStorage.getItem('username') == "admin" ? [<div onClick={openTerminalPage} className={styles.tabNormal}>Terminal</div>]:[])]}
+          tabPrefix={[...(selectedClusterNameRef.current == '' ? [<div onClick={openNewClusterModal} className={styles.tabSelected}><CustomIcon icon={FaPlus} /></div>] : [])]}
+          tabSuffix={[...(selectedClusterNameRef.current == '' && localStorage.getItem('username') == "admin" ? [<div onClick={openTerminalPage} className={styles.tabNormal}>Terminal</div>] : [])]}
           tabContents={[
             <ClusterList onClick={setDashboardTab} />,
             ...(isClusterOpenRef.current
               ? [
                 <Dashboard user={user} selectedCluster={selectedCluster} />,
-                <Settings user={user} selectedCluster={selectedCluster} onTabChange={handleTabChange} monitor={monitor}/>,
+                <Settings user={user} selectedCluster={selectedCluster} onTabChange={handleTabChange} monitor={monitor} />,
                 <Configs user={user} selectedCluster={selectedCluster} />,
                 ...(selectedCluster?.config?.graphiteMetrics && user?.grants['cluster-show-graphs']
                   ? [<Graphs selectedCluster={selectedCluster} />]
@@ -275,7 +275,7 @@ function Home() {
                   ? [<QueryRules selectedCluster={selectedCluster} />]
                   : []),
                 ...(user?.grants['db-show-schema'] ? [<Shards selectedCluster={selectedCluster} />] : []),
-                ...(user?.grants['cluster-grant'] ? [<Users selectedCluster={selectedCluster} user={user}/>] : [])
+                ...(user?.grants['cluster-grant'] ? [<Users selectedCluster={selectedCluster} user={user} />] : [])
               ]
               : globalTabsRef.current.includes('Clusters Peer') // monitor?.config?.cloud18 is false, do not show "Peer Clusters" tab
                 ? [<PeerClusterList onLogin={setDashboardTab} />, <PeerClusterList mode='shared' />, <ClustersGlobalSettings />]

--- a/share/dashboard_react/src/components/Modals/UserGrantModal.jsx
+++ b/share/dashboard_react/src/components/Modals/UserGrantModal.jsx
@@ -47,14 +47,15 @@ function UserGrantModal({ clusterName, selectedUser, isOpen, closeModal }) {
   const { theme } = useTheme()
   const { serviceAcl = [], serviceRoles = [] } = monitor
 
-  const loggedUser = localStorage.getItem('username')
+  const loggedUser = useSelector((state) => state.auth.user)
 
   useEffect(() => {
-    if (clusterData?.apiUsers?.[loggedUser]) {
-      const apiUser = clusterData.apiUsers[loggedUser]
+    const apiUser = clusterData?.apiUsers?.[loggedUser.User] ? clusterData?.apiUsers?.[loggedUser.User] : clusterData?.apiUsers?.[loggedUser.Email]
+
+    if (apiUser) {
       setUser(apiUser)
     }
-  }, [clusterData?.apiUsers?.[loggedUser]])
+  }, [clusterData?.apiUsers, loggedUser])
 
   useEffect(() => {
     setFirstLoad(true)


### PR DESCRIPTION
This pull request refactors how the logged-in user is accessed and used throughout several React components in the dashboard. Instead of reading the username directly from `localStorage`, the code now consistently retrieves the user from the Redux store via `useSelector`. Additionally, user lookup in `apiUsers` is improved to support both `User` and `Email` keys, and React effect dependencies are updated to reflect these changes. These updates enhance code consistency, reliability, and maintainability.

**User authentication and lookup improvements:**

* Replaced all instances of `localStorage.getItem('username')` with `useSelector((state) => state.auth.user)` to retrieve the logged-in user from Redux state in `ClusterApp`, `ClusterDB`, `Home`, and `UserGrantModal` components. [[1]](diffhunk://#diff-66b307bed43bb64497a03ca4b6d5b3307ebac90b1e80a1fd89031db5788475fdR25) [[2]](diffhunk://#diff-6cc5f42936a37856f7b9767dd8b6241f4a6792430be537573c1aa45fc1866562L27-R31) [[3]](diffhunk://#diff-64aa538ae37902cf9cc55ee965c82fa01e16a4a90e2401e121ce83bfb7d44007R66) [[4]](diffhunk://#diff-49684e2967f26c8d8a3931670909975cee6529542112a58854977a8c8370ea19L50-R58)
* Updated user lookup logic in `apiUsers` to check both `loggedUser.User` and `loggedUser.Email` properties, ensuring compatibility with different user identification schemes. [[1]](diffhunk://#diff-66b307bed43bb64497a03ca4b6d5b3307ebac90b1e80a1fd89031db5788475fdL80-R83) [[2]](diffhunk://#diff-6cc5f42936a37856f7b9767dd8b6241f4a6792430be537573c1aa45fc1866562L56-R63) [[3]](diffhunk://#diff-64aa538ae37902cf9cc55ee965c82fa01e16a4a90e2401e121ce83bfb7d44007L92-R95) [[4]](diffhunk://#diff-49684e2967f26c8d8a3931670909975cee6529542112a58854977a8c8370ea19L50-R58)

**React effect dependency updates:**

* Added `loggedUser` and other relevant state variables to dependency arrays of `useEffect` hooks to ensure components react to authentication changes and data updates. [[1]](diffhunk://#diff-66b307bed43bb64497a03ca4b6d5b3307ebac90b1e80a1fd89031db5788475fdL96-R96) [[2]](diffhunk://#diff-6cc5f42936a37856f7b9767dd8b6241f4a6792430be537573c1aa45fc1866562L91-R95) [[3]](diffhunk://#diff-64aa538ae37902cf9cc55ee965c82fa01e16a4a90e2401e121ce83bfb7d44007L123-R123) [[4]](diffhunk://#diff-49684e2967f26c8d8a3931670909975cee6529542112a58854977a8c8370ea19L50-R58)

**Minor bug fix:**

* Safely accessed `topologyStaging` property in `ClusterDetail` by using optional chaining to prevent runtime errors when `config` is undefined.