### PR TITLE
Implement GetCompactJson method and update handlerMuxClusters to use compact JSON representation for clusters

### DIFF
--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -22,6 +22,7 @@ import (
 
 	vault "github.com/hashicorp/vault/api"
 	auth "github.com/hashicorp/vault/api/auth/approle"
+	"github.com/iancoleman/strcase"
 	"github.com/siddontang/go/log"
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/opensvc"
@@ -33,6 +34,7 @@ import (
 	"github.com/signal18/replication-manager/utils/state"
 	"github.com/signal18/replication-manager/utils/tty"
 	"github.com/signal18/replication-manager/utils/version"
+	"github.com/tidwall/sjson"
 )
 
 func (cluster *Cluster) GetCrcTable() *crc64.Table {
@@ -1680,4 +1682,35 @@ func (cluster *Cluster) GetStagingServerFromConfig() *ServerMonitor {
 func (cluster *Cluster) GetToolsVersion(name string) (*version.Version, bool) {
 	toolVer, ok := cluster.VersionsMap.CheckAndGet(name)
 	return toolVer, ok
+}
+
+func (cluster *Cluster) GetCompactJson() ([]byte, error) {
+	result, err := json.Marshal(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err = sjson.SetBytes(result, "servers", []interface{}{})
+	if err != nil {
+		return nil, err
+	}
+
+	result, err = sjson.SetBytes(result, "proxies", []interface{}{})
+	if err != nil {
+		return nil, err
+	}
+
+	result, err = sjson.SetBytes(result, "apps", []interface{}{})
+	if err != nil {
+		return nil, err
+	}
+
+	for crkey := range cluster.Conf.Secrets {
+		result, err = sjson.SetBytes(result, fmt.Sprintf("config.%s", strcase.ToLowerCamel(crkey)), "*:*")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
 }

--- a/server/api.go
+++ b/server/api.go
@@ -1113,21 +1113,21 @@ func (repman *ReplicationManager) handlerMuxClusters(w http.ResponseWriter, r *h
 
 		sort.Sort(cluster.ClusterSorter(clusters))
 
-		cl, err := json.MarshalIndent(clusters, "", "\t")
-		if err != nil {
-			http.Error(w, "Error Marshal", 500)
-			return
-		}
+		var cl []byte = []byte("[")
 
 		for i, cluster := range clusters {
-			for crkey := range cluster.Conf.Secrets {
-				cl, err = sjson.SetBytes(cl, fmt.Sprintf("%d.config.%s", i, strcase.ToLowerCamel(crkey)), "*:*")
-				if err != nil {
-					http.Error(w, "Encoding error", 500)
-					return
-				}
+			cj, err := cluster.GetCompactJson()
+			if err != nil {
+				http.Error(w, "Error getting compact JSON: "+err.Error(), 500)
+				return
+			}
+			cl = append(cl, cj...)
+			if i < len(clusters)-1 {
+				cl = append(cl, ',')
 			}
 		}
+		cl = append(cl, ']')
+
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(cl)
 


### PR DESCRIPTION
This pull request refactors how clusters are serialized to JSON in the API, focusing on compact output and improved handling of sensitive configuration data. The main change is the introduction of a new method for generating compact JSON representations of clusters, which is now used in the API response instead of the previous approach. This improves maintainability and ensures secrets are masked consistently.

### API response serialization improvements

* Added a new `GetCompactJson` method to the `Cluster` struct that serializes the cluster to JSON, replaces the `servers`, `proxies`, and `apps` fields with empty arrays, and masks secret values in the `config` section. This centralizes and simplifies the logic for producing sanitized cluster JSON.
* Updated the API handler in `server/api.go` to use the new `GetCompactJson` method for each cluster, replacing the previous approach that manually masked secrets after marshaling. This results in cleaner and more reliable output.

### Dependency additions

* Added the `github.com/tidwall/sjson` and `github.com/iancoleman/strcase` libraries to support efficient JSON mutation and camel-case conversion for secret keys. [[1]](diffhunk://#diff-ebe18c11af755e19a8493b229fe8b73799087472ad6bc067ea4e2b69df70b6f7R25) [[2]](diffhunk://#diff-ebe18c11af755e19a8493b229fe8b73799087472ad6bc067ea4e2b69df70b6f7R37)