### PR TITLE
Restart container cookie handling improvements

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -753,7 +753,7 @@ func (cluster *Cluster) Run() {
 						go cluster.refreshApps(wg)
 						cluster.CheckWaitRunJobSSH()
 						cluster.CheckDummyConfigSendCookies()
-						// cluster.CheckRestartCookies()
+						cluster.CheckRestartContainerCookies()
 
 						// Monitor schema when shardproxy is used
 						if cluster.Conf.MdbsProxyOn && cluster.StateMachine.SchemaMonitorEndTime+60 < time.Now().Unix() {

--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -1171,21 +1171,21 @@ func (cluster *Cluster) CheckDummyConfigSendCookies() {
 	}
 }
 
-// CheckRestartCookies checks all servers for restart cookies and processes them
-func (cluster *Cluster) CheckRestartCookies() {
+// CheckRestartContainerCookies checks all servers for restart container cookies and processes them
+func (cluster *Cluster) CheckRestartContainerCookies() {
 	for _, srv := range cluster.Servers {
 		if srv == nil {
 			continue
 		}
 
-		if srv.HasRestartCookie() {
+		if srv.HasRestartContainerCookie() {
 			// Get the stored parameters
 			nodeParam := srv.RestartNode
 			ridParam := srv.RestartRid
 
 			if cluster.Conf != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
-					"Processing restart cookie for server %s (node: %s, rid: %s)", srv.URL, nodeParam, ridParam)
+					"Processing restart container cookie for server %s (node: %s, rid: %s)", srv.URL, nodeParam, ridParam)
 			}
 			// Call the restart function with stored parameters
 			err := cluster.RestartDatabaseService(srv, nodeParam, ridParam)
@@ -1195,7 +1195,7 @@ func (cluster *Cluster) CheckRestartCookies() {
 						"Failed to restart server %s: %s", srv.URL, err)
 				}
 				// Delete cookie even on error to avoid infinite retries
-				srv.DelRestartCookie()
+				srv.DelRestartContainerCookie()
 				// Clear stored parameters
 				srv.RestartNode = ""
 				srv.RestartRid = ""
@@ -1204,7 +1204,7 @@ func (cluster *Cluster) CheckRestartCookies() {
 	}
 }
 
-// CleanupRestartCookies removes any lingering restart cookies and clears parameters at cluster startup
+// CleanupRestartCookies removes any lingering restart container cookies and clears parameters at cluster startup
 // This prevents unwanted restarts from old cookies that may have been left from previous runs
 func (cluster *Cluster) CleanupRestartCookies() {
 	cleanedCount := 0
@@ -1214,15 +1214,15 @@ func (cluster *Cluster) CleanupRestartCookies() {
 		}
 
 		// Check if restart cookie exists
-		if srv.HasRestartCookie() {
+		if srv.HasRestartContainerCookie() {
 			if cluster.Conf != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
-					"Cleaning up lingering restart cookie for server %s (node: %s, rid: %s)",
+					"Cleaning up lingering restart container cookie for server %s (node: %s, rid: %s)",
 					srv.URL, srv.RestartNode, srv.RestartRid)
 			}
 
 			// Delete the cookie
-			srv.DelRestartCookie()
+			srv.DelRestartContainerCookie()
 			cleanedCount++
 		}
 
@@ -1233,6 +1233,6 @@ func (cluster *Cluster) CleanupRestartCookies() {
 
 	if cleanedCount > 0 && cluster.Conf != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
-			"Cleaned up %d restart cookie(s) at cluster startup", cleanedCount)
+			"Cleaned up %d restart container cookie(s) at cluster startup", cleanedCount)
 	}
 }

--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -1183,6 +1183,26 @@ func (cluster *Cluster) CheckRestartContainerCookies() {
 			nodeParam := srv.RestartNode
 			ridParam := srv.RestartRid
 
+			if ridParam == RestartRidJobsContainer && !srv.IsDown() {
+				running, err := srv.HasRunningDBJobs()
+				if err != nil {
+					if cluster.Conf != nil {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+							"Skipping restart container cookie for server %s (node: %s, rid: %s): unable to check running jobs: %s",
+							srv.URL, nodeParam, ridParam, err)
+					}
+					continue
+				}
+				if running {
+					if cluster.Conf != nil {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+							"Deferring restart container cookie for server %s (node: %s, rid: %s): jobs still running",
+							srv.URL, nodeParam, ridParam)
+					}
+					continue
+				}
+			}
+
 			if cluster.Conf != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
 					"Processing restart container cookie for server %s (node: %s, rid: %s)", srv.URL, nodeParam, ridParam)

--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -1186,19 +1186,21 @@ func (cluster *Cluster) CheckRestartContainerCookies() {
 			if ridParam == RestartRidJobsContainer && !srv.IsDown() {
 				running, err := srv.HasRunningDBJobs()
 				if err != nil {
-					if cluster.Conf != nil {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
-							"Skipping restart container cookie for server %s (node: %s, rid: %s): unable to check running jobs: %s",
-							srv.URL, nodeParam, ridParam, err)
-					}
+					cluster.SetState("WARN0165", state.State{
+						ErrType:   "WARNING",
+						ErrDesc:   fmt.Sprintf(clusterError["WARN0165"], srv.URL, fmt.Sprintf("unable to check running jobs: %s", err)),
+						ErrFrom:   "JOB",
+						ServerUrl: srv.URL,
+					})
 					continue
 				}
 				if running {
-					if cluster.Conf != nil {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
-							"Deferring restart container cookie for server %s (node: %s, rid: %s): jobs still running",
-							srv.URL, nodeParam, ridParam)
-					}
+					cluster.SetState("WARN0165", state.State{
+						ErrType:   "WARNING",
+						ErrDesc:   fmt.Sprintf(clusterError["WARN0165"], srv.URL, "jobs still running"),
+						ErrFrom:   "JOB",
+						ServerUrl: srv.URL,
+					})
 					continue
 				}
 			}

--- a/cluster/cluster_chk_restart_test.go
+++ b/cluster/cluster_chk_restart_test.go
@@ -13,18 +13,18 @@ import (
 	"testing"
 )
 
