### PR TITLE
feat: enhance app error handling and monitoring status updates

### DIFF
--- a/cluster/app.go
+++ b/cluster/app.go
@@ -21,35 +21,42 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const (
+	ErrAppConnectFailed    = "APPERR001"
+	ErrAppUnexpectedStatus = "APPERR002"
+	ErrAppTCPConnectFailed = "APPERR003"
+	ErrAppUnsupportedProto = "APPERR004"
+)
+
 // App defines a app
 type App struct {
-	Id                   string                  `json:"id" groups:"apps"`
-	Name                 string                  `json:"name" groups:"apps"`
-	Type                 string                  `json:"type" groups:"apps"`
-	Host                 string                  `json:"host" groups:"apps"`
-	HostIPV6             string                  `json:"hostIPV6"`
-	Port                 string                  `json:"port" groups:"apps"`
-	User                 string                  `json:"-"`
-	Pass                 string                  `json:"-"`
-	Version              string                  `json:"version" groups:"apps"`
-	Datadir              string                  `json:"datadir"`
-	State                string                  `json:"state"`
-	PrevState            string                  `json:"prevState"`
-	SlapOSDatadir        string                  `json:"slaposDatadir"`
-	ServiceName          string                  `json:"serviceName"`
-	Agent                string                  `json:"agent"`
-	Weight               string                  `json:"weight"`
-	FailCount            int                     `json:"failCount"`
-	ErrState             map[string]*state.State `json:"-"`
-	ClusterGroup         *Cluster                `json:"-"`
-	Process              *os.Process             `json:"process"`
-	RouteStatus          []config.RouteStatus    `json:"routeStatus"`
-	Variables            map[string]string       `json:"-"`
-	AppConfig            *config.AppConfig       `json:"config" groups:"apps"`
-	AppClusterSubstitute string                  `json:"appClusterSubstitute"`
-	TemplateMD5Prov      string                  `json:"templateMD5Prov"`
-	TemplateMD5          string                  `json:"templateMD5"`
-	IsHashingTemplate    bool                    `json:"isHashingTemplate"`
+	Id                   string                 `json:"id" groups:"apps"`
+	Name                 string                 `json:"name" groups:"apps"`
+	Type                 string                 `json:"type" groups:"apps"`
+	Host                 string                 `json:"host" groups:"apps"`
+	HostIPV6             string                 `json:"hostIPV6"`
+	Port                 string                 `json:"port" groups:"apps"`
+	User                 string                 `json:"-"`
+	Pass                 string                 `json:"-"`
+	Version              string                 `json:"version" groups:"apps"`
+	Datadir              string                 `json:"datadir"`
+	State                string                 `json:"state"`
+	PrevState            string                 `json:"prevState"`
+	SlapOSDatadir        string                 `json:"slaposDatadir"`
+	ServiceName          string                 `json:"serviceName"`
+	Agent                string                 `json:"agent"`
+	Weight               string                 `json:"weight"`
+	FailCount            int                    `json:"failCount"`
+	ErrState             map[string]state.State `json:"-"`
+	ClusterGroup         *Cluster               `json:"-"`
+	Process              *os.Process            `json:"process"`
+	RouteStatus          []config.RouteStatus   `json:"routeStatus"`
+	Variables            map[string]string      `json:"-"`
+	AppConfig            *config.AppConfig      `json:"config" groups:"apps"`
+	AppClusterSubstitute string                 `json:"appClusterSubstitute"`
+	TemplateMD5Prov      string                 `json:"templateMD5Prov"`
+	TemplateMD5          string                 `json:"templateMD5"`
+	IsHashingTemplate    bool                   `json:"isHashingTemplate"`
 	*sync.Mutex          `json:"-"`
 }
 
@@ -100,7 +107,7 @@ func NewApp(placement int, cluster *Cluster, appHost string) *App {
 	}
 
 	app.RouteStatus = make([]config.RouteStatus, 0)
-	app.ErrState = make(map[string]*state.State)
+	app.ErrState = make(map[string]state.State)
 	app.CheckPrimaryRoute()
 	return app
 }
