### PR TITLE
Fix dbjobs error logs

### DIFF
--- a/clients/client_config.go
+++ b/clients/client_config.go
@@ -399,8 +399,7 @@ func needRefreshConfig() bool {
 
 	_, err := cliAPICmd(urlpost, nil)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "API call error: %s", err)
-		os.Exit(1)
+		return false
 	}
 
 	return true

--- a/server/api_database.go
+++ b/server/api_database.go
@@ -3088,7 +3088,7 @@ func (repman *ReplicationManager) handlerMuxServersWriteLog(w http.ResponseWrite
 		switch vars["task"] {
 		case "mariabackup", "xtrabackup", "reseedxtrabackup", "reseedmariabackup", "flashbackxtrabackup", "flashbackmariadbackup":
 			mod = config.ConstLogModBackupStream
-		case "error", "slowquery", "zfssnapback", "optimize", "reseedmysqldump", "flashbackmysqldump", "stop", "restart", "start":
+		case "errorlog", "slowquery", "zfssnapback", "optimize", "reseedmysqldump", "flashbackmysqldump", "stop", "restart", "start":
 			mod = config.ConstLogModTask
 		default:
 			http.Error(w, "Bad request: Task is not registered", http.StatusBadRequest)

--- a/share/scripts/dbjobs_new.sh
+++ b/share/scripts/dbjobs_new.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPMAN_CLIENT="$SCRIPT_DIR/replication-manager-cli"
-ENC_KEY=$(encrypt_data "{\"secret\":\"$MYSQL_ROOT_PASSWORD\"}")
 
 USER=%%ENV:SVC_CONF_ENV_MYSQL_ROOT_USER%%
 PASSWORD=$MYSQL_ROOT_PASSWORD
@@ -31,12 +30,12 @@ if [ -x "$MARIADB_CLIENT" ]; then
     BINARY_CLIENT="$MARIADB_CLIENT $BINARY_CLIENT_PARAMETERS"
     BINARY_CHECK=$MARIADB_CHECK
     BINARY_DUMP=$MARIADB_DUMP
-    echo "Using MariaDB binaries."
+    echo "Job start: Using MariaDB binaries."
 elif [ -x "$MYSQL_CLIENT" ]; then
     BINARY_CLIENT="$MYSQL_CLIENT $BINARY_CLIENT_PARAMETERS"
     BINARY_CHECK=$MYSQL_CHECK
     BINARY_DUMP=$MYSQL_DUMP
-    echo "Using MySQL binaries."
+    echo "Job start: Using MySQL binaries."
 else
     echo "Neither MariaDB nor MySQL binaries are available."
     exit 1
@@ -284,14 +283,14 @@ read_log_file() {
                 break
             fi
 
-        batch+="$escaped\n"
-        if ((current_line % BATCH_SIZE == 0)); then
-            send_lines_to_api "$batch" "$job"
-            batch=""
-        fi
-        echo "$current_line" >"$checkpoint_file"
+            batch+="$escaped\n"
+            if ((current_line % BATCH_SIZE == 0)); then
+                send_lines_to_api "$batch" "$job"
+                batch=""
+            fi
+            echo "$current_line" >"$checkpoint_file"
 
-        done < <(sed -n "$current_line,${p}" "$log_file")
+        done < <(sed -n "${current_line},\$p" "$log_file")
 
         # Send any remaining lines in the batch after the first loop
         if [[ -n "$batch" ]]; then


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the client configuration logic, server API, and database job scripts. The main focus is on error handling, log processing, and script usability, with some minor adjustments to logging and task handling.

**Error handling and API robustness:**

* Updated the `needRefreshConfig()` function in `clients/client_config.go` to return `false` instead of exiting the process on API call errors, improving error handling and preventing abrupt termination.

**Server API task handling:**

* Corrected the task name from `"error"` to `"errorlog"` in the replication manager log handler in `server/api_database.go`, ensuring proper log mode assignment for error logs.

**Database job script improvements:**

* Removed unused encrypted key generation from `dbjobs_new.sh`, simplifying the script and eliminating unnecessary operations.

**Logging and messaging enhancements:**

* Updated startup messages in `dbjobs_new.sh` to clarify which database binaries are being used, making logs more informative for job starts.

**Log file processing fix:**

* Fixed the log file reading logic in `dbjobs_new.sh` by changing the `sed` command to correctly process lines from the current checkpoint to the end of the file, ensuring accurate batch processing.