### PR TITLE
Split cluster data and cluster logs for better performance

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -135,8 +135,8 @@ type Cluster struct {
 	WorkLoad                      config.WorkLoad        `json:"workLoad" groups:"web"`
 	Logrus                        *log.Logger            `json:"-"`
 	LogPushover                   *log.Logger            `json:"-"`
-	Log                           s18log.HttpLog         `json:"log" groups:"web"`
-	LogTask                       s18log.HttpLog         `json:"logTask" groups:"web"`
+	Log                           s18log.HttpLog         `json:"-" groups:"web"`
+	LogTask                       s18log.HttpLog         `json:"-" groups:"web"`
 	LogSlack                      *slackman.SlackManager `json:"-"`
 	JobResults                    *config.TasksMap       `json:"jobResults" groups:"web"`
 	FalsePositiveChecks           map[string]bool        `json:"falsePositiveChecks" groups:"web"`

--- a/cluster/cluster_acl.go
+++ b/cluster/cluster_acl.go
@@ -612,6 +612,8 @@ func (cluster *Cluster) IsURLPassACL(strUser string, URL string, errorPrint bool
 		return true
 	case "/api/clusters/" + cluster.Name + "/actions/refresh-apps-template":
 		return true
+	case "/api/clusters/" + cluster.Name + "/topology/http-logs":
+		return true
 	}
 
 	// Terminal ACL

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -1714,3 +1714,21 @@ func (cluster *Cluster) GetCompactJson() ([]byte, error) {
 
 	return result, nil
 }
+
+func (cluster *Cluster) GetWebLogsByType(logtype string) any {
+	switch logtype {
+	case "task":
+		return &cluster.LogTask
+	case "general":
+		return &cluster.Log
+	default:
+		return nil
+	}
+}
+
+func (cluster *Cluster) GetAllWebLogs() map[string]any {
+	logs := make(map[string]any)
+	logs["general"] = &cluster.Log
+	logs["task"] = &cluster.LogTask
+	return logs
+}

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -519,9 +519,9 @@ func (repman *ReplicationManager) handlerMuxAppDeployments(w http.ResponseWriter
 				return
 			}
 
-			for gidx, v := range node.AppConfig.Deployment.Variables {
+			for vidx, v := range node.AppConfig.Deployment.Variables {
 				if v.Type == "secret" {
-					dep, err = sjson.SetBytes(dep, fmt.Sprintf("variables.%d.value", gidx), "*****")
+					dep, err = sjson.SetBytes(dep, fmt.Sprintf("variables.%d.value", vidx), "*****")
 					if err != nil {
 						mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "API Error maskin secrets JSON: ", err)
 						http.Error(w, "Encoding error", 500)
@@ -532,6 +532,15 @@ func (repman *ReplicationManager) handlerMuxAppDeployments(w http.ResponseWriter
 
 			for gidx := range node.AppConfig.Deployment.Storages.GitClones {
 				dep, err = sjson.SetBytes(dep, fmt.Sprintf("storages.gitClones.%d.pass", gidx), "*****")
+				if err != nil {
+					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "API Error maskin secrets JSON: ", err)
+					http.Error(w, "Encoding error", 500)
+					return
+				}
+			}
+
+			for midx := range node.AppConfig.Deployment.Storages.S3Mounts {
+				dep, err = sjson.SetBytes(dep, fmt.Sprintf("storages.s3Mounts.%d.secretkey", midx), "*****")
 				if err != nil {
 					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "API Error maskin secrets JSON: ", err)
 					http.Error(w, "Encoding error", 500)

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -539,6 +539,14 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxLog)),
 	))
+	router.Handle("/api/clusters/{clusterName}/topology/http-logs", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxWebLog)),
+	))
+	router.Handle("/api/clusters/{clusterName}/topology/http-logs/{logType}", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxWebLog)),
+	))
 	router.Handle("/api/clusters/{clusterName}/topology/proxies", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxProxies)),
