### PR TITLE
Add DB credentials check to prevent invalid configuration

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -778,6 +778,7 @@ func (cluster *Cluster) Run() {
 
 				cluster.IsFailable = cluster.GetStatus()
 				cluster.IsMasterDown = cluster.GetMaster() == nil || cluster.GetMaster().IsFailed()
+				cluster.CheckDBCredentials()
 				// CheckFailed trigger failover code if passing all false positiv and constraints
 				cluster.CheckFailed()
 				cluster.IsConfigPathChange = cluster.HasConfigPathChanged()

--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -1035,3 +1035,12 @@ func (cluster *Cluster) CheckOpenSVCTresholds() {
 		cluster.SetState("WARN0151", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0151"], overswap), ErrFrom: "CLUSTER"})
 	}
 }
+
+func (cluster *Cluster) CheckDBCredentials() {
+	// This check is to prevent invalid credentials configuration
+	// when both users are the same but passwords are different
+	// which would lead to a non working replication
+	if cluster.GetDbUser() == cluster.GetRplUser() && cluster.GetDbPass() != cluster.GetRplPass() {
+		cluster.SetState("ERR00101", state.State{ErrType: "ERROR", ErrDesc: config.ClusterError["ERR00101"], ErrFrom: "CLUSTER"})
+	}
+}

--- a/config/error.go
+++ b/config/error.go
@@ -118,6 +118,7 @@ var ClusterError = map[string]string{
 	"ERR00098":  "Failed to enable GTID Mode on master node. Err: %s",
 	"ERR00099":  "Failed to enable GTID Mode on slave %s. Err: %s",
 	"ERR00100":  "Cluster is in switchover. Switchover started at %s",
+	"ERR00101":  "Cluster DB user is same as replication user, but with different password",
 	"WARN0022":  "Rejoining standalone server %s to master %s",
 	"WARN0023":  "Number of failed master ping has been reached",
 	"WARN0045":  "Provision task is in queue",


### PR DESCRIPTION
This pull request introduces a new validation to the cluster management logic to prevent misconfiguration of database and replication credentials. The main change is the addition of a check that ensures the database user and replication user do not share the same username while having different passwords, which could break replication. The following are the most important changes:

**Cluster credential validation:**

* Added the `CheckDBCredentials` method to the `Cluster` type in `cluster/cluster_chk.go`, which checks if the database user and replication user are identical but have different passwords, setting an error state if this is detected.
* Integrated the new `CheckDBCredentials` method into the cluster execution flow by calling it in the `Run` method of `cluster/cluster.go`.

**Error messaging:**

* Added a new error message `ERR00101` to the `ClusterError` map in `config/error.go` to describe the specific credential mismatch scenario.