### PR TITLE
Need fetch config

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -748,6 +748,9 @@ func (cluster *Cluster) Run() {
 						if cluster.Conf.TestInjectTraffic || cluster.Conf.TestInjectTrafficStaging || cluster.Conf.AutorejoinSlavePositionalHeartbeat || cluster.Conf.MonitorWriteHeartbeat {
 							cluster.InjectProxiesTraffic()
 						}
+
+						cluster.CheckNeedConfigFetch()
+
 						if cluster.StateMachine.GetHeartbeats()%10 == 0 {
 							cluster.CheckJobsVersion()
 							cluster.MonitorTableSchemaDiff()

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -673,6 +673,8 @@ func (cluster *Cluster) Run() {
 	cluster.Topology = config.TopoUnknown
 	cluster.Unlock()
 
+	cluster.CheckNeedConfigFetch()
+
 	for cluster.exit == false {
 		if !cluster.Conf.MonitorPause {
 			cluster.ServerIdList = cluster.GetDBServerIdList()
@@ -748,8 +750,6 @@ func (cluster *Cluster) Run() {
 						if cluster.Conf.TestInjectTraffic || cluster.Conf.TestInjectTrafficStaging || cluster.Conf.AutorejoinSlavePositionalHeartbeat || cluster.Conf.MonitorWriteHeartbeat {
 							cluster.InjectProxiesTraffic()
 						}
-
-						cluster.CheckNeedConfigFetch()
 
 						if cluster.StateMachine.GetHeartbeats()%10 == 0 {
 							cluster.CheckJobsVersion()

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -673,8 +673,6 @@ func (cluster *Cluster) Run() {
 	cluster.Topology = config.TopoUnknown
 	cluster.Unlock()
 
-	cluster.CheckNeedConfigFetch()
-
 	for cluster.exit == false {
 		if !cluster.Conf.MonitorPause {
 			cluster.ServerIdList = cluster.GetDBServerIdList()

--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -1162,3 +1162,9 @@ func (cluster *Cluster) CheckEstimatedBackupSize(backtype string) error {
 
 	return nil
 }
+
+func (cluster *Cluster) CheckNeedConfigFetch() {
+	for _, srv := range cluster.Servers {
+		srv.CheckNeedConfigFetch()
+	}
+}

--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -1165,6 +1165,9 @@ func (cluster *Cluster) CheckEstimatedBackupSize(backtype string) error {
 
 func (cluster *Cluster) CheckNeedConfigFetch() {
 	for _, srv := range cluster.Servers {
+		if srv == nil {
+			continue
+		}
 		srv.CheckNeedConfigFetch()
 	}
 }

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -398,6 +398,7 @@ func (cluster *Cluster) newServerMonitor(url string, user string, pass string, c
 		server.Conn, err = sqlx.Open("mysql", server.DSN)
 	}*/
 	server.SetConfigRefreshCookie()
+	server.CheckNeedConfigFetch()
 	go server.FetchLastBackupMetadata()
 	return server, err
 }

--- a/cluster/srv_chk.go
+++ b/cluster/srv_chk.go
@@ -610,3 +610,13 @@ func (server *ServerMonitor) CheckTaskNeeded(checktype string) (bool, error) {
 	}
 	return false, nil
 }
+
+func (server *ServerMonitor) CheckNeedConfigFetch() {
+	cluster := server.ClusterGroup
+	// Default action from cluster config
+	if cluster.Conf.ProvDbStartFetchConfig && server.HasNoConfigFetchCookie() {
+		server.DelNoConfigFetchCookie()
+	} else if !cluster.Conf.ProvDbStartFetchConfig && !server.HasNoConfigFetchCookie() {
+		server.SetNoConfigFetchCookie()
+	}
+}

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2374,6 +2374,7 @@ func (repman *ReplicationManager) switchClusterSettings(mycluster *cluster.Clust
 		mycluster.Conf.ProvDBConfigPreserve = !mycluster.Conf.ProvDBConfigPreserve
 	case "prov-db-start-fetch-config":
 		mycluster.Conf.ProvDbStartFetchConfig = !mycluster.Conf.ProvDbStartFetchConfig
+		mycluster.CheckNeedConfigFetch()
 	case "prov-db-apply-dynamic-config":
 		mycluster.SwitchDBApplyDynamicConfig()
 	case "prov-docker-daemon-private":
@@ -3540,6 +3541,7 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		mycluster.Conf.ProvDBConfigPreserve = applyIsActive(mycluster.Conf.ProvDBConfigPreserve, isactive)
 	case "prov-db-start-fetch-config":
 		mycluster.Conf.ProvDbStartFetchConfig = applyIsActive(mycluster.Conf.ProvDbStartFetchConfig, isactive)
+		mycluster.CheckNeedConfigFetch()
 	case "prov-db-apply-dynamic-config":
 		mycluster.Conf.ProvDBApplyDynamicConfig = applyIsActive(mycluster.Conf.ProvDBApplyDynamicConfig, isactive)
 	case "prov-docker-daemon-private":

--- a/server/api_database.go
+++ b/server/api_database.go
@@ -2287,12 +2287,7 @@ func (repman *ReplicationManager) handlerMuxServerStart(w http.ResponseWriter, r
 					node.DelConfigPathCookie() // Overwrite config path
 				}
 			} else if vars["cfgAction"] == "" {
-				// Default action from cluster config
-				if mycluster.Conf.ProvDbStartFetchConfig && node.HasNoConfigFetchCookie() {
-					node.DelNoConfigFetchCookie()
-				} else if !mycluster.Conf.ProvDbStartFetchConfig && !node.HasNoConfigFetchCookie() {
-					node.SetNoConfigFetchCookie()
-				}
+				node.CheckNeedConfigFetch()
 			} else { // If cfgAction is not empty and not "KEEP" or "FETCH" or "OVERWRITE"
 				http.Error(w, "Invalid config action", http.StatusBadRequest)
 				return
@@ -2713,21 +2708,30 @@ func (repman *ReplicationManager) handlerMuxServerNeedConfigFetch(w http.Respons
 		proxy := mycluster.GetProxyFromURL(vars["serverName"] + ":" + vars["serverPort"])
 		if node != nil {
 			if node.HasNoConfigFetchCookie() {
+				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Server %s:%s has no config fetch cookie, skip fetching new config.", vars["serverName"], vars["serverPort"])
+
 				w.WriteHeader(http.StatusInternalServerError)
 				w.Write([]byte("500 -No config fetch needed!"))
+				return
 			}
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Server %s:%s has no config fetch cookie, fetching new config.", vars["serverName"], vars["serverPort"])
 			w.Write([]byte("200 -Need config fetch!"))
 			return
 		} else if proxy != nil {
 			if proxy.HasNoConfigFetchCookie() {
+				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Proxy %s:%s has no config fetch cookie, skip fetching new config.", vars["serverName"], vars["serverPort"])
 				w.WriteHeader(http.StatusInternalServerError)
 				w.Write([]byte("500 -No config fetch needed!"))
+				return
 			}
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Proxy %s:%s has no config fetch cookie, fetching new config.", vars["serverName"], vars["serverPort"])
 			w.Write([]byte("200 -Need config fetch!"))
 			return
 		} else {
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Requesting config fetch check for invalid server %s:%s!", vars["serverName"], vars["serverPort"])
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte("500 -No valid server!"))
+			return
 		}
 	} else {
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
This pull request refactors and centralizes the logic for determining whether a server needs to fetch its configuration, making the process more maintainable and consistent throughout the codebase. The main changes include introducing a new `CheckNeedConfigFetch` method, updating handlers and settings toggles to use this method, and improving logging for configuration fetch decisions.

**Centralization and Refactoring of Config Fetch Logic:**

* Added a new method `CheckNeedConfigFetch` to the `ServerMonitor` and `Cluster` types, encapsulating the logic for setting or clearing the "no config fetch" cookie based on the cluster's `ProvDbStartFetchConfig` setting. This replaces duplicated logic in several places. [[1]](diffhunk://#diff-5bb4c626ee0cfad5a85fa30ec20e412f89ed0abf03e950a7511b28b8fdd89c80R613-R622) [[2]](diffhunk://#diff-a9c48f22ec1d87ff0d2873815cfa59dc52f9a82be452494ba540d4fe89a44774R1165-R1173)
* Updated server initialization and cluster operations to call `CheckNeedConfigFetch` at appropriate times, ensuring consistent config fetch state. [[1]](diffhunk://#diff-c5fffdb4a6a092160ddd24b95042ba54bfcb96dfb0e747bb200902aac778adb1R401) [[2]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R751)

**Integration with Cluster Settings and API:**

* Modified the cluster setting toggles (`switchClusterSettings` and `setClusterSetting`) to invoke `CheckNeedConfigFetch` whenever the `prov-db-start-fetch-config` setting is changed, ensuring all servers are updated immediately. [[1]](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afR2377) [[2]](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afR3544)
* Updated the server start handler to use the new `CheckNeedConfigFetch` method instead of duplicating the logic.

**Improved Logging and API Feedback:**

* Enhanced the config fetch check API handler to log actions and reasons for skipping or performing a config fetch, providing clearer diagnostics and feedback.