### PR TITLE
Enhance read-only and rejoin handling for topology staging

### DIFF
--- a/cluster/cluster_bash.go
+++ b/cluster/cluster_bash.go
@@ -89,7 +89,7 @@ func (cluster *Cluster) BashScriptDbServersChangeState(srv *ServerMonitor, newSt
 				cluster.StagingServer.SetReadOnly() // Set the old staging server to read only
 			}
 
-			cluster.StagingServer = srv          // Set the new staging server as the new staging server
+			cluster.SetStagingServer(srv)        // Set the new staging server as the new staging server
 			cluster.StagingServer.SetReadWrite() // Set the new staging server to read write for proxysql read-only checks
 		}
 

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -1663,3 +1663,17 @@ func (cluster *Cluster) GetOpenSVCStats() ([]opensvc.DaemonNodeStats, error) {
 	}
 	return stats, nil
 }
+
+func (cluster *Cluster) GetStagingServerFromConfig() *ServerMonitor {
+	if !cluster.Conf.TopologyStaging {
+		return nil
+	}
+
+	for _, srv := range cluster.Servers {
+		if srv.HostCnf == cluster.Conf.StagingServerHost {
+			return srv
+		}
+	}
+
+	return nil
+}

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -2615,3 +2615,26 @@ func (cluster *Cluster) SetResticPassword(cred string) {
 	new_secret.OldValue = cluster.Conf.GetDecryptedValue("backup-restic-password")
 	cluster.Conf.Secrets["backup-restic-password"] = new_secret
 }
+
+func (cluster *Cluster) SetStagingServer(srv *ServerMonitor) {
+	srvhost := ""
+	cluster.StagingServer = srv
+	if srv != nil {
+		srvhost = srv.HostCnf
+	}
+	cluster.Conf.StagingServerHost = srvhost
+}
+
+func (cluster *Cluster) SetStandaloneAsStaging() *ServerMonitor {
+	stagingsrv, _ := cluster.GetStandaloneServerByIndex(0)
+
+	stagingcnf := cluster.GetStagingServerFromConfig()
+	// Check if staging server is valid and standalone
+	if stagingcnf != nil && stagingcnf.IsStandAlone() {
+		stagingsrv = stagingcnf
+	}
+
+	cluster.SetStagingServer(stagingsrv)
+
+	return stagingsrv
+}

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -66,7 +66,7 @@ func (cluster *Cluster) RefreshStaging(source *Cluster, masterGTIDList string) e
 	if cluster.StagingServer == nil || cluster.StagingServer.State != stateUnconn {
 		for _, srv := range cluster.Servers {
 			if srv.State == stateUnconn {
-				cluster.StagingServer = srv
+				cluster.SetStagingServer(srv)
 				break
 			}
 		}

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -506,6 +506,17 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 		cluster.vmaster = nil
 	}
 
+	// Set staging server from config if not yet set and staging mode is on
+	if cluster.Conf.TopologyStaging && cluster.StagingServer == nil {
+		// Get staging server from config
+		staging := cluster.GetStagingServerFromConfig()
+
+		// Check if staging server is valid and standalone
+		if staging != nil && staging.IsStandAlone() {
+			cluster.SetStagingServer(staging)
+		}
+	}
+
 	if cluster.StateMachine.CanMonitor() {
 		return nil
 	}

