### PR TITLE
feat(backup): add support for customizable post-backup scripts

### DIFF
--- a/cluster/cluster_bash.go
+++ b/cluster/cluster_bash.go
@@ -226,3 +226,33 @@ func (cluster *Cluster) BinlogCopyScript(server *ServerMonitor, binlog string, i
 	}
 	return nil
 }
+
+func (cluster *Cluster) BackupPostScript(server *ServerMonitor, backtype config.BackupMethod, filepath string) error {
+	switch backtype {
+	case config.BackupMethodLogical:
+		if cluster.Conf.BackupLogicalPostScript != "" {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Calling backup logical post script at %s", cluster.Conf.BackupLogicalPostScript)
+			var out []byte
+			out, err := exec.Command(cluster.Conf.BackupLogicalPostScript, cluster.Name, server.Host, server.Port, filepath).CombinedOutput()
+			if err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "%s", err)
+				return err
+			}
+
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Backup logical post script done: %s", string(out))
+		}
+	case config.BackupMethodPhysical:
+		if cluster.Conf.BackupPhysicalPostScript != "" {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Calling backup physical post script at %s", cluster.Conf.BackupPhysicalPostScript)
+			var out []byte
+			out, err := exec.Command(cluster.Conf.BackupPhysicalPostScript, cluster.Name, server.Host, server.Port, filepath).CombinedOutput()
+			if err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "%s", err)
+				return err
+			}
+
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Backup physical post script done: %s", string(out))
+		}
+	}
+	return nil
+}

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -3303,6 +3303,7 @@ func (server *ServerMonitor) WriteBackupMetadata(backtype config.BackupMethod) {
 		}
 		lastmeta.Completed = true
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Metadata completed: %v", lastmeta)
+		cluster.BackupPostScript(server, backtype, lastmeta.Dest)
 	} else {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Error occured in backup, writing incomplete metadata for backup in %s", server.URL)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -682,6 +682,8 @@ type Config struct {
 	BackupDatabaseAnalyzeCron                 string                 `mapstructure:"scheduler-db-servers-analyze-cron" toml:"scheduler-db-servers-analyze-cron" json:"schedulerDbServersAnalyzeCron"`
 	BackupSaveScript                          string                 `mapstructure:"backup-save-script" toml:"backup-save-script" json:"backupSaveScript"`
 	BackupLoadScript                          string                 `mapstructure:"backup-load-script" toml:"backup-load-script" json:"backupLoadScript"`
+	BackupLogicalPostScript                   string                 `mapstructure:"backup-logical-post-script" toml:"backup-logical-post-script" json:"backupLogicalPostScript"`
+	BackupPhysicalPostScript                  string                 `mapstructure:"backup-physical-post-script" toml:"backup-physical-post-script" json:"backupPhysicalPostScript"`
 	CompressBackups                           bool                   `mapstructure:"compress-backups" toml:"compress-backups" json:"compressBackups"`
 	BackupSplitMysqlUser                      bool                   `mapstructure:"backup-split-mysql-user" toml:"backup-split-mysql-user" json:"backupSplitMysqlUser"`
 	BackupRestoreMysqlUser                    bool                   `mapstructure:"backup-restore-mysql-user" toml:"backup-restore-mysql-user" json:"backupRestoreMysqlUser"`

--- a/server/server.go
+++ b/server/server.go
@@ -819,6 +819,8 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 
 	flags.StringVar(&conf.BackupSaveScript, "backup-save-script", "", "Customized backup save script")
 	flags.StringVar(&conf.BackupLoadScript, "backup-load-script", "", "Customized backup load script")
+	flags.StringVar(&conf.BackupLogicalPostScript, "backup-logical-post-script", "", "Customized backup post script location. Params: <clustername> <hostname> <port> <backup-path>")
+	flags.StringVar(&conf.BackupPhysicalPostScript, "backup-physical-post-script", "", "Customized backup post script location. Params: <clustername> <hostname> <port> <backup-path>")
 	flags.BoolVar(&conf.CompressBackups, "compress-backups", false, "To compress backups")
 	flags.BoolVar(&conf.BackupSplitMysqlUser, "backup-split-mysql-user", false, "To split mysql user in backup")
 	flags.BoolVar(&conf.BackupRestoreMysqlUser, "backup-restore-mysql-user", true, "Restore mysql user alongside with backup")


### PR DESCRIPTION
This pull request introduces support for running custom post-backup scripts after logical and physical backups, enhancing the backup workflow with configurable hooks. The main changes involve adding new configuration options, updating command-line flags, and invoking the post-backup scripts at the appropriate stage in the backup process.

**Backup post-script support:**

* Added `BackupLogicalPostScript` and `BackupPhysicalPostScript` fields to the `Config` struct in `config/config.go` to allow specifying custom scripts to be executed after logical and physical backups.
* Registered new command-line flags `--backup-logical-post-script` and `--backup-physical-post-script` in `server/server.go` for configuring the post-backup script locations and parameters.

**Backup workflow integration:**

* Implemented the `BackupPostScript` method in `cluster/cluster_bash.go` to execute the configured post-backup scripts with cluster and server details as parameters, handling both logical and physical backup types.
* Updated the backup metadata writing process in `cluster/srv_job.go` to invoke the post-backup script after a successful backup, passing the backup destination path.