### PR TITLE
feat: Backup Helper and Metadata Management Enhancement

### DIFF
--- a/cluster/backup_helpers.go
+++ b/cluster/backup_helpers.go
@@ -20,6 +20,10 @@ import (
 	"github.com/signal18/replication-manager/utils/backupmgr"
 )
 
+// BackupRunOptions defines runtime overrides for backup execution behavior.
+// Line and RetentionDays influence default vs ad-hoc handling.
+// ResticEnabled can force enable/disable restic for this run.
+// BackupID is used for ad-hoc metadata naming.
 type BackupRunOptions struct {
 	Line          string
 	RetentionDays int
@@ -42,6 +46,9 @@ func normalizeBackupLine(value string) string {
 	}
 }
 
+// resolveBackupLine normalizes backup line selection and enforces ad-hoc
+// behavior when retention days are specified or when the server is not the
+// backup source or master.
 func (server *ServerMonitor) resolveBackupLine(opts BackupRunOptions) string {
 	line := normalizeBackupLine(opts.Line)
 	if opts.RetentionDays > 0 {
@@ -69,6 +76,8 @@ func (server *ServerMonitor) resolveBackupLine(opts BackupRunOptions) string {
 	return line
 }
 
+// shouldRunRestic decides whether restic should be used for a backup run.
+// It respects cluster config and an optional per-run override.
 func (server *ServerMonitor) shouldRunRestic(opts BackupRunOptions) bool {
 	cluster := server.ClusterGroup
 	if cluster == nil || !cluster.Conf.BackupRestic {

--- a/cluster/backup_helpers.go
+++ b/cluster/backup_helpers.go
@@ -1,0 +1,349 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// Authors: Guillaume Lefranc <guillaume@signal18.io>
+//          Stephane Varoqui  <svaroqui@gmail.com>
+// This source code is licensed under the GNU General Public License, version 3.
+
+package cluster
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/backupmgr"
+)
+
+type BackupRunOptions struct {
+	Line          string
+	RetentionDays int
+	ResticEnabled *bool
+	BackupID      int64
+}
+
+var adhocMetaFilePattern = regexp.MustCompile(`\.(\d+)\.meta\.json$`)
+
+func normalizeBackupLine(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	normalized = strings.ReplaceAll(normalized, "-", "")
+	switch normalized {
+	case backupmgr.BackupLineDefault:
+		return backupmgr.BackupLineDefault
+	case backupmgr.BackupLineAdhoc:
+		return backupmgr.BackupLineAdhoc
+	default:
+		return ""
+	}
+}
+
+func (server *ServerMonitor) resolveBackupLine(opts BackupRunOptions) string {
+	line := normalizeBackupLine(opts.Line)
+	if opts.RetentionDays > 0 {
+		line = backupmgr.BackupLineAdhoc
+	}
+	if line == "" {
+		line = backupmgr.BackupLineDefault
+	}
+
+	cluster := server.ClusterGroup
+	if cluster == nil {
+		return line
+	}
+
+	if line == backupmgr.BackupLineDefault {
+		backupServer := cluster.GetBackupServer()
+		master := cluster.GetMaster()
+		isAllowed := backupServer == server || master == server
+		if !isAllowed {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Backup request on %s treated as ad-hoc (not primary backup source or master)", server.URL)
+			line = backupmgr.BackupLineAdhoc
+		}
+	}
+
+	return line
+}
+
+func (server *ServerMonitor) shouldRunRestic(opts BackupRunOptions) bool {
+	cluster := server.ClusterGroup
+	if cluster == nil || !cluster.Conf.BackupRestic {
+		if opts.ResticEnabled != nil && *opts.ResticEnabled && cluster != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Restic requested but disabled for %s", server.URL)
+		}
+		return false
+	}
+
+	if opts.ResticEnabled == nil {
+		return true
+	}
+	return *opts.ResticEnabled
+}
+
+func (server *ServerMonitor) buildBackupMetaFileName(backupTool string, backupID int64, line string) string {
+	if backupTool == "" {
+		return ""
+	}
+
+	dir := server.GetMyBackupDirectory()
+	if normalizeBackupLine(line) == backupmgr.BackupLineAdhoc && backupID > 0 {
+		return filepath.Join(dir, fmt.Sprintf("%s.%d.meta.json", backupTool, backupID))
+	}
+	return filepath.Join(dir, fmt.Sprintf("%s.meta.json", backupTool))
+}
+
+func (server *ServerMonitor) backupMetaFilePath(meta *backupmgr.BackupMetadata) string {
+	if meta == nil {
+		return ""
+	}
+	if meta.MetaFile != "" {
+		if filepath.IsAbs(meta.MetaFile) {
+			return meta.MetaFile
+		}
+		return filepath.Join(server.GetMyBackupDirectory(), meta.MetaFile)
+	}
+	line := meta.BackupLine
+	if line == "" && meta.RetentionDays > 0 {
+		line = backupmgr.BackupLineAdhoc
+	}
+	return server.buildBackupMetaFileName(meta.BackupTool, meta.Id, line)
+}
+
+func parseAdhocMetaFileID(name string) (int64, bool) {
+	matches := adhocMetaFilePattern.FindStringSubmatch(name)
+	if len(matches) != 2 {
+		return 0, false
+	}
+	id, err := strconv.ParseInt(matches[1], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return id, true
+}
+
+func parseBackupToolFromMetaFilename(name string) string {
+	trimmed := strings.TrimSuffix(name, ".meta.json")
+	if trimmed == name {
+		return ""
+	}
+	// For adhoc files like "mysqldump.1234567890.meta.json", return "mysqldump"
+	// For default files like "mysqldump.meta.json", return "mysqldump"
+	idx := strings.LastIndex(trimmed, ".")
+	if idx < 0 {
+		// No dot found, so the trimmed string is the tool name (default case)
+		return trimmed
+	}
+	// Dot found, return everything before it (adhoc case)
+	return trimmed[:idx]
+}
+
+func readBackupMetadataFile(path string) (*backupmgr.BackupMetadata, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	meta := new(backupmgr.BackupMetadata)
+	if err := json.NewDecoder(file).Decode(meta); err != nil {
+		return nil, err
+	}
+	return meta, nil
+}
+
+func (server *ServerMonitor) LoadAdhocBackupMetadata() ([]*backupmgr.BackupMetadata, error) {
+	cluster := server.ClusterGroup
+	dir := server.GetMyBackupDirectory()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	metas := make([]*backupmgr.BackupMetadata, 0)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if !adhocMetaFilePattern.MatchString(name) {
+			continue
+		}
+
+		path := filepath.Join(dir, name)
+		meta, err := readBackupMetadataFile(path)
+		if err != nil {
+			if cluster != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "Failed reading ad-hoc backup metadata %s: %s", path, err)
+			}
+			continue
+		}
+		if meta == nil {
+			continue
+		}
+
+		meta.BackupLine = backupmgr.BackupLineAdhoc
+		if meta.Id == 0 {
+			if id, ok := parseAdhocMetaFileID(name); ok {
+				meta.Id = id
+			}
+		}
+		if meta.Id == 0 {
+			continue
+		}
+		if meta.BackupTool == "" {
+			meta.BackupTool = parseBackupToolFromMetaFilename(name)
+		}
+		if meta.BackupTool == "" {
+			continue
+		}
+		if meta.MetaFile == "" {
+			meta.MetaFile = path
+		}
+		if meta.Source == "" {
+			meta.Source = server.URL
+		}
+
+		if cluster != nil {
+			cluster.BackupMetaMap.Set(meta.Id, meta)
+		}
+		metas = append(metas, meta)
+	}
+
+	return metas, nil
+}
+
+func (server *ServerMonitor) GetLatestMetaForLine(method, line string) (int64, *backupmgr.BackupMetadata) {
+	cluster := server.ClusterGroup
+	if cluster == nil {
+		return 0, nil
+	}
+
+	normalizedLine := normalizeBackupLine(line)
+	applyLineFilter := normalizedLine != ""
+
+	var latest int64
+	var meta *backupmgr.BackupMetadata
+	cluster.BackupMetaMap.Range(func(k, v any) bool {
+		m := v.(*backupmgr.BackupMetadata)
+		valid := false
+		switch method {
+		case "logical":
+			if m.BackupMethod == backupmgr.BackupMethodLogical {
+				valid = true
+			}
+		case "physical":
+			if m.BackupMethod == backupmgr.BackupMethodPhysical {
+				valid = true
+			}
+		default:
+			if m.BackupTool == method {
+				valid = true
+			}
+		}
+
+		if m.Source != server.URL {
+			valid = false
+		}
+
+		if applyLineFilter {
+			if normalizedLine == backupmgr.BackupLineDefault && m.IsAdhoc() {
+				valid = false
+			}
+			if normalizedLine == backupmgr.BackupLineAdhoc && !m.IsAdhoc() {
+				valid = false
+			}
+		}
+
+		if valid && latest < m.Id {
+			latest = m.Id
+			meta = m
+		}
+
+		return true
+	})
+
+	return latest, meta
+}
+
+func (cluster *Cluster) PurgeExpiredAdhocBackups() {
+	if cluster == nil {
+		return
+	}
+
+	now := time.Now()
+	for _, server := range cluster.Servers {
+		if server == nil {
+			continue
+		}
+
+		metas, err := server.LoadAdhocBackupMetadata()
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Failed to load ad-hoc metadata on %s: %s", server.URL, err)
+			continue
+		}
+
+		for _, meta := range metas {
+			if meta == nil || !meta.IsAdhoc() || meta.RetentionDays <= 0 {
+				continue
+			}
+			if !meta.Completed {
+				continue
+			}
+			deadline, ok := retentionDeadline(meta)
+			if !ok || now.Before(deadline) {
+				continue
+			}
+
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Purging expired ad-hoc backup %d on %s", meta.Id, server.URL)
+
+			if meta.ResticSnapshotID != "" {
+				if cluster.Conf.BackupRestic {
+					if err := cluster.AddPurgeTask(meta.ResticSnapshotID); err != nil {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Failed to purge restic snapshot %s on %s: %s", meta.ResticSnapshotID, server.URL, err)
+					}
+				} else {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Restic disabled; skip purging snapshot %s on %s", meta.ResticSnapshotID, server.URL)
+				}
+			}
+
+			if meta.Dest != "" {
+				if err := os.RemoveAll(meta.Dest); err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Failed removing ad-hoc backup path %s on %s: %s", meta.Dest, server.URL, err)
+				}
+			}
+
+			metaPath := server.backupMetaFilePath(meta)
+			if metaPath != "" {
+				if err := os.Remove(metaPath); err != nil && !os.IsNotExist(err) {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Failed removing ad-hoc metadata %s on %s: %s", metaPath, server.URL, err)
+				}
+			}
+
+			cluster.BackupMetaMap.Delete(meta.Id)
+		}
+	}
+}
+
+func retentionDeadline(meta *backupmgr.BackupMetadata) (time.Time, bool) {
+	if meta == nil || meta.RetentionDays <= 0 {
+		return time.Time{}, false
+	}
+
+	base := meta.EndTime
+	if base.IsZero() {
+		base = meta.StartTime
+	}
+	if base.IsZero() && meta.Id > 0 {
+		base = time.Unix(meta.Id, 0)
+	}
+	if base.IsZero() {
+		return time.Time{}, false
+	}
+
+	return base.Add(time.Duration(meta.RetentionDays) * 24 * time.Hour), true
+}

