### PR TITLE
fix: prevent splitdump restore from binlogging

### DIFF
--- a/clients/client_splitrestore.go
+++ b/clients/client_splitrestore.go
@@ -21,11 +21,12 @@ import (
 )
 
 var (
-	cliSplitRestoreDir      string
-	cliSplitRestoreMysql    string
-	cliSplitRestoreMysqlArg string
-	cliSplitRestoreParallel int
-	cliSplitRestoreUser     bool
+	cliSplitRestoreDir           string
+	cliSplitRestoreMysql         string
+	cliSplitRestoreMysqlArg      string
+	cliSplitRestoreParallel      int
+	cliSplitRestoreUser          bool
+	cliSplitRestoreDisableBinlog bool
 )
 
 var splitRestoreCmd = &cobra.Command{
@@ -46,6 +47,7 @@ func initSplitRestoreFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&cliSplitRestoreMysqlArg, "mysql-args", "--force --batch", "Extra mysql client arguments")
 	cmd.Flags().IntVar(&cliSplitRestoreParallel, "parallel", 1, "Parallel workers for splitdump restore")
 	cmd.Flags().BoolVar(&cliSplitRestoreUser, "restore-user", true, "Restore mysql.system-all file when present")
+	cmd.Flags().BoolVar(&cliSplitRestoreDisableBinlog, "disable-binlog", false, "Disable binary logging for splitdump restore")
 }
 
 func runSplitrestore(ctx context.Context) error {
@@ -92,6 +94,10 @@ func runSplitrestore(ctx context.Context) error {
 		}
 		cmd := exec.CommandContext(ctx, cliSplitRestoreMysql, args...)
 		preamble := splitdump.RestorePreamble(path)
+		// CLI requires an explicit flag to disable binlog per file.
+		if cliSplitRestoreDisableBinlog {
+			preamble = "SET sql_log_bin=0;" + preamble
+		}
 		if preamble != "" {
 			reader = io.MultiReader(bytes.NewBufferString(preamble), reader)
 		}

--- a/clients/client_splitrestore.go
+++ b/clients/client_splitrestore.go
@@ -96,7 +96,7 @@ func runSplitrestore(ctx context.Context) error {
 		preamble := splitdump.RestorePreamble(path)
 		// CLI requires an explicit flag to disable binlog per file.
 		if cliSplitRestoreDisableBinlog {
-			preamble = "SET sql_log_bin=0;" + preamble
+			preamble = "SET sql_log_bin=0;\n" + preamble
 		}
 		if preamble != "" {
 			reader = io.MultiReader(bytes.NewBufferString(preamble), reader)

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -978,15 +978,6 @@ func (server *ServerMonitor) reseedMysqldumpWithMetadata(ctx context.Context, ba
 	return server.reseedMysqldumpWithSplitdump(ctx, backupPath, restoreUser)
 }
 
-func (server *ServerMonitor) restoreSplitdumpFile(path string) error {
-	return server.restoreSplitdumpFileContext(context.Background(), path)
-}
-
-func (server *ServerMonitor) restoreSplitdumpFileContext(ctx context.Context, path string) error {
-	preamble := splitdump.RestorePreamble(path)
-	return server.restoreSplitdumpFileContextWithPreamble(ctx, path, preamble)
-}
-
 func (server *ServerMonitor) restoreSplitdumpFileContextWithPreamble(ctx context.Context, path, preamble string) error {
 	file, err := os.Open(path)
 	if err != nil {
@@ -1103,7 +1094,7 @@ func (server *ServerMonitor) buildLogicalRestorePreamble() (string, int, error) 
 func (server *ServerMonitor) buildSplitdumpRestorePreamble(path string, sqlLogBin int) string {
 	preamble := splitdump.RestorePreamble(path)
 	if sqlLogBin == 0 {
-		return "SET sql_log_bin=0;" + preamble
+		return "SET sql_log_bin=0;\n" + preamble
 	}
 	return preamble
 }

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -983,6 +983,11 @@ func (server *ServerMonitor) restoreSplitdumpFile(path string) error {
 }
 
 func (server *ServerMonitor) restoreSplitdumpFileContext(ctx context.Context, path string) error {
+	preamble := splitdump.RestorePreamble(path)
+	return server.restoreSplitdumpFileContextWithPreamble(ctx, path, preamble)
+}
+
+func (server *ServerMonitor) restoreSplitdumpFileContextWithPreamble(ctx context.Context, path, preamble string) error {
 	file, err := os.Open(path)
 	if err != nil {
 		return err
@@ -1026,7 +1031,6 @@ func (server *ServerMonitor) restoreSplitdumpFileContext(ctx context.Context, pa
 		}
 	}
 
-	preamble := splitdump.RestorePreamble(path)
 	if preamble != "" {
 		reader = io.MultiReader(bytes.NewBufferString(preamble), reader)
 	}
@@ -1096,6 +1100,14 @@ func (server *ServerMonitor) buildLogicalRestorePreamble() (string, int, error) 
 	return cmdstring, sqlLogBin, nil
 }
 
+func (server *ServerMonitor) buildSplitdumpRestorePreamble(path string, sqlLogBin int) string {
+	preamble := splitdump.RestorePreamble(path)
+	if sqlLogBin == 0 {
+		return "SET sql_log_bin=0;" + preamble
+	}
+	return preamble
+}
+
 func (server *ServerMonitor) JobReseedSplitdumpWithMysql(ctx context.Context, backupPath string, restoreUser bool) error {
 	cluster := server.ClusterGroup
 	if cluster == nil {
@@ -1142,6 +1154,12 @@ func (server *ServerMonitor) JobReseedSplitdumpWithMysql(ctx context.Context, ba
 
 	defer server.SetInReseedBackup("")
 
+	// Each splitdump file runs in a new mysql client session, so apply a per-file preamble.
+	restoreFile := func(ctx context.Context, path string) error {
+		preamble := server.buildSplitdumpRestorePreamble(path, sqlLogBin)
+		return server.restoreSplitdumpFileContextWithPreamble(ctx, path, preamble)
+	}
+
 	restoreErr := splitdump.Restore(backupPath, splitdump.RestoreOptions{
 		Parallel:    cluster.Conf.BackupLogicalLoadThreads,
 		RestoreUser: restoreUser,
@@ -1149,7 +1167,7 @@ func (server *ServerMonitor) JobReseedSplitdumpWithMysql(ctx context.Context, ba
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModBackupStream, level, format, args...)
 		},
 		Context:                ctx,
-		RestoreFileWithContext: server.restoreSplitdumpFileContext,
+		RestoreFileWithContext: restoreFile,
 	})
 	if restoreErr != nil {
 		return restoreErr

--- a/cluster/srv_job_backup_preamble_test.go
+++ b/cluster/srv_job_backup_preamble_test.go
@@ -8,25 +8,33 @@ import (
 func TestBuildSplitdumpRestorePreamble(t *testing.T) {
 	server := &ServerMonitor{}
 	path := "test.sql"
+	pathWithSchema := "mydb.mytable.sql"
 
 	cases := []struct {
-		name       string
-		sqlLogBin  int
-		wantBinlog bool
+		name              string
+		sqlLogBin         int
+		path              string
+		wantSqlLogBinZero bool
+		wantUse           bool
 	}{
-		{name: "binlog-disabled", sqlLogBin: 0, wantBinlog: true},
-		{name: "binlog-enabled", sqlLogBin: 1, wantBinlog: false},
+		{name: "binlog-disabled", sqlLogBin: 0, path: path, wantSqlLogBinZero: true, wantUse: false},
+		{name: "binlog-enabled", sqlLogBin: 1, path: path, wantSqlLogBinZero: false, wantUse: false},
+		{name: "binlog-disabled-with-use", sqlLogBin: 0, path: pathWithSchema, wantSqlLogBinZero: true, wantUse: true},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := server.buildSplitdumpRestorePreamble(path, tc.sqlLogBin)
+			got := server.buildSplitdumpRestorePreamble(tc.path, tc.sqlLogBin)
 			hasBinlog := strings.Contains(got, "SET sql_log_bin=0;")
-			if hasBinlog != tc.wantBinlog {
-				t.Fatalf("buildSplitdumpRestorePreamble() binlog=%t, want %t", hasBinlog, tc.wantBinlog)
+			if hasBinlog != tc.wantSqlLogBinZero {
+				t.Fatalf("buildSplitdumpRestorePreamble() binlog=%t, want %t", hasBinlog, tc.wantSqlLogBinZero)
 			}
 			if !strings.Contains(got, "SET FOREIGN_KEY_CHECKS=0;") {
 				t.Fatalf("buildSplitdumpRestorePreamble() missing foreign key checks preamble")
+			}
+			hasUse := strings.Contains(got, "USE `mydb`;")
+			if hasUse != tc.wantUse {
+				t.Fatalf("buildSplitdumpRestorePreamble() use=%t, want %t", hasUse, tc.wantUse)
 			}
 		})
 	}

--- a/cluster/srv_job_backup_preamble_test.go
+++ b/cluster/srv_job_backup_preamble_test.go
@@ -1,0 +1,33 @@
+package cluster
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildSplitdumpRestorePreamble(t *testing.T) {
+	server := &ServerMonitor{}
+	path := "test.sql"
+
+	cases := []struct {
+		name       string
+		sqlLogBin  int
+		wantBinlog bool
+	}{
+		{name: "binlog-disabled", sqlLogBin: 0, wantBinlog: true},
+		{name: "binlog-enabled", sqlLogBin: 1, wantBinlog: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := server.buildSplitdumpRestorePreamble(path, tc.sqlLogBin)
+			hasBinlog := strings.Contains(got, "SET sql_log_bin=0;")
+			if hasBinlog != tc.wantBinlog {
+				t.Fatalf("buildSplitdumpRestorePreamble() binlog=%t, want %t", hasBinlog, tc.wantBinlog)
+			}
+			if !strings.Contains(got, "SET FOREIGN_KEY_CHECKS=0;") {
+				t.Fatalf("buildSplitdumpRestorePreamble() missing foreign key checks preamble")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Apply per-file sql_log_bin preambles on server restores and add a CLI flag to disable binlogging, with tests for preamble generation.