@@ -4304,6 +4312,47 @@ func (repman *ReplicationManager) handlerMuxLog(w http.ResponseWriter, r *http.R
 	e := json.NewEncoder(w)
 	e.SetIndent("", "\t")
 	err := e.Encode(clusterlogs)
+	if err != nil {
+		http.Error(w, "Encoding error", 500)
+		return
+	}
+}
+
+// handlerMuxWebLog handles the retrieval of web logs.
+// @Summary Retrieve web logs
+// @Description This endpoint retrieves the web logs.
+// @Tags ClusterTopology
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Success 200 {array} string "List of web logs"
+// @Failure 500 {string} string "Internal Server Error"
+// @Router /api/clusters/{clusterName}/topology/http-logs [get]
+// @Router /api/clusters/{clusterName}/topology/http-logs/{logType} [get]
+func (repman *ReplicationManager) handlerMuxWebLog(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+
+	cl := repman.getClusterByName(vars["clusterName"])
+	if cl == nil {
+		http.Error(w, "Cluster Not Found", 500)
+		return
+	}
+
+	if valid, _ := repman.IsValidClusterACL(r, cl); !valid {
+		http.Error(w, "No valid ACL", 403)
+		return
+	}
+
+	var logs any
+	if logType, ok := vars["logType"]; ok {
+		logs = cl.GetWebLogsByType(logType)
+	} else {
+		logs = cl.GetAllWebLogs()
+	}
+
+	e := json.NewEncoder(w)
+	e.SetIndent("", "\t")
+	err := e.Encode(logs)
 	if err != nil {
 		http.Error(w, "Encoding error", 500)
 		return

--- a/share/dashboard_react/src/Pages/Dashboard/components/Logs/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Logs/index.jsx
@@ -3,6 +3,7 @@ import TagPill from '../../../../components/TagPill'
 import { Box, Code } from '@chakra-ui/react'
 import styles from './styles.module.scss'
 import NotFound from '../../../../components/NotFound'
+import { useSelector } from 'react-redux'
 
 function Logs({ logs, className }) {
   const [isScrollable, setIsScrollable] = useState(true)
@@ -61,6 +62,16 @@ function Logs({ logs, className }) {
       </table>
     </Box>
   )
+}
+
+export const GeneralLogs = ({ className }) => {
+  const logs = useSelector((state) => state.cluster.clusterLogs.general)
+  return <Logs logs={logs?.buffer} className={className} />
+}
+
+export const TaskLogs = ({ className }) => {
+  const taskLogs = useSelector((state) => state.cluster.clusterLogs.task)
+  return <Logs logs={taskLogs?.buffer} className={className} />
 }
 
 export default Logs

--- a/share/dashboard_react/src/Pages/Dashboard/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/index.jsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux'
 import ClusterWorkload from './components/ClusterWorkload'
 import { Flex } from '@chakra-ui/react'
 import AccordionComponent from '../../components/AccordionComponent/index.jsx'
-import Logs from './components/Logs'
+import { GeneralLogs, TaskLogs } from './components/Logs'
 import DBServers from './components/DBServers'
 import Proxies from './components/Proxies'
 import Apps from './components/Apps/index.jsx'
@@ -51,8 +51,8 @@ function Dashboard({ selectedCluster, user }) {
           body={<Apps selectedCluster={selectedCluster} user={user} />}
         />)}
 
-      <AccordionComponent heading={'Cluster Logs'} body={<Logs logs={selectedCluster?.log?.buffer} />} />
-      <AccordionComponent heading={'Job Logs'} body={<Logs logs={selectedCluster?.logTask?.buffer} />} />
+      <AccordionComponent heading={'Cluster Logs'} body={<GeneralLogs />} />
+      <AccordionComponent heading={'Job Logs'} body={<TaskLogs />} />
     </Flex>
   )
 }

--- a/share/dashboard_react/src/Pages/Home/index.jsx
+++ b/share/dashboard_react/src/Pages/Home/index.jsx
@@ -23,7 +23,8 @@ import {
   getBackupStats,
   clearCluster,
   getClusterApps,
-  getOpenSVCStats
+  getOpenSVCStats,
+  getClusterLogs
 } from '../../redux/clusterSlice'
 import { getClusters, getMonitoredData, getClusterPeers, getClusterForSale } from '../../redux/globalClustersSlice'
 import { AppSettings } from '../../AppSettings'
