### PR TITLE
fix(arbitrator): resolve startup failure with missing config backup directory (#1309)

### DIFF
--- a/arbitrator/arbitrator_cmd.go
+++ b/arbitrator/arbitrator_cmd.go
@@ -52,6 +52,7 @@ func init() {
 	conf.FullVersion = FullVersion
 	conf.MemProfile = memprofile
 	conf.WithTarball = WithTarball
+	server.WithArbitration = "ON"
 	rootCmd.PersistentFlags().StringVar(&conf.ConfigFile, "config", "", "Configuration file (default is config.toml)")
 	rootCmd.Flags().StringVar(&conf.KeyPath, "keypath", "/etc/replication-manager/.replication-manager.key", "Encryption key file path")
 	rootCmd.PersistentFlags().BoolVar(&conf.Verbose, "verbose", false, "Print detailed execution info")

--- a/arbitrator/arbitrator_cmd.go
+++ b/arbitrator/arbitrator_cmd.go
@@ -15,9 +15,12 @@ package arbitrator
 import (
 	"fmt"
 
+	"github.com/signal18/replication-manager/server"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+var withArbitration = "ON"
 
 var rootCmd = &cobra.Command{
 	Use:   "replication-manager",
@@ -52,8 +55,9 @@ func init() {
 	conf.FullVersion = FullVersion
 	conf.MemProfile = memprofile
 	conf.WithTarball = WithTarball
-	server.WithArbitration = "ON"
+	server.WithArbitration = withArbitration
 	rootCmd.PersistentFlags().StringVar(&conf.ConfigFile, "config", "", "Configuration file (default is config.toml)")
+	rootCmd.PersistentFlags().StringVar(&conf.MonitoringSystemUser, "user", "", "OS User for running repman")
 	rootCmd.Flags().StringVar(&conf.KeyPath, "keypath", "/etc/replication-manager/.replication-manager.key", "Encryption key file path")
 	rootCmd.PersistentFlags().BoolVar(&conf.Verbose, "verbose", false, "Print detailed execution info")
 	rootCmd.PersistentFlags().StringVar(&memprofile, "memprofile", "/tmp/repmgr.mprof", "Write a memory profile to a file readable by pprof")

--- a/server/server.go
+++ b/server/server.go
@@ -276,16 +276,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 		//	initDeprecated() // not needed used alias in main
 	}
 	var usr string
-	var configPath string
-	//var pid string
-	if !isClient { // client should not use this
-		flag.StringVar(&usr, "user", "", "help message")
-	}
-	//flag.StringVar(&pid, "pidfile", "", "help message")
-	flag.StringVar(&configPath, "config", "", "help message")
-	flag.Parse()
-
-	if usr == "" && repman != nil {
+	if repman != nil && repman.OsUser != nil {
 		usr = repman.OsUser.Username
 	}
 	flags.StringVar(&conf.MonitoringSystemUser, "user", "", "OS User for running repman")
@@ -1185,7 +1176,7 @@ func (repman *ReplicationManager) initFS(conf config.Config) error {
 	//test y'a  un repertoire ./.replication-manager/share sinon on le créer
 	//repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Embeded run config dir : %s", conf.ConfDir)
 
-	if conf.ConfDirBackup == "" {
+	if conf.ConfDirBackup == "" && WithArbitration != "ON" {
 		repman.Logrus.Fatalf("Monitoring config backup directory not defined")
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"crypto/md5"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"hash"
 	"hash/crc64"
@@ -1183,7 +1182,9 @@ func (repman *ReplicationManager) initFS(conf config.Config) error {
 	if _, err := os.Stat(conf.ConfDirExtra); os.IsNotExist(err) {
 		os.MkdirAll(conf.ConfDirExtra, os.ModePerm)
 		os.MkdirAll(conf.ConfDirExtra+"/cluster.d", os.ModePerm)
-		os.MkdirAll(conf.ConfDirBackup, os.ModePerm)
+		if WithArbitration != "ON" && conf.ConfDirBackup != "" {
+			os.MkdirAll(conf.ConfDirBackup, os.ModePerm)
+		}
 	}
 
 	if conf.WithEmbed == "ON" {
@@ -1756,6 +1757,10 @@ func (repman *ReplicationManager) PushConfigToBackupDir() {
 	}()
 
 	if repman.Conf.WithEmbed == "ON" {
+		return
+	}
+
+	if WithArbitration == "ON" {
 		return
 	}
 

--- a/service/replication-manager-arb.service
+++ b/service/replication-manager-arb.service
@@ -1,9 +1,11 @@
 [Unit]
-Description=replication-manager arbitrator 
+Description=replication-manager arbitrator
 
 [Service]
 Type=simple
 ExecStart=/usr/bin/replication-manager-arb --user repman arbitrator
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/service/replication-manager-arb.service
+++ b/service/replication-manager-arb.service
@@ -3,7 +3,7 @@ Description=replication-manager arbitrator
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/replication-manager-arb --user=repman arbitrator
+ExecStart=/usr/bin/replication-manager-arb --user repman arbitrator
 
 [Install]
 WantedBy=multi-user.target

--- a/service/replication-manager-osc.service
+++ b/service/replication-manager-osc.service
@@ -4,7 +4,7 @@ Description=Signal 18 Replication Manager open source community edition
 [Service]
 Type=simple
 
-ExecStart=/usr/bin/replication-manager-osc --user=repman monitor
+ExecStart=/usr/bin/replication-manager-osc --user repman monitor
 Restart=on-failure
 RestartSec=5
 StartLimitBurst=3

--- a/service/replication-manager-pro.service
+++ b/service/replication-manager-pro.service
@@ -3,7 +3,7 @@ Description=Signal 18 Replication Manager provisioning edition
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/replication-manager-pro --user=repman monitor
+ExecStart=/usr/bin/replication-manager-pro --user repman monitor
 Restart=on-failure
 RestartSec=5
 StartLimitBurst=3


### PR DESCRIPTION
## Summary

Fixes #1309 - Arbitrator service failing to start with error "Monitoring config backup directory not defined"

## Problem Analysis

The arbitrator was failing during initialization due to multiple interconnected issues:

1. **Duplicate flag parsing**: Go's `flag` package was conflicting with Cobra, causing `--user` flag value to be lost when using `--user=value` syntax
2. **Empty ConfDirBackup**: User lookup failed with empty username, resulting in empty backup directory path
3. **Inappropriate fatal error**: Arbitrator never saves config and doesn't need backup directory, but the check didn't account for this

## Changes Made

### Core Fixes
- **server/server.go**:
  - Removed duplicate `flag.Parse()` that conflicted with Cobra flag handling
  - Removed unused `flag` import
  - Added `WithArbitration != "ON"` condition to skip ConfDirBackup requirement for arbitrator
  - Guarded `os.MkdirAll(conf.ConfDirBackup)` to prevent operations on empty paths
  - Added early return in `PushConfigToBackupDir()` when in arbitrator mode

- **server/server_cmd.go**:
  - `WithArbitration` variable already existed (defaults to "OFF")

- **arbitrator/arbitrator_cmd.go**:
  - Added `server` package import
  - Set `server.WithArbitration = "ON"` in init() to signal arbitrator mode
  - Registered `--user` flag as PersistentFlag on rootCmd

### Service Files
- **service/replication-manager-arb.service**:
  - Fixed flag syntax: `--user=repman` → `--user repman`
  - Added `Restart=on-failure` and `RestartSec=5` for consistency
  
- **service/replication-manager-osc.service**:
  - Fixed flag syntax: `--user=repman` → `--user repman`
  
- **service/replication-manager-pro.service**:
  - Fixed flag syntax: `--user=repman` → `--user repman`

## Test Results

All tests pass ✅

- ✅ Arbitrator builds successfully
- ✅ `--user` flag recognized and functional
- ✅ No "Monitoring config backup directory not defined" error
- ✅ No "unknown flag: --user" error
- ✅ Arbitrator starts and discovers cluster configuration
- ✅ Server builds continue to work normally with safety checks intact

## Verification

```bash
# Build arbitrator
make arb

# Test with --user flag
./build/binaries/replication-manager-arb --user repman arbitrator

# Test without --user flag
./build/binaries/replication-manager-arb arbitrator
```

Both scenarios now work correctly. The arbitrator proceeds to cluster discovery and database connection without requiring `ConfDirBackup` to be set.

## Backward Compatibility

No breaking changes:
- Service file syntax correction (old syntax was already broken)
- `WithArbitration` flag follows existing pattern used by `WithTarball`, `WithProvisioning`, etc.
- Server/client builds maintain identical behavior with `WithArbitration="OFF"`
- Arbitrator gets working binary instead of broken one

## Migration Notes

Users with custom systemd service files should update to space-separated flag syntax:
- ❌ Old: `--user=repman`
- ✅ New: `--user repman`

No other migration needed.