### PR TITLE
Fix code to accurately reflect mydumper and myloader path

### DIFF
--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -159,7 +159,7 @@ func (cluster *Cluster) GetMysqlDumpPath() string {
 
 func (cluster *Cluster) GetMyDumperPath() string {
 	if cluster.Conf.BackupMyDumperPath == "" {
-		//if mysqldump installed
+		//if mydumper installed
 		if path, err := exec.Command("which", "mydumper").Output(); err == nil {
 			strpath := strings.TrimRight(string(path), "\r\n")
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModConfigLoad, config.LvlDbg, "Using from os package: %s\n", strpath)
@@ -172,8 +172,8 @@ func (cluster *Cluster) GetMyDumperPath() string {
 }
 
 func (cluster *Cluster) GetMyLoaderPath() string {
-	if cluster.Conf.BackupMyDumperPath == "" {
-		//if mysqldump installed
+	if cluster.Conf.BackupMyLoaderPath == "" {
+		//if myloader installed
 		if path, err := exec.Command("which", "myloader").Output(); err == nil {
 			strpath := strings.TrimRight(string(path), "\r\n")
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModConfigLoad, config.LvlDbg, "Using from os package: %s\n", strpath)


### PR DESCRIPTION
This pull request fixes logic and comments in the methods for determining the paths to backup and restore tools in the `Cluster` struct. The changes ensure the correct configuration fields and tool names are used for `mydumper` and `myloader`.

Corrections to tool path logic:

* In `GetMyDumperPath`, the comment now correctly refers to `mydumper` instead of `mysqldump`.
* In `GetMyLoaderPath`, the logic now checks `BackupMyLoaderPath` and refers to `myloader` instead of incorrectly checking the dumper path and referring to `mysqldump`.