### PR TITLE
fix(cluster): correct proxy tracking in query rules monitoring

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1880,7 +1880,7 @@ func (cluster *Cluster) CompareSchemaBetweenMasterAndSlave(sl *ServerMonitor) ([
 		}
 	}
 
-	for tblname, _ := range slTables {
+	for tblname := range slTables {
 		_, ok := masterTables[tblname]
 		if !ok {
 			if cluster.IsInSchemaIgnore(tblname) {
@@ -1959,15 +1959,25 @@ func (cluster *Cluster) MonitorQueryRules() {
 				var myRule config.QueryRule
 				if clrule, ok := cluster.QueryRules[rule.Id]; ok {
 					myRule = clrule
-					duplicates := strings.Split(clrule.Proxies, ",")
+
+					// Handle existing proxies list
+					var proxyIds []string
+					if clrule.Proxies != "" {
+						proxyIds = strings.Split(clrule.Proxies, ",")
+					}
+
+					// Check if current proxy already tracked
 					found := false
-					for _, prxid := range duplicates {
+					for _, prxid := range proxyIds {
 						if prx.Id == prxid {
 							found = true
+							break
 						}
 					}
+
 					if !found {
-						duplicates = append(duplicates, prx.Id)
+						proxyIds = append(proxyIds, prx.Id)
+						myRule.Proxies = strings.Join(proxyIds, ",")
 					}
 				} else {
 					myRule.Id = rule.Id


### PR DESCRIPTION
MonitorQueryRules was building a proxy ID list but never persisting it, causing all proxies after the first to be lost. Also add break statement to stop iteration once proxy is found, handle empty string edge case, and use clearer variable names.

## Contributor Agreement

By submitting this pull request, I agree to the terms outlined in the [Contributor Agreement](CONTRIBUTING.md).
