### PR TITLE
MySQL Configuration Loading and Redaction Improvements

### DIFF
--- a/cluster/srv_cnf.go
+++ b/cluster/srv_cnf.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/misc"
+	"gopkg.in/ini.v1"
 )
 
 func (server *ServerMonitor) GetEnv() map[string]string {
@@ -627,13 +628,90 @@ func (server *ServerMonitor) ReadVariablesFromConfigFile(srcpath string, cnftype
 	}
 
 	// Read the file
-	err = server.VariablesMap.LoadFromConfigFile(srcpath, cnftype)
+	section, err := config.LoadMySQLConfigSection(srcpath)
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Error reading file %s: %s", srcpath, err)
+		return err
+	}
+
+	redactedSection := formatIniSectionRedacted(section)
+	if redactedSection != "" {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModConfigLoad, config.LvlDbg,
+			"Redacted mysqld section (%s) from %s:\n%s", cnftype, srcpath, redactedSection)
+	}
+
+	err = server.VariablesMap.LoadFromSection(section, cnftype)
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Error reading file %s: %s", srcpath, err)
 		return err
 	}
 
 	return nil
+}
+
+func formatIniSectionRedacted(section *ini.Section) string {
+	if section == nil {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.WriteString("[")
+	builder.WriteString(section.Name())
+	builder.WriteString("]\n")
+
+	for _, key := range section.Keys() {
+		selectedValue := redactIniValue(key.Name(), key.Value())
+		shadowValues := key.ValueWithShadows()
+		redactedShadows := make([]string, len(shadowValues))
+		for i, value := range shadowValues {
+			redactedShadows[i] = redactIniValue(key.Name(), value)
+		}
+
+		builder.WriteString(key.Name())
+		builder.WriteString(" = ")
+		builder.WriteString(selectedValue)
+		builder.WriteString(" (shadows: ")
+		if len(redactedShadows) == 0 {
+			builder.WriteString("none")
+		} else {
+			builder.WriteString(strings.Join(redactedShadows, ", "))
+		}
+		builder.WriteString(")\n")
+	}
+
+	return strings.TrimRight(builder.String(), "\n")
+}
+
+func redactIniValue(keyName string, value string) string {
+	if shouldRedactIniKey(keyName) {
+		return "<redacted>"
+	}
+	return value
+}
+
+func shouldRedactIniKey(keyName string) bool {
+	normalized := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(keyName), "-", "_"))
+	sensitiveTokens := []string{
+		"password",
+		"passwd",
+		"secret",
+		"token",
+		"ssl_key",
+		"ssl_cert",
+		"ssl_ca",
+		"private_key",
+		"access_key",
+		"secret_key",
+		"api_key",
+	}
+
+	for _, token := range sensitiveTokens {
+		if strings.Contains(normalized, token) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (server *ServerMonitor) ReadPreservedVariables() error {

--- a/cluster/srv_cnf.go
+++ b/cluster/srv_cnf.go
@@ -660,6 +660,7 @@ func formatIniSectionRedacted(section *ini.Section) string {
 	builder.WriteString("]\n")
 
 	for _, key := range section.Keys() {
+		// Use shadow values to reflect last-wins behavior in logs.
 		shadowValues := key.ValueWithShadows()
 		selectedValue := key.Value()
 		if len(shadowValues) > 0 {
@@ -715,6 +716,7 @@ func shouldRedactIniKey(keyName string) bool {
 		}
 	}
 
+	// MySQL/MariaDB auth keys often end with "_auth" (e.g., wsrep_sst_auth).
 	if normalized == "wsrep_sst_auth" || strings.HasSuffix(normalized, "_auth") {
 		return true
 	}

--- a/cluster/srv_cnf.go
+++ b/cluster/srv_cnf.go
@@ -660,8 +660,12 @@ func formatIniSectionRedacted(section *ini.Section) string {
 	builder.WriteString("]\n")
 
 	for _, key := range section.Keys() {
-		selectedValue := redactIniValue(key.Name(), key.Value())
 		shadowValues := key.ValueWithShadows()
+		selectedValue := key.Value()
+		if len(shadowValues) > 0 {
+			selectedValue = shadowValues[len(shadowValues)-1]
+		}
+		redactedValue := redactIniValue(key.Name(), selectedValue)
 		redactedShadows := make([]string, len(shadowValues))
 		for i, value := range shadowValues {
 			redactedShadows[i] = redactIniValue(key.Name(), value)
@@ -669,7 +673,7 @@ func formatIniSectionRedacted(section *ini.Section) string {
 
 		builder.WriteString(key.Name())
 		builder.WriteString(" = ")
-		builder.WriteString(selectedValue)
+		builder.WriteString(redactedValue)
 		builder.WriteString(" (shadows: ")
 		if len(redactedShadows) == 0 {
 			builder.WriteString("none")

--- a/cluster/srv_cnf.go
+++ b/cluster/srv_cnf.go
@@ -715,6 +715,10 @@ func shouldRedactIniKey(keyName string) bool {
 		}
 	}
 
+	if normalized == "wsrep_sst_auth" || strings.HasSuffix(normalized, "_auth") {
+		return true
+	}
+
 	return false
 }
 

--- a/config/manager/manager.go
+++ b/config/manager/manager.go
@@ -574,7 +574,7 @@ func (cm *ConfigManager) AddPullToGitignore(conf *config.Config) {
 		// If .gitignore doesn't exist, create it and write the line
 		err := os.WriteFile(gitignoreFile, []byte(lineToAdd+"\n"), 0644)
 		if err != nil {
-			cm.logger.Errorf("none", config.ConstLogModGit, "Error creating .gitignore:", err)
+			cm.logger.Errorf("none", config.ConstLogModGit, "Error creating .gitignore: %v", err)
 		}
 		return
 	}
@@ -582,7 +582,7 @@ func (cm *ConfigManager) AddPullToGitignore(conf *config.Config) {
 	// Open .gitignore for reading and appending
 	file, err := os.OpenFile(gitignoreFile, os.O_RDWR|os.O_APPEND, 0644)
 	if err != nil {
-		cm.logger.Errorf("none", config.ConstLogModGit, "Error opening .gitignore:", err)
+		cm.logger.Errorf("none", config.ConstLogModGit, "Error opening .gitignore: %v", err)
 		return
 	}
 	defer file.Close()
@@ -598,7 +598,7 @@ func (cm *ConfigManager) AddPullToGitignore(conf *config.Config) {
 	}
 
 	if scanner.Err() != nil {
-		cm.logger.Errorf("none", config.ConstLogModGit, "Error reading .gitignore:", scanner.Err())
+		cm.logger.Errorf("none", config.ConstLogModGit, "Error reading .gitignore: %v", scanner.Err())
 		return
 	}
 
@@ -606,7 +606,7 @@ func (cm *ConfigManager) AddPullToGitignore(conf *config.Config) {
 	if !lineExists {
 		_, err := file.WriteString(lineToAdd + "\n")
 		if err != nil {
-			cm.logger.Errorf("none", config.ConstLogModGit, "Error appending to .gitignore:", err)
+			cm.logger.Errorf("none", config.ConstLogModGit, "Error appending to .gitignore: %v", err)
 		}
 	}
 }
@@ -621,7 +621,7 @@ func (cm *ConfigManager) AddTempDirToGitignore(conf *config.Config) {
 		// If .gitignore doesn't exist, create it and write the line
 		err := os.WriteFile(gitignoreFile, []byte(lineToAdd+"\n"), 0644)
 		if err != nil {
-			cm.logger.Errorf("none", config.ConstLogModGit, "Error creating .gitignore:", err)
+			cm.logger.Errorf("none", config.ConstLogModGit, "Error creating .gitignore: %v", err)
 		}
 		return
 	}
@@ -629,7 +629,7 @@ func (cm *ConfigManager) AddTempDirToGitignore(conf *config.Config) {
 	// Open .gitignore for reading and appending
 	file, err := os.OpenFile(gitignoreFile, os.O_RDWR|os.O_APPEND, 0644)
 	if err != nil {
-		cm.logger.Errorf("none", config.ConstLogModGit, "Error opening .gitignore:", err)
+		cm.logger.Errorf("none", config.ConstLogModGit, "Error opening .gitignore: %v", err)
 		return
 	}
 	defer file.Close()
@@ -645,7 +645,7 @@ func (cm *ConfigManager) AddTempDirToGitignore(conf *config.Config) {
 	}
 
 	if scanner.Err() != nil {
-		cm.logger.Errorf("none", config.ConstLogModGit, "Error reading .gitignore:", scanner.Err())
+		cm.logger.Errorf("none", config.ConstLogModGit, "Error reading .gitignore: %v", scanner.Err())
 		return
 	}
 
@@ -653,7 +653,7 @@ func (cm *ConfigManager) AddTempDirToGitignore(conf *config.Config) {
 	if !lineExists {
 		_, err := file.WriteString(lineToAdd + "\n")
 		if err != nil {
-			cm.logger.Errorf("none", config.ConstLogModGit, "Error appending to .gitignore:", err)
+			cm.logger.Errorf("none", config.ConstLogModGit, "Error appending to .gitignore: %v", err)
 		}
 	}
 }
@@ -865,7 +865,7 @@ func (cm *ConfigManager) ShallowClone(conf *config.Config) error {
 func (cm *ConfigManager) RotateGitAccessToken(conf *config.Config) error {
 	acces_tok, err := githelper.GetGitLabTokenBasicAuth(conf.Cloud18GitUser, conf.GetDecryptedValue("cloud18-gitlab-password"), conf.IsEligibleForPrinting(config.ConstLogModGit, config.LvlDbg))
 	if err != nil {
-		cm.logger.Errorf("none", config.ConstLogModGit, err.Error()+conf.GetDecryptedValue("cloud18-gitlab-password")+"\n")
+		cm.logger.Errorf("none", config.ConstLogModGit, "%s\n", err.Error()+conf.GetDecryptedValue("cloud18-gitlab-password"))
 		conf.Cloud18 = false
 		return err
 	}

--- a/config/manager/manager.go
+++ b/config/manager/manager.go
@@ -865,7 +865,7 @@ func (cm *ConfigManager) ShallowClone(conf *config.Config) error {
 func (cm *ConfigManager) RotateGitAccessToken(conf *config.Config) error {
 	acces_tok, err := githelper.GetGitLabTokenBasicAuth(conf.Cloud18GitUser, conf.GetDecryptedValue("cloud18-gitlab-password"), conf.IsEligibleForPrinting(config.ConstLogModGit, config.LvlDbg))
 	if err != nil {
-		cm.logger.Errorf("none", config.ConstLogModGit, "%s\n", err.Error()+conf.GetDecryptedValue("cloud18-gitlab-password"))
+		cm.logger.Errorf("none", config.ConstLogModGit, "Error getting GitLab token: %v", err)
 		conf.Cloud18 = false
 		return err
 	}

--- a/config/maps.go
+++ b/config/maps.go
@@ -1207,13 +1207,16 @@ func (m *VariablesMap) loadFromSection(section *ini.Section, cnftype string) {
 
 		for _, key := range section.Keys() {
 			varname := normalizeConfigVarName(key.Name())
+			values := key.ValueWithShadows()
+			if len(values) == 0 {
+				continue
+			}
 			if slices.Contains(RepeatOptions, varname) {
-				values := key.ValueWithShadows()
 				for _, v := range values {
 					setValue(varname, v)
 				}
 			} else {
-				setValue(varname, key.Value())
+				setValue(varname, values[len(values)-1])
 			}
 		}
 	}

--- a/config/maps.go
+++ b/config/maps.go
@@ -1173,38 +1173,47 @@ func (m *VariablesMap) HasDifferences() bool {
 	return hasDiff
 }
 
-func (m *VariablesMap) LoadFromConfigFile(path string, cnftype string) error {
+func validateVariablesConfigType(cnftype string) error {
 	if cnftype != "config" && cnftype != "deployed" && cnftype != "preserved" {
 		return fmt.Errorf("invalid config type: %s", cnftype)
 	}
+	return nil
+}
 
+func normalizeConfigVarName(name string) string {
+	return strings.TrimSpace(strings.TrimPrefix(strings.ReplaceAll(name, "-", "_"), "loose_"))
+}
+
+func LoadMySQLConfigSection(path string) (*ini.Section, error) {
 	// Allow shadows to handle multiple same options
 	cfgFile, err := ini.LoadSources(ini.LoadOptions{AllowShadows: true, AllowBooleanKeys: true}, path)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	return cfgFile.Section("mysqld"), nil
+}
 
-	section := cfgFile.Section("mysqld")
-	for _, key := range section.Keys() {
-		varname := strings.TrimSpace(strings.TrimPrefix(strings.ReplaceAll(key.Name(), "-", "_"), "loose_"))
-		if slices.Contains(RepeatOptions, varname) {
-			values := key.ValueWithShadows()
-			for _, v := range values {
-				if cnftype == "config" {
-					m.SetConfigValue(varname, v)
-				} else if cnftype == "deployed" {
-					m.SetDeployedValue(varname, v)
-				} else if cnftype == "preserved" {
-					m.SetPreservedValue(varname, v)
+func (m *VariablesMap) loadFromSection(section *ini.Section, cnftype string) {
+	if section != nil {
+		var setValue func(string, string)
+		switch cnftype {
+		case "config":
+			setValue = m.SetConfigValue
+		case "deployed":
+			setValue = m.SetDeployedValue
+		case "preserved":
+			setValue = m.SetPreservedValue
+		}
+
+		for _, key := range section.Keys() {
+			varname := normalizeConfigVarName(key.Name())
+			if slices.Contains(RepeatOptions, varname) {
+				values := key.ValueWithShadows()
+				for _, v := range values {
+					setValue(varname, v)
 				}
-			}
-		} else {
-			if cnftype == "config" {
-				m.SetConfigValue(varname, key.Value())
-			} else if cnftype == "deployed" {
-				m.SetDeployedValue(varname, key.Value())
-			} else if cnftype == "preserved" {
-				m.SetPreservedValue(varname, key.Value())
+			} else {
+				setValue(varname, key.Value())
 			}
 		}
 	}
@@ -1213,6 +1222,26 @@ func (m *VariablesMap) LoadFromConfigFile(path string, cnftype string) error {
 	if cnftype == "deployed" {
 		m.MarkDeployedChanged()
 	}
+}
 
+func (m *VariablesMap) LoadFromSection(section *ini.Section, cnftype string) error {
+	if err := validateVariablesConfigType(cnftype); err != nil {
+		return err
+	}
+	m.loadFromSection(section, cnftype)
+	return nil
+}
+
+func (m *VariablesMap) LoadFromConfigFile(path string, cnftype string) error {
+	if err := validateVariablesConfigType(cnftype); err != nil {
+		return err
+	}
+
+	section, err := LoadMySQLConfigSection(path)
+	if err != nil {
+		return err
+	}
+
+	m.loadFromSection(section, cnftype)
 	return nil
 }

--- a/config/maps.go
+++ b/config/maps.go
@@ -1207,6 +1207,7 @@ func (m *VariablesMap) loadFromSection(section *ini.Section, cnftype string) {
 
 		for _, key := range section.Keys() {
 			varname := normalizeConfigVarName(key.Name())
+			// Use INI shadows to honor MySQL last-wins behavior for non-repeat options.
 			values := key.ValueWithShadows()
 			if len(values) == 0 {
 				continue
@@ -1216,6 +1217,7 @@ func (m *VariablesMap) loadFromSection(section *ini.Section, cnftype string) {
 					setValue(varname, v)
 				}
 			} else {
+				// Non-repeat option: last occurrence wins.
 				setValue(varname, values[len(values)-1])
 			}
 		}

--- a/config/replication.go
+++ b/config/replication.go
@@ -9,10 +9,10 @@ package config
 // ReplicationConfig contains all replication-related configuration
 type ReplicationConfig struct {
 	// Basic Replication Settings
-	Credential       string `mapstructure:"replication-credential" toml:"replication-credential" json:"replicationCredential"`
-	SourceName       string `mapstructure:"replication-source-name" toml:"replication-source-name" json:"replicationSourceName"`
-	UseSSL           bool   `mapstructure:"replication-use-ssl" toml:"replication-use-ssl" json:"replicationUseSsl"`
-	ErrorScript      string `mapstructure:"replication-error-script" toml:"replication-error-script" json:"replicationErrorScript"`
+	Credential             string `mapstructure:"replication-credential" toml:"replication-credential" json:"replicationCredential"`
+	SourceName             string `mapstructure:"replication-source-name" toml:"replication-source-name" json:"replicationSourceName"`
+	UseSSL                 bool   `mapstructure:"replication-use-ssl" toml:"replication-use-ssl" json:"replicationUseSsl"`
+	ErrorScript            string `mapstructure:"replication-error-script" toml:"replication-error-script" json:"replicationErrorScript"`
 	RestartOnSQLErrorMatch string `mapstructure:"replication-restart-on-sqlerror-match" toml:"replication-restart-on-sqlerror-match" json:"replicationRestartOnSqlLErrorMatch"`
 
 	// Master Connection
@@ -23,19 +23,19 @@ type ReplicationConfig struct {
 	MultisourceHeadClusters string `mapstructure:"replication-multisource-head-clusters" toml:"replication-multisource-head-clusters" json:"replicationMultisourceHeadClusters"`
 
 	// Topology Types
-	ActivePassive       bool   `mapstructure:"replication-active-passive" toml:"replication-active-passive" json:"replicationActivePassive"`
-	DynamicTopology     bool   `mapstructure:"replication-dynamic-topology" toml:"replication-dynamic-topology" json:"replicationDynamicTopology"`
-	MultiMaster         bool   `mapstructure:"replication-multi-master" toml:"replication-multi-master" json:"replicationMultiMaster"`
+	ActivePassive              bool `mapstructure:"replication-active-passive" toml:"replication-active-passive" json:"replicationActivePassive"`
+	DynamicTopology            bool `mapstructure:"replication-dynamic-topology" toml:"replication-dynamic-topology" json:"replicationDynamicTopology"`
+	MultiMaster                bool `mapstructure:"replication-multi-master" toml:"replication-multi-master" json:"replicationMultiMaster"`
 	MultiMasterConcurrentWrite bool `mapstructure:"replication-multi-master-concurrent-write" toml:"replication-multi-master-concurrent-write" json:"replicationMultiMasterConcurrentWrite"`
-	MultiMasterRing     bool   `mapstructure:"replication-multi-master-ring" toml:"replication-multi-master-ring" json:"replicationMultiMasterRing"`
-	MultiMasterRingUnsafe bool `mapstructure:"replication-multi-master-ring-unsafe" toml:"replication-multi-master-ring-unsafe" json:"replicationMultiMasterRingUnsafe"`
-	MultiTierSlave      bool   `mapstructure:"replication-multi-tier-slave" toml:"replication-multi-tier-slave" json:"replicationMultiTierSlave"`
-	NoRelay             bool   `mapstructure:"replication-master-slave-never-relay" toml:"replication-master-slave-never-relay" json:"replicationMasterSlaveNeverRelay"`
+	MultiMasterRing            bool `mapstructure:"replication-multi-master-ring" toml:"replication-multi-master-ring" json:"replicationMultiMasterRing"`
+	MultiMasterRingUnsafe      bool `mapstructure:"replication-multi-master-ring-unsafe" toml:"replication-multi-master-ring-unsafe" json:"replicationMultiMasterRingUnsafe"`
+	MultiTierSlave             bool `mapstructure:"replication-multi-tier-slave" toml:"replication-multi-tier-slave" json:"replicationMultiTierSlave"`
+	NoRelay                    bool `mapstructure:"replication-master-slave-never-relay" toml:"replication-master-slave-never-relay" json:"replicationMasterSlaveNeverRelay"`
 
 	// Multi-Master Wsrep (Galera)
-	MultiMasterWsrep      bool   `mapstructure:"replication-multi-master-wsrep" toml:"replication-multi-master-wsrep" json:"replicationMultiMasterWsrep"`
+	MultiMasterWsrep          bool   `mapstructure:"replication-multi-master-wsrep" toml:"replication-multi-master-wsrep" json:"replicationMultiMasterWsrep"`
 	MultiMasterWsrepSSTMethod string `mapstructure:"replication-multi-master-wsrep-sst-method" toml:"replication-multi-master-wsrep-sst-method" json:"replicationMultiMasterWsrepSSTMethod" validate:"omitempty,oneof=mariabackup xtrabackup-v2 rsync mysqldump"`
-	MultiMasterWsrepPort  int    `mapstructure:"replication-multi-master-wsrep-port" toml:"replication-multi-master-wsrep-port" json:"replicationMultiMasterWsrepPort" validate:"omitempty,min=1024,max=65535"`
+	MultiMasterWsrepPort      int    `mapstructure:"replication-multi-master-wsrep-port" toml:"replication-multi-master-wsrep-port" json:"replicationMultiMasterWsrepPort" validate:"omitempty,min=1024,max=65535"`
 
 	// Group Replication
 	MultiMasterGrouprep     bool `mapstructure:"replication-multi-master-grouprep" toml:"replication-multi-master-grouprep" json:"replicationMultiMasterGrouprep"`
@@ -65,10 +65,10 @@ func (r *ReplicationConfig) Validate() error {
 	// Validate SST method
 	if r.MultiMasterWsrep && r.MultiMasterWsrepSSTMethod != "" {
 		validMethods := map[string]bool{
-			"mariabackup":    true,
-			"xtrabackup-v2":  true,
-			"rsync":          true,
-			"mysqldump":      true,
+			"mariabackup":   true,
+			"xtrabackup-v2": true,
+			"rsync":         true,
+			"mysqldump":     true,
 		}
 		if !validMethods[r.MultiMasterWsrepSSTMethod] {
 			return NewValidationError("replication-multi-master-wsrep-sst-method", r.MultiMasterWsrepSSTMethod, "must be one of: mariabackup, xtrabackup-v2, rsync, mysqldump")
@@ -77,21 +77,35 @@ func (r *ReplicationConfig) Validate() error {
 
 	// Validate topology conflicts
 	topologyCount := 0
-	if r.ActivePassive { topologyCount++ }
-	if r.MultiMaster { topologyCount++ }
-	if r.MultiMasterRing { topologyCount++ }
-	if r.MultiMasterWsrep { topologyCount++ }
-	if r.MultiMasterGrouprep { topologyCount++ }
-	if r.MasterSlavePgStream { topologyCount++ }
-	if r.MasterSlavePgLogical { topologyCount++ }
-
-	if topologyCount > 1 {
-		return NewValidationError("replication-topology", topologyCount, "multiple replication topologies selected - only one topology can be active")
+	if r.ActivePassive {
+		topologyCount++
+	}
+	if r.MultiMaster {
+		topologyCount++
+	}
+	if r.MultiMasterRing {
+		topologyCount++
+	}
+	if r.MultiMasterWsrep {
+		topologyCount++
+	}
+	if r.MultiMasterGrouprep {
+		topologyCount++
+	}
+	if r.MasterSlavePgStream {
+		topologyCount++
+	}
+	if r.MasterSlavePgLogical {
+		topologyCount++
 	}
 
 	// PostgreSQL topologies are mutually exclusive
 	if r.MasterSlavePgStream && r.MasterSlavePgLogical {
 		return NewValidationError("replication-postgresql", "both", "PostgreSQL streaming and logical replication cannot both be enabled")
+	}
+
+	if topologyCount > 1 {
+		return NewValidationError("replication-topology", topologyCount, "multiple replication topologies selected - only one topology can be active")
 	}
 
 	return nil

--- a/config/variable_value_test.go
+++ b/config/variable_value_test.go
@@ -426,6 +426,31 @@ test_var = test_value
 	}
 }
 
+func TestVariablesMapLoadFromConfigFileBooleanKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	content := `[mysqld]
+skip_name_resolve
+`
+	path := filepath.Join(tmpDir, "bool.cnf")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	vm := NewVariablesMap()
+	if err := vm.LoadFromConfigFile(path, "config"); err != nil {
+		t.Fatalf("Failed to load config with boolean key: %v", err)
+	}
+
+	state := vm.Get("skip_name_resolve")
+	if state == nil || state.Config == nil {
+		t.Fatal("skip_name_resolve not loaded")
+	}
+
+	if state.Config.String() != "true" {
+		t.Errorf("Expected boolean key value 'true', got '%s'", state.Config.String())
+	}
+}
+
 // TestVariablesMapINIShadows tests that INI shadows (duplicate keys) are handled
 func TestVariablesMapINIShadows(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/config/variable_value_test.go
+++ b/config/variable_value_test.go
@@ -432,9 +432,11 @@ func TestVariablesMapINIShadows(t *testing.T) {
 
 	// Create config with duplicate keys (INI shadows)
 	content := `[mysqld]
-replicate_do_db = db1
-replicate_do_db = db2
-replicate_do_db = db3
+	replicate_do_db = db1
+	replicate_do_db = db2
+	replicate_do_db = db3
+	max_connections = 100
+	max_connections = 200
 `
 	path := filepath.Join(tmpDir, "shadows.cnf")
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
@@ -451,7 +453,7 @@ replicate_do_db = db3
 		t.Fatal("replicate_do_db not loaded")
 	}
 
-	// Should be a SliceValue with all three values
+	// Should be a SliceValue with all three values in order
 	slice, ok := state.Config.(*SliceValue)
 	if !ok {
 		t.Fatal("replicate_do_db should be SliceValue")
@@ -459,6 +461,17 @@ replicate_do_db = db3
 
 	if len(*slice) != 3 {
 		t.Errorf("Expected 3 values, got %d", len(*slice))
+	}
+	if (*slice)[0] != "db1" || (*slice)[1] != "db2" || (*slice)[2] != "db3" {
+		t.Errorf("Expected ordered values [db1 db2 db3], got %v", *slice)
+	}
+
+	maxConnections := vm.Get("max_connections")
+	if maxConnections == nil || maxConnections.Config == nil {
+		t.Fatal("max_connections not loaded")
+	}
+	if maxConnections.Config.String() != "200" {
+		t.Errorf("Expected last value 200 for max_connections, got %s", maxConnections.Config.String())
 	}
 }
 

--- a/config/variable_value_test.go
+++ b/config/variable_value_test.go
@@ -428,6 +428,7 @@ test_var = test_value
 
 func TestVariablesMapLoadFromConfigFileBooleanKey(t *testing.T) {
 	tmpDir := t.TempDir()
+	// Bare keys should parse as true when AllowBooleanKeys is enabled.
 	content := `[mysqld]
 skip_name_resolve
 `


### PR DESCRIPTION
This pull request introduces significant improvements to how MySQL configuration files are parsed, loaded, and logged, with a focus on correctness, security, and maintainability. The main enhancements include a refactor of the config loading logic to correctly handle INI file "shadows" (duplicate keys), improved redaction and logging of sensitive configuration values, and the addition of comprehensive tests for these behaviors. Additionally, logging in the Git ignore manager is now more consistent, and a minor bug in replication topology validation logic is fixed.

**MySQL Configuration Loading and Redaction Improvements**

* Refactored the logic for loading MySQL config files by introducing `LoadMySQLConfigSection`, `LoadFromSection`, and related helpers in `config/maps.go`. This ensures correct handling of INI "shadows" (duplicate keys), proper normalization of variable names, and correct "last-wins" behavior for non-repeat options. Sensitive keys are now redacted when logging config sections. (`[[1]](diffhunk://#diff-891cc70822efaa828be1b26673bfaf009f86d1a5a47438b24ec274c1ae2fc01eL630-R643)`, `[[2]](diffhunk://#diff-891cc70822efaa828be1b26673bfaf009f86d1a5a47438b24ec274c1ae2fc01eR652-R726)`, `[[3]](diffhunk://#diff-0f68f8437d79ad4173ef38cd1a9dcfb1d67e3f2a976f0ea0f52a76d999ae0cb1L1176-R1221)`, `[[4]](diffhunk://#diff-0f68f8437d79ad4173ef38cd1a9dcfb1d67e3f2a976f0ea0f52a76d999ae0cb1R1230-R1250)`)
* Added a new logging step in `cluster/srv_cnf.go` to log the loaded `[mysqld]` section with sensitive values redacted, improving security and traceability. (`[[1]](diffhunk://#diff-891cc70822efaa828be1b26673bfaf009f86d1a5a47438b24ec274c1ae2fc01eL630-R643)`, `[[2]](diffhunk://#diff-891cc70822efaa828be1b26673bfaf009f86d1a5a47438b24ec274c1ae2fc01eR652-R726)`)

**Testing Enhancements**

* Added tests to verify correct handling of boolean keys, INI shadows, and "last-wins" semantics for non-repeat options in configuration loading. This ensures robust parsing and correct value assignment for all supported config patterns. (`[[1]](diffhunk://#diff-8b1e3294d8fac0bd9ccc6173cbaf80dda46c0f08a705259958c772bad5f830e0R429-R454)`, `[[2]](diffhunk://#diff-8b1e3294d8fac0bd9ccc6173cbaf80dda46c0f08a705259958c772bad5f830e0R464-R465)`, `[[3]](diffhunk://#diff-8b1e3294d8fac0bd9ccc6173cbaf80dda46c0f08a705259958c772bad5f830e0L454-R482)`, `[[4]](diffhunk://#diff-8b1e3294d8fac0bd9ccc6173cbaf80dda46c0f08a705259958c772bad5f830e0R491-R501)`)

**Logging Consistency and Bug Fixes**

* Standardized error logging format in `config/manager/manager.go` for all `.gitignore` operations and GitLab token retrieval, improving log readability and debugging. (`[[1]](diffhunk://#diff-1044edc05bab58743afa8888d0afcd36f5b9f906ee596b436a5d45a6acd83842L577-R585)`, `[[2]](diffhunk://#diff-1044edc05bab58743afa8888d0afcd36f5b9f906ee596b436a5d45a6acd83842L601-R609)`, `[[3]](diffhunk://#diff-1044edc05bab58743afa8888d0afcd36f5b9f906ee596b436a5d45a6acd83842L624-R632)`, `[[4]](diffhunk://#diff-1044edc05bab58743afa8888d0afcd36f5b9f906ee596b436a5d45a6acd83842L648-R656)`, `[[5]](diffhunk://#diff-1044edc05bab58743afa8888d0afcd36f5b9f906ee596b436a5d45a6acd83842L868-R868)`)
* Fixed a bug in replication topology validation logic to ensure mutually exclusive topologies are enforced only after all checks, preventing false negatives. (`[config/replication.goL80-R110](diffhunk://#diff-b086b2eaf74034931d885a341061229a6a3048c3c14ea6ea7c2476ecf0bc694fL80-R110)`)

**Dependency Updates**

* Added `gopkg.in/ini.v1` import in `cluster/srv_cnf.go` to support advanced INI parsing features. (`[cluster/srv_cnf.goR21](diffhunk://#diff-891cc70822efaa828be1b26673bfaf009f86d1a5a47438b24ec274c1ae2fc01eR21)`)

These changes collectively make configuration management more secure, correct, and easier to maintain.