### PR TITLE
feat(home): update authorized tabs to include selected cluster name

### DIFF
--- a/share/dashboard_react/src/Pages/Home/index.jsx
+++ b/share/dashboard_react/src/Pages/Home/index.jsx
@@ -98,7 +98,7 @@ function Home() {
           const apiUser = clusterData.apiUsers[loggedUser.User] ? clusterData.apiUsers[loggedUser.User] : clusterData.apiUsers[loggedUser.Email]
           if (apiUser) {
             setUser(apiUser)
-            const authorizedTabs = ['Dashboard', 'Settings', 'Configs']
+            const authorizedTabs = [selectedClusterNameRef.current, 'Settings', 'Configs']
             if (clusterData.config.graphiteMetrics && apiUser.grants['cluster-show-graphs']) {
               authorizedTabs.push('Graphs')
             }


### PR DESCRIPTION
This pull request makes a small update to the list of authorized tabs for users in the `Home` component. The change dynamically sets the first tab to the current selected cluster name instead of the static `'Dashboard'` label.

- The `authorizedTabs` array in `Home` now uses `selectedClusterNameRef.current` as the first tab, making the tab label reflect the currently selected cluster rather than always displaying `'Dashboard'`.