### PR TITLE
Add backup restic repo config file

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -732,7 +732,7 @@ func (cluster *Cluster) Run() {
 							cluster.CheckAllBackupFreeSpace()
 							cluster.CheckAvailableCredit()
 						} else {
-							cluster.StateMachine.PreserveState("WARN0093", "WARN0084", "WARN0095", "WARN0101", "WARN0111", "WARN0112", "ERR00090", "WARN0102", "WARN0134", "WARN0139", "WARN0140", "WARN0141", "WARN0142", "WARN0143", "CREDIT01")
+							cluster.StateMachine.PreserveState("WARN0093", "WARN0084", "WARN0095", "WARN0101", "WARN0111", "WARN0112", "ERR00090", "WARN0102", "WARN0134", "WARN0139", "WARN0140", "WARN0141", "WARN0142", "WARN0143", "WARN0145", "CREDIT01")
 						}
 						if !cluster.CanInitNodes {
 							cluster.SetState("ERR00082", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00082"], cluster.errorInitNodes), ErrFrom: "OPENSVC"})

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -24,7 +24,7 @@ import (
 
 func (cluster *Cluster) ResticGetEnv() []string {
 	newEnv := append(os.Environ(), "RESTIC_PASSWORD="+cluster.Conf.GetDecryptedValue("backup-restic-password"))
-	newEnv = append(newEnv, "RESTIC_CACHE_DIR="+os.Getenv("HOME")+"/.cache/restic")
+	newEnv = append(newEnv, "RESTIC_CACHE_DIR="+cluster.Conf.WorkingDir+"/"+cluster.Name+"/.cache/restic")
 
 	if cluster.Conf.BackupResticAws {
 		newEnv = append(newEnv, "AWS_ACCESS_KEY_ID="+cluster.Conf.BackupResticAwsAccessKeyId)
@@ -368,4 +368,90 @@ func (cluster *Cluster) CheckAllBackupFreeSpace() {
 	}
 
 	wg.Wait()
+}
+
+// TODO: Restic password change
+func (cluster *Cluster) ChangeResticPassword(newpass string) error {
+	if !cluster.Conf.BackupRestic {
+		return fmt.Errorf("Restic backup is not enabled")
+	}
+
+	if newpass == "" {
+		return fmt.Errorf("New password is empty")
+	}
+
+	if newpass == cluster.Conf.GetDecryptedValue("backup-restic-password") {
+		return fmt.Errorf("New password is the same as the current one")
+	}
+
+	oldvalue := cluster.Conf.GetDecryptedValue("backup-restic-password")
+
+	cluster.ResticRepo.SetEnv(cluster.ResticGetEnv())
+
+	keylist, err := cluster.ResticRepo.ResticKeyList()
+	if err != nil {
+		cluster.SetState("WARN0150", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0150"], err), ErrFrom: "BACKUP"})
+		return err
+	}
+
+	keylen := len(keylist)
+	if keylen == 0 {
+		return fmt.Errorf("No keys found in the restic repository")
+	}
+
+	oldkeyid := ""
+	for _, key := range keylist {
+		if key.Current {
+			oldkeyid = key.Id
+			break
+		}
+	}
+
+	if _, err := os.Stat(cluster.ResticRepo.GetCacheDirPath()); os.IsNotExist(err) {
+		err := os.MkdirAll(cluster.ResticRepo.GetCacheDirPath(), os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("Error creating restic cache directory: %s", err)
+		}
+	}
+
+	newpassfile := filepath.Join(cluster.ResticRepo.GetCacheDirPath(), "newpass.txt")
+	err = os.WriteFile(newpassfile, []byte(newpass), 0600)
+	if err != nil {
+		return fmt.Errorf("failed to write new password file: %w", err)
+	}
+
+	defer func() {
+		if _, err := os.Stat(newpassfile); err == nil {
+			err := os.Remove(newpassfile)
+			if err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Failed to remove new password file: %s", err)
+			}
+		}
+	}()
+
+	err = cluster.ResticRepo.ResticAddPassword(newpassfile)
+	if err != nil {
+		cluster.SetState("WARN0150", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0150"], err), ErrFrom: "BACKUP"})
+		return err
+	}
+
+	cluster.Conf.BackupResticPassword = newpass
+	var new_secret config.Secret
+	new_secret.Value = cluster.Conf.BackupResticPassword
+	new_secret.OldValue = oldvalue
+	cluster.Conf.Secrets["backup-restic-password"] = new_secret
+
+	// Reload env with new password
+	cluster.ResticRepo.SetEnv(cluster.ResticGetEnv())
+
+	// Remove old key using new password
+	err = cluster.ResticRepo.ResticRemoveKey(oldkeyid)
+	if err != nil {
+		cluster.SetState("WARN0150", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0150"], err), ErrFrom: "BACKUP"})
+		return err
+	}
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Restic password changed successfully. New key added and old key removed.")
+
+	return nil
 }

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -371,7 +371,7 @@ func (cluster *Cluster) CheckAllBackupFreeSpace() {
 }
 
 // TODO: Restic password change
-func (cluster *Cluster) ChangeResticPassword(newpass string) error {
+func (cluster *Cluster) ChangeResticRepoPassword(newpass string) error {
 	if !cluster.Conf.BackupRestic {
 		return fmt.Errorf("Restic backup is not enabled")
 	}
@@ -384,13 +384,13 @@ func (cluster *Cluster) ChangeResticPassword(newpass string) error {
 		return fmt.Errorf("New password is the same as the current one")
 	}
 
-	oldvalue := cluster.Conf.GetDecryptedValue("backup-restic-password")
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModArchive, config.LvlInfo, "Changing restic password for cluster %s", cluster.Name)
 
 	cluster.ResticRepo.SetEnv(cluster.ResticGetEnv())
 
 	keylist, err := cluster.ResticRepo.ResticKeyList()
 	if err != nil {
-		cluster.SetState("WARN0150", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0150"], err), ErrFrom: "BACKUP"})
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModArchive, config.LvlErr, "Failed to list restic keys: %s", err)
 		return err
 	}
 
@@ -412,34 +412,43 @@ func (cluster *Cluster) ChangeResticPassword(newpass string) error {
 		if err != nil {
 			return fmt.Errorf("Error creating restic cache directory: %s", err)
 		}
+
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModArchive, config.LvlInfo, "Restic cache directory created: %s", cluster.ResticRepo.GetCacheDirPath())
 	}
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModArchive, config.LvlInfo, "Adding new key to restic repository")
 
 	newpassfile := filepath.Join(cluster.ResticRepo.GetCacheDirPath(), "newpass.txt")
 	err = os.WriteFile(newpassfile, []byte(newpass), 0600)
 	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModArchive, config.LvlErr, "Failed to write new password file: %s", err)
 		return fmt.Errorf("failed to write new password file: %w", err)
 	}
 
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModArchive, config.LvlInfo, "Temporary password file created: %s", newpassfile)
+
 	defer func() {
 		if _, err := os.Stat(newpassfile); err == nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModArchive, config.LvlInfo, "Removing temporary password file")
 			err := os.Remove(newpassfile)
 			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Failed to remove new password file: %s", err)
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModArchive, config.LvlErr, "Failed to remove temporary password file: %s", err)
 			}
 		}
 	}()
 
 	err = cluster.ResticRepo.ResticAddPassword(newpassfile)
 	if err != nil {
-		cluster.SetState("WARN0150", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0150"], err), ErrFrom: "BACKUP"})
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModArchive, config.LvlErr, "Failed to add new key to restic repository: %s", err)
 		return err
 	}
 
