### PR TITLE
Refactor login error handling to improve credential validation and response parsing

### DIFF
--- a/clients/client_cmd.go
+++ b/clients/client_cmd.go
@@ -453,20 +453,26 @@ func cliLogin() (string, error) {
 		log.Println("ERROR ", err)
 		return "", err
 	}
-	if resp.StatusCode == http.StatusForbidden {
-		return "", errors.New("Wrong credentential")
+
+	if resp.StatusCode == http.StatusOK {
+		type Result struct {
+			Token string `json:"token"`
+		}
+		var r Result
+		err = json.Unmarshal(body, &r)
+		if err != nil {
+			log.Println("ERROR in login", err)
+			return "", err
+		}
+		return r.Token, nil
 	}
 
-	type Result struct {
-		Token string `json:"token"`
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
+		return "", errors.New("Wrong credentials")
 	}
-	var r Result
-	err = json.Unmarshal(body, &r)
-	if err != nil {
-		log.Println("ERROR in login", err)
-		return "", err
-	}
-	return r.Token, nil
+
+	return "", errors.New("Error in login: " + string(body))
+
 }
 
 func cliSecretLogin() (string, error) {
@@ -493,20 +499,26 @@ func cliSecretLogin() (string, error) {
 		log.Println("ERROR ", err)
 		return "", err
 	}
-	if resp.StatusCode == http.StatusForbidden {
-		return "", errors.New("Wrong credentential")
+
+	if resp.StatusCode == http.StatusOK {
+		type Result struct {
+			Token string `json:"token"`
+		}
+		var r Result
+		err = json.Unmarshal(body, &r)
+		if err != nil {
+			log.Println("ERROR in login", err)
+			return "", err
+		}
+
+		return r.Token, nil
 	}
 
-	type Result struct {
-		Token string `json:"token"`
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
+		return "", errors.New("Wrong credentials")
 	}
-	var r Result
-	err = json.Unmarshal(body, &r)
-	if err != nil {
-		log.Println("ERROR in login", err)
-		return "", err
-	}
-	return r.Token, nil
+
+	return "", errors.New("Error in login: " + string(body))
 }
 
 func cliGetAllClusters() ([]string, error) {


### PR DESCRIPTION
This pull request improves error handling in the authentication logic for the CLI client by consolidating and clarifying how login errors are reported. The main changes ensure that both `cliLogin` and `cliSecretLogin` functions consistently handle HTTP status codes and return more descriptive error messages.

**Authentication error handling improvements:**

* Updated both `cliLogin` and `cliSecretLogin` to check for `http.StatusForbidden` and `http.StatusUnauthorized`, returning a unified "Wrong credentials" error message for these cases. [[1]](diffhunk://#diff-2179fb54539965b9fe1458052b8239c6470eee657b33aee9cdd2db90fa9afe57L456-R457) [[2]](diffhunk://#diff-2179fb54539965b9fe1458052b8239c6470eee657b33aee9cdd2db90fa9afe57R470-R477) [[3]](diffhunk://#diff-2179fb54539965b9fe1458052b8239c6470eee657b33aee9cdd2db90fa9afe57L496-R503) [[4]](diffhunk://#diff-2179fb54539965b9fe1458052b8239c6470eee657b33aee9cdd2db90fa9afe57R513-R523)
* For all other non-OK responses, both functions now return an error message that includes the response body for easier debugging. [[1]](diffhunk://#diff-2179fb54539965b9fe1458052b8239c6470eee657b33aee9cdd2db90fa9afe57R470-R477) [[2]](diffhunk://#diff-2179fb54539965b9fe1458052b8239c6470eee657b33aee9cdd2db90fa9afe57R513-R523)