### PR TITLE
Skip config and variables generation for ignored servers

### DIFF
--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -1168,6 +1168,9 @@ func (cluster *Cluster) CheckNeedConfigFetch() {
 		if srv == nil {
 			continue
 		}
+		if srv.IsIgnored() {
+			continue
+		}
 		srv.CheckNeedConfigFetch()
 	}
 }
@@ -1176,6 +1179,9 @@ func (cluster *Cluster) CheckNeedConfigFetch() {
 func (cluster *Cluster) CheckDummyConfigSendCookies() {
 	for _, srv := range cluster.Servers {
 		if srv == nil {
+			continue
+		}
+		if srv.IsIgnored() {
 			continue
 		}
 

--- a/cluster/cluster_cnf.go
+++ b/cluster/cluster_cnf.go
@@ -22,31 +22,6 @@ func (cluster *Cluster) GetPreservedVarsPath() string {
 	return filepath.Join(cluster.Conf.WorkingDir, cluster.Name, "preserved_variables.cnf")
 }
 
-// GetPreservedVarsInfo returns information about currently loaded preserved variables
-func (cluster *Cluster) GetPreservedVarsInfo() map[string]interface{} {
-	cluster.preservedVarsMutex.RLock()
-	defer cluster.preservedVarsMutex.RUnlock()
-
-	info := make(map[string]any)
-	info["loaded"] = cluster.preservedVarsLoaded
-	info["count"] = len(cluster.preservedVars)
-	info["path"] = cluster.GetPreservedVarsPath()
-
-	// Check if file exists
-	preservedPath := cluster.GetPreservedVarsPath()
-	if _, err := os.Stat(preservedPath); err == nil {
-		info["exists"] = true
-		if finfo, err := os.Stat(preservedPath); err == nil {
-			info["modified"] = finfo.ModTime()
-			info["size"] = finfo.Size()
-		}
-	} else {
-		info["exists"] = false
-	}
-
-	return info
-}
-
 // ReloadPreservedVars forces a reload of preserved variables from cluster working directory
 // Useful after manually editing the preserved_variables.cnf file
 func (cluster *Cluster) ReloadPreservedVars() error {

--- a/cluster/cluster_cnf.go
+++ b/cluster/cluster_cnf.go
@@ -27,7 +27,7 @@ func (cluster *Cluster) GetPreservedVarsInfo() map[string]interface{} {
 	cluster.preservedVarsMutex.RLock()
 	defer cluster.preservedVarsMutex.RUnlock()
 
-	info := make(map[string]interface{})
+	info := make(map[string]any)
 	info["loaded"] = cluster.preservedVarsLoaded
 	info["count"] = len(cluster.preservedVars)
 	info["path"] = cluster.GetPreservedVarsPath()
@@ -384,23 +384,6 @@ func (cluster *Cluster) initPreservedVars() error {
 		"Loaded %d preserved variables from %s", len(cluster.preservedVars), source)
 
 	return nil
-}
-
-// getPreservedValueForVar returns the preserved value for a variable from cluster-level config
-// Returns empty string if variable is not preserved at cluster level
-// This is checked BEFORE server-specific preserved files (01_preserved.cnf, etc.)
-func (cluster *Cluster) getPreservedValueForVar(varName string) (string, bool) {
-	cluster.preservedVarsMutex.RLock()
-	defer cluster.preservedVarsMutex.RUnlock()
-
-	upperName := strings.ToUpper(varName)
-
-	// Return value if it exists in loaded preserved variables
-	if val, ok := cluster.preservedVars[upperName]; ok {
-		return val, true
-	}
-
-	return "", false
 }
 
 // AddPreservedVar adds or updates a preserved variable

--- a/cluster/cluster_roll.go
+++ b/cluster/cluster_roll.go
@@ -18,6 +18,10 @@ func (cluster *Cluster) RollingReprov() error {
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Rolling reprovisionning")
 	masterID := cluster.GetMaster().Id
 	for _, slave := range cluster.slaves {
+		if slave == nil || slave.IsIgnored() {
+			continue
+		}
+
 		if !slave.IsDown() {
 			if !slave.IsMaintenance {
 				slave.SwitchMaintenance()
@@ -94,7 +98,7 @@ func (cluster *Cluster) RollingRestart() error {
 	cluster.SetFailSync(false)
 	defer cluster.SetFailSync(saveFailoverMode)
 	for _, slave := range cluster.slaves {
-		if slave.SourceClusterName != cluster.Name {
+		if slave == nil || slave.IsIgnored() {
 			continue
 		}
 		if !slave.IsDown() {
@@ -181,6 +185,9 @@ func (cluster *Cluster) RollingRestart() error {
 
 func (cluster *Cluster) RollingOptimize() {
 	for _, s := range cluster.slaves {
+		if s == nil || s.IsIgnored() {
+			continue
+		}
 		jobid, _ := s.JobOptimize()
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Optimize job id %d on %s ", jobid, s.URL)
 	}
@@ -191,7 +198,7 @@ func (cluster *Cluster) RollingJobsUpgrade() error {
 	var ts time.Time
 
 	for _, s := range cluster.slaves {
-		if s == nil {
+		if s == nil || s.IsIgnored() {
 			continue
 		}
 
@@ -213,7 +220,7 @@ func (cluster *Cluster) RollingJobsUpgrade() error {
 	}
 
 	for _, s := range cluster.GetStandaloneServers() {
-		if s == nil {
+		if s == nil || s.IsIgnored() {
 			continue
 		}
 
@@ -235,7 +242,7 @@ func (cluster *Cluster) RollingJobsUpgrade() error {
 	}
 
 	master := cluster.GetMaster()
-	if master == nil {
+	if master == nil || master.IsIgnored() {
 		return nil
 	}
 

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -1030,6 +1030,9 @@ func (cluster *Cluster) SetProxyServersCredential(credential string, proxytype s
 // Set Cookie for all servers that configuration has changed
 func (cluster *Cluster) SetConfigChangeCookie() {
 	for _, srv := range cluster.Servers {
+		if srv == nil || srv.IsIgnored() {
+			continue
+		}
 		srv.SetConfigCookie()        // Persist until config deployed
 		srv.SetConfigRefreshCookie() // Until config refreshed
 	}
@@ -1038,6 +1041,9 @@ func (cluster *Cluster) SetConfigChangeCookie() {
 // Set Cookie for all servers that configuration variables need refresh
 func (cluster *Cluster) SetConfigRefreshCookie() {
 	for _, srv := range cluster.Servers {
+		if srv == nil || srv.IsIgnored() {
+			continue
+		}
 		srv.SetConfigRefreshCookie()
 	}
 }
@@ -1054,6 +1060,9 @@ func (cluster *Cluster) SetDBReprovCookie() {
 }
 func (cluster *Cluster) SetDBConfigPathCookie() {
 	for _, srv := range cluster.Servers {
+		if srv == nil || srv.IsIgnored() {
+			continue
+		}
 		srv.SetConfigPathCookie()
 	}
 }

--- a/cluster/ignored_config_delta_test.go
+++ b/cluster/ignored_config_delta_test.go
@@ -1,0 +1,177 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+
+package cluster
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+)
+
+func newTestClusterWithServers(t *testing.T) (*Cluster, *ServerMonitor, *ServerMonitor) {
+	t.Helper()
+
+	cluster := &Cluster{
+		Name: "test-cluster",
+		Conf: &config.Config{},
+	}
+
+	active := newTestServerWithCluster(t, cluster, false)
+	ignored := newTestServerWithCluster(t, cluster, true)
+	cluster.Servers = serverList{active, ignored}
+
+	return cluster, active, ignored
+}
+
+func newTestServerWithCluster(t *testing.T, cluster *Cluster, ignored bool) *ServerMonitor {
+	t.Helper()
+
+	return &ServerMonitor{
+		Datadir:      t.TempDir(),
+		Host:         "127.0.0.1",
+		Port:         "3306",
+		ClusterGroup: cluster,
+		Ignored:      ignored,
+		VariablesMap: config.NewVariablesMap(),
+	}
+}
+
+func TestIgnoredServersSkipConfigCookies(t *testing.T) {
+	t.Run("SetConfigChangeCookie", func(t *testing.T) {
+		cluster, active, ignored := newTestClusterWithServers(t)
+
+		cluster.SetConfigChangeCookie()
+
+		if !active.HasConfigCookie() {
+			t.Error("expected config cookie for active server")
+		}
+		if !active.HasConfigRefreshCookie() {
+			t.Error("expected config refresh cookie for active server")
+		}
+		if ignored.HasConfigCookie() {
+			t.Error("ignored server should not receive config cookie")
+		}
+		if ignored.HasConfigRefreshCookie() {
+			t.Error("ignored server should not receive config refresh cookie")
+		}
+	})
+
+	t.Run("SetConfigRefreshCookie", func(t *testing.T) {
+		cluster, active, ignored := newTestClusterWithServers(t)
+
+		cluster.SetConfigRefreshCookie()
+
+		if !active.HasConfigRefreshCookie() {
+			t.Error("expected config refresh cookie for active server")
+		}
+		if ignored.HasConfigRefreshCookie() {
+			t.Error("ignored server should not receive config refresh cookie")
+		}
+	})
+
+	t.Run("SetDBConfigPathCookie", func(t *testing.T) {
+		cluster, active, ignored := newTestClusterWithServers(t)
+
+		cluster.SetDBConfigPathCookie()
+
+		if !active.HasConfigPathCookie() {
+			t.Error("expected config path cookie for active server")
+		}
+		if ignored.HasConfigPathCookie() {
+			t.Error("ignored server should not receive config path cookie")
+		}
+	})
+}
+
+func TestCheckNeedConfigFetchSkipsIgnoredServers(t *testing.T) {
+	cluster, active, ignored := newTestClusterWithServers(t)
+
+	cluster.Conf.ProvDbStartFetchConfig = false
+	cluster.CheckNeedConfigFetch()
+
+	if !active.HasNoConfigFetchCookie() {
+		t.Error("expected no-config-fetch cookie for active server")
+	}
+	if ignored.HasNoConfigFetchCookie() {
+		t.Error("ignored server should not receive no-config-fetch cookie")
+	}
+
+	active.SetNoConfigFetchCookie()
+	ignored.SetNoConfigFetchCookie()
+	cluster.Conf.ProvDbStartFetchConfig = true
+	cluster.CheckNeedConfigFetch()
+
+	if active.HasNoConfigFetchCookie() {
+		t.Error("expected no-config-fetch cookie to be removed for active server")
+	}
+	if !ignored.HasNoConfigFetchCookie() {
+		t.Error("ignored server should keep no-config-fetch cookie")
+	}
+}
+
+func TestWriteDeltaVariablesSkippedForIgnoredServer(t *testing.T) {
+	cluster := &Cluster{
+		Name: "test-cluster",
+		Conf: &config.Config{},
+	}
+	server := newTestServerWithCluster(t, cluster, true)
+
+	server.VariablesMap.SetConfigValue("max_connections", "100")
+	server.VariablesMap.SetDeployedValue("max_connections", "100")
+
+	if err := server.WriteDeltaVariables(); err != nil {
+		t.Fatalf("WriteDeltaVariables() returned error: %v", err)
+	}
+
+	deltaPath := filepath.Join(server.Datadir, "02_delta.cnf")
+	if _, err := os.Stat(deltaPath); err == nil {
+		t.Error("delta file should not be created for ignored server")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("unexpected error checking delta file: %v", err)
+	}
+}
+
+func TestProcessDummyConfigSendCookieSkippedForIgnoredServer(t *testing.T) {
+	cluster := &Cluster{
+		Name: "test-cluster",
+		Conf: &config.Config{},
+	}
+	server := newTestServerWithCluster(t, cluster, true)
+
+	if err := server.SetWaitDummyConfigSendCookie(); err != nil {
+		t.Fatalf("SetWaitDummyConfigSendCookie() failed: %v", err)
+	}
+	if !server.HasWaitDummyConfigSendCookie() {
+		t.Fatal("expected dummy config send cookie to exist")
+	}
+
+	if err := server.ProcessDummyConfigSendCookie(); err != nil {
+		t.Fatalf("ProcessDummyConfigSendCookie() returned error: %v", err)
+	}
+	if !server.HasWaitDummyConfigSendCookie() {
+		t.Error("ignored server should keep dummy config send cookie")
+	}
+}
+
+func TestGetDatabaseConfigSkippedForIgnoredServer(t *testing.T) {
+	cluster := &Cluster{
+		Name: "test-cluster",
+		Conf: &config.Config{},
+	}
+	server := newTestServerWithCluster(t, cluster, true)
+
+	if err := server.GetDatabaseConfig(); err != nil {
+		t.Fatalf("GetDatabaseConfig() returned error: %v", err)
+	}
+
+	configPath := filepath.Join(server.Datadir, "config.tar.gz")
+	if _, err := os.Stat(configPath); err == nil {
+		t.Error("config.tar.gz should not be generated for ignored server")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("unexpected error checking config.tar.gz: %v", err)
+	}
+}

--- a/cluster/srv_chk.go
+++ b/cluster/srv_chk.go
@@ -23,6 +23,9 @@ import (
 )
 
 func (server *ServerMonitor) CheckDBConfigPath() {
+	if server.IsIgnored() {
+		return
+	}
 	cluster := server.ClusterGroup
 	if cluster.IsInFailover() {
 		return
@@ -255,6 +258,9 @@ func (server *ServerMonitor) CheckReplication() string {
 
 // CheckSlaveSettings check slave variables & enforce if set
 func (server *ServerMonitor) CheckSlaveSettings() {
+	if server.IsIgnored() {
+		return
+	}
 	sl := server
 	cluster := server.ClusterGroup
 	master := cluster.GetMaster()
@@ -402,6 +408,9 @@ func (server *ServerMonitor) CheckSlaveSettings() {
 
 // CheckMasterSettings check master variables & enforce if set
 func (server *ServerMonitor) CheckMasterSettings() {
+	if server.IsIgnored() {
+		return
+	}
 	cluster := server.ClusterGroup
 	if cluster.Conf.ForceSlaveSemisync && server.HaveSemiSync == false {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Enforce semisync on Master %s", server.URL)
@@ -612,6 +621,9 @@ func (server *ServerMonitor) CheckTaskNeeded(checktype string) (bool, error) {
 }
 
 func (server *ServerMonitor) CheckNeedConfigFetch() {
+	if server.IsIgnored() {
+		return
+	}
 	cluster := server.ClusterGroup
 	// Default action from cluster config
 	if cluster.Conf.ProvDbStartFetchConfig && server.HasNoConfigFetchCookie() {

--- a/cluster/srv_cnf.go
+++ b/cluster/srv_cnf.go
@@ -266,6 +266,10 @@ func (server *ServerMonitor) GetDummyConfig() error {
 func (server *ServerMonitor) ProcessDummyConfigSendCookie() error {
 	cluster := server.ClusterGroup
 
+	if server.IsIgnored() {
+		return nil
+	}
+
 	if !server.HasWaitDummyConfigSendCookie() {
 		return nil
 	}
@@ -346,6 +350,11 @@ func (server *ServerMonitor) sendDummyConfigWithWait(configFile string, cookieMo
 
 func (server *ServerMonitor) getDatabaseConfig(preserve bool) error {
 	cluster := server.ClusterGroup
+
+	if server.IsIgnored() {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Skipping config generation for ignored server %s", server.URL)
+		return nil
+	}
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Database Config generation "+server.Datadir+"/config.tar.gz")
 	if server.IsCompute {
@@ -825,6 +834,10 @@ func isSafeForRuntimeFallback(varName string) bool {
 func (server *ServerMonitor) WriteDeltaVariables() error {
 	cluster := server.ClusterGroup
 	deltapath := filepath.Join(server.Datadir, "02_delta.cnf")
+
+	if server.IsIgnored() {
+		return nil
+	}
 
 	// Build content in memory first
 	var content strings.Builder

--- a/server/api_database.go
+++ b/server/api_database.go
@@ -3136,6 +3136,11 @@ func (repman *ReplicationManager) handlerMuxServersPortConfig(w http.ResponseWri
 		node := mycluster.GetServerFromURL(vars["serverName"] + ":" + vars["serverPort"])
 		proxy := mycluster.GetProxyFromURL(vars["serverName"] + ":" + vars["serverPort"])
 		if node != nil {
+			if node.IsIgnored() {
+				http.Error(w, "Server is ignored, skipping config regeneration", 500)
+				return
+			}
+
 			if vars["dummy"] == "dummy" {
 				node.GetDummyConfig()
 			} else {
@@ -3194,6 +3199,11 @@ func (repman *ReplicationManager) handlerMuxServersPortRegenerateConfig(w http.R
 		node := mycluster.GetServerFromURL(vars["serverName"] + ":" + vars["serverPort"])
 		proxy := mycluster.GetProxyFromURL(vars["serverName"] + ":" + vars["serverPort"])
 		if node != nil {
+			if node.IsIgnored() {
+				http.Error(w, "Server is ignored, skipping config regeneration", 500)
+				return
+			}
+
 			go func() {
 				defer mycluster.LogPanicToFile("printdefault")
 

--- a/server/api_database.go
+++ b/server/api_database.go
@@ -2817,6 +2817,12 @@ func (repman *ReplicationManager) handlerMuxServerNeedConfigFetch(w http.Respons
 		node := mycluster.GetServerFromURL(vars["serverName"] + ":" + vars["serverPort"])
 		proxy := mycluster.GetProxyFromURL(vars["serverName"] + ":" + vars["serverPort"])
 		if node != nil {
+			if node.IsIgnored() {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("500 -No config fetch needed!"))
+				return
+			}
+
 			if node.HasNoConfigFetchCookie() {
 				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Server %s:%s has no config fetch cookie, skip fetching new config.", vars["serverName"], vars["serverPort"])
 
@@ -2828,6 +2834,12 @@ func (repman *ReplicationManager) handlerMuxServerNeedConfigFetch(w http.Respons
 			w.Write([]byte("200 -Need config fetch!"))
 			return
 		} else if proxy != nil {
+			if proxy.IsIgnored() {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("500 -No config fetch needed!"))
+				return
+			}
+
 			if proxy.HasNoConfigFetchCookie() {
 				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Proxy %s:%s has no config fetch cookie, skip fetching new config.", vars["serverName"], vars["serverPort"])
 				w.WriteHeader(http.StatusInternalServerError)
@@ -4339,6 +4351,10 @@ func (repman *ReplicationManager) handlerMuxServersPortConfigReceiver(w http.Res
 			node = mycluster.GetServerFromURL(vars["serverName"] + ":" + vars["serverPort"])
 		}
 		if node != nil {
+			if node.IsIgnored() {
+				http.Error(w, "Server is ignored", 500)
+				return
+			}
 			node.DelConfigRefreshCookie()
 
 			env, err := node.JobReceiveConfigFiles()
@@ -4748,6 +4764,11 @@ func (repman *ReplicationManager) handlerMuxServerAllowJobsUpgrade(w http.Respon
 
 		node := mycluster.GetServerFromName(vars["serverName"])
 		if node != nil {
+			if node.IsIgnored() {
+				http.Error(w, "Server is ignored", 500)
+				return
+			}
+
 			node.SetWaitJobsUpgradeCookie()
 			w.WriteHeader(200)
 			w.Write([]byte("Flagged for jobs upgrade"))

--- a/share/dashboard_react/src/Pages/ClusterDB/components/ClusterDBTabContent/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterDB/components/ClusterDBTabContent/index.jsx
@@ -96,6 +96,7 @@ function ClusterDBTabContent({ tab, dbId, clusterName, digestMode, toggleDigestM
           onNavigateToPFSInstruments={onNavigateToPFSInstruments}
           searchFilter={variablesSearchFilter}
           user={user}
+          selectedDBServer={selectedDBServer}
         />
       ) : currentTab === 'opensvc' ? (
         <ServiceOpenSvc clusterName={clusterName} type="db" id={dbId} />

--- a/share/dashboard_react/src/Pages/ClusterDB/components/ClusterDBTabContent/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterDB/components/ClusterDBTabContent/index.jsx
@@ -18,7 +18,7 @@ import Errors from '../Errors'
 import ServerAudit from '../ServerAudit'
 import PFSInstruments from '../PFSInstruments'
 
-function ClusterDBTabContent({ tab, dbId, clusterName, digestMode, toggleDigestMode, user, selectedDBServer, variableMode, toggleVariableMode, onNavigateToPFSInstruments, onNavigateToVariables, variablesSearchFilter }) {
+function ClusterDBTabContent({ tab, dbId, clusterName, digestMode, toggleDigestMode, user, isIgnoredServer, variableMode, toggleVariableMode, onNavigateToPFSInstruments, onNavigateToVariables, variablesSearchFilter }) {
   const [currentTab, setCurrentTab] = useState('')
 
   const {
@@ -96,7 +96,7 @@ function ClusterDBTabContent({ tab, dbId, clusterName, digestMode, toggleDigestM
           onNavigateToPFSInstruments={onNavigateToPFSInstruments}
           searchFilter={variablesSearchFilter}
           user={user}
-          selectedDBServer={selectedDBServer}
+          isIgnoredServer={isIgnoredServer}
         />
       ) : currentTab === 'opensvc' ? (
         <ServiceOpenSvc clusterName={clusterName} type="db" id={dbId} />

--- a/share/dashboard_react/src/Pages/ClusterDB/components/Variables/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterDB/components/Variables/index.jsx
@@ -211,11 +211,10 @@ const areValuesEqual = (val1, val2, row) => {
   return String(val1) === String(val2)
 }
 
-function Variables({ clusterName, dbId, toggleVariableMode, variableMode, onNavigateToPFSInstruments, searchFilter, user, selectedDBServer }) {
+function Variables({ clusterName, dbId, toggleVariableMode, variableMode, onNavigateToPFSInstruments, searchFilter, user, isIgnoredServer }) {
   const [ vState, vDispatch ] = useReducer(reducer, defaultState)
   const dispatch = useDispatch()
   const variables = useSelector((state) => state.cluster.database.variables)
-  const isIgnoredServer = Boolean(selectedDBServer?.ignored)
 
   const [variablesData, setVariablesData] = useState(variables || [])
   const [variablesAllData, setvariablesAllData] = useState(variables || [])

--- a/share/dashboard_react/src/Pages/ClusterDB/components/Variables/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterDB/components/Variables/index.jsx
@@ -211,10 +211,11 @@ const areValuesEqual = (val1, val2, row) => {
   return String(val1) === String(val2)
 }
 
-function Variables({ clusterName, dbId, toggleVariableMode, variableMode, onNavigateToPFSInstruments, searchFilter, user }) {
+function Variables({ clusterName, dbId, toggleVariableMode, variableMode, onNavigateToPFSInstruments, searchFilter, user, selectedDBServer }) {
   const [ vState, vDispatch ] = useReducer(reducer, defaultState)
   const dispatch = useDispatch()
   const variables = useSelector((state) => state.cluster.database.variables)
+  const isIgnoredServer = Boolean(selectedDBServer?.ignored)
 
   const [variablesData, setVariablesData] = useState(variables || [])
   const [variablesAllData, setvariablesAllData] = useState(variables || [])
@@ -225,6 +226,7 @@ function Variables({ clusterName, dbId, toggleVariableMode, variableMode, onNavi
 
   // Truncate length for table cell values
   const TRUNCATE_LENGTH = 100
+  const disabledActionTooltip = "Server is ignored; variable edits are disabled"
 
   // Get username for user-specific localStorage key
   const username = localStorage.getItem('username') || 'default'
@@ -261,6 +263,11 @@ function Variables({ clusterName, dbId, toggleVariableMode, variableMode, onNavi
 
   const handleConfirm = () => {
     const { type } = confirmState
+
+    if (isIgnoredServer) {
+      closeConfirmModal()
+      return
+    }
     
     if (type === 'preserve') {
       dispatch(preserveVariable({ clusterName, dbId, variableName: payload, action: 'preserve' }))
@@ -288,6 +295,9 @@ function Variables({ clusterName, dbId, toggleVariableMode, variableMode, onNavi
   }
 
   const handleSaveCustomValue = (variableName, customValue) => {
+    if (isIgnoredServer) {
+      return
+    }
     dispatch(setCustomVariableValue({ clusterName, dbId, variableName, customValue }))
       .unwrap()
       .then(() => {
@@ -647,12 +657,16 @@ function Variables({ clusterName, dbId, toggleVariableMode, variableMode, onNavi
             {hasDiff && !hasPreserve && (
               <>
                 <RMIconButton 
-                  tooltip="Preserve deployed value (keep current database value)" 
+                  tooltip={isIgnoredServer ? disabledActionTooltip : "Preserve deployed value (keep current database value)"} 
                   icon={TbShield} 
                   colorScheme="blue"
                   size="sm"
+                  isDisabled={isIgnoredServer}
                   onClick={(e) => { 
                     e.stopPropagation()
+                    if (isIgnoredServer) {
+                      return
+                    }
                     vDispatch({ 
                       type: "SET_CONFIRM_ACTION", 
                       payload: { 
@@ -664,12 +678,16 @@ function Variables({ clusterName, dbId, toggleVariableMode, variableMode, onNavi
                   }} 
                 />
                 <RMIconButton 
-                  tooltip="Accept config value (use configurator value)" 
+                  tooltip={isIgnoredServer ? disabledActionTooltip : "Accept config value (use configurator value)"} 
                   icon={TbCheck} 
                   colorScheme="green"
                   size="sm"
+                  isDisabled={isIgnoredServer}
                   onClick={(e) => { 
                     e.stopPropagation()
+                    if (isIgnoredServer) {
+                      return
+                    }
                     vDispatch({ 
                       type: "SET_CONFIRM_ACTION", 
                       payload: { 
@@ -685,12 +703,16 @@ function Variables({ clusterName, dbId, toggleVariableMode, variableMode, onNavi
             {hasPreserve && !runtimeDiffersFromPreserved && (
               <>
                 <RMIconButton 
-                  tooltip="Clear preservation status" 
+                  tooltip={isIgnoredServer ? disabledActionTooltip : "Clear preservation status"} 
                   icon={TbTrash} 
                   colorScheme="red"
                   size="sm"
+                  isDisabled={isIgnoredServer}
                   onClick={(e) => { 
                     e.stopPropagation()
+                    if (isIgnoredServer) {
+                      return
+                    }
                     vDispatch({ 
                       type: "SET_CONFIRM_ACTION", 
                       payload: { 
@@ -706,12 +728,16 @@ function Variables({ clusterName, dbId, toggleVariableMode, variableMode, onNavi
             {runtimeDiffersFromPreserved && (
               <>
                 <RMIconButton 
-                  tooltip="Re-preserve with current runtime value (update preserved value to match runtime)" 
+                  tooltip={isIgnoredServer ? disabledActionTooltip : "Re-preserve with current runtime value (update preserved value to match runtime)"} 
                   icon={TbShield} 
                   colorScheme="orange"
                   size="sm"
+                  isDisabled={isIgnoredServer}
                   onClick={(e) => { 
                     e.stopPropagation()
+                    if (isIgnoredServer) {
+                      return
+                    }
                     vDispatch({ 
                       type: "SET_CONFIRM_ACTION", 
                       payload: { 
@@ -723,12 +749,16 @@ function Variables({ clusterName, dbId, toggleVariableMode, variableMode, onNavi
                   }} 
                 />
                 <RMIconButton 
-                  tooltip="Restart required to restore preserved value" 
+                  tooltip={isIgnoredServer ? disabledActionTooltip : "Restart required to restore preserved value"} 
                   icon={TbTrash} 
                   colorScheme="red"
                   size="sm"
+                  isDisabled={isIgnoredServer}
                   onClick={(e) => { 
                     e.stopPropagation()
+                    if (isIgnoredServer) {
+                      return
+                    }
                     vDispatch({ 
                       type: "SET_CONFIRM_ACTION", 
                       payload: { 
@@ -748,12 +778,16 @@ function Variables({ clusterName, dbId, toggleVariableMode, variableMode, onNavi
               </HStack>
             )}
             <RMIconButton 
-              tooltip="Edit/Override variable value (set custom value)" 
+              tooltip={isIgnoredServer ? disabledActionTooltip : "Edit/Override variable value (set custom value)"} 
               icon={TbEdit} 
               colorScheme="purple"
               size="sm"
+              isDisabled={isIgnoredServer}
               onClick={(e) => { 
                 e.stopPropagation()
+                if (isIgnoredServer) {
+                  return
+                }
                 vDispatch({ 
                   type: "SET_EDIT_MODAL", 
                   payload: { isOpen: true, data: row }
@@ -771,7 +805,7 @@ function Variables({ clusterName, dbId, toggleVariableMode, variableMode, onNavi
         minSize: 150
       })
     ],
-    [showCfg, showDeployed, showRuntime, showPreserve, onNavigateToPFSInstruments, vDispatch]
+    [showCfg, showDeployed, showRuntime, showPreserve, onNavigateToPFSInstruments, vDispatch, isIgnoredServer]
   )
 
   return (
@@ -828,6 +862,17 @@ function Variables({ clusterName, dbId, toggleVariableMode, variableMode, onNavi
             top={-1}
             onClick={handleDismissAlert}
           />
+        </Alert>
+      )}
+      {isIgnoredServer && (
+        <Alert status="warning" variant="left-accent" mb={4}>
+          <AlertIcon />
+          <Box flex="1">
+            <AlertTitle fontSize="sm" fontWeight="bold">Ignored Server</AlertTitle>
+            <AlertDescription fontSize="xs">
+              This server is marked as ignored. Variable preservation and custom overrides are disabled to avoid tampering.
+            </AlertDescription>
+          </Box>
         </Alert>
       )}
       <Flex className={styles.actions}>

--- a/share/dashboard_react/src/Pages/ClusterDB/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterDB/index.jsx
@@ -31,6 +31,8 @@ function ClusterDB(props) {
   const clusterData = useSelector((state) => state.cluster.clusterData)
   const loggedUser = useSelector((state) => state.auth.user)
 
+  const isIgnoredServer = Boolean(selectedDBServer?.ignored)
+
   useEffect(() => {
     let intervalId = 0
     let interval = localStorage.getItem('refresh_interval')
@@ -295,7 +297,7 @@ function ClusterDB(props) {
                     dbId={dbId}
                     clusterName={clusterName}
                     user={user}
-                    selectedDBServer={selectedDBServer}
+                    isIgnoredServer={isIgnoredServer}
                     variableMode={variableModeRef.current}
                     toggleVariableMode={toggleVariableMode}
                     onNavigateToPFSInstruments={navigateToPFSInstruments}


### PR DESCRIPTION
This pull request introduces consistent handling for "ignored" servers throughout the cluster management and dashboard codebase. The main change is the addition of checks for the `IsIgnored()` status in key server and cluster operations, ensuring that ignored servers are skipped during configuration, provisioning, job upgrades, variable management, and API responses. Additionally, the dashboard UI now disables variable editing actions for ignored servers, providing clear feedback to users.

**Backend: Cluster and Server Operations**

* Added `IsIgnored()` checks to all major cluster operations (`CheckNeedConfigFetch`, `CheckDummyConfigSendCookies`, `RollingReprov`, `RollingRestart`, `RollingOptimize`, `RollingJobsUpgrade`, and cookie-setting functions) to skip ignored servers and prevent unintended actions. [[1]](diffhunk://#diff-a9c48f22ec1d87ff0d2873815cfa59dc52f9a82be452494ba540d4fe89a44774R1171-R1173) [[2]](diffhunk://#diff-a9c48f22ec1d87ff0d2873815cfa59dc52f9a82be452494ba540d4fe89a44774R1184-R1186) [[3]](diffhunk://#diff-1f810d0aa8ddf4b013aca160b1db67c0cc3ff783e2eb96786369fc79b4075bbdR21-R24) [[4]](diffhunk://#diff-1f810d0aa8ddf4b013aca160b1db67c0cc3ff783e2eb96786369fc79b4075bbdL97-R101) [[5]](diffhunk://#diff-1f810d0aa8ddf4b013aca160b1db67c0cc3ff783e2eb96786369fc79b4075bbdR188-R190) [[6]](diffhunk://#diff-1f810d0aa8ddf4b013aca160b1db67c0cc3ff783e2eb96786369fc79b4075bbdL194-R201) [[7]](diffhunk://#diff-1f810d0aa8ddf4b013aca160b1db67c0cc3ff783e2eb96786369fc79b4075bbdL216-R223) [[8]](diffhunk://#diff-1f810d0aa8ddf4b013aca160b1db67c0cc3ff783e2eb96786369fc79b4075bbdL238-R245) [[9]](diffhunk://#diff-d5872677c3cc5c2ea2a32bdf57af1e39a3e2d5e5eb735fc8bbba65b445132846R1033-R1035) [[10]](diffhunk://#diff-d5872677c3cc5c2ea2a32bdf57af1e39a3e2d5e5eb735fc8bbba65b445132846R1044-R1046) [[11]](diffhunk://#diff-d5872677c3cc5c2ea2a32bdf57af1e39a3e2d5e5eb735fc8bbba65b445132846R1063-R1065)
* Updated server-level checks and operations (`CheckDBConfigPath`, `CheckSlaveSettings`, `CheckMasterSettings`, `CheckNeedConfigFetch`, `ProcessDummyConfigSendCookie`, `getDatabaseConfig`, `WriteDeltaVariables`) to return early for ignored servers, improving reliability and performance. [[1]](diffhunk://#diff-5bb4c626ee0cfad5a85fa30ec20e412f89ed0abf03e950a7511b28b8fdd89c80R26-R28) [[2]](diffhunk://#diff-5bb4c626ee0cfad5a85fa30ec20e412f89ed0abf03e950a7511b28b8fdd89c80R261-R263) [[3]](diffhunk://#diff-5bb4c626ee0cfad5a85fa30ec20e412f89ed0abf03e950a7511b28b8fdd89c80R411-R413) [[4]](diffhunk://#diff-5bb4c626ee0cfad5a85fa30ec20e412f89ed0abf03e950a7511b28b8fdd89c80R624-R626) [[5]](diffhunk://#diff-891cc70822efaa828be1b26673bfaf009f86d1a5a47438b24ec274c1ae2fc01eR269-R272) [[6]](diffhunk://#diff-891cc70822efaa828be1b26673bfaf009f86d1a5a47438b24ec274c1ae2fc01eR354-R358) [[7]](diffhunk://#diff-891cc70822efaa828be1b26673bfaf009f86d1a5a47438b24ec274c1ae2fc01eR838-R841)

**Backend: API Endpoints**

* Modified API handlers to return error responses when requests target ignored servers, preventing configuration fetches, upgrades, or file receipt jobs for these servers. [[1]](diffhunk://#diff-9b1e9c92a1d4b576cf629a1562fc7e24b19862a316743bbbd21ce80da72e284dR2820-R2825) [[2]](diffhunk://#diff-9b1e9c92a1d4b576cf629a1562fc7e24b19862a316743bbbd21ce80da72e284dR2837-R2842) [[3]](diffhunk://#diff-9b1e9c92a1d4b576cf629a1562fc7e24b19862a316743bbbd21ce80da72e284dR4354-R4357) [[4]](diffhunk://#diff-9b1e9c92a1d4b576cf629a1562fc7e24b19862a316743bbbd21ce80da72e284dR4767-R4771)

**Frontend: Dashboard Variable Management**

* Passed `selectedDBServer` to the `Variables` component and determined `isIgnoredServer` status to control UI behavior. [[1]](diffhunk://#diff-34fcc8c76e092d6b96e681cf12c30ce0cc7e7438647316f71dbc3b8292c8db52R99) [[2]](diffhunk://#diff-c99afc9d72402412ea4f35817b2bd40e25e6264eae84e9d30762f9903ebbda26L214-R218)
* Disabled variable editing actions (preserve, accept config, custom value) for ignored servers, including tooltips and action handlers, to prevent user interaction and clarify restrictions. [[1]](diffhunk://#diff-c99afc9d72402412ea4f35817b2bd40e25e6264eae84e9d30762f9903ebbda26R229) [[2]](diffhunk://#diff-c99afc9d72402412ea4f35817b2bd40e25e6264eae84e9d30762f9903ebbda26R267-R271) [[3]](diffhunk://#diff-c99afc9d72402412ea4f35817b2bd40e25e6264eae84e9d30762f9903ebbda26R298-R300) [[4]](diffhunk://#diff-c99afc9d72402412ea4f35817b2bd40e25e6264eae84e9d30762f9903ebbda26L650-R669) [[5]](diffhunk://#diff-c99afc9d72402412ea4f35817b2bd40e25e6264eae84e9d30762f9903ebbda26L667-R690)

**Code Clean-up**

* Removed unused cluster preserved variables info and value retrieval methods, streamlining the codebase. [[1]](diffhunk://#diff-cc163a3fe90c5dde5b08979c730fa66435dbc0bc1815adecdb59cd2c992598e3L25-L49) [[2]](diffhunk://#diff-cc163a3fe90c5dde5b08979c730fa66435dbc0bc1815adecdb59cd2c992598e3L389-L405)