### PR TITLE
Fix incorrect variable name for relay log file in SlaveStatus import

### DIFF
--- a/utils/dbhelper/dbhelper.go
+++ b/utils/dbhelper/dbhelper.go
@@ -253,7 +253,7 @@ func (s *SlaveStatus) ImportFromReplicaStatus(rs *ReplicaStatus) {
 	s.MasterPort = rs.SourcePort
 	s.MasterLogFile = rs.SourceLogFile
 	s.ReadMasterLogPos = rs.ReadSourceLogPos
-	s.RelayMasterLogFile = rs.RelayLogFile
+	s.RelayMasterLogFile = rs.RelaySourceLogFile
 	s.SlaveIORunning = rs.ReplicaIORunning
 	s.SlaveSQLRunning = rs.ReplicaSQLRunning
 	s.ExecMasterLogPos = rs.ExecSourceLogPos


### PR DESCRIPTION
This pull request makes a targeted fix in the `ImportFromReplicaStatus` method of `dbhelper.go` to ensure that the correct field from the `ReplicaStatus` struct is assigned to the `RelayMasterLogFile` field in `SlaveStatus`.

Field mapping correction:

* Updated the assignment in `ImportFromReplicaStatus` so that `RelayMasterLogFile` is now set from `RelaySourceLogFile` instead of `RelayLogFile`, ensuring accurate field mapping between `ReplicaStatus` and `SlaveStatus`.