### PR TITLE
feat(docs): add support for backup post-scripts and update Swagger definitions

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -20500,14 +20500,23 @@ const docTemplate = `{
                 "masterHost": {
                     "$ref": "#/definitions/sql.NullString"
                 },
+                "masterLastEventTime": {
+                    "$ref": "#/definitions/sql.NullString"
+                },
                 "masterLogFile": {
                     "$ref": "#/definitions/sql.NullString"
                 },
                 "masterPort": {
                     "$ref": "#/definitions/sql.NullString"
                 },
+                "masterRetryCount": {
+                    "$ref": "#/definitions/sql.NullInt64"
+                },
                 "masterServerId": {
                     "type": "integer"
+                },
+                "masterSlaveTimeDiff": {
+                    "$ref": "#/definitions/sql.NullInt64"
                 },
                 "masterUser": {
                     "$ref": "#/definitions/sql.NullString"
@@ -20558,6 +20567,9 @@ const docTemplate = `{
                     "type": "number"
                 },
                 "slaveIoRunning": {
+                    "$ref": "#/definitions/sql.NullString"
+                },
+                "slaveLastEventTime": {
                     "$ref": "#/definitions/sql.NullString"
                 },
                 "slaveSQLRunningState": {
@@ -20899,6 +20911,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "backupResticBinaryPath": {
+                    "type": "string"
+                },
+                "backupResticLocalRepository": {
                     "type": "string"
                 },
                 "backupResticRepository": {
@@ -22582,6 +22597,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "replicationMasterConnectRetry": {
+                    "type": "integer"
+                },
+                "replicationMasterRetryCount": {
                     "type": "integer"
                 },
                 "replicationMasterSlaveNeverRelay": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -20489,14 +20489,23 @@
                 "masterHost": {
                     "$ref": "#/definitions/sql.NullString"
                 },
+                "masterLastEventTime": {
+                    "$ref": "#/definitions/sql.NullString"
+                },
                 "masterLogFile": {
                     "$ref": "#/definitions/sql.NullString"
                 },
                 "masterPort": {
                     "$ref": "#/definitions/sql.NullString"
                 },
+                "masterRetryCount": {
+                    "$ref": "#/definitions/sql.NullInt64"
+                },
                 "masterServerId": {
                     "type": "integer"
+                },
+                "masterSlaveTimeDiff": {
+                    "$ref": "#/definitions/sql.NullInt64"
                 },
                 "masterUser": {
                     "$ref": "#/definitions/sql.NullString"
@@ -20547,6 +20556,9 @@
                     "type": "number"
                 },
                 "slaveIoRunning": {
+                    "$ref": "#/definitions/sql.NullString"
+                },
+                "slaveLastEventTime": {
                     "$ref": "#/definitions/sql.NullString"
                 },
                 "slaveSQLRunningState": {
@@ -20888,6 +20900,9 @@
                     "type": "string"
                 },
                 "backupResticBinaryPath": {
+                    "type": "string"
+                },
+                "backupResticLocalRepository": {
                     "type": "string"
                 },
                 "backupResticRepository": {
@@ -22571,6 +22586,9 @@
                     "type": "string"
                 },
                 "replicationMasterConnectRetry": {
+                    "type": "integer"
+                },
+                "replicationMasterRetryCount": {
                     "type": "integer"
                 },
                 "replicationMasterSlaveNeverRelay": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1588,12 +1588,18 @@ definitions:
         $ref: '#/definitions/sql.NullString'
       masterHost:
         $ref: '#/definitions/sql.NullString'
+      masterLastEventTime:
+        $ref: '#/definitions/sql.NullString'
       masterLogFile:
         $ref: '#/definitions/sql.NullString'
       masterPort:
         $ref: '#/definitions/sql.NullString'
+      masterRetryCount:
+        $ref: '#/definitions/sql.NullInt64'
       masterServerId:
         type: integer
+      masterSlaveTimeDiff:
+        $ref: '#/definitions/sql.NullInt64'
       masterUser:
         $ref: '#/definitions/sql.NullString'
       postgresExternalId:
@@ -1627,6 +1633,8 @@ definitions:
       slaveHeartbeatPeriod:
         type: number
       slaveIoRunning:
+        $ref: '#/definitions/sql.NullString'
+      slaveLastEventTime:
         $ref: '#/definitions/sql.NullString'
       slaveSQLRunningState:
         $ref: '#/definitions/sql.NullString'
@@ -1854,6 +1862,8 @@ definitions:
       backupResticAwsAccessKeyId:
         type: string
       backupResticBinaryPath:
+        type: string
+      backupResticLocalRepository:
         type: string
       backupResticRepository:
         type: string
@@ -2977,6 +2987,8 @@ definitions:
       replicationErrorScript:
         type: string
       replicationMasterConnectRetry:
+        type: integer
+      replicationMasterRetryCount:
         type: integer
       replicationMasterSlaveNeverRelay:
         type: boolean

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -3251,6 +3251,18 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 			return errors.New("Unable to decode")
 		}
 		mycluster.Conf.BackupMysqlclientOptions = string(val)
+	case "backup-logical-post-script":
+		val, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return errors.New("Unable to decode")
+		}
+		mycluster.Conf.BackupLogicalPostScript = string(val)
+	case "backup-physical-post-script":
+		val, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return errors.New("Unable to decode")
+		}
+		mycluster.Conf.BackupPhysicalPostScript = string(val)
 	case "cloud18-monthly-infra-cost":
 		val, _ := strconv.ParseFloat(value, 64)
 		mycluster.Conf.Cloud18MonthlyInfraCost = val

