### PR TITLE
Fix opensvc daemon status fetching too many

### DIFF
--- a/opensvc/clusterapi.go
+++ b/opensvc/clusterapi.go
@@ -1079,38 +1079,29 @@ func (collector *Collector) GetDaemonNodeStats() ([]DaemonNodeStats, error) {
 	urlget := fmt.Sprintf("https://%s:%s/daemon_status", collector.Host, collector.Port)
 
 	client := collector.GetHttpClient()
-	if collector.ClusterConf.IsEligibleForPrinting(config.ConstLogModOrchestrator, config.LvlInfo) {
-		collector.Logrus.WithField("FROM", "OpenSVC").Println("INFO ", urlget)
-	}
 
 	req, err := http.NewRequest("GET", urlget, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	req.Header.Set("Content-Type", "application/json")
 	if collector.UseAPI {
 		req.SetBasicAuth(collector.RplMgrUser, collector.RplMgrPassword)
 		//		collector.Logrus.WithField("FROM", "OpenSVC").Printf("Info opensvc login %s %s", collector.RplMgrUser, collector.RplMgrPassword)
 	} else {
-		req.Header.Set("o-node", "*")
+		req.Header.Set("o-node", "ANY")
 	}
+
 	resp, err := client.Do(req)
 	if err != nil {
-		if collector.ClusterConf.IsEligibleForPrinting(config.ConstLogModOrchestrator, config.LvlWarn) {
-			collector.Logrus.WithField("FROM", "OpenSVC").Println("OpenSVC API Error: ", err)
-		}
 		return nil, err
 	}
 	defer resp.Body.Close()
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		if collector.ClusterConf.IsEligibleForPrinting(config.ConstLogModOrchestrator, config.LvlWarn) {
-			collector.Logrus.WithField("FROM", "OpenSVC").Println("OpenSVC API Error: ", err)
-		}
 		return nil, err
-	}
-	if collector.ClusterConf.IsEligibleForPrinting(config.ConstLogModOrchestrator, config.LvlDbg) {
-		collector.Logrus.WithField("FROM", "OpenSVC").Println("OpenSVC API Response: ", string(body))
 	}
 
 	// Extract node stats using gjson

--- a/server/server.go
+++ b/server/server.go
@@ -2316,14 +2316,12 @@ func (repman *ReplicationManager) Run() error {
 			}
 
 			go repman.GetAppTemplates()
-
+			repman.ReloadOpenSVCStats()
 		}
 
 		if counter%300 == 0 {
 			repman.RefreshDiskStats()
 		}
-
-		go repman.ReloadOpenSVCStats()
 
 		counter++
 	}

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -117,7 +117,14 @@ export const getTopProcess = createAsyncThunk('cluster/getTopProcess', async ({ 
   } catch (error) {
     handleError(error, thunkAPI)
   }
-})
+}, {
+  condition: (_, { getState }) => {
+    const { cluster } = getState();
+    if (cluster.isFetching.top) {
+      return false;
+    }
+  }
+});
 
 export const getOpenSVCStats = createAsyncThunk('cluster/getOpenSVCStats', async ({ clusterName }, thunkAPI) => {
   try {
@@ -127,7 +134,14 @@ export const getOpenSVCStats = createAsyncThunk('cluster/getOpenSVCStats', async
   } catch (error) {
     handleError(error, thunkAPI)
   }
-})
+}, {
+  condition: (_, { getState }) => {
+    const { cluster } = getState();
+    if (cluster.isFetching.opensvcStats) {
+      return false;
+    }
+  }
+});
 
 export const getBackupSnapshot = createAsyncThunk('cluster/getBackupSnapshot', async ({ clusterName }, thunkAPI) => {
   try {
@@ -1690,6 +1704,8 @@ const initialState = {
     servers: false,
     proxies: false,
     certificates: false,
+    top: false,
+    opensvcStats: false,
   },
   error: null,
   clusterApps: null,
@@ -1809,8 +1825,10 @@ export const clusterSlice = createSlice({
           state.clusterCertificates = action.payload.data
         } else if (action.type.includes('getTopProcess')) {
           state.topProcess = action.payload.data
+          state.isFetching.top = false
         } else if (action.type.includes('getOpenSVCStats')) {
           state.opensvcStats = action.payload.data
+          state.isFetching.opensvcStats = false
         } else if (action.type.includes('getBackupSnapshot')) {
           state.backups.snapshots = action.payload.data
         } else if (action.type.includes('getBackupStats')) {
@@ -1858,6 +1876,8 @@ export const clusterSlice = createSlice({
         getClusterServers.pending,
         getClusterProxies.pending,
         getClusterCertificates.pending,
+        getTopProcess.pending,
+        getOpenSVCStats.pending,
       ),
       (state, action) => {
         if (action.type.includes('getClusterData')) {
@@ -1872,6 +1892,10 @@ export const clusterSlice = createSlice({
           state.isFetching.proxies = true
         } else if (action.type.includes('getClusterApps')) {
           state.isFetching.apps = true
+        } else if (action.type.includes('getTopProcess')) {
+          state.isFetching.top = true
+        } else if (action.type.includes('getOpenSVCStats')) {
+          state.isFetching.opensvcStats = true
         }
       }
     )
@@ -1897,6 +1921,10 @@ export const clusterSlice = createSlice({
           state.isFetching.proxies = false
         } else if (action.type.includes('getClusterApps')) {
           state.isFetching.apps = false
+        } else if (action.type.includes('getTopProcess')) {
+          state.isFetching.top = false
+        } else if (action.type.includes('getOpenSVCStats')) {
+          state.isFetching.opensvcStats = false
         }
       }
     )


### PR DESCRIPTION
This pull request improves both backend and frontend handling of OpenSVC node statistics and top process fetching, focusing on better request management and logging. The frontend now prevents duplicate fetches for cluster stats and top processes, while the backend removes verbose logging and streamlines how OpenSVC stats are refreshed.

**Frontend (React/Redux) improvements:**

* Prevents duplicate API requests for top process and OpenSVC stats by adding `condition` checks to `getTopProcess` and `getOpenSVCStats` thunks, which block requests if a fetch is already in progress. [[1]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424L120-R127) [[2]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424L130-R144)
* Adds and manages new `isFetching.top` and `isFetching.opensvcStats` flags in Redux state, updating them on request start and completion to track fetch status and support the new conditions. [[1]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1707-R1708) [[2]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1828-R1831) [[3]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1879-R1880) [[4]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1895-R1898) [[5]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1924-R1927)

**Backend (Go) improvements:**

* Removes verbose logging from `GetDaemonNodeStats` in `clusterapi.go` for cleaner logs and less noise during API errors and responses. Also changes the `o-node` header from `"*"` to `"ANY"` for non-API requests.
* Ensures OpenSVC stats are reloaded only once per loop iteration in `ReplicationManager.Run`, preventing redundant calls.