--- a/cluster/backup_helpers.go
+++ b/cluster/backup_helpers.go
@@ -88,6 +88,12 @@ func (server *ServerMonitor) buildBackupMetaFileName(backupTool string, backupID
 	if backupTool == "" {
 		return ""
 	}
+	if !isSafeBackupToolName(backupTool) {
+		if cluster := server.ClusterGroup; cluster != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Invalid backup tool name %q for metadata file", backupTool)
+		}
+		return ""
+	}
 
 	dir := server.GetMyBackupDirectory()
 	if normalizeBackupLine(line) == backupmgr.BackupLineAdhoc && backupID > 0 {
@@ -164,6 +170,8 @@ func (server *ServerMonitor) LoadAdhocBackupMetadata() ([]*backupmgr.BackupMetad
 	}
 
 	metas := make([]*backupmgr.BackupMetadata, 0)
+	var lastErr error
+	readErrors := 0
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -177,6 +185,8 @@ func (server *ServerMonitor) LoadAdhocBackupMetadata() ([]*backupmgr.BackupMetad
 		path := filepath.Join(dir, name)
 		meta, err := readBackupMetadataFile(path)
 		if err != nil {
+			readErrors++
+			lastErr = err
 			if cluster != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "Failed reading ad-hoc backup metadata %s: %s", path, err)
 			}
@@ -212,6 +222,10 @@ func (server *ServerMonitor) LoadAdhocBackupMetadata() ([]*backupmgr.BackupMetad
 			cluster.BackupMetaMap.Set(meta.Id, meta)
 		}
 		metas = append(metas, meta)
+	}
+
+	if readErrors > 0 {
+		return metas, fmt.Errorf("failed reading %d ad-hoc backup metadata file(s): %w", readErrors, lastErr)
 	}
 
 	return metas, nil
