### PR TITLE
fix(backup): restore legacy mydumper flags for backward compatibility…

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -883,7 +883,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.BackupMyDumperPath, "backup-mydumper-path", "", "Path to mydumper binary")
 	flags.StringVar(&conf.BackupMyLoaderPath, "backup-myloader-path", "", "Path to myloader binary")
 	flags.StringVar(&conf.BackupMyLoaderOptions, "backup-myloader-options", "--overwrite-tables --verbose=3 --innodb-optimize-keys=skip --max-threads-for-schema-creation=1 --max-threads-for-index-creation=1", "Extra options")
-	flags.StringVar(&conf.BackupMyDumperOptions, "backup-mydumper-options", "--chunk-filesize=1000 --compress --verbose=3 --triggers --routines --events --trx-tables --kill-long-queries", "Extra options")
+	flags.StringVar(&conf.BackupMyDumperOptions, "backup-mydumper-options", "--chunk-filesize=1000 --compress --less-locking --verbose=3 --triggers --routines --events --trx-consistency-only --kill-long-queries", "Extra options")
 	flags.StringVar(&conf.BackupMyDumperRegex, "backup-mydumper-regex", `^(?!(sys\.|performance_schema\.|information_schema\.|replication_manager_schema\.jobs|mysql\.gtid_slave_pos$))`, "Mydumper regex for backup")
 	flags.BoolVar(&conf.BackupMyDumperStream, "backup-mydumper-stream", false, "Enable mydumper stream mode to produce a single file")
 	flags.StringVar(&conf.BackupMyDumperStreamFormat, "backup-mydumper-stream-format", "", "Mydumper stream format (passed to --stream when set)")


### PR DESCRIPTION
… (#1351)

Revert default flags to use --less-locking and --trx-consistency-only. The version-aware logic in srv_job_backup.go automatically replaces these with --trx-tables for mydumper >= 0.18.1.

## Contributor Agreement

By submitting this pull request, I agree to the terms outlined in the [Contributor Agreement](CONTRIBUTING.md).
