### PR TITLE
feat: reload cluster service plan  

### DIFF
--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -262,6 +262,7 @@ var globalSettingsACLRules = []ACLRule{
 	{"/api/clusters/settings/actions/set", nil, []string{config.GrantGlobalSettings}},
 	{"/api/clusters/settings/actions/clear", nil, []string{config.GrantGlobalSettings}},
 	{"/api/clusters/settings/actions/reload-clusters-plans", nil, []string{config.GrantGlobalSettings}},
+	{"/api/clusters/settings/actions/reload-clusters-plan-info", nil, []string{config.GrantGlobalSettings}},
 }
 
 // terminalACLRules defines ACL rules for terminal access

--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -194,6 +194,7 @@ var clusterACLRules = []ACLRule{
 
 	// Cluster Settings
 	{"/settings/actions/reload", nil, []string{config.GrantClusterSettings}},
+	{"/settings/actions/reload-plan-info", nil, []string{config.GrantClusterSettings}},
 	{"/settings/actions/switch", nil, []string{config.GrantClusterSettings, config.GrantGlobalSettings}},
 	{"/settings/actions/set", nil, []string{config.GrantClusterSettings, config.GrantGlobalSettings}},
 	{"/settings/actions/clear", nil, []string{config.GrantClusterSettings, config.GrantGlobalSettings}},

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -316,11 +316,19 @@ const docTemplate = `{
                 "summary": "Reload cluster plan information (all clusters)",
                 "parameters": [
                     {
-                        "type": "boolean",
-                        "default": true,
-                        "description": "Redownload plan repository before reload",
-                        "name": "download",
-                        "in": "query"
+                        "description": "Reload plan repository options",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "download": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "description": "Redownload plan repository before reload"
+                                }
+                            }
+                        }
                     }
                 ],
                 "responses": {
@@ -354,11 +362,19 @@ const docTemplate = `{
                 "summary": "Reload cluster plans",
                 "parameters": [
                     {
-                        "type": "boolean",
-                        "default": true,
-                        "description": "Redownload plan repository before reload",
-                        "name": "download",
-                        "in": "query"
+                        "description": "Reload plan repository options",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "download": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "description": "Redownload plan repository before reload"
+                                }
+                            }
+                        }
                     }
                 ],
                 "responses": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -320,14 +320,7 @@ const docTemplate = `{
                         "name": "body",
                         "in": "body",
                         "schema": {
-                            "type": "object",
-                            "properties": {
-                                "download": {
-                                    "type": "boolean",
-                                    "default": true,
-                                    "description": "Redownload plan repository before reload"
-                                }
-                            }
+                            "$ref": "#/definitions/server.ReloadPlanRequest"
                         }
                     }
                 ],
@@ -366,14 +359,7 @@ const docTemplate = `{
                         "name": "body",
                         "in": "body",
                         "schema": {
-                            "type": "object",
-                            "properties": {
-                                "download": {
-                                    "type": "boolean",
-                                    "default": true,
-                                    "description": "Redownload plan repository before reload"
-                                }
-                            }
+                            "$ref": "#/definitions/server.ReloadPlanRequest"
                         }
                     }
                 ],
@@ -25671,6 +25657,14 @@ const docTemplate = `{
             "properties": {
                 "content": {
                     "type": "string"
+                }
+            }
+        },
+        "server.ReloadPlanRequest": {
+            "type": "object",
+            "properties": {
+                "download": {
+                    "type": "boolean"
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -307,6 +307,35 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/clusters/settings/actions/reload-clusters-plan-info": {
+            "post": {
+                "description": "This endpoint reloads the cluster plan information for all clusters without reapplying plans.",
+                "tags": [
+                    "ClusterActions"
+                ],
+                "summary": "Reload cluster plan information (all clusters)",
+                "responses": {
+                    "200": {
+                        "description": "Successfully reloaded plan information",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "No cluster",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/settings/actions/reload-clusters-plans": {
             "post": {
                 "description": "This endpoint reloads the cluster plans for all clusters.",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15183,6 +15183,58 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/clusters/{clusterName}/settings/actions/reload-plan-info": {
+            "post": {
+                "description": "This endpoint reloads the cluster plan information for all clusters.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterActions"
+                ],
+                "summary": "Reload cluster plan information",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully reloaded plan information",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "No cluster",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/settings/actions/reset-graphite-filterlist/{template}": {
             "post": {
                 "description": "This endpoint resets the Graphite filter list for the specified cluster.",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -314,6 +314,15 @@ const docTemplate = `{
                     "ClusterActions"
                 ],
                 "summary": "Reload cluster plan information (all clusters)",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Redownload plan repository before reload",
+                        "name": "download",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Successfully reloaded plan information",
@@ -343,6 +352,15 @@ const docTemplate = `{
                     "ClusterActions"
                 ],
                 "summary": "Reload cluster plans",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Redownload plan repository before reload",
+                        "name": "download",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Successfully reloaded plans",
@@ -15214,7 +15232,7 @@ const docTemplate = `{
         },
         "/api/clusters/{clusterName}/settings/actions/reload-plan-info": {
             "post": {
-                "description": "This endpoint reloads the cluster plan information for all clusters.",
+                "description": "This endpoint reloads the cluster plan information for the specified cluster.",
                 "consumes": [
                     "application/json"
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -305,11 +305,19 @@
                 "summary": "Reload cluster plan information (all clusters)",
                 "parameters": [
                     {
-                        "type": "boolean",
-                        "default": true,
-                        "description": "Redownload plan repository before reload",
-                        "name": "download",
-                        "in": "query"
+                        "description": "Reload plan repository options",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "download": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "description": "Redownload plan repository before reload"
+                                }
+                            }
+                        }
                     }
                 ],
                 "responses": {
@@ -343,11 +351,19 @@
                 "summary": "Reload cluster plans",
                 "parameters": [
                     {
-                        "type": "boolean",
-                        "default": true,
-                        "description": "Redownload plan repository before reload",
-                        "name": "download",
-                        "in": "query"
+                        "description": "Reload plan repository options",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "download": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "description": "Redownload plan repository before reload"
+                                }
+                            }
+                        }
                     }
                 ],
                 "responses": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -15172,6 +15172,58 @@
                 }
             }
         },