-// TestCheckRestartCookies_NoCookies tests when no cookies exist
-func TestCheckRestartCookies_NoCookies(t *testing.T) {
+// TestCheckRestartContainerCookies_NoCookies tests when no cookies exist
+func TestCheckRestartContainerCookies_NoCookies(t *testing.T) {
 	cluster := setupTestCluster(t, 3)
 	defer cleanupTestCluster(t, cluster)
 
 	// Test: Check when no cookies exist
-	cluster.CheckRestartCookies()
+	cluster.CheckRestartContainerCookies()
 
 	// Verify: Should complete without error
 	// All servers should still have no cookies
 	for i, srv := range cluster.Servers {
-		if srv != nil && srv.HasRestartCookie() {
+		if srv != nil && srv.HasRestartContainerCookie() {
 			t.Errorf("Server %d should not have cookie", i)
 		}
 	}
@@ -32,8 +32,8 @@ func TestCheckRestartCookies_NoCookies(t *testing.T) {
 	t.Log("No-cookie scenario handled correctly")
 }
 
-// TestCheckRestartCookies_WithCookie tests processing when cookie exists
-func TestCheckRestartCookies_WithCookie(t *testing.T) {
+// TestCheckRestartContainerCookies_WithCookie tests processing when cookie exists
+func TestCheckRestartContainerCookies_WithCookie(t *testing.T) {
 	tempDir := t.TempDir()
 	systemDir := filepath.Join(tempDir, ".system")
 	os.MkdirAll(systemDir, 0755)
@@ -47,13 +47,13 @@ func TestCheckRestartCookies_WithCookie(t *testing.T) {
 	// Test: Set parameters and cookie
 	server.RestartNode = "node1"
 	server.RestartRid = "container#jobs"
-	err := server.SetRestartCookie()
+	err := server.SetRestartContainerCookie()
 	if err != nil {
 		t.Fatalf("Failed to create cookie: %v", err)
 	}
 
 	// Verify: Cookie exists
-	if !server.HasRestartCookie() {
+	if !server.HasRestartContainerCookie() {
 		t.Error("Cookie should exist")
 	}
 
@@ -66,12 +66,12 @@ func TestCheckRestartCookies_WithCookie(t *testing.T) {
 	}
 
 	// Test: Delete cookie manually
-	server.DelRestartCookie()
+	server.DelRestartContainerCookie()
 	server.RestartNode = ""
 	server.RestartRid = ""
 
 	// Verify: Cookie deleted and parameters cleared
-	if server.HasRestartCookie() {
+	if server.HasRestartContainerCookie() {
 		t.Error("Cookie should be deleted")
 	}
 	if server.RestartNode != "" || server.RestartRid != "" {
@@ -81,8 +81,8 @@ func TestCheckRestartCookies_WithCookie(t *testing.T) {
 	t.Log("Cookie processing test completed")
 }
 
-// TestCheckRestartCookies_ConcurrentCalls tests concurrent calls to checker
-func TestCheckRestartCookies_ConcurrentCalls(t *testing.T) {
+// TestCheckRestartContainerCookies_ConcurrentCalls tests concurrent calls to checker
+func TestCheckRestartContainerCookies_ConcurrentCalls(t *testing.T) {
 	cluster := setupTestCluster(t, 3)
 	defer cleanupTestCluster(t, cluster)
 
@@ -98,7 +98,7 @@ func TestCheckRestartCookies_ConcurrentCalls(t *testing.T) {
 				}
 				done <- true
 			}()
-			cluster.CheckRestartCookies()
+			cluster.CheckRestartContainerCookies()
 		}()
 	}
 
@@ -135,13 +135,13 @@ func TestRestartParameterStorage(t *testing.T) {
 	}
 
 	// Test: Create cookie
-	err := server.SetRestartCookie()
+	err := server.SetRestartContainerCookie()
 	if err != nil {
 		t.Fatalf("Failed to create cookie: %v", err)
 	}
 
 	// Verify: Cookie exists
-	if !server.HasRestartCookie() {
+	if !server.HasRestartContainerCookie() {
 		t.Error("Cookie should exist")
 	}
 
@@ -161,7 +161,7 @@ func TestRestartParameterStorage(t *testing.T) {
 }
 
 // Benchmark restart cookie checking
-func BenchmarkCheckRestartCookies_NoCookies(b *testing.B) {
+func BenchmarkCheckRestartContainerCookies_NoCookies(b *testing.B) {
 	cluster := &Cluster{
 		Servers: make([]*ServerMonitor, 10),
 	}
@@ -180,11 +180,11 @@ func BenchmarkCheckRestartCookies_NoCookies(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		cluster.CheckRestartCookies()
+		cluster.CheckRestartContainerCookies()
 	}
 }
 
-func BenchmarkCheckRestartCookies_WithCookies(b *testing.B) {
+func BenchmarkCheckRestartContainerCookies_WithCookies(b *testing.B) {
 	cluster := &Cluster{
 		Servers: make([]*ServerMonitor, 10),
 	}
@@ -207,11 +207,11 @@ func BenchmarkCheckRestartCookies_WithCookies(b *testing.B) {
 		for _, srv := range cluster.Servers {
 			srv.RestartNode = "node1"
 			srv.RestartRid = ""
-			srv.SetRestartCookie()
+			srv.SetRestartContainerCookie()
 		}
 
 		// Process
-		cluster.CheckRestartCookies()
+		cluster.CheckRestartContainerCookies()
 	}
 }
 
@@ -226,7 +226,7 @@ func TestCleanupRestartCookies(t *testing.T) {
 		if i%2 == 0 { // Set cookies on even-indexed servers
 			srv.RestartNode = fmt.Sprintf("node-%d", i)
 			srv.RestartRid = fmt.Sprintf("rid-%d", i)
-			err := srv.SetRestartCookie()
+			err := srv.SetRestartContainerCookie()
 			if err != nil {
 				t.Fatalf("Failed to set restart cookie for server %d: %v", i, err)
 			}
@@ -240,13 +240,13 @@ func TestCleanupRestartCookies(t *testing.T) {
 	cookieCount := 0
 	paramCount := 0
 	for i, srv := range cluster.Servers {
-		if srv.HasRestartCookie() {
+		if srv.HasRestartContainerCookie() {
 			cookieCount++
 		}
 		if srv.RestartNode != "" || srv.RestartRid != "" {
 			paramCount++
 		}
-		if i%2 == 0 && !srv.HasRestartCookie() {
+		if i%2 == 0 && !srv.HasRestartContainerCookie() {
 			t.Errorf("Expected cookie for server %d", i)
 		}
 	}
@@ -265,7 +265,7 @@ func TestCleanupRestartCookies(t *testing.T) {
 
 	// Verify all cookies and parameters are cleaned up
 	for i, srv := range cluster.Servers {
-		if srv.HasRestartCookie() {
+		if srv.HasRestartContainerCookie() {
 			t.Errorf("Server %d still has restart cookie after cleanup", i)
 		}
 		if srv.RestartNode != "" {
@@ -284,8 +284,8 @@ func TestCleanupRestartCookies_EmptyCluster(t *testing.T) {
 
 	// Ensure no cookies exist
 	for _, srv := range cluster.Servers {
-		if srv.HasRestartCookie() {
-			srv.DelRestartCookie()
+		if srv.HasRestartContainerCookie() {
+			srv.DelRestartContainerCookie()
 		}
 		srv.RestartNode = ""
 		srv.RestartRid = ""
@@ -296,7 +296,7 @@ func TestCleanupRestartCookies_EmptyCluster(t *testing.T) {
 
 	// Verify state unchanged
 	for i, srv := range cluster.Servers {
-		if srv.HasRestartCookie() {
+		if srv.HasRestartContainerCookie() {
 			t.Errorf("Server %d unexpectedly has restart cookie", i)
 		}
 		if srv.RestartNode != "" || srv.RestartRid != "" {
@@ -317,7 +317,7 @@ func TestCleanupRestartCookies_NilServers(t *testing.T) {
 	if len(cluster.Servers) > 0 && cluster.Servers[0] != nil {
 		cluster.Servers[0].RestartNode = "test-node"
 		cluster.Servers[0].RestartRid = "test-rid"
-		err := cluster.Servers[0].SetRestartCookie()
+		err := cluster.Servers[0].SetRestartContainerCookie()
 		if err != nil {
 			t.Fatalf("Failed to set cookie: %v", err)
 		}
@@ -329,7 +329,7 @@ func TestCleanupRestartCookies_NilServers(t *testing.T) {
 	// Verify cleanup worked on non-nil servers
 	for i, srv := range cluster.Servers {
 		if srv != nil {
-			if srv.HasRestartCookie() {
+			if srv.HasRestartContainerCookie() {
 				t.Errorf("Server %d still has cookie after cleanup", i)
 			}
 			if srv.RestartNode != "" || srv.RestartRid != "" {

--- a/cluster/prov.go
+++ b/cluster/prov.go
@@ -498,7 +498,7 @@ func (cluster *Cluster) RestartDatabaseService(server *ServerMonitor, node strin
 		return errors.New("Restart not supported for this orchestrator yet")
 	}
 	if err == nil {
-		server.DelRestartCookie()
+		server.DelRestartContainerCookie()
 		// Clear stored parameters
 		server.RestartNode = ""
 		server.RestartRid = ""

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -223,8 +223,8 @@ type ServerMonitor struct {
 	IsNeedPathCheck             bool
 	HasConfigPathChanged        bool
 	HasConfigDiff               bool       `json:"hasConfigDiff"` // Indicates if there are differences between deployed and generated config
-	RestartNode                 string     // RestartNode stores node parameter for restart cookie (owned by cookie mechanism, single writer assumption)
-	RestartRid                  string     // RestartRid stores rid parameter for restart cookie (owned by cookie mechanism, single writer assumption)
+	RestartNode                 string     // RestartNode stores node parameter for restart container cookie (owned by cookie mechanism, single writer assumption)
+	RestartRid                  string     // RestartRid stores rid parameter for restart container cookie (owned by cookie mechanism, single writer assumption)
 	jobMutex                    sync.Mutex // protects IsRunningJobs flag
 	configGenMutex              sync.Mutex // protects config generation operations
 }

--- a/cluster/srv_del.go
+++ b/cluster/srv_del.go
@@ -62,6 +62,10 @@ func (server *ServerMonitor) DelRestartCookie() error {
 	return server.delCookie("cookie_restart")
 }
 
+func (server *ServerMonitor) DelRestartContainerCookie() error {
+	return server.delCookie("cookie_restart_container")
+}
+
 func (server *ServerMonitor) DelConfigCookie() error {
 	return server.delCookie("cookie_config")
 }

--- a/cluster/srv_has.go
+++ b/cluster/srv_has.go
@@ -147,6 +147,10 @@ func (server *ServerMonitor) HasRestartCookie() bool {
 	return server.hasCookie("cookie_restart")
 }
 
+func (server *ServerMonitor) HasRestartContainerCookie() bool {
+	return server.hasCookie("cookie_restart_container")
+}
+
 func (server *ServerMonitor) HasProvisionCookie() bool {
 	return server.hasCookie("cookie_prov")
 }

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -316,6 +316,33 @@ func (server *ServerMonitor) JobInsertTask(task string, port string, repmanhost 
 	return res.LastInsertId()
 }
 
+func (server *ServerMonitor) HasRunningDBJobs() (bool, error) {
+	if server.Conn == nil {
+		return false, errors.New("no pool connection")
+	}
+
+	conn, err := server.GetConnNoBinlog(server.Conn)
+	if err != nil {
+		return false, err
+	}
+	if conn == nil {
+		return false, errors.New("no connection established")
+	}
+	defer conn.Close()
+
+	query := "SELECT COUNT(*) FROM replication_manager_schema.jobs WHERE done=0 AND state IN (?, ?)"
+	var count int
+	err = server.ConnGetQueryWithTimeout(conn, JobTimeout, &count, query, JobStateRunning, JobStateHalted)
+	if err != nil {
+		if isTableMissingError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return count > 0, nil
+}
+
 func (server *ServerMonitor) JobBackupPhysical() error {
 	//server can be nil as no dicovered master
 	if server == nil {

--- a/cluster/srv_set.go
+++ b/cluster/srv_set.go
@@ -341,6 +341,10 @@ func (server *ServerMonitor) SetRestartCookie() error {
 	return server.createCookie("cookie_restart")
 }
 
+func (server *ServerMonitor) SetRestartContainerCookie() error {
+	return server.createCookie("cookie_restart_container")
+}
+
 func (server *ServerMonitor) SetWaitStartCookie() error {
 	return server.createCookie("cookie_waitstart")
 }

--- a/config/error.go
+++ b/config/error.go
@@ -236,6 +236,7 @@ var ClusterError = map[string]string{
 	"WARN0160":  "Replication Manager used a deprecated configuration variable in cluster %s. Keys: %s",
 	"WARN0163":  "Cluster %s is flagged for schema monitoring",
 	"WARN0164":  "Cluster %s has schema differences between master and slaves: %v",
+	"WARN0165":  "Restart container cookie deferred on %s: %s",
 	"MDEV20821": "MariaDB version has replication issue https://jira.mariadb.org/browse/MDEV-20821",
 	"MDEV28310": "MariaDB version has replication issue for non row format https://jira.mariadb.org/browse/MDEV-28310",
 	"MDEV19577": "MariaDB version has replication issue for non row format https://jira.mariadb.org/browse/MDEV-19577",

--- a/doc/implementation/restart-cookie/RESTART_COOKIE_CLEANUP_COMPLETE.md
+++ b/doc/implementation/restart-cookie/RESTART_COOKIE_CLEANUP_COMPLETE.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Successfully implemented automatic cleanup of stale restart cookies at cluster startup to prevent unwanted database restarts after process crashes.
+Successfully implemented automatic cleanup of stale restart container cookies at cluster startup to prevent unwanted database restarts after process crashes.
 
 ---
 
@@ -11,7 +11,7 @@ Successfully implemented automatic cleanup of stale restart cookies at cluster s
 - [x] **Cleanup Function Created** (`CleanupRestartCookies()`)
 - [x] **Integrated at Startup** (runs once after topology discovery)
 - [x] **Tests Written** (3 comprehensive tests)
-- [x] **Tests Passing** (7/7 total restart cookie tests)
+- [x] **Tests Passing** (7/7 total restart container cookie tests)
 - [x] **Code Compiles** (no new errors)
 - [x] **Documentation Complete** (2 new docs + updated summary)
 - [x] **Logging Added** (audit trail for cleanup actions)
@@ -90,14 +90,14 @@ ok      github.com/signal18/replication-manager/cluster    0.025s
 When replication-manager starts up, it automatically:
 
 1. **Scans all servers** in the cluster
-2. **Finds restart cookies** left from previous runs
+2. **Finds restart container cookies** left from previous runs
 3. **Deletes the cookies** from disk
 4. **Clears parameter fields** (RestartNode, RestartRid)
 5. **Logs cleanup actions** for audit trail
 
 ### Why It's Needed
 
-**Problem**: If replication-manager crashes after setting a restart cookie but before the restart completes, the cookie remains on disk. When the process restarts, the in-memory parameters are lost but the cookie file exists, potentially causing:
+**Problem**: If replication-manager crashes after setting a restart container cookie but before the restart completes, the cookie remains on disk. When the process restarts, the in-memory parameters are lost but the cookie file exists, potentially causing:
 - Unwanted restart attempts with empty parameters
 - Errors due to missing context
 - Confusion about restart state
@@ -142,7 +142,7 @@ When replication-manager starts up, it automatically:
    → CleanupRestartCookies()  ← NEW
 5. runOnceAfterTopology = false
 6. Monitor loop begins
-   - CheckRestartCookies() (processes valid cookies)
+   - CheckRestartContainerCookies() (processes valid cookies)
 ```
 
 **Key Point**: Cleanup runs BEFORE monitor loop, ensuring stale cookies are removed before any new ones are processed.
@@ -155,7 +155,7 @@ When replication-manager starts up, it automatically:
 
 1. **Create stale cookie**:
    ```bash
-   touch /var/lib/replication-manager/cluster1/server1/@cookie_restart
+   touch /var/lib/replication-manager/cluster1/server1/@cookie_restart_container
    ```
 
 2. **Start replication-manager**:
@@ -165,13 +165,13 @@ When replication-manager starts up, it automatically:
 
 3. **Check logs**:
    ```bash
-   grep "Cleaning up lingering restart cookie" /var/log/replication-manager.log
+   grep "Cleaning up lingering restart container cookie" /var/log/replication-manager.log
    grep "Cleaned up" /var/log/replication-manager.log
    ```
 
 4. **Verify cookie deleted**:
    ```bash
-   ls /var/lib/replication-manager/cluster1/server1/@cookie_restart
+   ls /var/lib/replication-manager/cluster1/server1/@cookie_restart_container
    # Should return: No such file or directory
    ```
 
@@ -270,7 +270,7 @@ When replication-manager starts up, it automatically:
 ## ✨ Summary
 
 ### What Was Built
-A simple, robust mechanism to automatically clean up stale restart cookies at cluster startup.
+A simple, robust mechanism to automatically clean up stale restart container cookies at cluster startup.
 
 ### Problem Solved
 Prevents unwanted database restarts from cookies left by previous process crashes.

--- a/doc/implementation/restart-cookie/RESTART_COOKIE_COMPLETE.md
+++ b/doc/implementation/restart-cookie/RESTART_COOKIE_COMPLETE.md
@@ -73,7 +73,7 @@ err := mycluster.RestartDatabaseService(node, nodeParam, ridParam)
 // NEW: Set cookie (non-blocking)
 node.RestartNode = nodeParam
 node.RestartRid = ridParam
-err := node.SetRestartCookie()
+err := node.SetRestartContainerCookie()
 ```
 
 **API Response:**
@@ -82,16 +82,16 @@ err := node.SetRestartCookie()
 
 ### 3. Checker Function (cluster_chk.go)
 
-Implemented `CheckRestartCookies()` following the same pattern as `CheckDummyConfigSendCookies()`:
+Implemented `CheckRestartContainerCookies()` following the same pattern as `CheckDummyConfigSendCookies()`:
 
 ```go
-func (cluster *Cluster) CheckRestartCookies() {
+func (cluster *Cluster) CheckRestartContainerCookies() {
     for _, srv := range cluster.Servers {
         if srv == nil {
             continue
         }
         
-        if srv.HasRestartCookie() {
+        if srv.HasRestartContainerCookie() {
             // Retrieve stored parameters
             nodeParam := srv.RestartNode
             ridParam := srv.RestartRid
@@ -103,7 +103,7 @@ func (cluster *Cluster) CheckRestartCookies() {
             if err != nil {
                 // Log error
                 // Clean up even on error
-                srv.DelRestartCookie()
+                srv.DelRestartContainerCookie()
                 srv.RestartNode = ""
                 srv.RestartRid = ""
             }
@@ -125,7 +125,7 @@ Added checker call in the main monitoring loop:
 ```go
 cluster.CheckWaitRunJobSSH()
 cluster.CheckDummyConfigSendCookies()
-cluster.CheckRestartCookies()  // ← NEW
+cluster.CheckRestartContainerCookies()  // ← NEW
 ```
 
 **Execution frequency:** Every monitor tick (default: 2 seconds)
@@ -147,11 +147,11 @@ func (server *ServerMonitor) SetRestartRid(value string) {
 ## Cookie Mechanism
 
 ### Cookie File Structure
-- **Location:** `{ServerDatadir}/@cookie_restart`
+- **Location:** `{ServerDatadir}/@cookie_restart_container`
 - **Content:** Empty file (just a marker)
-- **Creation:** Via `SetRestartCookie()`
-- **Detection:** Via `HasRestartCookie()`
-- **Deletion:** Via `DelRestartCookie()`
+- **Creation:** Via `SetRestartContainerCookie()`
+- **Detection:** Via `HasRestartContainerCookie()`
+- **Deletion:** Via `DelRestartContainerCookie()`
 
 ### Cookie Lifecycle
 
@@ -178,17 +178,17 @@ Created comprehensive test suite in `cluster_chk_restart_test.go`:
 
 ### Unit Tests
 
-1. **TestCheckRestartCookies_NoCookies**
+1. **TestCheckRestartContainerCookies_NoCookies**
    - Verifies checker handles no cookies gracefully
    - ✅ PASS
 
-2. **TestCheckRestartCookies_WithCookie**
+2. **TestCheckRestartContainerCookies_WithCookie**
    - Tests cookie creation and parameter storage
    - Verifies cookie deletion
    - Verifies parameter clearing
    - ✅ PASS
 
-3. **TestCheckRestartCookies_ConcurrentCalls**
+3. **TestCheckRestartContainerCookies_ConcurrentCalls**
    - Tests thread safety of checker function
    - Verifies no race conditions
    - ✅ PASS
@@ -200,20 +200,20 @@ Created comprehensive test suite in `cluster_chk_restart_test.go`:
 
 ### Benchmark Tests
 
-1. **BenchmarkCheckRestartCookies_NoCookies**
+1. **BenchmarkCheckRestartContainerCookies_NoCookies**
    - Performance baseline for no-cookie scenario
 
-2. **BenchmarkCheckRestartCookies_WithCookies**
+2. **BenchmarkCheckRestartContainerCookies_WithCookies**
    - Performance with active cookies
 
 ### Test Results
 ```
-=== RUN   TestCheckRestartCookies_NoCookies
---- PASS: TestCheckRestartCookies_NoCookies (0.00s)
-=== RUN   TestCheckRestartCookies_WithCookie
---- PASS: TestCheckRestartCookies_WithCookie (0.00s)
-=== RUN   TestCheckRestartCookies_ConcurrentCalls
---- PASS: TestCheckRestartCookies_ConcurrentCalls (0.00s)
+=== RUN   TestCheckRestartContainerCookies_NoCookies
+--- PASS: TestCheckRestartContainerCookies_NoCookies (0.00s)
+=== RUN   TestCheckRestartContainerCookies_WithCookie
+--- PASS: TestCheckRestartContainerCookies_WithCookie (0.00s)
+=== RUN   TestCheckRestartContainerCookies_ConcurrentCalls
+--- PASS: TestCheckRestartContainerCookies_ConcurrentCalls (0.00s)
 === RUN   TestRestartParameterStorage
 --- PASS: TestRestartParameterStorage (0.00s)
 PASS
@@ -226,7 +226,7 @@ ok  	github.com/signal18/replication-manager/cluster	0.326s
 |------|---------|-------|
 | `cluster/srv.go` | Added RestartNode and RestartRid fields | 219-220 |
 | `server/api_database.go` | Modified handlerMuxServerRestart | 2330-2390 |
-| `cluster/cluster_chk.go` | Added CheckRestartCookies() | 1186-1218 |
+| `cluster/cluster_chk.go` | Added CheckRestartContainerCookies() | 1186-1218 |
 | `cluster/cluster.go` | Integrated checker in monitor loop | 745 |
 | `cluster/srv_set.go` | Added setter methods | 472-479 |
 
@@ -277,7 +277,7 @@ ok  	github.com/signal18/replication-manager/cluster	0.326s
 ### Manual Inspection
 ```bash
 # Check for pending restart cookies
-ls -la /path/to/datadir/@cookie_restart
+ls -la /path/to/datadir/@cookie_restart_container
 
 # Monitor for cookie processing
 tail -f /path/to/logs | grep "restart cookie"
@@ -334,7 +334,7 @@ tail -f /path/to/logs | grep "restart cookie"
 |-----------|------------|------------|---------|
 | Config Push | `cookie_wait_dummy_send` | None | N/A |
 | Job SSH | `cookie_waitrunjobssh` | None | N/A |
-| **Restart** | `cookie_restart` | node, rid | In-memory fields |
+| **Restart** | `cookie_restart_container` | node, rid | In-memory fields |
 
 **Restart is unique** in that it stores parameters, but follows the same checker pattern.
 

--- a/regtest/test_restart_cookie.go
+++ b/regtest/test_restart_cookie.go
@@ -28,14 +28,14 @@ func (regtest *RegTest) TestRestartCookieBasic(cluster *cluster.Cluster, conf st
 	server.SetRestartRid("container#jobs")
 
 	// Create cookie
-	err := server.SetRestartCookie()
+	err := server.SetRestartContainerCookie()
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Failed to create restart cookie: %s", err)
 		return false
 	}
 
 	// Verify cookie exists
-	if !server.HasRestartCookie() {
+	if !server.HasRestartContainerCookie() {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Restart cookie was not created")
 		return false
 	}
@@ -54,14 +54,14 @@ func (regtest *RegTest) TestRestartCookieBasic(cluster *cluster.Cluster, conf st
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "Restart cookie and parameters verified")
 
 	// Delete cookie
-	err = server.DelRestartCookie()
+	err = server.DelRestartContainerCookie()
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Failed to delete restart cookie: %s", err)
 		return false
 	}
 
 	// Verify cookie deleted
-	if server.HasRestartCookie() {
+	if server.HasRestartContainerCookie() {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Restart cookie was not deleted")
 		return false
 	}
@@ -87,16 +87,16 @@ func (regtest *RegTest) TestRestartCookieLifecycle(cluster *cluster.Cluster, con
 	// Step 1: Set parameters and cookie
 	server.SetRestartNode("slave")
 	server.SetRestartRid("container#jobs")
-	err := server.SetRestartCookie()
+	err := server.SetRestartContainerCookie()
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Cookie creation failed: %s", err)
 		return false
 	}
 
-	// Step 2: Verify CheckRestartCookies can find it
+	// Step 2: Verify CheckRestartContainerCookies can find it
 	foundCookie := false
 	for _, srv := range cluster.GetServers() {
-		if srv.HasRestartCookie() {
+		if srv.HasRestartContainerCookie() {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "Monitor found restart cookie for server %s", srv.Id)
 			foundCookie = true
 
@@ -121,7 +121,7 @@ func (regtest *RegTest) TestRestartCookieLifecycle(cluster *cluster.Cluster, con
 	}
 
 	// Step 3: Clean up
-	server.DelRestartCookie()
+	server.DelRestartContainerCookie()
 	server.SetRestartNode("")
 	server.SetRestartRid("")
 
@@ -142,7 +142,7 @@ func (regtest *RegTest) TestRestartCookieMultipleServers(cluster *cluster.Cluste
 	// Set cookies on first two servers
 	servers[0].SetRestartNode("master")
 	servers[0].SetRestartRid("container#jobs")
-	err := servers[0].SetRestartCookie()
+	err := servers[0].SetRestartContainerCookie()
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Failed to create cookie on server 0: %s", err)
 		return false
@@ -150,7 +150,7 @@ func (regtest *RegTest) TestRestartCookieMultipleServers(cluster *cluster.Cluste
 
 	servers[1].SetRestartNode("slave")
 	servers[1].SetRestartRid("")
-	err = servers[1].SetRestartCookie()
+	err = servers[1].SetRestartContainerCookie()
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Failed to create cookie on server 1: %s", err)
 		return false
@@ -159,7 +159,7 @@ func (regtest *RegTest) TestRestartCookieMultipleServers(cluster *cluster.Cluste
 	// Verify both cookies exist
 	cookieCount := 0
 	for _, srv := range servers {
-		if srv.HasRestartCookie() {
+		if srv.HasRestartContainerCookie() {
 			cookieCount++
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "Found restart cookie on server %s (node: %s, rid: %s)",
 				srv.Id, srv.RestartNode, srv.RestartRid)
@@ -168,17 +168,17 @@ func (regtest *RegTest) TestRestartCookieMultipleServers(cluster *cluster.Cluste
 
 	if cookieCount != 2 {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Expected 2 cookies, found %d", cookieCount)
-		servers[0].DelRestartCookie()
-		servers[1].DelRestartCookie()
+		servers[0].DelRestartContainerCookie()
+		servers[1].DelRestartContainerCookie()
 		return false
 	}
 
 	// Clean up
-	servers[0].DelRestartCookie()
+	servers[0].DelRestartContainerCookie()
 	servers[0].SetRestartNode("")
 	servers[0].SetRestartRid("")
 
-	servers[1].DelRestartCookie()
+	servers[1].DelRestartContainerCookie()
 	servers[1].SetRestartNode("")
 	servers[1].SetRestartRid("")
 
@@ -199,7 +199,7 @@ func (regtest *RegTest) TestRestartCookieParameters(cluster *cluster.Cluster, co
 	// Test 1: Both parameters set
 	server.SetRestartNode("master")
 	server.SetRestartRid("container#jobs")
-	err := server.SetRestartCookie()
+	err := server.SetRestartContainerCookie()
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Test 1 failed: %s", err)
 		return false
@@ -207,17 +207,17 @@ func (regtest *RegTest) TestRestartCookieParameters(cluster *cluster.Cluster, co
 
 	if server.RestartNode != "master" || server.RestartRid != "container#jobs" {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Test 1: Parameters not set correctly")
-		server.DelRestartCookie()
+		server.DelRestartContainerCookie()
 		return false
 	}
 
-	server.DelRestartCookie()
+	server.DelRestartContainerCookie()
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "Test 1 passed: Both parameters")
 
 	// Test 2: Only node parameter
 	server.SetRestartNode("slave")
 	server.SetRestartRid("")
-	err = server.SetRestartCookie()
+	err = server.SetRestartContainerCookie()
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Test 2 failed: %s", err)
 		return false
@@ -225,17 +225,17 @@ func (regtest *RegTest) TestRestartCookieParameters(cluster *cluster.Cluster, co
 
 	if server.RestartNode != "slave" || server.RestartRid != "" {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Test 2: Parameters not set correctly")
-		server.DelRestartCookie()
+		server.DelRestartContainerCookie()
 		return false
 	}
 
-	server.DelRestartCookie()
+	server.DelRestartContainerCookie()
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "Test 2 passed: Node parameter only")
 
 	// Test 3: Empty parameters (default restart)
 	server.SetRestartNode("")
 	server.SetRestartRid("")
-	err = server.SetRestartCookie()
+	err = server.SetRestartContainerCookie()
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Test 3 failed: %s", err)
 		return false
@@ -243,11 +243,11 @@ func (regtest *RegTest) TestRestartCookieParameters(cluster *cluster.Cluster, co
 
 	if server.RestartNode != "" || server.RestartRid != "" {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Test 3: Parameters should be empty")
-		server.DelRestartCookie()
+		server.DelRestartContainerCookie()
 		return false
 	}
 
-	server.DelRestartCookie()
+	server.DelRestartContainerCookie()
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "Test 3 passed: Empty parameters")
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "Restart cookie parameters test passed")
@@ -267,7 +267,7 @@ func (regtest *RegTest) TestRestartCookieCleanup(cluster *cluster.Cluster, conf 
 	for i, srv := range cluster.GetServers() {
 		srv.SetRestartNode("node-" + srv.Id)
 		srv.SetRestartRid("rid-" + srv.Id)
-		err := srv.SetRestartCookie()
+		err := srv.SetRestartContainerCookie()
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Failed to create test cookie on server %d: %s", i, err)
 			return false
@@ -277,7 +277,7 @@ func (regtest *RegTest) TestRestartCookieCleanup(cluster *cluster.Cluster, conf 
 	// Verify cookies were created
 	cookieCountBefore := 0
 	for _, srv := range cluster.GetServers() {
-		if srv.HasRestartCookie() {
+		if srv.HasRestartContainerCookie() {
 			cookieCountBefore++
 		}
 	}
@@ -296,7 +296,7 @@ func (regtest *RegTest) TestRestartCookieCleanup(cluster *cluster.Cluster, conf 
 	cookieCountAfter := 0
 	paramCountAfter := 0
 	for _, srv := range cluster.GetServers() {
-		if srv.HasRestartCookie() {
+		if srv.HasRestartContainerCookie() {
 			cookieCountAfter++
 		}
 		if srv.RestartNode != "" || srv.RestartRid != "" {
@@ -339,7 +339,7 @@ func (regtest *RegTest) TestRestartCookieTiming(cluster *cluster.Cluster, conf s
 	server.SetRestartRid("container#jobs")
 
 	startTime := time.Now()
-	err := server.SetRestartCookie()
+	err := server.SetRestartContainerCookie()
 	createDuration := time.Since(startTime)
 
 	if err != nil {
@@ -352,7 +352,7 @@ func (regtest *RegTest) TestRestartCookieTiming(cluster *cluster.Cluster, conf s
 
 	// Verify cookie can be detected quickly
 	startTime = time.Now()
-	exists := server.HasRestartCookie()
+	exists := server.HasRestartContainerCookie()
 	checkDuration := time.Since(startTime)
 
 	if !exists {
@@ -365,7 +365,7 @@ func (regtest *RegTest) TestRestartCookieTiming(cluster *cluster.Cluster, conf s
 
 	// Delete cookie
 	startTime = time.Now()
-	err = server.DelRestartCookie()
+	err = server.DelRestartContainerCookie()
 	deleteDuration := time.Since(startTime)
 
 	if err != nil {
@@ -421,7 +421,7 @@ func (regtest *RegTest) TestRestartCookieConcurrent(cluster *cluster.Cluster, co
 			srv := servers[index]
 			srv.SetRestartNode("node-" + srv.Id)
 			srv.SetRestartRid("rid-" + srv.Id)
-			err := srv.SetRestartCookie()
+			err := srv.SetRestartContainerCookie()
 			if err != nil {
 				errors <- err
 			} else {
@@ -453,7 +453,7 @@ func (regtest *RegTest) TestRestartCookieConcurrent(cluster *cluster.Cluster, co
 			"Concurrent operations had %d errors", errorCount)
 		// Clean up
 		for _, srv := range servers {
-			srv.DelRestartCookie()
+			srv.DelRestartContainerCookie()
 			srv.SetRestartNode("")
 			srv.SetRestartRid("")
 		}
@@ -463,7 +463,7 @@ func (regtest *RegTest) TestRestartCookieConcurrent(cluster *cluster.Cluster, co
 	// Verify all cookies were created
 	cookieCount := 0
 	for _, srv := range servers {
-		if srv.HasRestartCookie() {
+		if srv.HasRestartContainerCookie() {
 			cookieCount++
 		}
 	}
@@ -473,7 +473,7 @@ func (regtest *RegTest) TestRestartCookieConcurrent(cluster *cluster.Cluster, co
 			"Expected %d cookies, found %d", len(servers), cookieCount)
 		// Clean up
 		for _, srv := range servers {
-			srv.DelRestartCookie()
+			srv.DelRestartContainerCookie()
 			srv.SetRestartNode("")
 			srv.SetRestartRid("")
 		}
@@ -485,7 +485,7 @@ func (regtest *RegTest) TestRestartCookieConcurrent(cluster *cluster.Cluster, co
 
 	// Clean up all cookies
 	for _, srv := range servers {
-		srv.DelRestartCookie()
+		srv.DelRestartContainerCookie()
 		srv.SetRestartNode("")
 		srv.SetRestartRid("")
 	}

--- a/server/api_database.go
+++ b/server/api_database.go
@@ -2390,13 +2390,13 @@ func (repman *ReplicationManager) handlerMuxServerRestart(w http.ResponseWriter,
 		return
 	}
 
-	// Store parameters and set restart cookie
+	// Store parameters and set restart container cookie
 	node.RestartNode = nodeParam
 	node.RestartRid = ridParam
-	err := node.SetRestartCookie()
+	err := node.SetRestartContainerCookie()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": fmt.Sprintf("Failed to set restart cookie: %s", err)})
+		json.NewEncoder(w).Encode(map[string]string{"error": fmt.Sprintf("Failed to set restart container cookie: %s", err)})
 		return
 	}
 


### PR DESCRIPTION
This pull request refactors and improves the handling of restart cookies for containers within the cluster management codebase. The main change is a systematic renaming and specialization of the "restart cookie" logic to "restart container cookie," along with added safety checks to prevent container restarts while jobs are still running. The update also includes corresponding changes to tests and supporting utility methods.

**Restart container cookie handling improvements:**

- Renamed all methods and logic from generic "restart cookie" to "restart container cookie" throughout the codebase, including `SetRestartContainerCookie`, `HasRestartContainerCookie`, and `DelRestartContainerCookie` in `ServerMonitor` and their usages in cluster management and test files. [[1]](diffhunk://#diff-a9c48f22ec1d87ff0d2873815cfa59dc52f9a82be452494ba540d4fe89a44774L1174-R1210) [[2]](diffhunk://#diff-3359c53cd545ac2269bf4d16689c9ca42de5c038e3ffbb4bcf8b0c737618796bR65-R68) [[3]](diffhunk://#diff-40216aab0bb2fa7849db8ca135a1a3f6c483d26068f6d666463618776b62078eR150-R153) [[4]](diffhunk://#diff-bb25ba1a09f11c52d7b182be6ecf1d9cd8f22ef0deb9ae440fe18a27f91fb6b8R344-R347) [[5]](diffhunk://#diff-e5ce50e4600740e28e2dd4ede6078dbb0191f02d8e4359f40a3cf0f753e5ab1cL16-R36) [[6]](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0L501-R501)
- Updated comments and log messages to refer to "restart container cookie" for clarity and consistency. [[1]](diffhunk://#diff-a9c48f22ec1d87ff0d2873815cfa59dc52f9a82be452494ba540d4fe89a44774L1207-R1229) [[2]](diffhunk://#diff-a9c48f22ec1d87ff0d2873815cfa59dc52f9a82be452494ba540d4fe89a44774L1217-R1247) [[3]](diffhunk://#diff-a9c48f22ec1d87ff0d2873815cfa59dc52f9a82be452494ba540d4fe89a44774L1236-R1258) [[4]](diffhunk://#diff-c5fffdb4a6a092160ddd24b95042ba54bfcb96dfb0e747bb200902aac778adb1L226-R227)

**Safety enhancements for container restarts:**

- Added a check in `CheckRestartContainerCookies` to defer restart if jobs are still running on the server, using the new `HasRunningDBJobs` method, and logging a warning if so. [[1]](diffhunk://#diff-a9c48f22ec1d87ff0d2873815cfa59dc52f9a82be452494ba540d4fe89a44774L1174-R1210) [[2]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fR319-R345) [[3]](diffhunk://#diff-8f064ed373b8d36dcd88ee3e4f22d7c10e6873d71411991b1882ae63e81a7a15R239)

**Test updates:**

- Refactored all related test and benchmark methods to use the new container-specific cookie methods and names, ensuring tests accurately reflect the new logic and naming conventions. [[1]](diffhunk://#diff-e5ce50e4600740e28e2dd4ede6078dbb0191f02d8e4359f40a3cf0f753e5ab1cL16-R36) [[2]](diffhunk://#diff-e5ce50e4600740e28e2dd4ede6078dbb0191f02d8e4359f40a3cf0f753e5ab1cL50-R56) [[3]](diffhunk://#diff-e5ce50e4600740e28e2dd4ede6078dbb0191f02d8e4359f40a3cf0f753e5ab1cL69-R74) [[4]](diffhunk://#diff-e5ce50e4600740e28e2dd4ede6078dbb0191f02d8e4359f40a3cf0f753e5ab1cL84-R85) [[5]](diffhunk://#diff-e5ce50e4600740e28e2dd4ede6078dbb0191f02d8e4359f40a3cf0f753e5ab1cL101-R101) [[6]](diffhunk://#diff-e5ce50e4600740e28e2dd4ede6078dbb0191f02d8e4359f40a3cf0f753e5ab1cL138-R144) [[7]](diffhunk://#diff-e5ce50e4600740e28e2dd4ede6078dbb0191f02d8e4359f40a3cf0f753e5ab1cL164-R164) [[8]](diffhunk://#diff-e5ce50e4600740e28e2dd4ede6078dbb0191f02d8e4359f40a3cf0f753e5ab1cL183-R187) [[9]](diffhunk://#diff-e5ce50e4600740e28e2dd4ede6078dbb0191f02d8e4359f40a3cf0f753e5ab1cL210-R214) [[10]](diffhunk://#diff-e5ce50e4600740e28e2dd4ede6078dbb0191f02d8e4359f40a3cf0f753e5ab1cL229-R229) [[11]](diffhunk://#diff-e5ce50e4600740e28e2dd4ede6078dbb0191f02d8e4359f40a3cf0f753e5ab1cL243-R249) [[12]](diffhunk://#diff-e5ce50e4600740e28e2dd4ede6078dbb0191f02d8e4359f40a3cf0f753e5ab1cL268-R268) [[13]](diffhunk://#diff-e5ce50e4600740e28e2dd4ede6078dbb0191f02d8e4359f40a3cf0f753e5ab1cL287-R288) [[14]](diffhunk://#diff-e5ce50e4600740e28e2dd4ede6078dbb0191f02d8e4359f40a3cf0f753e5ab1cL299-R299) [[15]](diffhunk://#diff-e5ce50e4600740e28e2dd4ede6078dbb0191f02d8e4359f40a3cf0f753e5ab1cL320-R320)

**Error and logging improvements:**

- Added a new warning code (`WARN0165`) for cases when a restart container cookie is deferred due to running jobs, improving observability.

**General code maintenance:**

- Updated the cluster run loop and supporting files to use the new container cookie methods, removing the old generic restart cookie logic. [[1]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4L756-R756) [[2]](diffhunk://#diff-c5b2d5711934311e6d87ce3282fe9d9db4e3b82a2e0742d8a8b3a76c0f9a78e0L501-R501)