### PR TITLE
Add context timeout in GetDaemonNodeStats

### DIFF
--- a/opensvc/clusterapi.go
+++ b/opensvc/clusterapi.go
@@ -1093,10 +1093,23 @@ func (collector *Collector) GetDaemonNodeStats() ([]DaemonNodeStats, error) {
 		req.Header.Set("o-node", "ANY")
 	}
 
+	ctx, cancel := context.WithTimeout(req.Context(), 10*time.Second)
+
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	startConnect := time.Now()
 	resp, err := client.Do(req)
+
+	stopConnect := time.Now()
+	if collector.ClusterConf.IsEligibleForPrinting(config.ConstLogModOrchestrator, config.LvlDbg) {
+		collector.Logrus.WithField("FROM", "OpenSVC").Printf("OpenSVC Connect took: %s\n", stopConnect.Sub(startConnect))
+	}
 	if err != nil {
 		return nil, err
 	}
+
+	defer client.CloseIdleConnections()
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
This pull request introduces improvements to the `GetDaemonNodeStats` function in `opensvc/clusterapi.go`, focusing on connection handling and diagnostics. The main changes add a timeout to HTTP requests, log connection durations for debugging, and ensure idle connections are properly closed.

Connection management and diagnostics:

* Added a 10-second timeout to the HTTP request context to prevent hanging requests.
* Logged the time taken to establish a connection when debug logging is enabled, aiding in performance monitoring.
* Ensured idle HTTP connections are closed after the request completes to improve resource management.