### PR TITLE
Fix flooding when fail to decrypt due to credentials change

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -656,6 +656,7 @@ var pstates3600 = []string{
 	"WARN0094",             // Restic
 	"WARN0132", "WARN0137", // App templates
 	"WARN0117", "WARN0118", "WARN0119", "WARN0120", "WARN0121", "WARN0156", "WARN0157", // Tools versions
+	"WARN0158", // Job secrets mismatch
 }
 
 func (cluster *Cluster) Run() {

--- a/cluster/cluster_sec.go
+++ b/cluster/cluster_sec.go
@@ -616,8 +616,6 @@ func (cluster *Cluster) SecretLoginCheck(vars map[string]string, rbody io.ReadCl
 	key := crypto.GetSHA256Hash(node.Pass)
 	iv := crypto.GetMD5Hash(node.Pass)
 
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "Received login with encrypted secret %s", decodedData.Data)
-
 	decrypted, err := node.DecodeSecret(decodedData.Data, key, iv)
 	if err != nil {
 		return nil, fmt.Errorf("Error decrypting data : %s", err.Error()), 500

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -3174,7 +3174,7 @@ func (server *ServerMonitor) ProcessFlashbackPhysical(task string) error {
 }
 
 // decryptAES256 runs openssl AES-256-CBC decryption and returns the plaintext bytes.
-func decryptAES256(encrypted, key, iv string) ([]byte, error) {
+func (server *ServerMonitor) DecryptAES256(encrypted, key, iv string) ([]byte, error) {
 	cmd := exec.Command("openssl", "aes-256-cbc", "-d", "-a", "-nosalt", "-K", key, "-iv", iv)
 	cmd.Stdin = strings.NewReader(encrypted + "\n")
 
@@ -3194,9 +3194,9 @@ func decryptAES256(encrypted, key, iv string) ([]byte, error) {
 	return out.Bytes(), nil
 }
 
-// parseDecryptedLogs parses JSON log entries from decrypted data
+// ParseDecryptedLogs parses JSON log entries from decrypted data
 // and feeds them into the server’s log parsing logic.
-func (server *ServerMonitor) parseDecryptedLogs(data []byte, mod int, task string) error {
+func (server *ServerMonitor) ParseDecryptedLogs(data []byte, mod int, task string) error {
 	// Convert to string for cleanup
 	output := string(data)
 
@@ -3222,35 +3222,6 @@ func (server *ServerMonitor) parseDecryptedLogs(data []byte, mod int, task strin
 	}
 
 	server.ParseLogEntries(logEntry, mod, task)
-	return nil
-}
-
-// WriteJobLogs decrypts an AES-256-CBC encrypted log stream and parses JSON log entries.
-func (server *ServerMonitor) WriteJobLogs(mod int, encrypted, key, iv, task string) error {
-	cluster := server.ClusterGroup
-
-	// Step 1: Decrypt
-	decrypted, err := decryptAES256(encrypted, key, iv)
-	if err != nil {
-		cluster.SetState("WARN0158", state.State{
-			ErrType:   "WARNING",
-			ErrDesc:   fmt.Sprintf(cluster.GetErrorList()["WARN0158"], server.URL, err.Error()),
-			ErrFrom:   "JOB",
-			ServerUrl: server.URL,
-		})
-		return err
-	}
-
-	// Step 2: Parse JSON logs
-	if err := server.parseDecryptedLogs(decrypted, mod, task); err != nil {
-		cluster.SetState("WARN0158", state.State{
-			ErrType:   "WARNING",
-			ErrDesc:   fmt.Sprintf(cluster.GetErrorList()["WARN0158"], server.URL, err.Error()),
-			ErrFrom:   "JOB",
-			ServerUrl: server.URL,
-		})
-	}
-
 	return nil
 }
 
@@ -3497,55 +3468,12 @@ func (server *ServerMonitor) JobReceiveConfigFiles() (*ConfigReceiverResponse, e
 
 func (server *ServerMonitor) DecodeSecret(encrypted, key, iv string) (string, error) {
 	cluster := server.ClusterGroup
-	eCmd := exec.Command("echo", encrypted)
-	// Create a pipe for the stdout of lsCmd
-	eStdout, err := eCmd.StdoutPipe()
+	output, err := server.DecryptAES256(encrypted, key, iv)
 	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error creating stdout pipe for log message: %s", err.Error())
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error decrypting secret: %s", err.Error())
 		return "", err
 	}
 
-	dCmd := exec.Command("openssl", "aes-256-cbc", "-d", "-a", "-nosalt", "-K", ""+key+"", "-iv", ""+iv+"")
-	dCmd.Stdin = eStdout
-	dStdout, err := dCmd.StdoutPipe()
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error piping log message decryption: %s", err.Error())
-		return "", err
-	}
-	// Start the first command
-	if err := eCmd.Start(); err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error starting log message: %s", err.Error())
-		return "", err
-	}
-
-	// Start the second command
-	if err := dCmd.Start(); err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error starting log message decrypt: %s", err.Error())
-		return "", err
-	}
-
-	// Create a buffer to hold the decrypted output
-	var decryptedOutput bytes.Buffer
-
-	// Copy the decrypted output to the buffer
-	_, err = io.Copy(&decryptedOutput, dStdout)
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error reading decrypted output: %s", err.Error())
-		return "", err
-	}
-
-	// Wait for the commands to complete
-	if err := eCmd.Wait(); err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error waiting for log message done: %s", err.Error())
-		return "", err
-	}
-
-	if err := dCmd.Wait(); err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error waiting for log message decription: %s", err.Error())
-		return "", err
-	}
-
-	output := decryptedOutput.Bytes()
 	pos := bytes.LastIndex(output, []byte("}"))
 	if pos > 1 {
 		output = output[:pos+1]

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -3176,7 +3176,7 @@ func (server *ServerMonitor) ProcessFlashbackPhysical(task string) error {
 // decryptAES256 runs openssl AES-256-CBC decryption and returns the plaintext bytes.
 func decryptAES256(encrypted, key, iv string) ([]byte, error) {
 	cmd := exec.Command("openssl", "aes-256-cbc", "-d", "-a", "-nosalt", "-K", key, "-iv", iv)
-	cmd.Stdin = strings.NewReader(encrypted)
+	cmd.Stdin = strings.NewReader(encrypted + "\n")
 
 	var out bytes.Buffer
 	var stderr bytes.Buffer

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -3209,7 +3209,7 @@ func (server *ServerMonitor) parseDecryptedLogs(data []byte, mod int, task strin
 
 			cluster.SetState("WARN0158", state.State{
 				ErrType:   "WARNING",
-				ErrDesc:   fmt.Sprintf(cluster.GetErrorList()["WARN0158"], server.URL, err.Error()),
+				ErrDesc:   fmt.Sprintf(cluster.GetErrorList()["WARN0158"], server.URL, err.Error(), string(data)),
 				ErrFrom:   "JOB",
 				ServerUrl: server.URL,
 			})

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -3197,31 +3197,31 @@ func decryptAES256(encrypted, key, iv string) ([]byte, error) {
 // parseDecryptedLogs parses JSON log entries from decrypted data
 // and feeds them into the server’s log parsing logic.
 func (server *ServerMonitor) parseDecryptedLogs(data []byte, mod int, task string) error {
-	cluster := server.ClusterGroup
-	dec := json.NewDecoder(bytes.NewReader(data))
+	// Convert to string for cleanup
+	output := string(data)
 
-	for {
-		var logEntry config.LogEntry
-		if err := dec.Decode(&logEntry); err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-
-			cluster.SetState("WARN0158", state.State{
-				ErrType:   "WARNING",
-				ErrDesc:   fmt.Sprintf(cluster.GetErrorList()["WARN0158"], server.URL, err.Error(), string(data)),
-				ErrFrom:   "JOB",
-				ServerUrl: server.URL,
-			})
-			continue
-		}
-
-		if task == "main" && logEntry.Level == "" {
-			logEntry.Level = config.LvlInfo
-		}
-
-		server.ParseLogEntries(logEntry, mod, task)
+	// Trim everything after the last '}'
+	if pos := strings.LastIndex(output, "}"); pos != -1 {
+		output = output[:pos+1]
+	} else {
+		return fmt.Errorf("no valid JSON object found in decrypted data")
 	}
+
+	// Optional: remove any leading non-JSON noise (e.g., shell output)
+	if start := strings.Index(output, "{"); start > 0 {
+		output = output[start:]
+	}
+
+	var logEntry config.LogEntry
+	if err := json.Unmarshal([]byte(output), &logEntry); err != nil {
+		return fmt.Errorf("failed to parse JSON log entry: %v", err)
+	}
+
+	if task == "main" && logEntry.Level == "" {
+		logEntry.Level = config.LvlInfo
+	}
+
+	server.ParseLogEntries(logEntry, mod, task)
 	return nil
 }
 
@@ -3243,7 +3243,12 @@ func (server *ServerMonitor) WriteJobLogs(mod int, encrypted, key, iv, task stri
 
 	// Step 2: Parse JSON logs
 	if err := server.parseDecryptedLogs(decrypted, mod, task); err != nil {
-		return err
+		cluster.SetState("WARN0158", state.State{
+			ErrType:   "WARNING",
+			ErrDesc:   fmt.Sprintf(cluster.GetErrorList()["WARN0158"], server.URL, err.Error()),
+			ErrFrom:   "JOB",
+			ServerUrl: server.URL,
+		})
 	}
 
 	return nil

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -3198,22 +3198,23 @@ func (server *ServerMonitor) DecryptAES256(encrypted, key, iv string) ([]byte, e
 // and feeds them into the server’s log parsing logic.
 func (server *ServerMonitor) ParseDecryptedLogs(data []byte, mod int, task string) error {
 	// Convert to string for cleanup
-	output := string(data)
 
 	// Trim everything after the last '}'
-	if pos := strings.LastIndex(output, "}"); pos != -1 {
-		output = output[:pos+1]
+	if pos := bytes.LastIndex(data, []byte("}")); pos != -1 {
+		data = data[:pos+1]
 	} else {
 		return fmt.Errorf("no valid JSON object found in decrypted data")
 	}
 
 	// Optional: remove any leading non-JSON noise (e.g., shell output)
-	if start := strings.Index(output, "{"); start > 0 {
-		output = output[start:]
+	if start := bytes.Index(data, []byte("{")); start > 0 {
+		data = data[start:]
+	} else if start == -1 {
+		return fmt.Errorf("no valid JSON object found in decrypted data")
 	}
 
 	var logEntry config.LogEntry
-	if err := json.Unmarshal([]byte(output), &logEntry); err != nil {
+	if err := json.Unmarshal(data, &logEntry); err != nil {
 		return fmt.Errorf("failed to parse JSON log entry: %v", err)
 	}
 
@@ -3468,15 +3469,24 @@ func (server *ServerMonitor) JobReceiveConfigFiles() (*ConfigReceiverResponse, e
 
 func (server *ServerMonitor) DecodeSecret(encrypted, key, iv string) (string, error) {
 	cluster := server.ClusterGroup
-	output, err := server.DecryptAES256(encrypted, key, iv)
+	data, err := server.DecryptAES256(encrypted, key, iv)
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error decrypting secret: %s", err.Error())
 		return "", err
 	}
 
-	pos := bytes.LastIndex(output, []byte("}"))
+	pos := bytes.LastIndex(data, []byte("}"))
 	if pos > 1 {
-		output = output[:pos+1]
+		data = data[:pos+1]
+	} else {
+		return "", errors.New("No valid JSON object found in decrypted data")
+	}
+
+	// Optional: remove any leading non-JSON noise (e.g., shell output)
+	if start := bytes.Index(data, []byte("{")); start > 0 {
+		data = data[start:]
+	} else if start == -1 {
+		return "", errors.New("No valid JSON object found in decrypted data")
 	}
 
 	var secretKey struct {
@@ -3484,9 +3494,9 @@ func (server *ServerMonitor) DecodeSecret(encrypted, key, iv string) (string, er
 		Server string `json:"server"`
 	}
 
-	err = json.Unmarshal(output, &secretKey)
+	err = json.Unmarshal(data, &secretKey)
 	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error loading JSON Entry: %s. Err: %s", output, err.Error())
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error loading JSON Entry: %s. Err: %s", data, err.Error())
 		return "", err
 	}
 

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -3173,48 +3173,46 @@ func (server *ServerMonitor) ProcessFlashbackPhysical(task string) error {
 	return nil
 }
 
-func (server *ServerMonitor) WriteJobLogs(mod int, encrypted, key, iv, task string) error {
-	cluster := server.ClusterGroup
-	eCmd := exec.Command("echo", encrypted)
-	// Create a pipe for the stdout of lsCmd
-	eStdout, err := eCmd.StdoutPipe()
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error creating stdout pipe for log message: %s", err.Error())
-		return err
-	}
+// decryptAES256 runs openssl AES-256-CBC decryption and returns the plaintext bytes.
+func decryptAES256(encrypted, key, iv string) ([]byte, error) {
+	cmd := exec.Command("openssl", "aes-256-cbc", "-d", "-a", "-nosalt", "-K", key, "-iv", iv)
+	cmd.Stdin = strings.NewReader(encrypted)
 
-	dCmd := exec.Command("openssl", "aes-256-cbc", "-d", "-a", "-nosalt", "-K", ""+key+"", "-iv", ""+iv+"")
-	dCmd.Stdin = eStdout
-	dStdout, err := dCmd.StdoutPipe()
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error piping log message decryption: %s", err.Error())
-		return err
-	}
-	// Start the first command
-	if err := eCmd.Start(); err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error starting log message: %s", err.Error())
-		return err
-	}
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
 
-	// Start the second command
-	if err := dCmd.Start(); err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error starting log message decrypt: %s", err.Error())
-		return err
-	}
-
-	// Read the output from grepCmd
-	scanner := bufio.NewScanner(dStdout)
-	for scanner.Scan() {
-		output := scanner.Text()
-		pos := strings.LastIndex(output, "}")
-		if pos > 10 {
-			output = output[:pos+1]
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return nil, fmt.Errorf("openssl decrypt error: %v (%s)", err, msg)
 		}
+		return nil, fmt.Errorf("openssl decrypt error: %v", err)
+	}
 
+	return out.Bytes(), nil
+}
+
+// parseDecryptedLogs parses JSON log entries from decrypted data
+// and feeds them into the server’s log parsing logic.
+func (server *ServerMonitor) parseDecryptedLogs(data []byte, mod int, task string) error {
+	cluster := server.ClusterGroup
+	dec := json.NewDecoder(bytes.NewReader(data))
+
+	for {
 		var logEntry config.LogEntry
-		err = json.Unmarshal([]byte(output), &logEntry)
-		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error loading JSON Entry: %s. Err: %s", output, err.Error())
+		if err := dec.Decode(&logEntry); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			cluster.SetState("WARN0158", state.State{
+				ErrType:   "WARNING",
+				ErrDesc:   fmt.Sprintf(cluster.GetErrorList()["WARN0158"], server.URL, err.Error()),
+				ErrFrom:   "JOB",
+				ServerUrl: server.URL,
+			})
 			continue
 		}
 
@@ -3224,20 +3222,27 @@ func (server *ServerMonitor) WriteJobLogs(mod int, encrypted, key, iv, task stri
 
 		server.ParseLogEntries(logEntry, mod, task)
 	}
+	return nil
+}
 
-	if err := scanner.Err(); err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error reading from log message decrypt: %s", err.Error())
+// WriteJobLogs decrypts an AES-256-CBC encrypted log stream and parses JSON log entries.
+func (server *ServerMonitor) WriteJobLogs(mod int, encrypted, key, iv, task string) error {
+	cluster := server.ClusterGroup
+
+	// Step 1: Decrypt
+	decrypted, err := decryptAES256(encrypted, key, iv)
+	if err != nil {
+		cluster.SetState("WARN0158", state.State{
+			ErrType:   "WARNING",
+			ErrDesc:   fmt.Sprintf(cluster.GetErrorList()["WARN0158"], server.URL, err.Error()),
+			ErrFrom:   "JOB",
+			ServerUrl: server.URL,
+		})
 		return err
 	}
 
-	// Wait for the commands to complete
-	if err := eCmd.Wait(); err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error waiting for log message done: %s", err.Error())
-		return err
-	}
-
-	if err := dCmd.Wait(); err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error waiting for log message decription: %s", err.Error())
+	// Step 2: Parse JSON logs
+	if err := server.parseDecryptedLogs(decrypted, mod, task); err != nil {
 		return err
 	}
 

--- a/cluster/srv_set.go
+++ b/cluster/srv_set.go
@@ -24,6 +24,7 @@ import (
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/dbhelper"
 	"github.com/signal18/replication-manager/utils/misc"
+	"github.com/signal18/replication-manager/utils/state"
 )
 
 func (server *ServerMonitor) SetPlacement(k int, ProvAgents string, SlapOSDBPartitions string, SchedulerReceiverPorts string) {
@@ -766,4 +767,14 @@ func (server *ServerMonitor) SetWaitJobsUpgradeCookie() error {
 
 func (server *ServerMonitor) SetRollingJobsUpgradeCookie() error {
 	return server.createCookie("cookie_rolling_jobs_upgrade")
+}
+
+func (server *ServerMonitor) SetErrState(key, errtype, from, desc string, args ...interface{}) {
+	cluster := server.ClusterGroup
+	cluster.SetState(key, state.State{
+		ErrType:   errtype,
+		ErrDesc:   fmt.Sprintf(desc, args...),
+		ErrFrom:   from,
+		ServerUrl: server.URL,
+	})
 }

--- a/config/error.go
+++ b/config/error.go
@@ -230,6 +230,7 @@ var ClusterError = map[string]string{
 	"WARN0155":  "Cluster is flagged for jobs upgrade",
 	"WARN0156":  "Logical dump tool version %s is different than last backup version %s",
 	"WARN0157":  "Physical dump tool version %s is different than last backup version %s",
+	"WARN0158":  "Secret mismatch for job script on node %s. Err: %s",
 	"MDEV20821": "MariaDB version has replication issue https://jira.mariadb.org/browse/MDEV-20821",
 	"MDEV28310": "MariaDB version has replication issue for non row format https://jira.mariadb.org/browse/MDEV-28310",
 	"MDEV19577": "MariaDB version has replication issue for non row format https://jira.mariadb.org/browse/MDEV-19577",

--- a/config/error.go
+++ b/config/error.go
@@ -230,7 +230,7 @@ var ClusterError = map[string]string{
 	"WARN0155":  "Cluster is flagged for jobs upgrade",
 	"WARN0156":  "Logical dump tool version %s is different than last backup version %s",
 	"WARN0157":  "Physical dump tool version %s is different than last backup version %s",
-	"WARN0158":  "Secret mismatch for job script on node %s. Err: %s",
+	"WARN0158":  "Secret mismatch for job script on node %s. Err: %s. Data : %s",
 	"MDEV20821": "MariaDB version has replication issue https://jira.mariadb.org/browse/MDEV-20821",
 	"MDEV28310": "MariaDB version has replication issue for non row format https://jira.mariadb.org/browse/MDEV-28310",
 	"MDEV19577": "MariaDB version has replication issue for non row format https://jira.mariadb.org/browse/MDEV-19577",

--- a/server/api_database.go
+++ b/server/api_database.go
@@ -3112,7 +3112,8 @@ func (repman *ReplicationManager) handlerMuxServersWriteLog(w http.ResponseWrite
 	mycluster := repman.getClusterByName(vars["clusterName"])
 	if mycluster != nil {
 		var mod int
-		switch vars["task"] {
+		task := vars["task"]
+		switch task {
 		case "errorlog":
 			mod = config.ConstLogModFetchErrorlog
 		case "slowquery":
@@ -3148,9 +3149,16 @@ func (repman *ReplicationManager) handlerMuxServersWriteLog(w http.ResponseWrite
 			key := crypto.GetSHA256Hash(node.Pass)
 			iv := crypto.GetMD5Hash(node.Pass)
 
-			err := node.WriteJobLogs(mod, decodedData.Data, key, iv, vars["task"])
+			decrypted, err := node.DecryptAES256(decodedData.Data, key, iv)
 			if err != nil {
+				node.SetErrState("WARN0158", "WARNING", "JOB", config.ClusterError["WARN0158"], node.URL, err.Error())
 				http.Error(w, "Error decrypting data : "+err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			if err := node.ParseDecryptedLogs(decrypted, mod, task); err != nil {
+				node.SetErrState("WARN0158", "WARNING", "JOB", config.ClusterError["WARN0158"], node.URL, err.Error())
+				http.Error(w, "Error parsing decrypted data : "+err.Error(), http.StatusInternalServerError)
 				return
 			}
 


### PR DESCRIPTION
This pull request refactors and improves the handling of encrypted job logs and secrets, focusing on simplifying the decryption flow, improving error handling, and adding new warning codes for secret mismatches. The changes introduce utility functions for decryption and error state management, and update the API logic to use these new utilities for better maintainability and clarity.

**Improvements to encrypted log and secret handling:**

* Refactored decryption logic by introducing `DecryptAES256` and `ParseDecryptedLogs` utility methods in `srv_job.go`, replacing the previous `WriteJobLogs` implementation. This simplifies the process of decrypting and parsing job logs, and centralizes error handling. (`cluster/srv_job.go` [[1]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fL3176-R3225) [[2]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fL3490-R3499)
* Updated secret decryption in `DecodeSecret` to use the new `DecryptAES256` utility, improving consistency and error reporting. (`cluster/srv_job.go` [cluster/srv_job.goL3490-R3499](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fL3490-R3499))

**Enhanced error and warning reporting:**

* Added new warning code `WARN0158` for job secret mismatches, including updates to the warning code list and error message mapping. (`cluster/cluster.go` [[1]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R659) `config/error.go` [[2]](diffhunk://#diff-8f064ed373b8d36dcd88ee3e4f22d7c10e6873d71411991b1882ae63e81a7a15R233)
* Introduced the `SetErrState` helper method in `ServerMonitor` (in `srv_set.go`) for streamlined error state management within the cluster. (`cluster/srv_set.go` [cluster/srv_set.goR771-R780](diffhunk://#diff-bb25ba1a09f11c52d7b182be6ecf1d9cd8f22ef0deb9ae440fe18a27f91fb6b8R771-R780))
* Updated the API handler for writing logs to use the new decryption and error state methods, ensuring that errors in decryption or parsing are logged with the new warning and reported to the client. (`server/api_database.go` [server/api_database.goL3151-R3164](diffhunk://#diff-9b1e9c92a1d4b576cf629a1562fc7e24b19862a316743bbbd21ce80da72e284dL3151-R3164))

**General code maintenance:**

* Minor code cleanup, such as improved variable naming and imports. (`cluster/srv_set.go` [[1]](diffhunk://#diff-bb25ba1a09f11c52d7b182be6ecf1d9cd8f22ef0deb9ae440fe18a27f91fb6b8R27) `server/api_database.go` [[2]](diffhunk://#diff-9b1e9c92a1d4b576cf629a1562fc7e24b19862a316743bbbd21ce80da72e284dL3115-R3116)

These changes collectively improve the reliability, maintainability, and clarity of the job log and secret handling code paths.