### PR TITLE
fix(cluster): add ClearOldCookies method to clean up old cookies during initialization

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -565,6 +565,8 @@ func (cluster *Cluster) InitFromConf() {
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Could not set server list %s", err)
 	}
+	cluster.ClearOldCookies()
+
 	err = cluster.newProxyList()
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Could not set proxy list %s", err)
@@ -1593,6 +1595,19 @@ func (cluster *Cluster) BackupLogs() {
 			s.JobBackupAuditLog()
 		}
 
+	}
+}
+
+func (cluster *Cluster) ClearOldCookies() {
+	for _, s := range cluster.Servers {
+		if s == nil {
+			continue
+		}
+
+		s.DelWaitAuditlogCookie()
+		s.DelWaitErrorlogCookie()
+		s.DelWaitSqlErrorlogCookie()
+		s.DelWaitSlowqueryCookie()
 	}
 }
 func (cluster *Cluster) RotateLogs() {


### PR DESCRIPTION
This pull request introduces a new method to the `Cluster` struct for clearing old log cookies, and ensures it is called during cluster initialization. These changes help maintain cleaner log states across servers when the cluster is set up.

**Log management improvements:**

* Added the `ClearOldCookies` method to the `Cluster` struct, which iterates over all servers and removes audit log, error log, SQL error log, and slow query log cookies.
* Updated the `InitFromConf` method to call `ClearOldCookies` after setting the server list, ensuring old log cookies are cleared during initialization.