### PR TITLE
feat(topology-target): add support for missing active-passive topology configuration

### DIFF
--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -763,6 +763,10 @@ func (cluster *Cluster) SetReplicationNoRelay(norelay bool) {
 }
 
 // topology setter
+func (cluster *Cluster) SetActivePassive(activepassive bool) {
+	cluster.Conf.ActivePassive = activepassive
+}
+
 func (cluster *Cluster) SetMultiTierSlave(multitierslave bool) {
 	cluster.Conf.MultiTierSlave = multitierslave
 }

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -686,7 +686,17 @@ func (cluster *Cluster) CheckSlavesReplicationsPurge() {
 
 func (cluster *Cluster) BootstrapTopology(topology string) error {
 	switch topology {
+	case "active-passive":
+		cluster.SetMultiMasterRing(false)
+		cluster.SetMultiTierSlave(false)
+		cluster.SetForceSlaveNoGtid(false)
+		cluster.SetMultiMaster(false)
+		cluster.SetBinlogServer(false)
+		cluster.SetMultiMasterWsrep(false)
+		cluster.SetMultiMasterGroupRep(false)
+		cluster.SetActivePassive(true)
 	case "master-slave":
+		cluster.SetActivePassive(false)
 		cluster.SetMultiMasterRing(false)
 		cluster.SetMultiTierSlave(false)
 		cluster.SetForceSlaveNoGtid(false)
@@ -702,6 +712,7 @@ func (cluster *Cluster) BootstrapTopology(topology string) error {
 		cluster.SetBinlogServer(false)
 		cluster.SetMultiMasterWsrep(false)
 		cluster.SetMultiMasterGroupRep(false)
+		cluster.SetActivePassive(false)
 	case "multi-master":
 		cluster.SetMultiMasterRing(false)
 		cluster.SetMultiTierSlave(false)
@@ -710,6 +721,7 @@ func (cluster *Cluster) BootstrapTopology(topology string) error {
 		cluster.SetBinlogServer(false)
 		cluster.SetMultiMasterWsrep(false)
 		cluster.SetMultiMasterGroupRep(false)
+		cluster.SetActivePassive(false)
 	case "multi-tier-slave":
 		cluster.SetMultiMasterRing(false)
 		cluster.SetMultiTierSlave(true)
@@ -718,6 +730,7 @@ func (cluster *Cluster) BootstrapTopology(topology string) error {
 		cluster.SetBinlogServer(false)
 		cluster.SetMultiMasterWsrep(false)
 		cluster.SetMultiMasterGroupRep(false)
+		cluster.SetActivePassive(false)
 	case "maxscale-binlog":
 		cluster.SetMultiMasterRing(false)
 		cluster.SetMultiTierSlave(false)
@@ -726,6 +739,7 @@ func (cluster *Cluster) BootstrapTopology(topology string) error {
 		cluster.SetBinlogServer(true)
 		cluster.SetMultiMasterWsrep(false)
 		cluster.SetMultiMasterGroupRep(false)
+		cluster.SetActivePassive(false)
 	case "multi-master-ring":
 		cluster.SetMultiTierSlave(false)
 		cluster.SetForceSlaveNoGtid(false)
@@ -734,6 +748,7 @@ func (cluster *Cluster) BootstrapTopology(topology string) error {
 		cluster.SetMultiMasterRing(true)
 		cluster.SetMultiMasterWsrep(false)
 		cluster.SetMultiMasterGroupRep(false)
+		cluster.SetActivePassive(false)
 	case "multi-master-wsrep":
 		cluster.SetMultiMasterRing(false)
 		cluster.SetMultiTierSlave(false)
@@ -743,6 +758,7 @@ func (cluster *Cluster) BootstrapTopology(topology string) error {
 		cluster.SetMultiMasterRing(false)
 		cluster.SetMultiMasterWsrep(true)
 		cluster.SetMultiMasterGroupRep(false)
+		cluster.SetActivePassive(false)
 	case "multi-master-grprep":
 		cluster.SetMultiMasterRing(false)
 		cluster.SetMultiTierSlave(false)
@@ -752,8 +768,9 @@ func (cluster *Cluster) BootstrapTopology(topology string) error {
 		cluster.SetMultiMasterRing(false)
 		cluster.SetMultiMasterWsrep(false)
 		cluster.SetMultiMasterGroupRep(true)
+		cluster.SetActivePassive(false)
 	default:
-		return errors.New("Invalid topology type, supported types are: master-slave, master-slave-no-gtid, multi-master, multi-tier-slave, maxscale-binlog, multi-master-ring, multi-master-wsrep, multi-master-grprep")
+		return errors.New("Invalid topology type, supported types are: master-slave, master-slave-no-gtid, multi-master, multi-tier-slave, maxscale-binlog, multi-master-ring, multi-master-wsrep, multi-master-grprep, active-passive")
 	}
 	cluster.SetTopologyTarget(topology)
 	return nil


### PR DESCRIPTION
This pull request adds support for an "active-passive" topology to the cluster configuration logic. The main changes include introducing a new setter method for the `ActivePassive` configuration, updating the topology bootstrapping function to handle the new topology type, and ensuring that the `ActivePassive` flag is set appropriately for all supported topologies.

### Topology support enhancements

* Added a new method `SetActivePassive` to the `Cluster` struct in `cluster/cluster_set.go`, allowing the `ActivePassive` flag to be set in the cluster configuration.
* Updated the `BootstrapTopology` function in `cluster/cluster_topo.go` to handle the new `"active-passive"` topology by setting relevant configuration flags and enabling `ActivePassive`.
* For all other existing topology types (e.g., `"master-slave"`, `"multi-master"`, etc.), explicitly set `ActivePassive` to `false` to avoid misconfiguration. [[1]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2R715) [[2]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2R724) [[3]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2R733) [[4]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2R742) [[5]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2R751) [[6]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2R761) [[7]](diffhunk://#diff-15342ddd357618bdaf8ddfb5a03c23f159bef7113c048efdab5a05761203b2a2R771-R773)
* Updated error handling to include `"active-passive"` in the list of supported topology types in error messages.