### PR TITLE
fix: enhance splitdump restore logic to handle GTID and missing table scenarios

### DIFF
--- a/clients/client_splitrestore.go
+++ b/clients/client_splitrestore.go
@@ -65,6 +65,11 @@ func runSplitrestore(ctx context.Context) error {
 	cliSplitRestoreMysql = mysqlPath
 
 	restoreFile := func(ctx context.Context, path string) error {
+		if splitdump.IsGtidSlavePosDataFile(path) {
+			logger(splitdump.LogWarn, "Splitdump restore skipped mysql.gtid_slave_pos data file: %s", path)
+			return nil
+		}
+
 		file, err := os.Open(path)
 		if err != nil {
 			return err
@@ -86,6 +91,10 @@ func runSplitrestore(ctx context.Context) error {
 			return fmt.Errorf("invalid mysql-args: %w", err)
 		}
 		cmd := exec.CommandContext(ctx, cliSplitRestoreMysql, args...)
+		preamble := splitdump.RestorePreamble(path)
+		if preamble != "" {
+			reader = io.MultiReader(bytes.NewBufferString(preamble), reader)
+		}
 		cmd.Stdin = reader
 		var stderr bytes.Buffer
 		cmd.Stderr = &stderr
@@ -93,6 +102,10 @@ func runSplitrestore(ctx context.Context) error {
 			errOutput := strings.TrimSpace(stderr.String())
 			if errOutput == "" {
 				errOutput = err.Error()
+			}
+			if splitdump.SchemaFromFilename(path) == "mysql" && splitdump.IsMissingTableError(errOutput) {
+				logger(splitdump.LogWarn, "Splitdump restore skipped missing mysql table for %s: %s", path, errOutput)
+				return nil
 			}
 			return fmt.Errorf("mysql restore failed for %s: %s", path, errOutput)
 		}

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -999,7 +999,56 @@ func (server *ServerMonitor) restoreSplitdumpFileContext(ctx context.Context, pa
 		reader = gzReader
 	}
 
+	cluster := server.ClusterGroup
+	schema := splitdump.SchemaFromFilename(path)
+	table := splitdump.TableFromFilename(path)
+	if schema == "mysql" {
+		if splitdump.IsGtidSlavePosDataFile(path) {
+			if cluster != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModBackupStream, config.LvlWarn,
+					"Splitdump restore skipped mysql.gtid_slave_pos data file: %s", filepath.Base(path))
+			}
+			return nil
+		}
+		if table != "" {
+			exists, err := server.tableExists(schema, table)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				if cluster != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModBackupStream, config.LvlWarn,
+						"Splitdump restore skipped missing mysql table %s for %s", table, filepath.Base(path))
+				}
+				return nil
+			}
+		}
+	}
+
+	preamble := splitdump.RestorePreamble(path)
+	if preamble != "" {
+		reader = io.MultiReader(bytes.NewBufferString(preamble), reader)
+	}
+
 	return server.executeMysqlRestoreContext(ctx, reader)