--- a/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
@@ -74,6 +74,14 @@ The script will be executed with the following parameters:
 7. Cluster Name
 `
 
+const BackupPostScriptRequirement = `Post-backup script will execute a script.  
+The script will be executed with the following parameters:  
+1. Cluster name
+2. DB Server Host
+3. DB Server Port
+4. Backup Path
+`
+
   const openCommonModal = () => {
     setIsCommonModalOpen(true)
   }
@@ -182,6 +190,33 @@ The script will be executed with the following parameters:
             }}
           />
         </Flex>
+      )
+    },
+    {
+      key: (
+        <Stack>
+          <Text>Logical Backup Post-Script</Text>
+        </Stack>
+      ),
+      value: (
+        <HStack width={'100%'}>
+          <TextForm
+            value={selectedCluster?.config?.backupLogicalPostScript}
+            confirmTitle={`Confirm backup-logical-post-script to `}
+            maxLength={1024}
+            className={styles.textbox}
+            onSave={(value) =>
+              dispatch(
+                setSetting({
+                  clusterName: selectedCluster?.name,
+                  setting: 'backup-logical-post-script',
+                  value: btoa(value)
+                })
+              )
+            }
+          />
+          <RMIconButton icon={HiQuestionMarkCircle} onClick={() => { setAction({ title: 'Backup Logical Post-Script', type: '', body: <Box><Markdown remarkPlugins={[remarkGfm]}>{BackupPostScriptRequirement}</Markdown></Box> }); openCommonModal() }} />
+        </HStack>
       )
     },
     {
@@ -326,6 +361,33 @@ The script will be executed with the following parameters:
             }
           />
         </Flex>
+      )
+    },
+    {
+      key: (
+        <Stack>
+          <Text>Physical Backup Post-Script</Text>
+        </Stack>
+      ),
+      value: (
+        <HStack width={'100%'}>
+          <TextForm
+            value={selectedCluster?.config?.backupPhysicalPostScript}
+            confirmTitle={`Confirm backup-physical-post-script to `}
+            maxLength={1024}
+            className={styles.textbox}
+            onSave={(value) =>
+              dispatch(
+                setSetting({
+                  clusterName: selectedCluster?.name,
+                  setting: 'backup-physical-post-script',
+                  value: btoa(value)
+                })
+              )
+            }
+          />
+          <RMIconButton icon={HiQuestionMarkCircle} onClick={() => { setAction({ title: 'Backup Physical Post-Script', type: '', body: <Box><Markdown remarkPlugins={[remarkGfm]}>{BackupPostScriptRequirement}</Markdown></Box> }); openCommonModal() }} />
+        </HStack>
       )
     },
     {


### PR DESCRIPTION
This pull request updates the documentation and UI to support new backup and replication configuration options, and introduces settings for post-backup scripts in the cluster management interface. The main changes are grouped below:

**Documentation and API Schema Updates:**

* Added new fields to the backup and replication configuration schemas, including `masterLastEventTime`, `masterRetryCount`, `masterSlaveTimeDiff`, `slaveLastEventTime`, `backupResticLocalRepository`, and `replicationMasterRetryCount` in `docs.go`, `swagger.json`, and `swagger.yaml`. These additions improve visibility and control over backup and replication processes. [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R20503-R20520) [[2]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R20572-R20574) [[3]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R20916-R20918) [[4]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R22602-R22604) [[5]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R20492-R20509) [[6]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R20561-R20563) [[7]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R20905-R20907) [[8]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R22591-R22593) [[9]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R1591-R1602) [[10]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R1637-R1638) [[11]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R1866-R1867) [[12]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R2991-R2992)

**Cluster Settings API:**

* Added support for setting and decoding new cluster configuration options: `backup-logical-post-script` and `backup-physical-post-script` in the `setClusterSetting` method, allowing post-backup scripts to be configured via the API.

**Dashboard UI Enhancements:**

* Introduced new UI fields for configuring "Logical Backup Post-Script" and "Physical Backup Post-Script" in the backup settings page, enabling users to set scripts that run after backups complete. These fields include help dialogs explaining the script parameters. [[1]](diffhunk://#diff-ef0c47fa54ff21d2c74ce82a6e0f85fd2465bfa78a0137323d64627c8186248cR195-R221) [[2]](diffhunk://#diff-ef0c47fa54ff21d2c74ce82a6e0f85fd2465bfa78a0137323d64627c8186248cR366-R392)
* Added a description for post-backup script requirements, clarifying the parameters passed to the script.

These changes collectively improve backup and replication configuration management and enhance the user experience for cluster administrators.