### PR TITLE
refactor(OnPremiseConnect): comment out failover check for provisioning, and will check failover outside connection wrapper

### DIFF
--- a/cluster/prov_onpremise_db.go
+++ b/cluster/prov_onpremise_db.go
@@ -37,9 +37,9 @@ func (cluster *Cluster) OnPremiseConnect(server *ServerMonitor) (*sshclient.Clie
 	if server == nil {
 		return nil, errors.New("OnPremise provisioning failed no server instance")
 	}
-	if cluster.IsInFailover() {
-		return nil, errors.New("OnPremise provisioning cancel during failover")
-	}
+	// if cluster.IsInFailover() {
+	// 	return nil, errors.New("OnPremise provisioning cancel during failover")
+	// }
 	if !cluster.Conf.OnPremiseSSH {
 		return nil, errors.New("onpremise-ssh disable ")
 	}


### PR DESCRIPTION
This pull request makes a small change to the on-premise provisioning logic in the `Cluster` class. The check for cluster failover during on-premise connection has been commented out, allowing on-premise provisioning to proceed even when the cluster is in failover.