### PR TITLE
Opensvc daemon status

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bluele/logrus_slack"
@@ -33,6 +34,7 @@ import (
 	"github.com/signal18/replication-manager/cluster/nbc"
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/config/manager"
+	"github.com/signal18/replication-manager/opensvc"
 	v3 "github.com/signal18/replication-manager/repmanv3"
 	"github.com/signal18/replication-manager/router/maxscale"
 	"github.com/signal18/replication-manager/utils/alert/mailer"
@@ -259,6 +261,7 @@ type Cluster struct {
 	VersionsMap         *config.VersionsMap
 	SessionManager      *tty.SessionManager `json:"-"`
 	SysBenchTpcMResults []SysBenchTpcResultPerMinute
+	OpenSVCStats        atomic.Value `json:"-"`
 }
 
 type SlavesOldestMasterFile struct {
@@ -364,6 +367,7 @@ func (cluster *Cluster) Init(confs *config.ConfVersion, cfgGroup string, tlog *s
 	cluster.debugLineMap = make(map[string]int)
 	cluster.AgentMaxFreq = make(map[string]int64)
 	cluster.ServiceTemplates = make([]string, 0)
+	cluster.OpenSVCStats.Store([]opensvc.DaemonNodeStats{})
 
 	*cluster.Conf = confs.ConfInit
 

--- a/cluster/cluster_acl.go
+++ b/cluster/cluster_acl.go
@@ -605,6 +605,8 @@ func (cluster *Cluster) IsURLPassACL(strUser string, URL string, errorPrint bool
 		return true
 	case "/api/clusters/" + cluster.Name + "/diffvariables":
 		return true
+	case "/api/clusters/" + cluster.Name + "/opensvc-stats":
+		return true
 	}
 
 	// Terminal ACL

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -24,6 +24,7 @@ import (
 	auth "github.com/hashicorp/vault/api/auth/approle"
 	"github.com/siddontang/go/log"
 	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/opensvc"
 	"github.com/signal18/replication-manager/peer"
 	"github.com/signal18/replication-manager/utils/archiver"
 	"github.com/signal18/replication-manager/utils/cron"
@@ -1647,4 +1648,18 @@ func (cluster *Cluster) SetAppLocalVolume(app *App, dir string) *config.Volume {
 
 func (cluster *Cluster) SetAppLocalMountVolume(app *App) *config.Volume {
 	return cluster.SetAppLocalVolume(app, "mnt")
+}
+
+func (cluster *Cluster) GetOpenSVCStats() ([]opensvc.DaemonNodeStats, error) {
+	stats := make([]opensvc.DaemonNodeStats, 0)
+
+	if cluster.Conf.ProvOrchestrator != "opensvc" {
+		return stats, errors.New("Not using OpenSVC")
+	}
+
+	stats, ok := cluster.OpenSVCStats.Load().([]opensvc.DaemonNodeStats)
+	if !ok {
+		return stats, errors.New("Failed to load OpenSVC stats")
+	}
+	return stats, nil
 }

--- a/cluster/prov.go
+++ b/cluster/prov.go
@@ -887,3 +887,16 @@ func (cluster *Cluster) ProvisionRotatePasswords(password string) error {
 	}
 	return nil
 }
+
+func (cluster *Cluster) ReloadOpenSVCDaemonNodeStats() error {
+	if cluster.GetOrchestrator() == config.ConstOrchestratorOpenSVC {
+		svc := cluster.OpenSVCConnect()
+		nodes, err := svc.GetDaemonNodeStats()
+		if err != nil {
+			return err
+		}
+
+		cluster.OpenSVCStats.Swap(nodes)
+	}
+	return nil
+}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -5487,6 +5487,58 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/clusters/{clusterName}/opensvc-stats": {
+            "get": {
+                "description": "Retrieves the OpenSVC daemon status of the specified cluster.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterGateway"
+                ],
+                "summary": "Get OpenSVC Daemon Status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OpenSVC daemon status fetched",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/opensvc.DaemonNodeStats"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "No cluster\" or \"Error getting OpenSVC stats",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/proxies/{proxyName}": {
             "get": {
                 "description": "Shows the proxies for that specific named cluster",
@@ -22201,6 +22253,17 @@ const docTemplate = `{
                 }
             }
         },
+        "opensvc.DaemonNodeStats": {
+            "type": "object",
+            "properties": {
+                "node": {
+                    "type": "string"
+                },
+                "stats": {
+                    "$ref": "#/definitions/opensvc.NodeStats"
+                }
+            }
+        },
         "opensvc.Host": {
             "type": "object",
             "properties": {
@@ -22239,6 +22302,29 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/opensvc.Service"
                     }
+                }
+            }
+        },
+        "opensvc.NodeStats": {
+            "type": "object",
+            "properties": {
+                "load_15m": {
+                    "type": "number"
+                },
+                "mem_avail": {
+                    "type": "integer"
+                },
+                "mem_total": {
+                    "type": "integer"
+                },
+                "score": {
+                    "type": "integer"
+                },
+                "swap_avail": {
+                    "type": "integer"
+                },
+                "swap_total": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5476,6 +5476,58 @@
                 }
             }
         },
+        "/api/clusters/{clusterName}/opensvc-stats": {
+            "get": {
+                "description": "Retrieves the OpenSVC daemon status of the specified cluster.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterGateway"
+                ],
+                "summary": "Get OpenSVC Daemon Status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OpenSVC daemon status fetched",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/opensvc.DaemonNodeStats"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "No cluster\" or \"Error getting OpenSVC stats",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/proxies/{proxyName}": {
             "get": {
                 "description": "Shows the proxies for that specific named cluster",
@@ -22190,6 +22242,17 @@
                 }
             }
         },
+        "opensvc.DaemonNodeStats": {
+            "type": "object",
+            "properties": {
+                "node": {
+                    "type": "string"
+                },
+                "stats": {
+                    "$ref": "#/definitions/opensvc.NodeStats"
+                }
+            }
+        },
         "opensvc.Host": {
             "type": "object",
             "properties": {
@@ -22228,6 +22291,29 @@
                     "items": {
                         "$ref": "#/definitions/opensvc.Service"
                     }
+                }
+            }
+        },
+        "opensvc.NodeStats": {
+            "type": "object",
+            "properties": {
+                "load_15m": {
+                    "type": "number"
+                },
+                "mem_avail": {
+                    "type": "integer"
+                },
+                "mem_total": {
+                    "type": "integer"
+                },
+                "score": {
+                    "type": "integer"
+                },
+                "swap_avail": {
+                    "type": "integer"
+                },
+                "swap_total": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3394,6 +3394,13 @@ definitions:
       net_network:
         type: string
     type: object
+  opensvc.DaemonNodeStats:
+    properties:
+      node:
+        type: string
+      stats:
+        $ref: '#/definitions/opensvc.NodeStats'
+    type: object
   opensvc.Host:
     properties:
       cpu_cores:
@@ -3420,6 +3427,21 @@ definitions:
         items:
           $ref: '#/definitions/opensvc.Service'
         type: array
+    type: object
+  opensvc.NodeStats:
+    properties:
+      load_15m:
+        type: number
+      mem_avail:
+        type: integer
+      mem_total:
+        type: integer
+      score:
+        type: integer
+      swap_avail:
+        type: integer
+      swap_total:
+        type: integer
     type: object
   opensvc.Service:
     properties:
@@ -7420,6 +7442,41 @@ paths:
           schema:
             type: string
       summary: Get Cluster Gateway Nodes
+      tags:
+      - ClusterGateway
+  /api/clusters/{clusterName}/opensvc-stats:
+    get:
+      description: Retrieves the OpenSVC daemon status of the specified cluster.
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OpenSVC daemon status fetched
+          schema:
+            items:
+              $ref: '#/definitions/opensvc.DaemonNodeStats'
+            type: array
+        "403":
+          description: No valid ACL
+          schema:
+            type: string
+        "500":
+          description: No cluster" or "Error getting OpenSVC stats
+          schema:
+            type: string
+      summary: Get OpenSVC Daemon Status
       tags:
       - ClusterGateway
   /api/clusters/{clusterName}/proxies/{proxyName}:

--- a/opensvc/clusterapi.go
+++ b/opensvc/clusterapi.go
@@ -1071,7 +1071,12 @@ func (collector *Collector) GetDaemonNodeStats() ([]DaemonNodeStats, error) {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.SetBasicAuth(collector.RplMgrUser, collector.RplMgrPassword)
+	if collector.UseAPI {
+		req.SetBasicAuth(collector.RplMgrUser, collector.RplMgrPassword)
+		//		collector.Logrus.WithField("FROM", "OpenSVC").Printf("Info opensvc login %s %s", collector.RplMgrUser, collector.RplMgrPassword)
+	} else {
+		req.Header.Set("o-node", "*")
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		if collector.ClusterConf.IsEligibleForPrinting(config.ConstLogModOrchestrator, config.LvlWarn) {

--- a/opensvc/clusterapi.go
+++ b/opensvc/clusterapi.go
@@ -1040,3 +1040,68 @@ func (collector *Collector) GetUniqueValuesFromSlicesRecursive(slices []interfac
 		}
 	}
 }
+
+type NodeStats struct {
+	Load15m   float64 `json:"load_15m"`
+	MemTotal  int64   `json:"mem_total"`
+	MemAvail  int64   `json:"mem_avail"`
+	SwapTotal int64   `json:"swap_total"`
+	SwapAvail int64   `json:"swap_avail"`
+	Score     int64   `json:"score"`
+}
+
+type DaemonNodeStats struct {
+	Node  string    `json:"node"`
+	Stats NodeStats `json:"stats"`
+}
+
+func (collector *Collector) GetDaemonNodeStats() ([]DaemonNodeStats, error) {
+
+	stats := make([]DaemonNodeStats, 0)
+
+	urlget := fmt.Sprintf("https://%s:%s/daemon_status", collector.Host, collector.Port)
+
+	client := collector.GetHttpClient()
+	if collector.ClusterConf.IsEligibleForPrinting(config.ConstLogModOrchestrator, config.LvlInfo) {
+		collector.Logrus.WithField("FROM", "OpenSVC").Println("INFO ", urlget)
+	}
+
+	req, err := http.NewRequest("GET", urlget, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(collector.RplMgrUser, collector.RplMgrPassword)
+	resp, err := client.Do(req)
+	if err != nil {
+		if collector.ClusterConf.IsEligibleForPrinting(config.ConstLogModOrchestrator, config.LvlWarn) {
+			collector.Logrus.WithField("FROM", "OpenSVC").Println("OpenSVC API Error: ", err)
+		}
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		if collector.ClusterConf.IsEligibleForPrinting(config.ConstLogModOrchestrator, config.LvlWarn) {
+			collector.Logrus.WithField("FROM", "OpenSVC").Println("OpenSVC API Error: ", err)
+		}
+		return nil, err
+	}
+	if collector.ClusterConf.IsEligibleForPrinting(config.ConstLogModOrchestrator, config.LvlDbg) {
+		collector.Logrus.WithField("FROM", "OpenSVC").Println("OpenSVC API Response: ", string(body))
+	}
+
+	// Extract node stats using gjson
+	key := "monitor.nodes.{node:@keys,stats:@values.#.stats}.@group"
+	result := gjson.GetBytes(body, key)
+	if !result.Exists() {
+		return nil, errors.New("No node stats found")
+	}
+
+	err = json.Unmarshal([]byte(result.Raw), &stats)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	return stats, nil
+}

--- a/opensvc/clusterapi.go
+++ b/opensvc/clusterapi.go
@@ -1053,11 +1053,26 @@ type NodeStats struct {
 type DaemonNodeStats struct {
 	Node  string    `json:"node"`
 	Stats NodeStats `json:"stats"`
+	Cores int64     `json:"cores"`
 }
 
 func (collector *Collector) GetDaemonNodeStats() ([]DaemonNodeStats, error) {
-
 	stats := make([]DaemonNodeStats, 0)
+
+	// Get the list of nodes
+	nodes, err := collector.GetNodes()
+	if err != nil {
+		return nil, err
+	}
+
+	coreList := make(map[string]int64)
+	for _, node := range nodes {
+		if node.Cpu_cores > 0 {
+			coreList[node.Node_name] = node.Cpu_cores
+		} else {
+			coreList[node.Node_name] = 1
+		}
+	}
 
 	urlget := fmt.Sprintf("https://%s:%s/daemon_status", collector.Host, collector.Port)
 
@@ -1106,6 +1121,14 @@ func (collector *Collector) GetDaemonNodeStats() ([]DaemonNodeStats, error) {
 	err = json.Unmarshal([]byte(result.Raw), &stats)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	for i, stat := range stats {
+		if cores, ok := coreList[stat.Node]; ok {
+			stats[i].Cores = cores
+		} else {
+			stats[i].Cores = 1
+		}
 	}
 
 	return stats, nil

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -60,6 +60,11 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterGatewayServiceNodes)),
 	))
 
+	router.Handle("/api/clusters/{clusterName}/opensvc-stats", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterOpenSVCDaemonStatus)),
+	))
+
 	//PROTECTED ENDPOINTS FOR CLUSTERS ACTIONS
 	router.Handle("/api/clusters/{clusterName}/settings", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
@@ -7458,6 +7463,55 @@ func (repman *ReplicationManager) handlerMuxClusterGatewayServiceNodes(w http.Re
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, err = w.Write(nodesJSON)
+		if err != nil {
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "API Error writing response: ", err)
+			http.Error(w, "Error writing response: "+err.Error(), 500)
+			return
+		}
+	} else {
+		http.Error(w, "No cluster", 500)
+		return
+	}
+}
+
+// handlerMuxClusterOpenSVCDaemonStatus handles the HTTP request to retrieve the OpenSVC daemon status of a cluster.
+// @Summary Get OpenSVC Daemon Status
+// @Description Retrieves the OpenSVC daemon status of the specified cluster.
+// @Tags ClusterGateway
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Success 200 {array} opensvc.DaemonNodeStats "OpenSVC daemon status fetched"
+// @Failure 403 {string} string "No valid ACL"
+// @Failure 500 {string} string "No cluster" or "Error getting OpenSVC stats"
+// @Router /api/clusters/{clusterName}/opensvc-stats [get]
+func (repman *ReplicationManager) handlerMuxClusterOpenSVCDaemonStatus(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster != nil {
+		if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+			http.Error(w, "No valid ACL", 403)
+			return
+		}
+
+		stats, err := mycluster.GetOpenSVCStats()
+		if err != nil {
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Error getting OpenSVC stats: ", err)
+			http.Error(w, "Error getting OpenSVC stats: "+err.Error(), 500)
+			return
+		}
+
+		// Marshal provided interface into JSON structure
+		statsJSON, err := json.Marshal(stats)
+		if err != nil {
+			http.Error(w, "Error marshalling stats: "+err.Error(), 500)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write(statsJSON)
 		if err != nil {
 			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "API Error writing response: ", err)
 			http.Error(w, "Error writing response: "+err.Error(), 500)

--- a/server/server.go
+++ b/server/server.go
@@ -26,6 +26,7 @@ import (
 	"slices"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"syscall"
 
 	"net/http"
@@ -161,6 +162,7 @@ type ReplicationManager struct {
 	ConfigManager                                    *manager.ConfigManager         `json:"-"`
 	MeetUserID                                       string                         `json:"-"`
 	DiskStatManager                                  *misc.DiskStatManager          `json:"-"`
+	OpenSVCStats                                     atomic.Value                   `json:"-"`
 	fileHook                                         log.Hook
 	repmanv3.UnimplementedClusterPublicServiceServer `json:"-"`
 	repmanv3.UnimplementedClusterServiceServer       `json:"-"`
@@ -1253,6 +1255,7 @@ func (repman *ReplicationManager) InitConfig(conf config.Config, init_git bool) 
 	repman.ImmuableFlagMaps = make(map[string]map[string]interface{})
 	repman.DynamicFlagMaps = make(map[string]map[string]interface{})
 	repman.Partners = make([]config.Partner, 0)
+	repman.OpenSVCStats.Store([]opensvc.DaemonNodeStats{})
 	ImmuableMap := make(map[string]interface{})
 	DynamicMap := make(map[string]interface{})
 	repman.cloud18CheckSum = nil
@@ -1924,6 +1927,34 @@ func (repman *ReplicationManager) GetExpectedUser() *user.User {
 	return ExpectedUser
 }
 
+func (repman *ReplicationManager) ReloadOpenSVCStats() {
+	if repman.Conf.ProvOrchestrator == "opensvc" {
+		globalstat := make([]opensvc.DaemonNodeStats, 0)
+		stats, err := repman.OpenSVC.GetDaemonNodeStats()
+		if err == nil {
+			globalstat = stats
+		}
+
+		repman.OpenSVCStats.Swap(globalstat)
+
+		for _, cl := range repman.Clusters {
+			if cl.Conf.ProvOrchestrator == "opensvc" {
+				if cl.Conf.ProvHost == repman.Conf.ProvHost {
+					cl.OpenSVCStats = repman.OpenSVCStats
+				} else {
+					clstats := make([]opensvc.DaemonNodeStats, 0)
+					svc := cl.OpenSVCConnect()
+					stats, err2 := svc.GetDaemonNodeStats()
+					if err2 == nil {
+						clstats = stats
+					}
+					cl.OpenSVCStats.Swap(clstats)
+				}
+			}
+		}
+	}
+}
+
 func (repman *ReplicationManager) Run() error {
 	var err error
 
@@ -2272,6 +2303,10 @@ func (repman *ReplicationManager) Run() error {
 			}
 
 			go repman.GetAppTemplates()
+
+			if repman.Conf.ProvOrchestrator == "opensvc" {
+				repman.ReloadOpenSVCStats()
+			}
 		}
 
 		if counter%300 == 0 {

--- a/server/server.go
+++ b/server/server.go
@@ -1930,17 +1930,22 @@ func (repman *ReplicationManager) GetExpectedUser() *user.User {
 func (repman *ReplicationManager) ReloadOpenSVCStats() {
 	if repman.Conf.ProvOrchestrator == "opensvc" {
 		globalstat := make([]opensvc.DaemonNodeStats, 0)
-		stats, err := repman.OpenSVC.GetDaemonNodeStats()
-		if err == nil {
-			globalstat = stats
-		}
-
-		repman.OpenSVCStats.Swap(globalstat)
+		fetched := false
 
 		for _, cl := range repman.Clusters {
 			if cl.Conf.ProvOrchestrator == "opensvc" {
 				if cl.Conf.ProvHost == repman.Conf.ProvHost {
-					cl.OpenSVCStats = repman.OpenSVCStats
+					if !fetched {
+						svc := cl.OpenSVCConnect()
+						stats, err := svc.GetDaemonNodeStats()
+						if err == nil {
+							globalstat = stats
+							fetched = true
+						}
+
+						repman.OpenSVCStats.Swap(globalstat)
+					}
+					cl.OpenSVCStats.Swap(globalstat)
 				} else {
 					clstats := make([]opensvc.DaemonNodeStats, 0)
 					svc := cl.OpenSVCConnect()

--- a/server/server.go
+++ b/server/server.go
@@ -2309,13 +2309,14 @@ func (repman *ReplicationManager) Run() error {
 
 			go repman.GetAppTemplates()
 
-			if repman.Conf.ProvOrchestrator == "opensvc" {
-				repman.ReloadOpenSVCStats()
-			}
 		}
 
 		if counter%300 == 0 {
 			repman.RefreshDiskStats()
+		}
+
+		if counter%15 == 0 && repman.Conf.ProvOrchestrator == "opensvc" {
+			repman.ReloadOpenSVCStats()
 		}
 
 		counter++

--- a/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload.jsx
@@ -85,7 +85,7 @@ const OpenSVCWorkload = function ({ workload }) {
   return (
     <Flex direction={'column'} gap='16px'>
       <Flex wrap='wrap' gap='16px' align='center' justify='space-evenly'>
-        {workload.nodes.map((nodeData) => (
+        {workload.map((nodeData) => (
           <OpenSVCNodeCard key={nodeData.node} nodeData={nodeData} />
         ))}
       </Flex>

--- a/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload.jsx
@@ -1,0 +1,96 @@
+import { Box, Flex, Text } from '@chakra-ui/react'
+import React from 'react'
+import Gauge from '../../../components/Gauge'
+import Card from '../../../components/Card';
+import { useSelector } from 'react-redux';
+import TagPill from '../../../components/TagPill';
+
+const getScoreColor = (score) => {
+  if (score >= 80) return 'green';
+  if (score >= 60) return 'orange';
+  return 'red';
+};
+
+const getLoadColor = (load, cores) => {
+  const percent = (load / cores) * 100;
+  if (percent < 70) return 'green';
+  if (percent < 90) return 'orange';
+  return 'red';
+};
+
+const OpenSVCNodeCard = ({ nodeData }) => {
+  const isDesktop = useSelector((state) => state.common.isDesktop)
+
+  const { node, stats, cores } = nodeData;
+  const loadPercent = ((stats.load_15m / cores) * 100).toFixed(1);
+  const cpuLoadColor = getLoadColor(stats.cpuLoad, node.cpuCores);
+  const memUsed = stats.mem_total - stats.mem_avail;
+  const swapUsed = stats.swap_total - stats.swap_avail;
+
+  return (
+    <Card
+      width={isDesktop ? '30%' : '100%'}
+      header={
+        <>
+          <Text>{node}</Text>
+          <Box ml='auto'>
+              <TagPill colorScheme={getScoreColor(stats.score)} text={`${stats.score}`} />
+          </Box>
+        </>
+      }
+      body={
+        <Flex direction='column' gap='16px'>
+          <Flex direction='column' gap='16px'>
+            <Flex justify='space-between' align='center'>
+              <Text>Load Average (15m)</Text>
+              <Text>{stats.load_15m}/{cores} ({loadPercent}%)</Text>
+            </Flex>
+            <Box width='100%' height='10px' bg='gray.200' borderRadius='5px' overflow='hidden'>
+              <Box
+                height='100%'
+                bg={cpuLoadColor}
+                width={`${Math.min(loadPercent, 100)}%`}
+                transition='width 0.3s ease-in-out'
+              />
+            </Box>
+          </Flex>
+
+          <Flex justify='space-around' gap='16px'>
+            <Gauge
+              minValue={0}
+              maxValue={stats.mem_total}
+              value={memUsed}
+              text='Memory Used'
+              appendTextToValue='MB'
+              width={isDesktop ? 120 : 100}
+              height={isDesktop ? 80 : 70}
+            />
+            <Gauge
+              minValue={0}
+              maxValue={stats.swap_total}
+              value={swapUsed}
+              text='Swap Used'
+              appendTextToValue='MB'
+              width={isDesktop ? 120 : 100}
+              height={isDesktop ? 80 : 70}
+            />
+          </Flex>
+        </Flex>
+      }
+    />
+  )
+}
+
+const OpenSVCWorkload = function ({ workload }) {
+  return (
+    <Flex direction={'column'} gap='16px'>
+      <Flex wrap='wrap' gap='16px' align='center' justify='space-evenly'>
+        {workload.nodes.map((nodeData) => (
+          <OpenSVCNodeCard key={nodeData.node} nodeData={nodeData} />
+        ))}
+      </Flex>
+    </Flex>
+  )
+}
+
+export default OpenSVCWorkload

--- a/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload/OpenSVCWorkload.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload/OpenSVCWorkload.jsx
@@ -5,7 +5,6 @@ import Card from '../../../../components/Card';
 import { useSelector } from 'react-redux';
 import TagPill from '../../../../components/TagPill';
 import styles from './styles.module.scss';
-import { convertSize } from '../../../../utility/common';
 
 const getScoreColor = (score) => {
   if (score >= 80) return 'green';
@@ -20,9 +19,7 @@ const getLoadColor = (load, cores) => {
   return 'red';
 };
 
-const OpenSVCNodeCard = ({ nodeData }) => {
-  const isDesktop = useSelector((state) => state.common.isDesktop)
-
+const OpenSVCNodeCard = ({ nodeData, width }) => {
   const { node, stats, cores } = nodeData;
   const loadPercent = ((stats.load_15m / cores) * 100).toFixed(1);
   const cpuLoadColor = getLoadColor(stats.cpuLoad, node.cpuCores);
@@ -31,7 +28,7 @@ const OpenSVCNodeCard = ({ nodeData }) => {
 
   return (
     <Card
-      width={isDesktop ? '30%' : '100%'}
+      width={width}
       header={
         <>
           <Text>{node}</Text>
@@ -89,11 +86,14 @@ const OpenSVCNodeCard = ({ nodeData }) => {
 }
 
 const OpenSVCWorkload = function ({ workload }) {
+  const isDesktop = useSelector((state) => state.common.isDesktop)
+  const third = workload && workload.length > 2 ? true : false;
+  const cardWidth = workload ? (isDesktop ? (third ? `33%` : `${Math.floor(100 / workload.length)}%`) : '100%') : '100%';
   return (
     <Flex direction={'column'} gap='8px' padding={'8px'}>
       <Flex wrap='wrap' gap='8px' align='center' justify='space-evenly'>
         {workload.map((nodeData) => (
-          <OpenSVCNodeCard key={nodeData.node} nodeData={nodeData} />
+          <OpenSVCNodeCard key={nodeData.node} nodeData={nodeData} width={cardWidth} />
         ))}
       </Flex>
     </Flex>

--- a/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload/OpenSVCWorkload.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload/OpenSVCWorkload.jsx
@@ -88,10 +88,10 @@ const OpenSVCNodeCard = ({ nodeData, width }) => {
 const OpenSVCWorkload = function ({ workload }) {
   const isDesktop = useSelector((state) => state.common.isDesktop)
   const third = workload && workload.length > 2 ? true : false;
-  const cardWidth = workload ? (isDesktop ? (third ? `33%` : `${Math.floor(100 / workload.length)}%`) : '100%') : '100%';
+  const cardWidth = workload ? (isDesktop ? (third ? `32%` : `${Math.floor(100 / workload.length) - 1}%`) : '100%') : '100%';
   return (
-    <Flex direction={'column'} gap='8px' padding={'8px'}>
-      <Flex wrap='wrap' gap='8px' align='center' justify='space-evenly'>
+    <Flex direction={'column'} padding={'8px'}>
+      <Flex wrap='wrap' gap='4px' align='center' justify='space-evenly'>
         {workload.map((nodeData) => (
           <OpenSVCNodeCard key={nodeData.node} nodeData={nodeData} width={cardWidth} />
         ))}

--- a/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload/OpenSVCWorkload.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload/OpenSVCWorkload.jsx
@@ -90,8 +90,8 @@ const OpenSVCNodeCard = ({ nodeData }) => {
 
 const OpenSVCWorkload = function ({ workload }) {
   return (
-    <Flex direction={'column'} gap='16px'>
-      <Flex wrap='wrap' gap='16px' align='center' justify='space-evenly'>
+    <Flex direction={'column'} gap='8px' padding={'8px'}>
+      <Flex wrap='wrap' gap='8px' align='center' justify='space-evenly'>
         {workload.map((nodeData) => (
           <OpenSVCNodeCard key={nodeData.node} nodeData={nodeData} />
         ))}

--- a/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload/OpenSVCWorkload.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload/OpenSVCWorkload.jsx
@@ -22,7 +22,7 @@ const getLoadColor = (load, cores) => {
 const OpenSVCNodeCard = ({ nodeData, width }) => {
   const { node, stats, cores } = nodeData;
   const loadPercent = ((stats.load_15m / cores) * 100).toFixed(1);
-  const cpuLoadColor = getLoadColor(stats.cpuLoad, node.cpuCores);
+  const cpuLoadColor = getLoadColor(stats.load_15m, cores || 1);
   const memUsed = stats.mem_total - stats.mem_avail;
   const swapUsed = stats.swap_total - stats.swap_avail;
 

--- a/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload/OpenSVCWorkload.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload/OpenSVCWorkload.jsx
@@ -5,6 +5,7 @@ import Card from '../../../../components/Card';
 import { useSelector } from 'react-redux';
 import TagPill from '../../../../components/TagPill';
 import styles from './styles.module.scss';
+import { convertSize } from '../../../../utility/common';
 
 const getScoreColor = (score) => {
   if (score >= 80) return 'green';

--- a/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload/OpenSVCWorkload.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload/OpenSVCWorkload.jsx
@@ -60,7 +60,7 @@ const OpenSVCNodeCard = ({ nodeData }) => {
             <Gauge
               minValue={0}
               maxValue={stats.mem_total}
-              value={convertSize(memUsed, "M", "M")}
+              value={memUsed}
               text={'Memory'}
               width={220}
               height={150}
@@ -71,7 +71,7 @@ const OpenSVCNodeCard = ({ nodeData }) => {
             <Gauge
               minValue={0}
               maxValue={stats.swap_total}
-              value={convertSize(swapUsed, "M", "M")}
+              value={swapUsed}
               text={'Swap'}
               width={220}
               height={150}

--- a/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload/OpenSVCWorkload.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload/OpenSVCWorkload.jsx
@@ -62,10 +62,11 @@ const OpenSVCNodeCard = ({ nodeData }) => {
               maxValue={stats.mem_total}
               value={memUsed}
               text={'Memory'}
-              width={220}
-              height={150}
+              width={180}
+              height={135}
               isDisabled={true}
               isGaugeSizeCustomized={false}
+              hideMinMax={false}
               textOverlayClassName={styles.textOverlay}
             />
             <Gauge
@@ -73,10 +74,11 @@ const OpenSVCNodeCard = ({ nodeData }) => {
               maxValue={stats.swap_total}
               value={swapUsed}
               text={'Swap'}
-              width={220}
-              height={150}
+              width={180}
+              height={135}
               isDisabled={true}
               isGaugeSizeCustomized={false}
+              hideMinMax={false}
               textOverlayClassName={styles.textOverlay}
             />
           </Flex>

--- a/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload/OpenSVCWorkload.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload/OpenSVCWorkload.jsx
@@ -1,9 +1,10 @@
 import { Box, Flex, Text } from '@chakra-ui/react'
 import React from 'react'
-import Gauge from '../../../components/Gauge'
-import Card from '../../../components/Card';
+import Gauge from '../../../../components/Gauge';
+import Card from '../../../../components/Card';
 import { useSelector } from 'react-redux';
-import TagPill from '../../../components/TagPill';
+import TagPill from '../../../../components/TagPill';
+import styles from './styles.module.scss';
 
 const getScoreColor = (score) => {
   if (score >= 80) return 'green';
@@ -34,7 +35,7 @@ const OpenSVCNodeCard = ({ nodeData }) => {
         <>
           <Text>{node}</Text>
           <Box ml='auto'>
-              <TagPill colorScheme={getScoreColor(stats.score)} text={`${stats.score}`} />
+            <TagPill colorScheme={getScoreColor(stats.score)} text={`${stats.score}`} />
           </Box>
         </>
       }
@@ -54,25 +55,28 @@ const OpenSVCNodeCard = ({ nodeData }) => {
               />
             </Box>
           </Flex>
-
-          <Flex justify='space-around' gap='16px'>
+          <Flex justify='space-around'>
             <Gauge
               minValue={0}
               maxValue={stats.mem_total}
-              value={memUsed}
-              text='Memory Used'
-              appendTextToValue='MB'
-              width={isDesktop ? 120 : 100}
-              height={isDesktop ? 80 : 70}
+              value={convertSize(memUsed, "M", "M")}
+              text={'Memory'}
+              width={220}
+              height={150}
+              isDisabled={true}
+              isGaugeSizeCustomized={false}
+              textOverlayClassName={styles.textOverlay}
             />
             <Gauge
               minValue={0}
               maxValue={stats.swap_total}
-              value={swapUsed}
-              text='Swap Used'
-              appendTextToValue='MB'
-              width={isDesktop ? 120 : 100}
-              height={isDesktop ? 80 : 70}
+              value={convertSize(swapUsed, "M", "M")}
+              text={'Swap'}
+              width={220}
+              height={150}
+              isDisabled={true}
+              isGaugeSizeCustomized={false}
+              textOverlayClassName={styles.textOverlay}
             />
           </Flex>
         </Flex>

--- a/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload/styles.module.scss
+++ b/share/dashboard_react/src/Pages/Dashboard/components/OpenSVCWorkload/styles.module.scss
@@ -1,0 +1,5 @@
+.gauge {
+    div[class*='textOverlay'] {
+    bottom: rem(12);
+    }
+}

--- a/share/dashboard_react/src/Pages/Home/index.jsx
+++ b/share/dashboard_react/src/Pages/Home/index.jsx
@@ -193,6 +193,7 @@ function Home() {
       }
       if (dashboardTabsRef.current[selectedTabRef.current - 1] === 'Tops') {
         dispatch(getTopProcess({ clusterName: selectedClusterNameRef.current }))
+        dispatch(getOpenSVCStats({ clusterName: selectedClusterNameRef.current }))
       }
       if (dashboardTabsRef.current[selectedTabRef.current - 1] === 'Query Rules') {
         dispatch(getQueryRules({ clusterName: selectedClusterNameRef.current }))

--- a/share/dashboard_react/src/Pages/Home/index.jsx
+++ b/share/dashboard_react/src/Pages/Home/index.jsx
@@ -22,7 +22,8 @@ import {
   pauseAutoReload,
   getBackupStats,
   clearCluster,
-  getClusterApps
+  getClusterApps,
+  getOpenSVCStats
 } from '../../redux/clusterSlice'
 import { getClusters, getMonitoredData, getClusterPeers, getClusterForSale } from '../../redux/globalClustersSlice'
 import { AppSettings } from '../../AppSettings'

--- a/share/dashboard_react/src/Pages/Top/index.jsx
+++ b/share/dashboard_react/src/Pages/Top/index.jsx
@@ -14,7 +14,7 @@ import Dropdown from '../../components/Dropdown'
 import RunTests from '../Dashboard/components/RunTests'
 import ServerStatus from '../../components/ServerStatus'
 import ShowMoreText from '../../components/ShowMoreText'
-import OpenSVCWorkload from '../Dashboard/components/OpenSVCWorkload'
+import OpenSVCWorkload from '../Dashboard/components/OpenSVCWorkload/OpenSVCWorkload'
 
 function Top({ selectedCluster }) {
   const dispatch = useDispatch()

--- a/share/dashboard_react/src/Pages/Top/index.jsx
+++ b/share/dashboard_react/src/Pages/Top/index.jsx
@@ -14,15 +14,16 @@ import Dropdown from '../../components/Dropdown'
 import RunTests from '../Dashboard/components/RunTests'
 import ServerStatus from '../../components/ServerStatus'
 import ShowMoreText from '../../components/ShowMoreText'
+import OpenSVCWorkload from '../Dashboard/components/OpenSVCWorkload'
 
 function Top({ selectedCluster }) {
   const dispatch = useDispatch()
   const [topProcessData, setTopProcessData] = useState([])
   const [numberOfRows, setNumberOfRows] = useState(convertObjectToArrayForDropdown([10, 15, 30, 40, 50]))
   const [selectedNumberOfRows, setSelectedNumberOfRows] = useState({ name: 10, value: 10 })
-  const {
-    cluster: { topProcess, clusterServers }
-  } = useSelector((state) => state)
+  const topProcess = useSelector((state) => state.cluster.topProcess)
+  const clusterServers = useSelector((state) => state.cluster.clusterServers)
+  const opensvcStats = useSelector((state) => state.cluster.opensvcStats)
 
   useEffect(() => {
     dispatch(getTopProcess({ clusterName: selectedCluster?.name }))
@@ -147,6 +148,13 @@ function Top({ selectedCluster }) {
         heading={'Tests'}
         body={<RunTests selectedCluster={selectedCluster} />}
       />
+      {selectedCluster?.config?.provOrchestrator == "opensvc" && opensvcStats && (
+        <AccordionComponent
+          className={styles.accordion}
+          heading={'OpenSVC Workload'}
+          body={<OpenSVCWorkload workload={opensvcStats} />}
+        />
+      )}
       {selectedCluster?.workLoad && (
         <AccordionComponent
           className={styles.accordion}

--- a/share/dashboard_react/src/Pages/Top/index.jsx
+++ b/share/dashboard_react/src/Pages/Top/index.jsx
@@ -8,7 +8,7 @@ import { createColumnHelper } from '@tanstack/react-table'
 import { DataTable } from '../../components/DataTable'
 import { convertObjectToArrayForDropdown, getColorFromServerStatus, getReadableTime } from '../../utility/common'
 import { Link } from 'react-router-dom'
-import { getTopProcess } from '../../redux/clusterSlice'
+import { getOpenSVCStats, getTopProcess } from '../../redux/clusterSlice'
 import BarGraph from '../../components/BarGraph'
 import Dropdown from '../../components/Dropdown'
 import RunTests from '../Dashboard/components/RunTests'
@@ -27,6 +27,7 @@ function Top({ selectedCluster }) {
 
   useEffect(() => {
     dispatch(getTopProcess({ clusterName: selectedCluster?.name }))
+    dispatch(getOpenSVCStats({ clusterName: selectedCluster?.name }))
   }, [])
 
   useEffect(() => {

--- a/share/dashboard_react/src/components/Gauge/index.jsx
+++ b/share/dashboard_react/src/components/Gauge/index.jsx
@@ -94,7 +94,7 @@ function Gauge({
               subArcs: [
                 { length: 0.33, color: '#5BE12C' },
                 { length: 0.33, color: '#F5CD19' },
-                { length: 0.33, color: '#EA4228' }
+                { length: 0.34, color: '#EA4228' }
               ]
             }}
             style={isGaugeSizeCustomized ? {} : { width: `${width}px`, height: `${height}px` }}

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -1774,6 +1774,7 @@ export const clusterSlice = createSlice({
         getDatabaseService.fulfilled,
         getDatabaseVariables.fulfilled,
         getTopProcess.fulfilled,
+        getOpenSVCStats.fulfilled,
         getBackupSnapshot.fulfilled,
         getBackupStats.fulfilled,
         getShardSchema.fulfilled,

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -119,6 +119,16 @@ export const getTopProcess = createAsyncThunk('cluster/getTopProcess', async ({ 
   }
 })
 
+export const getOpenSVCStats = createAsyncThunk('cluster/getOpenSVCStats', async ({ clusterName }, thunkAPI) => {
+  try {
+    const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+    const { data, status } = await clusterService.getOpenSVCStats(clusterName, baseURL)
+    return { data, status }
+  } catch (error) {
+    handleError(error, thunkAPI)
+  }
+})
+
 export const getBackupSnapshot = createAsyncThunk('cluster/getBackupSnapshot', async ({ clusterName }, thunkAPI) => {
   try {
     const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
@@ -1697,6 +1707,7 @@ const initialState = {
     stats: null
   },
   topProcess: null,
+  opensvcStats: null,
   jobs: null,
   shardSchema: null,
   queryRules: null,
@@ -1797,6 +1808,8 @@ export const clusterSlice = createSlice({
           state.clusterCertificates = action.payload.data
         } else if (action.type.includes('getTopProcess')) {
           state.topProcess = action.payload.data
+        } else if (action.type.includes('getOpenSVCStats')) {
+          state.opensvcStats = action.payload.data
         } else if (action.type.includes('getBackupSnapshot')) {
           state.backups.snapshots = action.payload.data
         } else if (action.type.includes('getBackupStats')) {

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -9,6 +9,7 @@ export const clusterService = {
   getClusterProxies,
   getClusterCertificates,
   getTopProcess,
+  getOpenSVCStats,
   getBackupSnapshot,
   getBackupStats,
   getJobs,
@@ -167,6 +168,10 @@ function getClusterCertificates(clusterName, baseURL) {
 
 function getTopProcess(clusterName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/top`)
+}
+
+function getOpenSVCStats(clusterName, baseURL) {
+  return getApi(baseURL).get(`clusters/${clusterName}/opensvc-stats`)
 }
 
 function getBackupSnapshot(clusterName, baseURL) {


### PR DESCRIPTION
This pull request introduces a new API endpoint for retrieving OpenSVC daemon node statistics for a cluster, along with the necessary backend support and documentation updates. The main changes include the implementation of the data retrieval logic, the addition of the endpoint handler, and updates to the OpenAPI/Swagger documentation to describe the new endpoint and its response schema.

**API and Backend Enhancements:**

* Added a new HTTP GET endpoint `/api/clusters/{clusterName}/opensvc-stats` that returns the OpenSVC daemon status for a specified cluster, including proper ACL checks and error handling. [[1]](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afR63-R67) [[2]](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afR7476-R7524) [[3]](diffhunk://#diff-a731c27675af8adff750e3acd4db4260f02693f0d35ec87b67fe23eb0bc2e08cR608-R609)
* Implemented the `GetDaemonNodeStats` method in `opensvc/clusterapi.go` to fetch and aggregate node statistics from the OpenSVC API, including node name, stats (load, memory, swap, score), and core count.
* Added `GetOpenSVCStats` and `ReloadOpenSVCDaemonNodeStats` methods to the `Cluster` struct to manage and refresh the cached OpenSVC stats using `atomic.Value` for thread safety. [[1]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R264) [[2]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R370) [[3]](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0R890-R902) [[4]](diffhunk://#diff-ebe18c11af755e19a8493b229fe8b73799087472ad6bc067ea4e2b69df70b6f7R1652-R1665)

**Documentation and OpenAPI/Swagger Updates:**

* Updated the OpenAPI/Swagger documentation (`docs.go`, `swagger.json`, `swagger.yaml`) to describe the new endpoint, its parameters, responses, and the schema for `opensvc.DaemonNodeStats` and `opensvc.NodeStats`. [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R5490-R5541) [[2]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R22256-R22266) [[3]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R22308-R22330) [[4]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R5479-R5530) [[5]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R22245-R22255) [[6]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R22297-R22319) [[7]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R3397-R3403) [[8]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R3431-R3445) [[9]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R7447-R7481)

**Dependency and Struct Updates:**

* Added necessary imports for `atomic` and the OpenSVC package in relevant files, and updated the `Cluster` and `ReplicationManager` structs to include `OpenSVCStats` for storing the stats data. [[1]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R26) [[2]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R37) [[3]](diffhunk://#diff-ebe18c11af755e19a8493b229fe8b73799087472ad6bc067ea4e2b69df70b6f7R27) [[4]](diffhunk://#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4R29) [[5]](diffhunk://#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4R165)

These changes collectively provide a new, documented, and secure way to access detailed OpenSVC node stats through the cluster management API.