### PR TITLE
Improve backup workflow and restic safeguards

### DIFF
--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -582,6 +582,14 @@ func (server *ServerMonitor) GetSlowLogTable(wg *sync.WaitGroup) error {
 	if cluster.IsInFailover() {
 		return nil
 	}
+
+	// Skip if server is in backup state and is backup server
+	if cluster.IsInBackup() {
+		if cluster.GetBackupServer() != nil && cluster.GetBackupServer().URL == server.URL {
+			return nil
+		}
+	}
+
 	if !server.HasLogsInSystemTables() {
 		return nil
 	}

--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -585,7 +585,8 @@ func (server *ServerMonitor) GetSlowLogTable(wg *sync.WaitGroup) error {
 
 	// Skip if server is in backup state and is backup server
 	if cluster.IsInBackup() {
-		if cluster.GetBackupServer() != nil && cluster.GetBackupServer().URL == server.URL {
+		bcksrv := cluster.GetBackupServer()
+		if bcksrv != nil && bcksrv.URL == server.URL {
 			return nil
 		}
 	}

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -1772,18 +1772,32 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(opts BackupRunOptions) 
 		}
 	}
 
+	var waited bool
 	//Wait for previous restic backup
 	if cluster.IsInBackup() {
+		waited = true
 		cluster.SetState("WARN0110", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0110"], "Logical", cluster.Conf.BackupLogicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
 		time.Sleep(1 * time.Second)
-
-		return server.JobBackupLogicalWithOptions(opts)
 	}
 
 	cluster.SetInLogicalBackupState(true)
 
 	// Defer always clears traditional flag; Restic flag cleared by async goroutine
 	defer cluster.SetInLogicalBackupState(false)
+
+	if waited {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Resuming logical backup %s after waiting for previous backup to finish for: %s", cluster.Conf.BackupLogicalType, server.URL)
+	}
+
+	waited = false
+	// Wait for logs job to finish to prevent conflicts with backup metadata updates
+	for server.IsInSlowQueryCapture {
+		if !waited {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Waiting for logs job to finish before starting backup on %s", server.URL)
+			waited = true
+		}
+		time.Sleep(1 * time.Second)
+	}
 
 	// CRITICAL FIX: Set Restic flag AFTER validation passes to prevent orphaned flags
 	// The defer clears InLogicalBackup immediately on return, but Restic backup

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -1774,7 +1774,7 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(opts BackupRunOptions) 
 
 	var waited bool
 	//Wait for previous restic backup
-	if cluster.IsInBackup() {
+	for cluster.IsInBackup() {
 		waited = true
 		cluster.SetState("WARN0110", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0110"], "Logical", cluster.Conf.BackupLogicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
 		time.Sleep(1 * time.Second)

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -1802,9 +1802,15 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(opts BackupRunOptions) 
 	// CRITICAL FIX: Set Restic flag AFTER validation passes to prevent orphaned flags
 	// The defer clears InLogicalBackup immediately on return, but Restic backup
 	// runs async. We must set InResticLogicalBackup NOW to maintain lock continuity.
+	resticScheduled := false
 	if resticEnabled {
 		// Set Restic flag now to ensure atomic transition (no gap where IsInBackup() = false)
 		cluster.SetInResticLogicalBackupState(true)
+		defer func() {
+			if !resticScheduled {
+				cluster.SetInResticLogicalBackupState(false)
+			}
+		}()
 	}
 
 	start := time.Now()
@@ -2035,13 +2041,16 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(opts BackupRunOptions) 
 
 	// NOTE: InResticLogicalBackup flag already set at function start for atomic transition
 	// No need to set it again here - it's already protecting the async operation
-	if resticEnabled {
+	if resticEnabled && err == nil {
 		resticPath := server.GetMyBackupDirectory()
 		if isAdhoc && server.LastBackupMeta.Logical != nil && server.LastBackupMeta.Logical.Dest != "" {
 			resticPath = server.LastBackupMeta.Logical.Dest
 		}
 		// Note: BackupRestic handles its own error logging and flag clearing if prerequisites fail
+		resticScheduled = true
 		server.BackupRestic(backupmgr.BackupMethodLogical, true, resticPath, server.BuildResticTags(backtype, cluster.Conf.BackupLogicalType, backupLine, server.LastBackupMeta.Logical)...)
+	} else if resticEnabled && err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Skipping restic backup because logical backup failed for: %s", server.URL)
 	}
 
 	return nil
@@ -3109,11 +3118,12 @@ func (server *ServerMonitor) JobFinishReceiveFile(task string) error {
 		// CRITICAL: Transition from traditional backup lock to Restic lock atomically
 		// Set Restic flag BEFORE clearing physical backup flag
 		resticEnabled := server.LastBackupMeta.Physical != nil && server.LastBackupMeta.Physical.ResticEnabled
+		backupCompleted := server.LastBackupMeta.Physical != nil && server.LastBackupMeta.Physical.Completed
 		backupLine := backupmgr.BackupLineDefault
 		if server.LastBackupMeta.Physical != nil && server.LastBackupMeta.Physical.BackupLine != "" {
 			backupLine = server.LastBackupMeta.Physical.BackupLine
 		}
-		if resticEnabled {
+		if resticEnabled && backupCompleted {
 			cluster.SetInResticPhysicalBackupState(true)
 			resticPath := server.GetMyBackupDirectory()
 			if server.LastBackupMeta.Physical != nil && server.LastBackupMeta.Physical.IsAdhoc() && server.LastBackupMeta.Physical.Dest != "" {
@@ -3123,6 +3133,8 @@ func (server *ServerMonitor) JobFinishReceiveFile(task string) error {
 			// Create restic snapshot asynchronously and update metadata when complete
 			// Note: BackupRestic handles its own error logging and flag clearing if prerequisites fail
 			server.BackupRestic(backupmgr.BackupMethodPhysical, true, resticPath, server.BuildResticTags(backtype, cluster.Conf.BackupPhysicalType, backupLine, server.LastBackupMeta.Physical)...)
+		} else if resticEnabled && !backupCompleted {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Skipping restic backup because physical backup not completed for: %s", server.URL)
 		}
 
 		// Now safe to clear traditional backup flag

--- a/config/config.go
+++ b/config/config.go
@@ -1465,6 +1465,8 @@ This is the list of task to be used in Task struct and Task table
 type TaskName string
 
 const (
+	ConstTaskDump               TaskName = "mysqldump"
+	ConstTaskMydumper           TaskName = "mydumper"
 	ConstTaskXB                 TaskName = "xtrabackup"
 	ConstTaskMB                 TaskName = "mariabackup"
 	ConstTaskError              TaskName = "errorlog"
@@ -1475,7 +1477,7 @@ const (
 	ConstTaskOptimize           TaskName = "optimize"
 	ConstTaskReseedXB           TaskName = "reseedxtrabackup"
 	ConstTaskReseedMB           TaskName = "reseedmariabackup"
-	ConstTaskDump               TaskName = "reseedmysqldump"
+	ConstTaskReseedDump         TaskName = "reseedmysqldump"
 	ConstTaskFlashXB            TaskName = "flashbackxtrabackup"
 	ConstTaskFlashMB            TaskName = "flashbackmariadbackup"
 	ConstTaskFlashDump          TaskName = "flashbackmysqldump"
@@ -3578,7 +3580,7 @@ func GetModuleNameForTask(task string) string {
 	// check if input compatible with TaskName type
 
 	switch TaskName(task) {
-	case ConstTaskXB, ConstTaskMB, ConstTaskReseedXB, ConstTaskReseedMB, ConstTaskDump, ConstTaskFlashXB, ConstTaskFlashMB, ConstTaskFlashDump:
+	case ConstTaskDump, ConstTaskXB, ConstTaskMB, ConstTaskReseedXB, ConstTaskReseedMB, ConstTaskReseedDump, ConstTaskFlashXB, ConstTaskFlashMB, ConstTaskFlashDump:
 		return ConstLogNameBackupStream
 	case ConstTaskError:
 		return ConstLogNameDbErrors

--- a/config/config.go
+++ b/config/config.go
@@ -3580,7 +3580,7 @@ func GetModuleNameForTask(task string) string {
 	// check if input compatible with TaskName type
 
 	switch TaskName(task) {
-	case ConstTaskDump, ConstTaskXB, ConstTaskMB, ConstTaskReseedXB, ConstTaskReseedMB, ConstTaskReseedDump, ConstTaskFlashXB, ConstTaskFlashMB, ConstTaskFlashDump:
+	case ConstTaskDump, ConstTaskMydumper, ConstTaskXB, ConstTaskMB, ConstTaskReseedXB, ConstTaskReseedMB, ConstTaskReseedDump, ConstTaskFlashXB, ConstTaskFlashMB, ConstTaskFlashDump:
 		return ConstLogNameBackupStream
 	case ConstTaskError:
 		return ConstLogNameDbErrors

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -5276,6 +5276,8 @@ const docTemplate = `{
                     },
                     {
                         "enum": [
+                            "mysqldump",
+                            "mydumper",
                             "xtrabackup",
                             "mariabackup",
                             "errorlog",
@@ -13549,6 +13551,8 @@ const docTemplate = `{
                     },
                     {
                         "enum": [
+                            "mysqldump",
+                            "mydumper",
                             "xtrabackup",
                             "mariabackup",
                             "errorlog",
@@ -14298,6 +14302,8 @@ const docTemplate = `{
                     },
                     {
                         "enum": [
+                            "mysqldump",
+                            "mydumper",
                             "xtrabackup",
                             "mariabackup",
                             "errorlog",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5265,6 +5265,8 @@
                     },
                     {
                         "enum": [
+                            "mysqldump",
+                            "mydumper",
                             "xtrabackup",
                             "mariabackup",
                             "errorlog",
@@ -13538,6 +13540,8 @@
                     },
                     {
                         "enum": [
+                            "mysqldump",
+                            "mydumper",
                             "xtrabackup",
                             "mariabackup",
                             "errorlog",
@@ -14287,6 +14291,8 @@
                     },
                     {
                         "enum": [
+                            "mysqldump",
+                            "mydumper",
                             "xtrabackup",
                             "mariabackup",
                             "errorlog",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -7850,6 +7850,8 @@ paths:
         type: string
       - description: Task Name
         enum:
+        - mysqldump
+        - mydumper
         - xtrabackup
         - mariabackup
         - errorlog
@@ -10098,6 +10100,8 @@ paths:
         type: string
       - description: taskname
         enum:
+        - mysqldump
+        - mydumper
         - xtrabackup
         - mariabackup
         - errorlog
@@ -10620,6 +10624,8 @@ paths:
         type: string
       - description: Type of check (e.g., 'config-refresh')
         enum:
+        - mysqldump
+        - mydumper
         - xtrabackup
         - mariabackup
         - errorlog


### PR DESCRIPTION
**Summary**
- Strengthen logical backup handling by ensuring restic snapshots only run after successful logical backup completion.
- Add explicit warning logs when restic is enabled but skipped due to logical backup failures.
- Gate physical restic snapshots on completed physical backup metadata to avoid partial or invalid snapshots.
- Introduce and use task constants for mysqldump/mydumper to make backup task tracking consistent and clearer.

**Rationale**
- Prevents restic from capturing incomplete or failed backup artifacts.
- Makes backup/restic decisions visible in logs for easier troubleshooting.
- Improves consistency of backup task identification and reporting.

**Included Commits**
- 47c8b6c9041ed12aa663dcd3c2a73a10c93a5d2a — feat(backup): enhance backup logic and add task constants for mysqldump and mydumper
- c2d312dede2a65f41701a2950304f4be7f8e156a — feat(backup): improve Restic backup handling and logging for logical and physical backups