@@ -109,10 +116,10 @@ func (app *App) RecordAppError(key string, st state.State) {
 	app.Lock()
 	defer app.Unlock()
 	if app.ErrState == nil {
-		app.ErrState = make(map[string]*state.State)
+		app.ErrState = make(map[string]state.State)
 	}
 
-	app.ErrState[key] = &st
+	app.ErrState[key] = st
 }
 
 func (app *App) ResetAppError(keys ...string) {
@@ -130,7 +137,7 @@ func (app *App) ClearAppError() {
 	app.Lock()
 	defer app.Unlock()
 
-	app.ErrState = make(map[string]*state.State)
+	app.ErrState = make(map[string]state.State)
 }
 
 func (app *App) AddFlags(flags *pflag.FlagSet, conf *config.AppConfig) {

--- a/cluster/app.go
+++ b/cluster/app.go
@@ -17,37 +17,39 @@ import (
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/misc"
+	"github.com/signal18/replication-manager/utils/state"
 	"github.com/spf13/pflag"
 )
 
 // App defines a app
 type App struct {
-	Id                   string               `json:"id" groups:"apps"`
-	Name                 string               `json:"name" groups:"apps"`
-	Type                 string               `json:"type" groups:"apps"`
-	Host                 string               `json:"host" groups:"apps"`
-	HostIPV6             string               `json:"hostIPV6"`
-	Port                 string               `json:"port" groups:"apps"`
-	User                 string               `json:"-"`
-	Pass                 string               `json:"-"`
-	Version              string               `json:"version" groups:"apps"`
-	Datadir              string               `json:"datadir"`
-	State                string               `json:"state"`
-	PrevState            string               `json:"prevState"`
-	SlapOSDatadir        string               `json:"slaposDatadir"`
-	ServiceName          string               `json:"serviceName"`
-	Agent                string               `json:"agent"`
-	Weight               string               `json:"weight"`
-	FailCount            int                  `json:"failCount"`
-	ClusterGroup         *Cluster             `json:"-"`
-	Process              *os.Process          `json:"process"`
-	RouteStatus          []config.RouteStatus `json:"routeStatus"`
-	Variables            map[string]string    `json:"-"`
-	AppConfig            *config.AppConfig    `json:"config" groups:"apps"`
-	AppClusterSubstitute string               `json:"appClusterSubstitute"`
-	TemplateMD5Prov      string               `json:"templateMD5Prov"`
-	TemplateMD5          string               `json:"templateMD5"`
-	IsHashingTemplate    bool                 `json:"isHashingTemplate"`
+	Id                   string                  `json:"id" groups:"apps"`
+	Name                 string                  `json:"name" groups:"apps"`
+	Type                 string                  `json:"type" groups:"apps"`
+	Host                 string                  `json:"host" groups:"apps"`
+	HostIPV6             string                  `json:"hostIPV6"`
+	Port                 string                  `json:"port" groups:"apps"`
+	User                 string                  `json:"-"`
+	Pass                 string                  `json:"-"`
+	Version              string                  `json:"version" groups:"apps"`
+	Datadir              string                  `json:"datadir"`
+	State                string                  `json:"state"`
+	PrevState            string                  `json:"prevState"`
+	SlapOSDatadir        string                  `json:"slaposDatadir"`
+	ServiceName          string                  `json:"serviceName"`
+	Agent                string                  `json:"agent"`
+	Weight               string                  `json:"weight"`
+	FailCount            int                     `json:"failCount"`
+	ErrState             map[string]*state.State `json:"-"`
+	ClusterGroup         *Cluster                `json:"-"`
+	Process              *os.Process             `json:"process"`
+	RouteStatus          []config.RouteStatus    `json:"routeStatus"`
+	Variables            map[string]string       `json:"-"`
+	AppConfig            *config.AppConfig       `json:"config" groups:"apps"`
+	AppClusterSubstitute string                  `json:"appClusterSubstitute"`
+	TemplateMD5Prov      string                  `json:"templateMD5Prov"`
+	TemplateMD5          string                  `json:"templateMD5"`
+	IsHashingTemplate    bool                    `json:"isHashingTemplate"`
 	*sync.Mutex          `json:"-"`
 }
 
@@ -98,8 +100,37 @@ func NewApp(placement int, cluster *Cluster, appHost string) *App {
 	}
 
 	app.RouteStatus = make([]config.RouteStatus, 0)
+	app.ErrState = make(map[string]*state.State)
 	app.CheckPrimaryRoute()
 	return app
+}
+
+func (app *App) RecordAppError(key string, st state.State) {
+	app.Lock()
+	defer app.Unlock()
+	if app.ErrState == nil {
+		app.ErrState = make(map[string]*state.State)
+	}
+
+	app.ErrState[key] = &st
+}
+
+func (app *App) ResetAppError(keys ...string) {
+	app.Lock()
+	defer app.Unlock()
+
+	if app.ErrState != nil {
+		for _, key := range keys {
+			delete(app.ErrState, key)
+		}
+	}
+}
+
+func (app *App) ClearAppError() {
+	app.Lock()
+	defer app.Unlock()
+
+	app.ErrState = make(map[string]*state.State)
 }
 
 func (app *App) AddFlags(flags *pflag.FlagSet, conf *config.AppConfig) {
@@ -138,8 +169,6 @@ func (app *App) Refresh() error {
 	case stateAppWarning:
 		app.SetState(stateAppWarning)
 	}
-
-	app.CheckAppCredits()
 
 	// Send alert if state has changed
 	if app.PrevState != app.State {

--- a/cluster/app_chk.go
+++ b/cluster/app_chk.go
@@ -18,8 +18,16 @@ import (
 func (app *App) GetMonitoringStatus() string {
 	routes := app.GetAppConfig().Deployment.Routes
 	var primaryStatus = stateAppRunning
+	appErrKeys := []string{"APPERR001", "APPERR002", "APPERR003", "APPERR004"}
 	if len(routes) == 0 {
+		app.RecordAppError("APPERR001", state.State{ErrType: "WARN", ErrKey: "APPERR001", ErrDesc: fmt.Sprintf(config.ClusterError["APPERR001"], app.GetId(), "no routes defined"), ServerUrl: app.Host})
+		app.ResetAppError("APPERR002", "APPERR003", "APPERR004")
 		return stateFailed
+	}
+
+	errStates := make(map[string]state.State)
+	setErrState := func(key string, desc string) {
+		errStates[key] = state.State{ErrType: "WARN", ErrKey: key, ErrDesc: desc, ServerUrl: app.Host}
 	}
 
 	routeStatuses := make([]config.RouteStatus, 0, len(routes))
@@ -32,17 +40,17 @@ func (app *App) GetMonitoringStatus() string {
 				routeStatus.Status = stateAppWarning
 				primaryStatus = stateAppWarning
 				if strings.HasPrefix(err.Error(), "unexpected status code") {
-					app.ClusterGroup.SetState("APPERR002", state.State{ErrType: "WARN", ErrKey: "APPERR002", ErrDesc: fmt.Sprintf(config.ClusterError["APPERR002"], app.GetId(), httpStatus), ServerUrl: app.Host})
+					setErrState("APPERR002", fmt.Sprintf(config.ClusterError["APPERR002"], app.GetId(), httpStatus))
 				} else {
-					app.ClusterGroup.SetState("APPERR001", state.State{ErrType: "WARN", ErrKey: "APPERR001", ErrDesc: fmt.Sprintf(config.ClusterError["APPERR001"], app.GetId(), err), ServerUrl: app.Host})
+					setErrState("APPERR001", fmt.Sprintf(config.ClusterError["APPERR001"], app.GetId(), err))
 				}
 
 				httpStatus, _, err := app.GetAppLocalHTTPStatus(route, false)
 				if err != nil {
 					if strings.HasPrefix(err.Error(), "unexpected status code") {
-						app.ClusterGroup.SetState("APPERR002", state.State{ErrType: "WARN", ErrKey: "APPERR002", ErrDesc: fmt.Sprintf(config.ClusterError["APPERR002"], app.GetId(), httpStatus), ServerUrl: app.Host})
+						setErrState("APPERR002", fmt.Sprintf(config.ClusterError["APPERR002"], app.GetId(), httpStatus))
 					} else {
-						app.ClusterGroup.SetState("APPERR001", state.State{ErrType: "WARN", ErrKey: "APPERR001", ErrDesc: fmt.Sprintf(config.ClusterError["APPERR001"], app.GetId(), err), ServerUrl: app.Host})
+						setErrState("APPERR001", fmt.Sprintf(config.ClusterError["APPERR001"], app.GetId(), err))
 					}
 
 					routeStatus.Status = stateFailed
@@ -60,10 +68,10 @@ func (app *App) GetMonitoringStatus() string {
 				routeStatus.Status = stateAppWarning
 				primaryStatus = stateAppWarning
 
-				app.ClusterGroup.SetState("APPERR003", state.State{ErrType: "WARN", ErrKey: "APPERR003", ErrDesc: fmt.Sprintf(config.ClusterError["APPERR003"], app.GetId(), err), ServerUrl: app.Host})
+				setErrState("APPERR003", fmt.Sprintf(config.ClusterError["APPERR003"], app.GetId(), err))
 
 				if err := app.GetAppLocalTCPStatus(route); err != nil {
-					app.ClusterGroup.SetState("APPERR003", state.State{ErrType: "WARN", ErrKey: "APPERR003", ErrDesc: fmt.Sprintf(config.ClusterError["APPERR003"], app.GetId(), err), ServerUrl: app.Host})
+					setErrState("APPERR003", fmt.Sprintf(config.ClusterError["APPERR003"], app.GetId(), err))
 					routeStatus.Status = stateFailed
 					if route.Primary {
 						primaryStatus = stateFailed
@@ -71,7 +79,7 @@ func (app *App) GetMonitoringStatus() string {
 				}
 			}
 		default:
-			app.ClusterGroup.SetState("APPERR004", state.State{ErrType: "WARN", ErrKey: "APPERR004", ErrDesc: fmt.Sprintf(config.ClusterError["APPERR004"], app.GetId(), route.Protocol), ServerUrl: app.Host})
+			setErrState("APPERR004", fmt.Sprintf(config.ClusterError["APPERR004"], app.GetId(), route.Protocol))
 			routeStatus.Status = stateFailed
 
 			if route.Primary {
@@ -84,9 +92,15 @@ func (app *App) GetMonitoringStatus() string {
 		routeStatuses = append(routeStatuses, routeStatus)
 	}
 
-	app.Lock()
-	defer app.Unlock()
-	app.RouteStatus = routeStatuses
+	for _, key := range appErrKeys {
+		if st, ok := errStates[key]; ok {
+			app.RecordAppError(key, st)
+		} else {
+			app.ResetAppError(key)
+		}
+	}
+
+	app.SetRouteStatuses(routeStatuses)
 
 	return primaryStatus
 }

--- a/cluster/app_chk.go
+++ b/cluster/app_chk.go
@@ -18,10 +18,10 @@ import (
 func (app *App) GetMonitoringStatus() string {
 	routes := app.GetAppConfig().Deployment.Routes
 	var primaryStatus = stateAppRunning
-	appErrKeys := []string{"APPERR001", "APPERR002", "APPERR003", "APPERR004"}
+	appErrKeys := []string{ErrAppConnectFailed, ErrAppUnexpectedStatus, ErrAppTCPConnectFailed, ErrAppUnsupportedProto}
 	if len(routes) == 0 {
-		app.RecordAppError("APPERR001", state.State{ErrType: "WARN", ErrKey: "APPERR001", ErrDesc: fmt.Sprintf(config.ClusterError["APPERR001"], app.GetId(), "no routes defined"), ServerUrl: app.Host})
-		app.ResetAppError("APPERR002", "APPERR003", "APPERR004")
+		app.RecordAppError(ErrAppConnectFailed, state.State{ErrType: "WARN", ErrKey: ErrAppConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), "no routes defined"), ServerUrl: app.Host})
+		app.ResetAppError(ErrAppUnexpectedStatus, ErrAppTCPConnectFailed, ErrAppUnsupportedProto)
 		return stateFailed
 	}
 
@@ -40,17 +40,17 @@ func (app *App) GetMonitoringStatus() string {
 				routeStatus.Status = stateAppWarning
 				primaryStatus = stateAppWarning
 				if strings.HasPrefix(err.Error(), "unexpected status code") {
-					setErrState("APPERR002", fmt.Sprintf(config.ClusterError["APPERR002"], app.GetId(), httpStatus))
+					setErrState(ErrAppUnexpectedStatus, fmt.Sprintf(config.ClusterError[ErrAppUnexpectedStatus], app.GetId(), httpStatus))
 				} else {
-					setErrState("APPERR001", fmt.Sprintf(config.ClusterError["APPERR001"], app.GetId(), err))
+					setErrState(ErrAppConnectFailed, fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), err))
 				}
 
 				httpStatus, _, err := app.GetAppLocalHTTPStatus(route, false)
 				if err != nil {
 					if strings.HasPrefix(err.Error(), "unexpected status code") {
-						setErrState("APPERR002", fmt.Sprintf(config.ClusterError["APPERR002"], app.GetId(), httpStatus))
+						setErrState(ErrAppUnexpectedStatus, fmt.Sprintf(config.ClusterError[ErrAppUnexpectedStatus], app.GetId(), httpStatus))
 					} else {
-						setErrState("APPERR001", fmt.Sprintf(config.ClusterError["APPERR001"], app.GetId(), err))
+						setErrState(ErrAppConnectFailed, fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), err))
 					}
 
 					routeStatus.Status = stateFailed
@@ -68,10 +68,10 @@ func (app *App) GetMonitoringStatus() string {
 				routeStatus.Status = stateAppWarning
 				primaryStatus = stateAppWarning
 
-				setErrState("APPERR003", fmt.Sprintf(config.ClusterError["APPERR003"], app.GetId(), err))
+				setErrState(ErrAppTCPConnectFailed, fmt.Sprintf(config.ClusterError[ErrAppTCPConnectFailed], app.GetId(), err))
 
 				if err := app.GetAppLocalTCPStatus(route); err != nil {
-					setErrState("APPERR003", fmt.Sprintf(config.ClusterError["APPERR003"], app.GetId(), err))
+					setErrState(ErrAppTCPConnectFailed, fmt.Sprintf(config.ClusterError[ErrAppTCPConnectFailed], app.GetId(), err))
 					routeStatus.Status = stateFailed
 					if route.Primary {
 						primaryStatus = stateFailed
@@ -79,7 +79,7 @@ func (app *App) GetMonitoringStatus() string {
 				}
 			}
 		default:
-			setErrState("APPERR004", fmt.Sprintf(config.ClusterError["APPERR004"], app.GetId(), route.Protocol))
+			setErrState(ErrAppUnsupportedProto, fmt.Sprintf(config.ClusterError[ErrAppUnsupportedProto], app.GetId(), route.Protocol))
 			routeStatus.Status = stateFailed
 
 			if route.Primary {

--- a/cluster/app_error_test.go
+++ b/cluster/app_error_test.go
@@ -1,0 +1,116 @@
+package cluster
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/state"
+)
+
+func newTestApp() *App {
+	return &App{Mutex: &sync.Mutex{}}
+}
+
+func TestRecordAppErrorThreadSafe(t *testing.T) {
+	app := newTestApp()
+
+	const total = 100
+	var wg sync.WaitGroup
+	wg.Add(total)
+
+	for i := 0; i < total; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			key := fmt.Sprintf("key-%d", i)
+			app.RecordAppError(key, state.State{ErrKey: key})
+		}()
+	}
+
+	wg.Wait()
+
+	if len(app.ErrState) != total {
+		t.Fatalf("expected %d error entries, got %d", total, len(app.ErrState))
+	}
+}
+
+func TestResetAppErrorMultipleKeys(t *testing.T) {
+	app := newTestApp()
+	app.ErrState = map[string]state.State{
+		"a": {ErrKey: "a"},
+		"b": {ErrKey: "b"},
+		"c": {ErrKey: "c"},
+	}
+
+	app.ResetAppError("a", "c", "missing")
+
+	if len(app.ErrState) != 1 {
+		t.Fatalf("expected 1 error entry remaining, got %d", len(app.ErrState))
+	}
+	if _, ok := app.ErrState["b"]; !ok {
+		t.Fatalf("expected key 'b' to remain in error state")
+	}
+	if _, ok := app.ErrState["a"]; ok {
+		t.Fatalf("expected key 'a' to be removed from error state")
+	}
+	if _, ok := app.ErrState["c"]; ok {
+		t.Fatalf("expected key 'c' to be removed from error state")
+	}
+}
+
+func TestClearAppErrorResetsMap(t *testing.T) {
+	app := newTestApp()
+	app.ErrState = map[string]state.State{
+		"a": {ErrKey: "a"},
+	}
+
+	oldMap := app.ErrState
+	app.ClearAppError()
+
+	if len(app.ErrState) != 0 {
+		t.Fatalf("expected cleared error state map, got %d entries", len(app.ErrState))
+	}
+
+	oldMap["old"] = state.State{ErrKey: "old"}
+	if _, ok := app.ErrState["old"]; ok {
+		t.Fatalf("expected new error state map after ClearAppError")
+	}
+}
+
+func TestSetRouteStatusesThreadSafe(t *testing.T) {
+	app := newTestApp()
+
+	const total = 50
+	var wg sync.WaitGroup
+	wg.Add(total)
+
+	for i := 0; i < total; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			app.SetRouteStatuses([]config.RouteStatus{
+				{
+					Route:  config.Route{CName: fmt.Sprintf("app-%d", i), Port: "80", Protocol: "https"},
+					Status: stateAppRunning,
+				},
+			})
+		}()
+	}
+
+	wg.Wait()
+
+	finalStatuses := []config.RouteStatus{{
+		Route:  config.Route{CName: "final", Port: "443", Protocol: "https"},
+		Status: stateAppRunning,
+	}}
+	app.SetRouteStatuses(finalStatuses)
+
+	if len(app.RouteStatus) != 1 {
+		t.Fatalf("expected 1 route status after final set, got %d", len(app.RouteStatus))
+	}
+	if app.RouteStatus[0].Route.CName != "final" {
+		t.Fatalf("expected final route status to be stored")
+	}
+}

--- a/cluster/app_set.go
+++ b/cluster/app_set.go
@@ -264,3 +264,9 @@ func (app *App) ApplyPlannedCredits() {
 		app.AppConfig.ProvAppCreditUsed = app.AppConfig.ProvAppCreditPlanned
 	}
 }
+
+func (app *App) SetRouteStatuses(routeStatuses []config.RouteStatus) {
+	app.Lock()
+	defer app.Unlock()
+	app.RouteStatus = routeStatuses
+}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -758,6 +758,7 @@ func (cluster *Cluster) Run() {
 						wg.Add(1)
 						go cluster.refreshProxies(wg)
 						go cluster.refreshApps(wg)
+						cluster.CheckAppsCredit()
 						cluster.CheckWaitRunJobSSH()
 						cluster.CheckDummyConfigSendCookies()
 						cluster.CheckRestartContainerCookies()
@@ -834,6 +835,8 @@ func (cluster *Cluster) Run() {
 
 					wg.Wait()
 				}
+
+				cluster.EmitAppErrors()
 
 				if cluster.HasDiscoverTopologyMismatchTarget() {
 					cluster.SetState("ERR00092", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00092"], cluster.Name, cluster.Topology, cluster.Conf.TopologyTarget), ErrFrom: "TOPO"})

--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -514,15 +514,11 @@ func (cluster *Cluster) EmitAppErrors() {
 		}
 		app.Lock()
 		for key, st := range app.ErrState {
-			if st == nil {
-				continue
-			}
-
 			if st.ErrKey == "" {
 				st.ErrKey = key
 			}
 
-			cluster.SetState(key, *st)
+			cluster.SetState(key, st)
 		}
 		app.Unlock()
 	}

--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -507,6 +507,27 @@ func (cluster *Cluster) refreshApps(wg *sync.WaitGroup) {
 	}
 }
 
+func (cluster *Cluster) EmitAppErrors() {
+	for _, app := range cluster.Apps {
+		if app == nil {
+			continue
+		}
+		app.Lock()
+		for key, st := range app.ErrState {
+			if st == nil {
+				continue
+			}
+
+			if st.ErrKey == "" {
+				st.ErrKey = key
+			}
+
+			cluster.SetState(key, *st)
+		}
+		app.Unlock()
+	}
+}
+
 func (cluster *Cluster) GetAppByURL(url string) (*App, int) {
 	var host, port string
 	newURL := strings.TrimSpace(url)
@@ -843,5 +864,13 @@ func (cluster *Cluster) EnqueueRefreshAppTemplateMD5(app *App) {
 		// Enqueued successfully
 	default:
 		// Channel full — drop silently
+	}
+}
+
+func (cluster *Cluster) CheckAppsCredit() {
+	for _, app := range cluster.Apps {
+		if app != nil {
+			app.CheckAppCredits()
+		}
 	}
 }


### PR DESCRIPTION
This pull request introduces a new mechanism for tracking and emitting application-level errors within the cluster management system. The changes center around adding an error state map to each `App`, providing methods to record, reset, and clear errors, and ensuring that these errors are emitted to the cluster state. Additionally, error handling in app monitoring has been refactored for clarity and maintainability.

**Error state management for applications:**

* Added an `ErrState` map to the `App` struct to track error states per application, along with new methods `RecordAppError`, `ResetAppError`, and `ClearAppError` for managing these errors. (`cluster/app.go`) [[1]](diffhunk://#diff-224ae3cc73abcacf80c0831721e294bfd26c49a57a67cc1fdb2343cf7ec098c6R43) [[2]](diffhunk://#diff-224ae3cc73abcacf80c0831721e294bfd26c49a57a67cc1fdb2343cf7ec098c6R103-R135)
* Refactored the `GetMonitoringStatus` method to use the new error recording/resetting methods instead of directly setting cluster state, and to update error states in a more organized way. (`cluster/app_chk.go`) [[1]](diffhunk://#diff-eb12dd02771a37146c067da99f1fd291b7fd120c75139dada42470b22377f19bR21-R32) [[2]](diffhunk://#diff-eb12dd02771a37146c067da99f1fd291b7fd120c75139dada42470b22377f19bL35-R53) [[3]](diffhunk://#diff-eb12dd02771a37146c067da99f1fd291b7fd120c75139dada42470b22377f19bL63-R82) [[4]](diffhunk://#diff-eb12dd02771a37146c067da99f1fd291b7fd120c75139dada42470b22377f19bL87-R103)

**Cluster-level error emission and credit checks:**

* Added a new `EmitAppErrors` method to the `Cluster` struct, which iterates through all apps and emits their error states to the cluster state. This is now called in the main cluster run loop. (`cluster/cluster_app.go`, `cluster/cluster.go`) [[1]](diffhunk://#diff-edd49cb31378c3c170dc35e10e00b3fa4e0185de10e53630739d5fcdc3374e29R510-R530) [[2]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R839-R840)
* Introduced a `CheckAppsCredit` method to the `Cluster` struct to ensure all apps have their credit checks performed during the cluster run loop. (`cluster/cluster_app.go`, `cluster/cluster.go`) [[1]](diffhunk://#diff-edd49cb31378c3c170dc35e10e00b3fa4e0185de10e53630739d5fcdc3374e29R869-R876) [[2]](diffhunk://#diff-86cbfc045d9b3441a4f4c2235e276915275698f1e70a42e38e74a846cb9bdcc4R761)

**Thread safety and code cleanup:**

* Added a `SetRouteStatuses` method to the `App` struct for thread-safe updates to `RouteStatus`. (`cluster/app_set.go`, `cluster/app_chk.go`) [[1]](diffhunk://#diff-3a636dd89812a721925a338276b9246bbce6d289ab3910fa9b64af72e4d69cebR267-R272) [[2]](diffhunk://#diff-eb12dd02771a37146c067da99f1fd291b7fd120c75139dada42470b22377f19bL87-R103)
* Removed redundant direct calls to `CheckAppCredits` from `App.Refresh`, as this is now handled at the cluster level. (`cluster/app.go`)