### PR TITLE
Fix server auto-rejoin and read-only handling in Ping function for topology staging

### DIFF
--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -599,11 +599,15 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 		}
 	}
 	if errss == sql.ErrNoRows || noChannel {
-		// If we reached this stage with a previously failed server, reintroduce
-		// it as unconnected server.master
+		// If we have no replication channel found
+		// This is either a master or a standalone server
+
 		if server.PrevState == stateFailed || server.PrevState == stateErrorAuth /*|| server.PrevState == stateSuspect*/ {
+			// If we reached this stage with a previously failed server, reintroduce it as unconnected server.master
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "State changed, init failed server %s as unconnected", server.URL)
-			if cluster.Conf.ReadOnly && !server.HaveWsrep && cluster.IsDiscovered() {
+
+			// if the config is read only and we are not in a wsrep cluster and we are not in topology staging mode
+			if cluster.Conf.ReadOnly && !server.HaveWsrep && cluster.IsDiscovered() && !cluster.Conf.TopologyStaging {
 				//GetMaster abstract master for galera multi master and master slave
 				if server.GetCluster().GetMaster() != nil {
 					if cluster.Status == ConstMonitorActif && server.GetCluster().GetMaster().Id != server.Id && !server.IsIgnoredReadonly() && !cluster.IsInFailover() {
@@ -630,15 +634,19 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 			server.FailCount = 0
 			cluster.backendStateChangeProxies()
 			server.SendAlert()
-			if cluster.Conf.Autorejoin && cluster.IsActive() {
-				server.RejoinMaster()
-			} else {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Auto Rejoin is disabled")
+
+			// Cancel autorejoin if in topology staging mode
+			if !cluster.Conf.TopologyStaging {
+				if cluster.Conf.Autorejoin && cluster.IsActive() {
+					server.RejoinMaster()
+				} else {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Auto Rejoin is disabled")
+				}
 			}
 
 		} else if server.State != stateMaster && server.PrevState != stateUnconn && server.State == stateUnconn {
 			// Master will never get discovery in topology if it does not get unconnected first it default to suspect
-			//	if cluster.GetTopology() != config.TopoMultiMasterWsrep {
+
 			if server.IsGroupReplicationSlave {
 				server.SetState(stateSlave)
 			} else {
@@ -646,8 +654,9 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 			}
 
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "From state %s to unconnected and non leader on server %s", server.PrevState, server.URL)
-			//	}
-			if cluster.Conf.ReadOnly && !server.HaveWsrep && cluster.IsDiscovered() && !server.IsIgnoredReadonly() && !cluster.IsInFailover() {
+
+			// if the config is read only and we are not in a wsrep cluster and we are not in topology staging mode
+			if cluster.Conf.ReadOnly && !server.HaveWsrep && cluster.IsDiscovered() && !server.IsIgnoredReadonly() && !cluster.IsInFailover() && !cluster.Conf.TopologyStaging {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Setting Read Only on unconnected server: %s no master state and replication found", server.URL)
 				server.SetReadOnly()
 			}


### PR DESCRIPTION
This pull request updates the server monitoring logic in `cluster/srv.go` to improve handling of server state transitions, especially in relation to topology staging mode and read-only configurations. The changes introduce additional checks to ensure certain actions, such as rejoining the master and setting servers to read-only, are only performed when not in topology staging mode. This helps prevent unintended state changes during cluster topology updates.

**State transition and topology staging improvements:**

* Added a check for `cluster.Conf.TopologyStaging` to prevent reintroducing a previously failed server as unconnected master when in topology staging mode.
* Updated logic for auto-rejoining the master to only proceed when not in topology staging mode, ensuring safer state transitions during topology updates.
* Modified the read-only state assignment for unconnected servers to include a check for topology staging mode, preventing changes when the cluster is in this transitional state.