--- a/cluster/prx_haproxy.go
+++ b/cluster/prx_haproxy.go
@@ -137,8 +137,7 @@ func (proxy *HaproxyProxy) Init() {
 
 	stagingsrv := cluster.StagingServer
 	if stagingsrv == nil {
-		stagingsrv, _ = cluster.GetStandaloneServerByIndex(0)
-		cluster.StagingServer = stagingsrv
+		stagingsrv = cluster.SetStandaloneAsStaging()
 	}
 
 	if cluster.Conf.TopologyStaging && proxy.IsStaging && stagingsrv != nil {
@@ -213,8 +212,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 	cluster := proxy.ClusterGroup
 	stagingsrv := cluster.StagingServer
 	if stagingsrv == nil {
-		stagingsrv, _ = cluster.GetStandaloneServerByIndex(0)
-		cluster.StagingServer = stagingsrv
+		stagingsrv = cluster.SetStandaloneAsStaging()
 	}
 	// if proxy.ClusterGroup.Conf.HaproxyStatHttp {
 
@@ -364,11 +362,6 @@ func (proxy *HaproxyProxy) Refresh() error {
 
 					if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
 						if !srv.IsStandAlone() {
-							if stagingsrv == nil {
-								stagingsrv, _ = cluster.GetStandaloneServerByIndex(0)
-								cluster.StagingServer = stagingsrv
-							}
-
 							if stagingsrv != nil {
 								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "[Staging] Detecting wrong master server in haproxy %s fixing it to standalone %s %s", proxy.Host+":"+proxy.Port, stagingsrv.Host, stagingsrv.Port)
 								msg, err := haRuntime.SetMaster(cluster.Conf.HaproxyStagingBackend, stagingsrv.Host, stagingsrv.Port)
@@ -510,11 +503,6 @@ func (proxy *HaproxyProxy) Refresh() error {
 	}
 	if !foundMasterInStat {
 		if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
-			if stagingsrv == nil {
-				stagingsrv, _ = cluster.GetStandaloneServerByIndex(0)
-				cluster.StagingServer = stagingsrv
-			}
-
 			if stagingsrv != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "[Staging] HAProxy has standalone in cluster but not in haproxy %s fixing it to standalone %s %s", proxy.Host+":"+proxy.Port, stagingsrv.Host, stagingsrv.Port)
 				msg, err := haRuntime.SetMaster(cluster.Conf.HaproxyStagingBackend, stagingsrv.Host, stagingsrv.Port)

--- a/cluster/prx_proxysql.go
+++ b/cluster/prx_proxysql.go
@@ -315,7 +315,7 @@ func (proxy *ProxySQLProxy) Refresh() error {
 
 	stagingsrv := cluster.StagingServer
 	if stagingsrv == nil {
-		stagingsrv, _ = cluster.GetStandaloneServerByIndex(0)
+		stagingsrv = cluster.SetStandaloneAsStaging()
 	}
 
 	for _, s := range cluster.Servers {

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -610,7 +610,7 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 			// If we reached this stage with a previously failed server, reintroduce it as unconnected server.master
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "State changed, init failed server %s as unconnected", server.URL)
 
-			// if the config is read only and we are not in a wsrep cluster and we are not in topology staging mode
+			// if the config is read only and we are not in a wsrep cluster and node is not staging server
 			if cluster.Conf.ReadOnly && !server.HaveWsrep && cluster.IsDiscovered() && !isStagingServer {
 				//GetMaster abstract master for galera multi master and master slave
 				if server.GetCluster().GetMaster() != nil {
@@ -639,6 +639,7 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 			cluster.backendStateChangeProxies()
 			server.SendAlert()
 
+			// if autorejoin is set and node is not staging server
 			if cluster.Conf.Autorejoin && cluster.IsActive() && !isStagingServer {
 				server.RejoinMaster()
 			} else {
@@ -656,7 +657,7 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "From state %s to unconnected and non leader on server %s", server.PrevState, server.URL)
 
-			// if the config is read only and we are not in a wsrep cluster and we are not in topology staging mode
+			// if the config is read only and we are not in a wsrep cluster and node is not staging server
 			if cluster.Conf.ReadOnly && !server.HaveWsrep && cluster.IsDiscovered() && !server.IsIgnoredReadonly() && !cluster.IsInFailover() && !isStagingServer {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Setting Read Only on unconnected server: %s no master state and replication found", server.URL)
 				server.SetReadOnly()

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -601,13 +601,17 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 	if errss == sql.ErrNoRows || noChannel {
 		// If we have no replication channel found
 		// This is either a master or a standalone server
+		isStagingServer := false
+		if cluster.Conf.TopologyStaging && cluster.StagingServer != nil && cluster.StagingServer.Id == server.Id {
+			isStagingServer = true
+		}
 
 		if server.PrevState == stateFailed || server.PrevState == stateErrorAuth /*|| server.PrevState == stateSuspect*/ {
 			// If we reached this stage with a previously failed server, reintroduce it as unconnected server.master
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "State changed, init failed server %s as unconnected", server.URL)
 
 			// if the config is read only and we are not in a wsrep cluster and we are not in topology staging mode
-			if cluster.Conf.ReadOnly && !server.HaveWsrep && cluster.IsDiscovered() && !cluster.Conf.TopologyStaging {
+			if cluster.Conf.ReadOnly && !server.HaveWsrep && cluster.IsDiscovered() && !isStagingServer {
 				//GetMaster abstract master for galera multi master and master slave
 				if server.GetCluster().GetMaster() != nil {
 					if cluster.Status == ConstMonitorActif && server.GetCluster().GetMaster().Id != server.Id && !server.IsIgnoredReadonly() && !cluster.IsInFailover() {
@@ -635,7 +639,7 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 			cluster.backendStateChangeProxies()
 			server.SendAlert()
 
-			if cluster.Conf.Autorejoin && cluster.IsActive() {
+			if cluster.Conf.Autorejoin && cluster.IsActive() && !isStagingServer {
 				server.RejoinMaster()
 			} else {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Auto Rejoin is disabled")
@@ -653,7 +657,7 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "From state %s to unconnected and non leader on server %s", server.PrevState, server.URL)
 
 			// if the config is read only and we are not in a wsrep cluster and we are not in topology staging mode
-			if cluster.Conf.ReadOnly && !server.HaveWsrep && cluster.IsDiscovered() && !server.IsIgnoredReadonly() && !cluster.IsInFailover() && !cluster.Conf.TopologyStaging {
+			if cluster.Conf.ReadOnly && !server.HaveWsrep && cluster.IsDiscovered() && !server.IsIgnoredReadonly() && !cluster.IsInFailover() && !isStagingServer {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Setting Read Only on unconnected server: %s no master state and replication found", server.URL)
 				server.SetReadOnly()
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -457,6 +457,7 @@ type Config struct {
 	TopologyStagingRefreshScript              string                 `mapstructure:"topology-staging-refresh-script" toml:"topology-staging-refresh-script" json:"topologyStagingRefreshScript"`
 	TopologyStagingPostDetachScript           string                 `mapstructure:"topology-staging-post-detach-script" toml:"topology-staging-post-detach-script" json:"topologyStagingPostDetachScript"`
 	StagingProxyHosts                         string                 `mapstructure:"staging-proxy-hosts" toml:"staging-proxy-hosts" json:"stagingProxyHosts"`
+	StagingServerHost                         string                 `mapstructure:"staging-server-host" toml:"staging-server-host" json:"stagingServerHost"`
 	GraphiteMetrics                           bool                   `scope:"server" mapstructure:"graphite-metrics" toml:"graphite-metrics" json:"graphiteMetrics"`
 	GraphiteEmbedded                          bool                   `scope:"server" mapstructure:"graphite-embedded" toml:"graphite-embedded" json:"graphiteEmbedded"`
 	GraphiteWhitelist                         bool                   `scope:"server" mapstructure:"graphite-whitelist" toml:"graphite-whitelist" json:"graphiteWhitelist"`

--- a/server/server.go
+++ b/server/server.go
@@ -490,6 +490,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.TopologyStagingRefreshScript, "topology-staging-refresh-script", "", "Topology staging refresh script path. Empty will use copy of embedded template in working directory")
 	flags.StringVar(&conf.TopologyStagingPostDetachScript, "topology-staging-post-detach-script", "", "Topology staging post detach script path. Empty will not execute anything")
 	flags.StringVar(&conf.StagingProxyHosts, "staging-proxy-hosts", "", "Staging proxy hosts list to monitor separated by commas")
+	flags.StringVar(&conf.StagingServerHost, "staging-server-host", "", "Staging database host")
 
 	flags.StringVar(&conf.PreScript, "failover-pre-script", "", "Path of pre-failover script")
 	flags.StringVar(&conf.PostScript, "failover-post-script", "", "Path of post-failover script")


### PR DESCRIPTION
This pull request introduces improvements to how the staging server is selected, tracked, and managed within the cluster. The main change is the addition of a new configuration option (`StagingServerHost`) that allows the staging server to be explicitly specified, along with associated logic to consistently set and update the staging server throughout the codebase. These changes help ensure that the correct server is used for staging, especially in scenarios involving failover, proxy refreshes, and cluster state transitions.

**Configuration and Staging Server Management**

* Added a new configuration field `StagingServerHost` to `Config`, enabling explicit specification of the staging server via configuration. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R460) [[2]](diffhunk://#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4R493)
* Implemented `GetStagingServerFromConfig` and `SetStagingServer` methods in `Cluster` to retrieve and set the staging server based on configuration, ensuring synchronization between cluster state and configuration. [[1]](diffhunk://#diff-ebe18c11af755e19a8493b229fe8b73799087472ad6bc067ea4e2b69df70b6f7R1666-R1679) [[2]](diffhunk://#diff-d5872677c3cc5c2ea2a32bdf57af1e39a3e2d5e5eb735fc8bbba65b445132846R2618-R2640)
* Updated logic in cluster initialization (`TopologyDiscover`), staging refresh, and proxy initialization/refresh methods to use the new configuration-based staging server selection, replacing previous ad-hoc selection of standalone servers. [[1]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2R509-R519) [[2]](diffhunk://#diff-ec443a688a4298a59c849d13303c9c79f65eab2fdfda6f55916634131a6019e7L69-R69) [[3]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL140-R140) [[4]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL216-R215) [[5]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL367-L371) [[6]](diffhunk://#diff-4eaf0517e84d1ac2ade9de4399d065156343139f0a363cfc1a9f8b335879d76aL513-L517) [[7]](diffhunk://#diff-6aa809290955116a865c7b22c6da125d8f447ecc92dae7221e9f8159492d110aL318-R318) [[8]](diffhunk://#diff-5306a5d3d9418e0cd4d3d5ee3f2b872b7dd63a19efe23104d6142515604cf93eL92-R92)

**Staging Server Behavior in Cluster Operations**

* Added logic in `ServerMonitor.Ping` to treat the staging server distinctly: certain actions (like auto-rejoin and read-only transitions) are now skipped for the staging server, improving reliability in staging mode. [[1]](diffhunk://#diff-c5fffdb4a6a092160ddd24b95042ba54bfcb96dfb0e747bb200902aac778adb1R604-R614) [[2]](diffhunk://#diff-c5fffdb4a6a092160ddd24b95042ba54bfcb96dfb0e747bb200902aac778adb1L638-R643) [[3]](diffhunk://#diff-c5fffdb4a6a092160ddd24b95042ba54bfcb96dfb0e747bb200902aac778adb1L655-R661)

These changes make staging server management more robust and predictable, especially in complex cluster topologies and during failover or refresh operations.