### PR TITLE
Enhance alert email formatting to include timestamp and improve cluster log matching for replication-manager-cli

### DIFF
--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -4282,7 +4282,7 @@ func (repman *ReplicationManager) handlerMuxLog(w http.ResponseWriter, r *http.R
 	vars := mux.Vars(r)
 
 	// (?i) = case-insensitive
-	pattern := fmt.Sprintf(`(?i)(^|[^A-Za-z0-9-_])%s([^A-Za-z0-9-_]|$)`, regexp.QuoteMeta(strings.TrimSpace(vars["clusterName"])))
+	pattern := fmt.Sprintf(`(?i)(^|[^A-Za-z0-9_\-])%s([^A-Za-z0-9_\-]|$)`, regexp.QuoteMeta(strings.TrimSpace(vars["clusterName"])))
 	re := regexp.MustCompile(pattern)
 
 	for _, slog := range repman.tlog.Buffer {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -4280,8 +4280,13 @@ func (repman *ReplicationManager) handlerMuxSwitchReadOnly(w http.ResponseWriter
 func (repman *ReplicationManager) handlerMuxLog(w http.ResponseWriter, r *http.Request) {
 	var clusterlogs []string
 	vars := mux.Vars(r)
+
+	// (?i) = case-insensitive
+	pattern := fmt.Sprintf(`(?i)\b%s\b`, regexp.QuoteMeta(vars["clusterName"]))
+	re := regexp.MustCompile(pattern)
+
 	for _, slog := range repman.tlog.Buffer {
-		if strings.Contains(slog, vars["clusterName"]) {
+		if re.MatchString(slog) {
 			clusterlogs = append(clusterlogs, slog)
 		}
 	}

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -4282,7 +4282,7 @@ func (repman *ReplicationManager) handlerMuxLog(w http.ResponseWriter, r *http.R
 	vars := mux.Vars(r)
 
 	// (?i) = case-insensitive
-	pattern := fmt.Sprintf(`(?i)\b%s\b`, regexp.QuoteMeta(vars["clusterName"]))
+	pattern := fmt.Sprintf(`(?i)(^|[^A-Za-z0-9])%s([^A-Za-z0-9]|$)`, regexp.QuoteMeta(strings.TrimSpace(vars["clusterName"])))
 	re := regexp.MustCompile(pattern)
 
 	for _, slog := range repman.tlog.Buffer {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -4282,7 +4282,7 @@ func (repman *ReplicationManager) handlerMuxLog(w http.ResponseWriter, r *http.R
 	vars := mux.Vars(r)
 
 	// (?i) = case-insensitive
-	pattern := fmt.Sprintf(`(?i)(^|[^A-Za-z0-9])%s([^A-Za-z0-9]|$)`, regexp.QuoteMeta(strings.TrimSpace(vars["clusterName"])))
+	pattern := fmt.Sprintf(`(?i)(^|[^A-Za-z0-9-_])%s([^A-Za-z0-9-_]|$)`, regexp.QuoteMeta(strings.TrimSpace(vars["clusterName"])))
 	re := regexp.MustCompile(pattern)
 
 	for _, slog := range repman.tlog.Buffer {

--- a/utils/alert/alert.go
+++ b/utils/alert/alert.go
@@ -3,6 +3,7 @@ package alert
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/jordan-wright/email"
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -20,6 +21,8 @@ type Alert struct {
 }
 
 func (a *Alert) EmailMessage(to string, mailer *mailer.Mailer) error {
+	ts := time.Now().Format(time.RFC1123)
+
 	e := email.NewEmail()
 	e.From = mailer.From
 	e.To = strings.Split(to, ",")
@@ -33,9 +36,9 @@ func (a *Alert) EmailMessage(to string, mailer *mailer.Mailer) error {
 	text := fmt.Sprintf("Alert: State changed from %s to %s\nMonitor: %s\nCluster: %s\n%s", a.PrevState, a.State, a.Instance, a.Cluster, host)
 	if a.PrevState == "" {
 		if a.Resolved {
-			text = fmt.Sprintf("Resolved: %s\nMonitor: %s\nCluster: %s\n%s", a.State, a.Instance, a.Cluster, host)
+			text = fmt.Sprintf("Resolved: %s\nMonitor: %s\nCluster: %s\n%s%s\n", a.State, a.Instance, a.Cluster, host, ts)
 		} else {
-			text = fmt.Sprintf("Alert: %s\nMonitor: %s\nCluster: %s\n%s", a.State, a.Instance, a.Cluster, host)
+			text = fmt.Sprintf("Alert: %s\nMonitor: %s\nCluster: %s\n%s%s\n", a.State, a.Instance, a.Cluster, host, ts)
 		}
 	}
 	e.Text = []byte(text)

--- a/utils/alert/alert.go
+++ b/utils/alert/alert.go
@@ -36,9 +36,9 @@ func (a *Alert) EmailMessage(to string, mailer *mailer.Mailer) error {
 	text := fmt.Sprintf("Alert: State changed from %s to %s\nMonitor: %s\nCluster: %s\n%s", a.PrevState, a.State, a.Instance, a.Cluster, host)
 	if a.PrevState == "" {
 		if a.Resolved {
-			text = fmt.Sprintf("Resolved: %s\nMonitor: %s\nCluster: %s\n%s%s\n", a.State, a.Instance, a.Cluster, host, ts)
+			text = fmt.Sprintf("Resolved: %s\nMonitor: %s\nCluster: %s\n%sTime: %s\n", a.State, a.Instance, a.Cluster, host, ts)
 		} else {
-			text = fmt.Sprintf("Alert: %s\nMonitor: %s\nCluster: %s\n%s%s\n", a.State, a.Instance, a.Cluster, host, ts)
+			text = fmt.Sprintf("Alert: %s\nMonitor: %s\nCluster: %s\n%sTime: %s\n", a.State, a.Instance, a.Cluster, host, ts)
 		}
 	}
 	e.Text = []byte(text)


### PR DESCRIPTION
This pull request introduces improvements to log filtering and alert email formatting. The main changes enhance the accuracy of cluster log searches and add timestamps to alert notifications, so late received email will not be a false alarm.

**Log filtering improvements:**

* Updated the cluster log filtering in `handlerMuxLog` (in `server/api_cluster.go`) to use case-insensitive, whole-word matching with regular expressions, making log retrieval more precise.

**Alert email enhancements:**

* Added the current timestamp to alert emails by importing the `time` package and formatting the timestamp using `time.RFC1123` in `utils/alert/alert.go`. [[1]](diffhunk://#diff-d5634bc9b8f9cd7e950e95b3fa4ead54f147af52df9be6c0dc1aa5c416997440R6) [[2]](diffhunk://#diff-d5634bc9b8f9cd7e950e95b3fa4ead54f147af52df9be6c0dc1aa5c416997440R24-R25)
* Modified the alert email message construction to include the timestamp for both resolved and new alerts, improving context for recipients.