### PR TITLE
fix(backup): replace deprecated mydumper flags with --trx-tables (#1351)

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -883,7 +883,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.BackupMyDumperPath, "backup-mydumper-path", "", "Path to mydumper binary")
 	flags.StringVar(&conf.BackupMyLoaderPath, "backup-myloader-path", "", "Path to myloader binary")
 	flags.StringVar(&conf.BackupMyLoaderOptions, "backup-myloader-options", "--overwrite-tables --verbose=3 --innodb-optimize-keys=skip --max-threads-for-schema-creation=1 --max-threads-for-index-creation=1", "Extra options")
-	flags.StringVar(&conf.BackupMyDumperOptions, "backup-mydumper-options", "--chunk-filesize=1000 --compress --less-locking --verbose=3 --triggers --routines --events --trx-consistency-only --kill-long-queries", "Extra options")
+	flags.StringVar(&conf.BackupMyDumperOptions, "backup-mydumper-options", "--chunk-filesize=1000 --compress --verbose=3 --triggers --routines --events --trx-tables --kill-long-queries", "Extra options")
 	flags.StringVar(&conf.BackupMyDumperRegex, "backup-mydumper-regex", `^(?!(sys\.|performance_schema\.|information_schema\.|replication_manager_schema\.jobs|mysql\.gtid_slave_pos$))`, "Mydumper regex for backup")
 	flags.BoolVar(&conf.BackupMyDumperStream, "backup-mydumper-stream", false, "Enable mydumper stream mode to produce a single file")
 	flags.StringVar(&conf.BackupMyDumperStreamFormat, "backup-mydumper-stream-format", "", "Mydumper stream format (passed to --stream when set)")


### PR DESCRIPTION
Replace --less-locking and --trx-consistency-only with --trx-tables for mydumper 0.21.3+ compatibility.

Fixes #1351 
