### PR TITLE
Job err 2002

### DIFF
--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -3267,7 +3267,11 @@ func (server *ServerMonitor) ParseLogEntries(entry config.LogEntry, mod int, tas
 			}
 			// Process the individual log line (e.g., write to file, send to a logging system, etc.)
 			if matches := err2002Regex.FindStringSubmatch(line); matches != nil {
-				cluster.SetState("ERR00102", state.State{ErrType: "WARN", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["ERR00102"], server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
+				if server.IsFailed() {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, mod, config.LvlDbg, "[%s] Job error: %s", server.URL, line)
+				} else {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, mod, config.LvlErr, "[%s] Job error: %s", server.URL, line)
+				}
 			} else if matches := endRegex.FindStringSubmatch(line); matches != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, mod, config.LvlInfo, "[%s] %s", server.URL, line)
 			} else if strings.Contains(line, "ERROR") || strings.Contains(line, "Error") {

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -3257,7 +3257,7 @@ func (server *ServerMonitor) ParseLogEntries(entry config.LogEntry, mod int, tas
 	binRegex := regexp.MustCompile(`filename '([^']+)', position '([^']+)', GTID of the last change '([^']+)'`)
 	startRegex := regexp.MustCompile(`Job [^']+ initiated`)
 	endRegex := regexp.MustCompile(`Job [^']+ ended with state`)
-	err2002Regex := regexp.MustCompile(`Error 2002 \(HY000\)`)
+	err2002Regex := regexp.MustCompile(`Database query failed`)
 
 	lines := strings.Split(strings.ReplaceAll(entry.Log, "\\n", "\n"), "\n")
 	for _, line := range lines {


### PR DESCRIPTION
This pull request updates the error handling logic in the `ParseLogEntries` method of `cluster/srv_job.go` to improve how job errors are detected and logged. The main change is switching the error detection from a specific MySQL error code to a more general database query failure, and adjusting how job errors are logged depending on the server's failure state.

**Error handling improvements:**

* Changed the error regex from matching `"Error 2002 (HY000)"` to the more general `"Database query failed"`, broadening the scope of error detection.
* Updated the error logging logic to log job errors at debug or error level depending on whether the server has failed, instead of setting the cluster state directly for this error.