### PR TITLE
feat(log): add handling for Error 2002 in log parsing and set error messages as state

### DIFF
--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -3257,6 +3257,7 @@ func (server *ServerMonitor) ParseLogEntries(entry config.LogEntry, mod int, tas
 	binRegex := regexp.MustCompile(`filename '([^']+)', position '([^']+)', GTID of the last change '([^']+)'`)
 	startRegex := regexp.MustCompile(`Job [^']+ initiated`)
 	endRegex := regexp.MustCompile(`Job [^']+ ended with state`)
+	err2002Regex := regexp.MustCompile(`Error 2002 \(HY000\)`)
 
 	lines := strings.Split(strings.ReplaceAll(entry.Log, "\\n", "\n"), "\n")
 	for _, line := range lines {
@@ -3265,7 +3266,9 @@ func (server *ServerMonitor) ParseLogEntries(entry config.LogEntry, mod int, tas
 				cluster.LogModulePrintf(cluster.Conf.Verbose, mod, config.LvlInfo, "[%s] Job initiated: %s", server.URL, task)
 			}
 			// Process the individual log line (e.g., write to file, send to a logging system, etc.)
-			if matches := endRegex.FindStringSubmatch(line); matches != nil {
+			if matches := err2002Regex.FindStringSubmatch(line); matches != nil {
+				cluster.SetState("ERR00102", state.State{ErrType: "WARN", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["ERR00102"], server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
+			} else if matches := endRegex.FindStringSubmatch(line); matches != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, mod, config.LvlInfo, "[%s] %s", server.URL, line)
 			} else if strings.Contains(line, "ERROR") || strings.Contains(line, "Error") {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, mod, config.LvlErr, "[%s] %s", server.URL, line)

--- a/config/error.go
+++ b/config/error.go
@@ -119,6 +119,7 @@ var ClusterError = map[string]string{
 	"ERR00099":  "Failed to enable GTID Mode on slave %s. Err: %s",
 	"ERR00100":  "Cluster is in switchover. Switchover started at %s",
 	"ERR00101":  "Cluster DB user is same as replication user, but with different password",
+	"ERR00102":  "Jobs unable to connect to db in %s",
 	"WARN0022":  "Rejoining standalone server %s to master %s",
 	"WARN0023":  "Number of failed master ping has been reached",
 	"WARN0045":  "Provision task is in queue",


### PR DESCRIPTION
This pull request introduces improved error handling for job log parsing in the cluster server monitor. The main change is the detection and reporting of database connection errors (specifically MySQL error 2002) during job execution, which helps with monitoring and troubleshooting cluster jobs.

**Error handling improvements:**

* Added a new error code `ERR00102` to the `ClusterError` map to represent jobs unable to connect to the database, with a corresponding error message template.
* Introduced a new regular expression `err2002Regex` in `srv_job.go` to detect MySQL error 2002 (connection error) in job logs.
* Updated the log parsing logic in `ParseLogEntries` to check for error 2002 lines first and set the cluster state to `ERR00102` with a warning if detected, before handling job end events.