### PR TITLE
Password rotation safeguards when one of the credentials is immutable

### DIFF
--- a/cluster/cluster_sec.go
+++ b/cluster/cluster_sec.go
@@ -35,7 +35,7 @@ func (cluster *Cluster) RotatePasswords() error {
 	}
 	if cluster.Conf.IsVaultUsed() {
 
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlInfo, "Start password rotation using Vault.")
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Start password rotation using Vault.")
 		vconfig := vault.DefaultConfig()
 
 		vconfig.Address = cluster.Conf.VaultServerAddr
@@ -43,35 +43,35 @@ func (cluster *Cluster) RotatePasswords() error {
 		client, err := cluster.GetVaultConnection()
 
 		if err != nil {
-			//cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlErr, "unable to initialize AppRole auth method: %v", err)
+			//cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "unable to initialize AppRole auth method: %v", err)
 			return err
 		}
 
 		if cluster.GetConf().VaultMode == VaultDbEngine {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlInfo, "Vault Database Engine mode activated")
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Vault Database Engine mode activated")
 			if cluster.GetDbUser() == cluster.GetRplUser() {
 
 				err := client.KVv1("").Put(context.Background(), "database/rotate-role/"+cluster.GetDbUser(), nil)
 				if err != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlInfo, "unable to rotate passwords for %s static role: %v", cluster.GetDbUser(), err)
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "unable to rotate passwords for %s static role: %v", cluster.GetDbUser(), err)
 				}
 			} else {
 
 				err := client.KVv1("").Put(context.Background(), "database/rotate-role/"+cluster.GetDbUser(), nil)
 				if err != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlInfo, "unable to rotate passwords for %s static role: %v", cluster.GetDbUser(), err)
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "unable to rotate passwords for %s static role: %v", cluster.GetDbUser(), err)
 				}
 
 				err = client.KVv1("").Put(context.Background(), "database/rotate-role/"+cluster.GetRplUser(), nil)
 				if err != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlInfo, "unable to rotate passwords for %s static role: %v", cluster.GetRplUser(), err)
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "unable to rotate passwords for %s static role: %v", cluster.GetRplUser(), err)
 				}
 			}
 		} else {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlInfo, "Vault config store v2 mode activated")
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Vault config store v2 mode activated")
 			if len(cluster.slaves) > 0 {
 				if !cluster.slaves.HasAllSlavesRunning() {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlErr, "Cluster replication is not all up, passwords can't be rotated! : %s", err)
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Cluster replication is not all up, passwords can't be rotated! : %s", err)
 					return nil
 				}
 			}
@@ -95,17 +95,17 @@ func (cluster *Cluster) RotatePasswords() error {
 				"replication-credential": cluster.GetRplUser() + ":" + new_password_rpl,
 			}
 
-			//cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault,config.LvlErr, "TEST password Rotation new mdp : %s, %s, decrypt val %s", new_password_db, new_password_proxysql, cluster.GetDecryptedValue("proxysql-password"))
+			//cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral,config.LvlErr, "TEST password Rotation new mdp : %s, %s, decrypt val %s", new_password_db, new_password_proxysql, cluster.GetDecryptedValue("proxysql-password"))
 
 			_, err = client.KVv2(cluster.Conf.VaultMount).Patch(context.Background(), cluster.GetConf().User, secretData_db)
 			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlErr, "Database Password rotation cancel, unable to write secret: %v", err)
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Database Password rotation cancel, unable to write secret: %v", err)
 				new_password_db = cluster.GetDbPass()
 			}
 
 			_, err = client.KVv2(cluster.Conf.VaultMount).Patch(context.Background(), cluster.GetConf().RplUser, secretData_rpl)
 			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlErr, "Replication Password rotation cancel, unable to write secret: %v", err)
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Replication Password rotation cancel, unable to write secret: %v", err)
 				new_password_rpl = cluster.GetRplPass()
 			}
 
