### PR TITLE
fix(active-passive): implement active-passive mode restrictions for read-only, failover, and replication bootstrap

### DIFF
--- a/cluster/cluster_fail.go
+++ b/cluster/cluster_fail.go
@@ -26,6 +26,11 @@ import (
 
 // MasterFailover triggers a leader change and returns the new master URL when single possible leader
 func (cluster *Cluster) MasterFailover(fail bool) bool {
+	if cluster.Conf.ActivePassive {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Failover/Switchover not allowed in active-passive mode")
+		return false
+	}
+
 	if cluster.GetTopology() == config.TopoMultiMasterRing || cluster.GetTopology() == config.TopoMultiMasterWsrep || cluster.GetTopology() == config.TopoMultiMasterGrouprep {
 		res := cluster.VMasterFailover(fail)
 		return res
@@ -350,7 +355,7 @@ func (cluster *Cluster) MasterFailover(fail bool) bool {
 			cluster.LogSQL(logs, err, cluster.oldMaster.URL, "MasterFailover", config.LvlErr, "Start slave failed on old master,%s reason:  %s ", cluster.oldMaster.URL, err)
 		}
 
-		if cluster.Conf.ReadOnly {
+		if !cluster.Conf.ActivePassive && cluster.Conf.ReadOnly {
 			logs, err = cluster.oldMaster.SetReadOnly()
 			cluster.LogSQL(logs, err, cluster.oldMaster.URL, "MasterFailover", config.LvlErr, "Could not set old master as read-only, %s", err)
 			/*	} else {
@@ -554,7 +559,7 @@ func (cluster *Cluster) SwitchSlavesToMaster(fail bool) {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Restarting old master replication relay server ready")
 			cluster.oldMaster.StartSlave()
 		}
-		if cluster.Conf.ReadOnly && cluster.Conf.MxsBinlogOn == false && !sl.IsIgnoredReadonly() {
+		if !cluster.Conf.ActivePassive && cluster.Conf.ReadOnly && cluster.Conf.MxsBinlogOn == false && !sl.IsIgnoredReadonly() {
 			logs, err = sl.SetReadOnly()
 			cluster.LogSQL(logs, err, sl.URL, "MasterFailover", config.LvlErr, "Could not set slave %s as read-only, %s", sl.URL, err)
 		} else {
@@ -1392,8 +1397,7 @@ func (cluster *Cluster) VMasterFailover(fail bool) bool {
 		logs, err := dbhelper.UnlockTables(cluster.oldMaster.Conn)
 		cluster.LogSQL(logs, err, cluster.oldMaster.URL, "MasterFailover", config.LvlErr, "Could not unlock tables on old master %s", err)
 
-		if cluster.Conf.ReadOnly {
-
+		if !cluster.Conf.ActivePassive && cluster.Conf.ReadOnly {
 			logs, err = cluster.oldMaster.SetReadOnly()
 			cluster.LogSQL(logs, err, cluster.oldMaster.URL, "MasterFailover", config.LvlErr, "Could not set old master as read-only, %s", err)
 

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -167,6 +167,9 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 		}
 	}
 
+	// Check topology Cluster all servers down
+	cluster.IsDown = cluster.AllServersFailed()
+
 	// if only one server
 	if len(cluster.Servers) == 1 || cluster.Conf.ActivePassive {
 		cluster.Topology = config.TopoActivePassive
@@ -181,8 +184,6 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 
 	// Check topology Cluster is down
 	cluster.TopologyClusterDown()
-	// Check topology Cluster all servers down
-	cluster.IsDown = cluster.AllServersFailed()
 	cluster.CheckSameServerID()
 
 	// Spider shard discover

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -168,10 +168,13 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 	}
 
 	// if only one server
-	if len(cluster.Servers) == 1 {
+	if len(cluster.Servers) == 1 || cluster.Conf.ActivePassive {
 		cluster.Topology = config.TopoActivePassive
-		for _, sv := range cluster.Servers {
-			cluster.master = sv
+
+		if len(cluster.Servers) == 1 {
+			for _, sv := range cluster.Servers {
+				cluster.master = sv
+			}
 		}
 		return nil
 	}

--- a/cluster/prov.go
+++ b/cluster/prov.go
@@ -625,7 +625,7 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 	}
 
 	// Assume master-slave if nothing else is declared
-	if cluster.Conf.MultiMasterRing == false && cluster.Conf.MultiMaster == false && cluster.Conf.MxsBinlogOn == false && cluster.Conf.MultiTierSlave == false {
+	if cluster.Conf.ActivePassive == false && cluster.Conf.MultiMasterRing == false && cluster.Conf.MultiMaster == false && cluster.Conf.MxsBinlogOn == false && cluster.Conf.MultiTierSlave == false {
 
 		for key, server := range cluster.Servers {
 			if server.State == stateFailed {
@@ -674,7 +674,7 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 		}
 	}
 	// Slave Relay
-	if cluster.Conf.MultiTierSlave == true {
+	if cluster.Conf.ActivePassive == false && cluster.Conf.MultiTierSlave == true {
 		relaykey := 1
 		if masterKey == 1 {
 			relaykey = 0
@@ -731,7 +731,7 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Environment bootstrapped with %s as master", cluster.Servers[masterKey].URL)
 	}
 	// Multi Master
-	if cluster.Conf.MultiMaster == true {
+	if cluster.Conf.ActivePassive == false && cluster.Conf.MultiMaster == true {
 		for _, server := range cluster.Servers {
 			if server.State == stateFailed {
 				continue
@@ -773,7 +773,7 @@ func (cluster *Cluster) BootstrapReplication(clean bool) error {
 		}
 	}
 	// Ring
-	if cluster.Conf.MultiMasterRing == true {
+	if cluster.Conf.ActivePassive == false && cluster.Conf.MultiMasterRing == true {
 		for _, server := range cluster.Servers {
 			if server.State == stateFailed {
 				continue

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -611,7 +611,7 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "State changed, init failed server %s as unconnected", server.URL)
 
 			// if the config is read only and we are not in a wsrep cluster and node is not staging server
-			if cluster.Conf.ReadOnly && !server.HaveWsrep && cluster.IsDiscovered() && !isStagingServer {
+			if !cluster.Conf.ActivePassive && cluster.Conf.ReadOnly && !server.HaveWsrep && cluster.IsDiscovered() && !isStagingServer {
 				//GetMaster abstract master for galera multi master and master slave
 				if server.GetCluster().GetMaster() != nil {
 					if cluster.Status == ConstMonitorActif && server.GetCluster().GetMaster().Id != server.Id && !server.IsIgnoredReadonly() && !cluster.IsInFailover() {
@@ -663,7 +663,7 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "From state %s to unconnected and non leader on server %s", server.PrevState, server.URL)
 
 			// if the config is read only and we are not in a wsrep cluster and node is not staging server
-			if cluster.Conf.ReadOnly && !server.HaveWsrep && cluster.IsDiscovered() && !server.IsIgnoredReadonly() && !cluster.IsInFailover() && !isStagingServer {
+			if !cluster.Conf.ActivePassive && cluster.Conf.ReadOnly && !server.HaveWsrep && cluster.IsDiscovered() && !server.IsIgnoredReadonly() && !cluster.IsInFailover() && !isStagingServer {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Setting Read Only on unconnected server: %s no master state and replication found", server.URL)
 				server.SetReadOnly()
 			}

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -627,7 +627,11 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 			server.SetConfigRefreshCookie() // set cookie to refresh config
 
 			if cluster.Topology == config.TopoActivePassive {
-				server.SetState(stateMaster)
+				if cluster.GetMaster() == nil {
+					server.SetMaster()
+				} else if cluster.GetMaster().Id != server.Id {
+					server.SetState(stateUnconn)
+				}
 			} else if cluster.GetTopology() != config.TopoMultiMasterWsrep || cluster.GetTopology() != config.TopoMultiMasterGrouprep {
 				if server.IsGroupReplicationSlave {
 					server.SetState(stateSlave)
@@ -682,7 +686,11 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 		} else if server.GetCluster().GetTopology() == config.TopoActivePassive {
 			if server.PrevState == stateSuspect || (server.PrevState == stateMaintenance && !server.IsMaintenance) {
 				//if active-passive topo and no replication, put the state at standalone
-				server.SetState(stateMaster)
+				if cluster.GetMaster() == nil || cluster.GetMaster().Id == server.Id {
+					server.SetState(stateMaster)
+				} else {
+					server.SetState(stateUnconn)
+				}
 			}
 		} else if server.State != stateMaster && server.PrevState == stateSlaveErr { // if not master and was slave error
 			server.SetState(stateUnconn)

--- a/cluster/srv_chk.go
+++ b/cluster/srv_chk.go
@@ -265,7 +265,7 @@ func (server *ServerMonitor) CheckSlaveSettings() {
 		//galera or binlog flashback need row based binlog
 		cluster.SetState("WARN0049", state.State{ErrType: config.LvlWarn, ErrDesc: fmt.Sprintf(clusterError["WARN0049"], sl.URL), ErrFrom: "TOPO", ServerUrl: sl.URL})
 	}
-	if cluster.Conf.ForceSlaveReadOnly && sl.ReadOnly == "OFF" && !server.IsIgnoredReadonly() && !cluster.IsMultiMaster() && !server.IsMaster() {
+	if cluster.Conf.ActivePassive == false && cluster.Conf.ForceSlaveReadOnly && sl.ReadOnly == "OFF" && !server.IsIgnoredReadonly() && !cluster.IsMultiMaster() && !server.IsMaster() {
 		// In non-multimaster mode, enforce read-only flag if the option is set
 		sl.SetReadOnly()
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Enforce read only on slave %s, ReadOnly:%s, InIgnored:%t MultiMaster:%t", sl.URL, sl.ReadOnly, server.IsIgnoredReadonly(), cluster.IsMultiMaster())

--- a/cluster/srv_rejoin.go
+++ b/cluster/srv_rejoin.go
@@ -47,6 +47,12 @@ func (server *ServerMonitor) RejoinMaster() error {
 	defer func() {
 		cluster.rejoinCond.Send <- true
 	}()
+
+	if cluster.Conf.ActivePassive {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Rejoining %s ignored caused by active-passive mode", server.URL)
+		return nil
+	}
+
 	if cluster.GetTopology() == config.TopoMultiMasterWsrep {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Rejoining leader %s ignored caused by wsrep protocol", server.URL)
 		return nil

--- a/regtest/test_switchover_assync_noreadonly_norplcheck.go
+++ b/regtest/test_switchover_assync_noreadonly_norplcheck.go
@@ -13,6 +13,11 @@ import (
 
 func (regtest *RegTest) TestSwitchoverNoReadOnlyNoRplCheck(cluster *cluster.Cluster, conf string, test *cluster.Test) bool {
 
+	if cluster.Conf.ActivePassive {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Test not applicable in active-passive mode")
+		return false
+	}
+
 	err := cluster.DisableSemisync()
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "%s", err)

--- a/regtest/test_switchover_assync_readonly_norplcheck.go
+++ b/regtest/test_switchover_assync_readonly_norplcheck.go
@@ -13,6 +13,11 @@ import (
 
 func (regtest *RegTest) TestSwitchoverReadOnlyNoRplCheck(cluster *cluster.Cluster, conf string, test *cluster.Test) bool {
 
+	if cluster.Conf.ActivePassive {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Test not applicable in active-passive mode")
+		return false
+	}
+
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "Master is %s", cluster.GetMaster().URL)
 	cluster.SetRplMaxDelay(0)
 	cluster.SetRplChecks(false)


### PR DESCRIPTION

This pull request introduces support for an active-passive cluster mode and ensures that switchover, failover, and replication logic are correctly restricted or adjusted when this mode is enabled. The changes add explicit checks for the `ActivePassive` configuration flag across various cluster management and monitoring functions, preventing operations that are not applicable in active-passive setups and refining topology detection.

**Active-Passive Mode Logic:**

* Added checks to prevent failover/switchover operations in active-passive mode, logging errors and returning early from methods such as `MasterFailover` and relevant regtests. [[1]](diffhunk://#diff-10db3690d5b665a5fa7d6ec14207976663953d5c0edac9c341e80f13af5bf7c4R29-R33) [[2]](diffhunk://#diff-ec0532cc851225e5a34e7da0e67bdea1da32010ec42abf77f08ae61be3423edaR16-R20) [[3]](diffhunk://#diff-e142b20507240b41e3f39635da7a628d28554bfd72feae54cd38acbf4bef71dcR16-R20)
* Updated topology discovery to set the topology to `TopoActivePassive` if `ActivePassive` is enabled, even for clusters with more than one server.

**Replication and Read-Only Handling:**

* Modified replication bootstrap logic to skip multi-master, multi-tier slave, and ring setups when `ActivePassive` is enabled, ensuring only appropriate replication strategies are used. [[1]](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0L628-R628) [[2]](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0L677-R677) [[3]](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0L734-R734) [[4]](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0L776-R776)
* Adjusted read-only enforcement logic in failover, switchover, server monitoring, and slave settings checks to only apply if not in active-passive mode. [[1]](diffhunk://#diff-10db3690d5b665a5fa7d6ec14207976663953d5c0edac9c341e80f13af5bf7c4L353-R358) [[2]](diffhunk://#diff-10db3690d5b665a5fa7d6ec14207976663953d5c0edac9c341e80f13af5bf7c4L557-R562) [[3]](diffhunk://#diff-10db3690d5b665a5fa7d6ec14207976663953d5c0edac9c341e80f13af5bf7c4L1395-R1400) [[4]](diffhunk://#diff-c5fffdb4a6a092160ddd24b95042ba54bfcb96dfb0e747bb200902aac778adb1L614-R614) [[5]](diffhunk://#diff-c5fffdb4a6a092160ddd24b95042ba54bfcb96dfb0e747bb200902aac778adb1L666-R666) [[6]](diffhunk://#diff-5bb4c626ee0cfad5a85fa30ec20e412f89ed0abf03e950a7511b28b8fdd89c80L268-R268)

**Cluster Operations and Monitoring:**

* Disabled master rejoin operations in active-passive mode, logging that the operation is ignored for this configuration.