-	cluster.Conf.BackupResticPassword = newpass
-	var new_secret config.Secret
-	new_secret.Value = cluster.Conf.BackupResticPassword
-	new_secret.OldValue = oldvalue
-	cluster.Conf.Secrets["backup-restic-password"] = new_secret
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModArchive, config.LvlInfo, "New key added to restic repository successfully. Saving new password.")
+
+	// Save new password in configuration
+	cluster.SetResticPassword(newpass)
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModArchive, config.LvlInfo, "New restic password saved in configuration successfully. Removing old key from repository using new password.")
 
 	// Reload env with new password
 	cluster.ResticRepo.SetEnv(cluster.ResticGetEnv())
@@ -447,11 +456,11 @@ func (cluster *Cluster) ChangeResticPassword(newpass string) error {
 	// Remove old key using new password
 	err = cluster.ResticRepo.ResticRemoveKey(oldkeyid)
 	if err != nil {
-		cluster.SetState("WARN0150", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0150"], err), ErrFrom: "BACKUP"})
-		return err
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModArchive, config.LvlErr, "Failed to remove old key from restic repository: %s", err)
+		return nil
 	}
 
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Restic password changed successfully. New key added and old key removed.")
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModArchive, config.LvlInfo, "Restic password changed successfully. New key added and old key removed.")
 
 	return nil
 }

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -136,7 +136,7 @@ func (cluster *Cluster) ResticFetchRepo() error {
 	_, err := cluster.ResticRepo.AddFetchTask(true)
 	if err != nil {
 		if !cluster.ResticRepo.CanInitRepo {
-			cluster.SetState("WARN0095", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0096"], "restic repo cannot be initialized"), ErrFrom: "BACKUP"})
+			cluster.SetState("WARN0095", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0095"], err), ErrFrom: "BACKUP"})
 		} else if cluster.ResticRepo.CanFetch && cluster.ResticRepo.HasLocks {
 			cluster.SetState("WARN0134", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0134"], cluster.ResticRepo.GetRepoPath()), ErrFrom: "BACKUP"})
 		} else {

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -9,6 +9,7 @@ package cluster
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/dustin/go-humanize"
@@ -16,6 +17,7 @@ import (
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/archiver"
 	"github.com/signal18/replication-manager/utils/dbhelper"
+	"github.com/signal18/replication-manager/utils/misc"
 	"github.com/signal18/replication-manager/utils/state"
 	"github.com/sirupsen/logrus"
 )
@@ -140,9 +142,64 @@ func (cluster *Cluster) ResticFetchRepo() error {
 		} else {
 			cluster.SetState("WARN0093", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0093"], err), ErrFrom: "BACKUP"})
 		}
+	} else {
+		if _, err2 := os.Stat(filepath.Join(cluster.Conf.WorkingDir, cluster.Name, "restic.config.bak")); os.IsNotExist(err2) {
+			if err2 := cluster.BackupResticConfig(); err2 != nil {
+				cluster.SetState("WARN0145", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0145"], err2), ErrFrom: "BACKUP"})
+			}
+		}
 	}
 
 	return err
+}
+
+func (cluster *Cluster) BackupResticConfig() error {
+	if !cluster.Conf.BackupRestic {
+		return nil
+	}
+
+	repopath := cluster.ResticRepo.GetRepoPath()
+	if repopath == "" {
+		return fmt.Errorf("restic repo path is empty")
+	}
+
+	dest := filepath.Join(cluster.Conf.WorkingDir, cluster.Name, "restic.config.bak")
+	src := filepath.Join(repopath, "config")
+
+	err := misc.CopyFile(src, dest)
+	if err != nil {
+		return err
+	}
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Restic config file backed up to %s", dest)
+	return nil
+}
+
+func (cluster *Cluster) RestoreResticConfig(force bool) error {
+	if !cluster.Conf.BackupRestic {
+		return nil
+	}
+
+	repopath := cluster.ResticRepo.GetRepoPath()
+	if repopath == "" {
+		return fmt.Errorf("restic repo path is empty")
+	}
+
+	_, err := os.Stat(filepath.Join(repopath, "config"))
+	if !os.IsNotExist(err) && !force {
+		return fmt.Errorf("restic config file already exists in repo path %s", repopath)
+	}
+
+	dest := filepath.Join(repopath, "config")
+	src := filepath.Join(cluster.Conf.WorkingDir, cluster.Name, "restic.config.bak")
+
+	err = misc.CopyFile(src, dest)
+	if err != nil {
+		return err
+	}
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Restic config file restored from %s", src)
+	return nil
 }
 
 func (cluster *Cluster) ResticUnlockRepo() error {

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -2603,3 +2603,11 @@ func (cluster *Cluster) SetDatabaseCredentials(role string, cred string) error {
 
 	return nil
 }
+
+func (cluster *Cluster) SetResticPassword(cred string) {
+	cluster.Conf.BackupResticPassword = cred
+	var new_secret config.Secret
+	new_secret.Value = cluster.Conf.BackupResticPassword
+	new_secret.OldValue = cluster.Conf.GetDecryptedValue("backup-restic-password")
+	cluster.Conf.Secrets["backup-restic-password"] = new_secret
+}

--- a/config/error.go
+++ b/config/error.go
@@ -216,6 +216,8 @@ var ClusterError = map[string]string{
 	"WARN0142":  "Not enough free space estimated for %s physical backup on %s. Mount: %s Free: %s Required: %s",
 	"WARN0143":  "Not enough free space estimated for binary log backup on %s. Mount: %s Free: %s Required: %s",
 	"WARN0144":  "HAProxy inconsistent server ID between haproxy %s and cluster %s for host %s",
+	"WARN0145":  "Failed to backup restic config file: %s",
+	"WARN0146":  "Failed to restore restic config file: %s",
 	"MDEV20821": "MariaDB version has replication issue https://jira.mariadb.org/browse/MDEV-20821",
 	"MDEV28310": "MariaDB version has replication issue for non row format https://jira.mariadb.org/browse/MDEV-28310",
 	"MDEV19577": "MariaDB version has replication issue for non row format https://jira.mariadb.org/browse/MDEV-19577",

--- a/config/manager/manager.go
+++ b/config/manager/manager.go
@@ -753,6 +753,12 @@ func (cm *ConfigManager) PushConfigToGit(conf *config.Config, clusterList []stri
 				cm.gitManager.CommitManager.AddFileToCommit(GitAddTask{Cluster: name, Filename: jsonPath, W: w, WaitGroup: &cwg})
 			}
 		}
+
+		// Add restic.config.bak if it exists (this will store the restic config which is crucial in case of missing restic config)
+		if _, err := os.Stat(filepath.Join(path, name, "restic.config.bak")); !os.IsNotExist(err) {
+			cwg.Add(1)
+			cm.gitManager.CommitManager.AddFileToCommit(GitAddTask{Cluster: name, Filename: filepath.Join(name, "restic.config.bak"), W: w, WaitGroup: &cwg})
+		}
 	}
 
 	// Add default.toml if it exists

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2229,6 +2229,123 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/clusters/{clusterName}/apps/actions/get-app-template": {
+            "get": {
+                "description": "Retrieves the tree structure of the application template repository for a specific cluster.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Apps"
+                ],
+                "summary": "Get App Template Repository Tree",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Application template repository tree structure",
+                        "schema": {
+                            "$ref": "#/definitions/treehelper.FileTreeCache"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid Git repository URL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Error creating Git client\" or \"Error getting repository tree\" or \"No cluster",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/apps/{appHost}/{appPort}/actions/drop": {
+            "post": {
+                "description": "Drops the monitoring configuration for a specific app in a cluster.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Apps"
+                ],
+                "summary": "Drop App Monitor",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "App ID",
+                        "name": "appId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "App monitor dropped successfully",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "No app found with the provided app ID\" or \"Cluster Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/apps/{appId}/git/{gitName}/actions/get-repo-tree": {
             "get": {
                 "description": "Retrieves the tree structure of a specified Git repository.",
@@ -4242,6 +4359,63 @@ const docTemplate = `{
                 "responses": {
                     "200": {
                         "description": "Archives purge queued",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "No cluster",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/archives/restore-config/{force}": {
+            "post": {
+                "description": "Restores the restic config for the specified cluster.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterBackups"
+                ],
+                "summary": "Restore Restic Config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "noforce",
+                        "description": "Force Restore",
+                        "name": "force",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Archives restore config done",
                         "schema": {
                             "type": "string"
                         }
@@ -17007,6 +17181,9 @@ const docTemplate = `{
                 },
                 "status": {
                     "type": "string"
+                },
+                "svname": {
+                    "type": "string"
                 }
             }
         },
@@ -19663,6 +19840,9 @@ const docTemplate = `{
                 "dbServersCredential": {
                     "type": "string"
                 },
+                "dbServersExecTimeout": {
+                    "type": "integer"
+                },
                 "dbServersHosts": {
                     "type": "string"
                 },
@@ -20069,6 +20249,12 @@ const docTemplate = `{
                 "logExternalScriptLevel": {
                     "type": "integer"
                 },
+                "logFetchErrorlogLevel": {
+                    "type": "integer"
+                },
+                "logFetchSlowqueryLevel": {
+                    "type": "integer"
+                },
                 "logFile": {
                     "type": "string"
                 },
@@ -20250,6 +20436,9 @@ const docTemplate = `{
                 },
                 "maxscalemBinaryPath": {
                     "type": "string"
+                },
+                "measurement": {
+                    "type": "boolean"
                 },
                 "measurementAutoClampLimit": {
                     "type": "boolean"
@@ -20561,6 +20750,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "provAppTemplateRepo": {
+                    "type": "string"
+                },
+                "provAppTemplateRepoBranch": {
                     "type": "string"
                 },
                 "provAppTemplateRepoPassword": {
@@ -20965,10 +21157,10 @@ const docTemplate = `{
                 "proxysqlBootstrapQueryRules": {
                     "type": "boolean"
                 },
-                "proxysqlBootstrapVariables": {
+                "proxysqlBootstrapUsers": {
                     "type": "boolean"
                 },
-                "proxysqlBootstrapyUsers": {
+                "proxysqlBootstrapVariables": {
                     "type": "boolean"
                 },
                 "proxysqlDebug": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2218,6 +2218,123 @@
                 }
             }
         },
+        "/api/clusters/{clusterName}/apps/actions/get-app-template": {
+            "get": {
+                "description": "Retrieves the tree structure of the application template repository for a specific cluster.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Apps"
+                ],
+                "summary": "Get App Template Repository Tree",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Application template repository tree structure",
+                        "schema": {
+                            "$ref": "#/definitions/treehelper.FileTreeCache"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid Git repository URL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Error creating Git client\" or \"Error getting repository tree\" or \"No cluster",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/apps/{appHost}/{appPort}/actions/drop": {
+            "post": {
+                "description": "Drops the monitoring configuration for a specific app in a cluster.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Apps"
+                ],
+                "summary": "Drop App Monitor",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "App ID",
+                        "name": "appId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "App monitor dropped successfully",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "No app found with the provided app ID\" or \"Cluster Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/apps/{appId}/git/{gitName}/actions/get-repo-tree": {
             "get": {
                 "description": "Retrieves the tree structure of a specified Git repository.",
@@ -4231,6 +4348,63 @@
                 "responses": {
                     "200": {
                         "description": "Archives purge queued",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "No cluster",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/clusters/{clusterName}/archives/restore-config/{force}": {
+            "post": {
+                "description": "Restores the restic config for the specified cluster.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterBackups"
+                ],
+                "summary": "Restore Restic Config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "noforce",
+                        "description": "Force Restore",
+                        "name": "force",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Archives restore config done",
                         "schema": {
                             "type": "string"
                         }
@@ -16996,6 +17170,9 @@
                 },
                 "status": {
                     "type": "string"
+                },
+                "svname": {
+                    "type": "string"
                 }
             }
         },
@@ -19652,6 +19829,9 @@
                 "dbServersCredential": {
                     "type": "string"
                 },
+                "dbServersExecTimeout": {
+                    "type": "integer"
+                },
                 "dbServersHosts": {
                     "type": "string"
                 },
@@ -20058,6 +20238,12 @@
                 "logExternalScriptLevel": {
                     "type": "integer"
                 },
+                "logFetchErrorlogLevel": {
+                    "type": "integer"
+                },
+                "logFetchSlowqueryLevel": {
+                    "type": "integer"
+                },
                 "logFile": {
                     "type": "string"
                 },
@@ -20239,6 +20425,9 @@
                 },
                 "maxscalemBinaryPath": {
                     "type": "string"
+                },
+                "measurement": {
+                    "type": "boolean"
                 },
                 "measurementAutoClampLimit": {
                     "type": "boolean"
@@ -20550,6 +20739,9 @@
                     "type": "string"
                 },
                 "provAppTemplateRepo": {
+                    "type": "string"
+                },
+                "provAppTemplateRepoBranch": {
                     "type": "string"
                 },
                 "provAppTemplateRepoPassword": {
@@ -20954,10 +21146,10 @@
                 "proxysqlBootstrapQueryRules": {
                     "type": "boolean"
                 },
-                "proxysqlBootstrapVariables": {
+                "proxysqlBootstrapUsers": {
                     "type": "boolean"
                 },
-                "proxysqlBootstrapyUsers": {
+                "proxysqlBootstrapVariables": {
                     "type": "boolean"
                 },
                 "proxysqlDebug": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -180,6 +180,8 @@ definitions:
         type: string
       status:
         type: string
+      svname:
+        type: string
     type: object
   cluster.Cluster:
     properties:
@@ -1956,6 +1958,8 @@ definitions:
         type: integer
       dbServersCredential:
         type: string
+      dbServersExecTimeout:
+        type: integer
       dbServersHosts:
         type: string
       dbServersIgnoredHosts:
@@ -2227,6 +2231,10 @@ definitions:
         type: integer
       logExternalScriptLevel:
         type: integer
+      logFetchErrorlogLevel:
+        type: integer
+      logFetchSlowqueryLevel:
+        type: integer
       logFile:
         type: string
       logFileLevel:
@@ -2349,6 +2357,8 @@ definitions:
         type: integer
       maxscalemBinaryPath:
         type: string
+      measurement:
+        type: boolean
       measurementAutoClampLimit:
         type: boolean
       monitoringAddress:
@@ -2556,6 +2566,8 @@ definitions:
       provAppMemory:
         type: string
       provAppTemplateRepo:
+        type: string
+      provAppTemplateRepoBranch:
         type: string
       provAppTemplateRepoPassword:
         type: string
@@ -2825,9 +2837,9 @@ definitions:
         type: boolean
       proxysqlBootstrapQueryRules:
         type: boolean
-      proxysqlBootstrapVariables:
+      proxysqlBootstrapUsers:
         type: boolean
-      proxysqlBootstrapyUsers:
+      proxysqlBootstrapVariables:
         type: boolean
       proxysqlDebug:
         type: boolean
@@ -5118,6 +5130,46 @@ paths:
       summary: Wait for databases to be ready for a specific cluster
       tags:
       - Cluster
+  /api/clusters/{clusterName}/apps/{appHost}/{appPort}/actions/drop:
+    post:
+      consumes:
+      - application/json
+      description: Drops the monitoring configuration for a specific app in a cluster.
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      - description: App ID
+        in: path
+        name: appId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: App monitor dropped successfully
+          schema:
+            type: string
+        "403":
+          description: No valid ACL
+          schema:
+            type: string
+        "500":
+          description: No app found with the provided app ID" or "Cluster Not Found
+          schema:
+            type: string
+      summary: Drop App Monitor
+      tags:
+      - Apps
   /api/clusters/{clusterName}/apps/{appId}/git/{gitName}/actions/get-repo-tree:
     get:
       consumes:
@@ -6344,6 +6396,47 @@ paths:
       summary: Get App Substitution Variables
       tags:
       - Apps
+  /api/clusters/{clusterName}/apps/actions/get-app-template:
+    get:
+      consumes:
+      - application/json
+      description: Retrieves the tree structure of the application template repository
+        for a specific cluster.
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Application template repository tree structure
+          schema:
+            $ref: '#/definitions/treehelper.FileTreeCache'
+        "400":
+          description: Invalid Git repository URL
+          schema:
+            type: string
+        "403":
+          description: No valid ACL
+          schema:
+            type: string
+        "500":
+          description: Error creating Git client" or "Error getting repository tree"
+            or "No cluster
+          schema:
+            type: string
+      summary: Get App Template Repository Tree
+      tags:
+      - Apps
   /api/clusters/{clusterName}/archives:
     get:
       description: This endpoint retrieves the backups for the specified cluster.
@@ -6516,6 +6609,45 @@ paths:
           schema:
             type: string
       summary: Purge Restic Backup
+      tags:
+      - ClusterBackups
+  /api/clusters/{clusterName}/archives/restore-config/{force}:
+    post:
+      description: Restores the restic config for the specified cluster.
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      - default: noforce
+        description: Force Restore
+        in: path
+        name: force
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Archives restore config done
+          schema:
+            type: string
+        "403":
+          description: No valid ACL
+          schema:
+            type: string
+        "500":
+          description: No cluster
+          schema:
+            type: string
+      summary: Restore Restic Config
       tags:
       - ClusterBackups
   /api/clusters/{clusterName}/archives/stats:

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -3105,11 +3105,40 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		if err != nil {
 			return errors.New("Unable to decode")
 		}
-		mycluster.Conf.BackupResticPassword = string(val)
-		var new_secret config.Secret
-		new_secret.Value = mycluster.Conf.BackupResticPassword
-		new_secret.OldValue = mycluster.Conf.GetDecryptedValue("backup-restic-password")
-		mycluster.Conf.Secrets["backup-restic-password"] = new_secret
+		newval := string(val)
+		if mycluster.Conf.BackupRestic {
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Restic backup is already enabled, testing new password validity")
+
+			// Test if new password is valid. If yes, can be used directly
+			err = mycluster.ResticRepo.ResticTestPassword(newval)
+			// If not valid, test if old password is valid (rotate password)
+			if err != nil {
+				err2 := mycluster.ResticRepo.ResticTestPassword(mycluster.Conf.GetDecryptedValue("backup-restic-password"))
+				if err2 == nil {
+					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Old restic password is valid, rotating password to new one")
+
+					// Old password is valid, we can use it to rotate password using ChangeResticRepoPassword
+					err = mycluster.ChangeResticRepoPassword(newval)
+					if err != nil {
+						mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Unable to change restic password: "+err.Error())
+						return errors.New("Unable to change restic password: " + err.Error())
+					}
+				} else {
+					// Old password is not valid, just use new password (maybe first time setup)
+					// If both old and new password are not valid, this will be detected later when trying to do a backup
+					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Both old and new restic password are not valid, assuming first time setup")
+					mycluster.SetResticPassword(newval)
+				}
+			} else {
+				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "New restic password is valid, using it")
+				mycluster.SetResticPassword(newval)
+			}
+		} else {
+			mycluster.SetResticPassword(newval)
+		}
+
+		mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Restic password updated")
+
 	case "backup-mydumper-options":
 		val, err := base64.StdEncoding.DecodeString(value)
 		if err != nil {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -135,6 +135,16 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxResetArchivesTaskQueue)),
 	))
 
+	router.Handle("/api/clusters/{clusterName}/archives/restore-config", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxArchivesRestoreConfig)),
+	))
+
+	router.Handle("/api/clusters/{clusterName}/archives/restore-config/{force}", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxArchivesRestoreConfig)),
+	))
+
 	router.Handle("/api/clusters/{clusterName}/certificates", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterCertificates)),
@@ -6575,6 +6585,57 @@ func (repman *ReplicationManager) handlerMuxRemoveExternalOps(w http.ResponseWri
 
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("Sponsor partnership removed!"))
+}
+
+// handlerMuxArchivesRestoreConfig handles the HTTP request to restore the restic config for a given cluster.
+// @Summary Restore Restic Config
+// @Description Restores the restic config for the specified cluster.
+// @Tags ClusterBackups
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Param force path string true "Force Restore" Enum(force, noforce) default(noforce)
+// @Success 200 {string} string "Archives restore config done"
+// @Failure 403 {string} string "No valid ACL"
+// @Failure 500 {string} string "No cluster"
+// @Router /api/clusters/{clusterName}/archives/restore-config/{force} [post]
+func (repman *ReplicationManager) handlerMuxArchivesRestoreConfig(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	var force bool
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+
+	if strings.ToLower(vars["force"]) == "force" {
+		force = true
+	}
+
+	if mycluster != nil {
+		if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+			http.Error(w, "No valid ACL", 403)
+			return
+		}
+		if !mycluster.Conf.BackupRestic {
+			http.Error(w, "Restic backup not enabled", 500)
+			return
+		}
+
+		if mycluster.ResticRepo == nil {
+			http.Error(w, "No restic repo", 500)
+			return
+		}
+
+		err := mycluster.RestoreResticConfig(force)
+		if err != nil {
+			http.Error(w, "Error restoring restic config: "+err.Error(), 500)
+			return
+		}
+	} else {
+		http.Error(w, "No cluster", 500)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("Archives restore config done"))
 }
 
 // handlerMuxArchivesFetch handles the HTTP request to fetch the restic snapshots for a given cluster.