@@ -116,7 +116,7 @@ func (cluster *Cluster) RotatePasswords() error {
 				}
 				_, err = client.KVv2(cluster.Conf.VaultMount).Patch(context.Background(), cluster.Conf.ProxysqlPassword, secretData_proxysql)
 				if err != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlErr, "ProxySQL Password rotation cancel, unable to write secret: %v", err)
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "ProxySQL Password rotation cancel, unable to write secret: %v", err)
 					new_password_proxysql = cluster.Conf.Secrets["proxysql-password"].Value
 				}
 				cluster.SetClusterProxyCredentialsFromConfig()
@@ -129,15 +129,15 @@ func (cluster *Cluster) RotatePasswords() error {
 				}
 				_, err = client.KVv2(cluster.Conf.VaultMount).Patch(context.Background(), cluster.Conf.MdbsProxyCredential, secretData_shardproxy)
 				if err != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlErr, "Shard Proxy Password rotation cancel, unable to write secret: %v", err)
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Shard Proxy Password rotation cancel, unable to write secret: %v", err)
 					new_password_shard = cluster.GetShardPass()
 				}
 				cluster.SetClusterProxyCredentialsFromConfig()
 
 			}
 
-			//cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault,config.LvlErr, "TEST password Rotation new mdp : %s, %s, decrypt val %s", new_password_db, new_password_proxysql, cluster.GetDecryptedValue("proxysql-password"))
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlInfo, "Secret written successfully. New password generated: db-servers-credential %s, replication-credential %s", cluster.Conf.PrintSecret(new_password_db), cluster.Conf.PrintSecret(new_password_rpl))
+			//cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral,config.LvlErr, "TEST password Rotation new mdp : %s, %s, decrypt val %s", new_password_db, new_password_proxysql, cluster.GetDecryptedValue("proxysql-password"))
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Secret written successfully. New password generated: db-servers-credential %s, replication-credential %s", cluster.Conf.PrintSecret(new_password_db), cluster.Conf.PrintSecret(new_password_rpl))
 
 			cluster.SetClusterMonitorCredentialsFromConfig()
 
@@ -160,7 +160,7 @@ func (cluster *Cluster) RotatePasswords() error {
 				for _, ss := range s.Replications {
 					err = s.rejoinSlaveChangePassword(&ss)
 					if err != nil {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlErr, "Fail of rejoinSlaveChangePassword during rotation password ", err)
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Fail of rejoinSlaveChangePassword during rotation password ", err)
 					}
 				}
 
@@ -193,12 +193,12 @@ func (cluster *Cluster) RotatePasswords() error {
 			}
 			err = cluster.ProvisionRotatePasswords(new_password_db)
 			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlErr, "Fail of ProvisionRotatePasswords during rotation password ", err)
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Fail of ProvisionRotatePasswords during rotation password ", err)
 			}
 
 			if cluster.GetConf().PushoverAppToken != "" && cluster.GetConf().PushoverUserToken != "" {
 				msg := "A password rotation has been made on Replication-Manager " + cluster.Name + " cluster. Check the new password on " + cluster.Conf.VaultServerAddr + " website on path " + cluster.Conf.VaultMount + cluster.Conf.User + " and " + cluster.Conf.VaultMount + cluster.Conf.RplUser + "."
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, "ALERT", msg)
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ALERT", msg)
 			}
 			if cluster.Conf.MailTo != "" {
 				msg := "A password rotation has been made\nCheck the new password on " + cluster.Conf.VaultServerAddr + " website on path " + cluster.Conf.VaultMount + cluster.Conf.User + " and " + cluster.Conf.VaultMount + cluster.Conf.RplUser + "."
@@ -209,10 +209,10 @@ func (cluster *Cluster) RotatePasswords() error {
 		}
 	} else {
 		if cluster.Conf.SecretKey != nil && cluster.GetConf().ConfRewrite {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlInfo, "Start Password rotation")
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Start Password rotation")
 			if len(cluster.slaves) > 0 {
 				if !cluster.slaves.HasAllSlavesRunning() {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlErr, "Cluster replication is not all up, passwords can't be rotated!")
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Cluster replication is not all up, passwords can't be rotated!")
 					return nil
 				}
 			}
