### PR TITLE
feat: add configurable splitdump shard size

### DIFF
--- a/clients/client_cmd.go
+++ b/clients/client_cmd.go
@@ -81,6 +81,7 @@ var (
 	cliLogDir                    string
 	cliOutputDir                 string
 	cliInputFile                 string
+	cliSplitDumpStreamSizeMax    string
 	cfgGroup                     string
 	memprofile                   string
 	cpuprofile                   string
@@ -281,6 +282,7 @@ func initStatusFlags(cmd *cobra.Command) {
 func initStatusFlagsDumpSplit(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&cliOutputDir, "outputdir", "./", "Directory to store files")
 	cmd.Flags().StringVar(&cliInputFile, "inputfile", "", "SQL file in text or gzip instead of stdin")
+	cmd.Flags().StringVar(&cliSplitDumpStreamSizeMax, "stream-size-max", "", "Max stream size before sharding (e.g. 16MiB, 1G; 0 disables sharding)")
 	viper.BindPFlags(cmd.Flags())
 }
 

--- a/clients/client_splitdump.go
+++ b/clients/client_splitdump.go
@@ -39,8 +39,8 @@ func runSplitdump(inputFile, outputDir string) error {
 		if err != nil {
 			return fmt.Errorf("invalid stream-size-max: %w", err)
 		}
-		options.StreamSizeMax = value
-		options.StreamSizeMaxSet = true
+		streamSizeMax := value
+		options.StreamSizeMax = &streamSizeMax
 	}
 
 	fmt.Printf("Outputing all tables to %s\n", outputDir)

--- a/clients/client_splitdump.go
+++ b/clients/client_splitdump.go
@@ -10,6 +10,7 @@ package clients
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -33,6 +34,15 @@ var splitDumpCmd = &cobra.Command{
 
 func runSplitdump(inputFile, outputDir string) error {
 	bus := splitdump.NewSplitDumpChannelBus()
+	var options splitdump.SplitDumpOptions
+	if strings.TrimSpace(cliSplitDumpStreamSizeMax) != "" {
+		value, err := splitdump.ParseSizeBytes(cliSplitDumpStreamSizeMax)
+		if err != nil {
+			return fmt.Errorf("invalid stream-size-max: %w", err)
+		}
+		options.StreamSizeMax = value
+		options.StreamSizeMaxSet = true
+	}
 
 	fmt.Printf("Outputing all tables to %s\n", outputDir)
 
@@ -50,7 +60,7 @@ func runSplitdump(inputFile, outputDir string) error {
 	}()
 	go func() {
 		defer wg.Done()
-		splitdump.SplitDumpLineParser(bus, outputDir)
+		splitdump.SplitDumpLineParser(bus, outputDir, options)
 	}()
 	//, conf.Combine, conf.OutputPath, conf.SkipData, conf.SkipTable)
 	go func() {

--- a/clients/client_splitdump.go
+++ b/clients/client_splitdump.go
@@ -10,7 +10,6 @@ package clients
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -35,7 +34,7 @@ var splitDumpCmd = &cobra.Command{
 func runSplitdump(inputFile, outputDir string) error {
 	bus := splitdump.NewSplitDumpChannelBus()
 	var options splitdump.SplitDumpOptions
-	if strings.TrimSpace(cliSplitDumpStreamSizeMax) != "" {
+	if cliSplitDumpStreamSizeMax != "" {
 		value, err := splitdump.ParseSizeBytes(cliSplitDumpStreamSizeMax)
 		if err != nil {
 			return fmt.Errorf("invalid stream-size-max: %w", err)

--- a/utils/splitdump/options.go
+++ b/utils/splitdump/options.go
@@ -14,11 +14,14 @@ type SplitDumpOptions struct {
 	StreamSizeMaxSet bool
 }
 
-func normalizeSplitDumpOptions(opts SplitDumpOptions) SplitDumpOptions {
+func normalizeSplitDumpOptions(opts SplitDumpOptions) (SplitDumpOptions, error) {
+	if opts.StreamSizeMaxSet && opts.StreamSizeMax < 0 {
+		return opts, fmt.Errorf("splitdump: stream size max must be >= 0")
+	}
 	if !opts.StreamSizeMaxSet {
 		opts.StreamSizeMax = defaultStreamSizeMax
 	}
-	return opts
+	return opts, nil
 }
 
 func ParseSizeBytes(input string) (int64, error) {

--- a/utils/splitdump/options.go
+++ b/utils/splitdump/options.go
@@ -1,0 +1,75 @@
+package splitdump
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+const defaultStreamSizeMax = int64(1024 * 1024 * 1024)
+
+type SplitDumpOptions struct {
+	StreamSizeMax    int64
+	StreamSizeMaxSet bool
+}
+
+func normalizeSplitDumpOptions(opts SplitDumpOptions) SplitDumpOptions {
+	if !opts.StreamSizeMaxSet {
+		opts.StreamSizeMax = defaultStreamSizeMax
+	}
+	return opts
+}
+
+func ParseSizeBytes(input string) (int64, error) {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return 0, nil
+	}
+	if strings.HasPrefix(trimmed, "-") {
+		return 0, fmt.Errorf("size must be >= 0")
+	}
+
+	idx := 0
+	for idx < len(trimmed) {
+		c := trimmed[idx]
+		if c < '0' || c > '9' {
+			break
+		}
+		idx++
+	}
+	if idx == 0 {
+		return 0, fmt.Errorf("size must start with digits")
+	}
+
+	value, err := strconv.ParseInt(trimmed[:idx], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid size value: %w", err)
+	}
+
+	suffix := strings.ToLower(strings.TrimSpace(trimmed[idx:]))
+	multiplier := int64(1)
+	switch suffix {
+	case "", "b":
+		multiplier = 1
+	case "k", "kb":
+		multiplier = 1000
+	case "m", "mb":
+		multiplier = 1000 * 1000
+	case "g", "gb":
+		multiplier = 1000 * 1000 * 1000
+	case "kib":
+		multiplier = 1024
+	case "mib":
+		multiplier = 1024 * 1024
+	case "gib":
+		multiplier = 1024 * 1024 * 1024
+	default:
+		return 0, fmt.Errorf("invalid size suffix %q", suffix)
+	}
+
+	if value > math.MaxInt64/multiplier {
+		return 0, fmt.Errorf("size overflows int64")
+	}
+	return value * multiplier, nil
+}

--- a/utils/splitdump/options.go
+++ b/utils/splitdump/options.go
@@ -10,18 +10,17 @@ import (
 const defaultStreamSizeMax = int64(1024 * 1024 * 1024)
 
 type SplitDumpOptions struct {
-	StreamSizeMax    int64
-	StreamSizeMaxSet bool
+	StreamSizeMax *int64
 }
 
-func normalizeSplitDumpOptions(opts SplitDumpOptions) (SplitDumpOptions, error) {
-	if opts.StreamSizeMaxSet && opts.StreamSizeMax < 0 {
-		return opts, fmt.Errorf("splitdump: stream size max must be >= 0")
+func normalizeSplitDumpOptions(opts SplitDumpOptions) (int64, error) {
+	if opts.StreamSizeMax == nil {
+		return defaultStreamSizeMax, nil
 	}
-	if !opts.StreamSizeMaxSet {
-		opts.StreamSizeMax = defaultStreamSizeMax
+	if *opts.StreamSizeMax < 0 {
+		return 0, fmt.Errorf("splitdump: stream size max must be >= 0")
 	}
-	return opts, nil
+	return *opts.StreamSizeMax, nil
 }
 
 func ParseSizeBytes(input string) (int64, error) {
@@ -61,12 +60,16 @@ func ParseSizeBytes(input string) (int64, error) {
 		multiplier = 1000 * 1000
 	case "g", "gb":
 		multiplier = 1000 * 1000 * 1000
+	case "t", "tb":
+		multiplier = 1000 * 1000 * 1000 * 1000
 	case "kib":
 		multiplier = 1024
 	case "mib":
 		multiplier = 1024 * 1024
 	case "gib":
 		multiplier = 1024 * 1024 * 1024
+	case "tib":
+		multiplier = 1024 * 1024 * 1024 * 1024
 	default:
 		return 0, fmt.Errorf("invalid size suffix %q", suffix)
 	}

--- a/utils/splitdump/options_test.go
+++ b/utils/splitdump/options_test.go
@@ -19,10 +19,13 @@ func TestParseSizeBytes(t *testing.T) {
 		{name: "giga", input: "1G", want: 1 * 1000 * 1000 * 1000},
 		{name: "giga-bytes", input: "1GB", want: 1 * 1000 * 1000 * 1000},
 		{name: "space-before-suffix", input: "16 MB", want: 16 * 1000 * 1000},
+		{name: "tera", input: "1T", want: 1 * 1000 * 1000 * 1000 * 1000},
+		{name: "tera-bytes", input: "1TB", want: 1 * 1000 * 1000 * 1000 * 1000},
 		{name: "kibi", input: "16KiB", want: 16 * 1024},
 		{name: "mebi", input: "16MiB", want: 16 * 1024 * 1024},
 		{name: "gibi", input: "1GiB", want: 1 * 1024 * 1024 * 1024},
-		{name: "invalid-suffix", input: "5TB", wantErr: true},
+		{name: "tebi", input: "1TiB", want: 1 * 1024 * 1024 * 1024 * 1024},
+		{name: "invalid-suffix", input: "5PB", wantErr: true},
 		{name: "invalid-number", input: "MiB", wantErr: true},
 		{name: "invalid-decimal", input: "1.5G", wantErr: true},
 		{name: "negative", input: "-1", wantErr: true},
@@ -48,7 +51,8 @@ func TestParseSizeBytes(t *testing.T) {
 }
 
 func TestNormalizeSplitDumpOptionsRejectsNegativeWhenSet(t *testing.T) {
-	_, err := normalizeSplitDumpOptions(SplitDumpOptions{StreamSizeMax: -1, StreamSizeMaxSet: true})
+	value := int64(-1)
+	_, err := normalizeSplitDumpOptions(SplitDumpOptions{StreamSizeMax: &value})
 	if err == nil {
 		t.Fatal("expected error for negative StreamSizeMax when set")
 	}

--- a/utils/splitdump/options_test.go
+++ b/utils/splitdump/options_test.go
@@ -1,0 +1,47 @@
+package splitdump
+
+import "testing"
+
+func TestParseSizeBytes(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    int64
+		wantErr bool
+	}{
+		{name: "empty", input: "", want: 0},
+		{name: "bytes", input: "42", want: 42},
+		{name: "zero", input: "0", want: 0},
+		{name: "kilo", input: "16K", want: 16 * 1000},
+		{name: "kilo-bytes", input: "16KB", want: 16 * 1000},
+		{name: "mega", input: "16M", want: 16 * 1000 * 1000},
+		{name: "mega-bytes", input: "16MB", want: 16 * 1000 * 1000},
+		{name: "giga", input: "1G", want: 1 * 1000 * 1000 * 1000},
+		{name: "giga-bytes", input: "1GB", want: 1 * 1000 * 1000 * 1000},
+		{name: "kibi", input: "16KiB", want: 16 * 1024},
+		{name: "mebi", input: "16MiB", want: 16 * 1024 * 1024},
+		{name: "gibi", input: "1GiB", want: 1 * 1024 * 1024 * 1024},
+		{name: "invalid-suffix", input: "5TB", wantErr: true},
+		{name: "invalid-number", input: "MiB", wantErr: true},
+		{name: "invalid-decimal", input: "1.5G", wantErr: true},
+		{name: "negative", input: "-1", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseSizeBytes(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Fatalf("ParseSizeBytes(%q) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/utils/splitdump/options_test.go
+++ b/utils/splitdump/options_test.go
@@ -45,3 +45,10 @@ func TestParseSizeBytes(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeSplitDumpOptionsRejectsNegativeWhenSet(t *testing.T) {
+	_, err := normalizeSplitDumpOptions(SplitDumpOptions{StreamSizeMax: -1, StreamSizeMaxSet: true})
+	if err == nil {
+		t.Fatal("expected error for negative StreamSizeMax when set")
+	}
+}

--- a/utils/splitdump/options_test.go
+++ b/utils/splitdump/options_test.go
@@ -18,6 +18,7 @@ func TestParseSizeBytes(t *testing.T) {
 		{name: "mega-bytes", input: "16MB", want: 16 * 1000 * 1000},
 		{name: "giga", input: "1G", want: 1 * 1000 * 1000 * 1000},
 		{name: "giga-bytes", input: "1GB", want: 1 * 1000 * 1000 * 1000},
+		{name: "space-before-suffix", input: "16 MB", want: 16 * 1000 * 1000},
 		{name: "kibi", input: "16KiB", want: 16 * 1024},
 		{name: "mebi", input: "16MiB", want: 16 * 1024 * 1024},
 		{name: "gibi", input: "1GiB", want: 1 * 1024 * 1024 * 1024},

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -167,13 +167,12 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 		}
 	}
 
-	opts, err = normalizeSplitDumpOptions(opts)
+	streamSizeMax, err := normalizeSplitDumpOptions(opts)
 	if err != nil {
 		finishWithError(err)
 		return
 	}
 	streamSize := int64(0)
-	streamSizeMax := opts.StreamSizeMax
 	for line := range bus.CurrentLine {
 		if !sourceDataDisabled {
 			lowerLine := strings.ToLower(line)

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -167,9 +167,9 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 		}
 	}
 
-	opts = normalizeSplitDumpOptions(opts)
-	if opts.StreamSizeMax < 0 {
-		finishWithError(fmt.Errorf("splitdump: stream size max must be >= 0"))
+	opts, err = normalizeSplitDumpOptions(opts)
+	if err != nil {
+		finishWithError(err)
 		return
 	}
 	streamSize := int64(0)

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -136,6 +136,7 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 	onTableScheme, onTableData, pastHeader := false, false, false
 	shardpad, schema := "", ""
 	shard := 0
+	dataTableName := ""
 	binlogRegexMariaDB := regexp.MustCompile(`CHANGE MASTER TO MASTER_LOG_FILE='(.+)', MASTER_LOG_POS=(\d+)`)
 	gtidRegexMariaDB := regexp.MustCompile(`SET GLOBAL gtid_slave_pos='(.+)'`)
 	binlogRegexMySQL := regexp.MustCompile(`CHANGE REPLICATION SOURCE TO SOURCE_LOG_FILE='(.+)', SOURCE_LOG_POS=(\d+)`)
@@ -193,7 +194,11 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 				shard++
 				closeTableFile()
 				shardpad = fmt.Sprintf(".%05d", shard)
-				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table ", "", 1), "`", "", -1)) + shardpad
+				baseTableName := dataTableName
+				if baseTableName == "" {
+					baseTableName = schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table ", "", 1), "`", "", -1))
+				}
+				tableName := baseTableName + shardpad
 				fmt.Printf("Processing table data %s ", tableName)
 				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
 				f, err = os.Create(tablePath)
@@ -214,6 +219,7 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 			if strings.HasPrefix(line, "UNLOCK TABLES;") {
 				onTableData = false
 				onTableScheme = false
+				dataTableName = ""
 				streamSize = 0
 				closeTableWriter()
 			}
@@ -259,7 +265,8 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 				}
 				closeTableFile()
 				shardpad = fmt.Sprintf(".%05d", shard)
-				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table ", "", 1), "`", "", -1)) + shardpad
+				dataTableName = schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table ", "", 1), "`", "", -1))
+				tableName := dataTableName + shardpad
 				fmt.Printf("Processing table data %s\n", tableName)
 				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
 				f, err = os.Create(tablePath)
@@ -279,6 +286,7 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 			} else if strings.HasPrefix(line, "-- Final view structure for view ") {
 				onTableData = false
 				onTableScheme = false
+				dataTableName = ""
 				//	onView = true
 				closeTableFile()
 				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Final view structure for view ", "", 1), "`", "", -1)) + "-schema-view"
@@ -294,6 +302,7 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 			} else if strings.HasPrefix(line, "INSTALL PLUGIN") || strings.HasPrefix(line, "CREATE USER") {
 				onTableData = false
 				onTableScheme = false
+				dataTableName = ""
 				closeTableFile()
 				tableName := "mysql.system-all"
 				fmt.Printf("Processing system schema %s\n", tableName)

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -105,7 +105,7 @@ func SplitDumpLineReader(bus *SplitDumpChannelBus, inputFile string) {
 }
 
 // LineParser reads the CurrentLine and figures out which channel to put it in.
-func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineFiles bool, outputDir string, skipData []string, skipTables []string*/) {
+func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitDumpOptions /*, combineFiles bool, outputDir string, skipData []string, skipTables []string*/) {
 	var drainOnce sync.Once
 	drainCurrentLine := func() {
 		drainOnce.Do(func() {
@@ -166,8 +166,13 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 		}
 	}
 
-	streamSize := 0
-	streamSizeMax := 1024 * 1024 * 1024
+	opts = normalizeSplitDumpOptions(opts)
+	if opts.StreamSizeMax < 0 {
+		finishWithError(fmt.Errorf("splitdump: stream size max must be >= 0"))
+		return
+	}
+	streamSize := int64(0)
+	streamSizeMax := opts.StreamSizeMax
 	for line := range bus.CurrentLine {
 		if !sourceDataDisabled {
 			lowerLine := strings.ToLower(line)
@@ -179,9 +184,9 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string /*, combineF
 			}
 		}
 		//	fmt.Printf("%s %b %b %b", line, onTableScheme, onTableData)
-		streamSize += len([]byte(line))
+		streamSize += int64(len([]byte(line)))
 
-		if streamSize > streamSizeMax {
+		if streamSizeMax > 0 && streamSize > streamSizeMax {
 			if tableFile == nil {
 				streamSize = 0
 			} else {

--- a/utils/splitdump/split_test.go
+++ b/utils/splitdump/split_test.go
@@ -2,6 +2,7 @@ package splitdump
 
 import (
 	"bytes"
+	"compress/gzip"
 	"io"
 	"os"
 	"path/filepath"
@@ -184,12 +185,37 @@ func TestSplitDumpLineParserShardsWithCustomStreamSize(t *testing.T) {
 		t.Fatal("timeout waiting for splitdump to finish")
 	}
 
+	shardPath := filepath.Join(outputDir, "mydb.mytable.00001.sql.gz")
+	if _, err := os.Stat(shardPath); err != nil {
+		t.Fatalf("expected shard file %s: %v", shardPath, err)
+	}
+
 	matches, err := filepath.Glob(filepath.Join(outputDir, "*.00001.sql.gz"))
 	if err != nil {
 		t.Fatalf("failed to glob shard files: %v", err)
 	}
 	if len(matches) == 0 {
 		t.Fatalf("expected shard file with .00001 suffix")
+	}
+
+	file, err := os.Open(shardPath)
+	if err != nil {
+		t.Fatalf("failed to open shard file: %v", err)
+	}
+	defer file.Close()
+
+	reader, err := gzip.NewReader(file)
+	if err != nil {
+		t.Fatalf("failed to read shard gzip: %v", err)
+	}
+	defer reader.Close()
+
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("failed to read shard content: %v", err)
+	}
+	if !strings.Contains(string(content), "INSERT INTO `mytable`") {
+		t.Fatalf("expected shard content to include INSERTs for mytable")
 	}
 }
 

--- a/utils/splitdump/split_test.go
+++ b/utils/splitdump/split_test.go
@@ -15,7 +15,7 @@ func TestSplitDumpLineParserEmptyInput(t *testing.T) {
 	outputDir := filepath.Join(t.TempDir(), "splitdump")
 	close(bus.CurrentLine)
 
-	go SplitDumpLineParser(bus, outputDir)
+	go SplitDumpLineParser(bus, outputDir, SplitDumpOptions{})
 
 	select {
 	case <-bus.Finished:
@@ -126,7 +126,7 @@ func TestSplitDumpLineParserMySQLGtidPurgedVariants(t *testing.T) {
 			bus := NewSplitDumpChannelBus()
 			outputDir := filepath.Join(t.TempDir(), "splitdump")
 
-			go SplitDumpLineParser(bus, outputDir)
+			go SplitDumpLineParser(bus, outputDir, SplitDumpOptions{})
 			bus.CurrentLine <- tc.line
 			close(bus.CurrentLine)
 
@@ -146,5 +146,89 @@ func TestSplitDumpLineParserMySQLGtidPurgedVariants(t *testing.T) {
 				t.Fatalf("expected metadata to contain %q, got: %s", expectedLine, data)
 			}
 		})
+	}
+}
+
+func TestSplitDumpLineParserShardsWithCustomStreamSize(t *testing.T) {
+	bus := NewSplitDumpChannelBus()
+	outputDir := filepath.Join(t.TempDir(), "splitdump")
+	options := SplitDumpOptions{StreamSizeMax: 16 * 1024 * 1024, StreamSizeMaxSet: true}
+
+	go SplitDumpLineParser(bus, outputDir, options)
+
+	lines := []string{
+		"USE `mydb`\n",
+		"-- Table structure for table `mytable`\n",
+		"CREATE TABLE `mytable` (id int)\n",
+		"-- Dumping data for table `mytable`\n",
+		"LOCK TABLES `mytable` WRITE;\n",
+	}
+	baseSize := int64(0)
+	for _, line := range lines {
+		baseSize += int64(len(line))
+		bus.CurrentLine <- line
+	}
+
+	insertLine := "INSERT INTO `mytable` VALUES (" + strings.Repeat("1,", 50) + "1);\n"
+	insertLen := int64(len(insertLine))
+	count := int((options.StreamSizeMax-baseSize)/insertLen) + 2
+	for i := 0; i < count; i++ {
+		bus.CurrentLine <- insertLine
+	}
+	bus.CurrentLine <- "UNLOCK TABLES;\n"
+	close(bus.CurrentLine)
+
+	select {
+	case <-bus.Finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for splitdump to finish")
+	}
+
+	matches, err := filepath.Glob(filepath.Join(outputDir, "*.00001.sql.gz"))
+	if err != nil {
+		t.Fatalf("failed to glob shard files: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("expected shard file with .00001 suffix")
+	}
+}
+
+func TestSplitDumpLineParserNoShardingWhenZero(t *testing.T) {
+	bus := NewSplitDumpChannelBus()
+	outputDir := filepath.Join(t.TempDir(), "splitdump")
+	options := SplitDumpOptions{StreamSizeMax: 0, StreamSizeMaxSet: true}
+
+	go SplitDumpLineParser(bus, outputDir, options)
+
+	lines := []string{
+		"USE `mydb`\n",
+		"-- Table structure for table `mytable`\n",
+		"CREATE TABLE `mytable` (id int)\n",
+		"-- Dumping data for table `mytable`\n",
+		"LOCK TABLES `mytable` WRITE;\n",
+	}
+	for _, line := range lines {
+		bus.CurrentLine <- line
+	}
+
+	insertLine := "INSERT INTO `mytable` VALUES (" + strings.Repeat("1,", 50) + "1);\n"
+	for i := 0; i < 2000; i++ {
+		bus.CurrentLine <- insertLine
+	}
+	bus.CurrentLine <- "UNLOCK TABLES;\n"
+	close(bus.CurrentLine)
+
+	select {
+	case <-bus.Finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for splitdump to finish")
+	}
+
+	matches, err := filepath.Glob(filepath.Join(outputDir, "*.00001.sql.gz"))
+	if err != nil {
+		t.Fatalf("failed to glob shard files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected no shard files when stream-size-max=0")
 	}
 }

--- a/utils/splitdump/split_test.go
+++ b/utils/splitdump/split_test.go
@@ -153,7 +153,8 @@ func TestSplitDumpLineParserMySQLGtidPurgedVariants(t *testing.T) {
 func TestSplitDumpLineParserShardsWithCustomStreamSize(t *testing.T) {
 	bus := NewSplitDumpChannelBus()
 	outputDir := filepath.Join(t.TempDir(), "splitdump")
-	options := SplitDumpOptions{StreamSizeMax: 16 * 1024 * 1024, StreamSizeMaxSet: true}
+	streamSizeMax := int64(16 * 1024 * 1024)
+	options := SplitDumpOptions{StreamSizeMax: &streamSizeMax}
 
 	go SplitDumpLineParser(bus, outputDir, options)
 
@@ -172,7 +173,7 @@ func TestSplitDumpLineParserShardsWithCustomStreamSize(t *testing.T) {
 
 	insertLine := "INSERT INTO `mytable` VALUES (" + strings.Repeat("1,", 50) + "1);\n"
 	insertLen := int64(len(insertLine))
-	count := int((options.StreamSizeMax-baseSize)/insertLen) + 2
+	count := int((streamSizeMax-baseSize)/insertLen) + 2
 	for i := 0; i < count; i++ {
 		bus.CurrentLine <- insertLine
 	}
@@ -222,7 +223,8 @@ func TestSplitDumpLineParserShardsWithCustomStreamSize(t *testing.T) {
 func TestSplitDumpLineParserNoShardingWhenZero(t *testing.T) {
 	bus := NewSplitDumpChannelBus()
 	outputDir := filepath.Join(t.TempDir(), "splitdump")
-	options := SplitDumpOptions{StreamSizeMax: 0, StreamSizeMaxSet: true}
+	streamSizeMax := int64(0)
+	options := SplitDumpOptions{StreamSizeMax: &streamSizeMax}
 
 	go SplitDumpLineParser(bus, outputDir, options)
 


### PR DESCRIPTION
- Summary:
  - Add SplitDumpOptions with a human‑readable --stream-size-max CLI flag to control splitdump sharding.
  - Treat 0 as “no sharding” while keeping the 1GB default when unset.
  - Add parser coverage and sharding/no‑sharding tests.
- Tests:
  - go test ./utils/splitdump/...
  - go test -tags clients ./clients/...