### PR TITLE
Add splitdump backup/restore support and harden pipelines

### DIFF
--- a/clients/client_api.go
+++ b/clients/client_api.go
@@ -29,7 +29,7 @@ var apiCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal("Error in API call")
 		} else {
-			fmt.Printf(res)
+			fmt.Print(res)
 		}
 	},
 	PostRun: func(cmd *cobra.Command, args []string) {

--- a/clients/client_cmd.go
+++ b/clients/client_cmd.go
@@ -362,6 +362,9 @@ func init() {
 	rootClientCmd.AddCommand(splitDumpCmd)
 	initStatusFlagsDumpSplit(splitDumpCmd)
 
+	rootClientCmd.AddCommand(splitRestoreCmd)
+	initSplitRestoreFlags(splitRestoreCmd)
+
 	rootClientCmd.AddCommand(bootstrapCmd)
 	initBootstrapFlags(bootstrapCmd)
 	initClusterFlags(bootstrapCmd)
@@ -431,7 +434,7 @@ func cliDisplayHelp() {
 
 func cliPrintLog(msg []string) {
 	for _, c := range msg {
-		log.Printf(c)
+		log.Print(c)
 	}
 }
 

--- a/clients/client_configurator.go
+++ b/clients/client_configurator.go
@@ -436,8 +436,8 @@ func cliDisplayConfigurator(configurator *configurator.Configurator) {
 	termbox.Clear(termbox.ColorWhite, termbox.ColorBlack)
 	headstr := fmt.Sprintf(" Signal18 Replication Manager Configurator")
 
-	cliPrintfTb(0, 0, termbox.ColorWhite, termbox.ColorBlack|termbox.AttrReverse|termbox.AttrBold, headstr)
-	cliPrintfTb(0, 1, termbox.ColorRed, termbox.ColorBlack|termbox.AttrReverse|termbox.AttrBold, cliConfirm)
+	cliPrintfTb(0, 0, termbox.ColorWhite, termbox.ColorBlack|termbox.AttrReverse|termbox.AttrBold, "%s", headstr)
+	cliPrintfTb(0, 1, termbox.ColorRed, termbox.ColorBlack|termbox.AttrReverse|termbox.AttrBold, "%s", cliConfirm)
 	cliTlog.Line = 3
 	tableau := "─"
 	tags := configurator.GetDBModuleTags()

--- a/clients/client_console.go
+++ b/clients/client_console.go
@@ -179,8 +179,8 @@ func cliDisplayMonitor() {
 	} else {
 		headstr += " |  Mode: Manual "
 	}
-	cliPrintfTb(0, 0, termbox.ColorWhite, termbox.ColorBlack|termbox.AttrReverse|termbox.AttrBold, headstr)
-	cliPrintfTb(0, 1, termbox.ColorRed, termbox.ColorBlack|termbox.AttrReverse|termbox.AttrBold, cliConfirm)
+	cliPrintfTb(0, 0, termbox.ColorWhite, termbox.ColorBlack|termbox.AttrReverse|termbox.AttrBold, "%s", headstr)
+	cliPrintfTb(0, 1, termbox.ColorRed, termbox.ColorBlack|termbox.AttrReverse|termbox.AttrBold, "%s", cliConfirm)
 	cliPrintfTb(0, 2, termbox.ColorWhite|termbox.AttrBold, termbox.ColorBlack, "%1s%15s %6s %15s %10s %12s %20s %20s %30s %6s %3s", " ", "Host", "Port", "Status", "Failures", "Using GTID", "Current GTID", "Slave GTID", "Replication Health", "Delay", "RO")
 	cliTlog.Line = 3
 	for i, server := range cliServers {
@@ -249,7 +249,7 @@ func cliDisplayMonitor() {
 	}
 }
 
-//cliLogPrint Used to print Help
+// cliLogPrint Used to print Help
 func cliLogPrint(msg ...interface{}) {
 	stamp := fmt.Sprint(time.Now().Format("2006/01/02 15:04:05"))
 

--- a/clients/client_regtest.go
+++ b/clients/client_regtest.go
@@ -88,11 +88,11 @@ var regTestCmd = &cobra.Command{
 
 				res, err := cliAPICmd(urlpost, params)
 				if err != nil {
-					fmt.Printf(string(data))
+					fmt.Print(string(data))
 					log.Fatal("Error in API call")
 				} else {
 					if res != "" {
-						fmt.Printf(res)
+						fmt.Print(res)
 
 						err = json.Unmarshal([]byte(res), &thistest)
 						if err != nil {
@@ -121,7 +121,7 @@ var regTestCmd = &cobra.Command{
 						}
 
 					} else {
-						fmt.Printf(string(data))
+						fmt.Print(string(data))
 					}
 				}
 			}

--- a/clients/client_server.go
+++ b/clients/client_server.go
@@ -99,7 +99,7 @@ var serverCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "API call error: %s", err)
 			os.Exit(1)
 		}
-		fmt.Printf(res)
+		fmt.Print(res)
 		os.Exit(0)
 	},
 }

--- a/clients/client_splitdump.go
+++ b/clients/client_splitdump.go
@@ -47,20 +47,32 @@ func runSplitdump(inputFile, outputDir string) error {
 
 	// wait for the writer to finish.
 	var readerErr error
-	errorCh := bus.Error
-	for {
+	finished := false
+	for !finished {
 		select {
-		case err, ok := <-errorCh:
+		case err, ok := <-bus.Error:
 			if !ok {
-				errorCh = nil
 				continue
 			}
 			if err != nil && readerErr == nil {
 				readerErr = err
 			}
 		case <-bus.Finished:
+			finished = true
+		}
+	}
+	for {
+		select {
+		case err, ok := <-bus.Error:
+			if !ok {
+				fmt.Printf("\n\n--finished in %s", time.Since(start))
+				return readerErr
+			}
+			if err != nil && readerErr == nil {
+				readerErr = err
+			}
+		default:
 			fmt.Printf("\n\n--finished in %s", time.Since(start))
-			close(bus.Finished)
 			return readerErr
 		}
 	}

--- a/clients/client_splitdump.go
+++ b/clients/client_splitdump.go
@@ -9,309 +9,45 @@
 package clients
 
 import (
-	"bufio"
-	"compress/gzip"
 	"fmt"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
 	"time"
 
-	"github.com/jacoblockett/sanitizefilename"
+	"github.com/signal18/replication-manager/utils/splitdump"
 	"github.com/spf13/cobra"
 )
-
-// SplitDumpChannelBusChannelBus a struct to hold all channels used by the different go routines
-type SplitDumpChannelBus struct {
-	Finished    chan bool
-	Log         chan string
-	CurrentLine chan string
-	TableName   chan string
-	TableScheme chan string
-	TableData   chan string
-}
-
-func isGzip(b *bufio.Reader) bool {
-	if m, err := b.Peek(2); err == nil {
-		return m[0] == 0x1f && m[1] == 0x8b
-	}
-	return false
-}
 
 var splitDumpCmd = &cobra.Command{
 	Use:   "splitdump",
 	Short: "Split MariaDB MySQL dump file",
 	Long:  `Convert stdin stream to a directory and files similar to mydumper output`,
 	Run: func(cmd *cobra.Command, args []string) {
-		bus := SplitDumpChannelBus{
-			Finished:    make(chan bool),
-			TableData:   make(chan string),
-			TableScheme: make(chan string),
-			TableName:   make(chan string),
-			CurrentLine: make(chan string),
+		if err := runSplitdump(cliInputFile, cliOutputDir); err != nil {
+			fmt.Println(err)
 		}
-
-		fmt.Printf("Outputing all tables to %s\n", cliOutputDir)
-
-		start := time.Now()
-		if cliInputFile != "" {
-			fmt.Printf("Begin processing %s\n", cliInputFile)
-		}
-
-		// create a pipeline of goroutines
-		go SplitDumpLineReader(bus)
-		go SplitDumpLineParser(bus, cliOutputDir)
-		//, conf.Combine, conf.OutputPath, conf.SkipData, conf.SkipTable)
-
-		// wait for the writer to finish.
-		<-bus.Finished
-		fmt.Printf("\n\n--finished in %s", time.Now().Sub(start))
-		close(bus.Finished)
 	},
 	PostRun: func(cmd *cobra.Command, args []string) {
 		// On exit.
 	},
 }
 
-func splitDumpOpenReader(f *os.File) *bufio.Reader {
-	pageSize := os.Getpagesize() * 2
-	buf := bufio.NewReaderSize(f, pageSize)
+func runSplitdump(inputFile, outputDir string) error {
+	bus := splitdump.NewSplitDumpChannelBus()
 
-	if isGzip(buf) {
-		gbuf, _ := gzip.NewReader(buf)
-		return bufio.NewReaderSize(gbuf, pageSize)
+	fmt.Printf("Outputing all tables to %s\n", outputDir)
+
+	start := time.Now()
+	if inputFile != "" {
+		fmt.Printf("Begin processing %s\n", inputFile)
 	}
 
-	return buf
-}
-func splitDumpOpenFile(path string) (*os.File, error) {
+	// create a pipeline of goroutines
+	go splitdump.SplitDumpLineReader(bus, inputFile)
+	go splitdump.SplitDumpLineParser(bus, outputDir)
+	//, conf.Combine, conf.OutputPath, conf.SkipData, conf.SkipTable)
 
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-
-	return file, nil
-}
-
-func splitDumpOpenReaderStdin() *bufio.Reader {
-	pageSize := os.Getpagesize() * 2
-	buf := bufio.NewReaderSize(os.Stdin, pageSize)
-	return buf
-}
-
-// LineReader reads `file` line-by-line and adds it to the `bus.CurrentLine` channel.
-// Note: This function closes `file`.
-func SplitDumpLineReader(bus SplitDumpChannelBus) {
-
-	r := splitDumpOpenReaderStdin()
-	if cliInputFile != "" {
-		file, err := splitDumpOpenFile(cliInputFile)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-		defer file.Close()
-		r = splitDumpOpenReader(file)
-	}
-	for line, err := r.ReadString('\n'); err == nil; line, err = r.ReadString('\n') {
-		bus.CurrentLine <- line
-	}
-
-	close(bus.CurrentLine)
-}
-
-// LineParser reads the CurrentLine and figures out which channel to put it in.
-func SplitDumpLineParser(bus SplitDumpChannelBus, outputDir string /*, combineFiles bool, outputDir string, skipData []string, skipTables []string*/) {
-	onTableScheme, onTableData, pastHeader := false, false, false
-	shardpad, schema := "", ""
-	shard := 0
-	binlogRegexMariaDB := regexp.MustCompile(`CHANGE MASTER TO MASTER_LOG_FILE='(.+)', MASTER_LOG_POS=(\d+)`)
-	gtidRegexMariaDB := regexp.MustCompile(`SET GLOBAL gtid_slave_pos='(.+)'`)
-	binlogRegexMySQL := regexp.MustCompile(`CHANGE REPLICATION SOURCE TO SOURCE_LOG_FILE='(.+)', SOURCE_LOG_POS=(\d+)`)
-	gtidRegexMySQL := regexp.MustCompile(`GTID_PURGED\s*=(\/\*!.+\*\/)?\s*'(.+)'`)
-	headerMetaData := fmt.Sprintf("-- Generated with replication-manager on %s\n\n", time.Now())
-	os.Mkdir(outputDir, os.ModePerm)
-	// numTables := 0
-	var f *os.File
-	var tableFile *gzip.Writer
-	var bgtid, bfile, bpos string
-
-	streamSize := 0
-	streamSizeMax := 1024 * 1024 * 1024
-	for line := range bus.CurrentLine {
-		//	fmt.Printf("%s %b %b %b", line, onTableScheme, onTableData)
-		streamSize += len([]byte(line))
-
-		if streamSize > streamSizeMax {
-			shard++
-			tableFile.Flush()
-			tableFile.Close()
-			f.Close()
-			shardpad = fmt.Sprintf(".%05d", shard)
-			tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table ", "", 1), "`", "", -1)) + shardpad
-			fmt.Printf("Processing table data %s ", tableName)
-			tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-			f, err := os.Create(tablePath)
-			if err != nil {
-				fmt.Printf("Error creating file %s %s\n", tablePath, err)
-				bus.Finished <- true
-				return
-			}
-			tableFile = gzip.NewWriter(f)
-			streamSize = 0
-		}
-		// The beginning of a mysqldump has some flags at the top of the file. Capture them into a variable.
-		if !pastHeader && strings.HasPrefix(line, "/*!40") {
-			headerMetaData += line
-		}
-		// Optimize for no test string durin table dump
-		if onTableData {
-			if strings.HasPrefix(line, "UNLOCK TABLES;") {
-				onTableData = false
-				onTableScheme = false
-				streamSize = 0
-				tableFile.Close()
-			}
-		} else {
-			if strings.HasPrefix(line, "USE ") {
-				schema = strings.TrimSpace(strings.Replace(strings.Replace(strings.Replace(line, "USE ", "", 1), ";", "", -1), "`", "", -1))
-			} else if strings.HasPrefix(line, "-- Table structure for table") {
-				//case for empty table enter dummy data
-				if onTableScheme && !onTableData {
-					onTableScheme = false
-					// add headers to each file unless we are combining all of them into 1 file.
-					tableFile.Flush()
-					tableFile.Close()
-					f.Close()
-				}
-				onTableScheme, onTableData = true, false
-				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Table structure for table ", "", 1), "`", "", -1)) + "-schema"
-				fmt.Printf("Processing table schema %s\n", tableName)
-				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-				f, err := os.Create(tablePath)
-				if err != nil {
-					fmt.Printf("Error creating file %s %s\n", tablePath, err)
-					bus.Finished <- true
-					return
-				}
-				tableFile = gzip.NewWriter(f)
-				pastHeader = true
-			} else if strings.HasPrefix(line, "LOCK TABLES `") {
-				onTableData, onTableScheme = true, false
-			} else if strings.HasPrefix(line, "-- Dumping data for table") {
-				// Case of data without table definition
-				if !onTableScheme {
-					tableFile.Flush()
-					tableFile.Close()
-					tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table", "", 1), "`", "", -1)) + "-schema"
-					fmt.Printf("Processing table schema %s\n", tableName)
-					tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-					f, err := os.Create(tablePath)
-					if err != nil {
-						fmt.Printf("Error creating file %s %s\n", tablePath, err)
-						bus.Finished <- true
-						return
-					}
-					tableFile = gzip.NewWriter(f)
-					tableFile.Write([]byte("\n--\n" + line))
-					pastHeader = true
-
-				}
-				tableFile.Flush()
-				tableFile.Close()
-				f.Close()
-				shardpad = fmt.Sprintf(".%05d", shard)
-				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table ", "", 1), "`", "", -1)) + shardpad
-				fmt.Printf("Processing table data %s\n", tableName)
-				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-				f, err := os.Create(tablePath)
-				if err != nil {
-					fmt.Printf("Error creating file %s %s\n", tablePath, err)
-					bus.Finished <- true
-					return
-				}
-				tableFile = gzip.NewWriter(f)
-
-				if !pastHeader {
-					// add the meta data to only the first table.
-					tableFile.Write([]byte(headerMetaData))
-				}
-				onTableScheme = false
-				onTableData = true
-
-			} else if strings.HasPrefix(line, "-- Final view structure for view ") {
-				onTableData = false
-				onTableScheme = false
-				//	onView = true
-				tableFile.Flush()
-				tableFile.Close()
-				f.Close()
-				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Final view structure for view ", "", 1), "`", "", -1)) + "-schema-view"
-				fmt.Printf("Processing view schema %s\n", tableName)
-				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-				f, err := os.Create(tablePath)
-				if err != nil {
-					fmt.Printf("Error creating file %s %s\n", tablePath, err)
-					bus.Finished <- true
-					return
-				}
-				tableFile = gzip.NewWriter(f)
-				//-- Dumping routines
-			} else if strings.HasPrefix(line, "INSTALL PLUGIN") || strings.HasPrefix(line, "CREATE USER") {
-				onTableData = false
-				onTableScheme = false
-				tableFile.Flush()
-				tableFile.Close()
-				f.Close()
-				tableName := "mysql.system-all"
-				fmt.Printf("Processing view schema %s\n", tableName)
-				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-				f, err := os.Create(tablePath)
-				if err != nil {
-					fmt.Printf("Error creating file %s %s\n", tablePath, err)
-					bus.Finished <- true
-					return
-				}
-				tableFile = gzip.NewWriter(f)
-			}
-			if matches := gtidRegexMariaDB.FindStringSubmatch(line); matches != nil {
-				bgtid = matches[1]
-			}
-			if matches := gtidRegexMySQL.FindStringSubmatch(line); matches != nil {
-				bgtid = matches[1]
-			}
-			if matches := binlogRegexMariaDB.FindStringSubmatch(line); matches != nil {
-				bfile = matches[1]
-				bpos = matches[2]
-			}
-			if matches := binlogRegexMySQL.FindStringSubmatch(line); matches != nil {
-				bfile = matches[1]
-				bpos = matches[2]
-			}
-		}
-
-		if pastHeader {
-			if tableFile != nil {
-				tableFile.Write([]byte(line))
-			}
-		}
-
-	}
-	tableFile.Flush()
-	tableFile.Close()
-	f.Close()
-	tablePath := filepath.Join(outputDir, "metadata")
-	f, err := os.Create(tablePath)
-	if err != nil {
-		fmt.Printf("Error creating file %s %s\n", tablePath, err)
-		bus.Finished <- true
-		return
-	}
-	line := fmt.Sprintf("[source]\n# Channel_Name = ''\nFile = %s\nPosition = %s\nExecuted_Gtid_Set = %s\n\n", bfile, bpos, bgtid)
-	f.Write([]byte(line))
-	f.Close()
-
-	bus.Finished <- true
+	// wait for the writer to finish.
+	<-bus.Finished
+	fmt.Printf("\n\n--finished in %s", time.Since(start))
+	close(bus.Finished)
+	return nil
 }

--- a/clients/client_splitdump.go
+++ b/clients/client_splitdump.go
@@ -10,6 +10,7 @@ package clients
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/signal18/replication-manager/utils/splitdump"
@@ -41,17 +42,31 @@ func runSplitdump(inputFile, outputDir string) error {
 	}
 
 	// create a pipeline of goroutines
-	go splitdump.SplitDumpLineReader(bus, inputFile)
-	go splitdump.SplitDumpLineParser(bus, outputDir)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		splitdump.SplitDumpLineReader(bus, inputFile)
+	}()
+	go func() {
+		defer wg.Done()
+		splitdump.SplitDumpLineParser(bus, outputDir)
+	}()
 	//, conf.Combine, conf.OutputPath, conf.SkipData, conf.SkipTable)
+	go func() {
+		wg.Wait()
+		close(bus.Error)
+	}()
 
-	// wait for the writer to finish.
+	// wait for the writer to finish and drain late errors.
 	var readerErr error
 	finished := false
-	for !finished {
+	errorsClosed := false
+	for !(finished && errorsClosed) {
 		select {
 		case err, ok := <-bus.Error:
 			if !ok {
+				errorsClosed = true
 				continue
 			}
 			if err != nil && readerErr == nil {
@@ -61,19 +76,6 @@ func runSplitdump(inputFile, outputDir string) error {
 			finished = true
 		}
 	}
-	for {
-		select {
-		case err, ok := <-bus.Error:
-			if !ok {
-				fmt.Printf("\n\n--finished in %s", time.Since(start))
-				return readerErr
-			}
-			if err != nil && readerErr == nil {
-				readerErr = err
-			}
-		default:
-			fmt.Printf("\n\n--finished in %s", time.Since(start))
-			return readerErr
-		}
-	}
+	fmt.Printf("\n\n--finished in %s", time.Since(start))
+	return readerErr
 }

--- a/clients/client_splitdump.go
+++ b/clients/client_splitdump.go
@@ -46,8 +46,22 @@ func runSplitdump(inputFile, outputDir string) error {
 	//, conf.Combine, conf.OutputPath, conf.SkipData, conf.SkipTable)
 
 	// wait for the writer to finish.
-	<-bus.Finished
-	fmt.Printf("\n\n--finished in %s", time.Since(start))
-	close(bus.Finished)
-	return nil
+	var readerErr error
+	errorCh := bus.Error
+	for {
+		select {
+		case err, ok := <-errorCh:
+			if !ok {
+				errorCh = nil
+				continue
+			}
+			if err != nil && readerErr == nil {
+				readerErr = err
+			}
+		case <-bus.Finished:
+			fmt.Printf("\n\n--finished in %s", time.Since(start))
+			close(bus.Finished)
+			return readerErr
+		}
+	}
 }

--- a/clients/client_splitdump_test.go
+++ b/clients/client_splitdump_test.go
@@ -1,0 +1,61 @@
+//go:build clients
+// +build clients
+
+package clients
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunSplitdumpFromFile(t *testing.T) {
+	outputDir := t.TempDir()
+	inputFile := filepath.Join(t.TempDir(), "dump.sql")
+
+	dump := strings.Join([]string{
+		"USE `test`;",
+		"-- Table structure for table `t1`",
+		"CREATE TABLE `t1` (",
+		"  `id` int",
+		");",
+		"CHANGE MASTER TO MASTER_LOG_FILE='bin.000001', MASTER_LOG_POS=123;",
+		"-- Dumping data for table `t1`",
+		"LOCK TABLES `t1` WRITE;",
+		"INSERT INTO `t1` VALUES (1);",
+		"UNLOCK TABLES;",
+		"",
+	}, "\n")
+
+	if err := os.WriteFile(inputFile, []byte(dump), 0644); err != nil {
+		t.Fatalf("failed to write input dump: %v", err)
+	}
+
+	if err := runSplitdump(inputFile, outputDir); err != nil {
+		t.Fatalf("runSplitdump error: %v", err)
+	}
+
+	metadataPath := filepath.Join(outputDir, "metadata")
+	metadata, err := os.ReadFile(metadataPath)
+	if err != nil {
+		t.Fatalf("failed to read metadata: %v", err)
+	}
+	metaStr := string(metadata)
+	if !strings.Contains(metaStr, "File = bin.000001") {
+		t.Fatalf("metadata missing binlog file: %s", metaStr)
+	}
+	if !strings.Contains(metaStr, "Position = 123") {
+		t.Fatalf("metadata missing position: %s", metaStr)
+	}
+
+	schemaFile := filepath.Join(outputDir, "test.t1-schema.sql.gz")
+	if _, err := os.Stat(schemaFile); err != nil {
+		t.Fatalf("schema file missing: %v", err)
+	}
+
+	dataFile := filepath.Join(outputDir, "test.t1.00000.sql.gz")
+	if _, err := os.Stat(dataFile); err != nil {
+		t.Fatalf("data file missing: %v", err)
+	}
+}

--- a/clients/client_splitrestore.go
+++ b/clients/client_splitrestore.go
@@ -1,0 +1,110 @@
+//go:build clients
+// +build clients
+
+package clients
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/signal18/replication-manager/utils/splitdump"
+)
+
+var (
+	cliSplitRestoreDir      string
+	cliSplitRestoreMysql    string
+	cliSplitRestoreMysqlArg string
+	cliSplitRestoreParallel int
+	cliSplitRestoreUser     bool
+)
+
+var splitRestoreCmd = &cobra.Command{
+	Use:   "splitrestore",
+	Short: "Restore splitdump directory",
+	Long:  "Restore a splitdump directory by streaming each file into the mysql client",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runSplitrestore(cmd.Context()); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	},
+}
+
+func initSplitRestoreFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&cliSplitRestoreDir, "input-dir", "", "Splitdump directory to restore")
+	cmd.Flags().StringVar(&cliSplitRestoreMysql, "mysql", "mysql", "Path to mysql client binary")
+	cmd.Flags().StringVar(&cliSplitRestoreMysqlArg, "mysql-args", "--force --batch", "Extra mysql client arguments")
+	cmd.Flags().IntVar(&cliSplitRestoreParallel, "parallel", 1, "Parallel workers for splitdump restore")
+	cmd.Flags().BoolVar(&cliSplitRestoreUser, "restore-user", true, "Restore mysql.system-all file when present")
+}
+
+func runSplitrestore(ctx context.Context) error {
+	if strings.TrimSpace(cliSplitRestoreDir) == "" {
+		return fmt.Errorf("input-dir is required")
+	}
+
+	start := time.Now()
+	logger := func(level, format string, args ...any) {
+		fmt.Printf("["+level+"] "+format+"\n", args...)
+	}
+
+	mysqlPath, err := exec.LookPath(cliSplitRestoreMysql)
+	if err != nil {
+		return fmt.Errorf("mysql client not found at %s: %w", cliSplitRestoreMysql, err)
+	}
+	cliSplitRestoreMysql = mysqlPath
+
+	restoreFile := func(ctx context.Context, path string) error {
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		var reader io.Reader = file
+		if strings.HasSuffix(strings.ToLower(path), ".gz") {
+			gzReader, err := gzip.NewReader(file)
+			if err != nil {
+				return err
+			}
+			defer gzReader.Close()
+			reader = gzReader
+		}
+
+		args := strings.Fields(cliSplitRestoreMysqlArg)
+		cmd := exec.CommandContext(ctx, cliSplitRestoreMysql, args...)
+		cmd.Stdin = reader
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			errOutput := strings.TrimSpace(stderr.String())
+			if errOutput == "" {
+				errOutput = err.Error()
+			}
+			return fmt.Errorf("mysql restore failed for %s: %s", path, errOutput)
+		}
+		return nil
+	}
+
+	if err := splitdump.Restore(cliSplitRestoreDir, splitdump.RestoreOptions{
+		Parallel:               cliSplitRestoreParallel,
+		RestoreUser:            cliSplitRestoreUser,
+		Logger:                 logger,
+		Context:                ctx,
+		RestoreFileWithContext: restoreFile,
+	}); err != nil {
+		return err
+	}
+
+	fmt.Printf("\n\n--finished in %s", time.Since(start))
+	return nil
+}

--- a/clients/client_splitrestore.go
+++ b/clients/client_splitrestore.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/spf13/cobra"
 
@@ -80,7 +81,10 @@ func runSplitrestore(ctx context.Context) error {
 			reader = gzReader
 		}
 
-		args := strings.Fields(cliSplitRestoreMysqlArg)
+		args, err := splitMysqlArgs(cliSplitRestoreMysqlArg)
+		if err != nil {
+			return fmt.Errorf("invalid mysql-args: %w", err)
+		}
 		cmd := exec.CommandContext(ctx, cliSplitRestoreMysql, args...)
 		cmd.Stdin = reader
 		var stderr bytes.Buffer
@@ -107,4 +111,77 @@ func runSplitrestore(ctx context.Context) error {
 
 	fmt.Printf("\n\n--finished in %s", time.Since(start))
 	return nil
+}
+
+func splitMysqlArgs(input string) ([]string, error) {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	var (
+		args       []string
+		current    strings.Builder
+		quote      rune
+		escaped    bool
+		argStarted bool
+	)
+
+	flush := func() {
+		args = append(args, current.String())
+		current.Reset()
+		argStarted = false
+	}
+
+	for _, r := range trimmed {
+		if escaped {
+			current.WriteRune(r)
+			escaped = false
+			argStarted = true
+			continue
+		}
+
+		if r == '\\' && quote != '\'' {
+			escaped = true
+			argStarted = true
+			continue
+		}
+
+		if r == '\'' || r == '"' {
+			if quote == 0 {
+				quote = r
+				argStarted = true
+				continue
+			}
+			if quote == r {
+				quote = 0
+				continue
+			}
+			current.WriteRune(r)
+			argStarted = true
+			continue
+		}
+
+		if quote == 0 && unicode.IsSpace(r) {
+			if argStarted {
+				flush()
+			}
+			continue
+		}
+
+		current.WriteRune(r)
+		argStarted = true
+	}
+
+	if escaped {
+		return nil, fmt.Errorf("trailing escape")
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unmatched quote")
+	}
+	if argStarted {
+		flush()
+	}
+
+	return args, nil
 }

--- a/clients/client_splitrestore.go
+++ b/clients/client_splitrestore.go
@@ -133,7 +133,9 @@ func splitMysqlArgs(input string) ([]string, error) {
 		argStarted = false
 	}
 
-	for _, r := range trimmed {
+	runes := []rune(trimmed)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
 		if escaped {
 			current.WriteRune(r)
 			escaped = false
@@ -141,10 +143,29 @@ func splitMysqlArgs(input string) ([]string, error) {
 			continue
 		}
 
-		if r == '\\' && quote != '\'' {
-			escaped = true
-			argStarted = true
-			continue
+		if r == '\\' {
+			switch quote {
+			case '\'':
+				current.WriteRune(r)
+				argStarted = true
+				continue
+			case 0:
+				if i+1 < len(runes) {
+					next := runes[i+1]
+					if unicode.IsSpace(next) || next == '\'' || next == '"' {
+						escaped = true
+						argStarted = true
+						continue
+					}
+				}
+				current.WriteRune(r)
+				argStarted = true
+				continue
+			default:
+				escaped = true
+				argStarted = true
+				continue
+			}
 		}
 
 		if r == '\'' || r == '"' {

--- a/clients/client_splitrestore_test.go
+++ b/clients/client_splitrestore_test.go
@@ -1,0 +1,80 @@
+//go:build clients
+// +build clients
+
+package clients
+
+import "testing"
+
+func TestSplitMysqlArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:  "simple flags",
+			input: "--force --batch",
+			want:  []string{"--force", "--batch"},
+		},
+		{
+			name:  "double quoted space",
+			input: "--password=\"a b\"",
+			want:  []string{"--password=a b"},
+		},
+		{
+			name:  "single quoted space",
+			input: "--user='my user'",
+			want:  []string{"--user=my user"},
+		},
+		{
+			name:  "escaped spaces",
+			input: "--socket=/path\\ with\\ space",
+			want:  []string{"--socket=/path with space"},
+		},
+		{
+			name:  "escaped quotes in double quotes",
+			input: "--arg=\"a \\\"b\\\" c\"",
+			want:  []string{"--arg=a \"b\" c"},
+		},
+		{
+			name:  "empty quoted arg",
+			input: "\"\"",
+			want:  []string{""},
+		},
+		{
+			name:    "unmatched quote",
+			input:   "--user=\"broken",
+			wantErr: true,
+		},
+		{
+			name:    "trailing escape",
+			input:   "--socket=path\\",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := splitMysqlArgs(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d args, want %d", len(got), len(tc.want))
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("arg %d = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/clients/client_splitrestore_test.go
+++ b/clients/client_splitrestore_test.go
@@ -33,6 +33,11 @@ func TestSplitMysqlArgs(t *testing.T) {
 			want:  []string{"--socket=/path with space"},
 		},
 		{
+			name:  "literal backslashes",
+			input: "--socket=C:\\temp\\data",
+			want:  []string{"--socket=C:\\temp\\data"},
+		},
+		{
 			name:  "escaped quotes in double quotes",
 			input: "--arg=\"a \\\"b\\\" c\"",
 			want:  []string{"--arg=a \"b\" c"},
@@ -48,9 +53,9 @@ func TestSplitMysqlArgs(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "trailing escape",
-			input:   "--socket=path\\",
-			wantErr: true,
+			name:  "trailing backslash",
+			input: "--socket=path\\",
+			want:  []string{"--socket=path\\"},
 		},
 	}
 

--- a/clients/client_topology.go
+++ b/clients/client_topology.go
@@ -59,8 +59,8 @@ func cliGetTopology() {
 		headstr += fmt.Sprintf("\n%19s %15s %6s %15s %10d %12s %20s %20s %30s %6d %3s %5s", server.Id, server.Host, server.Port, server.State, server.FailCount, server.GetReplicationUsingGtid(), gtidCurr, gtidSlave, "", server.GetReplicationDelay(), server.ReadOnly, boolToChar(server.IsMaintenance))
 
 	}
-	fmt.Printf(headstr)
-	fmt.Printf("\n")
+	fmt.Print(headstr)
+	fmt.Print("\n")
 }
 
 func boolToChar(v bool) string {

--- a/cluster/backup_helpers.go
+++ b/cluster/backup_helpers.go
@@ -248,6 +248,25 @@ func (server *ServerMonitor) backupMetaFilePath(meta *backupmgr.BackupMetadata) 
 	return defaultPath
 }
 
+func (server *ServerMonitor) resolveMysqldumpDest(isAdhoc bool, splitDump bool, start time.Time) (string, string, string, bool) {
+	dir := server.GetMyBackupDirectory()
+	filename := dir + "mysqldump.sql.gz"
+	if isAdhoc {
+		filename = fmt.Sprintf("%smysqldump.%d.sql.gz", dir, start.Unix())
+	}
+	outputdir := ""
+	if splitDump {
+		outputdir = filepath.Join(dir, "splitdump")
+		if isAdhoc {
+			outputdir = filepath.Join(dir, fmt.Sprintf("splitdump.%d", start.Unix()))
+		}
+	}
+	if splitDump {
+		return filename, outputdir, outputdir, false
+	}
+	return filename, outputdir, filename, true
+}
+
 func parseAdhocMetaFileID(name string) (int64, bool) {
 	matches := adhocMetaFilePattern.FindStringSubmatch(name)
 	if len(matches) != 2 {

--- a/cluster/backup_helpers_test.go
+++ b/cluster/backup_helpers_test.go
@@ -8,6 +8,7 @@ package cluster
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -430,6 +431,142 @@ func TestResolveBackupLine(t *testing.T) {
 			result := tt.server.resolveBackupLine(tt.opts)
 			if result != tt.expected {
 				t.Errorf("resolveBackupLine() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestResolveMysqldumpDest(t *testing.T) {
+	cluster := &Cluster{
+		Name:   "test-cluster",
+		Conf:   &config.Config{WorkingDir: t.TempDir()},
+		Logrus: logrus.New(),
+	}
+	server := &ServerMonitor{
+		Host:         "127.0.0.1",
+		Port:         "3306",
+		ClusterGroup: cluster,
+	}
+	start := time.Unix(1700000000, 0)
+	dir := server.GetMyBackupDirectory()
+
+	defaultFile := dir + "mysqldump.sql.gz"
+	adhocFile := fmt.Sprintf("%smysqldump.%d.sql.gz", dir, start.Unix())
+	splitDefault := filepath.Join(dir, "splitdump")
+	splitAdhoc := filepath.Join(dir, fmt.Sprintf("splitdump.%d", start.Unix()))
+
+	tests := []struct {
+		name           string
+		isAdhoc        bool
+		splitDump      bool
+		wantFilename   string
+		wantOutputDir  string
+		wantDest       string
+		wantCompressed bool
+	}{
+		{
+			name:           "Default no split",
+			isAdhoc:        false,
+			splitDump:      false,
+			wantFilename:   defaultFile,
+			wantOutputDir:  "",
+			wantDest:       defaultFile,
+			wantCompressed: true,
+		},
+		{
+			name:           "Default splitdump",
+			isAdhoc:        false,
+			splitDump:      true,
+			wantFilename:   defaultFile,
+			wantOutputDir:  splitDefault,
+			wantDest:       splitDefault,
+			wantCompressed: false,
+		},
+		{
+			name:           "Adhoc no split",
+			isAdhoc:        true,
+			splitDump:      false,
+			wantFilename:   adhocFile,
+			wantOutputDir:  "",
+			wantDest:       adhocFile,
+			wantCompressed: true,
+		},
+		{
+			name:           "Adhoc splitdump",
+			isAdhoc:        true,
+			splitDump:      true,
+			wantFilename:   adhocFile,
+			wantOutputDir:  splitAdhoc,
+			wantDest:       splitAdhoc,
+			wantCompressed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filename, outputdir, dest, compressed := server.resolveMysqldumpDest(tt.isAdhoc, tt.splitDump, start)
+			if filename != tt.wantFilename {
+				t.Fatalf("filename = %q, want %q", filename, tt.wantFilename)
+			}
+			if outputdir != tt.wantOutputDir {
+				t.Fatalf("outputdir = %q, want %q", outputdir, tt.wantOutputDir)
+			}
+			if dest != tt.wantDest {
+				t.Fatalf("dest = %q, want %q", dest, tt.wantDest)
+			}
+			if compressed != tt.wantCompressed {
+				t.Fatalf("compressed = %v, want %v", compressed, tt.wantCompressed)
+			}
+		})
+	}
+}
+
+func TestResolveMysqldumpDestNoSplitdump(t *testing.T) {
+	cluster := &Cluster{
+		Name:   "test-cluster",
+		Conf:   &config.Config{WorkingDir: t.TempDir()},
+		Logrus: logrus.New(),
+	}
+	server := &ServerMonitor{
+		Host:         "127.0.0.1",
+		Port:         "3306",
+		ClusterGroup: cluster,
+	}
+	start := time.Unix(1700000000, 0)
+	backupDir := server.GetMyBackupDirectory()
+
+	checks := []struct {
+		name       string
+		isAdhoc    bool
+		wantSuffix string
+	}{
+		{
+			name:       "Default",
+			isAdhoc:    false,
+			wantSuffix: "mysqldump.sql.gz",
+		},
+		{
+			name:       "Adhoc",
+			isAdhoc:    true,
+			wantSuffix: fmt.Sprintf("mysqldump.%d.sql.gz", start.Unix()),
+		},
+	}
+
+	for _, tt := range checks {
+		t.Run(tt.name, func(t *testing.T) {
+			filename, outputdir, dest, compressed := server.resolveMysqldumpDest(tt.isAdhoc, false, start)
+			wantFile := backupDir + tt.wantSuffix
+			if filename != wantFile {
+				t.Fatalf("filename = %q, want %q", filename, wantFile)
+			}
+			if outputdir != "" {
+				t.Fatalf("outputdir = %q, want empty", outputdir)
+			}
+			if dest != wantFile {
+				t.Fatalf("dest = %q, want %q", dest, wantFile)
+			}
+			if !compressed {
+				t.Fatalf("compressed = %v, want true", compressed)
 			}
 		})
 	}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -8,6 +8,7 @@ package cluster
 
 import (
 	"bytes"
+	"context"
 	"crypto/md5"
 	"crypto/tls"
 	"encoding/json"
@@ -919,7 +920,7 @@ func (cluster *Cluster) StateProcessing() {
 					if srv.HasWaitLogicalBackupCookie() {
 						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Server %s was waiting for logical backup", srv.URL)
 						go func() {
-							err := srv.JobReseedLogicalBackup("default")
+							err := srv.JobReseedLogicalBackup(context.Background(), "default")
 							if err != nil {
 								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Logical reseed on %s error: %s", srv.URL, err.Error())
 							}

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -26,6 +26,8 @@ import (
 	"github.com/signal18/replication-manager/utils/version"
 )
 
+var splitDumpTimestampRegex = regexp.MustCompile(`^\d+$`)
+
 func (cluster *Cluster) ResticGetEnv() []string {
 	newEnv := append(os.Environ(), "RESTIC_PASSWORD="+cluster.Conf.GetDecryptedValue("backup-restic-password"))
 	newEnv = append(newEnv, "RESTIC_CACHE_DIR="+cluster.Conf.WorkingDir+"/"+cluster.Name+"/.cache/restic")
@@ -1371,7 +1373,7 @@ func (cluster *Cluster) normalizeSplitDumpOutputDir(destination *ServerMonitor, 
 			return "", fmt.Errorf("splitdump output dir must be %s or %s.<timestamp>", defaultOutputDir, defaultOutputDir)
 		}
 		suffix := strings.TrimPrefix(outputBase, "splitdump.")
-		if suffix == "" || !regexp.MustCompile(`^\d+$`).MatchString(suffix) {
+		if suffix == "" || !splitDumpTimestampRegex.MatchString(suffix) {
 			return "", fmt.Errorf("splitdump output dir must be %s or %s.<timestamp>", defaultOutputDir, defaultOutputDir)
 		}
 	}

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -7,11 +7,16 @@
 package cluster
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/shirou/gopsutil/disk"
 	"github.com/signal18/replication-manager/config"
@@ -450,6 +455,9 @@ func (cluster *Cluster) resolveResticMountDirFromConfig(opts resticMountDirResol
 	mountDirSource := "default"
 	if trimmed := strings.TrimSpace(cluster.Conf.BackupResticMountDir); trimmed != "" {
 		mountDirSource = "config"
+		if opts.rejectDotDot && hasDotDotComponent(trimmed) {
+			return "", mountDirSource, fmt.Errorf("%s mount dir contains '..' component: %s", mountDirSource, trimmed)
+		}
 		if filepath.IsAbs(trimmed) {
 			mountDir = trimmed
 		} else {
@@ -1322,6 +1330,200 @@ func (cluster *Cluster) ChangeResticRepoPassword(newpass string) error {
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlInfo, "Restic password changed successfully. New key added and old key removed.")
 
+	return nil
+}
+
+func (cluster *Cluster) normalizeSplitDumpOutputDir(destination *ServerMonitor, outputDir string) (string, error) {
+	if destination == nil {
+		return "", fmt.Errorf("splitdump destination is nil")
+	}
+
+	trimmedOutputDir := strings.TrimSpace(outputDir)
+	if trimmedOutputDir == "" {
+		trimmedOutputDir = filepath.Join(destination.GetMyBackupDirectory(), "splitdump")
+	}
+
+	baseDir := filepath.Clean(destination.GetMyBackupDirectory())
+	baseDirAbs, err := filepath.Abs(baseDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve backup directory %s: %w", baseDir, err)
+	}
+
+	cleanOutputDir := filepath.Clean(trimmedOutputDir)
+	if cleanOutputDir == "." || cleanOutputDir == string(filepath.Separator) {
+		return "", fmt.Errorf("invalid splitdump output dir: %s", outputDir)
+	}
+	if !filepath.IsAbs(cleanOutputDir) {
+		cleanOutputDir = filepath.Join(baseDirAbs, cleanOutputDir)
+	}
+	outputDirAbs, err := filepath.Abs(cleanOutputDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve splitdump output dir %s: %w", cleanOutputDir, err)
+	}
+	if outputDirAbs == baseDirAbs {
+		return "", fmt.Errorf("splitdump output dir must be a subdirectory of %s", baseDirAbs)
+	}
+
+	defaultOutputDir := filepath.Join(baseDirAbs, "splitdump")
+	outputBase := filepath.Base(outputDirAbs)
+	if outputDirAbs != defaultOutputDir {
+		if !strings.HasPrefix(outputBase, "splitdump.") {
+			return "", fmt.Errorf("splitdump output dir must be %s or %s.<timestamp>", defaultOutputDir, defaultOutputDir)
+		}
+		suffix := strings.TrimPrefix(outputBase, "splitdump.")
+		if suffix == "" || !regexp.MustCompile(`^\d+$`).MatchString(suffix) {
+			return "", fmt.Errorf("splitdump output dir must be %s or %s.<timestamp>", defaultOutputDir, defaultOutputDir)
+		}
+	}
+
+	resolvedBaseDir, err := filepath.EvalSymlinks(baseDirAbs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Allow missing base dir; it may be created later during splitdump.
+			parentDir := filepath.Dir(baseDirAbs)
+			resolvedParentDir, parentErr := filepath.EvalSymlinks(parentDir)
+			if parentErr != nil {
+				return "", fmt.Errorf("failed to resolve backup directory parent %s: %w", parentDir, parentErr)
+			}
+			resolvedBaseDir = filepath.Join(resolvedParentDir, filepath.Base(baseDirAbs))
+		} else {
+			return "", fmt.Errorf("failed to resolve backup directory %s: %w", baseDirAbs, err)
+		}
+	}
+	resolvedOutputDir, err := filepath.EvalSymlinks(outputDirAbs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			parentDir := filepath.Dir(outputDirAbs)
+			resolvedParentDir, parentErr := filepath.EvalSymlinks(parentDir)
+			if parentErr != nil {
+				return "", fmt.Errorf("failed to resolve splitdump output dir parent %s: %w", parentDir, parentErr)
+			}
+			resolvedOutputDir = filepath.Join(resolvedParentDir, filepath.Base(outputDirAbs))
+		} else {
+			return "", fmt.Errorf("failed to resolve splitdump output dir %s: %w", outputDirAbs, err)
+		}
+	}
+	rel, err := filepath.Rel(resolvedBaseDir, resolvedOutputDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve splitdump output dir %s relative to %s: %w", outputDirAbs, baseDirAbs, err)
+	}
+	if rel == "." {
+		return "", fmt.Errorf("splitdump output dir must be a subdirectory of %s", baseDirAbs)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("splitdump output dir %s is outside backup directory %s", outputDirAbs, baseDirAbs)
+	}
+
+	return outputDirAbs, nil
+}
+
+func (cluster *Cluster) SplitDumpWithCli(ctx context.Context, destination *ServerMonitor, outputDir string, allowRotate bool, stdin io.Reader, stdout, stderr io.Writer) error {
+	if cluster == nil || cluster.Conf == nil {
+		return fmt.Errorf("cluster config is nil")
+	}
+	if destination == nil {
+		return fmt.Errorf("splitdump destination is nil")
+	}
+	if stdin == nil {
+		return fmt.Errorf("splitdump stdin is nil")
+	}
+	if stdout == nil {
+		return fmt.Errorf("splitdump stdout is nil")
+	}
+	if stderr == nil {
+		return fmt.Errorf("splitdump stderr is nil")
+	}
+	resolvedOutputDir, err := cluster.normalizeSplitDumpOutputDir(destination, outputDir)
+	if err != nil {
+		return err
+	}
+	outputDir = resolvedOutputDir
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
+		"Starting splitdump for server %s to %s", destination.URL, outputDir)
+
+	// Get CLI path and verify it's executable
+	cliPath := cluster.GetReplicationManagerCliPath()
+	if resolvedPath, err := exec.LookPath(cliPath); err == nil {
+		cliPath = resolvedPath
+	}
+	if info, err := os.Stat(cliPath); err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr,
+			"replication-manager-cli not found at %s: %v", cliPath, err)
+		return fmt.Errorf("replication-manager-cli not found at %s: %w", cliPath, err)
+	} else if info.Mode().Perm()&0111 == 0 {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr,
+			"replication-manager-cli is not executable: %s", cliPath)
+		return fmt.Errorf("replication-manager-cli is not executable: %s", cliPath)
+	}
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg,
+		"Using replication-manager-cli at %s", cliPath)
+
+	info, err := os.Stat(outputDir)
+	switch {
+	case os.IsNotExist(err):
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
+			"Creating splitdump output directory %s", outputDir)
+		if err := os.MkdirAll(outputDir, os.ModePerm); err != nil {
+			return fmt.Errorf("failed to create splitdump output dir %s: %w", outputDir, err)
+		}
+	case err != nil:
+		return fmt.Errorf("failed to stat splitdump output dir %s: %w", outputDir, err)
+	case !info.IsDir():
+		return fmt.Errorf("splitdump output path is not a directory: %s", outputDir)
+	default:
+		entries, err := os.ReadDir(outputDir)
+		if err != nil {
+			return fmt.Errorf("failed to read splitdump output dir %s: %w", outputDir, err)
+		}
+		if len(entries) > 0 {
+			if allowRotate {
+				rotatedDir := fmt.Sprintf("%s.old.%d", outputDir, time.Now().UnixNano())
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
+					"Rotating existing splitdump directory to %s", rotatedDir)
+				if err := os.Rename(outputDir, rotatedDir); err != nil {
+					return fmt.Errorf("failed to rotate splitdump output dir %s to %s: %w", outputDir, rotatedDir, err)
+				}
+			} else {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
+					"Removing existing splitdump directory %s before backup", outputDir)
+				if err := os.RemoveAll(outputDir); err != nil {
+					return fmt.Errorf("failed to remove splitdump output dir %s: %w", outputDir, err)
+				}
+			}
+			if err := os.MkdirAll(outputDir, os.ModePerm); err != nil {
+				return fmt.Errorf("failed to recreate splitdump output dir %s: %w", outputDir, err)
+			}
+		}
+	}
+
+	// Use parent context for cancellation control
+	// If caller wants a timeout, they should pass context.WithTimeout
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg,
+		"Executing splitdump command: %s splitdump --outputdir %s", cliPath, outputDir)
+
+	cmd := exec.CommandContext(ctx, cliPath, "splitdump", "--outputdir", outputDir)
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr,
+				"Splitdump cancelled due to timeout or cancellation")
+			return fmt.Errorf("splitdump cancelled: %w", err)
+		} else if errors.Is(err, context.Canceled) {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn,
+				"Splitdump cancelled by parent context")
+			return fmt.Errorf("splitdump cancelled: %w", err)
+		}
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr,
+			"Splitdump command failed: %v", err)
+		return err
+	}
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
+		"Splitdump completed successfully for server %s", destination.URL)
 	return nil
 }
 

--- a/cluster/cluster_bck_test.go
+++ b/cluster/cluster_bck_test.go
@@ -1,11 +1,11 @@
 package cluster
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -190,6 +190,149 @@ func TestResolveResticMountDirFromConfigStrictCleansPath(t *testing.T) {
 	expected := filepath.Join(tmpDir, "restic")
 	if mountDir != expected {
 		t.Fatalf("expected mount dir %q, got %q", expected, mountDir)
+	}
+}
+
+func TestNormalizeSplitDumpOutputDirDefault(t *testing.T) {
+	cluster := &Cluster{
+		Name: "test-cluster",
+		Conf: &config.Config{WorkingDir: t.TempDir()},
+	}
+	server := &ServerMonitor{
+		Host:         "127.0.0.1",
+		Port:         "3306",
+		ClusterGroup: cluster,
+	}
+	baseDirAbs, err := filepath.Abs(filepath.Clean(server.GetMyBackupDirectory()))
+	if err != nil {
+		t.Fatalf("failed to resolve base dir: %v", err)
+	}
+
+	outputDir, err := cluster.normalizeSplitDumpOutputDir(server, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := filepath.Join(baseDirAbs, "splitdump")
+	if outputDir != expected {
+		t.Fatalf("outputdir = %q, want %q", outputDir, expected)
+	}
+}
+
+func TestNormalizeSplitDumpOutputDirTimestamped(t *testing.T) {
+	cluster := &Cluster{
+		Name: "test-cluster",
+		Conf: &config.Config{WorkingDir: t.TempDir()},
+	}
+	server := &ServerMonitor{
+		Host:         "127.0.0.1",
+		Port:         "3306",
+		ClusterGroup: cluster,
+	}
+	baseDirAbs, err := filepath.Abs(filepath.Clean(server.GetMyBackupDirectory()))
+	if err != nil {
+		t.Fatalf("failed to resolve base dir: %v", err)
+	}
+
+	requested := filepath.Join(baseDirAbs, "splitdump.1700000000")
+	outputDir, err := cluster.normalizeSplitDumpOutputDir(server, requested)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outputDir != requested {
+		t.Fatalf("outputdir = %q, want %q", outputDir, requested)
+	}
+}
+
+func TestNormalizeSplitDumpOutputDirRelative(t *testing.T) {
+	cluster := &Cluster{
+		Name: "test-cluster",
+		Conf: &config.Config{WorkingDir: t.TempDir()},
+	}
+	server := &ServerMonitor{
+		Host:         "127.0.0.1",
+		Port:         "3306",
+		ClusterGroup: cluster,
+	}
+	baseDirAbs, err := filepath.Abs(filepath.Clean(server.GetMyBackupDirectory()))
+	if err != nil {
+		t.Fatalf("failed to resolve base dir: %v", err)
+	}
+
+	outputDir, err := cluster.normalizeSplitDumpOutputDir(server, "splitdump.1700000000")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := filepath.Join(baseDirAbs, "splitdump.1700000000")
+	if outputDir != expected {
+		t.Fatalf("outputdir = %q, want %q", outputDir, expected)
+	}
+}
+
+func TestNormalizeSplitDumpOutputDirRejectsInvalidSuffix(t *testing.T) {
+	cluster := &Cluster{
+		Name: "test-cluster",
+		Conf: &config.Config{WorkingDir: t.TempDir()},
+	}
+	server := &ServerMonitor{
+		Host:         "127.0.0.1",
+		Port:         "3306",
+		ClusterGroup: cluster,
+	}
+	baseDirAbs, err := filepath.Abs(filepath.Clean(server.GetMyBackupDirectory()))
+	if err != nil {
+		t.Fatalf("failed to resolve base dir: %v", err)
+	}
+
+	requested := filepath.Join(baseDirAbs, "splitdump.bad")
+	if _, err := cluster.normalizeSplitDumpOutputDir(server, requested); err == nil {
+		t.Fatalf("expected error for invalid splitdump suffix")
+	}
+}
+
+func TestNormalizeSplitDumpOutputDirRejectsOutsideBase(t *testing.T) {
+	cluster := &Cluster{
+		Name: "test-cluster",
+		Conf: &config.Config{WorkingDir: t.TempDir()},
+	}
+	server := &ServerMonitor{
+		Host:         "127.0.0.1",
+		Port:         "3306",
+		ClusterGroup: cluster,
+	}
+	outsideDir := filepath.Join(t.TempDir(), "splitdump.1700000000")
+	if _, err := cluster.normalizeSplitDumpOutputDir(server, outsideDir); err == nil {
+		t.Fatalf("expected error for splitdump path outside backup directory")
+	}
+}
+
+func TestNormalizeSplitDumpOutputDirRejectsSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test not supported on windows")
+	}
+	cluster := &Cluster{
+		Name: "test-cluster",
+		Conf: &config.Config{WorkingDir: t.TempDir()},
+	}
+	server := &ServerMonitor{
+		Host:         "127.0.0.1",
+		Port:         "3306",
+		ClusterGroup: cluster,
+	}
+	baseDirAbs, err := filepath.Abs(filepath.Clean(server.GetMyBackupDirectory()))
+	if err != nil {
+		t.Fatalf("failed to resolve base dir: %v", err)
+	}
+	outsideDir := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(outsideDir, 0755); err != nil {
+		t.Fatalf("failed to create outside dir: %v", err)
+	}
+	linkPath := filepath.Join(baseDirAbs, "splitdump")
+	if err := os.Symlink(outsideDir, linkPath); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	if _, err := cluster.normalizeSplitDumpOutputDir(server, linkPath); err == nil {
+		t.Fatalf("expected error for splitdump symlink escape")
 	}
 }
 
@@ -464,10 +607,6 @@ func TestResolveSnapshotDestPath(t *testing.T) {
 
 func TestReconcileSnapshotMetadataUsesCacheAndResticEnabled(t *testing.T) {
 	tmpDir := t.TempDir()
-	backupDir := filepath.Join(tmpDir, "backup")
-	if err := os.MkdirAll(backupDir, 0755); err != nil {
-		t.Fatalf("failed to create backup dir: %v", err)
-	}
 	cluster := &Cluster{
 		Conf:       &config.Config{WorkingDir: tmpDir},
 		WorkingDir: tmpDir,
@@ -477,18 +616,12 @@ func TestReconcileSnapshotMetadataUsesCacheAndResticEnabled(t *testing.T) {
 		}},
 	}
 	manager := cluster.getSnapshotMetadataManager()
-	meta := backupmgr.BackupMetadata{
-		BackupTool:       config.ConstBackupLogicalTypeMysqldump,
-		ResticEnabled:    true,
-		ResticSnapshotID: "snap-1",
-	}
-	data, err := json.Marshal(meta)
-	if err != nil {
-		t.Fatalf("failed to marshal metadata: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(backupDir, "mysqldump.meta.json"), data, 0644); err != nil {
-		t.Fatalf("failed to write metadata file: %v", err)
-	}
+	manager.cache.Update("snap-1", func(entry *snapshotMetadataCacheEntry) {
+		entry.Status = snapshotMetadataStatusReady
+		entry.Summaries = map[string]*SnapshotMetadataSummary{
+			"1|default": {ResticSnapshotID: "snap-1", BackupSessionID: "session-1"},
+		}
+	})
 	manager.cache.Update("snap-2", func(entry *snapshotMetadataCacheEntry) {
 		entry.Status = snapshotMetadataStatusReady
 		entry.Summaries = map[string]*SnapshotMetadataSummary{

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -245,6 +245,16 @@ func (cluster *Cluster) GetGottyClientPath() string {
 	return cluster.Conf.BackupGottyClientPath
 }
 
+func (cluster *Cluster) GetReplicationManagerCliPath() string {
+	if strings.TrimSpace(cluster.Conf.ReplicationManagerCliPath) == "" {
+		if path, err := exec.LookPath("replication-manager-cli"); err == nil {
+			return path
+		}
+		return "replication-manager-cli"
+	}
+	return cluster.Conf.ReplicationManagerCliPath
+}
+
 func (cluster *Cluster) GetMysqlServerBinaryPath() string {
 	if cluster.Conf.BackupMysqlclientPath == "" {
 		// Return installed mysql client on repman host instead of embedded if exists

--- a/cluster/cluster_job.go
+++ b/cluster/cluster_job.go
@@ -190,6 +190,9 @@ func (cluster *Cluster) JobParseMyDumperMetaNew(dir string) (config.MyDumperMeta
 	reFile := regexp.MustCompile(`^File\s*=\s*(.*)`)
 	rePos := regexp.MustCompile(`^Position\s*=\s*(\d+)`)
 	reGTID := regexp.MustCompile(`^Executed_Gtid_Set\s*=\s*(.*)`)
+	reSourceFile := regexp.MustCompile(`(?i)^SOURCE_LOG_FILE\s*=\s*"?(.+?)"?$`)
+	reSourcePos := regexp.MustCompile(`(?i)^SOURCE_LOG_POS\s*=\s*(\d+)`)
+	reSourceGTID := regexp.MustCompile(`(?i)^executed_gtid_set\s*=\s*"?(.+?)"?$`)
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -197,17 +200,23 @@ func (cluster *Cluster) JobParseMyDumperMetaNew(dir string) (config.MyDumperMeta
 		if binlogFile == "" {
 			if matches := reFile.FindStringSubmatch(line); matches != nil {
 				binlogFile = matches[1]
+			} else if matches := reSourceFile.FindStringSubmatch(line); matches != nil {
+				binlogFile = matches[1]
 			}
 		}
 
 		if position == "" {
 			if matches := rePos.FindStringSubmatch(line); matches != nil {
 				position = matches[1]
+			} else if matches := reSourcePos.FindStringSubmatch(line); matches != nil {
+				position = matches[1]
 			}
 		}
 
 		if gtidSet == "" {
 			if matches := reGTID.FindStringSubmatch(line); matches != nil {
+				gtidSet = matches[1]
+			} else if matches := reSourceGTID.FindStringSubmatch(line); matches != nil {
 				gtidSet = matches[1]
 			}
 		}

--- a/cluster/cluster_scheduler.go
+++ b/cluster/cluster_scheduler.go
@@ -1,14 +1,18 @@
 package cluster
 
-import "github.com/signal18/replication-manager/config"
+import (
+	"context"
+
+	"github.com/signal18/replication-manager/config"
+)
 
 func (cluster *Cluster) GetBackupLogicalFunction() func() {
 	return func() {
 		mysrv := cluster.GetBackupServer()
 		if mysrv != nil {
-			mysrv.JobBackupLogical()
+			mysrv.JobBackupLogical(context.Background())
 		} else if cluster.GetMaster() != nil {
-			cluster.GetMaster().JobBackupLogical()
+			cluster.GetMaster().JobBackupLogical(context.Background())
 		}
 	}
 }

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -240,7 +241,7 @@ func (cluster *Cluster) RefreshStaging(source *Cluster, masterGTIDList string) e
 
 		if cluster == source {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Reseed standalone %s", STG.URL)
-			err = STG.JobReseedLogicalBackup("default")
+			err = STG.JobReseedLogicalBackup(context.Background(), "default")
 			if err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "Reseed logical for refresh staging on %s failed: %s", STG.URL, err)
 				return err

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -77,7 +77,7 @@ func (cluster *Cluster) RefreshStaging(source *Cluster, masterGTIDList string) e
 		if bcksrv != nil && !bcksrv.HasBackupLogicalCookie() {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "[STAGING] Current master has no backup. Create logical backup for refresh staging on %s", bcksrv.URL)
 
-			err = bcksrv.JobBackupLogical()
+			err = bcksrv.JobBackupLogical(context.Background())
 			if err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "Create logical backup for refresh staging on %s failed: %s", bcksrv.URL, err)
 				return err

--- a/cluster/cluster_tool.go
+++ b/cluster/cluster_tool.go
@@ -18,12 +18,27 @@ func (cluster *Cluster) GetMyDumperCompatibleOptions() []string {
 		return parts
 	}
 
+	var hasSourceData bool
+	var hasReplicaData bool
+
 	for _, param := range parts {
 		if param == "" {
 			continue
 		}
 
+		if param == "--source-data" || strings.HasPrefix(param, "--source-data=") {
+			hasSourceData = true
+		}
+		if param == "--replica-data" || strings.HasPrefix(param, "--replica-data=") {
+			hasReplicaData = true
+		}
+
 		params = append(params, param)
+	}
+
+	if !hasSourceData && !hasReplicaData {
+		params = append(params, "--source-data=2")
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Mydumper options missing --source-data/--replica-data; adding --source-data=2 to capture binlog metadata")
 	}
 
 	return params

--- a/cluster/dump_stream_parser.go
+++ b/cluster/dump_stream_parser.go
@@ -1,0 +1,92 @@
+package cluster
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type dumpStreamParser struct {
+	binlogRegex *regexp.Regexp
+	gtidRegex   *regexp.Regexp
+	wantBinlog  bool
+	wantGTID    bool
+	remaining   string
+	onBinlog    func(file string, pos uint64)
+	onGTID      func(gtid string)
+}
+
+func newDumpStreamParser(binlogRegex, gtidRegex *regexp.Regexp, parseBinlog, parseGTID bool, onBinlog func(string, uint64), onGTID func(string)) *dumpStreamParser {
+	return &dumpStreamParser{
+		binlogRegex: binlogRegex,
+		gtidRegex:   gtidRegex,
+		wantBinlog:  parseBinlog,
+		wantGTID:    parseGTID,
+		onBinlog:    onBinlog,
+		onGTID:      onGTID,
+	}
+}
+
+func (p *dumpStreamParser) Enabled() bool {
+	return p.wantBinlog || p.wantGTID
+}
+
+func (p *dumpStreamParser) Consume(chunk []byte) {
+	if !p.Enabled() || len(chunk) == 0 {
+		return
+	}
+	content := p.remaining + string(chunk)
+	lines := strings.Split(content, "\n")
+	p.remaining = lines[len(lines)-1]
+	for _, line := range lines[:len(lines)-1] {
+		p.consumeLine(line)
+		if !p.Enabled() {
+			return
+		}
+	}
+}
+
+func (p *dumpStreamParser) Flush() {
+	if !p.Enabled() || p.remaining == "" {
+		p.remaining = ""
+		return
+	}
+	p.consumeLine(p.remaining)
+	p.remaining = ""
+}
+
+func (p *dumpStreamParser) consumeLine(line string) {
+	if !p.Enabled() {
+		return
+	}
+	line = strings.TrimRight(line, "\r")
+	if p.wantBinlog && p.binlogRegex != nil {
+		if matches := p.binlogRegex.FindStringSubmatch(line); len(matches) >= 3 {
+			pos, _ := strconv.ParseUint(matches[2], 10, 64)
+			if p.onBinlog != nil {
+				p.onBinlog(matches[1], pos)
+			}
+			p.wantBinlog = false
+		}
+	}
+	if p.wantGTID && p.gtidRegex != nil {
+		if matches := p.gtidRegex.FindStringSubmatch(line); len(matches) >= 2 {
+			gtid := firstNonEmpty(matches[1:])
+			if gtid != "" {
+				if p.onGTID != nil {
+					p.onGTID(gtid)
+				}
+				p.wantGTID = false
+			}
+		}
+	}
+}
+
+func firstNonEmpty(values []string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -239,6 +239,8 @@ type ServerMonitor struct {
 	pendingResticReseed      *ResticReseedRequest
 	resticReseedCleanupMutex sync.Mutex // protects resticReseedCleanup
 	resticReseedCleanup      map[string]*ResticReseedCleanupEntry
+	jobCancelMutex           sync.Mutex
+	jobCancelEntries         map[string]*jobCancelEntry
 }
 
 type ServerBackupMeta struct {

--- a/cluster/srv_bck.go
+++ b/cluster/srv_bck.go
@@ -10,6 +10,7 @@
 package cluster
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -175,7 +176,7 @@ func (server *ServerMonitor) ReseedPointInTime(meta backupmgr.PointInTimeMeta) e
 
 	switch backup.BackupTool {
 	case config.ConstBackupLogicalTypeMysqldump, config.ConstBackupLogicalTypeMydumper, config.ConstBackupLogicalTypeRiver, config.ConstBackupLogicalTypeDumpling:
-		err = server.JobReseedLogicalBackup(backup.BackupTool)
+		err = server.JobReseedLogicalBackup(context.Background(), backup.BackupTool)
 	case config.ConstBackupPhysicalTypeXtrabackup, config.ConstBackupPhysicalTypeMariaBackup:
 		err = server.JobReseedPhysicalBackup(backup.BackupTool)
 	default:

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -35,6 +35,11 @@ type DBTask struct {
 	id   int64
 }
 
+type jobCancelEntry struct {
+	cancel        context.CancelFunc
+	userRequested bool
+}
+
 /*
   - 0-2	Indicates Job still not done yet
   - 3		Indicate it's finished recently and check if there is post-job task
@@ -581,6 +586,63 @@ func (server *ServerMonitor) JobsCheckErrors(Conn *sqlx.Conn) error {
 	return err
 }
 
+func (server *ServerMonitor) registerJobCancel(task string, cancel context.CancelFunc) {
+	if strings.TrimSpace(task) == "" || cancel == nil {
+		return
+	}
+	server.jobCancelMutex.Lock()
+	if server.jobCancelEntries == nil {
+		server.jobCancelEntries = make(map[string]*jobCancelEntry)
+	}
+	server.jobCancelEntries[task] = &jobCancelEntry{cancel: cancel}
+	server.jobCancelMutex.Unlock()
+}
+
+func (server *ServerMonitor) clearJobCancel(task string) {
+	if strings.TrimSpace(task) == "" {
+		return
+	}
+	server.jobCancelMutex.Lock()
+	if server.jobCancelEntries != nil {
+		if server.jobCancelEntries[task] != nil {
+			delete(server.jobCancelEntries, task)
+		}
+	}
+	server.jobCancelMutex.Unlock()
+}
+
+func (server *ServerMonitor) requestJobCancel(task string) bool {
+	task = strings.TrimSpace(task)
+	if task == "" {
+		return false
+	}
+	var cancel context.CancelFunc
+	server.jobCancelMutex.Lock()
+	entry := server.jobCancelEntries[task]
+	if entry != nil {
+		entry.userRequested = true
+		cancel = entry.cancel
+	}
+	server.jobCancelMutex.Unlock()
+	if cancel != nil {
+		cancel()
+		return true
+	}
+	return entry != nil
+}
+
+func (server *ServerMonitor) isJobCancelRequested(task string) bool {
+	task = strings.TrimSpace(task)
+	if task == "" {
+		return false
+	}
+	server.jobCancelMutex.Lock()
+	entry := server.jobCancelEntries[task]
+	requested := entry != nil && entry.userRequested
+	server.jobCancelMutex.Unlock()
+	return requested
+}
+
 func (server *ServerMonitor) JobsCancelTasks(force bool, tasks ...string) error {
 	var err error
 	var canCancel bool = true
@@ -617,6 +679,16 @@ func (server *ServerMonitor) JobsCancelTasks(force bool, tasks ...string) error 
 
 	if !(canCancel || force) {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Failed to cancel tasks. No rows found or tasks already started", server.URL)
+	}
+
+	cancelRequested := false
+	for _, task := range tasks {
+		if server.requestJobCancel(task) {
+			cancelRequested = true
+		}
+	}
+	if cancelRequested {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Cancel requested for running tasks on %s", server.URL)
 	}
 
 	if !cluster.Conf.MonitorScheduler {

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -507,9 +507,12 @@ func (server *ServerMonitor) JobFlashbackPhysicalBackup() error {
 	return nil
 }
 
-func (server *ServerMonitor) JobReseedLogicalBackup(backtype string) error {
+func (server *ServerMonitor) JobReseedLogicalBackup(ctx context.Context, backtype string) error {
 	var err error
 	cluster := server.ClusterGroup
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if backtype == "default" {
 		backtype = cluster.Conf.BackupLogicalType
 	}
@@ -653,7 +656,7 @@ func (server *ServerMonitor) JobReseedLogicalBackup(backtype string) error {
 	server.JobsUpdateState(task, "processing", 1, 0)
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Receive reseed logical backup %s request for server: %s", backtype, server.URL)
 	if backtype == config.ConstBackupLogicalTypeMysqldump {
-		err = server.reseedMysqldumpWithMetadata(backupfile, cluster.Conf.BackupRestoreMysqlUser && source.LastBackupMeta.Logical != nil && source.LastBackupMeta.Logical.SplitUser, source.LastBackupMeta.Logical)
+		err = server.reseedMysqldumpWithMetadata(ctx, backupfile, cluster.Conf.BackupRestoreMysqlUser && source.LastBackupMeta.Logical != nil && source.LastBackupMeta.Logical.SplitUser, source.LastBackupMeta.Logical)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error reseed %s on %s: %s", backtype, server.URL, err.Error())
 			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
@@ -708,13 +711,16 @@ type JobReseedLogicalOptions struct {
 	SplitUser *bool
 }
 
-func (server *ServerMonitor) JobReseedLogicalBackupFromPath(backtype, backupPath string) error {
-	return server.JobReseedLogicalBackupFromPathWithOptions(backtype, backupPath, JobReseedLogicalOptions{})
+func (server *ServerMonitor) JobReseedLogicalBackupFromPath(ctx context.Context, backtype, backupPath string) error {
+	return server.JobReseedLogicalBackupFromPathWithOptions(ctx, backtype, backupPath, JobReseedLogicalOptions{})
 }
 
-func (server *ServerMonitor) JobReseedLogicalBackupFromPathWithOptions(backtype, backupPath string, opts JobReseedLogicalOptions) error {
+func (server *ServerMonitor) JobReseedLogicalBackupFromPathWithOptions(ctx context.Context, backtype, backupPath string, opts JobReseedLogicalOptions) error {
 	var err error
 	cluster := server.ClusterGroup
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if backtype == "default" {
 		backtype = cluster.Conf.BackupLogicalType
 	}
@@ -813,7 +819,7 @@ func (server *ServerMonitor) JobReseedLogicalBackupFromPathWithOptions(backtype,
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
 				"Using split-user override=%t for reseed logical backup from path %s on %s", splitUser, backupfile, server.URL)
 		}
-		err = server.reseedMysqldumpWithMetadata(backupfile, cluster.Conf.BackupRestoreMysqlUser && splitUser, master.LastBackupMeta.Logical)
+		err = server.reseedMysqldumpWithMetadata(ctx, backupfile, cluster.Conf.BackupRestoreMysqlUser && splitUser, master.LastBackupMeta.Logical)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error reseed %s on %s: %s", backtype, server.URL, err.Error())
 			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
@@ -930,7 +936,10 @@ func isSplitDumpDir(path string) (bool, error) {
 	return false, nil
 }
 
-func (server *ServerMonitor) reseedMysqldumpWithSplitdump(backupPath string, restoreUser bool) error {
+func (server *ServerMonitor) reseedMysqldumpWithSplitdump(ctx context.Context, backupPath string, restoreUser bool) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	isSplit, err := isSplitDumpDir(backupPath)
 	if err != nil {
 		return err
@@ -939,12 +948,15 @@ func (server *ServerMonitor) reseedMysqldumpWithSplitdump(backupPath string, res
 		cluster := server.ClusterGroup
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
 			"Splitdump detected at %s; restoring with mysql client", backupPath)
-		return server.JobReseedSplitdumpWithMysql(backupPath, restoreUser)
+		return server.JobReseedSplitdumpWithMysql(ctx, backupPath, restoreUser)
 	}
 	return server.JobReseedMysqldump(backupPath, restoreUser)
 }
 
-func (server *ServerMonitor) reseedMysqldumpWithMetadata(backupPath string, restoreUser bool, meta *backupmgr.BackupMetadata) error {
+func (server *ServerMonitor) reseedMysqldumpWithMetadata(ctx context.Context, backupPath string, restoreUser bool, meta *backupmgr.BackupMetadata) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if meta != nil {
 		if meta.Dest != "" {
 			pathsMatch, err := comparePaths(meta.Dest, backupPath)
@@ -959,9 +971,9 @@ func (server *ServerMonitor) reseedMysqldumpWithMetadata(backupPath string, rest
 		cluster := server.ClusterGroup
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
 			"Splitdump metadata detected for %s; restoring with mysql client", backupPath)
-		return server.JobReseedSplitdumpWithMysql(backupPath, restoreUser)
+		return server.JobReseedSplitdumpWithMysql(ctx, backupPath, restoreUser)
 	}
-	return server.reseedMysqldumpWithSplitdump(backupPath, restoreUser)
+	return server.reseedMysqldumpWithSplitdump(ctx, backupPath, restoreUser)
 }
 
 func (server *ServerMonitor) restoreSplitdumpFile(path string) error {
@@ -988,10 +1000,13 @@ func (server *ServerMonitor) restoreSplitdumpFileContext(ctx context.Context, pa
 	return server.executeMysqlRestoreContext(ctx, reader)
 }
 
-func (server *ServerMonitor) JobReseedSplitdumpWithMysql(backupPath string, restoreUser bool) error {
+func (server *ServerMonitor) JobReseedSplitdumpWithMysql(ctx context.Context, backupPath string, restoreUser bool) error {
 	cluster := server.ClusterGroup
 	if cluster == nil {
 		return fmt.Errorf("cluster not available")
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
 	start := time.Now()
@@ -1006,7 +1021,7 @@ func (server *ServerMonitor) JobReseedSplitdumpWithMysql(backupPath string, rest
 		Logger: func(level, format string, args ...any) {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModBackupStream, level, format, args...)
 		},
-		Context:                context.Background(),
+		Context:                ctx,
 		RestoreFileWithContext: server.restoreSplitdumpFileContext,
 	})
 	if restoreErr != nil {
@@ -1162,7 +1177,7 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 
 		// Handle mysqldump-based reseed
 	} else if backtype == config.ConstBackupLogicalTypeMysqldump {
-		err := server.reseedMysqldumpWithMetadata(backupfile, cluster.Conf.BackupRestoreMysqlUser && source.LastBackupMeta.Logical != nil && source.LastBackupMeta.Logical.SplitUser, source.LastBackupMeta.Logical)
+		err := server.reseedMysqldumpWithMetadata(context.Background(), backupfile, cluster.Conf.BackupRestoreMysqlUser && source.LastBackupMeta.Logical != nil && source.LastBackupMeta.Logical.SplitUser, source.LastBackupMeta.Logical)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error flashback %s on %s: %s", backtype, server.URL, err.Error())
 			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -35,6 +35,7 @@ import (
 	"github.com/signal18/replication-manager/utils/backupmgr"
 	"github.com/signal18/replication-manager/utils/misc"
 	river "github.com/signal18/replication-manager/utils/river"
+	"github.com/signal18/replication-manager/utils/splitdump"
 	"github.com/signal18/replication-manager/utils/state"
 )
 
@@ -534,26 +535,44 @@ func (server *ServerMonitor) JobReseedLogicalBackup(backtype string) error {
 	useMaster := true
 	source := master
 	var dest string
+	var destCandidates []string
 	switch backtype {
 	case config.ConstBackupLogicalTypeMysqldump, "script":
 		dest = "mysqldump.sql.gz"
+		destCandidates = []string{"mysqldump.sql.gz", "splitdump"}
 	case config.ConstBackupLogicalTypeMydumper:
 		dest = "mydumper"
 	case config.ConstBackupLogicalTypeDumpling:
 		dest = "dumpling"
 	}
+	if len(destCandidates) == 0 {
+		destCandidates = []string{dest}
+	}
 
-	backupfile := master.GetMyBackupDirectory() + dest
-
+	var backupfile string
 	bckserver := cluster.GetBackupServer()
 	if bckserver != nil && bckserver.HasBackupTypeCookie(backtype) {
-		if _, err := os.Stat(bckserver.GetMyBackupDirectory() + dest); err == nil {
-			backupfile = bckserver.GetMyBackupDirectory() + dest
+		if resolved, ok := resolveLogicalBackupPathFromMeta(bckserver, backtype); ok {
+			backupfile = resolved
+			useMaster = false
+			source = bckserver
+		} else if resolved, ok := findExistingBackupPath(bckserver, destCandidates); ok {
+			backupfile = resolved
 			useMaster = false
 			source = bckserver
 		} else {
 			//Remove false cookie
 			bckserver.DelBackupTypeCookie(backtype)
+		}
+	}
+
+	if backupfile == "" {
+		if resolved, ok := resolveLogicalBackupPathFromMeta(master, backtype); ok {
+			backupfile = resolved
+		} else if resolved, ok := findExistingBackupPath(master, destCandidates); ok {
+			backupfile = resolved
+		} else {
+			backupfile = master.GetMyBackupDirectory() + dest
 		}
 	}
 
@@ -633,7 +652,7 @@ func (server *ServerMonitor) JobReseedLogicalBackup(backtype string) error {
 	server.JobsUpdateState(task, "processing", 1, 0)
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Receive reseed logical backup %s request for server: %s", backtype, server.URL)
 	if backtype == config.ConstBackupLogicalTypeMysqldump {
-		err = server.JobReseedMysqldump(backupfile, cluster.Conf.BackupRestoreMysqlUser && source.LastBackupMeta.Logical != nil && source.LastBackupMeta.Logical.SplitUser)
+		err = server.reseedMysqldumpWithMetadata(backupfile, cluster.Conf.BackupRestoreMysqlUser && source.LastBackupMeta.Logical != nil && source.LastBackupMeta.Logical.SplitUser, source.LastBackupMeta.Logical)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error reseed %s on %s: %s", backtype, server.URL, err.Error())
 			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
@@ -793,7 +812,7 @@ func (server *ServerMonitor) JobReseedLogicalBackupFromPathWithOptions(backtype,
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
 				"Using split-user override=%t for reseed logical backup from path %s on %s", splitUser, backupfile, server.URL)
 		}
-		err = server.JobReseedMysqldump(backupfile, cluster.Conf.BackupRestoreMysqlUser && splitUser)
+		err = server.reseedMysqldumpWithMetadata(backupfile, cluster.Conf.BackupRestoreMysqlUser && splitUser, master.LastBackupMeta.Logical)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error reseed %s on %s: %s", backtype, server.URL, err.Error())
 			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
@@ -844,6 +863,194 @@ func (server *ServerMonitor) JobReseedLogicalBackupFromPathWithOptions(backtype,
 	return err
 }
 
+func findExistingBackupPath(server *ServerMonitor, candidates []string) (string, bool) {
+	for _, name := range candidates {
+		path := server.GetMyBackupDirectory() + name
+		if _, err := os.Stat(path); err == nil {
+			return path, true
+		}
+	}
+	return "", false
+}
+
+func resolveLogicalBackupPathFromMeta(server *ServerMonitor, backtype string) (string, bool) {
+	if server == nil {
+		return "", false
+	}
+	server.backupMetaMutex.Lock()
+	meta := server.LastBackupMeta.Logical
+	if meta == nil || !meta.Completed || meta.IsAdhoc() {
+		server.backupMetaMutex.Unlock()
+		return "", false
+	}
+	if meta.BackupTool != "" && meta.BackupTool != backtype {
+		server.backupMetaMutex.Unlock()
+		return "", false
+	}
+	dest := strings.TrimSpace(meta.Dest)
+	server.backupMetaMutex.Unlock()
+	if dest == "" {
+		return "", false
+	}
+	if !filepath.IsAbs(dest) {
+		dest = filepath.Join(server.GetMyBackupDirectory(), dest)
+	}
+	if _, err := os.Stat(dest); err != nil {
+		return "", false
+	}
+	return dest, true
+}
+
+func isSplitDumpDir(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	if !info.IsDir() {
+		return false, nil
+	}
+	metadataPath := filepath.Join(path, "metadata")
+	if metaInfo, err := os.Stat(metadataPath); err == nil && !metaInfo.IsDir() {
+		return true, nil
+	}
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasSuffix(name, ".sql") || strings.HasSuffix(name, ".sql.gz") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (server *ServerMonitor) reseedMysqldumpWithSplitdump(backupPath string, restoreUser bool) error {
+	isSplit, err := isSplitDumpDir(backupPath)
+	if err != nil {
+		return err
+	}
+	if isSplit {
+		cluster := server.ClusterGroup
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
+			"Splitdump detected at %s; restoring with mysql client", backupPath)
+		return server.JobReseedSplitdumpWithMysql(backupPath, restoreUser)
+	}
+	return server.JobReseedMysqldump(backupPath, restoreUser)
+}
+
+func (server *ServerMonitor) reseedMysqldumpWithMetadata(backupPath string, restoreUser bool, meta *backupmgr.BackupMetadata) error {
+	if meta != nil {
+		if meta.Dest != "" {
+			pathsMatch, err := comparePaths(meta.Dest, backupPath)
+			if err != nil {
+				meta = nil
+			} else if !pathsMatch {
+				meta = nil
+			}
+		}
+	}
+	if meta != nil && (meta.SplitDump || isSplitDumpName(meta.Dest)) {
+		cluster := server.ClusterGroup
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
+			"Splitdump metadata detected for %s; restoring with mysql client", backupPath)
+		return server.JobReseedSplitdumpWithMysql(backupPath, restoreUser)
+	}
+	return server.reseedMysqldumpWithSplitdump(backupPath, restoreUser)
+}
+
+func (server *ServerMonitor) restoreSplitdumpFile(path string) error {
+	return server.restoreSplitdumpFileContext(context.Background(), path)
+}
+
+func (server *ServerMonitor) restoreSplitdumpFileContext(ctx context.Context, path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	var reader io.Reader = file
+	if strings.HasSuffix(strings.ToLower(path), ".gz") {
+		gzReader, err := gzip.NewReader(file)
+		if err != nil {
+			return err
+		}
+		defer gzReader.Close()
+		reader = gzReader
+	}
+
+	return server.executeMysqlRestoreContext(ctx, reader)
+}
+
+func (server *ServerMonitor) JobReseedSplitdumpWithMysql(backupPath string, restoreUser bool) error {
+	cluster := server.ClusterGroup
+	if cluster == nil {
+		return fmt.Errorf("cluster not available")
+	}
+
+	start := time.Now()
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+		"Logical restore (splitdump+mysql) started at %s for: %s", start.Format(time.RFC3339), server.URL)
+
+	defer server.SetInReseedBackup("")
+
+	restoreErr := splitdump.Restore(backupPath, splitdump.RestoreOptions{
+		Parallel:    cluster.Conf.BackupLogicalLoadThreads,
+		RestoreUser: restoreUser,
+		Logger: func(level, format string, args ...any) {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModBackupStream, level, format, args...)
+		},
+		Context:                context.Background(),
+		RestoreFileWithContext: server.restoreSplitdumpFileContext,
+	})
+	if restoreErr != nil {
+		return restoreErr
+	}
+
+	elapsed := time.Since(start).Round(time.Second)
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+		"Finish logical restore (splitdump+mysql) in %s (started at %s) for: %s",
+		elapsed, start.Format(time.RFC3339), server.URL)
+	server.Refresh()
+
+	return nil
+}
+
+func comparePaths(left, right string) (bool, error) {
+	// Intentionally use Abs+Clean (no EvalSymlinks) so paths can be compared
+	// even when the target does not exist yet.
+	leftAbs, err := filepath.Abs(left)
+	if err != nil {
+		return false, err
+	}
+	rightAbs, err := filepath.Abs(right)
+	if err != nil {
+		return false, err
+	}
+	return filepath.Clean(leftAbs) == filepath.Clean(rightAbs), nil
+}
+
+func isSplitDumpName(path string) bool {
+	base := filepath.Base(path)
+	if base == "splitdump" {
+		return true
+	}
+	if !strings.HasPrefix(base, "splitdump.") {
+		return false
+	}
+	suffix := strings.TrimPrefix(base, "splitdump.")
+	if suffix == "" {
+		return false
+	}
+	_, err := strconv.ParseInt(suffix, 10, 64)
+	return err == nil
+}
+
 func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 	var dest, backupfile string
 	var err error
@@ -873,25 +1080,33 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 	// Decide on backup filename depending on the backup type
 	useMaster := true
 	source := master
+	var destCandidates []string
 	switch backtype {
 	case config.ConstBackupLogicalTypeMysqldump, "script":
 		dest = "mysqldump.sql.gz"
+		destCandidates = []string{"mysqldump.sql.gz", "splitdump"}
 	case config.ConstBackupLogicalTypeMydumper:
 		dest = "mydumper"
 	case config.ConstBackupLogicalTypeDumpling:
 		dest = "dumpling"
 	}
+	if len(destCandidates) == 0 {
+		destCandidates = []string{dest}
+	}
 
 	// Skip file lookup if using custom script
 	if backtype != "script" {
 		// Construct backup path on master
-		backupfile = master.GetMyBackupDirectory() + dest
+		backupfile, _ = findExistingBackupPath(master, destCandidates)
+		if backupfile == "" {
+			backupfile = master.GetMyBackupDirectory() + dest
+		}
 
 		// If a backup server has a valid backup for this type, use it instead
 		bckserver := cluster.GetBackupServer()
 		if bckserver != nil && bckserver.HasBackupTypeCookie(backtype) {
-			if _, err := os.Stat(bckserver.GetMyBackupDirectory() + dest); err == nil {
-				backupfile = bckserver.GetMyBackupDirectory() + dest
+			if resolved, ok := findExistingBackupPath(bckserver, destCandidates); ok {
+				backupfile = resolved
 				useMaster = false
 				source = bckserver
 			} else {
@@ -946,7 +1161,7 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 
 		// Handle mysqldump-based reseed
 	} else if backtype == config.ConstBackupLogicalTypeMysqldump {
-		err := server.JobReseedMysqldump(backupfile, cluster.Conf.BackupRestoreMysqlUser && source.LastBackupMeta.Logical != nil && source.LastBackupMeta.Logical.SplitUser)
+		err := server.reseedMysqldumpWithMetadata(backupfile, cluster.Conf.BackupRestoreMysqlUser && source.LastBackupMeta.Logical != nil && source.LastBackupMeta.Logical.SplitUser, source.LastBackupMeta.Logical)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error flashback %s on %s: %s", backtype, server.URL, err.Error())
 			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
@@ -1305,7 +1520,159 @@ func (server *ServerMonitor) JobBackupScript(destination string) error {
 	return err
 }
 
-func (server *ServerMonitor) JobBackupMysqldump(filename string) error {
+// getBackupRegexPatterns returns appropriate regex patterns based on DB version
+func (server *ServerMonitor) getBackupRegexPatterns() (*regexp.Regexp, *regexp.Regexp) {
+	binlogRegex := regexp.MustCompile(`CHANGE MASTER TO MASTER_LOG_FILE='(.+)', MASTER_LOG_POS=(\d+)`)
+	gtidRegex := regexp.MustCompile(`SET GLOBAL gtid_slave_pos='(.+)'`)
+
+	if server.DBVersion.IsMySQLOrPerconaGreater84() {
+		binlogRegex = regexp.MustCompile(`CHANGE REPLICATION SOURCE TO SOURCE_LOG_FILE='(.+)', SOURCE_LOG_POS=(\d+)`)
+	}
+	if server.DBVersion.IsMySQLOrPerconaGreater57() {
+		gtidRegex = regexp.MustCompile(`GTID_PURGED\s*=\s*(?:/\*![0-9]*\s*'([^']+)'\*/\s*|'([^']+)')`)
+	}
+
+	return binlogRegex, gtidRegex
+}
+
+func (server *ServerMonitor) shouldParseDumpBinlogGTID() (bool, bool) {
+	parseBinlog := true
+	parseGTID := server.IsMariaDB() || server.DBVersion.IsMySQLOrPerconaGreater57()
+	server.backupMetaMutex.Lock()
+	meta := server.LastBackupMeta.Logical
+	hasBinlog := meta != nil && meta.BinLogFileName != ""
+	hasGTID := meta != nil && meta.BinLogGtid != ""
+	server.backupMetaMutex.Unlock()
+	if hasBinlog {
+		parseBinlog = false
+	}
+	if hasGTID {
+		parseGTID = false
+	}
+	return parseBinlog, parseGTID
+}
+
+// createGzipWriter creates a gzip writer with configurable compression
+func (cluster *Cluster) createGzipWriter(filePath string, logModule int) (*os.File, *gzip.Writer, error) {
+	f, err := os.Create(filePath)
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, logModule, config.LvlErr,
+			"Error creating file %s: %s", filePath, err.Error())
+		return nil, nil, err
+	}
+
+	compressionLevel := cluster.getSanitizedCompressionLevel(logModule)
+	gw, err := gzip.NewWriterLevel(f, compressionLevel)
+	if err != nil {
+		f.Close()
+		cluster.LogModulePrintf(cluster.Conf.Verbose, logModule, config.LvlErr,
+			"Error creating gzip writer: %s", err.Error())
+		return nil, nil, err
+	}
+
+	return f, gw, nil
+}
+
+// spawnLogCopier spawns a goroutine to copy logs from reader to cluster logs
+func (server *ServerMonitor) spawnLogCopier(wg *sync.WaitGroup, r io.Reader, module int, level string) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		server.copyLogs(r, module, level)
+	}()
+}
+
+// drainErrorChannel drains all errors from a channel and combines them
+func drainErrorChannel(errCh <-chan error) error {
+	var combinedErr error
+	for err := range errCh {
+		if err != nil {
+			combinedErr = errors.Join(combinedErr, err)
+		}
+	}
+	return combinedErr
+}
+
+type splitDumpPipeline struct {
+	teeWriter  io.Writer
+	errCh      chan error
+	pipeWriter *io.PipeWriter
+	wg         *sync.WaitGroup
+}
+
+type fallbackWriter struct {
+	primary  io.Writer
+	fallback io.Writer
+	failed   bool
+}
+
+func (w *fallbackWriter) Write(p []byte) (int, error) {
+	if w.failed {
+		return w.fallback.Write(p)
+	}
+	if w.primary == nil {
+		return w.fallback.Write(p)
+	}
+	n, err := w.primary.Write(p)
+	if err != nil {
+		w.failed = true
+		return w.fallback.Write(p)
+	}
+	return n, nil
+}
+
+// setupSplitDumpPipeline sets up the splitdump processing pipeline
+func (server *ServerMonitor) setupSplitDumpPipeline(
+	ctx context.Context,
+	outputDir string,
+	allowRotate bool,
+	cancel context.CancelFunc,
+) *splitDumpPipeline {
+	cluster := server.ClusterGroup
+
+	splitDumpReader, splitDumpWriter := io.Pipe()
+	splitDumpErrCh := make(chan error, 1)
+	var splitDumpWG sync.WaitGroup
+	splitDumpWG.Add(1)
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
+		"Splitdump enabled for mysqldump output: %s", outputDir)
+
+	// Splitdump processor goroutine
+	go func() {
+		defer splitDumpWG.Done()
+		defer close(splitDumpErrCh)
+		defer splitDumpReader.Close()
+		stdoutR, stdoutW := io.Pipe()
+		stderrR, stderrW := io.Pipe()
+
+		var logWG sync.WaitGroup
+		server.spawnLogCopier(&logWG, stdoutR, config.ConstLogModBackupStream, config.LvlDbg)
+		server.spawnLogCopier(&logWG, stderrR, config.ConstLogModBackupStream, config.LvlDbg)
+
+		err := cluster.SplitDumpWithCli(ctx, server, outputDir, allowRotate, splitDumpReader, stdoutW, stderrW)
+		stdoutW.Close()
+		stderrW.Close()
+		logWG.Wait()
+
+		if err != nil {
+			splitDumpErrCh <- err
+			cancel()
+			_ = splitDumpWriter.CloseWithError(err)
+		}
+	}()
+
+	teeWriter := splitDumpWriter
+
+	return &splitDumpPipeline{
+		teeWriter:  teeWriter,
+		errCh:      splitDumpErrCh,
+		pipeWriter: splitDumpWriter,
+		wg:         &splitDumpWG,
+	}
+}
+
+func (server *ServerMonitor) JobBackupMysqldump(filename string, allowRotate bool) error {
 	cluster := server.ClusterGroup
 	var err error
 	var bckConn *sqlx.DB
@@ -1331,154 +1698,167 @@ func (server *ServerMonitor) JobBackupMysqldump(filename string) error {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Blocking DDL via BACKUP STAGE")
 	}
 
-	binlogRegex := regexp.MustCompile(`CHANGE MASTER TO MASTER_LOG_FILE='(.+)', MASTER_LOG_POS=(\d+)`)
-	gtidRegex := regexp.MustCompile(`SET GLOBAL gtid_slave_pos='(.+)'`)
-
-	if server.DBVersion.IsMySQLOrPerconaGreater84() {
-		binlogRegex = regexp.MustCompile(`CHANGE REPLICATION SOURCE TO SOURCE_LOG_FILE='(.+)', SOURCE_LOG_POS=(\d+)`)
-	}
-	if server.DBVersion.IsMySQLOrPerconaGreater57() {
-		gtidRegex = regexp.MustCompile(`GTID_PURGED\s*=(/\*!.+\*/)?\s*'(.+)'`)
-	}
+	// Prepare regex patterns
+	binlogRegex, gtidRegex := server.getBackupRegexPatterns()
 
 	var bfile, bgtid string
 	var bpos uint64
 
-	dumpCmd := exec.Command(cluster.GetMysqlDumpPath(), cluster.GetMysqlDumpOptions(server, server.JobGetDumpGtidParameter())...)
+	dumpCtx, dumpCancel := context.WithCancel(context.Background())
+	defer dumpCancel()
+	dumpCmd := exec.CommandContext(dumpCtx, cluster.GetMysqlDumpPath(), cluster.GetMysqlDumpOptions(server, server.JobGetDumpGtidParameter())...)
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s ", strings.Replace(dumpCmd.String(), "="+cluster.GetDbPass(), "=XXXX", -1))
 	// Get the stdout pipe from the command
 	stdout, err := dumpCmd.StdoutPipe()
 	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error getting stdout pipe:", err)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error getting stdout pipe: %s", err)
 		fmt.Println()
 		return err
 	}
 
-	// dumpCmd.Stdout = gw
 	stderrIn, _ := dumpCmd.StderrPipe()
 
-	f, err := os.Create(filename)
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error mysqldump backup request: %s", err.Error())
-		return err
-	}
-	defer f.Close()
+	// Setup output writer (gzip file or splitdump)
+	var teeWriter io.Writer
+	var splitDumpPipeline *splitDumpPipeline
+	var f *os.File
+	var gw *gzip.Writer
 
-	// Use configurable compression level for better performance/size tradeoff
-	compressionLevel := cluster.getSanitizedCompressionLevel(config.ConstLogModTask)
-	gw, err := gzip.NewWriterLevel(f, compressionLevel)
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error creating gzip writer: %s", err.Error())
-		return err
-	}
-	defer func() {
-		if err := gw.Flush(); err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error flushing gzip: %s", err.Error())
+	if cluster.Conf.BackupMysqldumpSplitDump {
+		splitDumpPipeline = server.setupSplitDumpPipeline(dumpCtx, filename, allowRotate, dumpCancel)
+		teeWriter = &fallbackWriter{primary: splitDumpPipeline.teeWriter, fallback: io.Discard}
+	} else {
+		f, gw, err = cluster.createGzipWriter(filename, config.ConstLogModTask)
+		if err != nil {
+			return err
 		}
-		if err := gw.Close(); err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error closing gzip: %s", err.Error())
-		}
-	}()
+		defer func() {
+			if err := gw.Flush(); err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error flushing gzip: %s", err.Error())
+			}
+			if err := gw.Close(); err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error closing gzip: %s", err.Error())
+			}
+			f.Close()
+		}()
+		teeWriter = gw
+	}
 
-	teeReader := io.TeeReader(stdout, gw)
-
-	err = dumpCmd.Start()
-	if err != nil {
+	// Start dump command
+	if err := dumpCmd.Start(); err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error backup request: %s", err)
 		return err
 	}
 
-	// Create a buffered reader to read the duplicated stream
+	// Process stdout stream
+	teeReader := io.TeeReader(stdout, teeWriter)
 	reader := bufio.NewReader(teeReader)
-	buffer := make([]byte, cluster.Conf.SSTSendBuffer) // 64 KB buffer
+	buffer := make([]byte, cluster.Conf.SSTSendBuffer)
+	errCh := make(chan error, 4)
 
-	errCh := make(chan error, 2) // Create a channel to send errors
 	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		server.copyLogs(stderrIn, config.ConstLogModBackupStream, config.LvlDbg)
-	}()
-	go func() {
-		defer wg.Done()
+	server.spawnLogCopier(&wg, stderrIn, config.ConstLogModBackupStream, config.LvlDbg)
 
-		var remainingLine string
+	parseBinlog, parseGTID := server.shouldParseDumpBinlogGTID()
+	parser := newDumpStreamParser(
+		binlogRegex,
+		gtidRegex,
+		parseBinlog,
+		parseGTID,
+		func(file string, pos uint64) {
+			server.backupMetaMutex.Lock()
+			hasBinlog := server.LastBackupMeta.Logical != nil && server.LastBackupMeta.Logical.BinLogFileName != ""
+			server.backupMetaMutex.Unlock()
+			if hasBinlog {
+				return
+			}
+			bfile = file
+			bpos = pos
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
+				"Binlog filename:%s, pos: %s", bfile, strconv.FormatUint(bpos, 10))
+		},
+		func(gtid string) {
+			server.backupMetaMutex.Lock()
+			hasGTID := server.LastBackupMeta.Logical != nil && server.LastBackupMeta.Logical.BinLogGtid != ""
+			server.backupMetaMutex.Unlock()
+			if hasGTID {
+				return
+			}
+			bgtid = gtid
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
+				"GTID:%s", bgtid)
+		},
+	)
+
+	// Main reading goroutine
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(errCh)
+		errSent := false
 
 		for {
 			n, err := reader.Read(buffer)
 			if err != nil && err != io.EOF {
-				errCh <- fmt.Errorf("Error reading buffer: %w", err) // Send the error through the channel with more context
+				if !errSent {
+					errCh <- fmt.Errorf("Error reading buffer: %w", err)
+					errSent = true
+				}
+				break
 			}
 			if n == 0 {
 				break
 			}
-
-			// Process buffer content
-			content := remainingLine + string(buffer[:n])
-			lines := strings.Split(content, "\n")
-			remainingLine = lines[len(lines)-1] // Last element is the remaining part
-
-			for _, line := range lines[:len(lines)-1] {
-				if server.LastBackupMeta.Logical.BinLogFileName == "" {
-					if matches := binlogRegex.FindStringSubmatch(line); matches != nil {
-						bfile = matches[1]
-						bpos, _ = strconv.ParseUint(matches[2], 10, 64)
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Binlog filename:%s, pos: %s", bfile, strconv.FormatUint(bpos, 10))
-					}
-				}
-
-				if server.LastBackupMeta.Logical.BinLogGtid == "" && server.IsMariaDB() {
-					if matches := gtidRegex.FindStringSubmatch(line); matches != nil {
-						bgtid = matches[1]
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "GTID:%s", bgtid)
-					}
-				}
+			if parser.Enabled() {
+				parser.Consume(buffer[:n])
 			}
 		}
 
-		// Process any remaining line data after the loop
-		if remainingLine != "" {
-			if server.LastBackupMeta.Logical.BinLogFileName == "" {
-				if matches := binlogRegex.FindStringSubmatch(remainingLine); matches != nil {
-					bfile = matches[1]
-					bpos, _ = strconv.ParseUint(matches[2], 10, 64)
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Binlog filename:%s, pos: %s", bfile, strconv.FormatUint(bpos, 10))
-				}
-			}
+		parser.Flush()
 
-			if server.LastBackupMeta.Logical.BinLogGtid == "" && server.IsMariaDB() {
-				if matches := gtidRegex.FindStringSubmatch(remainingLine); matches != nil {
-					bgtid = matches[1]
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "GTID:%s", bgtid)
-				}
-			}
+		if splitDumpPipeline != nil {
+			_ = splitDumpPipeline.pipeWriter.Close()
 		}
 
-		err := dumpCmd.Wait()
-
-		if err != nil {
+		if err := dumpCmd.Wait(); err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "mysqldump: %s", err)
-			errCh <- fmt.Errorf("Error mysqldump: %w", err) // Send the error through the channel with more context
+			select {
+			case errCh <- fmt.Errorf("mysqldump: %w", err):
+			default:
+			}
 		}
 	}()
 
-	// Wait for goroutines to finish
 	wg.Wait()
 
-	// Check for errors
-	select {
-	case err := <-errCh:
-		// Handle the error here
-		fmt.Println("Error occurred:", err)
-	default:
-		// No errors occurred
-		fmt.Println("No errors occurred")
+	// Collect all errors
+	var splitDumpErr, readErr error
+	if splitDumpPipeline != nil {
+		splitDumpPipeline.wg.Wait()
+		splitDumpErr = drainErrorChannel(splitDumpPipeline.errCh)
+		if splitDumpErr != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Splitdump error: %s", splitDumpErr)
+		}
 	}
 
-	server.LastBackupMeta.Logical.BinLogGtid = bgtid
-	server.LastBackupMeta.Logical.BinLogFilePos = bpos
-	server.LastBackupMeta.Logical.BinLogFileName = bfile
+	readErr = drainErrorChannel(errCh)
+	combinedErr := errors.Join(splitDumpErr, readErr)
+	if combinedErr != nil {
+		return combinedErr
+	}
+
+	server.backupMetaMutex.Lock()
+	if server.LastBackupMeta.Logical != nil {
+		if server.LastBackupMeta.Logical.BinLogGtid == "" && bgtid != "" {
+			server.LastBackupMeta.Logical.BinLogGtid = bgtid
+		}
+		if server.LastBackupMeta.Logical.BinLogFileName == "" && bfile != "" {
+			server.LastBackupMeta.Logical.BinLogFileName = bfile
+			server.LastBackupMeta.Logical.BinLogFilePos = bpos
+		}
+	}
+	server.backupMetaMutex.Unlock()
 
 	return err
 }
@@ -1496,22 +1876,13 @@ func (server *ServerMonitor) JobBackupMysqldumpUser() error {
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s ", strings.Replace(dumpCmd.String(), "="+cluster.GetDbPass(), "=XXXX", -1))
 
-	f, err := os.Create(userpath)
+	f, gw, err := cluster.createGzipWriter(userpath, config.ConstLogModTask)
 	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error mysqldump user backup request: %s", err.Error())
-		return err
-	}
-
-	// Use configurable compression level for better performance/size tradeoff
-	compressionLevel := cluster.getSanitizedCompressionLevel(config.ConstLogModTask)
-	gw, err := gzip.NewWriterLevel(f, compressionLevel)
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error creating gzip writer: %s", err.Error())
 		return err
 	}
 
 	// Buffer before gzip to improve compression
-	bw := bufio.NewWriterSize(gw, 64*1024) // 64KB buffer
+	bw := bufio.NewWriterSize(gw, 64*1024)
 	defer func() {
 		if err := bw.Flush(); err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error flushing buffer: %s", err.Error())
@@ -1525,20 +1896,13 @@ func (server *ServerMonitor) JobBackupMysqldumpUser() error {
 	dumpCmd.Stdout = gw
 	stderrIn, _ := dumpCmd.StderrPipe()
 
-	err = dumpCmd.Start()
-	if err != nil {
+	if err := dumpCmd.Start(); err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error backup request: %s", err)
 		return err
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		server.copyLogs(stderrIn, config.ConstLogModBackupStream, config.LvlDbg)
-	}()
-
-	// Wait for print log to finish
+	server.spawnLogCopier(&wg, stderrIn, config.ConstLogModBackupStream, config.LvlDbg)
 	wg.Wait()
 
 	err = dumpCmd.Wait()
@@ -1650,13 +2014,16 @@ func (server *ServerMonitor) JobBackupMyDumper(outputdir string) error {
 		valid = server.myDumperCopyLogs(stderrIn, config.ConstLogModBackupStream, config.LvlDbg)
 	}()
 	wg.Wait()
-	if err = dumpCmd.Wait(); err != nil && !valid {
+	if err = dumpCmd.Wait(); err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error mydumper:  %s", err)
 		return err
 	}
+	if !valid {
+		return fmt.Errorf("mydumper reported errors in output")
+	}
 
 	if e2 := cluster.JobParseMyDumperMeta(server.LastBackupMeta.Logical); e2 != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error parsing mydumper metadata: %s", err.Error())
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error parsing mydumper metadata: %s", e2.Error())
 	}
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Success backup data via mydumper. Setting logical cookie")
@@ -1754,7 +2121,7 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(opts BackupRunOptions) 
 	backupLine := server.resolveBackupLine(opts)
 	isAdhoc := backupLine == backupmgr.BackupLineAdhoc
 	resticEnabled := server.shouldRunRestic(opts)
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Request logical backup %s (%s line) for: %s", cluster.Conf.BackupLogicalType, backupLine, server.URL)
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Request logical backup %s for: %s", cluster.Conf.BackupLogicalType, server.URL)
 	if server.IsDown() {
 		return errors.New("Can't backup when server down")
 	}
@@ -1905,22 +2272,29 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(opts BackupRunOptions) 
 		//Change to switch since we only allow one type of backup (for now)
 		switch cluster.Conf.BackupLogicalType {
 		case config.ConstBackupLogicalTypeMysqldump:
-			filename := server.GetMyBackupDirectory() + "mysqldump.sql.gz"
-			if isAdhoc {
-				filename = fmt.Sprintf("%smysqldump.%d.sql.gz", server.GetMyBackupDirectory(), start.Unix())
-			}
+			filename, outputdir, dest, compressed := server.resolveMysqldumpDest(isAdhoc, cluster.Conf.BackupMysqldumpSplitDump, start)
 			oldV, _ := cluster.GetToolsVersion("client-dump")
 			if oldV != nil {
 				server.LastBackupMeta.Logical.BackupToolVersion = oldV.ToString()
 			}
-			server.LastBackupMeta.Logical.Dest = filename
-			server.LastBackupMeta.Logical.Compressed = true
+			server.LastBackupMeta.Logical.Dest = dest
+			server.LastBackupMeta.Logical.Compressed = compressed
+			server.LastBackupMeta.Logical.SplitDump = cluster.Conf.BackupMysqldumpSplitDump
 			if cluster.Conf.BackupKeepUntilValid && !isAdhoc {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Rename previous backup to .old")
-				exec.Command("mv", filename, filename+".old").Run()
+				if cluster.Conf.BackupMysqldumpSplitDump {
+					exec.Command("mv", outputdir, outputdir+".old").Run()
+				} else {
+					exec.Command("mv", filename, filename+".old").Run()
+				}
 			}
 
-			err = server.JobBackupMysqldump(filename)
+			allowRotate := cluster.Conf.BackupKeepUntilValid && !isAdhoc
+			if cluster.Conf.BackupMysqldumpSplitDump {
+				err = server.JobBackupMysqldump(outputdir, allowRotate)
+			} else {
+				err = server.JobBackupMysqldump(filename, allowRotate)
+			}
 			if err != nil {
 				if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
@@ -1929,7 +2303,11 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(opts BackupRunOptions) 
 				if e2 := server.JobsUpdateState(task, "Backup completed", 3, 1); e2 != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
 				}
-				_, e3 := os.Stat(filename)
+				checkPath := filename
+				if cluster.Conf.BackupMysqldumpSplitDump {
+					checkPath = outputdir
+				}
+				_, e3 := os.Stat(checkPath)
 				if e3 == nil {
 					server.LastBackupMeta.Logical.EndTime = time.Now()
 					server.LastBackupMeta.Logical.GetSizeAndFileCount()

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -999,16 +999,33 @@ func (server *ServerMonitor) restoreSplitdumpFileContext(ctx context.Context, pa
 		reader = gzReader
 	}
 
-	sqlLogBin := 0
+	return server.executeMysqlRestoreContext(ctx, reader)
+}
+
+func (server *ServerMonitor) buildLogicalRestorePreamble() (string, int, error) {
 	cluster := server.ClusterGroup
-	if cluster != nil {
-		master := cluster.GetMaster()
-		if master != nil && server.URL == master.URL {
-			sqlLogBin = 1
-		}
+	if cluster == nil {
+		return "", 0, fmt.Errorf("cluster not available")
 	}
-	cmdstring := fmt.Sprintf("SET sql_log_bin=%d;SET long_query_time=10;", sqlLogBin)
-	return server.executeMysqlRestoreContext(ctx, io.MultiReader(bytes.NewBufferString(cmdstring), reader))
+
+	// Align logical restores: reset binlog state, control binlog writes, and normalize slow log behavior.
+	sqlLogBin := 0
+	resetmaster := "RESET MASTER;"
+	if server.DBVersion.IsMySQLOrPerconaGreater84() {
+		resetmaster = "RESET BINARY LOGS AND GTIDS;"
+	}
+
+	master := cluster.GetMaster()
+	if master == nil {
+		return "", 0, fmt.Errorf("No master found. Cancel backup reseeding %s", server.URL)
+	}
+	if server.URL == master.URL {
+		sqlLogBin = 1
+		resetmaster = ""
+	}
+
+	cmdstring := fmt.Sprintf("%sSET sql_log_bin=%d;SET long_query_time=10;", resetmaster, sqlLogBin)
+	return cmdstring, sqlLogBin, nil
 }
 
 func (server *ServerMonitor) JobReseedSplitdumpWithMysql(ctx context.Context, backupPath string, restoreUser bool) error {
@@ -1020,8 +1037,13 @@ func (server *ServerMonitor) JobReseedSplitdumpWithMysql(ctx context.Context, ba
 		ctx = context.Background()
 	}
 
+	cmdstring, sqlLogBin, err := server.buildLogicalRestorePreamble()
+	if err != nil {
+		return err
+	}
+
 	var meta *splitdump.Metadata
-	meta, err := splitdump.ReadMetadata(backupPath)
+	meta, err = splitdump.ReadMetadata(backupPath)
 	if err != nil {
 		switch {
 		case errors.Is(err, os.ErrNotExist):
@@ -1041,14 +1063,14 @@ func (server *ServerMonitor) JobReseedSplitdumpWithMysql(ctx context.Context, ba
 	}
 
 	start := time.Now()
-	sqlLogBin := 0
-	if master := cluster.GetMaster(); master != nil && server.URL == master.URL {
-		sqlLogBin = 1
-	}
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
 		"Logical restore (splitdump+mysql) started at %s for: %s", start.Format(time.RFC3339), server.URL)
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
 		"Splitdump restore sets sql_log_bin=%d for %s", sqlLogBin, server.URL)
+	// Apply the same preamble as mysqldump restore once before parallelized splitdump files.
+	if err := server.executeMysqlRestoreContext(ctx, bytes.NewBufferString(cmdstring)); err != nil {
+		return err
+	}
 
 	defer server.SetInReseedBackup("")
 
@@ -1393,26 +1415,10 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string, restoreUser b
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s ", strings.Replace(clientCmd.String(), "="+cluster.GetDbPass(), "=XXXX", -1))
 
-	sql_log_bin := 0
-	resetmaster := "RESET MASTER;"
-	if server.DBVersion.IsMySQLOrPerconaGreater84() {
-		resetmaster = "RESET BINARY LOGS AND GTIDS;"
+	cmdstring, _, err := server.buildLogicalRestorePreamble()
+	if err != nil {
+		return err
 	}
-
-	master := cluster.GetMaster()
-	if master == nil {
-		return fmt.Errorf("No master found. Cancel backup reseeding %s", server.URL)
-	}
-	if server.URL == master.URL {
-		sql_log_bin = 1
-		resetmaster = ""
-	}
-
-	cmdstring := "%sSET sql_log_bin=%d;SET long_query_time=10;"
-	if server.DBVersion.IsMySQLOrPerconaGreater84() {
-		cmdstring = "%sSET sql_log_bin=%d;SET long_query_time=10;"
-	}
-	cmdstring = fmt.Sprintf(cmdstring, resetmaster, sql_log_bin)
 
 	var usergzfile io.Reader
 	if restoreUser {

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -40,6 +40,8 @@ import (
 	"github.com/signal18/replication-manager/utils/state"
 )
 
+var errJobCanceledByUser = errors.New("job canceled by user")
+
 func (server *ServerMonitor) JobBackupPhysical() error {
 	return server.JobBackupPhysicalWithOptions(BackupRunOptions{})
 }
@@ -1688,7 +1690,7 @@ func (server *ServerMonitor) setupSplitDumpPipeline(
 	}
 }
 
-func (server *ServerMonitor) JobBackupMysqldump(ctx context.Context, filename string, allowRotate bool) error {
+func (server *ServerMonitor) JobBackupMysqldump(ctx context.Context, task, filename string, allowRotate bool) error {
 	cluster := server.ClusterGroup
 	var err error
 	var bckConn *sqlx.DB
@@ -1725,6 +1727,8 @@ func (server *ServerMonitor) JobBackupMysqldump(ctx context.Context, filename st
 
 	dumpCtx, dumpCancel := context.WithCancel(ctx)
 	defer dumpCancel()
+	server.registerJobCancel(task, dumpCancel)
+	defer server.clearJobCancel(task)
 	dumpCmd := exec.CommandContext(dumpCtx, cluster.GetMysqlDumpPath(), cluster.GetMysqlDumpOptions(server, server.JobGetDumpGtidParameter())...)
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Command: %s ", strings.Replace(dumpCmd.String(), "="+cluster.GetDbPass(), "=XXXX", -1))
@@ -1767,6 +1771,9 @@ func (server *ServerMonitor) JobBackupMysqldump(ctx context.Context, filename st
 	// Start dump command
 	if err := dumpCmd.Start(); err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error backup request: %s", err)
+		if errors.Is(err, context.Canceled) && server.isJobCancelRequested(task) {
+			return errors.Join(errJobCanceledByUser, err)
+		}
 		return err
 	}
 
@@ -1864,6 +1871,24 @@ func (server *ServerMonitor) JobBackupMysqldump(ctx context.Context, filename st
 	readErr = drainErrorChannel(errCh)
 	combinedErr := errors.Join(splitDumpErr, readErr)
 	if combinedErr != nil {
+		if errors.Is(combinedErr, context.Canceled) && server.isJobCancelRequested(task) {
+			if cluster.Conf.BackupKeepUntilValid {
+				if _, statErr := os.Stat(filename); statErr == nil {
+					cancelPath := filename + ".canceled"
+					if _, err := os.Stat(cancelPath); err == nil {
+						cancelPath = fmt.Sprintf("%s.%d", cancelPath, time.Now().Unix())
+					}
+					if err := os.Rename(filename, cancelPath); err != nil {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Failed to preserve canceled backup %s: %s", filename, err)
+					} else {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Preserved canceled backup at %s", cancelPath)
+					}
+				} else if !os.IsNotExist(statErr) {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Failed to inspect canceled backup %s: %s", filename, statErr)
+				}
+			}
+			return errors.Join(errJobCanceledByUser, combinedErr)
+		}
 		return combinedErr
 	}
 
@@ -2313,12 +2338,16 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(ctx context.Context, op
 
 			allowRotate := cluster.Conf.BackupKeepUntilValid && !isAdhoc
 			if cluster.Conf.BackupMysqldumpSplitDump {
-				err = server.JobBackupMysqldump(ctx, outputdir, allowRotate)
+				err = server.JobBackupMysqldump(ctx, task, outputdir, allowRotate)
 			} else {
-				err = server.JobBackupMysqldump(ctx, filename, allowRotate)
+				err = server.JobBackupMysqldump(ctx, task, filename, allowRotate)
 			}
 			if err != nil {
-				if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
+				result := err.Error()
+				if errors.Is(err, errJobCanceledByUser) {
+					result = "cancelled by user"
+				}
+				if e2 := server.JobsUpdateState(task, result, 5, 1); e2 != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
 				}
 			} else {

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -1011,6 +1011,26 @@ func (server *ServerMonitor) JobReseedSplitdumpWithMysql(ctx context.Context, ba
 		ctx = context.Background()
 	}
 
+	var meta *splitdump.Metadata
+	meta, err := splitdump.ReadMetadata(backupPath)
+	if err != nil {
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn,
+				"Splitdump metadata not found; GTID will not be applied (%s)", backupPath)
+		case errors.Is(err, splitdump.ErrMetadataInvalid):
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn,
+				"Splitdump metadata invalid; GTID will not be applied (%s): %v", backupPath, err)
+		default:
+			return err
+		}
+		meta = nil
+	} else if meta.SourceData == 0 && meta.File == "" && meta.Position == 0 {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
+			"Splitdump metadata indicates source-data=0; GTID will not be applied (%s)", backupPath)
+		meta = nil
+	}
+
 	start := time.Now()
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
 		"Logical restore (splitdump+mysql) started at %s for: %s", start.Format(time.RFC3339), server.URL)
@@ -1028,6 +1048,26 @@ func (server *ServerMonitor) JobReseedSplitdumpWithMysql(ctx context.Context, ba
 	})
 	if restoreErr != nil {
 		return restoreErr
+	}
+
+	if meta != nil && meta.GTID != "" {
+		gtidValue := strings.ReplaceAll(meta.GTID, "'", "''")
+		switch {
+		case server.IsMariaDB() && server.HaveMariaDBGTID:
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
+				"Applying splitdump GTID for MariaDB on %s", server.URL)
+			if err := server.ExecQueryNoBinLog("SET GLOBAL gtid_slave_pos='"+gtidValue+"'", time.Second); err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn,
+					"Failed to apply splitdump GTID for MariaDB on %s: %v", server.URL, err)
+			}
+		case server.HasMySQLGTID() && server.DBVersion.IsMySQLOrPerconaGreater57():
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
+				"Applying splitdump GTID for MySQL on %s", server.URL)
+			if err := server.ExecQueryNoBinLog("SET @@GLOBAL.GTID_PURGED='"+gtidValue+"'", time.Second); err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn,
+					"Failed to apply splitdump GTID for MySQL on %s: %v", server.URL, err)
+			}
+		}
 	}
 
 	elapsed := time.Since(start).Round(time.Second)

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
@@ -1603,11 +1604,11 @@ type splitDumpPipeline struct {
 type fallbackWriter struct {
 	primary  io.Writer
 	fallback io.Writer
-	failed   bool
+	failed   atomic.Bool
 }
 
 func (w *fallbackWriter) Write(p []byte) (int, error) {
-	if w.failed {
+	if w.failed.Load() {
 		return w.fallback.Write(p)
 	}
 	if w.primary == nil {
@@ -1615,7 +1616,7 @@ func (w *fallbackWriter) Write(p []byte) (int, error) {
 	}
 	n, err := w.primary.Write(p)
 	if err != nil {
-		w.failed = true
+		w.failed.Store(true)
 		return w.fallback.Write(p)
 	}
 	return n, nil
@@ -1959,7 +1960,7 @@ func (server *ServerMonitor) JobBackupMyDumper(outputdir string) error {
 	}
 
 	threads := strconv.Itoa(cluster.Conf.BackupLogicalDumpThreads)
-	myargs := strings.Split(strings.ReplaceAll(cluster.Conf.BackupMyDumperOptions, "  ", " "), " ")
+	myargs := cluster.GetMyDumperCompatibleOptions()
 
 	// Handle deprecated flags for mydumper >= 0.18.1
 	if dumper.GreaterEqual("0.18.1") {

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -1688,10 +1688,13 @@ func (server *ServerMonitor) setupSplitDumpPipeline(
 	}
 }
 
-func (server *ServerMonitor) JobBackupMysqldump(filename string, allowRotate bool) error {
+func (server *ServerMonitor) JobBackupMysqldump(ctx context.Context, filename string, allowRotate bool) error {
 	cluster := server.ClusterGroup
 	var err error
 	var bckConn *sqlx.DB
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	defer cluster.SetInLogicalBackupState(false)
 
@@ -1720,7 +1723,7 @@ func (server *ServerMonitor) JobBackupMysqldump(filename string, allowRotate boo
 	var bfile, bgtid string
 	var bpos uint64
 
-	dumpCtx, dumpCancel := context.WithCancel(context.Background())
+	dumpCtx, dumpCancel := context.WithCancel(ctx)
 	defer dumpCancel()
 	dumpCmd := exec.CommandContext(dumpCtx, cluster.GetMysqlDumpPath(), cluster.GetMysqlDumpOptions(server, server.JobGetDumpGtidParameter())...)
 
@@ -2122,15 +2125,18 @@ func (server *ServerMonitor) JobBackupRiver() error {
 	return err
 }
 
-func (server *ServerMonitor) JobBackupLogical() error {
-	return server.JobBackupLogicalWithOptions(BackupRunOptions{})
+func (server *ServerMonitor) JobBackupLogical(ctx context.Context) error {
+	return server.JobBackupLogicalWithOptions(ctx, BackupRunOptions{})
 }
 
-func (server *ServerMonitor) JobBackupLogicalWithOptions(opts BackupRunOptions) error {
+func (server *ServerMonitor) JobBackupLogicalWithOptions(ctx context.Context, opts BackupRunOptions) error {
 	var err error
 	//server can be nil as no dicovered master
 	if server == nil {
 		return errors.New("No server defined")
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
 	cluster := server.ClusterGroup
@@ -2307,9 +2313,9 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(opts BackupRunOptions) 
 
 			allowRotate := cluster.Conf.BackupKeepUntilValid && !isAdhoc
 			if cluster.Conf.BackupMysqldumpSplitDump {
-				err = server.JobBackupMysqldump(outputdir, allowRotate)
+				err = server.JobBackupMysqldump(ctx, outputdir, allowRotate)
 			} else {
-				err = server.JobBackupMysqldump(filename, allowRotate)
+				err = server.JobBackupMysqldump(ctx, filename, allowRotate)
 			}
 			if err != nil {
 				if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -999,7 +999,16 @@ func (server *ServerMonitor) restoreSplitdumpFileContext(ctx context.Context, pa
 		reader = gzReader
 	}
 
-	return server.executeMysqlRestoreContext(ctx, reader)
+	sqlLogBin := 0
+	cluster := server.ClusterGroup
+	if cluster != nil {
+		master := cluster.GetMaster()
+		if master != nil && server.URL == master.URL {
+			sqlLogBin = 1
+		}
+	}
+	cmdstring := fmt.Sprintf("SET sql_log_bin=%d;SET long_query_time=10;", sqlLogBin)
+	return server.executeMysqlRestoreContext(ctx, io.MultiReader(bytes.NewBufferString(cmdstring), reader))
 }
 
 func (server *ServerMonitor) JobReseedSplitdumpWithMysql(ctx context.Context, backupPath string, restoreUser bool) error {
@@ -1032,8 +1041,14 @@ func (server *ServerMonitor) JobReseedSplitdumpWithMysql(ctx context.Context, ba
 	}
 
 	start := time.Now()
+	sqlLogBin := 0
+	if master := cluster.GetMaster(); master != nil && server.URL == master.URL {
+		sqlLogBin = 1
+	}
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
 		"Logical restore (splitdump+mysql) started at %s for: %s", start.Format(time.RFC3339), server.URL)
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
+		"Splitdump restore sets sql_log_bin=%d for %s", sqlLogBin, server.URL)
 
 	defer server.SetInReseedBackup("")
 

--- a/cluster/srv_job_backup_splitdump_test.go
+++ b/cluster/srv_job_backup_splitdump_test.go
@@ -1,0 +1,227 @@
+package cluster
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/signal18/replication-manager/config"
+	"github.com/sirupsen/logrus"
+)
+
+func newSplitDumpTestServer(t *testing.T) (*Cluster, *ServerMonitor) {
+	cluster := &Cluster{
+		Name:   "test-cluster",
+		Conf:   &config.Config{WorkingDir: t.TempDir()},
+		Logrus: logrus.New(),
+	}
+	server := &ServerMonitor{
+		Host:         "127.0.0.1",
+		Port:         "3306",
+		URL:          "127.0.0.1:3306",
+		ClusterGroup: cluster,
+	}
+	return cluster, server
+}
+
+func writeSplitDumpCliScript(t *testing.T, cluster *Cluster, exitCode int) {
+	cliPath := filepath.Join(t.TempDir(), "replication-manager-cli")
+	script := "#!/bin/sh\nexit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(cliPath, []byte(script), 0755); err != nil {
+		t.Fatalf("failed to write cli script: %v", err)
+	}
+	if err := os.Chmod(cliPath, 0755); err != nil {
+		t.Fatalf("failed to chmod cli script: %v", err)
+	}
+	cluster.Conf.ReplicationManagerCliPath = cliPath
+}
+
+func skipSplitDumpOnWindows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script not supported on windows")
+	}
+}
+
+func prepareSplitDumpOutputDir(t *testing.T, server *ServerMonitor) string {
+	outputDir := filepath.Join(server.GetMyBackupDirectory(), "splitdump")
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		t.Fatalf("failed to create splitdump dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, "old.sql"), []byte("old"), 0644); err != nil {
+		t.Fatalf("failed to write splitdump file: %v", err)
+	}
+	return outputDir
+}
+
+func runSplitDumpWithCli(t *testing.T, cluster *Cluster, server *ServerMonitor, outputDir string, allowRotate bool) {
+	ctx := context.Background()
+	if err := cluster.SplitDumpWithCli(ctx, server, outputDir, allowRotate, strings.NewReader(""), io.Discard, io.Discard); err != nil {
+		t.Fatalf("splitdump failed: %v", err)
+	}
+}
+
+func TestSplitDumpPipelineErrorCancelsContext(t *testing.T) {
+	skipSplitDumpOnWindows(t)
+
+	cluster, server := newSplitDumpTestServer(t)
+	writeSplitDumpCliScript(t, cluster, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	outputDir := filepath.Join(server.GetMyBackupDirectory(), "splitdump")
+	pipeline := server.setupSplitDumpPipeline(ctx, outputDir, false, cancel)
+	if pipeline == nil {
+		t.Fatal("expected splitdump pipeline")
+	}
+	if pipeline.pipeWriter != nil {
+		_ = pipeline.pipeWriter.Close()
+	}
+
+	select {
+	case err, ok := <-pipeline.errCh:
+		if !ok {
+			t.Fatal("expected splitdump error, channel closed")
+		}
+		if err == nil {
+			t.Fatal("expected splitdump error, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for splitdump error")
+	}
+
+	select {
+	case <-ctx.Done():
+		// expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for context cancellation")
+	}
+}
+
+func TestSplitDumpWithCliRemovesDirWhenRotationDisabled(t *testing.T) {
+	skipSplitDumpOnWindows(t)
+
+	cluster, server := newSplitDumpTestServer(t)
+	writeSplitDumpCliScript(t, cluster, 0)
+
+	outputDir := prepareSplitDumpOutputDir(t, server)
+	runSplitDumpWithCli(t, cluster, server, outputDir, false)
+
+	entries, err := os.ReadDir(outputDir)
+	if err != nil {
+		t.Fatalf("failed to read splitdump dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected empty splitdump dir after removal, got %d entries", len(entries))
+	}
+
+	rotated, err := filepath.Glob(outputDir + ".old.*")
+	if err != nil {
+		t.Fatalf("failed to glob rotated dirs: %v", err)
+	}
+	if len(rotated) != 0 {
+		t.Fatalf("expected no rotated dir, got %v", rotated)
+	}
+}
+
+func TestSplitDumpWithCliRotatesDirWhenEnabled(t *testing.T) {
+	skipSplitDumpOnWindows(t)
+
+	cluster, server := newSplitDumpTestServer(t)
+	writeSplitDumpCliScript(t, cluster, 0)
+
+	outputDir := prepareSplitDumpOutputDir(t, server)
+	runSplitDumpWithCli(t, cluster, server, outputDir, true)
+
+	rotated, err := filepath.Glob(outputDir + ".old.*")
+	if err != nil {
+		t.Fatalf("failed to glob rotated dirs: %v", err)
+	}
+	if len(rotated) == 0 {
+		t.Fatalf("expected rotated dir, got none")
+	}
+	oldFile := filepath.Join(rotated[0], "old.sql")
+	if _, err := os.Stat(oldFile); err != nil {
+		t.Fatalf("expected old file in rotated dir: %v", err)
+	}
+
+	entries, err := os.ReadDir(outputDir)
+	if err != nil {
+		t.Fatalf("failed to read splitdump dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected empty splitdump dir after rotation, got %d entries", len(entries))
+	}
+}
+
+func TestIsSplitDumpName(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{name: "splitdump", want: true},
+		{name: "splitdump.1700000000", want: true},
+		{name: "mysqldump.sql.gz", want: false},
+		{name: "splitdump.bad", want: false},
+		{name: "", want: false},
+	}
+
+	for _, tc := range cases {
+		if got := isSplitDumpName(tc.name); got != tc.want {
+			t.Fatalf("isSplitDumpName(%q) = %t, want %t", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestIsSplitDumpDir(t *testing.T) {
+	base := t.TempDir()
+
+	missingPath := filepath.Join(base, "missing")
+	if _, err := isSplitDumpDir(missingPath); err == nil {
+		t.Fatal("expected error for missing path")
+	}
+
+	filePath := filepath.Join(base, "file")
+	if err := os.WriteFile(filePath, []byte("x"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	if ok, err := isSplitDumpDir(filePath); err != nil || ok {
+		t.Fatalf("expected file path to be false, err=%v", err)
+	}
+
+	metadataDir := filepath.Join(base, "with-metadata")
+	if err := os.MkdirAll(metadataDir, 0755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(metadataDir, "metadata"), []byte("meta"), 0644); err != nil {
+		t.Fatalf("failed to write metadata: %v", err)
+	}
+	if ok, err := isSplitDumpDir(metadataDir); err != nil || !ok {
+		t.Fatalf("expected metadata dir to be true, err=%v", err)
+	}
+
+	dataDir := filepath.Join(base, "with-data")
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "db.table.00000.sql.gz"), []byte("data"), 0644); err != nil {
+		t.Fatalf("failed to write data file: %v", err)
+	}
+	if ok, err := isSplitDumpDir(dataDir); err != nil || !ok {
+		t.Fatalf("expected data dir to be true, err=%v", err)
+	}
+
+	emptyDir := filepath.Join(base, "empty")
+	if err := os.MkdirAll(emptyDir, 0755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+	if ok, err := isSplitDumpDir(emptyDir); err != nil || ok {
+		t.Fatalf("expected empty dir to be false, err=%v", err)
+	}
+}

--- a/cluster/srv_job_restic.go
+++ b/cluster/srv_job_restic.go
@@ -1426,7 +1426,7 @@ func (server *ServerMonitor) reseedFromResticRestore(ctx context.Context, snapsh
 				"Using restic metadata split-user=%t for snapshot %s",
 				splitUser, logSnapshotID)
 		}
-		return server.JobReseedLogicalBackupFromPathWithOptions(paths.BackupType, paths.TargetPaths[0], logicalOpts)
+		return server.JobReseedLogicalBackupFromPathWithOptions(ctx, paths.BackupType, paths.TargetPaths[0], logicalOpts)
 	case "physical":
 		payload := map[string]string{
 			"restic_snapshot_id": snapshotID,
@@ -2225,7 +2225,7 @@ func (server *ServerMonitor) reseedFromResticMount(ctx context.Context, snapshot
 
 	switch normalizedMethod {
 	case "logical":
-		return server.JobReseedLogicalBackupFromPath(paths.BackupType, paths.TargetPaths[0])
+		return server.JobReseedLogicalBackupFromPath(ctx, paths.BackupType, paths.TargetPaths[0])
 	case "physical":
 		task := "reseed" + paths.BackupType
 		if summary := getSnapshotMetadataForMethod(cluster, snapshotID, method, nil); summary != nil {

--- a/cluster/srv_job_restic.go
+++ b/cluster/srv_job_restic.go
@@ -1672,6 +1672,10 @@ func (server *ServerMonitor) reseedFromResticDump(ctx context.Context, snapshotI
 }
 
 func (server *ServerMonitor) executeMysqlRestore(reader io.Reader) error {
+	return server.executeMysqlRestoreContext(context.Background(), reader)
+}
+
+func (server *ServerMonitor) executeMysqlRestoreContext(ctx context.Context, reader io.Reader) error {
 	if reader == nil {
 		return fmt.Errorf("mysql restore reader is nil")
 	}
@@ -1679,6 +1683,10 @@ func (server *ServerMonitor) executeMysqlRestore(reader io.Reader) error {
 	cluster := server.ClusterGroup
 	if cluster == nil {
 		return fmt.Errorf("cluster not available")
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
 	mysqlPath := cluster.GetMysqlclientPath()
@@ -1695,7 +1703,7 @@ func (server *ServerMonitor) executeMysqlRestore(reader io.Reader) error {
 
 	cliParams := append(cluster.GetDumpCredentials(server), server.GetSSLClientParam("client")...)
 	cliParams = append(cliParams, strings.Split(cluster.Conf.BackupMysqlclientOptions, " ")...)
-	cmd := exec.Command(cluster.GetMysqlclientPath(), misc.RemoveEmptyString(cliParams)...)
+	cmd := exec.CommandContext(ctx, cluster.GetMysqlclientPath(), misc.RemoveEmptyString(cliParams)...)
 	cmd.Stdin = reader
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/cluster/srv_job_test.go
+++ b/cluster/srv_job_test.go
@@ -1,0 +1,126 @@
+package cluster
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/backupmgr"
+)
+
+func TestDumpStreamParserExtractsBinlogAndGTID(t *testing.T) {
+	binlogRegex := regexp.MustCompile(`CHANGE MASTER TO MASTER_LOG_FILE='(.+)', MASTER_LOG_POS=(\d+)`)
+	gtidRegex := regexp.MustCompile(`SET GLOBAL gtid_slave_pos='(.+)'`)
+
+	var gotFile string
+	var gotPos uint64
+	var gotGTID string
+
+	parser := newDumpStreamParser(
+		binlogRegex,
+		gtidRegex,
+		true,
+		true,
+		func(file string, pos uint64) {
+			gotFile = file
+			gotPos = pos
+		},
+		func(gtid string) {
+			gotGTID = gtid
+		},
+	)
+
+	chunks := [][]byte{
+		[]byte("header line\nCHANGE MASTER TO MASTER_LOG_FILE='mysql-bin.000123', MASTER_LOG_POS=45"),
+		[]byte("6\nother line\nSET GLOBAL gtid_slave_pos='0-1-2'\ntrailer"),
+	}
+
+	for _, chunk := range chunks {
+		parser.Consume(chunk)
+	}
+	parser.Flush()
+
+	if gotFile != "mysql-bin.000123" {
+		t.Fatalf("binlog file = %q, want %q", gotFile, "mysql-bin.000123")
+	}
+	if gotPos != 456 {
+		t.Fatalf("binlog pos = %d, want %d", gotPos, 456)
+	}
+	if gotGTID != "0-1-2" {
+		t.Fatalf("gtid = %q, want %q", gotGTID, "0-1-2")
+	}
+	if parser.Enabled() {
+		t.Fatalf("parser should be disabled after extraction")
+	}
+}
+
+func TestDumpStreamParserExtractsMySQL8(t *testing.T) {
+	binlogRegex := regexp.MustCompile(`CHANGE REPLICATION SOURCE TO SOURCE_LOG_FILE='(.+)', SOURCE_LOG_POS=(\d+)`)
+	gtidRegex := regexp.MustCompile(`GTID_PURGED\s*=\s*(?:/\*![0-9]*\s*'([^']+)'\*/\s*|'([^']+)')`)
+
+	var gotFile string
+	var gotPos uint64
+	var gotGTID string
+
+	parser := newDumpStreamParser(
+		binlogRegex,
+		gtidRegex,
+		true,
+		true,
+		func(file string, pos uint64) {
+			gotFile = file
+			gotPos = pos
+		},
+		func(gtid string) {
+			gotGTID = gtid
+		},
+	)
+
+	chunks := [][]byte{
+		[]byte("header\nCHANGE REPLICATION SOURCE TO SOURCE_LOG_FILE='mysql-bin.000777', SOURCE_LOG_POS=9"),
+		[]byte("87\nSET @@GLOBAL.GTID_PURGED=/*!80000 '3E11FA47-71CA-11E1-9E33-C80AA9429562:1-19'*/;\n"),
+	}
+
+	for _, chunk := range chunks {
+		parser.Consume(chunk)
+	}
+	parser.Flush()
+
+	if gotFile != "mysql-bin.000777" {
+		t.Fatalf("binlog file = %q, want %q", gotFile, "mysql-bin.000777")
+	}
+	if gotPos != 987 {
+		t.Fatalf("binlog pos = %d, want %d", gotPos, 987)
+	}
+	want := "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-19"
+	if gotGTID != want {
+		t.Fatalf("gtid = %q, want %q", gotGTID, want)
+	}
+	if parser.Enabled() {
+		t.Fatalf("parser should be disabled after extraction")
+	}
+}
+
+func TestShouldParseDumpBinlogGTIDRespectsExistingMetadata(t *testing.T) {
+	cluster := &Cluster{
+		Name: "test-cluster",
+		Conf: &config.Config{WorkingDir: t.TempDir()},
+	}
+	server := &ServerMonitor{
+		Host:         "127.0.0.1",
+		Port:         "3306",
+		ClusterGroup: cluster,
+	}
+	server.LastBackupMeta.Logical = &backupmgr.BackupMetadata{
+		BinLogFileName: "mysql-bin.000001",
+		BinLogGtid:     "0-1-2",
+	}
+
+	parseBinlog, parseGTID := server.shouldParseDumpBinlogGTID()
+	if parseBinlog {
+		t.Fatalf("expected parseBinlog to be false when binlog file already set")
+	}
+	if parseGTID {
+		t.Fatalf("expected parseGTID to be false when GTID already set")
+	}
+}

--- a/cluster/srv_rejoin.go
+++ b/cluster/srv_rejoin.go
@@ -11,6 +11,7 @@
 package cluster
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -219,7 +220,7 @@ func (server *ServerMonitor) ReseedMasterSST() error {
 		if cluster.Conf.BackupLoadScript != "" {
 			server.JobReseedBackupScript()
 		} else if cluster.Conf.AutorejoinLogicalBackup {
-			err := server.JobReseedLogicalBackup("default")
+			err := server.JobReseedLogicalBackup(context.Background(), "default")
 			if err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "Reseed logical for rejoin on %s failed: %s", server.URL, err)
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -815,8 +815,10 @@ type Config struct {
 	BackupMysqlbinlogPath                  string                 `mapstructure:"backup-mysqlbinlog-path" toml:"backup-mysqlbinlog-path" json:"backupMysqlbinlogPath"`
 	BackupMysqlclientPath                  string                 `mapstructure:"backup-mysqlclient-path" toml:"backup-mysqlclient-path" json:"backupMysqlclientPath"`
 	BackupMysqlclientOptions               string                 `mapstructure:"backup-mysqlclient-options" toml:"backup-mysqlclient-options" json:"backupMysqlclientOptions"`
+	BackupMysqldumpSplitDump               bool                   `mapstructure:"backup-mysqldump-splitdump" toml:"backup-mysqldump-splitdump" json:"backupMysqldumpSplitDump"`
 	BackupMytopPath                        string                 `mapstructure:"backup-mytop-path" toml:"backup-mytop-path" json:"backupMytopPath"`
 	BackupGottyClientPath                  string                 `mapstructure:"backup-gotty-client-path" toml:"backup-gotty-client-path" json:"backupGottyClientPath"`
+	ReplicationManagerCliPath              string                 `mapstructure:"replication-manager-cli-path" toml:"replication-manager-cli-path" json:"replicationManagerCliPath"`
 	BackupBinlogs                          bool                   `mapstructure:"backup-binlogs" toml:"backup-binlogs" json:"backupBinlogs"`
 	BackupBinlogsKeep                      int                    `mapstructure:"backup-binlogs-keep" toml:"backup-binlogs-keep" json:"backupBinlogsKeep"`
 	BackupLockDDL                          bool                   `mapstructure:"backup-lockddl" toml:"backup-lockddl" json:"backupLockDDL"`

--- a/regtest/test_restic_reseed_dump.go
+++ b/regtest/test_restic_reseed_dump.go
@@ -6,6 +6,7 @@
 package regtest
 
 import (
+	"context"
 	"time"
 
 	clusterpkg "github.com/signal18/replication-manager/cluster"
@@ -56,7 +57,7 @@ func (regtest *RegTest) TestResticReseedDump(cl *clusterpkg.Cluster, conf string
 	}
 
 	cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST", "Trigger logical backup to restic")
-	if err := master.JobBackupLogical(); err != nil {
+	if err := master.JobBackupLogical(context.Background()); err != nil {
 		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "JobBackupLogical failed: %s", err)
 		return false
 	}

--- a/regtest/test_restic_reseed_fallback.go
+++ b/regtest/test_restic_reseed_fallback.go
@@ -6,6 +6,7 @@
 package regtest
 
 import (
+	"context"
 	"time"
 
 	clusterpkg "github.com/signal18/replication-manager/cluster"
@@ -56,7 +57,7 @@ func (regtest *RegTest) TestResticReseedFallback(cl *clusterpkg.Cluster, conf st
 	}
 
 	cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST", "Trigger logical backup to restic")
-	if err := master.JobBackupLogical(); err != nil {
+	if err := master.JobBackupLogical(context.Background()); err != nil {
 		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "JobBackupLogical failed: %s", err)
 		return false
 	}

--- a/regtest/test_restic_reseed_mount.go
+++ b/regtest/test_restic_reseed_mount.go
@@ -6,6 +6,7 @@
 package regtest
 
 import (
+	"context"
 	"time"
 
 	clusterpkg "github.com/signal18/replication-manager/cluster"
@@ -60,7 +61,7 @@ func (regtest *RegTest) TestResticReseedMount(cl *clusterpkg.Cluster, conf strin
 	}
 
 	cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST", "Trigger logical backup to restic")
-	if err := master.JobBackupLogical(); err != nil {
+	if err := master.JobBackupLogical(context.Background()); err != nil {
 		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "JobBackupLogical failed: %s", err)
 		return false
 	}

--- a/regtest/test_restic_reseed_mydumper.go
+++ b/regtest/test_restic_reseed_mydumper.go
@@ -6,6 +6,7 @@
 package regtest
 
 import (
+	"context"
 	"time"
 
 	clusterpkg "github.com/signal18/replication-manager/cluster"
@@ -80,7 +81,7 @@ func (regtest *RegTest) TestResticReseedMydumper(cl *clusterpkg.Cluster, conf st
 	cl.Conf.CompressBackups = true
 
 	cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST", "Trigger compressed mydumper backup to restic")
-	if err := master.JobBackupLogical(); err != nil {
+	if err := master.JobBackupLogical(context.Background()); err != nil {
 		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "JobBackupLogical failed: %s", err)
 		return false
 	}
@@ -124,7 +125,7 @@ func (regtest *RegTest) TestResticReseedMydumper(cl *clusterpkg.Cluster, conf st
 	cl.Conf.CompressBackups = false
 
 	cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST", "Trigger uncompressed mydumper backup to restic")
-	if err := master.JobBackupLogical(); err != nil {
+	if err := master.JobBackupLogical(context.Background()); err != nil {
 		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "JobBackupLogical failed: %s", err)
 		return false
 	}

--- a/regtest/test_restic_reseed_mysqldump.go
+++ b/regtest/test_restic_reseed_mysqldump.go
@@ -6,6 +6,7 @@
 package regtest
 
 import (
+	"context"
 	"time"
 
 	clusterpkg "github.com/signal18/replication-manager/cluster"
@@ -76,7 +77,7 @@ func (regtest *RegTest) TestResticReseedMysqldump(cl *clusterpkg.Cluster, conf s
 	cl.Conf.CompressBackups = true
 
 	cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST", "Trigger compressed mysqldump backup to restic")
-	if err := master.JobBackupLogical(); err != nil {
+	if err := master.JobBackupLogical(context.Background()); err != nil {
 		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "JobBackupLogical failed: %s", err)
 		return false
 	}
@@ -120,7 +121,7 @@ func (regtest *RegTest) TestResticReseedMysqldump(cl *clusterpkg.Cluster, conf s
 	cl.Conf.CompressBackups = false
 
 	cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST", "Trigger uncompressed mysqldump backup to restic")
-	if err := master.JobBackupLogical(); err != nil {
+	if err := master.JobBackupLogical(context.Background()); err != nil {
 		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "JobBackupLogical failed: %s", err)
 		return false
 	}

--- a/regtest/test_restic_reseed_restore.go
+++ b/regtest/test_restic_reseed_restore.go
@@ -6,6 +6,7 @@
 package regtest
 
 import (
+	"context"
 	"time"
 
 	clusterpkg "github.com/signal18/replication-manager/cluster"
@@ -53,7 +54,7 @@ func (regtest *RegTest) TestResticReseedRestore(cl *clusterpkg.Cluster, conf str
 	}
 
 	cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST", "Trigger logical backup to restic")
-	if err := master.JobBackupLogical(); err != nil {
+	if err := master.JobBackupLogical(context.Background()); err != nil {
 		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "JobBackupLogical failed: %s", err)
 		return false
 	}

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -4350,7 +4350,7 @@ func (repman *ReplicationManager) setRepmanSetting(name string, value string) er
 			return err
 		}
 		repman.Conf.BackupMyDumperPath = storeValue
-	case "backup-myloader-path ":
+	case "backup-myloader-path":
 		_, storeValue, err := resolveExecutablePath(value, "backup-myloader-path")
 		if err != nil {
 			return err

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -7,6 +7,7 @@
 package server
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
@@ -7816,7 +7817,7 @@ func (repman *ReplicationManager) handlerMuxReseedFromParent(w http.ResponseWrit
 					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Reseed from parent cluster %s done", pcluster.Name)
 					// Refresh staging is done. Now we can start the backup
 					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Starting backup for cluster %s", mycluster.Name)
-					go cmaster.JobBackupLogical()
+					go cmaster.JobBackupLogical(context.Background())
 				} else {
 					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Refresh standalone failed: %s", err)
 				}

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -15,6 +15,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -2452,6 +2454,8 @@ func (repman *ReplicationManager) switchClusterSettings(mycluster *cluster.Clust
 		mycluster.Conf.BackupSplitMysqlUser = !mycluster.Conf.BackupSplitMysqlUser
 	case "backup-restore-mysql-user":
 		mycluster.Conf.BackupRestoreMysqlUser = !mycluster.Conf.BackupRestoreMysqlUser
+	case "backup-mysqldump-splitdump":
+		mycluster.Conf.BackupMysqldumpSplitDump = !mycluster.Conf.BackupMysqldumpSplitDump
 	case "backup-check-free-space":
 		mycluster.Conf.BackupCheckFreeSpace = !mycluster.Conf.BackupCheckFreeSpace
 	case "backup-estimate-size":
@@ -2837,6 +2841,37 @@ func validateResticSizeValue(value, setting string) error {
 		return fmt.Errorf("invalid value for %s: %q", setting, value)
 	}
 	return nil
+}
+
+func resolveExecutablePath(value, setting string) (string, string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", "", nil
+	}
+	resolved := trimmed
+	storeValue := trimmed
+	if strings.ContainsRune(trimmed, filepath.Separator) {
+		abs, err := filepath.Abs(trimmed)
+		if err != nil {
+			return "", "", fmt.Errorf("%s is invalid: %w", setting, err)
+		}
+		resolved = abs
+		storeValue = abs
+	} else {
+		path, err := exec.LookPath(trimmed)
+		if err != nil {
+			return "", "", fmt.Errorf("%s not found in PATH: %s", setting, trimmed)
+		}
+		resolved = path
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", "", fmt.Errorf("%s not found at %s: %w", setting, resolved, err)
+	}
+	if info.Mode().Perm()&0111 == 0 {
+		return "", "", fmt.Errorf("%s is not executable: %s", setting, resolved)
+	}
+	return resolved, storeValue, nil
 }
 
 func GetApiChangeLogFormat(name, value string) (string, []interface{}) {
@@ -3548,6 +3583,12 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 			return errors.New("unable to decode")
 		}
 		mycluster.Conf.BackupMysqlclientOptions = string(val)
+	case "replication-manager-cli-path":
+		_, storeValue, err := resolveExecutablePath(value, "replication-manager-cli-path")
+		if err != nil {
+			return err
+		}
+		mycluster.Conf.ReplicationManagerCliPath = storeValue
 	case "backup-logical-post-script":
 		val, err := base64.StdEncoding.DecodeString(value)
 		if err != nil {
@@ -3859,6 +3900,8 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		mycluster.Conf.BackupSplitMysqlUser = applyIsActive(mycluster.Conf.BackupSplitMysqlUser, isactive)
 	case "backup-restore-mysql-user":
 		mycluster.Conf.BackupRestoreMysqlUser = applyIsActive(mycluster.Conf.BackupRestoreMysqlUser, isactive)
+	case "backup-mysqldump-splitdump":
+		mycluster.Conf.BackupMysqldumpSplitDump = applyIsActive(mycluster.Conf.BackupMysqldumpSplitDump, isactive)
 	case "backup-check-free-space":
 		mycluster.Conf.BackupCheckFreeSpace = applyIsActive(mycluster.Conf.BackupCheckFreeSpace, isactive)
 	case "backup-estimate-size":
@@ -4295,23 +4338,59 @@ func (repman *ReplicationManager) setRepmanSetting(name string, value string) er
 	case "prov-service-plan":
 		repman.Conf.ProvServicePlan = value
 	case "sysbench-binary-path":
-		repman.Conf.SysbenchBinaryPath = value
+		_, storeValue, err := resolveExecutablePath(value, "sysbench-binary-path")
+		if err != nil {
+			return err
+		}
+		repman.Conf.SysbenchBinaryPath = storeValue
 	case "backup-mydumper-path":
-		repman.Conf.BackupMyDumperPath = value
+		_, storeValue, err := resolveExecutablePath(value, "backup-mydumper-path")
+		if err != nil {
+			return err
+		}
+		repman.Conf.BackupMyDumperPath = storeValue
 	case "backup-myloader-path ":
-		repman.Conf.BackupMyLoaderPath = value
+		_, storeValue, err := resolveExecutablePath(value, "backup-myloader-path")
+		if err != nil {
+			return err
+		}
+		repman.Conf.BackupMyLoaderPath = storeValue
 	case "backup-mysqlbinlog-path":
-		repman.Conf.BackupMysqlbinlogPath = value
+		_, storeValue, err := resolveExecutablePath(value, "backup-mysqlbinlog-path")
+		if err != nil {
+			return err
+		}
+		repman.Conf.BackupMysqlbinlogPath = storeValue
 	case "backup-mysqlclient-path":
-		repman.Conf.BackupMysqlclientPath = value
+		_, storeValue, err := resolveExecutablePath(value, "backup-mysqlclient-path")
+		if err != nil {
+			return err
+		}
+		repman.Conf.BackupMysqlclientPath = storeValue
 	case "backup-mysqldump-path":
-		repman.Conf.BackupMysqldumpPath = value
+		_, storeValue, err := resolveExecutablePath(value, "backup-mysqldump-path")
+		if err != nil {
+			return err
+		}
+		repman.Conf.BackupMysqldumpPath = storeValue
 	case "backup-restic-binary-path":
-		repman.Conf.BackupResticBinaryPath = value
+		_, storeValue, err := resolveExecutablePath(value, "backup-restic-binary-path")
+		if err != nil {
+			return err
+		}
+		repman.Conf.BackupResticBinaryPath = storeValue
 	case "haproxy-binary-path":
-		repman.Conf.HaproxyBinaryPath = value
+		_, storeValue, err := resolveExecutablePath(value, "haproxy-binary-path")
+		if err != nil {
+			return err
+		}
+		repman.Conf.HaproxyBinaryPath = storeValue
 	case "maxscale-binary-path":
-		repman.Conf.MxsBinaryPath = value
+		_, storeValue, err := resolveExecutablePath(value, "maxscale-binary-path")
+		if err != nil {
+			return err
+		}
+		repman.Conf.MxsBinaryPath = storeValue
 	case "log-file-level", "log-level-file":
 		val, _ := strconv.Atoi(value)
 		repman.Conf.LogFileLevel = val

--- a/server/api_database.go
+++ b/server/api_database.go
@@ -7,6 +7,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1182,7 +1183,7 @@ func (repman *ReplicationManager) handlerMuxServerBackupLogical(w http.ResponseW
 		}
 		node := mycluster.GetServerFromName(vars["serverName"])
 		if node != nil {
-			go node.JobBackupLogical()
+			go node.JobBackupLogical(context.Background())
 		} else {
 			http.Error(w, "Server Not Found", 500)
 			return

--- a/server/api_database.go
+++ b/server/api_database.go
@@ -1252,7 +1252,7 @@ func (repman *ReplicationManager) handlerMuxServerReseed(w http.ResponseWriter, 
 		node := mycluster.GetServerFromName(vars["serverName"])
 		if node != nil {
 			if vars["backupMethod"] == "logicalbackup" {
-				err := node.JobReseedLogicalBackup("default")
+				err := node.JobReseedLogicalBackup(r.Context(), "default")
 				if err != nil {
 					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR", "logical reseed restore failed %s", err)
 					http.Error(w, "Error reseed logical backup", 500)

--- a/server/server.go
+++ b/server/server.go
@@ -893,8 +893,10 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.BackupMysqlbinlogPath, "backup-mysqlbinlog-path", "", "Path to mysqlbinlog binary")
 	flags.StringVar(&conf.BackupMysqlclientPath, "backup-mysqlclient-path", "", "Path to mysql client binary")
 	flags.StringVar(&conf.BackupMysqlclientOptions, "backup-mysqlclient-options", "--force --batch", "Extra options")
+	flags.BoolVar(&conf.BackupMysqldumpSplitDump, "backup-mysqldump-splitdump", false, "Split mysqldump output using splitdump")
 	flags.StringVar(&conf.BackupMytopPath, "backup-mytop-path", "", "Path to mytop binary")
 	flags.StringVar(&conf.BackupGottyClientPath, "backup-gotty-client-path", "", "Path to gotty client binary")
+	flags.StringVar(&conf.ReplicationManagerCliPath, "replication-manager-cli-path", "", "Path to replication-manager-cli binary")
 	flags.BoolVar(&conf.BackupRestoreVersionStrict, "backup-restore-version-strict", false, "During restore, check backup version against tools version. False will just issue a warning. True will abort restore")
 
 	flags.BoolVar(&conf.BackupBinlogs, "backup-binlogs", false, "Archive binlogs")

--- a/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
@@ -86,6 +86,13 @@ The script will be executed with the following parameters:
 4. Backup Path
 `
 
+  const SplitDumpRequirement = `Splitdump sends mysqldump output through replication-manager-cli splitdump.  
+When enabled, mysqldump output is written to a splitdump directory (uncompressed) instead of a single .sql.gz file.  
+Ensure the CLI is available in PATH or set a custom CLI path below.`
+
+  const ReplicationManagerCliRequirement = `Path to replication-manager-cli used for splitdump processing.  
+Leave empty to use PATH lookup (replication-manager-cli).`
+
   const openCommonModal = () => {
     setIsCommonModalOpen(true)
   }
@@ -286,6 +293,60 @@ The script will be executed with the following parameters:
                 clusterName: selectedCluster?.name,
                 setting: 'backup-mysqldump-options',
                 value: btoa(value)
+              })
+            )
+          }
+        />
+      )
+    },
+    {
+      key: (
+        <HStack spacing={2}>
+          <Text>Mysqldump splitdump output</Text>
+          <RMIconButton
+            icon={HiQuestionMarkCircle}
+            onClick={() => openInfoModal('Mysqldump splitdump', SplitDumpRequirement)}
+          />
+        </HStack>
+      ),
+      value: (
+        <RMSwitch
+          isChecked={selectedCluster?.config?.backupMysqldumpSplitDump}
+          isDisabled={user?.grants['cluster-settings'] == false}
+          confirmTitle={'Confirm switch settings for backup-mysqldump-splitdump?'}
+          onChange={() =>
+            dispatch(
+              switchSetting({
+                clusterName: selectedCluster?.name,
+                setting: 'backup-mysqldump-splitdump'
+              })
+            )
+          }
+        />
+      )
+    },
+    {
+      key: (
+        <HStack spacing={2}>
+          <Text>Replication Manager CLI path</Text>
+          <RMIconButton
+            icon={HiQuestionMarkCircle}
+            onClick={() => openInfoModal('Replication Manager CLI path', ReplicationManagerCliRequirement)}
+          />
+        </HStack>
+      ),
+      value: (
+        <TextForm
+          value={selectedCluster?.config?.replicationManagerCliPath}
+          confirmTitle={`Confirm replication-manager-cli-path to `}
+          maxLength={1024}
+          className={styles.textbox}
+          onSave={(value) =>
+            dispatch(
+              setSetting({
+                clusterName: selectedCluster?.name,
+                setting: 'replication-manager-cli-path',
+                value: value
               })
             )
           }

--- a/utils/backupmgr/backup.go
+++ b/utils/backupmgr/backup.go
@@ -56,6 +56,7 @@ type BackupMetadata struct {
 	BinLogGtid        string         `json:"binLogUuid"`
 	Completed         bool           `json:"completed"`
 	SplitUser         bool           `json:"splitUser"`
+	SplitDump         bool           `json:"splitDump"`
 	Previous          int64          `json:"previous"`
 	ResticEnabled     bool           `json:"resticEnabled,omitempty"`
 	ResticSnapshotID  string         `json:"resticSnapshotID"`

--- a/utils/splitdump/restore.go
+++ b/utils/splitdump/restore.go
@@ -1,0 +1,342 @@
+package splitdump
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	LogError = "ERROR"
+	LogWarn  = "WARN"
+	LogInfo  = "INFO"
+	LogDebug = "DEBUG"
+)
+
+var ErrMetadataInvalid = errors.New("splitdump metadata invalid")
+
+type Metadata struct {
+	File     string
+	Position uint64
+	GTID     string
+}
+
+type RestoreOptions struct {
+	Parallel               int
+	RestoreUser            bool
+	StrictMetadata         bool
+	Logger                 func(level, format string, args ...any)
+	RestoreFile            func(path string) error
+	Context                context.Context
+	RestoreFileWithContext func(ctx context.Context, path string) error
+}
+
+type FileSet struct {
+	Schema []string
+	Data   []string
+}
+
+type dataGroup struct {
+	key   string
+	paths []string
+}
+
+func ReadMetadata(backupPath string) (*Metadata, error) {
+	metadataPath := filepath.Join(backupPath, "metadata")
+	data, err := os.ReadFile(metadataPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read splitdump metadata: %w", err)
+	}
+	meta := &Metadata{}
+	positionSet := false
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "[") {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "File ="):
+			meta.File = strings.TrimSpace(strings.TrimPrefix(line, "File ="))
+		case strings.HasPrefix(line, "Position ="):
+			posStr := strings.TrimSpace(strings.TrimPrefix(line, "Position ="))
+			if posStr == "" {
+				return nil, fmt.Errorf("%w: missing position", ErrMetadataInvalid)
+			}
+			pos, err := strconv.ParseUint(posStr, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("%w: invalid position %q: %v", ErrMetadataInvalid, posStr, err)
+			}
+			meta.Position = pos
+			positionSet = true
+		case strings.HasPrefix(line, "Executed_Gtid_Set ="):
+			meta.GTID = strings.TrimSpace(strings.TrimPrefix(line, "Executed_Gtid_Set ="))
+		}
+	}
+	if meta.File == "" {
+		return nil, fmt.Errorf("%w: missing binlog file", ErrMetadataInvalid)
+	}
+	if !positionSet {
+		return nil, fmt.Errorf("%w: missing position", ErrMetadataInvalid)
+	}
+	return meta, nil
+}
+
+func ListFiles(backupPath string, restoreUser bool) (FileSet, error) {
+	entries, err := os.ReadDir(backupPath)
+	if err != nil {
+		return FileSet{}, err
+	}
+	set := FileSet{}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		isSchema, ok := classifyFile(name, restoreUser)
+		if !ok {
+			continue
+		}
+		fullPath := filepath.Join(backupPath, name)
+		if isSchema {
+			set.Schema = append(set.Schema, fullPath)
+		} else {
+			set.Data = append(set.Data, fullPath)
+		}
+	}
+	sort.Strings(set.Schema)
+	sortSplitdumpDataFiles(set.Data)
+	return set, nil
+}
+
+func Restore(backupPath string, opts RestoreOptions) error {
+	if opts.RestoreFile == nil && opts.RestoreFileWithContext == nil {
+		return fmt.Errorf("splitdump restore requires RestoreFile")
+	}
+	logf := func(level, format string, args ...any) {
+		if opts.Logger != nil {
+			opts.Logger(level, format, args...)
+		}
+	}
+	ctx := opts.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	meta, err := ReadMetadata(backupPath)
+	if err != nil {
+		if opts.StrictMetadata {
+			return err
+		}
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			logf(LogWarn, "Splitdump metadata not found; continuing without binlog info")
+		case errors.Is(err, ErrMetadataInvalid):
+			logf(LogWarn, "Splitdump metadata malformed; continuing without binlog info: %v", err)
+		default:
+			return err
+		}
+	} else {
+		logf(LogInfo, "Splitdump metadata loaded (file=%s pos=%d)", meta.File, meta.Position)
+	}
+
+	files, err := ListFiles(backupPath, opts.RestoreUser)
+	if err != nil {
+		return err
+	}
+	logf(LogInfo, "Splitdump restore files listed (schema=%d data=%d)", len(files.Schema), len(files.Data))
+
+	for _, schemaFile := range files.Schema {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		logf(LogDebug, "Splitdump restoring schema (%s)", filepath.Base(schemaFile))
+		var err error
+		if opts.RestoreFileWithContext != nil {
+			err = opts.RestoreFileWithContext(ctx, schemaFile)
+		} else {
+			err = opts.RestoreFile(schemaFile)
+		}
+		if err != nil {
+			logf(LogError, "Splitdump schema restore failed (%s): %v", filepath.Base(schemaFile), err)
+			cancel()
+			return err
+		}
+	}
+
+	parallel := opts.Parallel
+	if parallel < 1 {
+		parallel = 1
+	}
+	if parallel > len(files.Data) && len(files.Data) > 0 {
+		parallel = len(files.Data)
+	}
+
+	if len(files.Data) == 0 {
+		logf(LogInfo, "Splitdump restore completed (no data files)")
+		return nil
+	}
+
+	dataGroups := groupSplitdumpDataFiles(files.Data)
+	if len(dataGroups) == 0 {
+		logf(LogInfo, "Splitdump restore completed (no data files)")
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	var firstErr error
+	var errOnce sync.Once
+
+	setErr := func(err error) {
+		errOnce.Do(func() {
+			firstErr = err
+			cancel()
+		})
+	}
+
+	groupJobs := make(chan dataGroup)
+	groupWorker := func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case group, ok := <-groupJobs:
+				if !ok {
+					return
+				}
+				for _, path := range group.paths {
+					select {
+					case <-ctx.Done():
+						return
+					default:
+					}
+					logf(LogDebug, "Splitdump restoring data (%s)", filepath.Base(path))
+					var err error
+					if opts.RestoreFileWithContext != nil {
+						err = opts.RestoreFileWithContext(ctx, path)
+					} else {
+						err = opts.RestoreFile(path)
+					}
+					if err != nil {
+						logf(LogError, "Splitdump data restore failed (%s): %v", filepath.Base(path), err)
+						setErr(err)
+						return
+					}
+				}
+			}
+		}
+	}
+
+	if parallel > len(dataGroups) {
+		parallel = len(dataGroups)
+	}
+
+	for i := 0; i < parallel; i++ {
+		wg.Add(1)
+		go groupWorker()
+	}
+
+	logf(LogInfo, "Splitdump restoring data files (count=%d parallel=%d)", len(files.Data), parallel)
+
+sendLoop:
+	for _, group := range dataGroups {
+		select {
+		case <-ctx.Done():
+			break sendLoop
+		case groupJobs <- group:
+		}
+	}
+	close(groupJobs)
+	wg.Wait()
+
+	if firstErr == nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		logf(LogInfo, "Splitdump restore completed")
+	}
+	return firstErr
+}
+
+func classifyFile(name string, restoreUser bool) (isSchema bool, ok bool) {
+	lower := strings.ToLower(name)
+	if lower == "metadata" {
+		return false, false
+	}
+	if strings.HasSuffix(lower, ".sql.gz") || strings.HasSuffix(lower, ".sql") {
+		switch {
+		case strings.HasSuffix(lower, "-schema.sql.gz") || strings.HasSuffix(lower, "-schema.sql"):
+			return true, true
+		case strings.HasSuffix(lower, "-schema-view.sql.gz") || strings.HasSuffix(lower, "-schema-view.sql"):
+			return true, true
+		case lower == "mysql.system-all.sql.gz" || lower == "mysql.system-all.sql":
+			if !restoreUser {
+				return false, false
+			}
+			return true, true
+		default:
+			return false, true
+		}
+	}
+	return false, false
+}
+
+func sortSplitdumpDataFiles(paths []string) {
+	sort.SliceStable(paths, func(i, j int) bool {
+		left := filepath.Base(paths[i])
+		right := filepath.Base(paths[j])
+		leftKey, leftShard := splitdumpDataKey(left)
+		rightKey, rightShard := splitdumpDataKey(right)
+		if leftKey == rightKey {
+			return leftShard < rightShard
+		}
+		return leftKey < rightKey
+	})
+}
+
+func groupSplitdumpDataFiles(paths []string) []dataGroup {
+	if len(paths) == 0 {
+		return nil
+	}
+	groups := make([]dataGroup, 0)
+	var current dataGroup
+	for _, path := range paths {
+		key, _ := splitdumpDataKey(filepath.Base(path))
+		if current.key == "" {
+			current = dataGroup{key: key, paths: []string{path}}
+			continue
+		}
+		if key == current.key {
+			current.paths = append(current.paths, path)
+			continue
+		}
+		groups = append(groups, current)
+		current = dataGroup{key: key, paths: []string{path}}
+	}
+	if current.key != "" {
+		groups = append(groups, current)
+	}
+	return groups
+}
+
+func splitdumpDataKey(name string) (key string, shard int) {
+	key = strings.TrimSuffix(name, ".sql.gz")
+	key = strings.TrimSuffix(key, ".sql")
+	shard = 0
+	if len(key) > 6 && key[len(key)-6] == '.' {
+		suffix := key[len(key)-5:]
+		if n, err := strconv.Atoi(suffix); err == nil {
+			shard = n
+			key = key[:len(key)-6]
+		}
+	}
+	return key, shard
+}

