### PR TITLE
1259 mysqlbinlog option issue after rejoin when using mysql 84

### DIFF
--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -887,7 +887,7 @@ func (server *ServerMonitor) GetSSLClientParam(tool string) []string {
 					sslMode = "VERIFY_CA" // Only verify CA if no SSL mode is set
 				}
 
-				if ver.IsMySQLOrPerconaSSLMode() { // client supports --ssl-mode
+				if ver.IsMySQLOrPerconaGreater8() { // client removed --ssl support in 8.0, use --ssl-mode
 					switch sslMode {
 					case "DISABLED":
 						return []string{"--ssl-mode=DISABLED"}
@@ -914,7 +914,7 @@ func (server *ServerMonitor) GetSSLClientParam(tool string) []string {
 					}
 				}
 			} else {
-				if ver.IsMySQLOrPerconaSSLMode() { // client supports --ssl-mode
+				if ver.IsMySQLOrPerconaGreater8() { // client removed --ssl support in 8.0, use --ssl-mode
 					if sslMode != "" {
 						return []string{"--ssl-mode=" + sslMode} // No verify server cert
 					} else {

--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -887,7 +887,7 @@ func (server *ServerMonitor) GetSSLClientParam(tool string) []string {
 					sslMode = "VERIFY_CA" // Only verify CA if no SSL mode is set
 				}
 
-				if server.DBVersion.IsMySQLOrPerconaSSLMode() && ver.IsMySQLOrPerconaSSLMode() { // Use","--ssl-mode
+				if ver.IsMySQLOrPerconaSSLMode() { // client supports --ssl-mode
 					switch sslMode {
 					case "DISABLED":
 						return []string{"--ssl-mode=DISABLED"}
@@ -901,6 +901,9 @@ func (server *ServerMonitor) GetSSLClientParam(tool string) []string {
 				} else { // Use old","--ssl equivalent
 					switch sslMode {
 					case "DISABLED":
+						if tool == "client-dump" || tool == "client-binlog" {
+							return []string{"--ssl=FALSE"}
+						}
 						return []string{"--skip-ssl"}
 					case "PREFERRED", "REQUIRED":
 						return []string{"--ssl", "--ssl-verify-server-cert=false"}
@@ -911,7 +914,7 @@ func (server *ServerMonitor) GetSSLClientParam(tool string) []string {
 					}
 				}
 			} else {
-				if server.DBVersion.IsMySQLOrPerconaSSLMode() && ver.IsMySQLOrPerconaSSLMode() { // Use","--ssl-mode
+				if ver.IsMySQLOrPerconaSSLMode() { // client supports --ssl-mode
 					if sslMode != "" {
 						return []string{"--ssl-mode=" + sslMode} // No verify server cert
 					} else {
@@ -919,6 +922,9 @@ func (server *ServerMonitor) GetSSLClientParam(tool string) []string {
 					}
 				} else { // Use old","--ssl equivalent
 					if sslMode == "DISABLED" {
+						if tool == "client-dump" || tool == "client-binlog" {
+							return []string{"--ssl=FALSE"}
+						}
 						return []string{"--skip-ssl"}
 					}
 

--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -876,10 +876,8 @@ func (server *ServerMonitor) GetSSLClientParam(tool string) []string {
 		if !noSSLParams {
 			sslMode = cluster.Conf.HostsTlsSslMode
 
-			if skipVerify {
-				if cluster.Conf.HostsTlsSslMode == "" {
-					sslMode = "REQUIRED" // No verify server cert
-				}
+			if cluster.Conf.HostsTlsSslMode == "" && skipVerify {
+				sslMode = "REQUIRED" // No verify server cert
 			}
 
 			if cacertfile != "" && clicertfile != "" && clikeyfile != "" {
@@ -915,10 +913,10 @@ func (server *ServerMonitor) GetSSLClientParam(tool string) []string {
 				}
 			} else {
 				if ver.IsMySQLOrPerconaGreater8() { // client removed --ssl support in 8.0, use --ssl-mode
-					if sslMode != "" {
-						return []string{"--ssl-mode=" + sslMode} // No verify server cert
+					if sslMode == "" {
+						return []string{} // Use default SSL mode of client
 					} else {
-						return []string{"--ssl-mode=PREFERRED"} // No verify server cert
+						return []string{"--ssl-mode=" + sslMode} // No verify server cert
 					}
 				} else { // Use old","--ssl equivalent
 					if sslMode == "DISABLED" {

--- a/cluster/srv_rejoin.go
+++ b/cluster/srv_rejoin.go
@@ -733,7 +733,12 @@ func (server *ServerMonitor) backupBinlog(crash *Crash) error {
 	filepath.Walk(cluster.Conf.WorkingDir+"/", server.deletefiles)
 
 	var params []string = make([]string, 0)
-	params = append(params, "--read-from-remote-server", "--raw", "--stop-never-slave-server-id=10000", "--user="+cluster.GetRplUser(), "--password="+cluster.GetRplPass(), "--host="+misc.Unbracket(server.Host), "--port="+server.Port, "--result-file="+cluster.Conf.WorkingDir+"/"+cluster.Name+"-server"+strconv.FormatUint(uint64(server.ServerID), 10)+"-", "--start-position="+crash.FailoverMasterLogPos)
+	if server.DBVersion.IsMySQLOrPerconaGreater84() {
+		params = append(params, "--connection-server-id=10000")
+	} else {
+		params = append(params, "--stop-never-slave-server-id=10000")
+	}
+	params = append(params, "--read-from-remote-server", "--raw", "--user="+cluster.GetRplUser(), "--password="+cluster.GetRplPass(), "--host="+misc.Unbracket(server.Host), "--port="+server.Port, "--result-file="+cluster.Conf.WorkingDir+"/"+cluster.Name+"-server"+strconv.FormatUint(uint64(server.ServerID), 10)+"-", "--start-position="+crash.FailoverMasterLogPos)
 	params = append(params, server.GetSSLClientParam("client-binlog")...)
 	params = append(params, crash.FailoverMasterLogFile)
 	cmdrun = exec.Command(cluster.GetMysqlBinlogPath(), misc.RemoveEmptyString(params)...)

--- a/utils/version/version.go
+++ b/utils/version/version.go
@@ -86,7 +86,7 @@ func ParseDBFlavor(version string) string {
 
 func NewFullVersionFromString(flavor, vstring string) (*Version, int, int) {
 	// Updated regex to capture numeric version and optional suffix without including dash
-	versionRegex := `[a-zA-Z]*\s*([0-9]{1,3}(?:\.[0-9]{1,3}){0,2})(?:[-_.]([0-9A-Za-z-]+))?`
+	versionRegex := `([0-9]{1,3}\.(?:[0-9]{1,3}){0,2})(?:[-_.]([0-9A-Za-z-]+))?`
 	re := regexp.MustCompile(versionRegex)
 	// Find all matches and capture numeric version with optional suffix
 	matches := re.FindAllStringSubmatch(vstring, 2)
@@ -131,7 +131,7 @@ func NewFullVersionFromString(flavor, vstring string) (*Version, int, int) {
 
 func NewVersionFromString(flavor, vstring string) (*Version, int) {
 	// Updated regex to capture numeric version and optional suffix without including dash
-	versionRegex := `[a-zA-Z]*\s*([0-9]{1,3}(?:\.[0-9]{1,3}){0,2})(?:[-_.]([0-9A-Za-z]+))?`
+	versionRegex := `([0-9]{1,3}(?:\.[0-9]{1,3}){0,2})(?:[-_.]([0-9A-Za-z]+))?`
 	re := regexp.MustCompile(versionRegex)
 	// Find all matches and capture numeric version with optional suffix
 	match := re.FindStringSubmatch(vstring)

--- a/utils/version/version.go
+++ b/utils/version/version.go
@@ -131,7 +131,7 @@ func NewFullVersionFromString(flavor, vstring string) (*Version, int, int) {
 
 func NewVersionFromString(flavor, vstring string) (*Version, int) {
 	// Updated regex to capture numeric version and optional suffix without including dash
-	versionRegex := `([0-9]{1,3}(?:\.[0-9]{1,3}){0,2})(?:[-_.]([0-9A-Za-z]+))?`
+	versionRegex := `([0-9]{1,3}\.(?:[0-9]{1,3}){0,2})(?:[-_.]([0-9A-Za-z]+))?`
 	re := regexp.MustCompile(versionRegex)
 	// Find all matches and capture numeric version with optional suffix
 	match := re.FindStringSubmatch(vstring)

--- a/utils/version/version.go
+++ b/utils/version/version.go
@@ -345,16 +345,7 @@ func (mv *Version) IsMySQLOrPerconaGreater8() bool {
 	return (mv.Flavor == "MySQL" || mv.Flavor == "Percona") && (mv.Major >= 8)
 }
 
-// IsMySQLOrPerconaGreater84 checks if the version is MySQL or Percona 8.4 or greater
-func (mv *Version) IsMySQLOrPerconaSSLMode() bool {
-	if mv == nil {
-		return false
-	}
-
-	return (mv.Flavor == "MySQL" || mv.Flavor == "Percona") && mv.GreaterEqual("8.0.26")
-}
-
-// IsMariaDBGreater113 checks if the version is MariaDB 11.3 or greater which introduce breaking changes in SSL
+// IsMariaDBGreater113 checks if the version is MariaDB 11.3 or greater which introduces breaking changes in SSL
 func (mv *Version) IsMariaDBGreater113() bool {
 	if mv == nil {
 		return false


### PR DESCRIPTION
This pull request updates SSL parameter handling and version parsing logic for MySQL, Percona, and MariaDB clients to improve compatibility with recent server versions and client tools. The main changes focus on correctly setting SSL parameters based on client and server versions, refining version detection, and updating command-line options for binlog backups.

**SSL parameter handling improvements:**

* Updated `GetSSLClientParam` in `srv_get.go` to use `--ssl-mode` only for MySQL/Percona 8.0+ clients, and to return `--ssl=FALSE` for `client-dump` and `client-binlog` tools when SSL is disabled, ensuring correct compatibility with client command-line options. [[1]](diffhunk://#diff-1f102cb4f0681169e52bd5cbd3b82ade67edf8c28f57cc0d9bb8500e72de97acL879-R888) [[2]](diffhunk://#diff-1f102cb4f0681169e52bd5cbd3b82ade67edf8c28f57cc0d9bb8500e72de97acR902-R904) [[3]](diffhunk://#diff-1f102cb4f0681169e52bd5cbd3b82ade67edf8c28f57cc0d9bb8500e72de97acL914-R925)
* Removed the obsolete `IsMySQLOrPerconaSSLMode` version check and replaced usage with the new `IsMySQLOrPerconaGreater8` function, simplifying SSL mode logic for newer client versions.

**Binlog backup compatibility:**

* In `backupBinlog` in `srv_rejoin.go`, adjusted command-line parameters to use `--connection-server-id=10000` for MySQL/Percona 8.4+ and `--stop-never-slave-server-id=10000` for older versions, ensuring correct binlog backup behavior across versions.

**Version parsing improvements:**

* Refined regular expressions in `version.go` to more accurately extract numeric version information from strings, removing unnecessary leading text matching and improving robustness for version detection. [[1]](diffhunk://#diff-6190a4bad4a6f7cb61dcedcf512daf14f1758c8a211cb28e1961fe94bd64584cL89-R89) [[2]](diffhunk://#diff-6190a4bad4a6f7cb61dcedcf512daf14f1758c8a211cb28e1961fe94bd64584cL134-R134)