### PR TITLE
Raise alert level from WARN to ERROR for duplicate server ID

### DIFF
--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -791,7 +791,7 @@ func (cluster *Cluster) CheckSameServerID() {
 				continue
 			}
 			if s.ServerID == sothers.ServerID {
-				cluster.SetState("WARN0087", state.State{ErrType: config.LvlWarn, ErrDesc: fmt.Sprintf(clusterError["WARN0087"], s.URL, sothers.URL), ErrFrom: "MON", ServerUrl: s.URL})
+				cluster.SetState("WARN0087", state.State{ErrType: config.LvlErr, ErrDesc: fmt.Sprintf(clusterError["WARN0087"], s.URL, sothers.URL), ErrFrom: "MON", ServerUrl: s.URL})
 
 			}
 		}

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -639,11 +639,14 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 			cluster.backendStateChangeProxies()
 			server.SendAlert()
 
-			// if autorejoin is set and node is not staging server
-			if cluster.Conf.Autorejoin && cluster.IsActive() && !isStagingServer {
-				server.RejoinMaster()
-			} else if isStagingServer {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Preventing auto rejoin on staging server %s", server.URL)
+			// if autorejoin is set
+			if cluster.Conf.Autorejoin && cluster.IsActive() {
+				// rejoin if not staging server
+				if isStagingServer {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Preventing auto rejoin on staging server %s", server.URL)
+				} else {
+					server.RejoinMaster()
+				}
 			} else {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Auto Rejoin is disabled")
 			}

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -642,6 +642,8 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 			// if autorejoin is set and node is not staging server
 			if cluster.Conf.Autorejoin && cluster.IsActive() && !isStagingServer {
 				server.RejoinMaster()
+			} else if isStagingServer {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Preventing auto rejoin on staging server %s", server.URL)
 			} else {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Auto Rejoin is disabled")
 			}


### PR DESCRIPTION
This pull request introduces two main changes to the cluster monitoring and server rejoin logic. The first change upgrades the severity level of duplicate server ID detection, and the second refines the auto rejoin logic to explicitly prevent rejoining for staging servers while providing clearer logging.

Error handling improvements:

* Duplicate server ID detection now sets the state to an error (`LvlErr`) instead of a warning (`LvlWarn`) in the `CheckSameServerID` method within `cluster_chk.go`. This ensures that duplicate server IDs are treated as critical issues.

Auto rejoin logic enhancements:

* The auto rejoin process in the `Ping` method of `srv.go` now explicitly checks for staging servers and prevents auto rejoining for them, logging an informational message when this occurs. This clarifies the behavior and avoids unintended rejoin attempts on staging servers.