### PR TITLE
feat: Add logging for backup and restore operations with timestamps

### DIFF
--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -411,6 +411,7 @@ func (server *ServerMonitor) JobBackupPhysicalWithOptions(opts BackupRunOptions)
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Receive physical backup %s (%s line) request for server: %s", cluster.Conf.BackupPhysicalType, backupLine, server.URL)
 
 	now := time.Now()
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Physical backup %s started at %s for: %s", cluster.Conf.BackupPhysicalType, now.Format(time.RFC3339), server.URL)
 	var port string
 	var err error
 	var backupext string = ".xbtream"
@@ -1269,6 +1270,8 @@ func (server *ServerMonitor) JobZFSSnapBack() (int64, error) {
 
 func (server *ServerMonitor) JobReseedMyLoader(backupdir string, restoreUser bool) error {
 	cluster := server.ClusterGroup
+	start := time.Now()
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Logical restore (myloader) started at %s for: %s", start.Format(time.RFC3339), server.URL)
 	threads := strconv.Itoa(cluster.Conf.BackupLogicalLoadThreads)
 
 	if restoreUser {
@@ -1332,7 +1335,8 @@ func (server *ServerMonitor) JobReseedMyLoader(backupdir string, restoreUser boo
 	if err := dumpCmd.Wait(); err != nil {
 		return err
 	}
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Finish logical restaure %s for: %s", cluster.Conf.BackupLogicalType, server.URL)
+	elapsed := time.Since(start).Round(time.Second)
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Finish logical restore (myloader) in %s (started at %s) for: %s", elapsed, start.Format(time.RFC3339), server.URL)
 	server.Refresh()
 
 	return nil
@@ -1343,6 +1347,8 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string, restoreUser b
 	var err error
 	defer server.SetInReseedBackup("")
 
+	start := time.Now()
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Logical restore (mysqldump) started at %s for: %s", start.Format(time.RFC3339), server.URL)
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Sending logical backup to reseed %s", server.URL)
 
 	server.StopSlave()
@@ -1418,6 +1424,8 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string, restoreUser b
 		return fmt.Errorf("Error waiting reseed %s at %s", server.URL, err)
 	}
 
+	elapsed := time.Since(start).Round(time.Second)
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Finish logical restore (mysqldump) in %s (started at %s) for: %s", elapsed, start.Format(time.RFC3339), server.URL)
 	return nil
 }
 
@@ -1465,6 +1473,8 @@ func (server *ServerMonitor) ReadMysqldumpUser(backupfile string) (io.Reader, er
 func (server *ServerMonitor) JobReseedBackupScript() {
 	cluster := server.ClusterGroup
 	defer server.SetInReseedBackup("")
+	start := time.Now()
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Logical restore (script) started at %s for: %s", start.Format(time.RFC3339), server.URL)
 
 	cmd := exec.Command(cluster.Conf.BackupLoadScript, misc.Unbracket(server.Host), misc.Unbracket(cluster.master.Host), server.Port, server.GetCluster().GetMaster().Port, cluster.GetDbUser(), cluster.GetDbPass(), cluster.Name)
 
@@ -1488,7 +1498,8 @@ func (server *ServerMonitor) JobReseedBackupScript() {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "My reload script: %s", err)
 		return
 	}
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Finish logical restaure from load script on %s ", server.URL)
+	elapsed := time.Since(start).Round(time.Second)
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Finish logical restore (script) in %s (started at %s) for: %s", elapsed, start.Format(time.RFC3339), server.URL)
 
 }
 
@@ -2390,6 +2401,7 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(opts BackupRunOptions) 
 	}
 
 	start := time.Now()
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Logical backup %s started at %s for: %s", cluster.Conf.BackupLogicalType, start.Format(time.RFC3339), server.URL)
 	var prevId int64
 	if !isAdhoc {
 		prev := cluster.BackupMetaMap.GetPreviousBackup(cluster.Conf.BackupLogicalType, server.URL)
@@ -2603,6 +2615,12 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(opts BackupRunOptions) 
 	} else {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "[ERROR] Finish logical backup %s for: %s", cluster.Conf.BackupLogicalType, server.URL)
 	}
