### PR TITLE
Fix haproxy failed to set master with custom backend name in config, and improve logging

### DIFF
--- a/cluster/prx.go
+++ b/cluster/prx.go
@@ -177,6 +177,7 @@ type Backend struct {
 	Host           string `json:"host"`
 	Port           string `json:"port"`
 	Status         string `json:"status"`
+	Svname         string `json:"svname"`
 	PrxName        string `json:"prxName"`
 	PrxStatus      string `json:"prxStatus"`
 	PrxConnections string `json:"prxConnections"`

--- a/cluster/prx_get.go
+++ b/cluster/prx_get.go
@@ -424,3 +424,17 @@ func (p *Proxy) GetSshEnv() string {
 	}
 	return "export REPLICATION_MANAGER_HOST_USER=\"" + p.GetUser() + "\";export REPLICATION_MANAGER_HOST_PASSWORD=\"" + p.GetPass() + "\";export REPLICATION_MANAGER_URL=\"https://" + p.ClusterGroup.Conf.MonitorAddress + ":" + p.ClusterGroup.Conf.APIPort + "\";export REPLICATION_MANAGER_USER=\"" + adminuser + "\";export REPLICATION_MANAGER_PASSWORD=\"" + adminpassword + "\";export REPLICATION_MANAGER_HOST_NAME=\"" + p.GetHost() + "\";export REPLICATION_MANAGER_HOST_PORT=\"" + p.GetPort() + "\";export REPLICATION_MANAGER_HOST_TYPE=\"" + p.Type + "\";export REPLICATION_MANAGER_CLUSTER_NAME=\"" + p.ClusterGroup.Name + "\"\n"
 }
+
+func (p *Proxy) GetReadBackendDetail(srv *ServerMonitor) *Backend {
+	if srv == nil {
+		return nil
+	}
+
+	for _, b := range p.BackendsRead {
+		if b.Host == srv.Host && b.Port == srv.Port {
+			return &b
+		}
+	}
+
+	return nil
+}

--- a/cluster/prx_haproxy.go
+++ b/cluster/prx_haproxy.go
@@ -267,9 +267,9 @@ func (proxy *HaproxyProxy) Refresh() error {
 
 		// API return space sparator conveting to csv
 		showleaderstate = strings.Replace(showleaderstate, " ", ",", -1)
-		if cluster.Conf.HaproxyDebug {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "haproxy show servers state response :%s", showleaderstate)
-		}
+
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "haproxy show servers state response :%s", showleaderstate)
+
 		showleaderstatereader := io.NopCloser(bytes.NewReader([]byte(showleaderstate)))
 
 		defer showleaderstatereader.Close()
@@ -284,9 +284,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 				return err
 			}
 			if len(line) > 17 {
-				if cluster.Conf.HaproxyDebug {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy adding IP map %s %s", line[4], line[17])
-				}
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "HAProxy adding IP map %s %s", line[4], line[17])
 				backend_ip_host[line[4]] = line[17]
 			}
 		}
@@ -307,9 +305,9 @@ func (proxy *HaproxyProxy) Refresh() error {
 		cluster.SetState("ERR00052", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00052"], err), ErrFrom: "MON"})
 		return err
 	}
-	if cluster.Conf.HaproxyDebug {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy show stat result: %s", result)
-	}
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "HAProxy show stat result: %s", result)
+
 	r := io.NopCloser(bytes.NewReader([]byte(result)))
 	defer r.Close()
 	reader := csv.NewReader(r)
@@ -344,11 +342,12 @@ func (proxy *HaproxyProxy) Refresh() error {
 			}
 
 			srv := cluster.GetServerFromURL(host)