@@ -175,6 +176,7 @@ function Home() {
     } else if (selectedClusterNameRef.current) {
       if (!isAutoReloadPaused) {
         dispatch(getClusterData({ clusterName: selectedClusterNameRef.current }))
+        dispatch(getClusterLogs({ clusterName: selectedClusterNameRef.current }))
         dispatch(getClusterAlerts({ clusterName: selectedClusterNameRef.current }))
         dispatch(getClusterMaster({ clusterName: selectedClusterNameRef.current }))
         dispatch(getClusterServers({ clusterName: selectedClusterNameRef.current }))

--- a/share/dashboard_react/src/Pages/Maintenance/index.jsx
+++ b/share/dashboard_react/src/Pages/Maintenance/index.jsx
@@ -9,7 +9,7 @@ import TableType3 from '../../components/TableType3'
 import { useDispatch, useSelector } from 'react-redux'
 import BackupSettings from '../Settings/BackupSettings'
 import SchedulerSettings from '../Settings/SchedulerSettings'
-import Logs from '../Dashboard/components/Logs'
+import { TaskLogs } from '../Dashboard/components/Logs'
 import DatabaseJobs from './DatabaseJobs'
 
 function Maintenance({ selectedCluster, user }) {
@@ -275,7 +275,7 @@ function Maintenance({ selectedCluster, user }) {
         headerClassName={styles.accordionHeader}
         panelClassName={styles.accordionPanel}
         heading={'Job Logs'}
-        body={<Logs logs={selectedCluster?.logTask?.buffer} />}
+        body={<TaskLogs />}
       />
     </VStack>
   )

--- a/share/dashboard_react/src/Pages/Shards/index.jsx
+++ b/share/dashboard_react/src/Pages/Shards/index.jsx
@@ -10,7 +10,7 @@ import RMButton from '../../components/RMButton'
 import { getTablePct } from '../../utility/common'
 import Gauge from '../../components/Gauge'
 import AccordionComponent from '../../components/AccordionComponent'
-import Logs from '../Dashboard/components/Logs'
+import  { GeneralLogs, TaskLogs } from '../Dashboard/components/Logs'
 import NotFound from '../../components/NotFound'
 
 function Shards({ selectedCluster }) {
@@ -107,12 +107,12 @@ function Shards({ selectedCluster }) {
       <AccordionComponent
         className={styles.accordion}
         heading={'Cluster Logs'}
-        body={<Logs logs={selectedCluster?.log?.buffer} />}
+        body={<GeneralLogs />}
       />
       <AccordionComponent
         className={styles.accordion}
         heading={'Job Logs'}
-        body={<Logs logs={selectedCluster?.logTask?.buffer} />}
+        body={<TaskLogs />}
       />
     </VStack>
   )

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -39,6 +39,23 @@ export const getClusterAlerts = createAsyncThunk('cluster/getClusterAlerts', asy
   }
 });
 
+export const getClusterLogs = createAsyncThunk('cluster/getClusterLogs', async ({ clusterName }, thunkAPI) => {
+  try {
+    const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+    const { data, status } = await clusterService.getClusterLogs(clusterName, baseURL)
+    return { data, status }
+  } catch (error) {
+    handleError(error, thunkAPI)
+  }
+}, {
+  condition: (_, { getState }) => {
+    const { cluster } = getState();
+    if (cluster.isFetching.logs) {
+      return false;
+    }
+  }
+});
+
 export const getClusterMaster = createAsyncThunk('cluster/getClusterMaster', async ({ clusterName }, thunkAPI) => {
   try {
     const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
@@ -1760,12 +1777,17 @@ const initialState = {
     certificates: false,
     top: false,
     opensvcStats: false,
+    logs: false,
   },
   error: null,
   clusterApps: null,
   clusterAppStates: null,
   clusterData: null,
   clusterAlerts: null,
+  clusterLogs: {
+    general : null,
+    task : null,
+  },
   clusterMaster: null,
   clusterServers: null,
   clusterProxies: null,
@@ -1836,6 +1858,7 @@ export const clusterSlice = createSlice({
       isAnyOf(
         getClusterData.fulfilled,
         getClusterAlerts.fulfilled,
+        getClusterLogs.fulfilled,
         getClusterMaster.fulfilled,
         getClusterServers.fulfilled,
         getClusterProxies.fulfilled,
@@ -1853,28 +1876,31 @@ export const clusterSlice = createSlice({
       ),
       (state, action) => {
         if (action.type.includes('getClusterData')) {
-          state.isFetching.cluster = false
           state.clusterData = action.payload.data
+          state.isFetching.cluster = false
         } else if (action.type.includes('getClusterAlerts')) {
-          state.isFetching.alerts = false
           state.clusterAlerts = action.payload.data
+          state.isFetching.alerts = false
+        } else if (action.type.includes('getClusterLogs')) {
+          state.clusterLogs = action.payload.data || {}
+          state.isFetching.logs = false
         } else if (action.type.includes('getClusterMaster')) {
-          state.isFetching.master = false
           state.clusterMaster = action.payload.data
+          state.isFetching.master = false
         } else if (action.type.includes('getClusterServers')) {
-          state.isFetching.servers = false
           if (action.payload?.data && action.meta.arg?.clusterName == state.clusterData?.name) {
             state.clusterServers = action.payload.data
             state.clusterStates = action.payload?.data?.map((server) => `${server.state}-${server.isVirtualMaster}`).join(',') || ''
           }
+          state.isFetching.servers = false
         } else if (action.type.includes('getClusterApps')) {
-          state.isFetching.apps = false
           state.clusterApps = action.payload?.data
           state.clusterAppStates = action.payload?.data?.map((server) => `${server.state}-${server.isVirtualMaster}`).join(',') || ''
+          state.isFetching.apps = false
         } else if (action.type.includes('getClusterProxies')) {
-          state.isFetching.proxies = false
           state.clusterProxies = action.payload?.data
           state.clusterProxiesStaging = action.payload?.data?.filter((proxy) => proxy.isStaging).map((proxy) => proxy.name).join(',') || ''
+          state.isFetching.proxies = false
         } else if (action.type.includes('getClusterCertificates')) {
           state.clusterCertificates = action.payload.data
         } else if (action.type.includes('getTopProcess')) {
@@ -1925,6 +1951,7 @@ export const clusterSlice = createSlice({
     builder.addMatcher(
       isAnyOf(
         getClusterData.pending,
+        getClusterLogs.pending,
         getClusterAlerts.pending,
         getClusterMaster.pending,
         getClusterServers.pending,
@@ -1936,6 +1963,8 @@ export const clusterSlice = createSlice({
       (state, action) => {
         if (action.type.includes('getClusterData')) {
           state.isFetching.cluster = true
+        } else if (action.type.includes('getClusterLogs')) {
+          state.isFetching.logs = true
         } else if (action.type.includes('getClusterAlerts')) {
           state.isFetching.alerts = true
         } else if (action.type.includes('getClusterMaster')) {
@@ -1957,6 +1986,7 @@ export const clusterSlice = createSlice({
     builder.addMatcher(
       isAnyOf(
         getClusterData.rejected,
+        getClusterLogs.rejected,
         getClusterAlerts.rejected,
         getClusterMaster.rejected,
         getClusterServers.rejected,
@@ -1965,6 +1995,8 @@ export const clusterSlice = createSlice({
       ), (state, action) => {
         if (action.type.includes('getClusterData')) {
           state.isFetching.cluster = false
+        } else if (action.type.includes('getClusterLogs')) {
+          state.isFetching.logs = false
         } else if (action.type.includes('getClusterAlerts')) {
           state.isFetching.alerts = false
         } else if (action.type.includes('getClusterMaster')) {

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -4,6 +4,7 @@ export const clusterService = {
   // Cluster data APIs
   getClusterData,
   getClusterAlerts,
+  getClusterLogs,
   getClusterMaster,
   getClusterServers,
   getClusterProxies,
@@ -162,6 +163,10 @@ function getClusterServers(clusterName, baseURL) {
 
 function getClusterProxies(clusterName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/topology/proxies`)
+}
+
+function getClusterLogs(clusterName, baseURL) {
+  return getApi(baseURL).get(`clusters/${clusterName}/topology/http-logs`)
 }
 
 function getClusterCertificates(clusterName, baseURL) {


### PR DESCRIPTION
This pull request introduces a new backend API and frontend integration for retrieving and displaying cluster logs and job logs in the dashboard and related pages. The changes streamline how logs are fetched and rendered, replacing previous prop-based approaches with Redux-managed state and async actions. Additionally, secret masking in deployment responses is improved, and ACLs and struct field visibility are updated for better security and usability.

**Backend API and Security Improvements**

* Added new endpoints `/api/clusters/{clusterName}/topology/http-logs` and `/api/clusters/{clusterName}/topology/http-logs/{logType}` to serve general and task logs for clusters, with ACL enforcement and proper encoding. [[1]](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afR542-R549) [[2]](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afR4321-R4361) [[3]](diffhunk://#diff-ebe18c11af755e19a8493b229fe8b73799087472ad6bc067ea4e2b69df70b6f7R1717-R1734)
* Updated ACL logic to allow access to the new log endpoints.
* Changed `Cluster` struct fields `Log` and `LogTask` to not be serialized in API responses, improving security.
* Enhanced secret masking in deployment responses by ensuring both variable secrets and S3 storage secret keys are masked before sending to clients. [[1]](diffhunk://#diff-c161535a368ab9f06930f05fee7e73047213d2d866fc3baffe8f727a0d11ffb8L522-R524) [[2]](diffhunk://#diff-c161535a368ab9f06930f05fee7e73047213d2d866fc3baffe8f727a0d11ffb8R542-R550)

**Frontend Integration and State Management**

* Implemented Redux async thunk `getClusterLogs` and associated state management to fetch and store cluster logs, with loading and error handling. [[1]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R42-R58) [[2]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1780-R1790) [[3]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1861) [[4]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424L1856-R1903) [[5]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1954) [[6]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1966-R1967) [[7]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1989) [[8]](diffhunk://#diff-4fb7eb9b8d7c870284eb8419cc70c57eca2439f9df14541a6f5cf679b948c424R1998-R1999)
* Added service method for fetching logs from the new API endpoint. [[1]](diffhunk://#diff-7bbc99751675465360b02f80d806f62b29109dd0a66e704ac6e8b47a480693fbR7) [[2]](diffhunk://#diff-7bbc99751675465360b02f80d806f62b29109dd0a66e704ac6e8b47a480693fbR168-R171)
* Updated dashboard and maintenance pages to use new `GeneralLogs` and `TaskLogs` components, which read logs from Redux state instead of props, ensuring consistent log display across the app. [[1]](diffhunk://#diff-540eb8b8f3d3aa2ef4eec02cd330f2e4bda4f3d8ab81ada6b575656e6ed4cc1fR6) [[2]](diffhunk://#diff-540eb8b8f3d3aa2ef4eec02cd330f2e4bda4f3d8ab81ada6b575656e6ed4cc1fR67-R76) [[3]](diffhunk://#diff-35dac702bdd34e72d9f22a269d5b03919f79298478ea12193c052db267e89f03L8-R8) [[4]](diffhunk://#diff-35dac702bdd34e72d9f22a269d5b03919f79298478ea12193c052db267e89f03L54-R55) [[5]](diffhunk://#diff-ce75ee3cff3d510ef5f5ba04865fb768841d25d7bc3bce1b14ed3424cde9cac4L12-R12) [[6]](diffhunk://#diff-ce75ee3cff3d510ef5f5ba04865fb768841d25d7bc3bce1b14ed3424cde9cac4L278-R278) [[7]](diffhunk://#diff-d0901944958b724990c4c9e6d04443ceb1525e924ff0fa41c252a85fe364bb44L13-R13) [[8]](diffhunk://#diff-d0901944958b724990c4c9e6d04443ceb1525e924ff0fa41c252a85fe364bb44L110-R115)
* Ensured logs are fetched whenever cluster data is loaded, keeping the UI up-to-date. [[1]](diffhunk://#diff-64aa538ae37902cf9cc55ee965c82fa01e16a4a90e2401e121ce83bfb7d44007L26-R27) [[2]](diffhunk://#diff-64aa538ae37902cf9cc55ee965c82fa01e16a4a90e2401e121ce83bfb7d44007R179)