+	elapsed := time.Since(start).Round(time.Second)
+	backupLogLevel := config.LvlInfo
+	if err != nil {
+		backupLogLevel = config.LvlWarn
+	}
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, backupLogLevel, "Logical backup %s completed in %s (started at %s) for: %s", cluster.Conf.BackupLogicalType, elapsed, start.Format(time.RFC3339), server.URL)
 
 	// Create restic snapshot asynchronously and update metadata when complete
 	backtype := "logical"
@@ -3312,11 +3330,16 @@ func (server *ServerMonitor) WaitAndSendSST(task string, filename string, uncomp
 	if count > 0 {
 		server.JobsUpdateState(task, "processing", 1, 0)
 		go func() {
+			sendStart := time.Now()
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModSST, config.LvlInfo, "SST send for %s started at %s (file: %s)", task, sendStart.Format(time.RFC3339), filename)
 			err := cluster.SSTRunSender(filename, server, uncompress)
+			elapsed := time.Since(sendStart).Round(time.Second)
 			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModSST, config.LvlErr, err.Error())
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModSST, config.LvlErr, "SST send for %s failed after %s: %s", task, elapsed, err.Error())
 				server.JobsUpdateState(task, err.Error(), 5, 0)
+				return
 			}
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModSST, config.LvlInfo, "SST send for %s completed in %s (started at %s)", task, elapsed, sendStart.Format(time.RFC3339))
 		}()
 		return nil
 	} else {
@@ -3740,6 +3763,14 @@ func (server *ServerMonitor) JobFinishReceiveFile(task string) error {
 	case config.ConstBackupPhysicalTypeXtrabackup, config.ConstBackupPhysicalTypeMariaBackup:
 		backtype := "physical"
 		server.WriteBackupMetadata(backupmgr.BackupMethodPhysical)
+		if server.LastBackupMeta.Physical != nil && !server.LastBackupMeta.Physical.StartTime.IsZero() {
+			backupTool := server.LastBackupMeta.Physical.BackupTool
+			if backupTool == "" {
+				backupTool = cluster.Conf.BackupPhysicalType
+			}
+			elapsed := time.Since(server.LastBackupMeta.Physical.StartTime).Round(time.Second)
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Physical backup %s completed in %s (started at %s) for: %s", backupTool, elapsed, server.LastBackupMeta.Physical.StartTime.Format(time.RFC3339), server.URL)
+		}
 
 		// CRITICAL: Transition from traditional backup lock to Restic lock atomically
 		// Set Restic flag BEFORE clearing physical backup flag


### PR DESCRIPTION
This pull request improves logging for backup and restore operations in the `cluster/srv_job.go` file by adding detailed start and completion timestamps, as well as elapsed time for each operation. These changes enhance traceability and make it easier to monitor the duration and status of logical and physical backup/restore jobs.

**Enhanced logging of backup and restore operations:**

* Added log statements to record the start time for physical backup, logical backup, and all logical restore operations (`myloader`, `mysqldump`, and script-based restores), including the server URL and backup type. [[1]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fR414) [[2]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fR2404) [[3]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fR1273-R1274) [[4]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fR1350-R1351) [[5]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fR1476-R1477)
* Updated log statements to include elapsed time and start time when logical restore operations complete, improving visibility into operation duration. [[1]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fL1335-R1339) [[2]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fR1427-R1428) [[3]](diffhunk://#diff-2acc9b9b78acb496c5d51c62db04a151d92717d322003e701bb3526902c3864fL1491-R1502)
* Enhanced completion logging for logical backup jobs to include elapsed time, start time, and log level adjustment based on error status.
* Improved SST (State Snapshot Transfer) send operation logging to include start time, elapsed time, and error handling details.

**Physical backup completion logging:**

* Added a log entry for physical backup completion, showing elapsed time and start time, using metadata from the backup process.