### PR TITLE
Add configuration handling for rolling restart in StartDatabaseWaitRejoin

### DIFF
--- a/cluster/cluster_tst.go
+++ b/cluster/cluster_tst.go
@@ -303,6 +303,16 @@ func (cluster *Cluster) StartDatabaseWaitRejoin(server *ServerMonitor) error {
 	wg2 := new(sync.WaitGroup)
 	wg2.Add(1)
 	go cluster.WaitRejoin(wg2)
+
+	// Default action from cluster configuration
+	// If ProvDbStartFetchConfig is set to true, we want the server to fetch configuration on rolling restart
+	// If ProvDbStartFetchConfig is set to false, we want the server to NOT fetch configuration on rolling restart
+	if cluster.Conf.ProvDbStartFetchConfig && server.HasNoConfigFetchCookie() {
+		server.DelNoConfigFetchCookie()
+	} else if !cluster.Conf.ProvDbStartFetchConfig && !server.HasNoConfigFetchCookie() {
+		server.SetNoConfigFetchCookie()
+	}
+
 	err := cluster.StartDatabaseService(server)
 	wg2.Wait()
 	return err


### PR DESCRIPTION
This pull request adds logic to the `StartDatabaseWaitRejoin` function in `cluster/cluster_tst.go` to control whether the server fetches configuration during a rolling restart, based on the cluster configuration and the presence of a config fetch cookie.

Configuration-driven server behavior:

* In `StartDatabaseWaitRejoin`, the server now checks the `ProvDbStartFetchConfig` flag in `cluster.Conf` and the state of its config fetch cookie. If configuration fetching is enabled and the cookie is present, the cookie is deleted to allow fetching; if fetching is disabled and the cookie is absent, the cookie is set to prevent fetching.