### PR TITLE
Fix version mismatch and rename functions to generic terminology

### DIFF
--- a/cluster/cluster_version.go
+++ b/cluster/cluster_version.go
@@ -14,11 +14,11 @@ func (cluster *Cluster) RefreshToolVersions() {
 		cluster.SetState("WARN0117", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0117"], err), ErrFrom: "CLUSTER"})
 	}
 
-	if err := cluster.RefreshMysqlDumpVersion(); err != nil {
+	if err := cluster.RefreshDBClientDumpVersion(); err != nil {
 		cluster.SetState("WARN0118", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0118"], err), ErrFrom: "CLUSTER"})
 	}
 
-	if err := cluster.RefreshMysqlBinlogVersion(); err != nil {
+	if err := cluster.RefreshDBClientBinlogVersion(); err != nil {
 		cluster.SetState("WARN0119", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0119"], err), ErrFrom: "CLUSTER"})
 	}
 
@@ -82,7 +82,7 @@ func (cluster *Cluster) RefreshDBClientVersion() error {
 	return nil
 }
 
-func (cluster *Cluster) SetMysqlDumpVersion(v *version.Version) error {
+func (cluster *Cluster) SetDBClientDumpVersion(v *version.Version) error {
 	if v == nil {
 		return fmt.Errorf("nil version provided")
 	}
@@ -94,7 +94,7 @@ func (cluster *Cluster) SetMysqlDumpVersion(v *version.Version) error {
 	return nil
 }
 
-func (cluster *Cluster) RefreshMysqlDumpVersion() error {
+func (cluster *Cluster) RefreshDBClientDumpVersion() error {
 	cstring := "changed"
 	oldV, _ := cluster.GetToolsVersion("client-dump")
 	if oldV == nil {
@@ -120,7 +120,7 @@ func (cluster *Cluster) RefreshMysqlDumpVersion() error {
 	}
 
 	if hasChanged {
-		err := cluster.SetMysqlDumpVersion(v)
+		err := cluster.SetDBClientDumpVersion(v)
 		if err != nil {
 			return err
 		}
@@ -131,7 +131,7 @@ func (cluster *Cluster) RefreshMysqlDumpVersion() error {
 	return nil
 }
 
-func (cluster *Cluster) SetMysqlBinlogVersion(v *version.Version) error {
+func (cluster *Cluster) SetDBClientBinlogVersion(v *version.Version) error {
 	if v == nil {
 		return fmt.Errorf("nil version provided")
 	}
@@ -143,7 +143,7 @@ func (cluster *Cluster) SetMysqlBinlogVersion(v *version.Version) error {
 	return nil
 }
 
-func (cluster *Cluster) RefreshMysqlBinlogVersion() error {
+func (cluster *Cluster) RefreshDBClientBinlogVersion() error {
 	cstring := "changed"
 	oldV, _ := cluster.GetToolsVersion("client-binlog")
 	if oldV == nil {
@@ -168,7 +168,7 @@ func (cluster *Cluster) RefreshMysqlBinlogVersion() error {
 	}
 
 	if hasChanged {
-		err := cluster.SetMysqlBinlogVersion(v)
+		err := cluster.SetDBClientBinlogVersion(v)
 		if err != nil {
 			return err
 		}

--- a/cluster/cluster_version.go
+++ b/cluster/cluster_version.go
@@ -120,7 +120,7 @@ func (cluster *Cluster) RefreshMysqlDumpVersion() error {
 	}
 
 	if hasChanged {
-		err := cluster.SetDBClientVersion(v)
+		err := cluster.SetMysqlDumpVersion(v)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This pull request refactors several method names in the `cluster/cluster_version.go` file to use more generic "DBClient" terminology instead of the previous "Mysql" specific names. This change improves the clarity and extensibility of the code by making it less tied to a specific database technology.

**Refactoring for generic database client terminology:**

* Renamed methods related to dump version management from `SetMysqlDumpVersion`, `RefreshMysqlDumpVersion` to `SetDBClientDumpVersion`, `RefreshDBClientDumpVersion` throughout the file. [[1]](diffhunk://#diff-753699163d76dab4febf62d5ffa1e11e3ca3521fc83a5f73a260ae9932c06aa0L85-R85) [[2]](diffhunk://#diff-753699163d76dab4febf62d5ffa1e11e3ca3521fc83a5f73a260ae9932c06aa0L97-R97) [[3]](diffhunk://#diff-753699163d76dab4febf62d5ffa1e11e3ca3521fc83a5f73a260ae9932c06aa0L123-R123)
* Renamed methods related to binlog version management from `SetMysqlBinlogVersion`, `RefreshMysqlBinlogVersion` to `SetDBClientBinlogVersion`, `RefreshDBClientBinlogVersion` throughout the file. [[1]](diffhunk://#diff-753699163d76dab4febf62d5ffa1e11e3ca3521fc83a5f73a260ae9932c06aa0L134-R134) [[2]](diffhunk://#diff-753699163d76dab4febf62d5ffa1e11e3ca3521fc83a5f73a260ae9932c06aa0L146-R146) [[3]](diffhunk://#diff-753699163d76dab4febf62d5ffa1e11e3ca3521fc83a5f73a260ae9932c06aa0L171-R171)
* Updated calls to the renamed methods in `RefreshToolVersions` to use the new generic names.