### PR TITLE
Metrics collection and reporting refactor

### DIFF
--- a/cluster/app.go
+++ b/cluster/app.go
@@ -16,7 +16,6 @@ import (
 	"sync"
 
 	"github.com/signal18/replication-manager/config"
-	"github.com/signal18/replication-manager/graphite"
 	"github.com/signal18/replication-manager/utils/misc"
 	"github.com/spf13/pflag"
 )
@@ -80,20 +79,8 @@ func (cluster *Cluster) newAppList() error {
 	return nil
 }
 
-func (cluster *Cluster) SendAppStats(app *App) error {
-	return app.SendStats()
-}
-
-func (app *App) SendStats() error {
-	cluster := app.ClusterGroup
-	graph, err := graphite.NewGraphite(cluster.Conf.GraphiteCarbonHost, cluster.Conf.GraphiteCarbonPort)
-	if err != nil {
-		return err
-	}
-
-	graph.Disconnect()
-
-	return nil
+func (app *App) FetchStats() {
+	// TO DO: implement app specific stats fetching
 }
 
 func NewApp(placement int, cluster *Cluster, appHost string) *App {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -785,6 +785,10 @@ func (cluster *Cluster) Run() {
 							go cluster.CheckSlavesReplicationsPurge()
 						}
 						cluster.PrintDelayStat()
+
+						if cluster.Conf.GraphiteMetrics && cluster.StateMachine.GetHeartbeats()%5 == 0 {
+							cluster.SendGraphiteMetrics()
+						}
 					} else {
 						cluster.StateMachine.PreserveState("ERR00100")
 					}

--- a/cluster/cluster_graphite.go
+++ b/cluster/cluster_graphite.go
@@ -27,6 +27,7 @@ type ClusterGraphite struct {
 	UseBlacklist bool
 	Whitelist    []*regexp.Regexp
 	Blacklist    []*regexp.Regexp
+	metrics      []graphite.Metric
 	lock         sync.Mutex
 }
 
@@ -114,7 +115,14 @@ func (cg *ClusterGraphite) GetGraphiteConnection() (*graphite.Graphite, error) {
 	return cg.gc, nil
 }
 
-func (cg *ClusterGraphite) SendMetrics(metrics []graphite.Metric) error {
+func (cg *ClusterGraphite) AddMetrics(metrics []graphite.Metric) {
+	cg.lock.Lock()
+	defer cg.lock.Unlock()
+
+	cg.metrics = append(cg.metrics, metrics...)
+}
+
+func (cg *ClusterGraphite) SendGraphiteMetrics() error {
 	cg.lock.Lock()
 	defer cg.lock.Unlock()
 
@@ -128,10 +136,12 @@ func (cg *ClusterGraphite) SendMetrics(metrics []graphite.Metric) error {
 		return err
 	}
 
-	err = graph.SendMetrics(metrics)
+	err = graph.SendMetrics(cg.metrics)
 	if err != nil {
 		return err
 	}
+
+	cg.metrics = make([]graphite.Metric, 0) // Clear metrics after sending
 
 	return nil
 }

--- a/cluster/prx.go
+++ b/cluster/prx.go
@@ -127,7 +127,7 @@ type DatabaseProxy interface {
 	GetEnv() map[string]string
 	GetSshEnv() string
 	GetConfigProxyModule(variable string) string
-	SendStats() error
+	FetchStats()
 
 	OpenSVCGetProxyDefaultSection() map[string]string
 
@@ -420,7 +420,7 @@ func (cluster *Cluster) refreshProxies(wcg *sync.WaitGroup) {
 				pr.SetPrevState(pr.GetState())
 			}
 			if cluster.Conf.GraphiteMetrics {
-				pr.SendStats()
+				pr.FetchStats()
 			}
 			//	pr.DelLock()
 		}
@@ -445,11 +445,7 @@ func (cluster *Cluster) initProxies() {
 	}
 }
 
-func (cluster *Cluster) SendProxyStats(proxy DatabaseProxy) error {
-	return proxy.SendStats()
-}
-
-func (proxy *Proxy) SendStats() error {
+func (proxy *Proxy) FetchStats() {
 	metrics := make([]graphite.Metric, 0)
 
 	for _, wbackend := range proxy.BackendsWrite {
@@ -476,5 +472,5 @@ func (proxy *Proxy) SendStats() error {
 		metrics = append(metrics, graphite.NewMetric(fmt.Sprintf("proxy.%s%s.%s.latency", proxy.Type, proxy.Id, server), wbackend.PrxLatency, time.Now().Unix()))
 	}
 
-	return proxy.GetCluster().SendMetrics(metrics)
+	proxy.GetCluster().AddMetrics(metrics)
 }

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1153,7 +1153,7 @@ func (server *ServerMonitor) Refresh() error {
 
 	// Initialize graphite monitoring
 	if cluster.Conf.GraphiteMetrics {
-		go server.SendDatabaseStats()
+		go server.FetchDatabaseStats()
 	}
 	return nil
 }

--- a/cluster/srv_snd.go
+++ b/cluster/srv_snd.go
@@ -93,9 +93,9 @@ func (server *ServerMonitor) GetDatabaseMetrics() []graphite.Metric {
 	return metrics
 }
 
-func (server *ServerMonitor) SendDatabaseStats() error {
+func (server *ServerMonitor) FetchDatabaseStats() error {
 	metrics := server.GetDatabaseMetrics()
-	server.GetCluster().SendMetrics(metrics)
+	server.GetCluster().AddMetrics(metrics)
 	return nil
 }
 

--- a/cluster/srv_snd.go
+++ b/cluster/srv_snd.go
@@ -93,10 +93,8 @@ func (server *ServerMonitor) GetDatabaseMetrics() []graphite.Metric {
 	return metrics
 }
 
-func (server *ServerMonitor) FetchDatabaseStats() error {
-	metrics := server.GetDatabaseMetrics()
-	server.GetCluster().AddMetrics(metrics)
-	return nil
+func (server *ServerMonitor) FetchDatabaseStats() {
+	server.GetCluster().AddMetrics(server.GetDatabaseMetrics())
 }
 
 func (server *ServerMonitor) SendAlert() error {


### PR DESCRIPTION
This pull request refactors how metrics are collected and sent to Graphite throughout the codebase. The main change is the decoupling of metrics collection from their transmission: metrics are now accumulated and sent in batches at regular intervals, rather than being sent immediately after collection. This improves efficiency and reliability of metric reporting.

**Metrics collection and reporting refactor:**

* Replaced all `SendStats` methods with `FetchStats` methods in the `App`, `Proxy`, and `ServerMonitor` classes, changing their responsibilities from sending metrics directly to just collecting and adding them to a buffer. (`cluster/app.go` [[1]](diffhunk://#diff-224ae3cc73abcacf80c0831721e294bfd26c49a57a67cc1fdb2343cf7ec098c6L83-R83) `cluster/prx.go` [[2]](diffhunk://#diff-a1c4554e1b8f361bf9e6d5a29900403ccee9c45fd57c773806c064fc53ca4bcaL130-R130) [[3]](diffhunk://#diff-a1c4554e1b8f361bf9e6d5a29900403ccee9c45fd57c773806c064fc53ca4bcaL448-R448) [[4]](diffhunk://#diff-a1c4554e1b8f361bf9e6d5a29900403ccee9c45fd57c773806c064fc53ca4bcaL479-R475) `cluster/srv.go` [[5]](diffhunk://#diff-c5fffdb4a6a092160ddd24b95042ba54bfcb96dfb0e747bb200902aac778adb1L1156-R1156) `cluster/srv_snd.go` [[6]](diffhunk://#diff-595c4b4eedd70fc0ee0135c815295182475836b514282cf8e58fa7c92f6219acL96-R97)
* Updated all places where metrics were previously sent directly to now use the new `FetchStats` methods for collection only. (`cluster/prx.go` [[1]](diffhunk://#diff-a1c4554e1b8f361bf9e6d5a29900403ccee9c45fd57c773806c064fc53ca4bcaL423-R423) `cluster/app.go` [[2]](diffhunk://#diff-224ae3cc73abcacf80c0831721e294bfd26c49a57a67cc1fdb2343cf7ec098c6L83-R83) `cluster/srv.go` [[3]](diffhunk://#diff-c5fffdb4a6a092160ddd24b95042ba54bfcb96dfb0e747bb200902aac778adb1L1156-R1156)

**Batching and sending metrics:**

* Introduced a metrics buffer (`metrics []graphite.Metric`) and locking in `ClusterGraphite` to accumulate metrics before sending. Added new `AddMetrics` and `SendGraphiteMetrics` methods to manage this buffer and send all collected metrics in one batch, clearing the buffer after sending. (`cluster/cluster_graphite.go` [[1]](diffhunk://#diff-8e6ecfd1be9481c05f849c2d65200d9967df1e87cf30101d2e6637d3a6ff0146R30) [[2]](diffhunk://#diff-8e6ecfd1be9481c05f849c2d65200d9967df1e87cf30101d2e6637d3a6ff0146L117-R125) [[3]](diffhunk://#diff-8e6ecfd1be9481c05f849c2d65200d9967df1e87cf30101d2e6637d3a6ff0146L131-R145)
* Updated the cluster's main run loop to send metrics to Graphite every 5 heartbeats if enabled, using the new batch sending mechanism. (`cluster/cluster.go` [cluster/cluster.goR788-R791](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R788-R791))

**Codebase cleanup:**

* Removed the unused import of `graphite` from `cluster/app.go` as metrics sending is now handled centrally. (`cluster/app.go` [cluster/app.goL19](diffhunk://#diff-224ae3cc73abcacf80c0831721e294bfd26c49a57a67cc1fdb2343cf7ec098c6L19))