### PR TITLE
fix: make MyDumper flag handling safer and conflict-free

### DIFF
--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -1609,14 +1609,14 @@ func (server *ServerMonitor) JobBackupMyDumper(outputdir string) error {
 			updatedArgs = append(updatedArgs, arg)
 		}
 		// Add --trx-tables if not already present
-		hasTrxTables := false
+		hasTrxTablesArg := false
 		for _, arg := range updatedArgs {
-			if strings.HasPrefix(arg, "--trx-tables") {
-				hasTrxTables = true
+			if strings.HasPrefix(arg, "--trx-tables") || arg == "--no-trx-tables" { // Check for both --trx-tables and --no-trx-tables to avoid conflicts
+				hasTrxTablesArg = true
 				break
 			}
 		}
-		if !hasTrxTables {
+		if !hasTrxTablesArg {
 			updatedArgs = append(updatedArgs, "--trx-tables")
 		}
 		myargs = updatedArgs

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -1611,7 +1611,7 @@ func (server *ServerMonitor) JobBackupMyDumper(outputdir string) error {
 		// Add --trx-tables if not already present
 		hasTrxTablesArg := false
 		for _, arg := range updatedArgs {
-			if strings.HasPrefix(arg, "--trx-tables") || arg == "--no-trx-tables" { // Check for both --trx-tables and --no-trx-tables to avoid conflicts
+			if arg == "--trx-tables" || strings.HasPrefix(arg, "--trx-tables=") || arg == "--no-trx-tables" { // Check for both --trx-tables and --no-trx-tables to avoid conflicts
 				hasTrxTablesArg = true
 				break
 			}

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -1611,7 +1611,7 @@ func (server *ServerMonitor) JobBackupMyDumper(outputdir string) error {
 		// Add --trx-tables if not already present
 		hasTrxTables := false
 		for _, arg := range updatedArgs {
-			if arg == "--trx-tables" {
+			if strings.HasPrefix(arg, "--trx-tables") {
 				hasTrxTables = true
 				break
 			}
@@ -1622,7 +1622,7 @@ func (server *ServerMonitor) JobBackupMyDumper(outputdir string) error {
 		myargs = updatedArgs
 	}
 
-	if dumper.GreaterEqual("0.15.3") {
+	if dumper.GreaterEqual("0.15.3") && !slices.Contains(myargs, "--clear") {
 		myargs = append(myargs, "--clear")
 	}
 	myargs = append(myargs, "--outputdir", outputdir, "--threads", threads, "--host", misc.Unbracket(server.Host), "--port", server.Port, "--user", cluster.GetDbUser(), "--password", cluster.GetDbPass())


### PR DESCRIPTION
**Summary**
This PR tightens MyDumper argument processing to avoid conflicting or duplicate flags. It recognizes both --trx-tables and --trx-tables=... as already present, and it also respects an explicit --no-trx-tables so we don’t append --trx-tables on top. In addition, it only appends --clear for compatible MyDumper versions when that flag isn’t already in the user-provided args.

**Why**
- Users can pass --trx-tables=... or --no-trx-tables today; adding --trx-tables unconditionally can override intent or create conflicts. https://github.com/mydumper/mydumper/pull/2047
- Duplicate flags can cause unpredictable behavior or confusing logs.
- --clear should be added only when supported and not already specified.

**What Changed**
- Detects both --trx-tables and --no-trx-tables to prevent conflicting injection.
- Treats --trx-tables=... as present by checking prefix matches.
- Appends --clear only for MyDumper >= 0.15.3 and only if it is not already in the args.