+        "/api/clusters/{clusterName}/settings/actions/reload-plan-info": {
+            "post": {
+                "description": "This endpoint reloads the cluster plan information for all clusters.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ClusterActions"
+                ],
+                "summary": "Reload cluster plan information",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "Bearer \u003cAdd access token here\u003e",
+                        "description": "Insert your access token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cluster Name",
+                        "name": "clusterName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully reloaded plan information",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "No cluster",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/{clusterName}/settings/actions/reset-graphite-filterlist/{template}": {
             "post": {
                 "description": "This endpoint resets the Graphite filter list for the specified cluster.",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -296,6 +296,35 @@
                 }
             }
         },
+        "/api/clusters/settings/actions/reload-clusters-plan-info": {
+            "post": {
+                "description": "This endpoint reloads the cluster plan information for all clusters without reapplying plans.",
+                "tags": [
+                    "ClusterActions"
+                ],
+                "summary": "Reload cluster plan information (all clusters)",
+                "responses": {
+                    "200": {
+                        "description": "Successfully reloaded plan information",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "No valid ACL",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "No cluster",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/clusters/settings/actions/reload-clusters-plans": {
             "post": {
                 "description": "This endpoint reloads the cluster plans for all clusters.",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -309,14 +309,7 @@
                         "name": "body",
                         "in": "body",
                         "schema": {
-                            "type": "object",
-                            "properties": {
-                                "download": {
-                                    "type": "boolean",
-                                    "default": true,
-                                    "description": "Redownload plan repository before reload"
-                                }
-                            }
+                            "$ref": "#/definitions/server.ReloadPlanRequest"
                         }
                     }
                 ],
@@ -355,14 +348,7 @@
                         "name": "body",
                         "in": "body",
                         "schema": {
-                            "type": "object",
-                            "properties": {
-                                "download": {
-                                    "type": "boolean",
-                                    "default": true,
-                                    "description": "Redownload plan repository before reload"
-                                }
-                            }
+                            "$ref": "#/definitions/server.ReloadPlanRequest"
                         }
                     }
                 ],
@@ -25660,6 +25646,14 @@
             "properties": {
                 "content": {
                     "type": "string"
+                }
+            }
+        },
+        "server.ReloadPlanRequest": {
+            "type": "object",
+            "properties": {
+                "download": {
+                    "type": "boolean"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -303,6 +303,15 @@
                     "ClusterActions"
                 ],
                 "summary": "Reload cluster plan information (all clusters)",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Redownload plan repository before reload",
+                        "name": "download",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Successfully reloaded plan information",
@@ -332,6 +341,15 @@
                     "ClusterActions"
                 ],
                 "summary": "Reload cluster plans",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Redownload plan repository before reload",
+                        "name": "download",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Successfully reloaded plans",
@@ -15203,7 +15221,7 @@
         },
         "/api/clusters/{clusterName}/settings/actions/reload-plan-info": {
             "post": {
-                "description": "This endpoint reloads the cluster plan information for all clusters.",
+                "description": "This endpoint reloads the cluster plan information for the specified cluster.",
                 "consumes": [
                     "application/json"
                 ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -16312,11 +16312,16 @@ paths:
       description: This endpoint reloads the cluster plan information for all clusters
         without reapplying plans.
       parameters:
-      - default: true
-        description: Redownload plan repository before reload
-        in: query
-        name: download
-        type: boolean
+      - description: Reload plan repository options
+        in: body
+        name: body
+        schema:
+          properties:
+            download:
+              default: true
+              description: Redownload plan repository before reload
+              type: boolean
+          type: object
       responses:
         "200":
           description: Successfully reloaded plan information
@@ -16337,11 +16342,16 @@ paths:
     post:
       description: This endpoint reloads the cluster plans for all clusters.
       parameters:
-      - default: true
-        description: Redownload plan repository before reload
-        in: query
-        name: download
-        type: boolean
+      - description: Reload plan repository options
+        in: body
+        name: body
+        schema:
+          properties:
+            download:
+              default: true
+              description: Redownload plan repository before reload
+              type: boolean
+          type: object
       responses:
         "200":
           description: Successfully reloaded plans

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -14734,7 +14734,8 @@ paths:
     post:
       consumes:
       - application/json
-      description: This endpoint reloads the cluster plan information for all clusters.
+      description: This endpoint reloads the cluster plan information for the specified
+        cluster.
       parameters:
       - default: Bearer <Add access token here>
         description: Insert your access token
@@ -16310,6 +16311,12 @@ paths:
     post:
       description: This endpoint reloads the cluster plan information for all clusters
         without reapplying plans.
+      parameters:
+      - default: true
+        description: Redownload plan repository before reload
+        in: query
+        name: download
+        type: boolean
       responses:
         "200":
           description: Successfully reloaded plan information
@@ -16329,6 +16336,12 @@ paths:
   /api/clusters/settings/actions/reload-clusters-plans:
     post:
       description: This endpoint reloads the cluster plans for all clusters.
+      parameters:
+      - default: true
+        description: Redownload plan repository before reload
+        in: query
+        name: download
+        type: boolean
       responses:
         "200":
           description: Successfully reloaded plans

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4272,6 +4272,11 @@ definitions:
       content:
         type: string
     type: object
+  server.ReloadPlanRequest:
+    properties:
+      download:
+        type: boolean
+    type: object
   server.ReplicationManager:
     properties:
       agents:
@@ -16316,12 +16321,7 @@ paths:
         in: body
         name: body
         schema:
-          properties:
-            download:
-              default: true
-              description: Redownload plan repository before reload
-              type: boolean
-          type: object
+          $ref: '#/definitions/server.ReloadPlanRequest'
       responses:
         "200":
           description: Successfully reloaded plan information
@@ -16346,12 +16346,7 @@ paths:
         in: body
         name: body
         schema:
-          properties:
-            download:
-              default: true
-              description: Redownload plan repository before reload
-              type: boolean
-          type: object
+          $ref: '#/definitions/server.ReloadPlanRequest'
       responses:
         "200":
           description: Successfully reloaded plans

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -16306,6 +16306,26 @@ paths:
       summary: Retrieve peer clusters for a user
       tags:
       - Cloud18
+  /api/clusters/settings/actions/reload-clusters-plan-info:
+    post:
+      description: This endpoint reloads the cluster plan information for all clusters
+        without reapplying plans.
+      responses:
+        "200":
+          description: Successfully reloaded plan information
+          schema:
+            type: string
+        "403":
+          description: No valid ACL
+          schema:
+            type: string
+        "500":
+          description: No cluster
+          schema:
+            type: string
+      summary: Reload cluster plan information (all clusters)
+      tags:
+      - ClusterActions
   /api/clusters/settings/actions/reload-clusters-plans:
     post:
       description: This endpoint reloads the cluster plans for all clusters.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -14730,6 +14730,41 @@ paths:
       summary: Reload Graphite filter list for a specific cluster
       tags:
       - ClusterGraphite
+  /api/clusters/{clusterName}/settings/actions/reload-plan-info:
+    post:
+      consumes:
+      - application/json
+      description: This endpoint reloads the cluster plan information for all clusters.
+      parameters:
+      - default: Bearer <Add access token here>
+        description: Insert your access token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Cluster Name
+        in: path
+        name: clusterName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully reloaded plan information
+          schema:
+            type: string
+        "403":
+          description: No valid ACL
+          schema:
+            type: string
+        "500":
+          description: No cluster
+          schema:
+            type: string
+      summary: Reload cluster plan information
+      tags:
+      - ClusterActions
   /api/clusters/{clusterName}/settings/actions/reset-graphite-filterlist/{template}:
     post:
       consumes:

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -268,6 +268,10 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxReloadPlans)),
 	))
