### PR TITLE
reduce the interval for job secrets mismatch check

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -649,6 +649,7 @@ var pstates30 = []string{
 	"WARN0101", "WARN0111", "WARN0112", // Backup related
 	"WARN0139", "WARN0140", "WARN0141", "WARN0142", "WARN0143", "WARN0150", "WARN0151", // Tresholds
 	"WARN0147", "WARN0148", "WARN0153", "WARN0154", // Jobs related
+	"WARN0158", // Job secrets mismatch
 	"CREDIT01", // Credit related
 }
 
@@ -656,7 +657,6 @@ var pstates3600 = []string{
 	"WARN0094",             // Restic
 	"WARN0132", "WARN0137", // App templates
 	"WARN0117", "WARN0118", "WARN0119", "WARN0120", "WARN0121", "WARN0156", "WARN0157", // Tools versions
-	"WARN0158", // Job secrets mismatch
 }
 
 func (cluster *Cluster) Run() {


### PR DESCRIPTION
This pull request updates the warning state lists in `cluster/cluster.go` to ensure that the `WARN0158` warning (Job secrets mismatch) is tracked at the correct interval. The change moves `WARN0158` from the `pstates3600` list (checked every 3600 cycles) to the `pstates30` list (checked every 30 cycles), ensuring more frequent detection of job secrets mismatches.

Warning state tracking adjustments:

* Moved `WARN0158` (Job secrets mismatch) from the `pstates3600` list to the `pstates30` list so that this warning is now checked every 30 cycles instead.