--- a/utils/splitdump/restore.go
+++ b/utils/splitdump/restore.go
@@ -22,9 +22,10 @@ const (
 var ErrMetadataInvalid = errors.New("splitdump metadata invalid")
 
 type Metadata struct {
-	File     string
-	Position uint64
-	GTID     string
+	File       string
+	Position   uint64
+	GTID       string
+	SourceData int
 }
 
 type RestoreOptions struct {
@@ -55,6 +56,8 @@ func ReadMetadata(backupPath string) (*Metadata, error) {
 	}
 	meta := &Metadata{}
 	positionSet := false
+	sourceDataSet := false
+	positionMissing := false
 	lines := strings.Split(string(data), "\n")
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
@@ -62,12 +65,24 @@ func ReadMetadata(backupPath string) (*Metadata, error) {
 			continue
 		}
 		switch {
+		case strings.HasPrefix(line, "Source_Data ="):
+			srcStr := strings.TrimSpace(strings.TrimPrefix(line, "Source_Data ="))
+			if srcStr == "" {
+				return nil, fmt.Errorf("%w: missing source data", ErrMetadataInvalid)
+			}
+			src, err := strconv.Atoi(srcStr)
+			if err != nil {
+				return nil, fmt.Errorf("%w: invalid source data %q: %v", ErrMetadataInvalid, srcStr, err)
+			}
+			meta.SourceData = src
+			sourceDataSet = true
 		case strings.HasPrefix(line, "File ="):
 			meta.File = strings.TrimSpace(strings.TrimPrefix(line, "File ="))
 		case strings.HasPrefix(line, "Position ="):
 			posStr := strings.TrimSpace(strings.TrimPrefix(line, "Position ="))
 			if posStr == "" {
-				return nil, fmt.Errorf("%w: missing position", ErrMetadataInvalid)
+				positionMissing = true
+				continue
 			}
 			pos, err := strconv.ParseUint(posStr, 10, 64)
 			if err != nil {
@@ -79,10 +94,13 @@ func ReadMetadata(backupPath string) (*Metadata, error) {
 			meta.GTID = strings.TrimSpace(strings.TrimPrefix(line, "Executed_Gtid_Set ="))
 		}
 	}
+	if sourceDataSet && meta.SourceData == 0 {
+		return meta, nil
+	}
 	if meta.File == "" {
 		return nil, fmt.Errorf("%w: missing binlog file", ErrMetadataInvalid)
 	}
-	if !positionSet {
+	if positionMissing || !positionSet {
 		return nil, fmt.Errorf("%w: missing position", ErrMetadataInvalid)
 	}
 	return meta, nil

--- a/utils/splitdump/restore_test.go
+++ b/utils/splitdump/restore_test.go
@@ -1,0 +1,236 @@
+package splitdump
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestReadMetadataAllowsMissingGTID(t *testing.T) {
+	dir := t.TempDir()
+	content := "[source]\nFile = mysql-bin.000123\nPosition = 456\n"
+	if err := os.WriteFile(filepath.Join(dir, "metadata"), []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write metadata: %v", err)
+	}
+
+	meta, err := ReadMetadata(dir)
+	if err != nil {
+		t.Fatalf("expected metadata to parse, got error: %v", err)
+	}
+	if meta.File != "mysql-bin.000123" {
+		t.Fatalf("unexpected file: %s", meta.File)
+	}
+	if meta.Position != 456 {
+		t.Fatalf("unexpected position: %d", meta.Position)
+	}
+	if meta.GTID != "" {
+		t.Fatalf("expected empty GTID, got: %s", meta.GTID)
+	}
+}
+
+func TestReadMetadataRequiresFileAndPosition(t *testing.T) {
+	dir := t.TempDir()
+	content := "[source]\nPosition = 456\n"
+	if err := os.WriteFile(filepath.Join(dir, "metadata"), []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write metadata: %v", err)
+	}
+	_, err := ReadMetadata(dir)
+	if err == nil {
+		t.Fatalf("expected error for missing file")
+	}
+	if !errors.Is(err, ErrMetadataInvalid) {
+		t.Fatalf("expected invalid metadata error, got: %v", err)
+	}
+}
+
+func TestReadMetadataRequiresPosition(t *testing.T) {
+	dir := t.TempDir()
+	content := "[source]\nFile = mysql-bin.000123\n"
+	if err := os.WriteFile(filepath.Join(dir, "metadata"), []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write metadata: %v", err)
+	}
+	_, err := ReadMetadata(dir)
+	if err == nil {
+		t.Fatalf("expected error for missing position")
+	}
+	if !errors.Is(err, ErrMetadataInvalid) {
+		t.Fatalf("expected invalid metadata error, got: %v", err)
+	}
+}
+
+func TestRestoreIgnoresMalformedMetadata(t *testing.T) {
+	dir := t.TempDir()
+	content := "[source]\nFile = mysql-bin.000123\n"
+	if err := os.WriteFile(filepath.Join(dir, "metadata"), []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write metadata: %v", err)
+	}
+	dataPath := filepath.Join(dir, "db.tbl.sql")
+	if err := os.WriteFile(dataPath, []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to write data file: %v", err)
+	}
+
+	var mu sync.Mutex
+	var restored []string
+	var logs []string
+	logger := func(level, format string, args ...any) {
+		mu.Lock()
+		logs = append(logs, fmt.Sprintf("%s:%s", level, fmt.Sprintf(format, args...)))
+		mu.Unlock()
+	}
+	restoreFile := func(path string) error {
+		mu.Lock()
+		restored = append(restored, filepath.Base(path))
+		mu.Unlock()
+		return nil
+	}
+
+	if err := Restore(dir, RestoreOptions{Parallel: 1, Logger: logger, RestoreFile: restoreFile}); err != nil {
+		t.Fatalf("expected restore to continue, got error: %v", err)
+	}
+
+	mu.Lock()
+	gotRestored := append([]string(nil), restored...)
+	gotLogs := append([]string(nil), logs...)
+	mu.Unlock()
+
+	if len(gotRestored) != 1 || gotRestored[0] != filepath.Base(dataPath) {
+		t.Fatalf("unexpected restored files: %#v", gotRestored)
+	}
+
+	foundWarn := false
+	for _, entry := range gotLogs {
+		if strings.HasPrefix(entry, LogWarn+":") && strings.Contains(entry, "metadata malformed") {
+			foundWarn = true
+			break
+		}
+	}
+	if !foundWarn {
+		t.Fatalf("expected warning about malformed metadata, got logs: %#v", gotLogs)
+	}
+}
+
+func TestRestoreStrictMetadataMissing(t *testing.T) {
+	dir := t.TempDir()
+	dataPath := filepath.Join(dir, "db.tbl.sql")
+	if err := os.WriteFile(dataPath, []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to write data file: %v", err)
+	}
+
+	var mu sync.Mutex
+	var restored []string
+	restoreFile := func(path string) error {
+		mu.Lock()
+		restored = append(restored, filepath.Base(path))
+		mu.Unlock()
+		return nil
+	}
+
+	err := Restore(dir, RestoreOptions{Parallel: 1, StrictMetadata: true, RestoreFile: restoreFile})
+	if err == nil {
+		t.Fatalf("expected restore error for missing metadata")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected metadata not found error, got: %v", err)
+	}
+
+	mu.Lock()
+	gotRestored := append([]string(nil), restored...)
+	mu.Unlock()
+	if len(gotRestored) != 0 {
+		t.Fatalf("unexpected restored files: %#v", gotRestored)
+	}
+}
+
+func TestRestoreStrictMetadataInvalid(t *testing.T) {
+	dir := t.TempDir()
+	content := "[source]\nFile = mysql-bin.000123\n"
+	if err := os.WriteFile(filepath.Join(dir, "metadata"), []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write metadata: %v", err)
+	}
+	dataPath := filepath.Join(dir, "db.tbl.sql")
+	if err := os.WriteFile(dataPath, []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to write data file: %v", err)
+	}
+
+	var mu sync.Mutex
+	var restored []string
+	restoreFile := func(path string) error {
+		mu.Lock()
+		restored = append(restored, filepath.Base(path))
+		mu.Unlock()
+		return nil
+	}
+
+	err := Restore(dir, RestoreOptions{Parallel: 1, StrictMetadata: true, RestoreFile: restoreFile})
+	if err == nil {
+		t.Fatalf("expected restore error for invalid metadata")
+	}
+	if !errors.Is(err, ErrMetadataInvalid) {
+		t.Fatalf("expected invalid metadata error, got: %v", err)
+	}
+
+	mu.Lock()
+	gotRestored := append([]string(nil), restored...)
+	mu.Unlock()
+	if len(gotRestored) != 0 {
+		t.Fatalf("unexpected restored files: %#v", gotRestored)
+	}
+}
+
+func TestListFilesOrderingAndClassification(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		"db.tbl-schema.sql.gz",
+		"db.tbl-schema-view.sql.gz",
+		"mysql.system-all.sql.gz",
+		"db.tbl.sql.gz",
+		"db.tbl.00002.sql.gz",
+		"db.tbl.00001.sql.gz",
+		"db.other.sql.gz",
+		"metadata",
+	}
+	for _, name := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to write file %s: %v", name, err)
+		}
+	}
+
+	set, err := ListFiles(dir, true)
+	if err != nil {
+		t.Fatalf("ListFiles error: %v", err)
+	}
+
+	other := filepath.Join(dir, "db.other.sql.gz")
+	base := filepath.Join(dir, "db.tbl.sql.gz")
+	shard1 := filepath.Join(dir, "db.tbl.00001.sql.gz")
+	shard2 := filepath.Join(dir, "db.tbl.00002.sql.gz")
+
+	wantData := []string{other, base, shard1, shard2}
+	if !reflect.DeepEqual(set.Data, wantData) {
+		t.Fatalf("unexpected data order: %#v", set.Data)
+	}
+
+	wantSchema := []string{
+		filepath.Join(dir, "db.tbl-schema-view.sql.gz"),
+		filepath.Join(dir, "db.tbl-schema.sql.gz"),
+		filepath.Join(dir, "mysql.system-all.sql.gz"),
+	}
+	if !reflect.DeepEqual(set.Schema, wantSchema) {
+		t.Fatalf("unexpected schema list: %#v", set.Schema)
+	}
+
+	setNoUser, err := ListFiles(dir, false)
+	if err != nil {
+		t.Fatalf("ListFiles error: %v", err)
+	}
+	for _, path := range setNoUser.Schema {
+		if filepath.Base(path) == "mysql.system-all.sql.gz" {
+			t.Fatalf("expected mysql.system-all.sql.gz to be excluded when restoreUser=false")
+		}
+	}
+}

--- a/utils/splitdump/restore_test.go
+++ b/utils/splitdump/restore_test.go
@@ -63,6 +63,28 @@ func TestReadMetadataRequiresPosition(t *testing.T) {
 	}
 }
 
