### PR TITLE
Fix typo in ProxysqlCopyGrants toml and json tag in config struct

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -401,7 +401,7 @@ type Config struct {
 	ProxysqlPassword                          string                 `mapstructure:"proxysql-password" toml:"proxysql-password" json:"proxysqlPassword"`
 	ProxysqlWriterHostgroup                   string                 `mapstructure:"proxysql-writer-hostgroup" toml:"proxysql-writer-hostgroup" json:"proxysqlWriterHostgroup"`
 	ProxysqlReaderHostgroup                   string                 `mapstructure:"proxysql-reader-hostgroup" toml:"proxysql-reader-hostgroup" json:"proxysqlReaderHostgroup"`
-	ProxysqlCopyGrants                        bool                   `mapstructure:"proxysql-bootstrap-users" toml:"proxysql-bootstarp-users" json:"proxysqlBootstrapyUsers"`
+	ProxysqlCopyGrants                        bool                   `mapstructure:"proxysql-bootstrap-users" toml:"proxysql-bootstrap-users" json:"proxysqlBootstrapUsers"`
 	ProxysqlBootstrap                         bool                   `mapstructure:"proxysql-bootstrap" toml:"proxysql-bootstrap" json:"proxysqlBootstrap"`
 	ProxysqlBootstrapVariables                bool                   `mapstructure:"proxysql-bootstrap-variables" toml:"proxysql-bootstrap-variables" json:"proxysqlBootstrapVariables"`
 	ProxysqlBootstrapHG                       bool                   `mapstructure:"proxysql-bootstrap-hostgroups" toml:"proxysql-bootstrap-hostgroups" json:"proxysqlBootstrapHostgroups"`


### PR DESCRIPTION
This pull request contains a fix to the `Config` struct in `config/config.go`, correcting a typo in the TOML and JSON tags for the `ProxysqlCopyGrants` field to ensure proper configuration mapping.