+	router.Handle("/api/clusters/settings/actions/reload-clusters-plan-info", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxReloadPlansInfo)),
+	))
 	router.Handle("/api/clusters/{clusterName}/settings/actions/set-cron/{settingName}/{settingValue:.*}", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxSetCron)),
@@ -4494,6 +4498,10 @@ func (repman *ReplicationManager) switchServerSetting(user string, URL string, n
 // @Router /api/clusters/settings/actions/reload-clusters-plans [post]
 func (repman *ReplicationManager) handlerMuxReloadPlans(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
+	shouldDownload := true
+	if download := r.URL.Query().Get("download"); download == "false" || download == "0" || download == "no" {
+		shouldDownload = false
+	}
 
 	var mycluster *cluster.Cluster
 	for _, v := range repman.Clusters {
@@ -4506,11 +4514,58 @@ func (repman *ReplicationManager) handlerMuxReloadPlans(w http.ResponseWriter, r
 	if mycluster != nil {
 		valid, apiuser := repman.IsValidClusterACL(r, mycluster)
 		if valid {
-			repman.InitServicePlans()
+			if shouldDownload {
+				repman.InitServicePlans()
+			}
 			for _, cl := range repman.Clusters {
 				//Don't print error with no valid ACL
 				if cl.IsURLPassACL(apiuser, r.URL.Path, false) {
 					cl.SetServicePlan(cl.Conf.ProvServicePlan)
+				}
+			}
+		} else {
+			http.Error(w, fmt.Sprintf("User doesn't have required ACL for global setting: %s", r.URL.Path), http.StatusForbidden)
+			return
+		}
+	} else {
+		http.Error(w, "No cluster", http.StatusInternalServerError)
+		return
+	}
+}
+
+// handlerMuxReloadPlansInfo handles the reloading of cluster plan information.
+// @Summary Reload cluster plan information (all clusters)
+// @Description This endpoint reloads the cluster plan information for all clusters without reapplying plans.
+// @Tags ClusterActions
+// @Success 200 {string} string "Successfully reloaded plan information"
+// @Failure 403 {string} string "No valid ACL"
+// @Failure 500 {string} string "No cluster"
+// @Router /api/clusters/settings/actions/reload-clusters-plan-info [post]
+func (repman *ReplicationManager) handlerMuxReloadPlansInfo(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	shouldDownload := true
+	if download := r.URL.Query().Get("download"); download == "false" || download == "0" || download == "no" {
+		shouldDownload = false
+	}
+
+	var mycluster *cluster.Cluster
+	for _, v := range repman.Clusters {
+		if v != nil {
+			mycluster = v
+			break
+		}
+	}
+
+	if mycluster != nil {
+		valid, apiuser := repman.IsValidClusterACL(r, mycluster)
+		if valid {
+			if shouldDownload {
+				repman.InitServicePlans()
+			}
+			for _, cl := range repman.Clusters {
+				//Don't print error with no valid ACL
+				if cl.IsURLPassACL(apiuser, r.URL.Path, false) {
+					cl.SetServicePlanInfos(cl.Conf.ProvServicePlan)
 				}
 			}
 		} else {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -4497,6 +4497,7 @@ func shouldDownloadFromQuery(values url.Values) bool {
 // @Summary Reload cluster plans
 // @Description This endpoint reloads the cluster plans for all clusters.
 // @Tags ClusterActions
+// @Param download query bool false "Redownload plan repository before reload" default(true)
 // @Success 200 {string} string "Successfully reloaded plans"
 // @Failure 403 {string} string "No valid ACL"
 // @Failure 500 {string} string "No cluster"
@@ -4525,6 +4526,8 @@ func (repman *ReplicationManager) handlerMuxReloadPlans(w http.ResponseWriter, r
 					cl.SetServicePlan(cl.Conf.ProvServicePlan)
 				}
 			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Successfully reloaded plans"))
 		} else {
 			http.Error(w, fmt.Sprintf("User doesn't have required ACL for global setting: %s", r.URL.Path), http.StatusForbidden)
 			return
@@ -4539,6 +4542,7 @@ func (repman *ReplicationManager) handlerMuxReloadPlans(w http.ResponseWriter, r
 // @Summary Reload cluster plan information (all clusters)
 // @Description This endpoint reloads the cluster plan information for all clusters without reapplying plans.
 // @Tags ClusterActions
+// @Param download query bool false "Redownload plan repository before reload" default(true)
 // @Success 200 {string} string "Successfully reloaded plan information"
 // @Failure 403 {string} string "No valid ACL"
 // @Failure 500 {string} string "No cluster"
@@ -4567,6 +4571,8 @@ func (repman *ReplicationManager) handlerMuxReloadPlansInfo(w http.ResponseWrite
 					cl.SetServicePlanInfos(cl.Conf.ProvServicePlan)
 				}
 			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Successfully reloaded plan information"))
 		} else {
 			http.Error(w, fmt.Sprintf("User doesn't have required ACL for global setting: %s", r.URL.Path), http.StatusForbidden)
 			return
@@ -4579,7 +4585,7 @@ func (repman *ReplicationManager) handlerMuxReloadPlansInfo(w http.ResponseWrite
 
 // handlerMuxReloadPlanInfo handles the reloading of cluster plan information.
 // @Summary Reload cluster plan information
-// @Description This endpoint reloads the cluster plan information for all clusters.
+// @Description This endpoint reloads the cluster plan information for the specified cluster.
 // @Tags ClusterActions
 // @Accept json
 // @Produce json
@@ -4598,7 +4604,10 @@ func (repman *ReplicationManager) handlerMuxReloadPlanInfo(w http.ResponseWriter
 			http.Error(w, "No valid ACL", http.StatusForbidden)
 			return
 		}
+		// Intentionally skip download toggle here to avoid global plan repo reload side effects.
 		mycluster.SetServicePlanInfos(mycluster.Conf.ProvServicePlan)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Successfully reloaded plan information"))
 	} else {
 		http.Error(w, "No cluster", http.StatusInternalServerError)
 		return

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -4488,6 +4488,11 @@ func (repman *ReplicationManager) switchServerSetting(user string, URL string, n
 	return nil
 }
 
+func shouldDownloadFromQuery(values url.Values) bool {
+	download := values.Get("download")
+	return !(download == "false" || download == "0" || download == "no")
+}
+
 // handlerMuxReloadPlans handles the reloading of cluster plans.
 // @Summary Reload cluster plans
 // @Description This endpoint reloads the cluster plans for all clusters.
@@ -4498,10 +4503,7 @@ func (repman *ReplicationManager) switchServerSetting(user string, URL string, n
 // @Router /api/clusters/settings/actions/reload-clusters-plans [post]
 func (repman *ReplicationManager) handlerMuxReloadPlans(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	shouldDownload := true
-	if download := r.URL.Query().Get("download"); download == "false" || download == "0" || download == "no" {
-		shouldDownload = false
-	}
+	shouldDownload := shouldDownloadFromQuery(r.URL.Query())
 
 	var mycluster *cluster.Cluster
 	for _, v := range repman.Clusters {
@@ -4543,10 +4545,7 @@ func (repman *ReplicationManager) handlerMuxReloadPlans(w http.ResponseWriter, r
 // @Router /api/clusters/settings/actions/reload-clusters-plan-info [post]
 func (repman *ReplicationManager) handlerMuxReloadPlansInfo(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	shouldDownload := true
-	if download := r.URL.Query().Get("download"); download == "false" || download == "0" || download == "no" {
-		shouldDownload = false
-	}
+	shouldDownload := shouldDownloadFromQuery(r.URL.Query())
 
 	var mycluster *cluster.Cluster
 	for _, v := range repman.Clusters {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -228,6 +228,10 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxSettingsReload)),
 	))
+	router.Handle("/api/clusters/{clusterName}/settings/actions/reload-plan-info", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxReloadPlanInfo)),
+	))
 	router.Handle("/api/clusters/settings/actions/switch/{settingName}", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxSwitchGlobalSettings)),
@@ -4513,6 +4517,34 @@ func (repman *ReplicationManager) handlerMuxReloadPlans(w http.ResponseWriter, r
 			http.Error(w, fmt.Sprintf("User doesn't have required ACL for global setting: %s", r.URL.Path), http.StatusForbidden)
 			return
 		}
+	} else {
+		http.Error(w, "No cluster", http.StatusInternalServerError)
+		return
+	}
+}
+
+// handlerMuxReloadPlanInfo handles the reloading of cluster plan information.
+// @Summary Reload cluster plan information
+// @Description This endpoint reloads the cluster plan information for all clusters.
+// @Tags ClusterActions
+// @Accept json
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Success 200 {string} string "Successfully reloaded plan information"
+// @Failure 403 {string} string "No valid ACL"
+// @Failure 500 {string} string "No cluster"
+// @Router /api/clusters/{clusterName}/settings/actions/reload-plan-info [post]
+func (repman *ReplicationManager) handlerMuxReloadPlanInfo(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster != nil {
+		if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+			http.Error(w, "No valid ACL", http.StatusForbidden)
+			return
+		}
+		mycluster.SetServicePlanInfos(mycluster.Conf.ProvServicePlan)
 	} else {
 		http.Error(w, "No cluster", http.StatusInternalServerError)
 		return

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -4488,23 +4488,39 @@ func (repman *ReplicationManager) switchServerSetting(user string, URL string, n
 	return nil
 }
 
-func shouldDownloadFromQuery(values url.Values) bool {
-	download := values.Get("download")
-	return !(download == "false" || download == "0" || download == "no")
+type ReloadPlanRequest struct {
+	Download *bool `json:"download"`
+}
+
+func shouldDownloadFromRequest(r *http.Request) bool {
+	if r == nil || r.Body == nil {
+		return true
+	}
+	var payload ReloadPlanRequest
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		if errors.Is(err, io.EOF) {
+			return true
+		}
+		return true
+	}
+	if payload.Download == nil {
+		return true
+	}
+	return *payload.Download
 }
 
 // handlerMuxReloadPlans handles the reloading of cluster plans.
 // @Summary Reload cluster plans
 // @Description This endpoint reloads the cluster plans for all clusters.
 // @Tags ClusterActions
-// @Param download query bool false "Redownload plan repository before reload" default(true)
+// @Param body body ReloadPlanRequest false "Reload plan repository options"
 // @Success 200 {string} string "Successfully reloaded plans"
 // @Failure 403 {string} string "No valid ACL"
 // @Failure 500 {string} string "No cluster"
 // @Router /api/clusters/settings/actions/reload-clusters-plans [post]
 func (repman *ReplicationManager) handlerMuxReloadPlans(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	shouldDownload := shouldDownloadFromQuery(r.URL.Query())
+	shouldDownload := shouldDownloadFromRequest(r)
 
 	var mycluster *cluster.Cluster
 	for _, v := range repman.Clusters {
@@ -4542,14 +4558,14 @@ func (repman *ReplicationManager) handlerMuxReloadPlans(w http.ResponseWriter, r
 // @Summary Reload cluster plan information (all clusters)
 // @Description This endpoint reloads the cluster plan information for all clusters without reapplying plans.
 // @Tags ClusterActions
-// @Param download query bool false "Redownload plan repository before reload" default(true)
+// @Param body body ReloadPlanRequest false "Reload plan repository options"
 // @Success 200 {string} string "Successfully reloaded plan information"
 // @Failure 403 {string} string "No valid ACL"
 // @Failure 500 {string} string "No cluster"
 // @Router /api/clusters/settings/actions/reload-clusters-plan-info [post]
 func (repman *ReplicationManager) handlerMuxReloadPlansInfo(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	shouldDownload := shouldDownloadFromQuery(r.URL.Query())
+	shouldDownload := shouldDownloadFromRequest(r)
 
 	var mycluster *cluster.Cluster
 	for _, v := range repman.Clusters {

--- a/server/api_cluster_test.go
+++ b/server/api_cluster_test.go
@@ -1,7 +1,8 @@
 package server
 
 import (
-	"net/url"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -106,29 +107,24 @@ func TestValidateResticSizeValue(t *testing.T) {
 	}
 }
 
-func TestShouldDownloadFromQuery(t *testing.T) {
+func TestShouldDownloadFromRequest(t *testing.T) {
 	tests := []struct {
-		name  string
-		value string
-		want  bool
+		name string
+		body string
+		want bool
 	}{
 		{"Empty", "", true},
-		{"False", "false", false},
-		{"Zero", "0", false},
-		{"No", "no", false},
-		{"True", "true", true},
-		{"Yes", "yes", true},
-		{"Other", "maybe", true},
+		{"False", `{"download":false}`, false},
+		{"True", `{"download":true}`, true},
+		{"InvalidJSON", "{", true},
+		{"MissingField", `{"other":true}`, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			values := url.Values{}
-			if tt.value != "" {
-				values.Set("download", tt.value)
-			}
-			if got := shouldDownloadFromQuery(values); got != tt.want {
-				t.Fatalf("shouldDownloadFromQuery(%q) = %v, want %v", tt.value, got, tt.want)
+			req := httptest.NewRequest("POST", "/", strings.NewReader(tt.body))
+			if got := shouldDownloadFromRequest(req); got != tt.want {
+				t.Fatalf("shouldDownloadFromRequest(%q) = %v, want %v", tt.body, got, tt.want)
 			}
 		})
 	}

--- a/server/api_cluster_test.go
+++ b/server/api_cluster_test.go
@@ -1,6 +1,9 @@
 package server
 
-import "testing"
+import (
+	"net/url"
+	"testing"
+)
 
 func TestNormalizeCompressionOverride(t *testing.T) {
 	tests := []struct {
@@ -98,6 +101,34 @@ func TestValidateResticSizeValue(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("unexpected error for %q: %v", tt.value, err)
+			}
+		})
+	}
+}
+
+func TestShouldDownloadFromQuery(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"Empty", "", true},
+		{"False", "false", false},
+		{"Zero", "0", false},
+		{"No", "no", false},
+		{"True", "true", true},
+		{"Yes", "yes", true},
+		{"Other", "maybe", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values := url.Values{}
+			if tt.value != "" {
+				values.Set("download", tt.value)
+			}
+			if got := shouldDownloadFromQuery(values); got != tt.want {
+				t.Fatalf("shouldDownloadFromQuery(%q) = %v, want %v", tt.value, got, tt.want)
 			}
 		})
 	}

--- a/share/dashboard_react/src/Pages/ClustersGlobalSettings/CloudSettings.jsx
+++ b/share/dashboard_react/src/Pages/ClustersGlobalSettings/CloudSettings.jsx
@@ -1,13 +1,13 @@
-import { Box, Flex, HStack, Link } from '@chakra-ui/react'
+import { Box, Checkbox, Flex, HStack, Link } from '@chakra-ui/react'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import styles from './styles.module.scss'
 import RMSwitch from '../../components/RMSwitch'
 import { useDispatch } from 'react-redux'
 import TableType2 from '../../components/TableType2'
-import { switchGlobalSetting, setGlobalSetting, reloadClustersPlan } from '../../redux/globalClustersSlice'
+import { switchGlobalSetting, setGlobalSetting, reloadClustersPlan, reloadClustersPlanInfo } from '../../redux/globalClustersSlice'
 import TextForm from '../../components/TextForm'
 import RMIconButton from '../../components/RMIconButton'
-import { HiQuestionMarkCircle, HiRefresh } from 'react-icons/hi'
+import { HiOutlineInformationCircle, HiQuestionMarkCircle, HiRefresh } from 'react-icons/hi'
 import ConfirmModal from '../../components/Modals/ConfirmModal'
 import TagPill from '../../components/TagPill'
 import RMButton from '../../components/RMButton'
@@ -27,6 +27,7 @@ function CloudSettings({ config }) {
   const {title,type} = action
   const [isCommonModalOpen, setIsCommonModalOpen] = useState(false)
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false)
+  const [shouldRedownloadPlans, setShouldRedownloadPlans] = useState(true)
   const errInvalidGrant = (err) => { if (err?.message?.includes("invalid_grant")) err.message = <>{err.message}. <Link href="https://gitlab.signal18.io/users/sign_up" target='_blank'><u>Click here to Sign Up</u></Link></>; return err }
 
   const benefits = `Registered Replication Manager to Cloud18 benefit many advantages  
@@ -62,9 +63,11 @@ Start create an account in https://gitlab.signal18.io
     } else if (type === 'cloud18-disconnect') {
       dispatch(setGlobalSetting({ setting: 'cloud18', value: "false", errMsgFunc: errInvalidGrant }))
     } else if (type === 'reload-clusters-plan') {
-      dispatch(reloadClustersPlan({}))
+      dispatch(reloadClustersPlan({ download: shouldRedownloadPlans }))
+    } else if (type === 'reload-clusters-plan-info') {
+      dispatch(reloadClustersPlanInfo({ download: shouldRedownloadPlans }))
     }
-  }, [type])
+  }, [type, shouldRedownloadPlans])
 
   const disableConnect = useMemo(() => (config?.cloud18GitUser === "" || config?.cloud18Domain === "" || config?.cloud18SubDomain === "" || config?.cloud18SubDomainZone === ""),[config?.cloud18GitUser, config?.cloud18Domain, config?.cloud18SubDomain, config?.cloud18SubDomainZone])
 
@@ -158,7 +161,28 @@ Start create an account in https://gitlab.signal18.io
     {
       key: 'Reload All Clusters Plans',
       value: (
-        <RMIconButton icon={HiRefresh} onClick={() => { setAction({title:'Confirm reload all clusters plans?', type: 'reload-clusters-plan'}); openConfirmModal() }} />
+        <HStack>
+          <RMIconButton
+            icon={HiRefresh}
+            tooltip='Reload plans (reapply)'
+            aria-label='Reload all clusters plans'
+            onClick={() => {
+              setShouldRedownloadPlans(true)
+              setAction({ title: 'Confirm reload all clusters plans?', type: 'reload-clusters-plan' })
+              openConfirmModal()
+            }}
+          />
+          <RMIconButton
+            icon={HiOutlineInformationCircle}
+            tooltip='Reload plan info only'
+            aria-label='Reload all clusters plan info'
+            onClick={() => {
+              setShouldRedownloadPlans(true)
+              setAction({ title: 'Confirm reload all clusters plan info?', type: 'reload-clusters-plan-info' })
+              openConfirmModal()
+            }}
+          />
+        </HStack>
       )
     },
   ]
@@ -173,6 +197,16 @@ Start create an account in https://gitlab.signal18.io
             closeConfirmModal()
           }}
           title={title}
+          body={
+            (type === 'reload-clusters-plan' || type === 'reload-clusters-plan-info') && (
+              <Checkbox
+                isChecked={shouldRedownloadPlans}
+                onChange={(event) => setShouldRedownloadPlans(event.target.checked)}
+              >
+                Redownload plan repository before reload
+              </Checkbox>
+            )
+          }
           onConfirmClick={() => {
             actionHandler()
             closeConfirmModal()

--- a/share/dashboard_react/src/Pages/Settings/CloudSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/CloudSettings.jsx
@@ -9,13 +9,16 @@ import { setSetting, switchSetting } from '../../redux/settingsSlice'
 import TextForm from '../../components/TextForm'
 import SetCredentialsModal from '../../components/Modals/SetCredentialsModal'
 import RMIconButton from '../../components/RMIconButton'
-import { HiKey } from 'react-icons/hi'
+import { HiKey, HiPlay, HiRefresh } from 'react-icons/hi'
 import { TbDatabaseDollar, TbDatabaseOff, TbDatabaseStar, TbDatabaseX, TbDeviceDesktopDollar, TbDeviceDesktopOff, TbDeviceDesktopStar, TbDeviceDesktopX, TbUserCancel } from 'react-icons/tb'
 import { acceptExternalRole, endExternalRole, quoteExternalRole, refuseExternalRole, subscribeExternalRole } from '../../redux/clusterSlice'
 import TextInputModal from '../../components/Modals/TextInputModal'
 import TermsModal from '../../components/Modals/TermsModal'
 import NumberInputModal from '../../components/Modals/NumberInputModal'
 import { getTermsData } from '../../redux/globalClustersSlice'
+import ConfirmModal from '../../components/Modals/ConfirmModal'
+import { settingsService } from '../../services/settingsService'
+import { showErrorToast, showSuccessToast } from '../../redux/toastSlice'
 
 function CloudSettings({ selectedCluster, user }) {
   const dispatch = useDispatch()
@@ -34,6 +37,8 @@ function CloudSettings({ selectedCluster, user }) {
   const [isTermsModalOpen, setIsTermsModalOpen] = useState(null)
   const [isTextModalOpen, setIsTextModalOpen] = useState(false)
   const [isNumberModalOpen, setIsNumberModalOpen] = useState(false)
+  const [isReloadPlanInfoModalOpen, setIsReloadPlanInfoModalOpen] = useState(false)
+  const [isReloadPlanInfoLoading, setIsReloadPlanInfoLoading] = useState(false)
   const { type, title, roles, payload } = action
 
   const getPlanOptions = (plist = []) => [{ name: "No Plan", value: '' }, ...plist?.map((obj) => ({ name: obj.plan, value: obj.plan }))]
@@ -87,6 +92,41 @@ function CloudSettings({ selectedCluster, user }) {
   const openNumberModal = () => {
     setIsNumberModalOpen(true)
   }
+
+  const closeReloadPlanInfoModal = () => {
+    setIsReloadPlanInfoModalOpen(false)
+  }
+
+  const handleReloadPlanInfo = useCallback(async () => {
+    if (!selectedCluster?.name || isReloadPlanInfoLoading) {
+      return
+    }
+    setIsReloadPlanInfoLoading(true)
+    try {
+      const { data, status } = await settingsService.reloadPlanInfo(selectedCluster.name, baseURL)
+      if (status === 200) {
+        dispatch(
+          showSuccessToast({
+            status: 'success',
+            title: 'Reload plan info requested'
+          })
+        )
+      } else {
+        throw new Error(data)
+      }
+    } catch (error) {
+      dispatch(
+        showErrorToast({
+          status: 'error',
+          title: 'Reload plan info failed',
+          description: error?.message || error
+        })
+      )
+    } finally {
+      setIsReloadPlanInfoLoading(false)
+      closeReloadPlanInfoModal()
+    }
+  }, [selectedCluster?.name, isReloadPlanInfoLoading, baseURL, dispatch])
 
   const handleConfirm = (value) => {
     if (type === 'quote-extdbops') {
@@ -149,7 +189,7 @@ function CloudSettings({ selectedCluster, user }) {
         {
           key: 'Cluster Plan',
           value: (
-            <Flex className={styles.dropdownContainer}>
+            <HStack className={styles.dropdownContainer}>
               <Dropdown
                 options={planOptions}
                 id='plan'
@@ -166,7 +206,33 @@ function CloudSettings({ selectedCluster, user }) {
                   )
                 }}
               />
-            </Flex>
+              <RMIconButton
+                icon={HiPlay}
+                tooltip='Reapply plan'
+                aria-label='Reapply plan'
+                confirm
+                confirmTitle='Confirm reapply plan?'
+                confirmBody={`This will re-apply plan "${selectedCluster?.config?.provServicePlan || 'No Plan'}" to the cluster.`}
+                onClick={() => {
+                  dispatch(
+                    setSetting({
+                      clusterName: selectedCluster?.name,
+                      setting: 'prov-service-plan',
+                      value: selectedCluster?.config?.provServicePlan || ''
+                    })
+                  )
+                }}
+                isDisabled={user?.grants['cluster-settings'] == false || !selectedCluster?.name || !selectedCluster?.config?.provServicePlan}
+              />
+              <RMIconButton
+                icon={HiRefresh}
+                tooltip='Reload plan info'
+                aria-label='Reload plan info'
+                onClick={() => setIsReloadPlanInfoModalOpen(true)}
+                isDisabled={isReloadPlanInfoLoading || user?.grants['cluster-settings'] == false || !selectedCluster?.config?.provServicePlan}
+                isLoading={isReloadPlanInfoLoading}
+              />
+            </HStack>
           )
         },
         {
@@ -385,6 +451,16 @@ function CloudSettings({ selectedCluster, user }) {
       {isTermsModalOpen && <TermsModal terms={finalterms} title={title} isOpen={isTermsModalOpen} onConfirmClick={handleConfirm} closeModal={closeTermsModal} />}
       {isTextModalOpen && <TextInputModal isOpen={isTextModalOpen} title={title} fieldname={'Reason'} onSave={handleConfirm} isRequired={true} closeModal={() => { setIsTextModalOpen(false); }} />}
       {isNumberModalOpen && <NumberInputModal isOpen={isNumberModalOpen} title={title} fieldname={'Cost'} onSave={handleConfirm} isRequired={true} closeModal={() => { setIsNumberModalOpen(false); }} />}
+      {isReloadPlanInfoModalOpen && (
+        <ConfirmModal
+          isOpen={isReloadPlanInfoModalOpen}
+          title={'Confirm reload plan info?'}
+          closeModal={closeReloadPlanInfoModal}
+          onConfirmClick={handleReloadPlanInfo}
+          confirmButtonText='Reload'
+          confirmButtonProps={{ isLoading: isReloadPlanInfoLoading, isDisabled: isReloadPlanInfoLoading }}
+        />
+      )}
     </Flex>
   )
 }

--- a/share/dashboard_react/src/redux/globalClustersSlice.js
+++ b/share/dashboard_react/src/redux/globalClustersSlice.js
@@ -163,14 +163,27 @@ export const setGlobalSetting = createGuardedAsyncThunk(
   }
 )
 
-export const reloadClustersPlan = createGuardedAsyncThunk('globalClusters/reloadClustersPlan', async ({ }, thunkAPI) => {
+export const reloadClustersPlan = createGuardedAsyncThunk('globalClusters/reloadClustersPlan', async ({ download = true }, thunkAPI) => {
   try {
-    const { data, status } = await globalClustersService.reloadClustersPlan()
+    const { data, status } = await globalClustersService.reloadClustersPlan(download)
     showSuccessBanner('All clusters plan reloaded!', status, thunkAPI)
     return { data, status }
   } catch (error) {
     console.log('error::', error)
     showErrorBanner('Failed to reload clusters plans!', error, thunkAPI)
+    return handleError(error, thunkAPI)
+  }
+}
+)
+
+export const reloadClustersPlanInfo = createGuardedAsyncThunk('globalClusters/reloadClustersPlanInfo', async ({ download = true }, thunkAPI) => {
+  try {
+    const { data, status } = await globalClustersService.reloadClustersPlanInfo(download)
+    showSuccessBanner('All clusters plan info reloaded!', status, thunkAPI)
+    return { data, status }
+  } catch (error) {
+    console.log('error::', error)
+    showErrorBanner('Failed to reload clusters plan info!', error, thunkAPI)
     return handleError(error, thunkAPI)
   }
 }

--- a/share/dashboard_react/src/services/globalClustersService.js
+++ b/share/dashboard_react/src/services/globalClustersService.js
@@ -62,11 +62,11 @@ function renameCluster(clusterName, newClusterName) {
 }
 
 function reloadClustersPlan(download = true) {
-  return getApi().get(`clusters/settings/actions/reload-clusters-plans`, { download })
+  return getApi().post(`clusters/settings/actions/reload-clusters-plans`, { download })
 }
 
 function reloadClustersPlanInfo(download = true) {
-  return getApi().get(`clusters/settings/actions/reload-clusters-plan-info`, { download })
+  return getApi().post(`clusters/settings/actions/reload-clusters-plan-info`, { download })
 }
 
 function refreshAppTemplateRepo(clusterName, baseURL) {

--- a/share/dashboard_react/src/services/globalClustersService.js
+++ b/share/dashboard_react/src/services/globalClustersService.js
@@ -13,6 +13,7 @@ export const globalClustersService = {
   dropCluster,
   renameCluster,
   reloadClustersPlan,
+  reloadClustersPlanInfo,
   refreshAppTemplateRepo
 }
 
@@ -60,8 +61,12 @@ function renameCluster(clusterName, newClusterName) {
   return getApi().post(`clusters/actions/rename/${clusterName}/${newClusterName}`)
 }
 
-function reloadClustersPlan() {
-  return getApi().get(`clusters/settings/actions/reload-clusters-plans`)
+function reloadClustersPlan(download = true) {
+  return getApi().get(`clusters/settings/actions/reload-clusters-plans`, { download })
+}
+
+function reloadClustersPlanInfo(download = true) {
+  return getApi().get(`clusters/settings/actions/reload-clusters-plan-info`, { download })
 }
 
 function refreshAppTemplateRepo(clusterName, baseURL) {

--- a/share/dashboard_react/src/services/settingsService.js
+++ b/share/dashboard_react/src/services/settingsService.js
@@ -11,7 +11,8 @@ export const settingsService = {
   switchAppSettings,
   clearAppSetting,
   resetAppFromTemplate,
-  saveAppAsTemplate
+  saveAppAsTemplate,
+  reloadPlanInfo
 }
 
 function switchSettings(clusterName, setting, baseURL) {
@@ -68,4 +69,8 @@ function resetAppFromTemplate( clusterName, appId, template, baseURL) {
 
 function saveAppAsTemplate( clusterName, appId, template, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/apps/${appId}/settings/actions/save-as-template/${template}`)
+}
+
+function reloadPlanInfo(clusterName, baseURL) {
+  return getApi(baseURL).post(`clusters/${clusterName}/settings/actions/reload-plan-info`)
 }


### PR DESCRIPTION
This pull request introduces new API endpoints for reloading cluster plan information, both globally and for individual clusters, and updates the backend and frontend to support these features. It also adds a utility function for handling query parameters and corresponding tests, and enhances the frontend UI to allow users to control whether plans should be redownloaded. The most important changes are grouped below.

**API Endpoints and Backend Logic:**

* Added new POST API endpoints `/api/clusters/settings/actions/reload-clusters-plan-info` (global) and `/api/clusters/{clusterName}/settings/actions/reload-plan-info` (per-cluster) to reload cluster plan information without reapplying plans, including ACL rules and handler implementations in `server/api_cluster.go` and `cluster/cluster_acl_rules.go`. [[1]](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afR231-R234) [[2]](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afR271-R274) [[3]](diffhunk://#diff-83327e61fb47dcbff469bb937a3fa011a4bd79b850829345128ac84a5745bd8dR265) [[4]](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afR4538-R4607)
* Updated OpenAPI/Swagger documentation (`docs/swagger.yaml`, `docs/swagger.json`, `docs/docs.go`) to document the new endpoints and their parameters/responses. [[1]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R14733-R14767) [[2]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R16309-R16328) [[3]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R299-R327) [[4]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R15204-R15255) [[5]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R310-R338) [[6]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R15215-R15266)

**Backend Utility and Testing:**

* Introduced a utility function `shouldDownloadFromQuery` to parse the `download` query parameter, controlling whether plans should be redownloaded, and added unit tests for this logic. [[1]](diffhunk://#diff-f1073c50723fa877308a3803341b610f6d9893b83e7ad2bf2de3c961f5b212afR4491-R4495) [[2]](diffhunk://#diff-291e8e91132ac521a4976417fe783c37a767bed262a755bc42eb3c3f91863b8aL3-R6) [[3]](diffhunk://#diff-291e8e91132ac521a4976417fe783c37a767bed262a755bc42eb3c3f91863b8aR108-R135)

**Frontend Enhancements:**

* Updated the Cloud Settings React page to support the new reload endpoints, including a checkbox for users to control whether plans should be redownloaded, and dispatched the appropriate Redux actions for both plan and plan info reloads. [[1]](diffhunk://#diff-f0fff925d0c922665e7039f127c72edccc31ca6bce5cdfd9eb7fedc3f501f46cL1-R10) [[2]](diffhunk://#diff-f0fff925d0c922665e7039f127c72edccc31ca6bce5cdfd9eb7fedc3f501f46cR30) [[3]](diffhunk://#diff-f0fff925d0c922665e7039f127c72edccc31ca6bce5cdfd9eb7fedc3f501f46cL65-R70)