@@ -275,6 +289,9 @@ func (cluster *Cluster) PurgeExpiredAdhocBackups() {
 		return
 	}
 
+	// BackupMetaMap is backed by sync.Map, so Range/Delete are safe for concurrent use.
+	// Purge operations intentionally rely on that thread-safety to avoid additional locks.
+
 	now := time.Now()
 	for _, server := range cluster.Servers {
 		if server == nil {
@@ -288,10 +305,7 @@ func (cluster *Cluster) PurgeExpiredAdhocBackups() {
 		}
 
 		for _, meta := range metas {
-			if meta == nil || !meta.IsAdhoc() || meta.RetentionDays <= 0 {
-				continue
-			}
-			if !meta.Completed {
+			if meta == nil || !meta.IsAdhoc() || meta.RetentionDays <= 0 || !meta.Completed {
 				continue
 			}
 			deadline, ok := retentionDeadline(meta)
@@ -312,7 +326,10 @@ func (cluster *Cluster) PurgeExpiredAdhocBackups() {
 			}
 
 			if meta.Dest != "" {
-				if err := os.RemoveAll(meta.Dest); err != nil {
+				backupDir := server.GetMyBackupDirectory()
+				if !isPathWithinBase(backupDir, meta.Dest) {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Skip removing ad-hoc backup path %s on %s: outside backup directory", meta.Dest, server.URL)
+				} else if err := os.RemoveAll(meta.Dest); err != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Failed removing ad-hoc backup path %s on %s: %s", meta.Dest, server.URL, err)
 				}
 			}
@@ -339,11 +356,52 @@ func retentionDeadline(meta *backupmgr.BackupMetadata) (time.Time, bool) {
 		base = meta.StartTime
 	}
 	if base.IsZero() && meta.Id > 0 {
-		base = time.Unix(meta.Id, 0)
+		if isLikelyUnixTimestamp(meta.Id) {
+			base = time.Unix(meta.Id, 0)
+		}
 	}
 	if base.IsZero() {
 		return time.Time{}, false
 	}
 
 	return base.Add(time.Duration(meta.RetentionDays) * 24 * time.Hour), true
+}
+
+func isLikelyUnixTimestamp(value int64) bool {
+	if value <= 0 {
+		return false
+	}
+	// Avoid treating small sequential IDs as timestamps.
+	minTimestamp := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
+	maxTimestamp := time.Now().Add(24 * time.Hour).Unix()
+	return value >= minTimestamp && value <= maxTimestamp
+}
+
+func isSafeBackupToolName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	return filepath.Base(name) == name
+}
+
+func isPathWithinBase(baseDir, target string) bool {
+	if baseDir == "" || target == "" {
+		return false
+	}
+	baseAbs, err := filepath.Abs(baseDir)
+	if err != nil {
+		return false
+	}
+	targetAbs, err := filepath.Abs(target)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(baseAbs, targetAbs)
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return true
+	}
+	return !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && rel != ".."
 }

--- a/cluster/backup_helpers_test.go
+++ b/cluster/backup_helpers_test.go
@@ -196,15 +196,17 @@ func TestRetentionDeadline(t *testing.T) {
 }
 
 func TestBuildBackupMetaFileName(t *testing.T) {
-	// Note: buildBackupMetaFileName needs GetMyBackupDirectory which requires ClusterGroup
-	// This test is limited and should be enhanced with proper cluster mock
-	// For now, skip tests that require full cluster setup
-	t.Skip("Skipping buildBackupMetaFileName test - requires full cluster setup")
-
-	server := &ServerMonitor{
-		Host: "127.0.0.1",
-		Port: "3306",
+	cluster := &Cluster{
+		Name:   "test-cluster",
+		Conf:   &config.Config{WorkingDir: t.TempDir()},
+		Logrus: logrus.New(),
 	}
+	server := &ServerMonitor{
+		Host:         "127.0.0.1",
+		Port:         "3306",
+		ClusterGroup: cluster,
+	}
+	backupDir := server.GetMyBackupDirectory()
 
 	tests := []struct {
 		name       string
@@ -235,6 +237,13 @@ func TestBuildBackupMetaFileName(t *testing.T) {
 			expectFile: "xtrabackup.9999.meta.json",
 		},
 		{
+			name:       "Adhoc without ID uses default",
+			backupTool: "mydumper",
+			backupID:   0,
+			line:       "adhoc",
+			expectFile: "mydumper.meta.json",
+		},
+		{
 			name:       "Empty tool",
 			backupTool: "",
 			backupID:   123,
@@ -258,10 +267,9 @@ func TestBuildBackupMetaFileName(t *testing.T) {
 					t.Errorf("Expected empty result, got %q", result)
 				}
 			} else {
-				expectedSuffix := tt.expectFile
-				if filepath.Base(result) != expectedSuffix {
-					t.Errorf("buildBackupMetaFileName() = %q, expected to end with %q",
-						result, expectedSuffix)
+				expectedPath := filepath.Join(backupDir, tt.expectFile)
+				if result != expectedPath {
+					t.Errorf("buildBackupMetaFileName() = %q, expected %q", result, expectedPath)
 				}
 			}
 		})

--- a/cluster/backup_helpers_test.go
+++ b/cluster/backup_helpers_test.go
@@ -1,0 +1,434 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// Authors: Guillaume Lefranc <guillaume@signal18.io>
+//          Stephane Varoqui  <svaroqui@gmail.com>
+// This source code is licensed under the GNU General Public License, version 3.
+
+package cluster
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/signal18/replication-manager/utils/backupmgr"
+)
+
+func TestNormalizeBackupLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"Default lowercase", "default", backupmgr.BackupLineDefault},
+		{"Default uppercase", "DEFAULT", backupmgr.BackupLineDefault},
+		{"Default with spaces", "  default  ", backupmgr.BackupLineDefault},
+		{"Default with hyphens", "de-fault", backupmgr.BackupLineDefault},
+		{"Adhoc lowercase", "adhoc", backupmgr.BackupLineAdhoc},
+		{"Adhoc uppercase", "ADHOC", backupmgr.BackupLineAdhoc},
+		{"Adhoc with spaces", "  adhoc  ", backupmgr.BackupLineAdhoc},
+		{"Adhoc with hyphens", "ad-hoc", backupmgr.BackupLineAdhoc},
+		{"Invalid input", "invalid", ""},
+		{"Empty string", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeBackupLine(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizeBackupLine(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseAdhocMetaFileID(t *testing.T) {
+	tests := []struct {
+		name       string
+		filename   string
+		expectedID int64
+		expectedOK bool
+	}{
+		{"Valid adhoc file", "mysqldump.1234567890.meta.json", 1234567890, true},
+		{"Valid with tool name", "mariabackup.9876543210.meta.json", 9876543210, true},
+		{"Invalid - no ID", "mysqldump.meta.json", 0, false},
+		{"Invalid - not numeric", "mysqldump.abc.meta.json", 0, false},
+		{"Invalid - wrong extension", "mysqldump.123.meta.txt", 0, false},
+		{"Invalid - no extension", "mysqldump.123", 0, false},
+		{"Edge case - zero ID", "tool.0.meta.json", 0, true},
+		{"Edge case - negative (invalid)", "tool.-123.meta.json", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, ok := parseAdhocMetaFileID(tt.filename)
+			if id != tt.expectedID || ok != tt.expectedOK {
+				t.Errorf("parseAdhocMetaFileID(%q) = (%d, %v), want (%d, %v)",
+					tt.filename, id, ok, tt.expectedID, tt.expectedOK)
+			}
+		})
+	}
+}
+
+func TestParseBackupToolFromMetaFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		expected string
+	}{
+		{"Mysqldump default", "mysqldump.meta.json", "mysqldump"},
+		{"Mysqldump adhoc", "mysqldump.1234567890.meta.json", "mysqldump"},
+		{"Mariabackup default", "mariabackup.meta.json", "mariabackup"},
+		{"Xtrabackup adhoc", "xtrabackup.9876543210.meta.json", "xtrabackup"},
+		{"Invalid - no extension", "mysqldump", ""},
+		{"Invalid - wrong extension", "mysqldump.meta.txt", ""},
+		{"Invalid - no dot separator", "mysqldumpmeta.json", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseBackupToolFromMetaFilename(tt.filename)
+			if result != tt.expected {
+				t.Errorf("parseBackupToolFromMetaFilename(%q) = %q, want %q",
+					tt.filename, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRetentionDeadline(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name      string
+		meta      *backupmgr.BackupMetadata
+		expectOK  bool
+		checkDiff time.Duration // Expected time difference from now
+	}{
+		{
+			name: "Valid with EndTime",
+			meta: &backupmgr.BackupMetadata{
+				EndTime:       now.Add(-48 * time.Hour),
+				RetentionDays: 7,
+			},
+			expectOK:  true,
+			checkDiff: (7*24 - 48) * time.Hour,
+		},
+		{
+			name: "Valid with StartTime only",
+			meta: &backupmgr.BackupMetadata{
+				StartTime:     now.Add(-24 * time.Hour),
+				RetentionDays: 3,
+			},
+			expectOK:  true,
+			checkDiff: (3*24 - 24) * time.Hour,
+		},
+		{
+			name: "Valid with ID as timestamp",
+			meta: &backupmgr.BackupMetadata{
+				Id:            time.Now().Add(-12 * time.Hour).Unix(),
+				RetentionDays: 1,
+			},
+			expectOK:  true,
+			checkDiff: 12 * time.Hour,
+		},
+		{
+			name: "Invalid - zero retention",
+			meta: &backupmgr.BackupMetadata{
+				EndTime:       now,
+				RetentionDays: 0,
+			},
+			expectOK: false,
+		},
+		{
+			name: "Invalid - negative retention",
+			meta: &backupmgr.BackupMetadata{
+				EndTime:       now,
+				RetentionDays: -1,
+			},
+			expectOK: false,
+		},
+		{
+			name: "Invalid - no timestamp",
+			meta: &backupmgr.BackupMetadata{
+				RetentionDays: 7,
+			},
+			expectOK: false,
+		},
+		{
+			name:     "Invalid - nil metadata",
+			meta:     nil,
+			expectOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deadline, ok := retentionDeadline(tt.meta)
+			if ok != tt.expectOK {
+				t.Errorf("retentionDeadline() ok = %v, want %v", ok, tt.expectOK)
+			}
+			if tt.expectOK {
+				if deadline.IsZero() {
+					t.Error("Expected non-zero deadline")
+				}
+				// Check that deadline is approximately correct (within 1 second tolerance)
+				expectedDeadline := now.Add(tt.checkDiff)
+				diff := deadline.Sub(expectedDeadline)
+				if diff < -time.Second || diff > time.Second {
+					t.Errorf("Deadline difference too large: %v (expected within 1s)", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildBackupMetaFileName(t *testing.T) {
+	// Note: buildBackupMetaFileName needs GetMyBackupDirectory which requires ClusterGroup
+	// This test is limited and should be enhanced with proper cluster mock
+	// For now, skip tests that require full cluster setup
+	t.Skip("Skipping buildBackupMetaFileName test - requires full cluster setup")
+
+	server := &ServerMonitor{
+		Host: "127.0.0.1",
+		Port: "3306",
+	}
+
+	tests := []struct {
+		name       string
+		backupTool string
+		backupID   int64
+		line       string
+		expectFile string
+	}{
+		{
+			name:       "Default line",
+			backupTool: "mysqldump",
+			backupID:   0,
+			line:       "default",
+			expectFile: "mysqldump.meta.json",
+		},
+		{
+			name:       "Adhoc line with ID",
+			backupTool: "mariabackup",
+			backupID:   1234567890,
+			line:       "adhoc",
+			expectFile: "mariabackup.1234567890.meta.json",
+		},
+		{
+			name:       "Adhoc normalized",
+			backupTool: "xtrabackup",
+			backupID:   9999,
+			line:       "ad-hoc",
+			expectFile: "xtrabackup.9999.meta.json",
+		},
+		{
+			name:       "Empty tool",
+			backupTool: "",
+			backupID:   123,
+			line:       "default",
+			expectFile: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := server.buildBackupMetaFileName(tt.backupTool, tt.backupID, tt.line)
+			if tt.expectFile == "" {
+				if result != "" {
+					t.Errorf("Expected empty result, got %q", result)
+				}
+			} else {
+				expectedSuffix := tt.expectFile
+				if filepath.Base(result) != expectedSuffix {
+					t.Errorf("buildBackupMetaFileName() = %q, expected to end with %q",
+						result, expectedSuffix)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveBackupLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     BackupRunOptions
+		isMaster bool
+		isBackup bool
+		expected string
+	}{
+		{
+			name:     "Default with retention forces adhoc",
+			opts:     BackupRunOptions{Line: "default", RetentionDays: 7},
+			expected: backupmgr.BackupLineAdhoc,
+		},
+		{
+			name:     "Explicit adhoc",
+			opts:     BackupRunOptions{Line: "adhoc"},
+			expected: backupmgr.BackupLineAdhoc,
+		},
+		{
+			name:     "Empty defaults to default",
+			opts:     BackupRunOptions{},
+			isMaster: true,
+			isBackup: true,
+			expected: backupmgr.BackupLineDefault,
+		},
+		{
+			name:     "Default on non-backup server forces adhoc",
+			opts:     BackupRunOptions{Line: "default"},
+			isMaster: false,
+			isBackup: false,
+			expected: backupmgr.BackupLineAdhoc,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Note: This is a simplified test. Full test would require cluster setup
+			// which is complex. This tests the normalization logic.
+			server := &ServerMonitor{}
+			result := server.resolveBackupLine(tt.opts)
+
+			// Basic validation - should return either "default" or "adhoc"
+			if result != backupmgr.BackupLineDefault && result != backupmgr.BackupLineAdhoc {
+				t.Errorf("resolveBackupLine() returned invalid line: %q", result)
+			}
+		})
+	}
+}
+
+func TestShouldRunRestic(t *testing.T) {
+	tests := []struct {
+		name             string
+		resticConfigured bool
+		resticEnabled    *bool
+		expected         bool
+	}{
+		{
+			name:             "Configured and enabled",
+			resticConfigured: true,
+			resticEnabled:    nil,
+			expected:         true,
+		},
+		{
+			name:             "Configured and explicitly enabled",
+			resticConfigured: true,
+			resticEnabled:    boolPtr(true),
+			expected:         true,
+		},
+		{
+			name:             "Configured but explicitly disabled",
+			resticConfigured: true,
+			resticEnabled:    boolPtr(false),
+			expected:         false,
+		},
+		{
+			name:             "Not configured, no override",
+			resticConfigured: false,
+			resticEnabled:    nil,
+			expected:         false,
+		},
+		{
+			name:             "Not configured, explicit enable (should be false)",
+			resticConfigured: false,
+			resticEnabled:    boolPtr(true),
+			expected:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &ServerMonitor{}
+			opts := BackupRunOptions{
+				ResticEnabled: tt.resticEnabled,
+			}
+
+			// Note: Full test would need cluster with BackupRestic config
+			// This is a simplified test of the logic
+			result := server.shouldRunRestic(opts)
+
+			// Without cluster, should always return false
+			if result != false {
+				t.Errorf("shouldRunRestic() without cluster = %v, want false", result)
+			}
+		})
+	}
+}
+
+func TestReadBackupMetadataFile(t *testing.T) {
+	// Create a temporary test file
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.meta.json")
+
+	testData := `{
+		"id": 1234567890,
+		"backupTool": "mysqldump",
+		"backupMethod": 1,
+		"completed": true,
+		"retentionDays": 7
+	}`
+
+	err := os.WriteFile(testFile, []byte(testData), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	meta, err := readBackupMetadataFile(testFile)
+	if err != nil {
+		t.Fatalf("readBackupMetadataFile() error = %v", err)
+	}
+
+	if meta.Id != 1234567890 {
+		t.Errorf("meta.Id = %d, want 1234567890", meta.Id)
+	}
+	if meta.BackupTool != "mysqldump" {
+		t.Errorf("meta.BackupTool = %q, want 'mysqldump'", meta.BackupTool)
+	}
+	if !meta.Completed {
+		t.Error("meta.Completed = false, want true")
+	}
+	if meta.RetentionDays != 7 {
+		t.Errorf("meta.RetentionDays = %d, want 7", meta.RetentionDays)
+	}
+}
+
+func TestReadBackupMetadataFile_Invalid(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{"Invalid JSON", `{invalid json`},
+		{"Empty file", ``},
+		{"Wrong format", `["array", "not", "object"]`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			testFile := filepath.Join(tmpDir, "invalid.meta.json")
+
+			err := os.WriteFile(testFile, []byte(tt.content), 0644)
+			if err != nil {
+				t.Fatalf("Failed to create test file: %v", err)
+			}
+
+			_, err = readBackupMetadataFile(testFile)
+			if err == nil {
+				t.Error("Expected error for invalid metadata file, got nil")
+			}
+		})
+	}
+}
+
+func TestReadBackupMetadataFile_NotExists(t *testing.T) {
+	_, err := readBackupMetadataFile("/nonexistent/path/file.json")
+	if err == nil {
+		t.Error("Expected error for non-existent file, got nil")
+	}
+}
+
+// Helper function
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/cluster/backup_helpers_test.go
+++ b/cluster/backup_helpers_test.go
@@ -7,9 +7,11 @@
 package cluster
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -575,6 +577,96 @@ func TestIsPathWithinBase(t *testing.T) {
 	}
 	if isPathWithinBase(base, "/tmp") {
 		t.Errorf("expected /tmp to be outside %s", base)
+	}
+}
+
+func TestPurgeExpiredAdhocBackupsConcurrent(t *testing.T) {
+	cluster := &Cluster{
+		Name:          "test-cluster",
+		Conf:          &config.Config{WorkingDir: t.TempDir()},
+		StateMachine:  &state.StateMachine{},
+		Logrus:        logrus.New(),
+		BackupMetaMap: backupmgr.NewBackupMetaMap(),
+	}
+	cluster.StateMachine.Init()
+
+	servers := serverList{
+		{Host: "127.0.0.1", Port: "3306", URL: "127.0.0.1:3306", ClusterGroup: cluster},
+		{Host: "127.0.0.2", Port: "3307", URL: "127.0.0.2:3307", ClusterGroup: cluster},
+	}
+	cluster.Servers = servers
+
+	baseTime := time.Now().Add(-48 * time.Hour)
+	type metaPaths struct {
+		id       int64
+		metaFile string
+		destDir  string
+	}
+	paths := make([]metaPaths, 0, len(servers))
+
+	for i, server := range servers {
+		backupDir := server.GetMyBackupDirectory()
+		destDir := filepath.Join(backupDir, "adhoc", server.Host)
+		if err := os.MkdirAll(destDir, 0755); err != nil {
+			t.Fatalf("failed to create dest dir: %v", err)
+		}
+
+		id := baseTime.Unix() + int64(i+1)
+		meta := &backupmgr.BackupMetadata{
+			Id:            id,
+			BackupTool:    "mysqldump",
+			RetentionDays: 1,
+			Completed:     true,
+			EndTime:       baseTime,
+			Dest:          destDir,
+			BackupLine:    backupmgr.BackupLineAdhoc,
+			Source:        server.URL,
+		}
+		metaFile := server.buildBackupMetaFileName(meta.BackupTool, meta.Id, backupmgr.BackupLineAdhoc)
+		if metaFile == "" {
+			t.Fatalf("failed to build metadata file path")
+		}
+		payload, err := json.Marshal(meta)
+		if err != nil {
+			t.Fatalf("failed to marshal metadata: %v", err)
+		}
+		if err := os.WriteFile(metaFile, payload, 0644); err != nil {
+			t.Fatalf("failed to write metadata file: %v", err)
+		}
+
+		cluster.BackupMetaMap.Set(meta.Id, meta)
+		paths = append(paths, metaPaths{id: meta.Id, metaFile: metaFile, destDir: destDir})
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cluster.PurgeExpiredAdhocBackups()
+		}()
+	}
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cluster.BackupMetaMap.Range(func(_, _ any) bool { return true })
+		}()
+	}
+
+	wg.Wait()
+
+	for _, entry := range paths {
+		if got := cluster.BackupMetaMap.Get(entry.id); got != nil {
+			t.Errorf("expected metadata %d to be removed", entry.id)
+		}
+		if _, err := os.Stat(entry.metaFile); err == nil {
+			t.Errorf("expected metadata file %s to be removed", entry.metaFile)
+		}
+		if _, err := os.Stat(entry.destDir); err == nil {
+			t.Errorf("expected dest dir %s to be removed", entry.destDir)
+		}
 	}
 }
 

--- a/cluster/backup_helpers_test.go
+++ b/cluster/backup_helpers_test.go
@@ -9,10 +9,14 @@ package cluster
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/backupmgr"
+	"github.com/signal18/replication-manager/utils/state"
+	"github.com/sirupsen/logrus"
 )
 
 func TestNormalizeBackupLine(t *testing.T) {
@@ -126,11 +130,19 @@ func TestRetentionDeadline(t *testing.T) {
 		{
 			name: "Valid with ID as timestamp",
 			meta: &backupmgr.BackupMetadata{
-				Id:            time.Now().Add(-12 * time.Hour).Unix(),
+				Id:            now.Add(-12 * time.Hour).Unix(),
 				RetentionDays: 1,
 			},
 			expectOK:  true,
 			checkDiff: 12 * time.Hour,
+		},
+		{
+			name: "Invalid - ID not a timestamp",
+			meta: &backupmgr.BackupMetadata{
+				Id:            12345,
+				RetentionDays: 1,
+			},
+			expectOK: false,
 		},
 		{
 			name: "Invalid - zero retention",
@@ -229,6 +241,13 @@ func TestBuildBackupMetaFileName(t *testing.T) {
 			line:       "default",
 			expectFile: "",
 		},
+		{
+			name:       "Invalid tool path",
+			backupTool: "../mysqldump",
+			backupID:   123,
+			line:       "default",
+			expectFile: "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -249,50 +268,111 @@ func TestBuildBackupMetaFileName(t *testing.T) {
 	}
 }
 
+func newBackupLineCluster(t *testing.T) (*Cluster, *ServerMonitor, *ServerMonitor, *ServerMonitor) {
+	t.Helper()
+
+	sm := &state.StateMachine{}
+	sm.Init()
+	sm.Discovered = true
+
+	cluster := &Cluster{
+		Name:         "test-cluster",
+		Conf:         &config.Config{},
+		StateMachine: sm,
+		Logrus:       logrus.New(),
+	}
+
+	master := &ServerMonitor{
+		Id:           "1",
+		URL:          "master:3306",
+		State:        stateMaster,
+		ClusterGroup: cluster,
+	}
+	backup := &ServerMonitor{
+		Id:             "2",
+		URL:            "backup:3306",
+		State:          stateSlave,
+		PreferedBackup: true,
+		ClusterGroup:   cluster,
+	}
+	other := &ServerMonitor{
+		Id:           "3",
+		URL:          "other:3306",
+		State:        stateSlave,
+		ClusterGroup: cluster,
+	}
+
+	cluster.master = master
+	cluster.Servers = serverList{master, backup, other}
+
+	return cluster, master, backup, other
+}
+
 func TestResolveBackupLine(t *testing.T) {
 	tests := []struct {
 		name     string
+		server   *ServerMonitor
 		opts     BackupRunOptions
-		isMaster bool
-		isBackup bool
 		expected string
 	}{
 		{
 			name:     "Default with retention forces adhoc",
+			server:   nil,
 			opts:     BackupRunOptions{Line: "default", RetentionDays: 7},
 			expected: backupmgr.BackupLineAdhoc,
 		},
 		{
 			name:     "Explicit adhoc",
+			server:   nil,
 			opts:     BackupRunOptions{Line: "adhoc"},
 			expected: backupmgr.BackupLineAdhoc,
 		},
 		{
-			name:     "Empty defaults to default",
-			opts:     BackupRunOptions{},
-			isMaster: true,
-			isBackup: true,
+			name:     "Default on master stays default",
+			server:   nil,
+			opts:     BackupRunOptions{Line: "default"},
 			expected: backupmgr.BackupLineDefault,
 		},
 		{
-			name:     "Default on non-backup server forces adhoc",
+			name:     "Default on backup server stays default",
+			server:   nil,
 			opts:     BackupRunOptions{Line: "default"},
-			isMaster: false,
-			isBackup: false,
+			expected: backupmgr.BackupLineDefault,
+		},
+		{
+			name:     "Default on other server forces adhoc",
+			server:   nil,
+			opts:     BackupRunOptions{Line: "default"},
+			expected: backupmgr.BackupLineAdhoc,
+		},
+		{
+			name:     "Empty line on other server forces adhoc",
+			server:   nil,
+			opts:     BackupRunOptions{},
 			expected: backupmgr.BackupLineAdhoc,
 		},
 	}
 
+	_, master, backup, other := newBackupLineCluster(t)
+
+	for i := range tests {
+		switch tests[i].name {
+		case "Default on master stays default":
+			tests[i].server = master
+		case "Default on backup server stays default":
+			tests[i].server = backup
+		case "Default on other server forces adhoc", "Empty line on other server forces adhoc":
+			tests[i].server = other
+		default:
+			tests[i].server = master
+		}
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Note: This is a simplified test. Full test would require cluster setup
-			// which is complex. This tests the normalization logic.
-			server := &ServerMonitor{}
-			result := server.resolveBackupLine(tt.opts)
-
-			// Basic validation - should return either "default" or "adhoc"
-			if result != backupmgr.BackupLineDefault && result != backupmgr.BackupLineAdhoc {
-				t.Errorf("resolveBackupLine() returned invalid line: %q", result)
+			result := tt.server.resolveBackupLine(tt.opts)
+			if result != tt.expected {
+				t.Errorf("resolveBackupLine() = %q, want %q", result, tt.expected)
 			}
 		})
 	}
@@ -303,6 +383,7 @@ func TestShouldRunRestic(t *testing.T) {
 		name             string
 		resticConfigured bool
 		resticEnabled    *bool
+		clusterNil       bool
 		expected         bool
 	}{
 		{
@@ -335,22 +416,31 @@ func TestShouldRunRestic(t *testing.T) {
 			resticEnabled:    boolPtr(true),
 			expected:         false,
 		},
+		{
+			name:       "Cluster is nil",
+			clusterNil: true,
+			expected:   false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := &ServerMonitor{}
+			if !tt.clusterNil {
+				cluster := &Cluster{
+					Name:   "test-cluster",
+					Conf:   &config.Config{BackupRestic: tt.resticConfigured},
+					Logrus: logrus.New(),
+				}
+				server.ClusterGroup = cluster
+				server.URL = "server:3306"
+			}
 			opts := BackupRunOptions{
 				ResticEnabled: tt.resticEnabled,
 			}
-
-			// Note: Full test would need cluster with BackupRestic config
-			// This is a simplified test of the logic
 			result := server.shouldRunRestic(opts)
-
-			// Without cluster, should always return false
-			if result != false {
-				t.Errorf("shouldRunRestic() without cluster = %v, want false", result)
+			if result != tt.expected {
+				t.Errorf("shouldRunRestic() = %v, want %v", result, tt.expected)
 			}
 		})
 	}
@@ -425,6 +515,58 @@ func TestReadBackupMetadataFile_NotExists(t *testing.T) {
 	_, err := readBackupMetadataFile("/nonexistent/path/file.json")
 	if err == nil {
 		t.Error("Expected error for non-existent file, got nil")
+	}
+}
+
+func TestLoadAdhocBackupMetadataReturnsError(t *testing.T) {
+	cluster := &Cluster{
+		Name:          "test-cluster",
+		Conf:          &config.Config{WorkingDir: t.TempDir()},
+		StateMachine:  &state.StateMachine{},
+		Logrus:        logrus.New(),
+		BackupMetaMap: backupmgr.NewBackupMetaMap(),
+	}
+	cluster.StateMachine.Init()
+	server := &ServerMonitor{
+		Host:         "127.0.0.1",
+		Port:         "3306",
+		URL:          "127.0.0.1:3306",
+		ClusterGroup: cluster,
+	}
+
+	backupDir := server.GetMyBackupDirectory()
+	validPath := filepath.Join(backupDir, "mysqldump.123.meta.json")
+	invalidPath := filepath.Join(backupDir, "mysqldump.456.meta.json")
+
+	validData := `{"backupTool":"mysqldump","backupMethod":1,"completed":true,"retentionDays":1}`
+	if err := os.WriteFile(validPath, []byte(validData), 0644); err != nil {
+		t.Fatalf("failed to write valid metadata: %v", err)
+	}
+	if err := os.WriteFile(invalidPath, []byte("{invalid"), 0644); err != nil {
+		t.Fatalf("failed to write invalid metadata: %v", err)
+	}
+
+	metas, err := server.LoadAdhocBackupMetadata()
+	if err == nil {
+		t.Fatalf("expected error when reading invalid metadata")
+	}
+	if !strings.Contains(err.Error(), "failed reading") {
+		t.Fatalf("expected error summary, got %v", err)
+	}
+	if len(metas) != 1 {
+		t.Fatalf("expected 1 valid metadata, got %d", len(metas))
+	}
+}
+
+func TestIsPathWithinBase(t *testing.T) {
+	base := t.TempDir()
+	child := filepath.Join(base, "child")
+
+	if !isPathWithinBase(base, child) {
+		t.Errorf("expected %s to be within %s", child, base)
+	}
+	if isPathWithinBase(base, "/tmp") {
+		t.Errorf("expected /tmp to be outside %s", base)
 	}
 }
 


### PR DESCRIPTION
This pull request introduces a new file, `backup_helpers.go`, in the `cluster` package, providing a comprehensive set of helper functions and types to manage backup metadata, retention, and cleanup operations for MariaDB/MySQL clusters. The changes improve how ad-hoc and default backups are identified, stored, and purged, and add utilities for working with backup metadata files.

Key new features and improvements:

**Backup Metadata Management:**
- Added multiple helper functions for reading, parsing, and normalizing backup metadata files, including functions to build metadata file names, extract backup tool names, and parse backup IDs from filenames.
- Introduced the `BackupRunOptions` struct to encapsulate options for backup runs, improving code clarity and maintainability.

**Ad-hoc Backup Handling:**
- Implemented `LoadAdhocBackupMetadata` to load all ad-hoc backup metadata files for a server, ensuring metadata is correctly populated and registered in the cluster’s backup metadata map.
- Added logic to resolve whether a backup should be treated as ad-hoc or default based on server role and retention settings.

**Backup Retention and Purging:**
- Added `PurgeExpiredAdhocBackups`, which iterates over all servers in a cluster and purges expired ad-hoc backups and their associated metadata and storage, including integration with Rest