--- a/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
@@ -19,10 +19,10 @@ import { DataTable } from '../../components/DataTable'
 import ResticPurgeStrategy from './ResticPurgeStrategy'
 import NumberInput from '../../components/NumberInput'
 
-const sizeGenerator = () => { 
+const sizeGenerator = () => {
   const result = []
   let i = 1024;
-  while( i <= 1024 * 1024 * 1024) {
+  while (i <= 1024 * 1024 * 1024) {
     result.push(i)
     i = i * 2
   }
@@ -403,7 +403,7 @@ The script will be executed with the following parameters:
         </Flex>
       )
     },
-   {
+    {
       key: 'Use Compression',
       value: (
         <RMSwitch
@@ -611,126 +611,120 @@ The script will be executed with the following parameters:
             />
           )
         },
-        ...(selectedCluster?.config?.backupRestic ? [
-          {
-            key: 'Backup restic binary path',
-            value: (
-              <TextForm
-                value={selectedCluster?.config?.backupResticBinaryPath}
-                confirmTitle={`Confirm backup-restic-binary-path to `}
-                className={styles.textbox}
-                onSave={(value) =>
-                  dispatch(
-                    setSetting({
-                      clusterName: selectedCluster?.name,
-                      setting: 'backup-restic-binary-path',
-                      value: value
-                    })
-                  )
-                }
-              />
-            )
-          },
-          {
-            key: 'Backup restic password',
-            value: (
-              <TextForm
-                value={selectedCluster?.config?.backupResticPassword}
-                confirmTitle={`Confirm backup-restic-password to `}
-                className={styles.textbox}
-                onSave={(value) =>
-                  dispatch(
-                    setSetting({
-                      clusterName: selectedCluster?.name,
-                      setting: 'backup-restic-password',
-                      value: btoa(value)
-                    })
-                  )
-                }
-              />
-            )
-          },
-          {
-            key: 'Backup restic aws',
-            value: (
-              <RMSwitch
-                isChecked={selectedCluster?.config?.backupResticAws}
-                isDisabled={user?.grants['cluster-settings'] == false}
-                confirmTitle={'Confirm switch settings for backup-restic-aws?'}
-                onChange={() =>
-                  dispatch(switchSetting({ clusterName: selectedCluster?.name, setting: 'backup-restic-aws' }))
-                }
-              />
-            )
-          },
-          ...(selectedCluster?.config?.backupResticAws ? [
-            {
-              key: 'Backup restic access key id',
-              value: (
-                <TextForm
-                  value={selectedCluster?.config?.backupResticAwsAccessKeyId}
-                  confirmTitle={`Confirm backup-restic-binary-path to `}
-                  className={styles.textbox}
-                  onSave={(value) =>
-                    dispatch(
-                      setSetting({
-                        clusterName: selectedCluster?.name,
-                        setting: 'backup-restic-aws-access-key-id',
-                        value: value
-                      })
-                    )
-                  }
-                />
-              )
-            },
-            {
-              key: 'Backup restic aws access secret',
-              value: (
-                <TextForm
-                  value={selectedCluster?.config?.backupResticAwsAccessSecret}
-                  confirmTitle={`Confirm backup-restic-aws-access-secret to `}
-                  className={styles.textbox}
-                  onSave={(value) =>
-                    dispatch(
-                      setSetting({
-                        clusterName: selectedCluster?.name,
-                        setting: 'backup-restic-aws-access-secret',
-                        value: btoa(value)
-                      })
-                    )
-                  }
-                />
-              )
-            },
-            {
-              key: 'Backup restic aws bucket',
-              value: (
-                <TextForm
-                  value={selectedCluster?.config?.backupResticRepository}
-                  confirmTitle={`Confirm backup-restic-repository to `}
-                  className={styles.textbox}
-                  onSave={(value) =>
-                    dispatch(
-                      setSetting({
-                        clusterName: selectedCluster?.name,
-                        setting: 'backup-restic-repository',
-                        value: btoa(value)
-                      })
-                    )
-                  }
-                />
-              )
-            }
-          ] : []
-          ),
-          {
-            key: 'Restic Purge Strategy',
-            value: (
-              <ResticPurgeStrategy clusterName={selectedCluster?.name} config={selectedCluster?.config} />
-            )
-          }
-        ] : []
-        )
+        {
+          key: 'Backup restic binary path',
+          value: (
+            <TextForm
+              value={selectedCluster?.config?.backupResticBinaryPath}
+              confirmTitle={`Confirm backup-restic-binary-path to `}
+              className={styles.textbox}
+              onSave={(value) =>
+                dispatch(
+                  setSetting({
+                    clusterName: selectedCluster?.name,
+                    setting: 'backup-restic-binary-path',
+                    value: value
+                  })
+                )
+              }
+            />
+          )
+        },
+        {
+          key: 'Backup restic password',
+          value: (
+            <TextForm
+              value={selectedCluster?.config?.backupResticPassword}
+              confirmTitle={`Confirm backup-restic-password to `}
+              className={styles.textbox}
+              onSave={(value) =>
+                dispatch(
+                  setSetting({
+                    clusterName: selectedCluster?.name,
+                    setting: 'backup-restic-password',
+                    value: btoa(value)
+                  })
+                )
+              }
+            />
+          )
+        },
+        {
+          key: 'Backup restic aws',
+          value: (
+            <RMSwitch
+              isChecked={selectedCluster?.config?.backupResticAws}
+              isDisabled={user?.grants['cluster-settings'] == false}
+              confirmTitle={'Confirm switch settings for backup-restic-aws?'}
+              onChange={() =>
+                dispatch(switchSetting({ clusterName: selectedCluster?.name, setting: 'backup-restic-aws' }))
+              }
+            />
+          )
+        },
+        {
+          key: 'Backup restic access key id',
+          value: (
+            <TextForm
+              value={selectedCluster?.config?.backupResticAwsAccessKeyId}
+              confirmTitle={`Confirm backup-restic-aws-access-key-id to `}
+              className={styles.textbox}
+              onSave={(value) =>
+                dispatch(
+                  setSetting({
+                    clusterName: selectedCluster?.name,
+                    setting: 'backup-restic-aws-access-key-id',
+                    value: value
+                  })
+                )
+              }
+            />
+          )
+        },
+        {
+          key: 'Backup restic aws access secret',
+          value: (
+            <TextForm
+              value={selectedCluster?.config?.backupResticAwsAccessSecret}
+              confirmTitle={`Confirm backup-restic-aws-access-secret to `}
+              className={styles.textbox}
+              onSave={(value) =>
+                dispatch(
+                  setSetting({
+                    clusterName: selectedCluster?.name,
+                    setting: 'backup-restic-aws-access-secret',
+                    value: btoa(value)
+                  })
+                )
+              }
+            />
+          )
+        },
+        {
+          key: 'Backup restic aws bucket',
+          value: (
+            <TextForm
+              value={selectedCluster?.config?.backupResticRepository}
+              confirmTitle={`Confirm backup-restic-repository to `}
+              className={styles.textbox}
+              onSave={(value) =>
+                dispatch(
+                  setSetting({
+                    clusterName: selectedCluster?.name,
+                    setting: 'backup-restic-repository',
+                    value: btoa(value)
+                  })
+                )
+              }
+            />
+          )
+        },
+        {
+          key: 'Restic Purge Strategy',
+          value: (
+            <ResticPurgeStrategy clusterName={selectedCluster?.name} config={selectedCluster?.config} />
+          )
+        }
       ]
     },
     {

--- a/utils/archiver/restic.go
+++ b/utils/archiver/restic.go
@@ -21,20 +21,24 @@ import (
 type TaskType int
 
 const (
-	PurgeTask TaskType = iota
+	FetchTask TaskType = iota
+	PurgeTask
 	BackupTask
-	FetchTask
 	UnlockTask
 )
 
 func GetTaskName(TaskType TaskType) string {
 	switch TaskType {
 	case 0:
-		return "purge"
+		return "fetch"
 	case 1:
 		return "backup"
 	case 2:
-		return "fetch"
+		return "purge"
+	case 3:
+		return "unlock"
+	case 4:
+		return "changepass"
 	default:
 		return "Unknown"
 	}
@@ -42,13 +46,14 @@ func GetTaskName(TaskType TaskType) string {
 
 // Task represents a queue task
 type ResticTask struct {
-	ID         int               `json:"task_id"`
-	DirPath    string            `json:"dir_path"`
-	Tags       []string          `json:"tags"`
-	Type       TaskType          `json:"task_type"`
-	Opt        ResticPurgeOption `json:"opt"`
-	ErrorState state.State       `json:"error_state"`
-	Result     chan ResticResult `json:"-"` // Only used if caller needs the result
+	ID          int               `json:"task_id"`
+	DirPath     string            `json:"dir_path"`
+	NewPassFile string            `json:"new_pass_file"`
+	Tags        []string          `json:"tags"`
+	Type        TaskType          `json:"task_type"`
+	Opt         ResticPurgeOption `json:"opt"`
+	ErrorState  state.State       `json:"error_state"`
+	Result      chan ResticResult `json:"-"` // Only used if caller needs the result
 }
 
 // ResticResult holds the output or error of a task
@@ -138,6 +143,19 @@ func (repo *ResticRepo) GetRepoPath() string {
 	return ""
 }
 
+func (repo *ResticRepo) GetCacheDirPath() string {
+	repo.Mutex.Lock()
+	defer repo.Mutex.Unlock()
+
+	for _, env := range repo.Env {
+		if strings.HasPrefix(env, "RESTIC_CACHE_DIR") {
+			return strings.Split(env, "=")[1]
+		}
+	}
+
+	return ""
+}
+
 // GenerateTaskID ensures unique task IDs
 func (repo *ResticRepo) GenerateTaskID() int {
 	repo.Mutex.Lock()
@@ -213,14 +231,14 @@ func (repo *ResticRepo) worker() {
 
 		var result ResticResult
 		switch task.Type {
+		case FetchTask:
+			err := repo.ResticFetchRepo()
+			result = ResticResult{TaskID: task.ID, Error: err}
 		case PurgeTask:
 			err := repo.ResticPurgeRepo(task.Opt)
 			result = ResticResult{TaskID: task.ID, Error: err}
 		case BackupTask:
 			err := repo.ResticBackup(task.DirPath, task.Tags)
-			result = ResticResult{TaskID: task.ID, Error: err}
-		case FetchTask:
-			err := repo.ResticFetchRepo()
 			result = ResticResult{TaskID: task.ID, Error: err}
 		case UnlockTask:
 			err := repo.ResticUnlockRepo()
@@ -290,10 +308,10 @@ func (repo *ResticRepo) AddPurgeTask(opt ResticPurgeOption, waitForResult bool) 
 	return nil, nil
 }
 
-func (repo *ResticRepo) AddBackupTask(taskType TaskType, dirpath string, tags []string, waitForResult bool) (*ResticResult, error) {
+func (repo *ResticRepo) AddBackupTask(dirpath string, tags []string, waitForResult bool) (*ResticResult, error) {
 	task := ResticTask{
 		ID:      repo.GenerateTaskID(),
-		Type:    taskType,
+		Type:    BackupTask,
 		DirPath: dirpath,
 		Tags:    tags,
 	}
@@ -795,5 +813,94 @@ func (repo *ResticRepo) ResticUnlockRepo() error {
 	}
 
 	repo.HasLocks = false
+	return nil
+}
+
+// ResticChangePassword changes the repository password
+func (repo *ResticRepo) ResticAddPassword(newpassfile string) error {
+	if !repo.GetCanFetch() {
+		time.Sleep(time.Second)
+		return repo.ResticAddPassword(newpassfile)
+	}
+
+	repo.SetCanFetch(false)
+	defer repo.SetCanFetch(true)
+
+	// Prepare the arguments for the "backup" command
+	args := []string{"key", "add", "--new-password-file", newpassfile}
+
+	// Execute the Restic "list locks" command using RunCommand
+	stdout, stderr, err := repo.RunCommand(args, logrus.InfoLevel, true)
+	if err != nil {
+		return fmt.Errorf("failed to add repo password: %v, stderr: %s", err, stderr)
+	}
+
+	if !strings.Contains(string(stdout), "saved new key as") {
+		return fmt.Errorf("failed to add new key: %s. stderr: %s", stdout, stderr)
+	}
+
+	return nil
+}
+
+type ResticKey struct {
+	Current  bool   `json:"current"`
+	Id       string `json:"id"`
+	UserName string `json:"userName"`
+	HostName string `json:"hostName"`
+	Created  string `json:"created"`
+}
+
+func (repo *ResticRepo) ResticKeyList() ([]ResticKey, error) {
+	if !repo.GetCanFetch() {
+		time.Sleep(time.Second)
+		return repo.ResticKeyList()
+	}
+
+	repo.SetCanFetch(false)
+	defer repo.SetCanFetch(true)
+
+	// Prepare the arguments for the "key list" command
+	args := []string{"key", "list", "--json"}
+
+	// Execute the Restic "key list" command using RunCommand
+	stdout, stderr, err := repo.RunCommand(args, logrus.DebugLevel, true)
+	if err != nil {
+		if strings.Contains(string(stderr), "no such file or directory") {
+			_ = repo.ResticInitRepo(false)
+		}
+		// Handle error (including stderr)
+		return nil, fmt.Errorf("failed to list repo keys: %v, stderr: %s", err, stderr)
+	}
+
+	var keys []ResticKey
+	if err := json.Unmarshal(stdout, &keys); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal repo keys: %v", err)
+	}
+
+	return keys, nil
+}
+
+func (repo *ResticRepo) ResticRemoveKey(keyid string) error {
+	if !repo.GetCanFetch() {
+		time.Sleep(time.Second)
+		return repo.ResticRemoveKey(keyid)
+	}
+
+	repo.SetCanFetch(false)
+	defer repo.SetCanFetch(true)
+
+	// Prepare the arguments for the "key remove" command
+	args := []string{"key", "remove", keyid}
+
+	// Execute the Restic "key remove" command using RunCommand
+	stdout, stderr, err := repo.RunCommand(args, logrus.InfoLevel, true)
+	if err != nil {
+		return fmt.Errorf("failed to remove repo key: %v, stderr: %s", err, stderr)
+	}
+
+	if !strings.Contains(string(stdout), "removed key") {
+		return fmt.Errorf("failed to remove key: %s. stderr: %s", stdout, stderr)
+	}
+
 	return nil
 }

--- a/utils/archiver/restic.go
+++ b/utils/archiver/restic.go
@@ -130,6 +130,25 @@ func (repo *ResticRepo) SetEnv(env []string) {
 	repo.Env = env
 }
 
+// UpdateEnvKey updates the environment variable for the Restic repository
+func (repo *ResticRepo) UpdateEnvKey(key, value string) {
+	repo.Mutex.Lock()
+	defer repo.Mutex.Unlock()
+
+	found := false
+	for i, env := range repo.Env {
+		if strings.HasPrefix(env, key+"=") {
+			repo.Env[i] = fmt.Sprintf("%s=%s", key, value)
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		repo.Env = append(repo.Env, fmt.Sprintf("%s=%s", key, value))
+	}
+}
+
 func (repo *ResticRepo) GetRepoPath() string {
 	repo.Mutex.Lock()
 	defer repo.Mutex.Unlock()
@@ -829,7 +848,7 @@ func (repo *ResticRepo) ResticAddPassword(newpassfile string) error {
 	// Prepare the arguments for the "backup" command
 	args := []string{"key", "add", "--new-password-file", newpassfile}
 
-	// Execute the Restic "list locks" command using RunCommand
+	// Execute the Restic "key add" command using RunCommand
 	stdout, stderr, err := repo.RunCommand(args, logrus.InfoLevel, true)
 	if err != nil {
 		return fmt.Errorf("failed to add repo password: %v, stderr: %s", err, stderr)
@@ -900,6 +919,32 @@ func (repo *ResticRepo) ResticRemoveKey(keyid string) error {
 
 	if !strings.Contains(string(stdout), "removed key") {
 		return fmt.Errorf("failed to remove key: %s. stderr: %s", stdout, stderr)
+	}
+
+	return nil
+}
+
+func (repo *ResticRepo) ResticTestPassword(newpass string) error {
+	if !repo.GetCanFetch() {
+		time.Sleep(time.Second)
+		return repo.ResticTestPassword(newpass)
+	}
+
+	repo.SetCanFetch(false)
+	defer repo.SetCanFetch(true)
+
+	// Temporarily add the new password file to the environment
+	originalEnv := repo.Env
+	repo.UpdateEnvKey("RESTIC_PASSWORD", newpass)
+	defer func() { repo.Env = originalEnv }() // Restore original env after function
+
+	// Test the new password by listing keys
+	args := []string{"key", "list", "--json"}
+
+	// Execute the Restic "key list" command using RunCommand
+	_, stderr, err := repo.RunCommand(args, logrus.DebugLevel, true)
+	if err != nil {
+		return fmt.Errorf("failed to test repo password: %v, stderr: %s", err, stderr)
 	}
 
 	return nil


### PR DESCRIPTION
This pull request introduces several improvements and new features related to restic backup management, error handling, API documentation, and configuration handling. The most significant changes are the implementation of restic config backup/restore capabilities, the addition of a restic password rotation method, enhancements to error reporting, and updates to the OpenAPI documentation for new endpoints and configuration fields.

**Restic Backup Management:**

- Added automatic backup and restore functionality for the restic repository config file (`restic.config.bak`). The config is backed up after a successful fetch and can be restored via a new method, with corresponding warnings added for failure cases. (`cluster/cluster_bck.go`, `config/error.go`, [[1]](diffhunk://#diff-eb7be6f71b81f7dd226a6985f412f36c5d14559999797bf6c7fa5c815232eea9L137-R204) [[2]](diffhunk://#diff-8f064ed373b8d36dcd88ee3e4f22d7c10e6873d71411991b1882ae63e81a7a15R219-R220)
- Updated the location of the restic cache directory to be cluster-specific, improving isolation between clusters. (`cluster/cluster_bck.go`, [cluster/cluster_bck.goR12-R27](diffhunk://#diff-eb7be6f71b81f7dd226a6985f412f36c5d14559999797bf6c7fa5c815232eea9R12-R27))
- Ensured that `restic.config.bak` is included in configuration commits to Git, making disaster recovery easier. (`config/manager/manager.go`, [config/manager/manager.goR756-R761](diffhunk://#diff-1044edc05bab58743afa8888d0afcd36f5b9f906ee596b436a5d45a6acd83842R756-R761))

**Restic Password Management:**

- Added a method to rotate the restic repository password, including adding a new key, updating the configuration, and removing the old key securely. (`cluster/cluster_bck.go`, [[1]](diffhunk://#diff-d5872677c3cc5c2ea2a32bdf57af1e39a3e2d5e5eb735fc8bbba65b445132846R2606-R2613) [[2]](diffhunk://#diff-eb7be6f71b81f7dd226a6985f412f36c5d14559999797bf6c7fa5c815232eea9R372-R466)

**Error Handling:**

- Introduced new error codes and messages for restic config backup and restore failures, improving observability and troubleshooting. (`config/error.go`, [config/error.goR219-R220](diffhunk://#diff-8f064ed373b8d36dcd88ee3e4f22d7c10e6873d71411991b1882ae63e81a7a15R219-R220))
- Extended the state preservation logic to include the new warning for restic config backup issues. (`cluster/cluster.go`, [cluster/cluster.goL735-R735](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4L735-R735))

**API Documentation:**

- Documented new API endpoints for restoring restic config and for app template management, and updated the OpenAPI schema with new configuration fields and corrected field names. (`docs/docs.go`, [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R4381-R4437) F529b86fL529b86fL2229R2229, [[2]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R17184-R17186) [[3]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R19843-R19845) [[4]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R20252-R20257) [[5]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R20440-R20442) [[6]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R20755-R20757) [[7]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4L20968-R21163)

**Configuration Handling:**

- Added a helper to update the restic password and secret in the cluster configuration, ensuring the new password is saved and old values are tracked. (`cluster/cluster_set.go`, [cluster/cluster_set.goR2606-R2613](diffhunk://#diff-d5872677c3cc5c2ea2a32bdf57af1e39a3e2d5e5eb735fc8bbba65b445132846R2606-R2613))

These changes significantly improve the robustness and manageability of restic backups, enhance error reporting, and keep the API documentation and configuration handling up to date.

- **Restic Backup Enhancements:**
  - Implemented backup and restore for the restic config file, with error handling and state tracking. (`cluster/cluster_bck.go`, `config/error.go`, `cluster/cluster.go`, [[1]](diffhunk://#diff-eb7be6f71b81f7dd226a6985f412f36c5d14559999797bf6c7fa5c815232eea9L137-R204) [[2]](diffhunk://#diff-8f064ed373b8d36dcd88ee3e4f22d7c10e6873d71411991b1882ae63e81a7a15R219-R220) [[3]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4L735-R735)
  - Changed restic cache directory to be cluster-specific. (`cluster/cluster_bck.go`, [cluster/cluster_bck.goR12-R27](diffhunk://#diff-eb7be6f71b81f7dd226a6985f412f36c5d14559999797bf6c7fa5c815232eea9R12-R27))
  - Ensured `restic.config.bak` is included in Git commits for disaster recovery. (`config/manager/manager.go`, [config/manager/manager.goR756-R761](diffhunk://#diff-1044edc05bab58743afa8888d0afcd36f5b9f906ee596b436a5d45a6acd83842R756-R761))

- **Restic Password Rotation:**
  - Added a method to rotate the restic repository password, including key management and configuration update. (`cluster/cluster_bck.go`, [[1]](diffhunk://#diff-eb7be6f71b81f7dd226a6985f412f36c5d14559999797bf6c7fa5c815232eea9R372-R466) [[2]](diffhunk://#diff-d5872677c3cc5c2ea2a32bdf57af1e39a3e2d5e5eb735fc8bbba65b445132846R2606-R2613)

- **API Documentation Updates:**
  - Added documentation for new endpoints and updated configuration schemas and field names. (`docs/docs.go`, [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R4381-R4437) [[2]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R2232-R2348) [[3]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R17184-R17186) [[4]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R19843-R19845) [[5]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R20252-R20257) [[6]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R20440-R20442) [[7]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R20755-R20757) [[8]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4L20968-R21163)