### PR TITLE
Add error handling for deployment and storage field changes

### DIFF
--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -1596,6 +1596,9 @@ export const deploymentFieldChange = createAsyncThunk(
     try {
       const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
       const { data, status } = await clusterService.deploymentFieldChange(clusterName, appId, field, index, key, value, baseURL)
+      if (status !== 200) {
+        throw new Error(data)
+      }
       showSuccessBanner('Deployment field updated!', status, thunkAPI)
       return { data, status }
     } catch (error) {
@@ -1611,6 +1614,9 @@ export const deploymentFieldIndexAdd = createAsyncThunk(
     try {
       const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
       const { data, status } = await clusterService.deploymentFieldIndexAdd(clusterName, appId, field, value, baseURL)
+      if (status !== 200) {
+        throw new Error(data)
+      }
       showSuccessBanner('New deployment field row added!', status, thunkAPI)
       return { data, status }
     } catch (error) {
@@ -1625,6 +1631,9 @@ export const deploymentFieldIndexDrop = createAsyncThunk(
     try {
       const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
       const { data, status } = await clusterService.deploymentFieldIndexDrop(clusterName, appId, field, index, baseURL)
+      if (status !== 200) {
+        throw new Error(data)
+      }
       showSuccessBanner('Deployment field row dropped!', status, thunkAPI)
       return { data, status }
     } catch (error) {
@@ -1640,6 +1649,9 @@ export const storageFieldChange = createAsyncThunk(
     try {
       const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
       const { data, status } = await clusterService.storageFieldChange(clusterName, appId, field, index, key, value, baseURL)
+      if (status !== 200) {
+        throw new Error(data)
+      }
       showSuccessBanner('storage field updated!', status, thunkAPI)
       return { data, status }
     } catch (error) {
@@ -1655,6 +1667,9 @@ export const storageFieldIndexAdd = createAsyncThunk(
     try {
       const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
       const { data, status } = await clusterService.storageFieldIndexAdd(clusterName, appId, field, value, baseURL)
+      if (status !== 200) {
+        throw new Error(data)
+      }
       showSuccessBanner('New storage field row added!', status, thunkAPI)
       return { data, status }
     } catch (error) {
@@ -1669,6 +1684,9 @@ export const storageFieldIndexDrop = createAsyncThunk(
     try {
       const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
       const { data, status } = await clusterService.storageFieldIndexDrop(clusterName, appId, field, index, baseURL)
+      if (status !== 200) {
+        throw new Error(data)
+      }
       showSuccessBanner('storage field row dropped!', status, thunkAPI)
       return { data, status }
     } catch (error) {
@@ -1685,6 +1703,9 @@ export const connectDockerRegistry = createAsyncThunk(
     try {
       const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
       const { data, status } = await clusterService.connectDockerRegistry(clusterName, dockerRegistry, baseURL)
+      if (status !== 200) {
+        throw new Error(data)
+      }
       showSuccessBanner('New server added!', status, thunkAPI)
       return { data, status }
     } catch (error) {


### PR DESCRIPTION
This pull request improves error handling in several async thunk actions in `clusterSlice.js` by explicitly checking for unsuccessful HTTP responses and throwing errors when the response status is not 200. This ensures that failed backend operations are properly surfaced as errors in the Redux workflow, rather than being treated as successful actions.

Error handling improvements for async thunks:

* Added status code checks after service calls in the following thunks: `deploymentFieldChange`, `deploymentFieldIndexAdd`, `deploymentFieldIndexDrop`, `storageFieldChange`, `storageFieldIndexAdd`, `storageFieldIndexDrop`, and `connectDockerRegistry`. If the response status is not 200, an error is thrown with the response data. [[1]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1599-R1601) [[2]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1617-R1619) [[3]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1634-R1636) [[4]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1652-R1654) [[5]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1670-R1672) [[6]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1687-R1689) [[7]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1706-R1708)