@@ -271,7 +271,7 @@ func (cluster *Cluster) RotatePasswords() error {
 				for _, ss := range s.Replications {
 					err := s.rejoinSlaveChangePassword(&ss)
 					if err != nil {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlErr, "Fail of rejoinSlaveChangePassword during rotation password ", err)
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Fail of rejoinSlaveChangePassword during rotation password ", err)
 					}
 				}
 
@@ -304,12 +304,12 @@ func (cluster *Cluster) RotatePasswords() error {
 			}
 			err := cluster.ProvisionRotatePasswords(new_password_db)
 			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlErr, "Fail of ProvisionRotatePasswords during rotation password ", err)
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Fail of ProvisionRotatePasswords during rotation password ", err)
 			}
 
 			if cluster.GetConf().PushoverAppToken != "" && cluster.GetConf().PushoverUserToken != "" {
 				msg := "A password rotation has been made on Replication-Manager " + cluster.Name + " cluster. Check the new password on " + cluster.Conf.VaultServerAddr + " website on path " + cluster.Conf.VaultMount + cluster.Conf.User + " and " + cluster.Conf.VaultMount + cluster.Conf.RplUser + "."
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, "ALERT", msg)
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ALERT", msg)
 			}
 			if cluster.Conf.MailTo != "" {
 				msg := "A password rotation has been made\nCheck the new password on " + cluster.Conf.VaultServerAddr + " website on path " + cluster.Conf.VaultMount + cluster.Conf.User + " and " + cluster.Conf.VaultMount + cluster.Conf.RplUser + "."
@@ -317,7 +317,7 @@ func (cluster *Cluster) RotatePasswords() error {
 				go cluster.SendEMailMessage(cluster.ToAlertMessage(msg), subj, cluster.GetAlertRecipients(AlertRecipient{To: cluster.Conf.MailTo, All: true}))
 			}
 
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModVault, config.LvlInfo, "Password rotation is done.")
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Password rotation is done.")
 			cluster.ConfigManager.SaveConfig(cluster, false)
 		}
 		return nil

--- a/cluster/cluster_sec.go
+++ b/cluster/cluster_sec.go
@@ -287,7 +287,7 @@ func (cluster *Cluster) RotatePasswords() error {
 
 			}
 