+func TestReadMetadataSourceDataZeroSkipsBinlog(t *testing.T) {
+	dir := t.TempDir()
+	content := "[source]\nSource_Data = 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "metadata"), []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write metadata: %v", err)
+	}
+
+	meta, err := ReadMetadata(dir)
+	if err != nil {
+		t.Fatalf("expected metadata to parse, got error: %v", err)
+	}
+	if meta.SourceData != 0 {
+		t.Fatalf("unexpected source data: %d", meta.SourceData)
+	}
+	if meta.File != "" {
+		t.Fatalf("expected empty file, got: %s", meta.File)
+	}
+	if meta.Position != 0 {
+		t.Fatalf("expected zero position, got: %d", meta.Position)
+	}
+}
+
 func TestRestoreIgnoresMalformedMetadata(t *testing.T) {
 	dir := t.TempDir()
 	content := "[source]\nFile = mysql-bin.000123\n"

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -49,6 +49,7 @@ func splitDumpOpenReader(f *os.File) *bufio.Reader {
 	if isGzip(buf) {
 		gbuf, err := gzip.NewReader(buf)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "splitdump: warning: gzip header detected but failed to init gzip reader; falling back to raw reader: %v\n", err)
 			if _, seekErr := f.Seek(0, io.SeekStart); seekErr == nil {
 				return bufio.NewReaderSize(f, pageSize)
 			}

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jacoblockett/sanitizefilename"
@@ -105,6 +106,15 @@ func SplitDumpLineReader(bus *SplitDumpChannelBus, inputFile string) {
 
 // LineParser reads the CurrentLine and figures out which channel to put it in.
 func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineFiles bool, outputDir string, skipData []string, skipTables []string*/) {
+	var drainOnce sync.Once
+	drainCurrentLine := func() {
+		drainOnce.Do(func() {
+			go func() {
+				for range bus.CurrentLine {
+				}
+			}()
+		})
+	}
 	reportError := func(err error) {
 		if err == nil {
 			return
@@ -118,6 +128,7 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 		}
 	}
 	finishWithError := func(err error) {
+		drainCurrentLine()
 		reportError(err)
 		bus.Finished <- true
 	}

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -105,7 +105,7 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 	binlogRegexMariaDB := regexp.MustCompile(`CHANGE MASTER TO MASTER_LOG_FILE='(.+)', MASTER_LOG_POS=(\d+)`)
 	gtidRegexMariaDB := regexp.MustCompile(`SET GLOBAL gtid_slave_pos='(.+)'`)
 	binlogRegexMySQL := regexp.MustCompile(`CHANGE REPLICATION SOURCE TO SOURCE_LOG_FILE='(.+)', SOURCE_LOG_POS=(\d+)`)
-	gtidRegexMySQL := regexp.MustCompile(`GTID_PURGED\s*=(\/\*!.+\*\/)?\s*'(.+)'`)
+	gtidRegexMySQL := regexp.MustCompile(`GTID_PURGED\s*=\s*(?:\/\*![^*]*\*\/\s*)?'([^']+)'`)
 	headerMetaData := fmt.Sprintf("-- Generated with replication-manager on %s\n\n", time.Now())
 	os.Mkdir(outputDir, os.ModePerm)
 	// numTables := 0

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -17,6 +17,7 @@ import (
 // SplitDumpChannelBusChannelBus a struct to hold all channels used by the different go routines
 type SplitDumpChannelBus struct {
 	Finished    chan bool
+	Error       chan error
 	Log         chan string
 	CurrentLine chan string
 	TableName   chan string
@@ -27,6 +28,7 @@ type SplitDumpChannelBus struct {
 func NewSplitDumpChannelBus() *SplitDumpChannelBus {
 	return &SplitDumpChannelBus{
 		Finished:    make(chan bool),
+		Error:       make(chan error, 1),
 		Log:         make(chan string),
 		CurrentLine: make(chan string),
 		TableName:   make(chan string),
@@ -79,13 +81,13 @@ func splitDumpOpenReaderStdin() *bufio.Reader {
 // LineReader reads `file` line-by-line and adds it to the `bus.CurrentLine` channel.
 // Note: This function closes `file`.
 func SplitDumpLineReader(bus *SplitDumpChannelBus, inputFile string) {
-
 	r := splitDumpOpenReaderStdin()
 	if inputFile != "" {
 		file, err := splitDumpOpenFile(inputFile)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			bus.Error <- err
+			close(bus.CurrentLine)
+			return
 		}
 		defer file.Close()
 		r = splitDumpOpenReader(file)
@@ -99,6 +101,23 @@ func SplitDumpLineReader(bus *SplitDumpChannelBus, inputFile string) {
 
 // LineParser reads the CurrentLine and figures out which channel to put it in.
 func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineFiles bool, outputDir string, skipData []string, skipTables []string*/) {
+	reportError := func(err error) {
+		if err == nil {
+			return
+		}
+		defer func() {
+			_ = recover()
+		}()
+		select {
+		case bus.Error <- err:
+		default:
+		}
+	}
+	finishWithError := func(err error) {
+		reportError(err)
+		bus.Finished <- true
+	}
+
 	onTableScheme, onTableData, pastHeader := false, false, false
 	shardpad, schema := "", ""
 	shard := 0
@@ -107,11 +126,16 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 	binlogRegexMySQL := regexp.MustCompile(`CHANGE REPLICATION SOURCE TO SOURCE_LOG_FILE='(.+)', SOURCE_LOG_POS=(\d+)`)
 	gtidRegexMySQL := regexp.MustCompile(`GTID_PURGED\s*=\s*(?:\/\*![^*]*\*\/\s*)?'([^']+)'`)
 	headerMetaData := fmt.Sprintf("-- Generated with replication-manager on %s\n\n", time.Now())
-	os.Mkdir(outputDir, os.ModePerm)
+	if err := os.MkdirAll(outputDir, os.ModePerm); err != nil {
+		finishWithError(fmt.Errorf("splitdump: create output dir %s: %w", outputDir, err))
+		return
+	}
 	// numTables := 0
 	var f *os.File
+	var err error
 	var tableFile *gzip.Writer
 	var bgtid, bfile, bpos string
+	sourceDataDisabled := false
 	closeTableWriter := func() {
 		if tableFile != nil {
 			_ = tableFile.Flush()
@@ -130,6 +154,15 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 	streamSize := 0
 	streamSizeMax := 1024 * 1024 * 1024
 	for line := range bus.CurrentLine {
+		if !sourceDataDisabled {
+			lowerLine := strings.ToLower(line)
+			if strings.Contains(lowerLine, "source-data=0") {
+				sourceDataDisabled = true
+				bgtid = ""
+				bfile = ""
+				bpos = ""
+			}
+		}
 		//	fmt.Printf("%s %b %b %b", line, onTableScheme, onTableData)
 		streamSize += len([]byte(line))
 
@@ -143,10 +176,9 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table ", "", 1), "`", "", -1)) + shardpad
 				fmt.Printf("Processing table data %s ", tableName)
 				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-				f, err := os.Create(tablePath)
+				f, err = os.Create(tablePath)
 				if err != nil {
-					fmt.Printf("Error creating file %s %s\n", tablePath, err)
-					bus.Finished <- true
+					finishWithError(fmt.Errorf("splitdump: create file %s: %w", tablePath, err))
 					return
 				}
 				tableFile = gzip.NewWriter(f)
@@ -179,10 +211,9 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Table structure for table ", "", 1), "`", "", -1)) + "-schema"
 				fmt.Printf("Processing table schema %s\n", tableName)
 				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-				f, err := os.Create(tablePath)
+				f, err = os.Create(tablePath)
 				if err != nil {
-					fmt.Printf("Error creating file %s %s\n", tablePath, err)
-					bus.Finished <- true
+					finishWithError(fmt.Errorf("splitdump: create file %s: %w", tablePath, err))
 					return
 				}
 				tableFile = gzip.NewWriter(f)
@@ -196,10 +227,9 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 					tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table", "", 1), "`", "", -1)) + "-schema"
 					fmt.Printf("Processing table schema %s\n", tableName)
 					tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-					f, err := os.Create(tablePath)
+					f, err = os.Create(tablePath)
 					if err != nil {
-						fmt.Printf("Error creating file %s %s\n", tablePath, err)
-						bus.Finished <- true
+						finishWithError(fmt.Errorf("splitdump: create file %s: %w", tablePath, err))
 						return
 					}
 					tableFile = gzip.NewWriter(f)
@@ -212,10 +242,9 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table ", "", 1), "`", "", -1)) + shardpad
 				fmt.Printf("Processing table data %s\n", tableName)
 				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-				f, err := os.Create(tablePath)
+				f, err = os.Create(tablePath)
 				if err != nil {
-					fmt.Printf("Error creating file %s %s\n", tablePath, err)
-					bus.Finished <- true
+					finishWithError(fmt.Errorf("splitdump: create file %s: %w", tablePath, err))
 					return
 				}
 				tableFile = gzip.NewWriter(f)
@@ -235,10 +264,9 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Final view structure for view ", "", 1), "`", "", -1)) + "-schema-view"
 				fmt.Printf("Processing view schema %s\n", tableName)
 				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-				f, err := os.Create(tablePath)
+				f, err = os.Create(tablePath)
 				if err != nil {
-					fmt.Printf("Error creating file %s %s\n", tablePath, err)
-					bus.Finished <- true
+					finishWithError(fmt.Errorf("splitdump: create file %s: %w", tablePath, err))
 					return
 				}
 				tableFile = gzip.NewWriter(f)
@@ -250,27 +278,28 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 				tableName := "mysql.system-all"
 				fmt.Printf("Processing view schema %s\n", tableName)
 				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-				f, err := os.Create(tablePath)
+				f, err = os.Create(tablePath)
 				if err != nil {
-					fmt.Printf("Error creating file %s %s\n", tablePath, err)
-					bus.Finished <- true
+					finishWithError(fmt.Errorf("splitdump: create file %s: %w", tablePath, err))
 					return
 				}
 				tableFile = gzip.NewWriter(f)
 			}
-			if matches := gtidRegexMariaDB.FindStringSubmatch(line); matches != nil {
-				bgtid = matches[1]
-			}
-			if matches := gtidRegexMySQL.FindStringSubmatch(line); matches != nil {
-				bgtid = matches[1]
-			}
-			if matches := binlogRegexMariaDB.FindStringSubmatch(line); matches != nil {
-				bfile = matches[1]
-				bpos = matches[2]
-			}
-			if matches := binlogRegexMySQL.FindStringSubmatch(line); matches != nil {
-				bfile = matches[1]
-				bpos = matches[2]
+			if !sourceDataDisabled {
+				if matches := gtidRegexMariaDB.FindStringSubmatch(line); matches != nil {
+					bgtid = matches[1]
+				}
+				if matches := gtidRegexMySQL.FindStringSubmatch(line); matches != nil {
+					bgtid = matches[1]
+				}
+				if matches := binlogRegexMariaDB.FindStringSubmatch(line); matches != nil {
+					bfile = matches[1]
+					bpos = matches[2]
+				}
+				if matches := binlogRegexMySQL.FindStringSubmatch(line); matches != nil {
+					bfile = matches[1]
+					bpos = matches[2]
+				}
 			}
 		}
 
@@ -283,14 +312,20 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 	}
 	closeTableFile()
 	tablePath := filepath.Join(outputDir, "metadata")
-	f, err := os.Create(tablePath)
+	f, err = os.Create(tablePath)
 	if err != nil {
-		fmt.Printf("Error creating file %s %s\n", tablePath, err)
-		bus.Finished <- true
+		finishWithError(fmt.Errorf("splitdump: create file %s: %w", tablePath, err))
 		return
 	}
-	line := fmt.Sprintf("[source]\n# Channel_Name = ''\nFile = %s\nPosition = %s\nExecuted_Gtid_Set = %s\n\n", bfile, bpos, bgtid)
-	f.Write([]byte(line))
+	metaLines := []string{"[source]", "# Channel_Name = ''"}
+	if sourceDataDisabled {
+		metaLines = append(metaLines, "Source_Data = 0")
+	}
+	metaLines = append(metaLines, fmt.Sprintf("File = %s", bfile))
+	metaLines = append(metaLines, fmt.Sprintf("Position = %s", bpos))
+	metaLines = append(metaLines, fmt.Sprintf("Executed_Gtid_Set = %s", bgtid), "")
+	line := strings.Join(metaLines, "\n")
+	_, _ = f.Write([]byte(line))
 	f.Close()
 
 	bus.Finished <- true

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -1,0 +1,284 @@
+package splitdump
+
+import (
+	"bufio"
+	"compress/gzip"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/jacoblockett/sanitizefilename"
+)
+
+// SplitDumpChannelBusChannelBus a struct to hold all channels used by the different go routines
+type SplitDumpChannelBus struct {
+	Finished    chan bool
+	Log         chan string
+	CurrentLine chan string
+	TableName   chan string
+	TableScheme chan string
+	TableData   chan string
+}
+
+func NewSplitDumpChannelBus() *SplitDumpChannelBus {
+	return &SplitDumpChannelBus{
+		Finished:    make(chan bool),
+		Log:         make(chan string),
+		CurrentLine: make(chan string),
+		TableName:   make(chan string),
+		TableScheme: make(chan string),
+		TableData:   make(chan string),
+	}
+}
+
+func isGzip(b *bufio.Reader) bool {
+	if m, err := b.Peek(2); err == nil {
+		return m[0] == 0x1f && m[1] == 0x8b
+	}
+	return false
+}
+
+func splitDumpOpenReader(f *os.File) *bufio.Reader {
+	pageSize := os.Getpagesize() * 2
+	buf := bufio.NewReaderSize(f, pageSize)
+
+	if isGzip(buf) {
+		gbuf, _ := gzip.NewReader(buf)
+		return bufio.NewReaderSize(gbuf, pageSize)
+	}
+
+	return buf
+}
+func splitDumpOpenFile(path string) (*os.File, error) {
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}
+
+func splitDumpOpenReaderStdin() *bufio.Reader {
+	pageSize := os.Getpagesize() * 2
+	buf := bufio.NewReaderSize(os.Stdin, pageSize)
+	return buf
+}
+
+// LineReader reads `file` line-by-line and adds it to the `bus.CurrentLine` channel.
+// Note: This function closes `file`.
+func SplitDumpLineReader(bus *SplitDumpChannelBus, inputFile string) {
+
+	r := splitDumpOpenReaderStdin()
+	if inputFile != "" {
+		file, err := splitDumpOpenFile(inputFile)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		defer file.Close()
+		r = splitDumpOpenReader(file)
+	}
+	for line, err := r.ReadString('\n'); err == nil; line, err = r.ReadString('\n') {
+		bus.CurrentLine <- line
+	}
+
+	close(bus.CurrentLine)
+}
+
+// LineParser reads the CurrentLine and figures out which channel to put it in.
+func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineFiles bool, outputDir string, skipData []string, skipTables []string*/) {
+	onTableScheme, onTableData, pastHeader := false, false, false
+	shardpad, schema := "", ""
+	shard := 0
+	binlogRegexMariaDB := regexp.MustCompile(`CHANGE MASTER TO MASTER_LOG_FILE='(.+)', MASTER_LOG_POS=(\d+)`)
+	gtidRegexMariaDB := regexp.MustCompile(`SET GLOBAL gtid_slave_pos='(.+)'`)
+	binlogRegexMySQL := regexp.MustCompile(`CHANGE REPLICATION SOURCE TO SOURCE_LOG_FILE='(.+)', SOURCE_LOG_POS=(\d+)`)
+	gtidRegexMySQL := regexp.MustCompile(`GTID_PURGED\s*=(\/\*!.+\*\/)?\s*'(.+)'`)
+	headerMetaData := fmt.Sprintf("-- Generated with replication-manager on %s\n\n", time.Now())
+	os.Mkdir(outputDir, os.ModePerm)
+	// numTables := 0
+	var f *os.File
+	var tableFile *gzip.Writer
+	var bgtid, bfile, bpos string
+
+	streamSize := 0
+	streamSizeMax := 1024 * 1024 * 1024
+	for line := range bus.CurrentLine {
+		//	fmt.Printf("%s %b %b %b", line, onTableScheme, onTableData)
+		streamSize += len([]byte(line))
+
+		if streamSize > streamSizeMax {
+			shard++
+			tableFile.Flush()
+			tableFile.Close()
+			f.Close()
+			shardpad = fmt.Sprintf(".%05d", shard)
+			tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table ", "", 1), "`", "", -1)) + shardpad
+			fmt.Printf("Processing table data %s ", tableName)
+			tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
+			f, err := os.Create(tablePath)
+			if err != nil {
+				fmt.Printf("Error creating file %s %s\n", tablePath, err)
+				bus.Finished <- true
+				return
+			}
+			tableFile = gzip.NewWriter(f)
+			streamSize = 0
+		}
+		// The beginning of a mysqldump has some flags at the top of the file. Capture them into a variable.
+		if !pastHeader && strings.HasPrefix(line, "/*!40") {
+			headerMetaData += line
+		}
+		// Optimize for no test string durin table dump
+		if onTableData {
+			if strings.HasPrefix(line, "UNLOCK TABLES;") {
+				onTableData = false
+				onTableScheme = false
+				streamSize = 0
+				tableFile.Close()
+			}
+		} else {
+			if strings.HasPrefix(line, "USE ") {
+				schema = strings.TrimSpace(strings.Replace(strings.Replace(strings.Replace(line, "USE ", "", 1), ";", "", -1), "`", "", -1))
+			} else if strings.HasPrefix(line, "-- Table structure for table") {
+				//case for empty table enter dummy data
+				if onTableScheme && !onTableData {
+					onTableScheme = false
+					// add headers to each file unless we are combining all of them into 1 file.
+					tableFile.Flush()
+					tableFile.Close()
+					f.Close()
+				}
+				onTableScheme, onTableData = true, false
+				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Table structure for table ", "", 1), "`", "", -1)) + "-schema"
+				fmt.Printf("Processing table schema %s\n", tableName)
+				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
+				f, err := os.Create(tablePath)
+				if err != nil {
+					fmt.Printf("Error creating file %s %s\n", tablePath, err)
+					bus.Finished <- true
+					return
+				}
+				tableFile = gzip.NewWriter(f)
+				pastHeader = true
+			} else if strings.HasPrefix(line, "LOCK TABLES `") {
+				onTableData, onTableScheme = true, false
+			} else if strings.HasPrefix(line, "-- Dumping data for table") {
+				// Case of data without table definition
+				if !onTableScheme {
+					tableFile.Flush()
+					tableFile.Close()
+					tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table", "", 1), "`", "", -1)) + "-schema"
+					fmt.Printf("Processing table schema %s\n", tableName)
+					tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
+					f, err := os.Create(tablePath)
+					if err != nil {
+						fmt.Printf("Error creating file %s %s\n", tablePath, err)
+						bus.Finished <- true
+						return
+					}
+					tableFile = gzip.NewWriter(f)
+					tableFile.Write([]byte("\n--\n" + line))
+					pastHeader = true
+
+				}
+				tableFile.Flush()
+				tableFile.Close()
+				f.Close()
+				shardpad = fmt.Sprintf(".%05d", shard)
+				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table ", "", 1), "`", "", -1)) + shardpad
+				fmt.Printf("Processing table data %s\n", tableName)
+				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
+				f, err := os.Create(tablePath)
+				if err != nil {
+					fmt.Printf("Error creating file %s %s\n", tablePath, err)
+					bus.Finished <- true
+					return
+				}
+				tableFile = gzip.NewWriter(f)
+
+				if !pastHeader {
+					// add the meta data to only the first table.
+					tableFile.Write([]byte(headerMetaData))
+				}
+				onTableScheme = false
+				onTableData = true
+
+			} else if strings.HasPrefix(line, "-- Final view structure for view ") {
+				onTableData = false
+				onTableScheme = false
+				//	onView = true
+				tableFile.Flush()
+				tableFile.Close()
+				f.Close()
+				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Final view structure for view ", "", 1), "`", "", -1)) + "-schema-view"
+				fmt.Printf("Processing view schema %s\n", tableName)
+				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
+				f, err := os.Create(tablePath)
+				if err != nil {
+					fmt.Printf("Error creating file %s %s\n", tablePath, err)
+					bus.Finished <- true
+					return
+				}
+				tableFile = gzip.NewWriter(f)
+				//-- Dumping routines
+			} else if strings.HasPrefix(line, "INSTALL PLUGIN") || strings.HasPrefix(line, "CREATE USER") {
+				onTableData = false
+				onTableScheme = false
+				tableFile.Flush()
+				tableFile.Close()
+				f.Close()
+				tableName := "mysql.system-all"
+				fmt.Printf("Processing view schema %s\n", tableName)
+				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
+				f, err := os.Create(tablePath)
+				if err != nil {
+					fmt.Printf("Error creating file %s %s\n", tablePath, err)
+					bus.Finished <- true
+					return
+				}
+				tableFile = gzip.NewWriter(f)
+			}
+			if matches := gtidRegexMariaDB.FindStringSubmatch(line); matches != nil {
+				bgtid = matches[1]
+			}
+			if matches := gtidRegexMySQL.FindStringSubmatch(line); matches != nil {
+				bgtid = matches[1]
+			}
+			if matches := binlogRegexMariaDB.FindStringSubmatch(line); matches != nil {
+				bfile = matches[1]
+				bpos = matches[2]
+			}
+			if matches := binlogRegexMySQL.FindStringSubmatch(line); matches != nil {
+				bfile = matches[1]
+				bpos = matches[2]
+			}
+		}
+
+		if pastHeader {
+			if tableFile != nil {
+				tableFile.Write([]byte(line))
+			}
+		}
+
+	}
+	tableFile.Flush()
+	tableFile.Close()
+	f.Close()
+	tablePath := filepath.Join(outputDir, "metadata")
+	f, err := os.Create(tablePath)
+	if err != nil {
+		fmt.Printf("Error creating file %s %s\n", tablePath, err)
+		bus.Finished <- true
+		return
+	}
+	line := fmt.Sprintf("[source]\n# Channel_Name = ''\nFile = %s\nPosition = %s\nExecuted_Gtid_Set = %s\n\n", bfile, bpos, bgtid)
+	f.Write([]byte(line))
+	f.Close()
+
+	bus.Finished <- true
+}

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -18,22 +18,14 @@ import (
 type SplitDumpChannelBus struct {
 	Finished    chan bool
 	Error       chan error
-	Log         chan string
 	CurrentLine chan string
-	TableName   chan string
-	TableScheme chan string
-	TableData   chan string
 }
 
 func NewSplitDumpChannelBus() *SplitDumpChannelBus {
 	return &SplitDumpChannelBus{
 		Finished:    make(chan bool),
 		Error:       make(chan error, 1),
-		Log:         make(chan string),
 		CurrentLine: make(chan string),
-		TableName:   make(chan string),
-		TableScheme: make(chan string),
-		TableData:   make(chan string),
 	}
 }
 

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -268,7 +268,7 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 				onTableScheme = false
 				closeTableFile()
 				tableName := "mysql.system-all"
-				fmt.Printf("Processing view schema %s\n", tableName)
+				fmt.Printf("Processing system schema %s\n", tableName)
 				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
 				f, err = os.Create(tablePath)
 				if err != nil {

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"compress/gzip"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -46,7 +47,13 @@ func splitDumpOpenReader(f *os.File) *bufio.Reader {
 	buf := bufio.NewReaderSize(f, pageSize)
 
 	if isGzip(buf) {
-		gbuf, _ := gzip.NewReader(buf)
+		gbuf, err := gzip.NewReader(buf)
+		if err != nil {
+			if _, seekErr := f.Seek(0, io.SeekStart); seekErr == nil {
+				return bufio.NewReaderSize(f, pageSize)
+			}
+			return buf
+		}
 		return bufio.NewReaderSize(gbuf, pageSize)
 	}
 
@@ -104,6 +111,20 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 	var f *os.File
 	var tableFile *gzip.Writer
 	var bgtid, bfile, bpos string
+	closeTableWriter := func() {
+		if tableFile != nil {
+			_ = tableFile.Flush()
+			_ = tableFile.Close()
+			tableFile = nil
+		}
+	}
+	closeTableFile := func() {
+		closeTableWriter()
+		if f != nil {
+			_ = f.Close()
+			f = nil
+		}
+	}
 
 	streamSize := 0
 	streamSizeMax := 1024 * 1024 * 1024
@@ -112,22 +133,24 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 		streamSize += len([]byte(line))
 
 		if streamSize > streamSizeMax {
-			shard++
-			tableFile.Flush()
-			tableFile.Close()
-			f.Close()
-			shardpad = fmt.Sprintf(".%05d", shard)
-			tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table ", "", 1), "`", "", -1)) + shardpad
-			fmt.Printf("Processing table data %s ", tableName)
-			tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-			f, err := os.Create(tablePath)
-			if err != nil {
-				fmt.Printf("Error creating file %s %s\n", tablePath, err)
-				bus.Finished <- true
-				return
+			if tableFile == nil {
+				streamSize = 0
+			} else {
+				shard++
+				closeTableFile()
+				shardpad = fmt.Sprintf(".%05d", shard)
+				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table ", "", 1), "`", "", -1)) + shardpad
+				fmt.Printf("Processing table data %s ", tableName)
+				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
+				f, err := os.Create(tablePath)
+				if err != nil {
+					fmt.Printf("Error creating file %s %s\n", tablePath, err)
+					bus.Finished <- true
+					return
+				}
+				tableFile = gzip.NewWriter(f)
+				streamSize = 0
 			}
-			tableFile = gzip.NewWriter(f)
-			streamSize = 0
 		}
 		// The beginning of a mysqldump has some flags at the top of the file. Capture them into a variable.
 		if !pastHeader && strings.HasPrefix(line, "/*!40") {
@@ -139,7 +162,7 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 				onTableData = false
 				onTableScheme = false
 				streamSize = 0
-				tableFile.Close()
+				closeTableWriter()
 			}
 		} else {
 			if strings.HasPrefix(line, "USE ") {
@@ -149,9 +172,7 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 				if onTableScheme && !onTableData {
 					onTableScheme = false
 					// add headers to each file unless we are combining all of them into 1 file.
-					tableFile.Flush()
-					tableFile.Close()
-					f.Close()
+					closeTableFile()
 				}
 				onTableScheme, onTableData = true, false
 				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Table structure for table ", "", 1), "`", "", -1)) + "-schema"
@@ -170,8 +191,7 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 			} else if strings.HasPrefix(line, "-- Dumping data for table") {
 				// Case of data without table definition
 				if !onTableScheme {
-					tableFile.Flush()
-					tableFile.Close()
+					closeTableWriter()
 					tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table", "", 1), "`", "", -1)) + "-schema"
 					fmt.Printf("Processing table schema %s\n", tableName)
 					tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
@@ -186,9 +206,7 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 					pastHeader = true
 
 				}
-				tableFile.Flush()
-				tableFile.Close()
-				f.Close()
+				closeTableFile()
 				shardpad = fmt.Sprintf(".%05d", shard)
 				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table ", "", 1), "`", "", -1)) + shardpad
 				fmt.Printf("Processing table data %s\n", tableName)
@@ -212,9 +230,7 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 				onTableData = false
 				onTableScheme = false
 				//	onView = true
-				tableFile.Flush()
-				tableFile.Close()
-				f.Close()
+				closeTableFile()
 				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Final view structure for view ", "", 1), "`", "", -1)) + "-schema-view"
 				fmt.Printf("Processing view schema %s\n", tableName)
 				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
@@ -229,9 +245,7 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 			} else if strings.HasPrefix(line, "INSTALL PLUGIN") || strings.HasPrefix(line, "CREATE USER") {
 				onTableData = false
 				onTableScheme = false
-				tableFile.Flush()
-				tableFile.Close()
-				f.Close()
+				closeTableFile()
 				tableName := "mysql.system-all"
 				fmt.Printf("Processing view schema %s\n", tableName)
 				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
@@ -266,9 +280,7 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 		}
 
 	}
-	tableFile.Flush()
-	tableFile.Close()
-	f.Close()
+	closeTableFile()
 	tablePath := filepath.Join(outputDir, "metadata")
 	f, err := os.Create(tablePath)
 	if err != nil {

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -84,8 +84,20 @@ func SplitDumpLineReader(bus *SplitDumpChannelBus, inputFile string) {
 		defer file.Close()
 		r = splitDumpOpenReader(file)
 	}
-	for line, err := r.ReadString('\n'); err == nil; line, err = r.ReadString('\n') {
-		bus.CurrentLine <- line
+	for {
+		line, err := r.ReadString('\n')
+		if err == nil {
+			bus.CurrentLine <- line
+			continue
+		}
+		if err == io.EOF {
+			if line != "" {
+				bus.CurrentLine <- line
+			}
+			break
+		}
+		bus.Error <- err
+		break
 	}
 
 	close(bus.CurrentLine)

--- a/utils/splitdump/split_test.go
+++ b/utils/splitdump/split_test.go
@@ -74,3 +74,49 @@ func TestSplitDumpOpenReaderInvalidGzip(t *testing.T) {
 		t.Fatalf("expected fallback warning in stderr, got: %s", logged)
 	}
 }
+
+func TestSplitDumpLineParserMySQLGtidPurgedVariants(t *testing.T) {
+	cases := []struct {
+		name     string
+		line     string
+		expected string
+	}{
+		{
+			name:     "plain",
+			line:     "SET @@GLOBAL.GTID_PURGED='01234567-89ab-cdef-0123-456789abcdef:1-10';\n",
+			expected: "01234567-89ab-cdef-0123-456789abcdef:1-10",
+		},
+		{
+			name:     "with-comment",
+			line:     "SET @@GLOBAL.GTID_PURGED=/*!80000 '+'*/ '01234567-89ab-cdef-0123-456789abcdef:1-20';\n",
+			expected: "01234567-89ab-cdef-0123-456789abcdef:1-20",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bus := NewSplitDumpChannelBus()
+			outputDir := filepath.Join(t.TempDir(), "splitdump")
+
+			go SplitDumpLineParser(bus, outputDir)
+			bus.CurrentLine <- tc.line
+			close(bus.CurrentLine)
+
+			select {
+			case <-bus.Finished:
+			case <-time.After(2 * time.Second):
+				t.Fatal("timeout waiting for splitdump to finish")
+			}
+
+			metadataPath := filepath.Join(outputDir, "metadata")
+			data, err := os.ReadFile(metadataPath)
+			if err != nil {
+				t.Fatalf("failed to read metadata file: %v", err)
+			}
+			expectedLine := "Executed_Gtid_Set = " + tc.expected
+			if !strings.Contains(string(data), expectedLine) {
+				t.Fatalf("expected metadata to contain %q, got: %s", expectedLine, data)
+			}
+		})
+	}
+}

--- a/utils/splitdump/split_test.go
+++ b/utils/splitdump/split_test.go
@@ -1,0 +1,52 @@
+package splitdump
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSplitDumpLineParserEmptyInput(t *testing.T) {
+	bus := NewSplitDumpChannelBus()
+	outputDir := filepath.Join(t.TempDir(), "splitdump")
+	close(bus.CurrentLine)
+
+	go SplitDumpLineParser(bus, outputDir)
+
+	select {
+	case <-bus.Finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for splitdump to finish")
+	}
+
+	metadataPath := filepath.Join(outputDir, "metadata")
+	if _, err := os.Stat(metadataPath); err != nil {
+		t.Fatalf("metadata file missing: %v", err)
+	}
+}
+
+func TestSplitDumpOpenReaderInvalidGzip(t *testing.T) {
+	inputPath := filepath.Join(t.TempDir(), "bad.gz")
+	data := []byte{0x1f, 0x8b}
+	if err := os.WriteFile(inputPath, data, 0644); err != nil {
+		t.Fatalf("failed to write input file: %v", err)
+	}
+
+	file, err := os.Open(inputPath)
+	if err != nil {
+		t.Fatalf("failed to open input file: %v", err)
+	}
+	defer file.Close()
+
+	reader := splitDumpOpenReader(file)
+	got := make([]byte, len(data))
+	if _, err := io.ReadFull(reader, got); err != nil {
+		t.Fatalf("failed to read input file: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("unexpected input bytes: %v", got)
+	}
+}

--- a/utils/splitdump/split_test.go
+++ b/utils/splitdump/split_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -41,12 +42,35 @@ func TestSplitDumpOpenReaderInvalidGzip(t *testing.T) {
 	}
 	defer file.Close()
 
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to capture stderr: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() {
+		os.Stderr = oldStderr
+	})
+
 	reader := splitDumpOpenReader(file)
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close stderr writer: %v", err)
+	}
+	logged, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("failed to read stderr: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("failed to close stderr reader: %v", err)
+	}
 	got := make([]byte, len(data))
 	if _, err := io.ReadFull(reader, got); err != nil {
 		t.Fatalf("failed to read input file: %v", err)
 	}
 	if !bytes.Equal(got, data) {
 		t.Fatalf("unexpected input bytes: %v", got)
+	}
+	if !strings.Contains(string(logged), "falling back to raw reader") {
+		t.Fatalf("expected fallback warning in stderr, got: %s", logged)
 	}
 }

--- a/utils/splitdump/split_test.go
+++ b/utils/splitdump/split_test.go
@@ -75,6 +75,34 @@ func TestSplitDumpOpenReaderInvalidGzip(t *testing.T) {
 	}
 }
 
+func TestSplitDumpLineReaderErrorClosesCurrentLine(t *testing.T) {
+	bus := NewSplitDumpChannelBus()
+	inputPath := filepath.Join(t.TempDir(), "missing.sql")
+
+	go SplitDumpLineReader(bus, inputPath)
+
+	select {
+	case err, ok := <-bus.Error:
+		if !ok {
+			t.Fatal("expected error channel to be open for first read")
+		}
+		if err == nil {
+			t.Fatal("expected error from SplitDumpLineReader")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for splitdump error")
+	}
+
+	select {
+	case _, ok := <-bus.CurrentLine:
+		if ok {
+			t.Fatal("expected CurrentLine channel to be closed")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for CurrentLine channel close")
+	}
+}
+
 func TestSplitDumpLineParserMySQLGtidPurgedVariants(t *testing.T) {
 	cases := []struct {
 		name     string


### PR DESCRIPTION
**Summary**
- Add splitdump utilities (split + restore) with metadata handling, strictness controls, and tests.
- Wire splitdump into logical backup/reseed flow, including output dir normalization, metadata-driven restore behavior, and per-table restore ordering.
- Add client splitdump/splitrestore commands, improve CLI output handling, and add parser/arg tests.
- Expose splitdump and CLI path settings via config, API, and dashboard UI.
- Harden splitdump parsing (empty input, invalid gzip), improve MySQL GTID_PURGED capture, and add targeted tests.

 
**Notable changes**
- New splitdump package: utils/splitdump/*
- Cluster integration: cluster/srv_job_backup.go, cluster/cluster_bck.go, cluster/dump_stream_parser.go
- Client commands/tests: clients/client_splitdump.go, clients/client_splitrestore.go
- Settings/UI: config/config.go, server/api_cluster.go, server/server.go, share/dashboard_react/src/Pages/Settings/BackupSettings.jsx