-			// if cluster.Conf.HaproxyDebug {
+
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy stat lookup writer: host %s translated to %s", line[73], host)
-			// }
+
 			if srv != nil {
-				bkw := Backend{
+				foundMasterInStat = true
+				proxy.BackendsWrite = append(proxy.BackendsWrite, Backend{
 					Host:           srv.Host,
 					Port:           srv.Port,
 					Status:         srv.State,
@@ -358,40 +357,35 @@ func (proxy *HaproxyProxy) Refresh() error {
 					PrxByteIn:      line[8],
 					PrxByteOut:     line[9],
 					PrxLatency:     line[61], //ttime: average session time in ms over the 1024 last requests
-				}
+				})
 
-				if bkw.PrxName != "" {
-					foundMasterInStat = true
-					proxy.BackendsWrite = append(proxy.BackendsWrite, bkw)
+				if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
+					if !srv.IsStandAlone() {
+						if stagingsrv == nil {
+							stagingsrv, _ = cluster.GetStandaloneServerByIndex(0)
+							cluster.StagingServer = stagingsrv
+						}
 
-					if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
-						if !srv.IsStandAlone() {
-							if stagingsrv == nil {
-								stagingsrv, _ = cluster.GetStandaloneServerByIndex(0)
-								cluster.StagingServer = stagingsrv
-							}
-
-							if stagingsrv != nil {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "[Staging] Detecting wrong master server in haproxy %s fixing it to standalone %s %s", proxy.Host+":"+proxy.Port, stagingsrv.Host, stagingsrv.Port)
-								msg, err := haRuntime.SetMaster(stagingsrv.Host, stagingsrv.Port)
-								if err != nil {
-									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
-								} else {
-									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
-								}
+						if stagingsrv != nil {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "[Staging] Detecting wrong master server in haproxy %s fixing it to standalone %s %s", proxy.Host+":"+proxy.Port, stagingsrv.Host, stagingsrv.Port)
+							msg, err := haRuntime.SetMaster(stagingsrv.Host, stagingsrv.Port)
+							if err != nil {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
+							} else {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
 							}
 						}
-					} else {
-						if !srv.IsMaster() {
-							master := cluster.GetMaster()
-							if master != nil {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "Detecting wrong master server in haproxy %s fixing it to master %s %s", proxy.Host+":"+proxy.Port, master.Host, master.Port)
-								msg, err := haRuntime.SetMaster(master.Host, master.Port)
-								if err != nil {
-									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
-								} else {
-									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
-								}
+					}
+				} else {
+					if !srv.IsMaster() {
+						master := cluster.GetMaster()
+						if master != nil {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "Detecting wrong master server in haproxy %s fixing it to master %s %s", proxy.Host+":"+proxy.Port, master.Host, master.Port)
+							msg, err := haRuntime.SetMaster(master.Host, master.Port)
+							if err != nil {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
+							} else {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
 							}
 						}
 					}
@@ -416,7 +410,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy stat lookup reader: host %s translated to %s", line[73], host)
 			}
 			if srv != nil {
-				bkr := Backend{
+				proxy.BackendsRead = append(proxy.BackendsRead, Backend{
 					Host:           srv.Host,
 					Port:           srv.Port,
 					Status:         srv.State,
@@ -426,65 +420,13 @@ func (proxy *HaproxyProxy) Refresh() error {
 					PrxByteIn:      line[8],
 					PrxByteOut:     line[9],
 					PrxLatency:     line[61],
-				}
+				})
 
-				if bkr.PrxName != "" {
-					proxy.BackendsRead = append(proxy.BackendsRead, bkr)
-					if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
-						if stagingsrv != nil {
-							if srv.Id == stagingsrv.Id { // Only activate staging server for read
-								if line[17] == "DRAIN" {
-									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy staging is DRAIN in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
-									msg, err := haRuntime.SetReady(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
-									if err != nil {
-										cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
-									} else {
-										cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
-									}
-								}
-							} else { // Deactivate other servers
-								if line[17] == "UP" {
-									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy non-staging backend state is UP in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
-									msg, err := haRuntime.SetDrain(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
-									if err != nil {
-										cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
-									} else {
-										cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
-									}
-								}
-							}
-						}
-					} else {
-						if (srv.State == stateSlaveErr || srv.State == stateRelayErr || srv.State == stateSlaveLate || srv.State == stateRelayLate || srv.IsIgnored()) && line[17] == "UP" || srv.State == stateWsrepLate || srv.State == stateWsrepDonor {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy detecting broken replication and UP state in haproxy %s drain  server %s", proxy.Host+":"+proxy.Port, srv.URL)
-							msg, err := haRuntime.SetDrain(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
-							if err != nil {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
-							} else {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlInfo, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
-							}
-						}
-						if (srv.State == stateSlave || srv.State == stateRelay || (srv.State == stateWsrep && !srv.IsLeader())) && line[17] == "DRAIN" && !srv.IsIgnored() {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy valid replication and DRAIN state in haproxy %s enable traffic on server %s", proxy.Host+":"+proxy.Port, srv.URL)
-							msg, err := haRuntime.SetReady(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
-							if err != nil {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
-							} else {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
-							}
-						}
-						if srv.IsMaster() {
-							if !cluster.Configurator.HasProxyReadLeader() && line[17] == "UP" {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy master is not configured as reader but state is UP in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
-								msg, err := haRuntime.SetDrain(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
-								if err != nil {
-									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
-								} else {
-									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
-								}
-							}
-							if cluster.Configurator.HasProxyReadLeader() && line[17] == "DRAIN" {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy master is configured as reader but state is DRAIN in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
+				if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
+					if stagingsrv != nil {
+						if srv.Id == stagingsrv.Id { // Only activate staging server for read
+							if line[17] == "DRAIN" {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy staging is DRAIN in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
 								msg, err := haRuntime.SetReady(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
 								if err != nil {
 									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
@@ -492,17 +434,66 @@ func (proxy *HaproxyProxy) Refresh() error {
 									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 								}
 							}
+						} else { // Deactivate other servers
+							if line[17] == "UP" {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy non-staging backend state is UP in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
+								msg, err := haRuntime.SetDrain(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
+								if err != nil {
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+								} else {
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+								}
+							}
 						}
 					}
+				} else {
+					if (srv.State == stateSlaveErr || srv.State == stateRelayErr || srv.State == stateSlaveLate || srv.State == stateRelayLate || srv.IsIgnored()) && line[17] == "UP" || srv.State == stateWsrepLate || srv.State == stateWsrepDonor {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy detecting broken replication and UP state in haproxy %s drain  server %s", proxy.Host+":"+proxy.Port, srv.URL)
+						msg, err := haRuntime.SetDrain(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
+						if err != nil {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+						} else {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlInfo, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+						}
+					}
+					if (srv.State == stateSlave || srv.State == stateRelay || (srv.State == stateWsrep && !srv.IsLeader())) && line[17] == "DRAIN" && !srv.IsIgnored() {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy valid replication and DRAIN state in haproxy %s enable traffic on server %s", proxy.Host+":"+proxy.Port, srv.URL)
+						msg, err := haRuntime.SetReady(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
+						if err != nil {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+						} else {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+						}
+					}
+					if srv.IsMaster() {
+						if !cluster.Configurator.HasProxyReadLeader() && line[17] == "UP" {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy master is not configured as reader but state is UP in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
+							msg, err := haRuntime.SetDrain(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
+							if err != nil {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+							} else {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+							}
+						}
+						if cluster.Configurator.HasProxyReadLeader() && line[17] == "DRAIN" {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy master is configured as reader but state is DRAIN in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
+							msg, err := haRuntime.SetReady(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
+							if err != nil {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+							} else {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+							}
+						}
+					}
+				}
 
-					if srv.IsMaintenance && line[17] == "UP" {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy detecting server %s in maintenance but proxy %s reports UP  ", srv.URL, proxy.Host+":"+proxy.Port)
-						proxy.SetMaintenance(srv)
-					}
-					if !srv.IsMaintenance && line[17] == "MAINT" {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy detecting server %s UP but proxy %s reports in maintenance ", srv.URL, proxy.Host+":"+proxy.Port)
-						proxy.SetMaintenance(srv)
-					}
+				if srv.IsMaintenance && line[17] == "UP" {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy detecting server %s in maintenance but proxy %s reports UP  ", srv.URL, proxy.Host+":"+proxy.Port)
+					proxy.SetMaintenance(srv)
+				}
+				if !srv.IsMaintenance && line[17] == "MAINT" {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy detecting server %s UP but proxy %s reports in maintenance ", srv.URL, proxy.Host+":"+proxy.Port)
+					proxy.SetMaintenance(srv)
 				}
 			}
 		}
@@ -567,19 +558,16 @@ func (proxy *Proxy) SetMaintenance(server *ServerMonitor) {
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "HAProxy can not set maintenance %s backend %s : %s", server.URL, cluster.Conf.HaproxyAPIReadBackend, err)
 		}
-		if cluster.Conf.HaproxyDebug {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy set maintenance %s backend %s result: %s", server.URL, cluster.Conf.HaproxyAPIReadBackend, res)
-		}
+
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "HAProxy set maintenance %s backend %s result: %s", server.URL, cluster.Conf.HaproxyAPIReadBackend, res)
 	} else {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy set server %s/%s state ready ", server.Id, cluster.Conf.HaproxyAPIReadBackend)
 		res, err := haRuntime.SetReady(server.Id, cluster.Conf.HaproxyAPIReadBackend)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "HAProxy can not set ready %s backend %s : %s", server.URL, cluster.Conf.HaproxyAPIReadBackend, err)
 		}
-		if cluster.Conf.HaproxyDebug {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy set ready %s backend %s result: %s", server.URL, cluster.Conf.HaproxyAPIReadBackend, res)
-		}
 
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "HAProxy set ready %s backend %s result: %s", server.URL, cluster.Conf.HaproxyAPIReadBackend, res)
 	}
 	if server.IsMaster() {
 		if server.IsMaintenance {
@@ -589,9 +577,8 @@ func (proxy *Proxy) SetMaintenance(server *ServerMonitor) {
 			if err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "HAProxy can not set maintenance %s backend %s : %s", server.URL, cluster.Conf.HaproxyAPIReadBackend, err)
 			}
-			if cluster.Conf.HaproxyDebug {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy set maintenance result: %s", res)
-			}
+
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "HAProxy set maintenance result: %s", res)
 
 		} else {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy set ready for server %s ", server.URL)
@@ -600,9 +587,8 @@ func (proxy *Proxy) SetMaintenance(server *ServerMonitor) {
 			if err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "HAProxy can not set ready %s backend %s : %s", server.URL, cluster.Conf.HaproxyAPIWriteBackend, err)
 			}
-			if cluster.Conf.HaproxyDebug {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy set ready %s backend %s result: %s", server.URL, cluster.Conf.HaproxyAPIWriteBackend, res)
-			}
+
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "HAProxy set ready %s backend %s result: %s", server.URL, cluster.Conf.HaproxyAPIWriteBackend, res)
 		}
 	}
 }

--- a/cluster/prx_haproxy.go
+++ b/cluster/prx_haproxy.go
@@ -452,7 +452,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 					}
 				} else {
 					if (srv.State == stateSlaveErr || srv.State == stateRelayErr || srv.State == stateSlaveLate || srv.State == stateRelayLate || srv.IsIgnored()) && line[17] == "UP" || srv.State == stateWsrepLate || srv.State == stateWsrepDonor {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy detecting broken replication and UP state in haproxy %s drain  server %s", proxy.Host+":"+proxy.Port, srv.URL)
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy detecting broken replication and UP state in haproxy %s drain server %s (%s)", proxy.Host+":"+proxy.Port, srv.Id, srv.URL)
 						msg, err := haRuntime.SetDrain(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
 						if err != nil {
 							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)

--- a/cluster/prx_haproxy.go
+++ b/cluster/prx_haproxy.go
@@ -371,7 +371,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 
 							if stagingsrv != nil {
 								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "[Staging] Detecting wrong master server in haproxy %s fixing it to standalone %s %s", proxy.Host+":"+proxy.Port, stagingsrv.Host, stagingsrv.Port)
-								msg, err := haRuntime.SetMaster(stagingsrv.Host, stagingsrv.Port)
+								msg, err := haRuntime.SetMaster(cluster.Conf.HaproxyStagingBackend, stagingsrv.Host, stagingsrv.Port)
 								if err != nil {
 									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
 								} else {
@@ -384,7 +384,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 							master := cluster.GetMaster()
 							if master != nil {
 								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "Detecting wrong master server in haproxy %s fixing it to master %s %s", proxy.Host+":"+proxy.Port, master.Host, master.Port)
-								msg, err := haRuntime.SetMaster(master.Host, master.Port)
+								msg, err := haRuntime.SetMaster(cluster.Conf.HaproxyAPIWriteBackend, master.Host, master.Port)
 								if err != nil {
 									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
 								} else {
@@ -511,7 +511,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 
 			if stagingsrv != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "[Staging] HAProxy has standalone in cluster but not in haproxy %s fixing it to standalone %s %s", proxy.Host+":"+proxy.Port, stagingsrv.Host, stagingsrv.Port)
-				msg, err := haRuntime.SetMaster(stagingsrv.Host, stagingsrv.Port)
+				msg, err := haRuntime.SetMaster(cluster.Conf.HaproxyStagingBackend, stagingsrv.Host, stagingsrv.Port)
 				if err != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
 				} else {
@@ -521,7 +521,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 		} else {
 			master := cluster.GetMaster()
 			if master != nil && master.IsLeader() {
-				res, err := haRuntime.SetMaster(master.Host, master.Port)
+				res, err := haRuntime.SetMaster(cluster.Conf.HaproxyAPIWriteBackend, master.Host, master.Port)
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy has leader in cluster but not in %s fixing it to master %s return %s", proxy.Host+":"+proxy.Port, master.URL, res)
 				if err != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "HAProxy cannot add leader %s in cluster but not in %s : %s", master.URL, proxy.Host+":"+proxy.Port, err)

--- a/cluster/prx_haproxy.go
+++ b/cluster/prx_haproxy.go
@@ -410,8 +410,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 				host = backend_ip_host[host]
 			}
 			srv := cluster.GetServerFromURL(host)
-
-			if srv.Id != line[1] {
+			if srv != nil && srv.Id != line[1] {
 				cluster.SetState("WARN0144", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0144"], line[1], srv.Id, host), ErrFrom: "HAProxy", ServerUrl: srv.URL})
 			}
 

--- a/cluster/prx_haproxy.go
+++ b/cluster/prx_haproxy.go
@@ -346,8 +346,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "HAProxy stat lookup writer: host %s translated to %s", line[73], host)
 
 			if srv != nil {
-				foundMasterInStat = true
-				proxy.BackendsWrite = append(proxy.BackendsWrite, Backend{
+				bkw := Backend{
 					Host:           srv.Host,
 					Port:           srv.Port,
 					Status:         srv.State,
@@ -357,35 +356,40 @@ func (proxy *HaproxyProxy) Refresh() error {
 					PrxByteIn:      line[8],
 					PrxByteOut:     line[9],
 					PrxLatency:     line[61], //ttime: average session time in ms over the 1024 last requests
-				})
+				}
 
-				if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
-					if !srv.IsStandAlone() {
-						if stagingsrv == nil {
-							stagingsrv, _ = cluster.GetStandaloneServerByIndex(0)
-							cluster.StagingServer = stagingsrv
-						}
+				if bkw.PrxName != "" {
+					foundMasterInStat = true
+					proxy.BackendsWrite = append(proxy.BackendsWrite, bkw)
 
-						if stagingsrv != nil {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "[Staging] Detecting wrong master server in haproxy %s fixing it to standalone %s %s", proxy.Host+":"+proxy.Port, stagingsrv.Host, stagingsrv.Port)
-							msg, err := haRuntime.SetMaster(stagingsrv.Host, stagingsrv.Port)
-							if err != nil {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
-							} else {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
+					if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
+						if !srv.IsStandAlone() {
+							if stagingsrv == nil {
+								stagingsrv, _ = cluster.GetStandaloneServerByIndex(0)
+								cluster.StagingServer = stagingsrv
+							}
+
+							if stagingsrv != nil {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "[Staging] Detecting wrong master server in haproxy %s fixing it to standalone %s %s", proxy.Host+":"+proxy.Port, stagingsrv.Host, stagingsrv.Port)
+								msg, err := haRuntime.SetMaster(stagingsrv.Host, stagingsrv.Port)
+								if err != nil {
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
+								} else {
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
+								}
 							}
 						}
-					}
-				} else {
-					if !srv.IsMaster() {
-						master := cluster.GetMaster()
-						if master != nil {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "Detecting wrong master server in haproxy %s fixing it to master %s %s", proxy.Host+":"+proxy.Port, master.Host, master.Port)
-							msg, err := haRuntime.SetMaster(master.Host, master.Port)
-							if err != nil {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
-							} else {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
+					} else {
+						if !srv.IsMaster() {
+							master := cluster.GetMaster()
+							if master != nil {
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "Detecting wrong master server in haproxy %s fixing it to master %s %s", proxy.Host+":"+proxy.Port, master.Host, master.Port)
+								msg, err := haRuntime.SetMaster(master.Host, master.Port)
+								if err != nil {
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
+								} else {
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
+								}
 							}
 						}
 					}
@@ -406,9 +410,9 @@ func (proxy *HaproxyProxy) Refresh() error {
 				host = backend_ip_host[host]
 			}
 			srv := cluster.GetServerFromURL(host)
-			if cluster.Conf.HaproxyDebug {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "HAProxy stat lookup reader: host %s translated to %s", line[73], host)
-			}
+
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "HAProxy stat lookup reader: host %s translated to %s", line[73], host)
+
 			if srv != nil {
 				proxy.BackendsRead = append(proxy.BackendsRead, Backend{
 					Host:           srv.Host,
@@ -542,9 +546,9 @@ func (proxy *Proxy) SetMaintenance(server *ServerMonitor) {
 		proxy.Init()
 		return
 	}
-	//if cluster.Conf.HaproxyDebug {
+
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy set maintenance for server %s ", server.URL)
-	//}
+
 	haRuntime := haproxy.Runtime{
 		Binary:   cluster.Conf.HaproxyBinaryPath,
 		SockFile: filepath.Join(proxy.Datadir+"/var", "/haproxy.stats.sock"),

--- a/cluster/prx_haproxy.go
+++ b/cluster/prx_haproxy.go
@@ -343,7 +343,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 
 			srv := cluster.GetServerFromURL(host)
 
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy stat lookup writer: host %s translated to %s", line[73], host)
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "HAProxy stat lookup writer: host %s translated to %s", line[73], host)
 
 			if srv != nil {
 				foundMasterInStat = true
@@ -407,7 +407,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 			}
 			srv := cluster.GetServerFromURL(host)
 			if cluster.Conf.HaproxyDebug {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy stat lookup reader: host %s translated to %s", line[73], host)
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "HAProxy stat lookup reader: host %s translated to %s", line[73], host)
 			}
 			if srv != nil {
 				proxy.BackendsRead = append(proxy.BackendsRead, Backend{

--- a/cluster/prx_haproxy.go
+++ b/cluster/prx_haproxy.go
@@ -370,9 +370,9 @@ func (proxy *HaproxyProxy) Refresh() error {
 							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "[Staging] Detecting wrong master server in haproxy %s fixing it to standalone %s %s", proxy.Host+":"+proxy.Port, stagingsrv.Host, stagingsrv.Port)
 							msg, err := haRuntime.SetMaster(stagingsrv.Host, stagingsrv.Port)
 							if err != nil {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
 							} else {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
 							}
 						}
 					}
@@ -383,9 +383,9 @@ func (proxy *HaproxyProxy) Refresh() error {
 							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "Detecting wrong master server in haproxy %s fixing it to master %s %s", proxy.Host+":"+proxy.Port, master.Host, master.Port)
 							msg, err := haRuntime.SetMaster(master.Host, master.Port)
 							if err != nil {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
 							} else {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
 							}
 						}
 					}
@@ -429,9 +429,9 @@ func (proxy *HaproxyProxy) Refresh() error {
 								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy staging is DRAIN in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
 								msg, err := haRuntime.SetReady(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
 								if err != nil {
-									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 								} else {
-									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 								}
 							}
 						} else { // Deactivate other servers
@@ -439,9 +439,9 @@ func (proxy *HaproxyProxy) Refresh() error {
 								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy non-staging backend state is UP in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
 								msg, err := haRuntime.SetDrain(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
 								if err != nil {
-									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 								} else {
-									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 								}
 							}
 						}
@@ -451,18 +451,18 @@ func (proxy *HaproxyProxy) Refresh() error {
 						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy detecting broken replication and UP state in haproxy %s drain  server %s", proxy.Host+":"+proxy.Port, srv.URL)
 						msg, err := haRuntime.SetDrain(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
 						if err != nil {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 						} else {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlInfo, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 						}
 					}
 					if (srv.State == stateSlave || srv.State == stateRelay || (srv.State == stateWsrep && !srv.IsLeader())) && line[17] == "DRAIN" && !srv.IsIgnored() {
 						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy valid replication and DRAIN state in haproxy %s enable traffic on server %s", proxy.Host+":"+proxy.Port, srv.URL)
 						msg, err := haRuntime.SetReady(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
 						if err != nil {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 						} else {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 						}
 					}
 					if srv.IsMaster() {
@@ -470,18 +470,18 @@ func (proxy *HaproxyProxy) Refresh() error {
 							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy master is not configured as reader but state is UP in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
 							msg, err := haRuntime.SetDrain(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
 							if err != nil {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 							} else {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 							}
 						}
 						if cluster.Configurator.HasProxyReadLeader() && line[17] == "DRAIN" {
 							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy master is configured as reader but state is DRAIN in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
 							msg, err := haRuntime.SetReady(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
 							if err != nil {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 							} else {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 							}
 						}
 					}
@@ -509,9 +509,9 @@ func (proxy *HaproxyProxy) Refresh() error {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "[Staging] HAProxy has standalone in cluster but not in haproxy %s fixing it to standalone %s %s", proxy.Host+":"+proxy.Port, stagingsrv.Host, stagingsrv.Port)
 				msg, err := haRuntime.SetMaster(stagingsrv.Host, stagingsrv.Port)
 				if err != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlErr, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
 				} else {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
 				}
 			}
 		} else {

--- a/cluster/prx_haproxy.go
+++ b/cluster/prx_haproxy.go
@@ -411,6 +411,10 @@ func (proxy *HaproxyProxy) Refresh() error {
 			}
 			srv := cluster.GetServerFromURL(host)
 
+			if srv.Id != line[1] {
+				cluster.SetState("WARN0144", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0144"], line[1], srv.Id, host), ErrFrom: "HAProxy", ServerUrl: srv.URL})
+			}
+
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "HAProxy stat lookup reader: host %s translated to %s", line[73], host)
 
 			if srv != nil {

--- a/cluster/prx_haproxy.go
+++ b/cluster/prx_haproxy.go
@@ -410,31 +410,34 @@ func (proxy *HaproxyProxy) Refresh() error {
 				host = backend_ip_host[host]
 			}
 			srv := cluster.GetServerFromURL(host)
-			if srv != nil && srv.Id != line[1] {
-				cluster.SetState("WARN0144", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0144"], line[1], srv.Id, host), ErrFrom: "HAProxy", ServerUrl: srv.URL})
-			}
+			// if srv != nil && srv.Id != line[1] {
+			// 	cluster.SetState("WARN0144", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0144"], line[1], srv.Id, host), ErrFrom: "HAProxy", ServerUrl: srv.URL})
+			// }
 
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "HAProxy stat lookup reader: host %s translated to %s", line[73], host)
 
 			if srv != nil {
-				proxy.BackendsRead = append(proxy.BackendsRead, Backend{
+				bkr := Backend{
 					Host:           srv.Host,
 					Port:           srv.Port,
 					Status:         srv.State,
+					Svname:         line[1],
 					PrxName:        line[73],
 					PrxStatus:      line[17],
 					PrxConnections: line[5],
 					PrxByteIn:      line[8],
 					PrxByteOut:     line[9],
 					PrxLatency:     line[61],
-				})
+				}
+
+				proxy.BackendsRead = append(proxy.BackendsRead, bkr)
 
 				if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
 					if stagingsrv != nil {
 						if srv.Id == stagingsrv.Id { // Only activate staging server for read
 							if line[17] == "DRAIN" {
 								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy staging is DRAIN in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
-								msg, err := haRuntime.SetReady(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
+								msg, err := haRuntime.SetReady(bkr.Svname, cluster.Conf.HaproxyAPIReadBackend)
 								if err != nil {
 									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 								} else {
@@ -444,7 +447,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 						} else { // Deactivate other servers
 							if line[17] == "UP" {
 								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy non-staging backend state is UP in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
-								msg, err := haRuntime.SetDrain(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
+								msg, err := haRuntime.SetDrain(bkr.Svname, cluster.Conf.HaproxyAPIReadBackend)
 								if err != nil {
 									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 								} else {
@@ -456,7 +459,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 				} else {
 					if (srv.State == stateSlaveErr || srv.State == stateRelayErr || srv.State == stateSlaveLate || srv.State == stateRelayLate || srv.IsIgnored()) && line[17] == "UP" || srv.State == stateWsrepLate || srv.State == stateWsrepDonor {
 						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy detecting broken replication and UP state in haproxy %s drain server %s (%s)", proxy.Host+":"+proxy.Port, srv.Id, srv.URL)
-						msg, err := haRuntime.SetDrain(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
+						msg, err := haRuntime.SetDrain(bkr.Svname, cluster.Conf.HaproxyAPIReadBackend)
 						if err != nil {
 							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 						} else {
@@ -465,7 +468,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 					}
 					if (srv.State == stateSlave || srv.State == stateRelay || (srv.State == stateWsrep && !srv.IsLeader())) && line[17] == "DRAIN" && !srv.IsIgnored() {
 						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy valid replication and DRAIN state in haproxy %s enable traffic on server %s", proxy.Host+":"+proxy.Port, srv.URL)
-						msg, err := haRuntime.SetReady(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
+						msg, err := haRuntime.SetReady(bkr.Svname, cluster.Conf.HaproxyAPIReadBackend)
 						if err != nil {
 							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 						} else {
@@ -475,7 +478,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 					if srv.IsMaster() {
 						if !cluster.Configurator.HasProxyReadLeader() && line[17] == "UP" {
 							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy master is not configured as reader but state is UP in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
-							msg, err := haRuntime.SetDrain(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
+							msg, err := haRuntime.SetDrain(bkr.Svname, cluster.Conf.HaproxyAPIReadBackend)
 							if err != nil {
 								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 							} else {
@@ -484,7 +487,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 						}
 						if cluster.Configurator.HasProxyReadLeader() && line[17] == "DRAIN" {
 							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy master is configured as reader but state is DRAIN in haproxy %s for server %s", proxy.Host+":"+proxy.Port, srv.URL)
-							msg, err := haRuntime.SetReady(srv.Id, cluster.Conf.HaproxyAPIReadBackend)
+							msg, err := haRuntime.SetReady(bkr.Svname, cluster.Conf.HaproxyAPIReadBackend)
 							if err != nil {
 								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (server: %s)", proxy.Host+":"+proxy.Port, msg, srv.Host+":"+srv.Port)
 							} else {
@@ -540,7 +543,7 @@ func (cluster *Cluster) setMaintenanceHaproxy(pr *Proxy, server *ServerMonitor) 
 	pr.SetMaintenance(server)
 }
 
-func (proxy *Proxy) SetMaintenance(server *ServerMonitor) {
+func (proxy *HaproxyProxy) SetMaintenance(server *ServerMonitor) {
 	cluster := proxy.ClusterGroup
 	if !cluster.Conf.HaproxyOn {
 		return
@@ -559,9 +562,15 @@ func (proxy *Proxy) SetMaintenance(server *ServerMonitor) {
 		Host:     proxy.Host,
 	}
 
+	svname := server.Id
+	bkr := proxy.GetReadBackendDetail(server)
+	if bkr != nil {
+		svname = bkr.Svname
+	}
+
 	if server.IsMaintenance {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy set server %s/%s state maint ", server.Id, cluster.Conf.HaproxyAPIReadBackend)
-		res, err := haRuntime.SetMaintenance(server.Id, cluster.Conf.HaproxyAPIReadBackend)
+		res, err := haRuntime.SetMaintenance(svname, cluster.Conf.HaproxyAPIReadBackend)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "HAProxy can not set maintenance %s backend %s : %s", server.URL, cluster.Conf.HaproxyAPIReadBackend, err)
 		}
@@ -569,13 +578,14 @@ func (proxy *Proxy) SetMaintenance(server *ServerMonitor) {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "HAProxy set maintenance %s backend %s result: %s", server.URL, cluster.Conf.HaproxyAPIReadBackend, res)
 	} else {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy set server %s/%s state ready ", server.Id, cluster.Conf.HaproxyAPIReadBackend)
-		res, err := haRuntime.SetReady(server.Id, cluster.Conf.HaproxyAPIReadBackend)
+		res, err := haRuntime.SetReady(svname, cluster.Conf.HaproxyAPIReadBackend)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "HAProxy can not set ready %s backend %s : %s", server.URL, cluster.Conf.HaproxyAPIReadBackend, err)
 		}
 
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "HAProxy set ready %s backend %s result: %s", server.URL, cluster.Conf.HaproxyAPIReadBackend, res)
 	}
+
 	if server.IsMaster() {
 		if server.IsMaintenance {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy set maintenance for server %s ", server.URL)

--- a/config/error.go
+++ b/config/error.go
@@ -215,6 +215,7 @@ var ClusterError = map[string]string{
 	"WARN0141":  "Not enough free space estimated for %s logical backup on %s. Mount: %s Free: %s Required: %s",
 	"WARN0142":  "Not enough free space estimated for %s physical backup on %s. Mount: %s Free: %s Required: %s",
 	"WARN0143":  "Not enough free space estimated for binary log backup on %s. Mount: %s Free: %s Required: %s",
+	"WARN0144":  "HAProxy inconsistent server ID between haproxy %s and cluster %s for host %s",
 	"MDEV20821": "MariaDB version has replication issue https://jira.mariadb.org/browse/MDEV-20821",
 	"MDEV28310": "MariaDB version has replication issue for non row format https://jira.mariadb.org/browse/MDEV-28310",
 	"MDEV19577": "MariaDB version has replication issue for non row format https://jira.mariadb.org/browse/MDEV-19577",

--- a/router/haproxy/runtime_api.go
+++ b/router/haproxy/runtime_api.go
@@ -46,7 +46,7 @@ func (r *Runtime) GetVersion() (string, error) {
 	return string(result), nil
 }
 
-func (r *Runtime) SetMaster(host string, port string) (string, error) {
+func (r *Runtime) SetMaster(writebackend string, host string, port string) (string, error) {
 
 	if net.ParseIP(host) == nil {
 		return r.SetMasterFQDN(host, port)
@@ -56,7 +56,7 @@ func (r *Runtime) SetMaster(host string, port string) (string, error) {
 		return "", err
 	}
 	defer conn.Close()
-	_, err = conn.Write([]byte("set server service_write/leader addr " + host + " port " + port + "\n"))
+	_, err = conn.Write([]byte("set server " + writebackend + "/leader addr " + host + " port " + port + "\n"))
 	if err != nil {
 
 		return "", err

--- a/router/haproxy/runtime_api.go
+++ b/router/haproxy/runtime_api.go
@@ -46,17 +46,17 @@ func (r *Runtime) GetVersion() (string, error) {
 	return string(result), nil
 }
 
-func (r *Runtime) SetMaster(writebackend string, host string, port string) (string, error) {
+func (r *Runtime) SetMaster(pool string, host string, port string) (string, error) {
 
 	if net.ParseIP(host) == nil {
-		return r.SetMasterFQDN(host, port)
+		return r.SetMasterFQDN(pool, host, port)
 	}
 	conn, err := net.DialTimeout("tcp", r.Host+":"+r.Port, DefaultTimeout)
 	if err != nil {
 		return "", err
 	}
 	defer conn.Close()
-	_, err = conn.Write([]byte("set server " + writebackend + "/leader addr " + host + " port " + port + "\n"))
+	_, err = conn.Write([]byte("set server " + pool + "/leader addr " + host + " port " + port + "\n"))
 	if err != nil {
 
 		return "", err
@@ -70,13 +70,13 @@ func (r *Runtime) SetMaster(writebackend string, host string, port string) (stri
 	return string(result), nil
 }
 
-func (r *Runtime) SetMasterFQDN(host string, port string) (string, error) {
+func (r *Runtime) SetMasterFQDN(pool string, host string, port string) (string, error) {
 	conn, err := net.DialTimeout("tcp", r.Host+":"+r.Port, DefaultTimeout)
 	if err != nil {
 		return "", err
 	}
 	defer conn.Close()
-	_, err = conn.Write([]byte("set server service_write/leader fqdn " + host + " port " + port + "\n"))
+	_, err = conn.Write([]byte("set server " + pool + "/leader fqdn " + host + " port " + port + "\n"))
 	if err != nil {
 
 		return "", err

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2635,16 +2635,27 @@ func applyIsActive(oldValue bool, isactive *bool) bool {
 	return *isactive
 }
 
+func GetApiChangeLogFormat(name, value string) (string, []interface{}) {
+	switch name {
+	case "replication-credential", "db-servers-credential", "proxysql-servers-credential", "proxy-servers-backend-max-connections", "proxy-servers-backend-max-replication-lag", "maxscale-servers-credential", "shardproxy-servers-credential", "mail-smtp-password", "mail-smtp-user", "mail-to", "mail-from", "cloud18-gitlab-user", "cloud18-gitlab-password", "backup-restic-aws-access-key-id", "backup-restic-aws-access-secret", "backup-restic-password", "cloud18-dba-user-credentials", "cloud18-sponsor-user-credentials":
+		return "API receive set setting %s to ****", []interface{}{name}
+	default:
+		return "API receive set setting %s to %s", []interface{}{name, value}
+	}
+}
+
 func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, name string, value string) error {
 	var isactive *bool = setIsActive(value)
 	var err error
 
+	fmtlog, logargs := GetApiChangeLogFormat(name, value)
+
 	//not immutable
 	if !mycluster.Conf.IsVariableImmutable(name) {
-		mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "API receive set setting %s to %s", name, value)
+		mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", fmtlog, logargs...)
 	} else {
 		mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Overwriting an immutable parameter defined in config , please use config-merge command to preserve them between restart")
-		mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "API receive set setting %s to %s", name, value)
+		mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", fmtlog, logargs...)
 	}
 
 	switch name {
@@ -3714,12 +3725,15 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 func (repman *ReplicationManager) setRepmanSetting(name string, value string) error {
 	var isactive bool = strings.ToLower(value) == "on"
 	var v int
+
+	fmtLog, logArgs := GetApiChangeLogFormat(name, value)
+
 	//not immutable
 	if !repman.Conf.IsVariableImmutable(name) {
-		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, "INFO", "API receive set setting %s to %s", name, value)
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, "INFO", fmtLog, logArgs...)
 	} else {
 		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Overwriting an immutable parameter defined in config , please use config-merge command to preserve them between restart")
-		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, "INFO", "API receive set setting %s to %s", name, value)
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, "INFO", fmtLog, logArgs...)
 	}
 
 	switch name {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2641,10 +2641,10 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 
 	//not immutable
 	if !mycluster.Conf.IsVariableImmutable(name) {
-		mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "API receive set setting %s", name)
+		mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "API receive set setting %s to %s", name, value)
 	} else {
 		mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Overwriting an immutable parameter defined in config , please use config-merge command to preserve them between restart")
-		mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "API receive set setting %s", name)
+		mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "API receive set setting %s to %s", name, value)
 	}
 
 	switch name {
@@ -3716,10 +3716,10 @@ func (repman *ReplicationManager) setRepmanSetting(name string, value string) er
 	var v int
 	//not immutable
 	if !repman.Conf.IsVariableImmutable(name) {
-		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, "INFO", "API receive set setting %s", name)
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, "INFO", "API receive set setting %s to %s", name, value)
 	} else {
 		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Overwriting an immutable parameter defined in config , please use config-merge command to preserve them between restart")
-		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, "INFO", "API receive set setting %s", name)
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, "INFO", "API receive set setting %s to %s", name, value)
 	}
 
 	switch name {


### PR DESCRIPTION
This pull request introduces several improvements and refactoring to the HAProxy proxy management logic, focusing on better backend identification, more precise logging, and improved maintenance operations. The changes enhance how backend servers are referenced and managed, especially in maintenance scenarios, and unify the logging level for debugging information.

### Backend identification and maintenance operations

* Added a new `Svname` field to the `Backend` struct and updated backend management code to use this field (instead of server IDs) when performing HAProxy operations, improving accuracy in backend identification. Also, the `SetMaintenance` method now uses `Svname` if available. (`cluster/prx.go`, `cluster/prx_haproxy.go`, `cluster/prx_get.go`) [[1]](diffhunk://#diff-a1c4554e1b8f361bf9e6d5a29900403ccee9c45fd57c773806c064fc53ca4bcaR180) [[2]](diffhunk://#diff-8b0d38870e7bcd1aeb287c845b257885a0354a0c2930b1e6c327168b97eaaba2R427-R440) [[3]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL554-R588)
* Changed the receiver type of the `SetMaintenance` method from `Proxy` to `HaproxyProxy` to ensure the method is only available for HAProxy-specific proxy types. (`cluster/prx_haproxy.go`)

### Logging improvements

* Standardized all debug and info logging to use the `config.LvlDbg` level for HAProxy-related messages, replacing previous conditional debug logging and info-level logs. This makes debugging output more consistent and easier to filter. (`cluster/prx_haproxy.go`) [[1]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL270-R272) [[2]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL287-R287) [[3]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL310-R310) [[4]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL347-R347) [[5]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL415-R424) [[6]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL592-R598)
* Updated error and debug log module references from `ConstLogModProxy` to `ConstLogModHAProxy` for HAProxy-related operations, improving log clarity and categorization. (`cluster/prx_haproxy.go`) [[1]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL376-R378) [[2]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL389-R391) [[3]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL519-R530)

### HAProxy runtime API usage

* Modified calls to HAProxy runtime API methods (`SetMaster`, `SetReady`, `SetDrain`, `SetMaintenance`) to use the new `Svname` field and updated backend configuration references, ensuring correct backend targeting in both staging and regular topologies. (`cluster/prx_haproxy.go`) [[1]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL376-R378) [[2]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL389-R391) [[3]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL415-R424) [[4]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL431-R494) [[5]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL519-R530) [[6]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL554-R588)

These changes collectively improve HAProxy proxy management by making backend identification more robust, maintenance operations more reliable, and logging more consistent for debugging and monitoring.