### PR TITLE
fix: compact mysql restore errors

### DIFF
--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -1509,8 +1509,9 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string, restoreUser b
 		clientCmd.Stdin = io.MultiReader(bytes.NewBufferString(cmdstring), fz)
 	}
 
-	stderr, _ := clientCmd.StdoutPipe()
-	clientCmd.Stderr = clientCmd.Stdout
+	stdout, _ := clientCmd.StdoutPipe()
+	var stderr bytes.Buffer
+	clientCmd.Stderr = &stderr
 
 	if err := clientCmd.Start(); err != nil {
 		return fmt.Errorf("Can't start mysql client:%s at %s", err, strings.ReplaceAll(clientCmd.String(), "="+cluster.GetDbPass(), "=XXXX"))
@@ -1521,14 +1522,21 @@ func (server *ServerMonitor) JobReseedMysqldump(backupfile string, restoreUser b
 
 	go func() {
 		defer wg.Done()
-		server.copyLogs(stderr, config.ConstLogModBackupStream, config.LvlDbg)
+		server.copyLogs(stdout, config.ConstLogModBackupStream, config.LvlDbg)
 	}()
 
-	wg.Wait()
-
 	err = clientCmd.Wait()
+	wg.Wait()
 	if err != nil {
-		return fmt.Errorf("Error waiting reseed %s at %s", server.URL, err)
+		errOutput := strings.TrimSpace(stderr.String())
+		formatted := server.formatMysqlRestoreError(errOutput)
+		if formatted == "" {
+			formatted = errOutput
+		}
+		if formatted == "" {
+			formatted = err.Error()
+		}
+		return fmt.Errorf("Error waiting reseed %s: %s: %w", server.URL, formatted, err)
 	}
 
 	elapsed := time.Since(start).Round(time.Second)

--- a/cluster/srv_job_restic.go
+++ b/cluster/srv_job_restic.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -1675,6 +1676,77 @@ func (server *ServerMonitor) executeMysqlRestore(reader io.Reader) error {
 	return server.executeMysqlRestoreContext(context.Background(), reader)
 }
 
+var mysqlRestoreErrorLineRe = regexp.MustCompile(`(?i)^ERROR\s+\d+\s+\([0-9A-Z]+\)(?:\s+at\s+line\s+\d+:|\s*:|\s+at\s+line\s+\d+\s*:)`)
+var mysqlRestoreTableRe = regexp.MustCompile(`(?is)\b(?:ALTER\s+TABLE|INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s*([^\s(;]+)`)
+
+func (server *ServerMonitor) formatMysqlRestoreError(stderr string) string {
+	trimmed := strings.TrimSpace(stderr)
+	if trimmed == "" {
+		return ""
+	}
+
+	var errLine string
+	lines := strings.Split(trimmed, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "mysql:") {
+			line = strings.TrimSpace(strings.TrimPrefix(line, "mysql:"))
+		}
+		if strings.HasPrefix(line, "[ERROR]") {
+			line = strings.TrimSpace(strings.TrimPrefix(line, "[ERROR]"))
+			if !strings.HasPrefix(line, "ERROR ") {
+				line = "ERROR " + line
+			}
+		}
+		if mysqlRestoreErrorLineRe.MatchString(line) {
+			errLine = line
+			break
+		}
+	}
+	if errLine == "" {
+		return ""
+	}
+
+	var table string
+	if match := mysqlRestoreTableRe.FindStringSubmatch(trimmed); len(match) > 1 {
+		table = normalizeMysqlRestoreTable(match[1])
+	}
+	if table == "" {
+		return errLine
+	}
+	return fmt.Sprintf("%s - TABLE %s", errLine, table)
+}
+
+func normalizeMysqlRestoreTable(raw string) string {
+	table := strings.TrimSpace(raw)
+	if table == "" {
+		return ""
+	}
+	for _, prefix := range []string{"(", "`"} {
+		table = strings.TrimPrefix(table, prefix)
+	}
+	for _, suffix := range []string{";", ",", ")", "`"} {
+		table = strings.TrimSuffix(table, suffix)
+	}
+	table = strings.ReplaceAll(table, "`.`", ".")
+	table = strings.ReplaceAll(table, "`", "")
+
+	upper := strings.ToUpper(table)
+	keywords := []string{"DISABLE", "ENABLE", "VALUES", "SET", "WHERE", "JOIN", "INNER", "LEFT", "RIGHT", "CROSS", "ON", "ADD", "DROP", "ALTER", "RENAME", "KEYS"}
+	for _, keyword := range keywords {
+		if idx := strings.Index(upper, keyword); idx > 0 {
+			table = strings.TrimSpace(table[:idx])
+			upper = strings.ToUpper(table)
+		}
+	}
+
+	table = strings.TrimRight(table, ".")
+	return strings.TrimSpace(table)
+}
+
 func (server *ServerMonitor) executeMysqlRestoreContext(ctx context.Context, reader io.Reader) error {
 	if reader == nil {
 		return fmt.Errorf("mysql restore reader is nil")
@@ -1710,14 +1782,18 @@ func (server *ServerMonitor) executeMysqlRestoreContext(ctx context.Context, rea
 
 	if err := cmd.Run(); err != nil {
 		errOutput := strings.TrimSpace(stderr.String())
-		if errOutput == "" {
-			errOutput = err.Error()
+		formatted := server.formatMysqlRestoreError(errOutput)
+		if formatted == "" {
+			formatted = errOutput
+		}
+		if formatted == "" {
+			formatted = err.Error()
 		}
 		cluster.LogModulePrintf(cluster.Conf.Verbose,
 			config.ConstLogModRestic,
 			config.LvlErr,
-			"mysql restore failed: %s", errOutput)
-		return fmt.Errorf("mysql restore failed: %s: %w", errOutput, err)
+			"mysql restore failed: %s", formatted)
+		return fmt.Errorf("mysql restore failed: %s: %w", formatted, err)
 	}
 
 	return nil

--- a/cluster/srv_job_restic_test.go
+++ b/cluster/srv_job_restic_test.go
@@ -133,6 +133,38 @@ func TestVerifyRestoredBackupUsesAlternateCompressionPath(t *testing.T) {
 	}
 }
 
+func TestFormatMysqlRestoreError(t *testing.T) {
+	server := &ServerMonitor{}
+	for _, tc := range []struct {
+		name     string
+		stderr   string
+		expected string
+	}{
+		{
+			name:     "mysql error with insert table",
+			stderr:   "mysql: [ERROR] 1046 (3D000) at line 5: No database selected\n-------------- INSERT INTOdb.customer8VALUES (1, 2)\n",
+			expected: "ERROR 1046 (3D000) at line 5: No database selected - TABLE db.customer8",
+		},
+		{
+			name:     "error with alter table and schema",
+			stderr:   "ERROR 1146 (42S02) at line 1: Table 'db.customer8' doesn't exist\n/*!40000 ALTER TABLE`db`.`customer8`DISABLE KEYS */\n",
+			expected: "ERROR 1146 (42S02) at line 1: Table 'db.customer8' doesn't exist - TABLE db.customer8",
+		},
+		{
+			name:     "error without table",
+			stderr:   "ERROR 1234 (HY000) at line 9: Some error without statement\n",
+			expected: "ERROR 1234 (HY000) at line 9: Some error without statement",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := server.formatMysqlRestoreError(tc.stderr)
+			if got != tc.expected {
+				t.Fatalf("unexpected formatted error\nexpected: %s\nactual:   %s", tc.expected, got)
+			}
+		})
+	}
+}
+
 func TestBuildResticReseedPayload(t *testing.T) {
 	server := &ServerMonitor{}
 	summary := &SnapshotMetadataSummary{


### PR DESCRIPTION
Summary
- Parse mysql restore stderr to keep only the error line and schema-qualified table.
- Stop logging full queries during mysqldump and splitdump restore failures.
- Add tests for mysql restore error formatting.