### PR TITLE
feat(Backup): add support for sftp by introducing backup-restic-local-repository configuration

### DIFF
--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -42,6 +42,12 @@ func (cluster *Cluster) ResticGetEnv() []string {
 	return newEnv
 }
 
+func (cluster *Cluster) ReloadResticEnv() {
+	if cluster.ResticManager != nil {
+		cluster.ResticManager.SetEnv(cluster.ResticGetEnv())
+	}
+}
+
 func (cluster *Cluster) CheckResticInstallation() {
 	if cluster.Conf.BackupRestic && cluster.VersionsMap.Get("restic") == nil {
 		if err := cluster.RefreshResticVersion(); err != nil {
@@ -99,7 +105,7 @@ func (cluster *Cluster) StartResticManager() error {
 	}
 
 	cluster.ResticManager = backupmgr.NewResticRepo(cluster.Conf.BackupResticBinaryPath, cluster.MessageChan, config.ConstLogModRestic)
-	cluster.ResticManager.SetEnv(cluster.ResticGetEnv())
+	cluster.ReloadResticEnv()
 	go cluster.ResticFetchRepo()
 	return nil
 }
@@ -481,7 +487,7 @@ func (cluster *Cluster) ChangeResticRepoPassword(newpass string) error {
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlInfo, "Changing restic password for cluster %s", cluster.Name)
 
-	cluster.ResticManager.SetEnv(cluster.ResticGetEnv())
+	cluster.ReloadResticEnv()
 
 	keylist, err := cluster.ResticManager.GetRepoKeyList()
 	if err != nil {
@@ -546,7 +552,7 @@ func (cluster *Cluster) ChangeResticRepoPassword(newpass string) error {
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlInfo, "New restic password saved in configuration successfully. Removing old key from repository using new password.")
 
 	// Reload env with new password
-	cluster.ResticManager.SetEnv(cluster.ResticGetEnv())
+	cluster.ReloadResticEnv()
 
 	// Remove old key using new password
 	err = cluster.ResticManager.RemoveRepoKey(oldkeyid)

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -1542,7 +1542,13 @@ func (cluster *Cluster) GetVaultToken() {
 }
 
 func (cluster *Cluster) GetResticLocalDir() string {
-	return cluster.Conf.WorkingDir + "/" + config.ConstStreamingSubDir + "/archive/" + cluster.Name
+	if cluster.Conf.BackupResticLocalRepository != "" {
+		return cluster.Conf.BackupResticLocalRepository // To support sftp repository e.g. sftp:user@host:/path/to/repo
+	}
+
+	// Persist the restic local repo path to prevent wrong paths if WorkingDir change during runtime
+	cluster.Conf.BackupResticLocalRepository = cluster.Conf.WorkingDir + "/" + config.ConstStreamingSubDir + "/archive/" + cluster.Name
+	return cluster.Conf.BackupResticLocalRepository
 }
 
 func (cluster *Cluster) GetExecEnv() []string {

--- a/config/config.go
+++ b/config/config.go
@@ -729,6 +729,7 @@ type Config struct {
 	BackupKeepWithinYearly                    string                 `mapstructure:"backup-keep-within-yearly" toml:"backup-keep-within-yearly" json:"backupKeepWithinYearly"`
 	BackupRestic                              bool                   `mapstructure:"backup-restic" toml:"backup-restic" json:"backupRestic"`
 	BackupResticBinaryPath                    string                 `mapstructure:"backup-restic-binary-path" toml:"backup-restic-binary-path" json:"backupResticBinaryPath"`
+	BackupResticLocalRepository               string                 `mapstructure:"backup-restic-local-repository" toml:"backup-restic-local-repository" json:"backupResticLocalRepository"`
 	BackupResticAwsAccessKeyId                string                 `mapstructure:"backup-restic-aws-access-key-id" toml:"backup-restic-aws-access-key-id" json:"backupResticAwsAccessKeyId"`
 	BackupResticAwsAccessSecret               string                 `mapstructure:"backup-restic-aws-access-secret"  toml:"backup-restic-aws-access-secret" json:"-"`
 	BackupResticRepository                    string                 `mapstructure:"backup-restic-repository" toml:"backup-restic-repository" json:"backupResticRepository"`

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -3153,12 +3153,20 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 	case "log-level-file":
 		val, _ := strconv.Atoi(value)
 		mycluster.Conf.LogFileLevel = val
+	case "backup-restic-local-repository":
+		val, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return errors.New("Unable to decode")
+		}
+		mycluster.Conf.BackupResticLocalRepository = string(val)
+		mycluster.ReloadResticEnv()
 	case "backup-restic-repository":
 		val, err := base64.StdEncoding.DecodeString(value)
 		if err != nil {
 			return errors.New("Unable to decode")
 		}
 		mycluster.Conf.BackupResticRepository = string(val)
+		mycluster.ReloadResticEnv()
 	case "backup-restic-aws-access-key-id":
 		mycluster.Conf.BackupResticAwsAccessKeyId = value
 	case "backup-restic-aws-access-secret":

--- a/server/server.go
+++ b/server/server.go
@@ -796,6 +796,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.BackupResticBinaryPath, "backup-restic-binary-path", "/usr/bin/restic", "Path to restic binary")
 	flags.StringVar(&conf.BackupResticAwsAccessKeyId, "backup-restic-aws-access-key-id", "admin", "Restic backup AWS key id")
 	flags.StringVar(&conf.BackupResticAwsAccessSecret, "backup-restic-aws-access-secret", "secret", "Restic backup AWS key sercret")
+	flags.StringVar(&conf.BackupResticLocalRepository, "backup-restic-local-repository", "", "Restic local repository path. Empty by default to use repo per cluster in datadir/backups/archive/<clustername>")
 	flags.StringVar(&conf.BackupResticRepository, "backup-restic-repository", "s3:https://s3.signal18.io/backups", "Restic backend repository")
 	flags.StringVar(&conf.BackupResticPassword, "backup-restic-password", "secret", "Restic backend password")
 	flags.BoolVar(&conf.BackupResticAws, "backup-restic-aws", false, "Restic will archive to s3 or to datadir/backups/archive")

--- a/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
@@ -631,6 +631,25 @@ The script will be executed with the following parameters:
           )
         },
         {
+          key: 'Backup restic local repository',
+          value: (
+            <TextForm
+              value={selectedCluster?.config?.backupResticLocalRepository}
+              confirmTitle={`Confirm backup-restic-local-repository to `}
+              className={styles.textbox}
+              onSave={(value) =>
+                dispatch(
+                  setSetting({
+                    clusterName: selectedCluster?.name,
+                    setting: 'backup-restic-local-repository',
+                    value: value
+                  })
+                )
+              }
+            />
+          )
+        },
+        {
           key: 'Backup restic password',
           value: (
             <TextForm

--- a/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
@@ -642,7 +642,7 @@ The script will be executed with the following parameters:
                   setSetting({
                     clusterName: selectedCluster?.name,
                     setting: 'backup-restic-local-repository',
-                    value: value
+                    value: btoa(value)
                   })
                 )
               }


### PR DESCRIPTION
This pull request introduces enhancements to the configuration and management of Restic backup repositories, focusing on improved flexibility for specifying local repository paths and ensuring environment variables are correctly updated when settings change. The changes span configuration structures, runtime logic, API handling, and the user interface.

**Configuration and Environment Management:**

* Added a new configuration field `BackupResticLocalRepository` to allow explicit specification of the Restic local repository path, improving support for custom and remote (e.g., SFTP) repositories. (`config/config.go`, [config/config.goR732](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R732))
* Updated the logic in `GetResticLocalDir` to prioritize `BackupResticLocalRepository` if set, and persist the computed repository path to configuration to prevent inconsistencies during runtime changes. (`cluster/cluster_get.go`, [cluster/cluster_get.goL1545-R1551](diffhunk://#diff-ebe18c11af755e19a8493b229fe8b73799087472ad6bc067ea4e2b69df70b6f7L1545-R1551))

**Runtime and API Handling:**

* Introduced the `ReloadResticEnv` method to centralize and streamline updating Restic environment variables, replacing multiple direct calls to `SetEnv` throughout the codebase. (`cluster/cluster_bck.go`, [[1]](diffhunk://#diff-eb7be6f71b81f7dd226a6985f412f36c5d14559999797bf6c7fa5c815232eea9R45-R50) [[2]](diffhunk://#diff-eb7be6f71b81f7dd226a6985f412f36c5d14559999797bf6c7fa5c815232eea9L102-R108) [[3]](diffhunk://#diff-eb7be6f71b81f7dd226a6985f412f36c5d14559999797bf6c7fa5c815232eea9L484-R490) [[4]](diffhunk://#diff-eb7be6f71b81f7dd226a6985f412f36c5d14559999797bf6c7fa5c815232eea9L549-R555)
* Modified the cluster settings API to support updating `backup-restic-local-repository` and `backup-restic-repository` at runtime, with immediate environment reload to ensure changes take effect without restart. (`server/api_cluster.go`, [server/api_cluster.goR3156-R3169](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afR3156-R3169))
* Added a new command-line flag for specifying `backup-restic-local-repository`, enabling configuration via startup parameters. (`server/server.go`, [server/server.goR799](diffhunk://#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4R799))

**User Interface:**

* Added a new editable field for "Backup restic local repository" to the backup settings page, allowing users to set or change the repository path from the dashboard. (`share/dashboard_react/src/Pages/Settings/BackupSettings.jsx`, [share/dashboard_react/src/Pages/Settings/BackupSettings.jsxR633-R651](diffhunk://#diff-ef0c47fa54ff21d2c74ce82a6e0f85fd2465bfa78a0137323d64627c8186248cR633-R651))