+}
+
+func (server *ServerMonitor) tableExists(schema, table string) (bool, error) {
+	if server == nil {
+		return false, fmt.Errorf("server not available")
+	}
+	if server.Conn == nil {
+		return false, fmt.Errorf("server connection not available")
+	}
+	if strings.TrimSpace(schema) == "" || strings.TrimSpace(table) == "" {
+		return false, fmt.Errorf("schema and table are required")
+	}
+	var count int
+	row := server.Conn.QueryRow("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?", schema, table)
+	if err := row.Scan(&count); err != nil {
+		return false, fmt.Errorf("table exists query failed: %w", err)
+	}
+	return count > 0, nil
 }
 
 func (server *ServerMonitor) buildLogicalRestorePreamble() (string, int, error) {

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -1011,6 +1011,7 @@ func (server *ServerMonitor) restoreSplitdumpFileContext(ctx context.Context, pa
 			return nil
 		}
 		if table != "" {
+			// Server path proactively checks information_schema; CLI path reacts to mysql error output instead.
 			exists, err := server.tableExists(schema, table)
 			if err != nil {
 				return err
@@ -1034,17 +1035,35 @@ func (server *ServerMonitor) restoreSplitdumpFileContext(ctx context.Context, pa
 }
 
 func (server *ServerMonitor) tableExists(schema, table string) (bool, error) {
-	if server == nil {
-		return false, fmt.Errorf("server not available")
-	}
 	if server.Conn == nil {
-		return false, fmt.Errorf("server connection not available")
+		cluster := server.ClusterGroup
+		if cluster != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModBackupStream, config.LvlWarn,
+				"Splitdump restore skipped mysql table check for %s.%s: server connection not available", schema, table)
+		}
+		return false, nil
 	}
+	return tableExistsQuery(func() rowScanner {
+		return server.Conn.QueryRow("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?", schema, table)
+	}, schema, table)
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func tableExistsQuery(query func() rowScanner, schema, table string) (bool, error) {
 	if strings.TrimSpace(schema) == "" || strings.TrimSpace(table) == "" {
 		return false, fmt.Errorf("schema and table are required")
 	}
+	if query == nil {
+		return false, fmt.Errorf("query function is required")
+	}
 	var count int
-	row := server.Conn.QueryRow("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?", schema, table)
+	row := query()
+	if row == nil {
+		return false, fmt.Errorf("query returned nil row")
+	}
 	if err := row.Scan(&count); err != nil {
 		return false, fmt.Errorf("table exists query failed: %w", err)
 	}

--- a/cluster/srv_job_backup_tableexists_test.go
+++ b/cluster/srv_job_backup_tableexists_test.go
@@ -1,0 +1,95 @@
+package cluster
+
+import (
+	"errors"
+	"testing"
+)
+
+type stubRow struct {
+	scan func(dest ...any) error
+}
+
+func (r stubRow) Scan(dest ...any) error {
+	return r.scan(dest...)
+}
+
+func TestTableExistsQuerySchemaValidation(t *testing.T) {
+	_, err := tableExistsQuery(func() rowScanner { return stubRow{} }, "", "tbl")
+	if err == nil {
+		t.Fatal("expected error for empty schema")
+	}
+
+	_, err = tableExistsQuery(func() rowScanner { return stubRow{} }, "db", "")
+	if err == nil {
+		t.Fatal("expected error for empty table")
+	}
+}
+
+func TestTableExistsQueryNilQuery(t *testing.T) {
+	_, err := tableExistsQuery(nil, "db", "tbl")
+	if err == nil {
+		t.Fatal("expected error for nil query function")
+	}
+}
+
+func TestTableExistsQueryNilRow(t *testing.T) {
+	_, err := tableExistsQuery(func() rowScanner { return nil }, "db", "tbl")
+	if err == nil {
+		t.Fatal("expected error for nil row")
+	}
+}
+
+func TestTableExistsQueryReturnsTrue(t *testing.T) {
+	got, err := tableExistsQuery(func() rowScanner {
+		return stubRow{scan: func(dest ...any) error {
+			*(dest[0].(*int)) = 1
+			return nil
+		}}
+	}, "mysql", "user")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got {
+		t.Fatal("expected table to exist")
+	}
+}
+
+func TestTableExistsQueryReturnsFalse(t *testing.T) {
+	got, err := tableExistsQuery(func() rowScanner {
+		return stubRow{scan: func(dest ...any) error {
+			*(dest[0].(*int)) = 0
+			return nil
+		}}
+	}, "mysql", "missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
+		t.Fatal("expected table to be missing")
+	}
+}
+
+func TestTableExistsQueryScanError(t *testing.T) {
+	scanErr := errors.New("scan failed")
+	_, err := tableExistsQuery(func() rowScanner {
+		return stubRow{scan: func(dest ...any) error {
+			return scanErr
+		}}
+	}, "mysql", "user")
+	if err == nil {
+		t.Fatal("expected scan error")
+	}
+}
+
+func TestTableExistsSkipsWhenConnectionUnavailable(t *testing.T) {
+	_, server := newSplitDumpTestServer(t)
+	server.Conn = nil
+
+	got, err := server.tableExists("mysql", "user")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
+		t.Fatal("expected table check to be skipped")
+	}
+}

--- a/utils/splitdump/restore.go
+++ b/utils/splitdump/restore.go
@@ -371,10 +371,10 @@ func TableFromFilename(name string) string {
 
 func IsSchemaFile(name string) bool {
 	base := filepath.Base(name)
-	lower := strings.ToLower(base)
-	if lower == "mysql.system-all.sql.gz" || lower == "mysql.system-all.sql" || lower == "mysql.system-all" {
+	if isMysqlSystemAll(base) {
 		return true
 	}
+	lower := strings.ToLower(base)
 	return strings.HasSuffix(lower, "-schema.sql.gz") ||
 		strings.HasSuffix(lower, "-schema.sql") ||
 		strings.HasSuffix(lower, "-schema-view.sql.gz") ||
@@ -405,10 +405,10 @@ func RestorePreamble(name string) string {
 
 func splitdumpSchemaTable(name string) (string, string) {
 	base := filepath.Base(name)
-	lower := strings.ToLower(base)
-	if lower == "mysql.system-all.sql.gz" || lower == "mysql.system-all.sql" || lower == "mysql.system-all" {
+	if isMysqlSystemAll(base) {
 		return "mysql", ""
 	}
+	lower := strings.ToLower(base)
 	if !strings.HasSuffix(lower, ".sql.gz") && !strings.HasSuffix(lower, ".sql") {
 		return "", ""
 	}
@@ -417,12 +417,7 @@ func splitdumpSchemaTable(name string) (string, string) {
 	trimmed = strings.TrimSuffix(trimmed, ".sql")
 	trimmed = strings.TrimSuffix(trimmed, "-schema-view")
 	trimmed = strings.TrimSuffix(trimmed, "-schema")
-	if len(trimmed) > 6 && trimmed[len(trimmed)-6] == '.' {
-		suffix := trimmed[len(trimmed)-5:]
-		if _, err := strconv.Atoi(suffix); err == nil {
-			trimmed = trimmed[:len(trimmed)-6]
-		}
-	}
+	trimmed, _ = splitdumpDataKey(trimmed)
 	if trimmed == "" {
 		return "", ""
 	}
@@ -431,4 +426,9 @@ func splitdumpSchemaTable(name string) (string, string) {
 		return "", ""
 	}
 	return parts[0], parts[1]
+}
+
+func isMysqlSystemAll(name string) bool {
+	lower := strings.ToLower(name)
+	return lower == "mysql.system-all.sql.gz" || lower == "mysql.system-all.sql" || lower == "mysql.system-all"
 }

--- a/utils/splitdump/restore.go
+++ b/utils/splitdump/restore.go
@@ -358,3 +358,77 @@ func splitdumpDataKey(name string) (key string, shard int) {
 	}
 	return key, shard
 }
+
+func SchemaFromFilename(name string) string {
+	schema, _ := splitdumpSchemaTable(name)
+	return schema
+}
+
+func TableFromFilename(name string) string {
+	_, table := splitdumpSchemaTable(name)
+	return table
+}
+
+func IsSchemaFile(name string) bool {
+	base := filepath.Base(name)
+	lower := strings.ToLower(base)
+	if lower == "mysql.system-all.sql.gz" || lower == "mysql.system-all.sql" || lower == "mysql.system-all" {
+		return true
+	}
+	return strings.HasSuffix(lower, "-schema.sql.gz") ||
+		strings.HasSuffix(lower, "-schema.sql") ||
+		strings.HasSuffix(lower, "-schema-view.sql.gz") ||
+		strings.HasSuffix(lower, "-schema-view.sql")
+}
+
+func IsGtidSlavePosDataFile(name string) bool {
+	schema, table := splitdumpSchemaTable(name)
+	if schema != "mysql" || table != "gtid_slave_pos" {
+		return false
+	}
+	return !IsSchemaFile(name)
+}
+
+func IsMissingTableError(errOutput string) bool {
+	lower := strings.ToLower(errOutput)
+	return strings.Contains(lower, "error 1146") || strings.Contains(lower, "42s02")
+}
+
+func RestorePreamble(name string) string {
+	schema := SchemaFromFilename(name)
+	if schema == "" {
+		return "SET FOREIGN_KEY_CHECKS=0;\n"
+	}
+	escaped := strings.ReplaceAll(schema, "`", "``")
+	return "SET FOREIGN_KEY_CHECKS=0;\nUSE `" + escaped + "`;\n"
+}
+
+func splitdumpSchemaTable(name string) (string, string) {
+	base := filepath.Base(name)
+	lower := strings.ToLower(base)
+	if lower == "mysql.system-all.sql.gz" || lower == "mysql.system-all.sql" || lower == "mysql.system-all" {
+		return "mysql", ""
+	}
+	if !strings.HasSuffix(lower, ".sql.gz") && !strings.HasSuffix(lower, ".sql") {
+		return "", ""
+	}
+
+	trimmed := strings.TrimSuffix(base, ".sql.gz")
+	trimmed = strings.TrimSuffix(trimmed, ".sql")
+	trimmed = strings.TrimSuffix(trimmed, "-schema-view")
+	trimmed = strings.TrimSuffix(trimmed, "-schema")
+	if len(trimmed) > 6 && trimmed[len(trimmed)-6] == '.' {
+		suffix := trimmed[len(trimmed)-5:]
+		if _, err := strconv.Atoi(suffix); err == nil {
+			trimmed = trimmed[:len(trimmed)-6]
+		}
+	}
+	if trimmed == "" {
+		return "", ""
+	}
+	parts := strings.SplitN(trimmed, ".", 2)
+	if len(parts) < 2 {
+		return "", ""
+	}
+	return parts[0], parts[1]
+}

--- a/utils/splitdump/restore_test.go
+++ b/utils/splitdump/restore_test.go
@@ -368,3 +368,37 @@ func TestIsMissingTableError(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSchemaFile(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "db.tbl-schema.sql.gz", want: true},
+		{name: "db.tbl-schema.sql", want: true},
+		{name: "db.tbl-schema-view.sql.gz", want: true},
+		{name: "db.tbl-schema-view.sql", want: true},
+		{name: "mysql.system-all.sql.gz", want: true},
+		{name: "mysql.system-all.sql", want: true},
+		{name: "mysql.system-all", want: true},
+		{name: "db.tbl.sql.gz", want: false},
+		{name: "db.tbl.00001.sql.gz", want: false},
+		{name: "not-a-splitdump.txt", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSchemaFile(tt.name); got != tt.want {
+				t.Fatalf("IsSchemaFile(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRestorePreambleEscapesSchema(t *testing.T) {
+	name := "db`name.tbl.sql.gz"
+	want := "SET FOREIGN_KEY_CHECKS=0;\nUSE `db``name`;\n"
+	if got := RestorePreamble(name); got != want {
+		t.Fatalf("RestorePreamble(%q) = %q, want %q", name, got, want)
+	}
+}

--- a/utils/splitdump/restore_test.go
+++ b/utils/splitdump/restore_test.go
@@ -256,3 +256,115 @@ func TestListFilesOrderingAndClassification(t *testing.T) {
 		}
 	}
 }
+
+func TestSchemaFromFilename(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "db.tbl-schema.sql.gz", want: "db"},
+		{name: "db.tbl.sql.gz", want: "db"},
+		{name: "db.tbl.sql", want: "db"},
+		{name: "db.tbl-schema-view.sql.gz", want: "db"},
+		{name: "db.tbl.00001.sql.gz", want: "db"},
+		{name: filepath.Join("dir", "sub", "db.tbl-schema.sql"), want: "db"},
+		{name: "mysql.system-all.sql.gz", want: "mysql"},
+		{name: "mysql.system-all", want: "mysql"},
+		{name: "not-a-splitdump.txt", want: ""},
+		{name: "no-dot.sql.gz", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SchemaFromFilename(tt.name); got != tt.want {
+				t.Fatalf("SchemaFromFilename(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTableFromFilename(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "db.tbl-schema.sql.gz", want: "tbl"},
+		{name: "db.tbl.sql.gz", want: "tbl"},
+		{name: "db.tbl.00001.sql.gz", want: "tbl"},
+		{name: "db.tbl-schema-view.sql", want: "tbl"},
+		{name: "mysql.system-all.sql.gz", want: ""},
+		{name: "no-dot.sql", want: ""},
+		{name: "not-a-splitdump.txt", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TableFromFilename(tt.name); got != tt.want {
+				t.Fatalf("TableFromFilename(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRestorePreamble(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "db.tbl-schema.sql.gz", want: "SET FOREIGN_KEY_CHECKS=0;\nUSE `db`;\n"},
+		{name: "mysql.system-all.sql.gz", want: "SET FOREIGN_KEY_CHECKS=0;\nUSE `mysql`;\n"},
+		{name: "db.tbl.00001.sql.gz", want: "SET FOREIGN_KEY_CHECKS=0;\nUSE `db`;\n"},
+		{name: "db.tbl-schema-view.sql", want: "SET FOREIGN_KEY_CHECKS=0;\nUSE `db`;\n"},
+		{name: "no-dot.sql", want: "SET FOREIGN_KEY_CHECKS=0;\n"},
+		{name: "not-a-splitdump.txt", want: "SET FOREIGN_KEY_CHECKS=0;\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RestorePreamble(tt.name); got != tt.want {
+				t.Fatalf("RestorePreamble(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsGtidSlavePosDataFile(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "mysql.gtid_slave_pos.00000.sql.gz", want: true},
+		{name: "mysql.gtid_slave_pos.sql.gz", want: true},
+		{name: "mysql.gtid_slave_pos-schema.sql.gz", want: false},
+		{name: "db.gtid_slave_pos.00000.sql.gz", want: false},
+		{name: "not-a-splitdump.txt", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsGtidSlavePosDataFile(tt.name); got != tt.want {
+				t.Fatalf("IsGtidSlavePosDataFile(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsMissingTableError(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "ERROR 1146 (42S02) at line 6: Table 'mysql.column_stats' doesn't exist", want: true},
+		{name: "error 1146: Table 'mysql.column_stats' doesn't exist", want: true},
+		{name: "ERROR 1062 (23000): Duplicate entry", want: false},
+		{name: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsMissingTableError(tt.name); got != tt.want {
+				t.Fatalf("IsMissingTableError(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}

--- a/utils/splitdump/restore_test.go
+++ b/utils/splitdump/restore_test.go
@@ -351,19 +351,20 @@ func TestIsGtidSlavePosDataFile(t *testing.T) {
 
 func TestIsMissingTableError(t *testing.T) {
 	tests := []struct {
-		name string
-		want bool
+		name  string
+		input string
+		want  bool
 	}{
-		{name: "ERROR 1146 (42S02) at line 6: Table 'mysql.column_stats' doesn't exist", want: true},
-		{name: "error 1146: Table 'mysql.column_stats' doesn't exist", want: true},
-		{name: "ERROR 1062 (23000): Duplicate entry", want: false},
-		{name: "", want: false},
+		{name: "with 1146 and sqlstate", input: "ERROR 1146 (42S02) at line 6: Table 'mysql.column_stats' doesn't exist", want: true},
+		{name: "with 1146 only", input: "error 1146: Table 'mysql.column_stats' doesn't exist", want: true},
+		{name: "duplicate entry", input: "ERROR 1062 (23000): Duplicate entry", want: false},
+		{name: "empty", input: "", want: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsMissingTableError(tt.name); got != tt.want {
-				t.Fatalf("IsMissingTableError(%q) = %v, want %v", tt.name, got, tt.want)
+			if got := IsMissingTableError(tt.input); got != tt.want {
+				t.Fatalf("IsMissingTableError(%q) = %v, want %v", tt.input, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
- Summary:
  - Skip mysql.gtid_slave_pos data files during splitdump restores and add warning logs for skipped files.
  - Add restore preamble to set FOREIGN_KEY_CHECKS and schema context before loading data.
  - Gracefully ignore missing mysql system tables during restore to avoid hard failures.
  - Add filename parsing helpers and tests for schema/table detection and error classification.