-			if cluster.GetConf().ProxysqlOn && cluster.HasAllProxyUp() {
+			if cluster.GetConf().ProxysqlOn && cluster.HasAllProxyUp() && !cluster.IsVariableImmutable("proxysql-password") {
 				for _, pri := range cluster.Proxies {
 					if prx, ok := pri.(*ProxySQLProxy); ok {
 						prx.RotateMonitoringPasswords(new_password_db)
@@ -297,7 +297,7 @@ func (cluster *Cluster) RotatePasswords() error {
 
 				}
 			}
-			if cluster.GetConf().MdbsProxyOn && cluster.HasAllProxyUp() {
+			if cluster.GetConf().MdbsProxyOn && cluster.HasAllProxyUp() && !cluster.IsVariableImmutable("shardproxy-credential") {
 				for _, pri := range cluster.Proxies {
 					if prx, ok := pri.(*MariadbShardProxy); ok {
 						prx.RotateProxyPasswords(new_password_shard)

--- a/cluster/cluster_sec.go
+++ b/cluster/cluster_sec.go
@@ -209,6 +209,11 @@ func (cluster *Cluster) RotatePasswords() error {
 		}
 	} else {
 		if cluster.Conf.SecretKey != nil && cluster.GetConf().ConfRewrite {
+			if cluster.IsVariableImmutable("db-servers-credential") || cluster.IsVariableImmutable("replication-credential") {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Password rotation cancel, one of the credential is immutable.")
+				return nil
+			}
+
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Start Password rotation")
 			if len(cluster.slaves) > 0 {
 				if !cluster.slaves.HasAllSlavesRunning() {

--- a/cluster/cluster_sec.go
+++ b/cluster/cluster_sec.go
@@ -209,8 +209,13 @@ func (cluster *Cluster) RotatePasswords() error {
 		}
 	} else {
 		if cluster.Conf.SecretKey != nil && cluster.GetConf().ConfRewrite {
-			if cluster.IsVariableImmutable("db-servers-credential") || cluster.IsVariableImmutable("replication-credential") {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Password rotation cancel, one of the credential is immutable.")
+			if cluster.IsVariableImmutable("db-servers-credential") {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Database user credential is immutable, password rotation cancelled.")
+				return nil
+			}
+
+			if cluster.IsVariableImmutable("replication-credential") {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Replication user credential is immutable, password rotation cancelled.")
 				return nil
 			}
 
@@ -240,14 +245,14 @@ func (cluster *Cluster) RotatePasswords() error {
 			new_Secret.Value = cluster.GetRplUser() + ":" + new_password_rpl
 			cluster.Conf.Secrets["replication-credential"] = new_Secret
 
-			if cluster.GetConf().ProxysqlOn && cluster.HasAllProxyUp() {
+			if cluster.GetConf().ProxysqlOn && cluster.HasAllProxyUp() && !cluster.IsVariableImmutable("proxysql-password") {
 				new_Secret.OldValue = cluster.Conf.Secrets["proxysql-password"].Value
 				new_Secret.Value = new_password_proxysql
 				cluster.Conf.Secrets["proxysql-password"] = new_Secret
 				cluster.SetClusterProxyCredentialsFromConfig()
 			}
 
-			if cluster.GetConf().MdbsProxyOn && cluster.HasAllProxyUp() {
+			if cluster.GetConf().MdbsProxyOn && cluster.HasAllProxyUp() && !cluster.IsVariableImmutable("shardproxy-credential") {
 				var new_Secret config.Secret
 				new_Secret.OldValue = cluster.Conf.Secrets["shardproxy-credential"].Value
 				new_Secret.Value = cluster.GetShardUser() + ":" + new_password_shard


### PR DESCRIPTION
This pull request updates the password rotation logic in `cluster_sec.go` to improve logging consistency and add safeguards for immutable credentials. The main changes are switching all log messages from the Vault-specific log module to the general log module, and introducing checks to prevent password rotation for credentials marked as immutable.

**Password rotation safeguards:**

* Added checks to prevent rotation of credentials (`db-servers-credential`, `replication-credential`, `proxysql-password`, `shardproxy-credential`) if they are marked as immutable, logging an error and cancelling rotation when necessary. [[1]](diffhunk://#diff-89499a9363af1248642be519d364cacdbbb5f8354f4911215cb496704a7aa4ffL212-R225) [[2]](diffhunk://#diff-89499a9363af1248642be519d364cacdbbb5f8354f4911215cb496704a7aa4ffL238-R255) [[3]](diffhunk://#diff-89499a9363af1248642be519d364cacdbbb5f8354f4911215cb496704a7aa4ffL274-R290) [[4]](diffhunk://#diff-89499a9363af1248642be519d364cacdbbb5f8354f4911215cb496704a7aa4ffL290-R300)

**Logging improvements:**

* All calls to `cluster.LogModulePrintf` in the `RotatePasswords` function now use `config.ConstLogModGeneral` instead of `config.ConstLogModVault`, ensuring consistent use of the general log module for password rotation events. [[1]](diffhunk://#diff-89499a9363af1248642be519d364cacdbbb5f8354f4911215cb496704a7aa4ffL38-R74) [[2]](diffhunk://#diff-89499a9363af1248642be519d364cacdbbb5f8354f4911215cb496704a7aa4ffL98-R108) [[3]](diffhunk://#diff-89499a9363af1248642be519d364cacdbbb5f8354f4911215cb496704a7aa4ffL119-R119) [[4]](diffhunk://#diff-89499a9363af1248642be519d364cacdbbb5f8354f4911215cb496704a7aa4ffL132-R140) [[5]](diffhunk://#diff-89499a9363af1248642be519d364cacdbbb5f8354f4911215cb496704a7aa4ffL163-R163) [[6]](diffhunk://#diff-89499a9363af1248642be519d364cacdbbb5f8354f4911215cb496704a7aa4ffL196-R201) [[7]](diffhunk://#diff-89499a9363af1248642be519d364cacdbbb5f8354f4911215cb496704a7aa4ffL307-R330)

These changes enhance the clarity of logs and protect critical credentials from unintended rotation.