### PR TITLE
Clear clusters on unauthorized access

### DIFF
--- a/share/dashboard_react/src/Pages/Login/index.jsx
+++ b/share/dashboard_react/src/Pages/Login/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, Suspense } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
-import { login } from '../../redux/authSlice'
+import { login, logout } from '../../redux/authSlice'
 import styles from './styles.module.scss'
 import { Box, Container, FormControl, FormLabel, FormErrorMessage, Heading, Input, Stack, Text } from '@chakra-ui/react'
 import PageContainer from '../PageContainer'
@@ -10,6 +10,8 @@ import PasswordControl from '../../components/PasswordControl'
 import RMButton from '../../components/RMButton'
 import Message from '../../components/Message'
 import { useTheme } from '../../ThemeProvider'
+import { clearCluster } from '../../redux/clusterSlice'
+import { clearClusters } from '../../redux/globalClustersSlice'
 
 function Login(props) {
   const [username, setUsername] = useState('')
@@ -28,6 +30,11 @@ function Login(props) {
   useEffect(() => {
     if (isAuthorized()) {
       navigate('/')
+    } else {
+      // If not authorized, ensure the user is logged out and clear clusters
+      dispatch(logout());
+      dispatch(clearClusters());
+      dispatch(clearCluster());
     }
   }, [])
 

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -19,6 +19,7 @@ import AddUserModal from '../Modals/AddUserModal'
 import MattermostIntegration from '../../Pages/Mattermost';
 import { getMeetInfo, logoutFromMeet } from '../../redux/meetSlice';
 import { selectMeetUIState } from '../../redux/memoize'
+import { clearClusters } from '../../redux/globalClustersSlice'
 
 function Navbar({ username }) {
   const dispatch = useDispatch()
@@ -101,6 +102,7 @@ function Navbar({ username }) {
     localStorage.removeItem('selectedChannel');
     localStorage.removeItem('userID')
     dispatch(logout())
+    dispatch(clearClusters())
     dispatch(clearCluster())
   }
   const openAddUserModal = () => {


### PR DESCRIPTION
This pull request improves the application's authentication flow and state management by ensuring that user and cluster-related data is properly cleared when logging out or when the user is not authorized. The changes affect both the login page and the navbar component.

**Authentication and state clearing enhancements:**

* In the `Login` page (`index.jsx`), when a user is not authorized, the app now explicitly dispatches `logout`, `clearClusters`, and `clearCluster` actions to ensure all relevant state is reset.
* The `Navbar` component's logout handler now also dispatches `clearClusters` and `clearCluster` actions, in addition to the existing `logout`, to clear cluster-related state on user logout.

**Imports and code organization:**

* Added imports for `logout`, `clearCluster`, and `clearClusters` in the `Login` page to support the new state clearing logic. [[1]](diffhunk://#diff-bef496b0557c56796111538d7dece9f8829f5cd2b4578a6794a088fab053efa7L4-R4) [[2]](diffhunk://#diff-bef496b0557c56796111538d7dece9f8829f5cd2b4578a6794a088fab053efa7R13-R14)
* Added import for `clearClusters` in the `Navbar` component to support cluster state clearing on logout.