### PR TITLE
Fix table creation queries to ensure they create if not exists and correct variable usage

### DIFF
--- a/utils/dbhelper/dbhelper.go
+++ b/utils/dbhelper/dbhelper.go
@@ -3608,15 +3608,15 @@ func FetchLogsToBufferTable(conn *sqlx.Conn, version *version.Version, table str
 	ctx, cancel = context.WithTimeout(context.Background(), timeout)
 	if _, err := conn.ExecContext(ctx, query); err != nil {
 		cancel()
-		return fmt.Errorf("Unable to create drop replication_manager_schema.%s: %s", desttablename, err.Error())
+		return fmt.Errorf("Unable to create drop replication_manager_schema.%s: %s", copytablename, err.Error())
 	}
 	cancel()
 
-	query = "CREATE TABLE `replication_manager_schema`." + copytablename + " LIKE `mysql`." + table
+	query = "CREATE TABLE IF NOT EXISTS `replication_manager_schema`." + copytablename + " LIKE `mysql`." + table
 	ctx, cancel = context.WithTimeout(context.Background(), timeout)
 	if _, err := conn.ExecContext(ctx, query); err != nil {
 		cancel()
-		return fmt.Errorf("Unable to create table replication_manager_schema.%s: %s", desttablename, err.Error())
+		return fmt.Errorf("Unable to create table replication_manager_schema.%s: %s", copytablename, err.Error())
 	}
 	cancel()
 
@@ -3709,6 +3709,14 @@ func MoveLogsToDailyTable(conn *sqlx.Conn, version *version.Version, table strin
 	if _, err := conn.ExecContext(ctx, query); err != nil {
 		cancel()
 		return fmt.Errorf("Unable to create table replication_manager_schema.%s: %s", desttablename, err.Error())
+	}
+	cancel()
+
+	query = "CREATE TABLE IF NOT EXISTS `replication_manager_schema`." + copytablename + " LIKE `mysql`." + table
+	ctx, cancel = context.WithTimeout(context.Background(), timeout)
+	if _, err := conn.ExecContext(ctx, query); err != nil {
+		cancel()
+		return fmt.Errorf("Unable to create table replication_manager_schema.%s: %s", copytablename, err.Error())
 	}
 	cancel()
 


### PR DESCRIPTION
This pull request updates the logic for creating and handling tables in the replication manager schema within the `dbhelper.go` utility. The main improvements are focused on error reporting accuracy and ensuring that tables are only created if they do not already exist.

**Database table management improvements:**

* Changed error messages in both `FetchLogsToBufferTable` and `MoveLogsToDailyTable` to reference the correct table name (`copytablename`) instead of `desttablename` for better clarity when reporting failures.
* Updated table creation logic to use `CREATE TABLE IF NOT EXISTS` for `replication_manager_schema.copytablename`, preventing errors if the table already exists. This change is applied in both functions. [[1]](diffhunk://#diff-e9e0167b5c5254cf7532586841c5126202e3eecc885ba66aa23747877ccb6398L3611-R3619) [[2]](diffhunk://#diff-e9e0167b5c5254cf7532586841c5126202e3eecc885ba66aa23747877ccb6398R3715-R3722)