### PR TITLE
Refactor restic mount directory handling to use <working-dir>/<cluster>/mount as default path to prevent permission problem; update related tests and documentation.

### DIFF
--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -397,7 +397,7 @@ type resticMountDirResolveOptions struct {
 	logSanitize        bool
 }
 
-const resticDefaultMountBase = "/mnt/restic"
+const resticDefaultMountSubdir = "mount"
 
 type resticMountOptionMeta struct {
 	mountDirSource  string
@@ -445,11 +445,21 @@ func (cluster *Cluster) resolveResticMountDirFromConfig(opts resticMountDirResol
 		return "", "", fmt.Errorf("cluster name is empty")
 	}
 
-	mountDir := filepath.Join(resticDefaultMountBase, clusterName)
+	baseDir := filepath.Join(cluster.WorkingDir, resticDefaultMountSubdir)
+	mountDir := baseDir
 	mountDirSource := "default"
 	if trimmed := strings.TrimSpace(cluster.Conf.BackupResticMountDir); trimmed != "" {
-		mountDir = trimmed
 		mountDirSource = "config"
+		if filepath.IsAbs(trimmed) {
+			mountDir = trimmed
+		} else {
+			baseDir := filepath.Join(cluster.WorkingDir, resticDefaultMountSubdir)
+			mountDir = filepath.Join(baseDir, trimmed)
+			cluster.LogModulePrintf(cluster.Conf.Verbose,
+				config.ConstLogModRestic,
+				config.LvlInfo,
+				"Resolved relative restic mount dir from config: %s -> %s (base %s)", trimmed, mountDir, baseDir)
+		}
 	}
 
 	var err error
@@ -458,7 +468,7 @@ func (cluster *Cluster) resolveResticMountDirFromConfig(opts resticMountDirResol
 		return "", mountDirSource, err
 	}
 	if opts.enforceDefaultBase && mountDirSource == "default" {
-		base := filepath.Clean(resticDefaultMountBase)
+		base := filepath.Clean(filepath.Join(cluster.WorkingDir, resticDefaultMountSubdir))
 		rel, relErr := filepath.Rel(base, mountDir)
 		if relErr != nil || rel == "" || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 			mountErr := fmt.Errorf("default mount dir %s escapes base %s", mountDir, base)
@@ -599,7 +609,7 @@ func (cluster *Cluster) sanitizeAndValidateResticMountOptions(mountOpt *backupmg
 		return fmt.Errorf("restic mount target dir must be absolute: %s", mountOpt.TargetDir)
 	}
 	if meta.targetDirSource == "default" && meta.mountDirSource == "default" {
-		base := filepath.Clean(resticDefaultMountBase)
+		base := filepath.Clean(filepath.Join(cluster.WorkingDir, resticDefaultMountSubdir))
 		rel, relErr := filepath.Rel(base, mountOpt.TargetDir)
 		if relErr != nil || rel == "" || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 			mountErr := fmt.Errorf("default restic mount dir %s escapes base %s", mountOpt.TargetDir, base)

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -453,7 +453,6 @@ func (cluster *Cluster) resolveResticMountDirFromConfig(opts resticMountDirResol
 		if filepath.IsAbs(trimmed) {
 			mountDir = trimmed
 		} else {
-			baseDir := filepath.Join(cluster.WorkingDir, resticDefaultMountSubdir)
 			mountDir = filepath.Join(baseDir, trimmed)
 			cluster.LogModulePrintf(cluster.Conf.Verbose,
 				config.ConstLogModRestic,
@@ -469,6 +468,7 @@ func (cluster *Cluster) resolveResticMountDirFromConfig(opts resticMountDirResol
 	}
 	if opts.enforceDefaultBase && mountDirSource == "default" {
 		base := filepath.Clean(filepath.Join(cluster.WorkingDir, resticDefaultMountSubdir))
+		// filepath.Rel does not resolve symlinks; callers should avoid untrusted bases.
 		rel, relErr := filepath.Rel(base, mountDir)
 		if relErr != nil || rel == "" || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 			mountErr := fmt.Errorf("default mount dir %s escapes base %s", mountDir, base)
@@ -480,6 +480,26 @@ func (cluster *Cluster) resolveResticMountDirFromConfig(opts resticMountDirResol
 	}
 
 	return mountDir, mountDirSource, nil
+}
+
+// ResolveResticMountDirFromConfig returns the configured restic mount directory and source.
+func (cluster *Cluster) ResolveResticMountDirFromConfig() (string, string, error) {
+	return cluster.resolveResticMountDirFromConfig(resticMountDirResolveOptions{
+		requireAbs:         false,
+		rejectDotDot:       false,
+		enforceDefaultBase: false,
+		logSanitize:        false,
+	})
+}
+
+// ResolveResticMountDirFromConfigStrict enforces extra safety for API usage.
+func (cluster *Cluster) ResolveResticMountDirFromConfigStrict() (string, string, error) {
+	return cluster.resolveResticMountDirFromConfig(resticMountDirResolveOptions{
+		requireAbs:         false,
+		rejectDotDot:       true,
+		enforceDefaultBase: true,
+		logSanitize:        true,
+	})
 }
 
 func resticLogSnapshotID(cluster *Cluster, snapshotID string) string {

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -440,12 +440,8 @@ func (cluster *Cluster) resolveResticMountDirFromConfig(opts resticMountDirResol
 	if cluster == nil || cluster.Conf == nil {
 		return "", "", fmt.Errorf("cluster config is nil")
 	}
-	clusterName := strings.TrimSpace(cluster.GetClusterName())
-	if clusterName == "" {
-		return "", "", fmt.Errorf("cluster name is empty")
-	}
 
-	baseDir := filepath.Join(cluster.WorkingDir, resticDefaultMountSubdir)
+	baseDir := filepath.Join(cluster.WorkingDir, resticDefaultMountSubdir) // cluster.WorkingDir already has cluster name
 	mountDir := baseDir
 	mountDirSource := "default"
 	if trimmed := strings.TrimSpace(cluster.Conf.BackupResticMountDir); trimmed != "" {

--- a/cluster/cluster_bck_test.go
+++ b/cluster/cluster_bck_test.go
@@ -159,6 +159,40 @@ func TestResticPurgeSnapshotUsesSnapshotID(t *testing.T) {
 	}
 }
 
+func TestResolveResticMountDirFromConfigStrictRejectsDotDot(t *testing.T) {
+	tmpDir := t.TempDir()
+	cluster := &Cluster{
+		Name:       "cluster1",
+		WorkingDir: tmpDir,
+		Conf: &config.Config{
+			BackupResticMountDir: "../etc",
+		},
+	}
+	if _, _, err := cluster.ResolveResticMountDirFromConfigStrict(); err == nil {
+		t.Fatalf("expected error for mount dir containing '..'")
+	}
+}
+
+func TestResolveResticMountDirFromConfigStrictCleansPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	raw := tmpDir + string(filepath.Separator) + string(filepath.Separator) + "restic"
+	cluster := &Cluster{
+		Name:       "cluster1",
+		WorkingDir: tmpDir,
+		Conf: &config.Config{
+			BackupResticMountDir: raw,
+		},
+	}
+	mountDir, _, err := cluster.ResolveResticMountDirFromConfigStrict()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := filepath.Join(tmpDir, "restic")
+	if mountDir != expected {
+		t.Fatalf("expected mount dir %q, got %q", expected, mountDir)
+	}
+}
+
 func TestBuildSnapshotMetadataIndexFromCache(t *testing.T) {
 	cluster := &Cluster{
 		Conf:          &config.Config{},

--- a/cluster/srv_job_restic_test.go
+++ b/cluster/srv_job_restic_test.go
@@ -200,7 +200,7 @@ func TestExpandResticMountTemplateRejectsUnknownTokens(t *testing.T) {
 }
 
 func TestBuildResticMountSnapshotCandidatesNoSwap(t *testing.T) {
-	mountDir := "/mnt/restic/cluster1"
+	mountDir := "/var/lib/replication-manager/cluster1/mount"
 	seen := make(map[string]struct{})
 	candidates := buildResticMountSnapshotCandidates(
 		mountDir,
@@ -223,7 +223,7 @@ func TestBuildResticMountSnapshotCandidatesNoSwap(t *testing.T) {
 }
 
 func TestBuildResticMountSnapshotCandidatesTimeTemplate(t *testing.T) {
-	mountDir := "/mnt/restic/cluster1"
+	mountDir := "/var/lib/replication-manager/cluster1/mount"
 	candidates := buildResticMountSnapshotCandidates(
 		mountDir,
 		[]string{"snapshots/%T"},

--- a/config/config.go
+++ b/config/config.go
@@ -788,6 +788,7 @@ type Config struct {
 	// BackupResticMountRecoveryEnabled controls cleanup of stale restic mounts on startup.
 	BackupResticMountRecoveryEnabled bool `mapstructure:"backup-restic-mount-recovery-enabled" toml:"backup-restic-mount-recovery-enabled" json:"backupResticMountRecoveryEnabled"`
 	// BackupResticMountDir defines the base directory for restic FUSE mounts.
+	// Default base is <working-dir>/<cluster>/mount. Relative paths resolve under that base.
 	BackupResticMountDir                   string                 `scope:"server" mapstructure:"backup-restic-mount-dir" toml:"backup-restic-mount-dir" json:"backupResticMountDir"`
 	BackupResticReseedCleanup              bool                   `mapstructure:"backup-restic-reseed-cleanup" toml:"backup-restic-reseed-cleanup" json:"backupResticReseedCleanup"`
 	BackupResticReseedTimeout              int                    `mapstructure:"backup-restic-reseed-timeout" toml:"backup-restic-reseed-timeout" json:"backupResticReseedTimeout"`

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -22556,7 +22556,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "backupResticMountDir": {
-                    "description": "BackupResticMountDir defines the base directory for restic FUSE mounts.",
+				"description": "BackupResticMountDir defines the base directory for restic FUSE mounts. Default base is <working-dir>/<cluster>/mount to avoid permission issues; relative paths resolve under that base.",
                     "type": "string"
                 },
                 "backupResticMountHost": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -22545,7 +22545,7 @@
                     "type": "boolean"
                 },
                 "backupResticMountDir": {
-                    "description": "BackupResticMountDir defines the base directory for restic FUSE mounts.",
+                    "description": "BackupResticMountDir defines the base directory for restic FUSE mounts. Default base is <working-dir>/<cluster>/mount to avoid permission issues; relative paths resolve under that base.",
                     "type": "string"
                 },
                 "backupResticMountHost": {

--- a/server/api_restic.go
+++ b/server/api_restic.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"path/filepath"
 	"strings"
 
 	"github.com/codegangsta/negroni"
@@ -118,22 +117,12 @@ func (repman *ReplicationManager) handlerMuxResticMountToggle(w http.ResponseWri
 	}
 
 	// Construct mount directory path
-	resticMountBaseDir := filepath.Join(mycluster.WorkingDir, "mount")
-	mountDir := resticMountBaseDir
-	if trimmed := strings.TrimSpace(mycluster.Conf.BackupResticMountDir); trimmed != "" {
-		if filepath.IsAbs(trimmed) {
-			mountDir = trimmed
-		} else {
-			baseDir := filepath.Join(mycluster.WorkingDir, "mount")
-			mountDir = filepath.Join(baseDir, trimmed)
-			mycluster.LogModulePrintf(mycluster.Conf.Verbose,
-				config.ConstLogModRestic,
-				config.LvlInfo,
-				"Resolved relative restic mount dir from config: %s -> %s (base %s)", trimmed, mountDir, baseDir)
-		}
+	mountDir, _, err := mycluster.ResolveResticMountDirFromConfigStrict()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Invalid restic mount dir: %v", err), http.StatusBadRequest)
+		return
 	}
 
-	var err error
 	var response ResticMountStatusResponse
 
 	switch action {

--- a/server/api_restic.go
+++ b/server/api_restic.go
@@ -118,10 +118,19 @@ func (repman *ReplicationManager) handlerMuxResticMountToggle(w http.ResponseWri
 	}
 
 	// Construct mount directory path
-	resticMountBaseDir := "/mnt/restic"
-	mountDir := filepath.Join(resticMountBaseDir, clusterName)
-	if mycluster.Conf.BackupResticMountDir != "" {
-		mountDir = mycluster.Conf.BackupResticMountDir
+	resticMountBaseDir := filepath.Join(mycluster.WorkingDir, "mount")
+	mountDir := resticMountBaseDir
+	if trimmed := strings.TrimSpace(mycluster.Conf.BackupResticMountDir); trimmed != "" {
+		if filepath.IsAbs(trimmed) {
+			mountDir = trimmed
+		} else {
+			baseDir := filepath.Join(mycluster.WorkingDir, "mount")
+			mountDir = filepath.Join(baseDir, trimmed)
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose,
+				config.ConstLogModRestic,
+				config.LvlInfo,
+				"Resolved relative restic mount dir from config: %s -> %s (base %s)", trimmed, mountDir, baseDir)
+		}
 	}
 
 	var err error

--- a/server/server.go
+++ b/server/server.go
@@ -821,7 +821,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.BackupResticReseedStrategy, "backup-restic-reseed-strategy", "auto", "Restic reseed strategy: auto (prefer mount when FUSE is available; mysqldump may stream via dump), restore (extract to disk), dump (stream single file), mount (FUSE filesystem)")
 	flags.StringVar(&conf.BackupResticReseedTempDir, "backup-restic-reseed-temp-dir", "", "Temporary directory for restic reseed operations (empty = cluster datadir/backup/restic_temp/<snapshot_id>)")
 	flags.IntVar(&conf.BackupResticMetadataExtractorConcurrency, "backup-restic-metadata-extractor-concurrency", 2, "Number of concurrent restic snapshot metadata extractions")
-	flags.StringVar(&conf.BackupResticMountDir, "backup-restic-mount-dir", "", "Base directory for restic FUSE mounts. Empty uses /mnt/restic/<clustername>.")
+	flags.StringVar(&conf.BackupResticMountDir, "backup-restic-mount-dir", "", "Base directory for restic FUSE mounts. Empty uses <working-dir>/<cluster>/mount to avoid permission issues. Relative paths resolve under <working-dir>/<cluster>/mount.")
 	flags.StringVar(&conf.BackupResticMountTargetDir, "backup-restic-mount-target-dir", "", "Restic mount target directory. Empty uses default mount path.")
 	flags.StringVar(&conf.BackupResticMountHost, "backup-restic-mount-host", "", "Restic mount host filter (comma-separated).")
 	flags.StringVar(&conf.BackupResticMountTag, "backup-restic-mount-tag", "", "Restic mount tag filter (space-separated; commas preserved inside tags).")

--- a/share/dashboard_react/src/Pages/Settings/ResticMountSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticMountSettings.jsx
@@ -106,6 +106,11 @@ Time template uses Go layout (e.g. 2006-01-02T15:04:05Z07:00); empty = RFC3339.`
 Reseed mounts are *not pinned*; they auto-unmount once all reseed jobs release their mount reference.  
 If a reseed is running, Unmount will wait until the job finishes before stopping the mount.`
 
+  const ResticMountDestinationHelp = `backup-restic-mount-dir sets the base directory for restic FUSE mounts.  
+Empty uses \\`<working-dir>/<cluster>/mount\\` to avoid permission issues.  
+Relative values resolve under \\`<working-dir>/<cluster>/mount\\` (e.g. snapshots -> \\`/var/lib/replication-manager/<cluster>/mount/snapshots\\`).  
+backup-restic-mount-target-dir overrides the final mount target when set.`
+
   const openCommonModal = () => {
     setIsCommonModalOpen(true)
   }
@@ -402,7 +407,18 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
             sectionKey: 'mount-destination',
             isOpen: isMountDestinationOpen,
             setOpen: setIsMountDestinationOpen,
-            title: 'Mount destination',
+            title: (
+              <HStack spacing={2} align='center'>
+                <Text className={styles.panelTitle}>Mount destination</Text>
+                <RMIconButton
+                  icon={HiQuestionMarkCircle}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    openInfoModal('Restic Mount Destination', ResticMountDestinationHelp)
+                  }}
+                />
+              </HStack>
+            ),
             description: 'Choose where restic mounts snapshots for inspection or restore.',
             controlsId: 'restic-mount-destination-content',
             content: (

--- a/utils/backupmgr/restic_test.go
+++ b/utils/backupmgr/restic_test.go
@@ -1481,14 +1481,14 @@ func TestResticMountStatePersistence(t *testing.T) {
 	if statePath == "" {
 		t.Fatalf("expected mount state path to be set")
 	}
-	if err := repo.writeMountState("/mnt/restic/test", 1234); err != nil {
+	if err := repo.writeMountState("/var/lib/replication-manager/cluster1/mount/test", 1234); err != nil {
 		t.Fatalf("writeMountState failed: %v", err)
 	}
 	state, err := repo.loadMountState()
 	if err != nil {
 		t.Fatalf("loadMountState failed: %v", err)
 	}
-	if state.Path != "/mnt/restic/test" || state.PID != 1234 {
+	if state.Path != "/var/lib/replication-manager/cluster1/mount/test" || state.PID != 1234 {
 		t.Fatalf("unexpected mount state: %+v", state)
 	}
 	repo.clearMountState()


### PR DESCRIPTION
This pull request updates the default location and configuration logic for restic FUSE mount directories to improve security and flexibility. The default base directory for restic mounts is now set to `<working-dir>/<cluster>/mount` instead of `/mnt/restic`, reducing the risk of permission issues. The logic for resolving relative and absolute paths for mount directories has been improved throughout the codebase, and documentation and help text have been updated to reflect these changes.

**Restic mount directory logic and configuration:**

* Changed the default restic mount base directory from `/mnt/restic` to `<working-dir>/<cluster>/mount` in both code and configuration, including updating the constant and all usages. [[1]](diffhunk://#diff-eb7be6f71b81f7dd226a6985f412f36c5d14559999797bf6c7fa5c815232eea9L400-R400) [[2]](diffhunk://#diff-c42ebd4d8e47143f3ba426db62e75d60cacac579da154f1775601f50da25f2b7L121-R133)
* Improved logic for resolving `BackupResticMountDir`: relative paths are now resolved under the new default base, and absolute paths are respected. Added informative logging when resolving relative paths. [[1]](diffhunk://#diff-eb7be6f71b81f7dd226a6985f412f36c5d14559999797bf6c7fa5c815232eea9L448-R462) [[2]](diffhunk://#diff-c42ebd4d8e47143f3ba426db62e75d60cacac579da154f1775601f50da25f2b7L121-R133)
* Updated validation and enforcement logic to ensure that default and relative mount directories do not escape the intended base directory. [[1]](diffhunk://#diff-eb7be6f71b81f7dd226a6985f412f36c5d14559999797bf6c7fa5c815232eea9L461-R471) [[2]](diffhunk://#diff-eb7be6f71b81f7dd226a6985f412f36c5d14559999797bf6c7fa5c815232eea9L602-R612)

**Documentation and user interface updates:**

* Updated configuration comments, CLI flag descriptions, OpenAPI docs, and Swagger JSON to describe the new default and path resolution behavior for `backup-restic-mount-dir`. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R791) [[2]](diffhunk://#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4L824-R824) [[3]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4L22559-R22559) [[4]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524L22548-R22548)
* Enhanced the dashboard UI with improved help text and an info button explaining the new mount directory behavior. [[1]](diffhunk://#diff-77f2a912a64f090dd8d176b0fc137072cd94a4a81bd634ee60b7e9c0c65c6d53R109-R113) [[2]](diffhunk://#diff-77f2a912a64f090dd8d176b0fc137072cd94a4a81bd634ee60b7e9c0c65c6d53L405-R421)

**Test updates:**

* Updated tests to use the new default mount directory paths, ensuring consistency with the revised logic. [[1]](diffhunk://#diff-1531cdd57fc580e6311d43960a4c3a4cd6a843b297bbec034f37bc82ae8aabdcL203-R203) [[2]](diffhunk://#diff-1531cdd57fc580e6311d43960a4c3a4cd6a843b297bbec034f37bc82ae8aabdcL226-R226) [[3]](diffhunk://#diff-2fa9dbeaa01dd46babeb9b5c94c0537abff6c99c2eb38066a6d033bcc6bfca6fL1484-R1491)