### PR TITLE
Add log directory flag and set default log path in config print jobs

### DIFF
--- a/clients/client_cmd.go
+++ b/clients/client_cmd.go
@@ -78,6 +78,7 @@ var (
 	cliConsoleServerIndex        int
 	cliShowObjects               string
 	cliConfirm                   string
+	cliLogDir                    string
 	cfgGroup                     string
 	memprofile                   string
 	cpuprofile                   string
@@ -315,6 +316,7 @@ func initClusterFlags(cmd *cobra.Command) {
 }
 
 func initPrintDefaultsFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVar(&cliLogDir, "log-dir", "", "Log directory")
 	initClusterFlags(cmd)
 	initServerFlags(cmd)
 }

--- a/clients/client_config.go
+++ b/clients/client_config.go
@@ -49,9 +49,13 @@ func RunConfigPrintJobs() error {
 		return fmt.Errorf("failed to fetch config receiver: %w", err)
 	}
 
+	if cliLogDir == "" {
+		cliLogDir = os.TempDir()
+	}
+
 	// Step 2: Prepare log file paths
-	dummyLog := filepath.Join(os.TempDir(), "dummy.log")
-	currentLog := filepath.Join(os.TempDir(), "current.log")
+	dummyLog := filepath.Join(cliLogDir, "dummy.log")
+	currentLog := filepath.Join(cliLogDir, "current.log")
 
 	var wg sync.WaitGroup
 	wg.Add(2)


### PR DESCRIPTION
This pull request introduces a new command-line flag to allow users to specify a custom log directory, and updates the code to use this directory for log file creation. If the flag is not set, the system default temporary directory is used as before.

New log directory support:

* Added a new `--log-dir` flag to the CLI, allowing users to specify a custom directory for log files (`cliLogDir`). [[1]](diffhunk://#diff-2179fb54539965b9fe1458052b8239c6470eee657b33aee9cdd2db90fa9afe57R319) [[2]](diffhunk://#diff-2179fb54539965b9fe1458052b8239c6470eee657b33aee9cdd2db90fa9afe57R81)
* Updated log file creation in `RunConfigPrintJobs` to use the specified `cliLogDir`, defaulting to the OS temp directory if not set.
