### PR TITLE
fix: harden splitdump sharding and restore file coverage

### DIFF
--- a/clients/client_splitdump_test.go
+++ b/clients/client_splitdump_test.go
@@ -6,6 +6,7 @@ package clients
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -37,5 +38,55 @@ func TestRunSplitdumpAcceptsZeroStreamSize(t *testing.T) {
 	outputDir := filepath.Join(t.TempDir(), "splitdump")
 	if err := runSplitdump(inputPath, outputDir); err != nil {
 		t.Fatalf("unexpected error for zero stream-size-max: %v", err)
+	}
+}
+
+func TestRunSplitdumpFromFile(t *testing.T) {
+	outputDir := t.TempDir()
+	inputFile := filepath.Join(t.TempDir(), "dump.sql")
+
+	dump := strings.Join([]string{
+		"USE `test`;",
+		"-- Table structure for table `t1`",
+		"CREATE TABLE `t1` (",
+		"  `id` int",
+		");",
+		"CHANGE MASTER TO MASTER_LOG_FILE='bin.000001', MASTER_LOG_POS=123;",
+		"-- Dumping data for table `t1`",
+		"LOCK TABLES `t1` WRITE;",
+		"INSERT INTO `t1` VALUES (1);",
+		"UNLOCK TABLES;",
+		"",
+	}, "\n")
+
+	if err := os.WriteFile(inputFile, []byte(dump), 0644); err != nil {
+		t.Fatalf("failed to write input dump: %v", err)
+	}
+
+	if err := runSplitdump(inputFile, outputDir); err != nil {
+		t.Fatalf("runSplitdump error: %v", err)
+	}
+
+	metadataPath := filepath.Join(outputDir, "metadata")
+	metadata, err := os.ReadFile(metadataPath)
+	if err != nil {
+		t.Fatalf("failed to read metadata: %v", err)
+	}
+	metaStr := string(metadata)
+	if !strings.Contains(metaStr, "File = bin.000001") {
+		t.Fatalf("metadata missing binlog file: %s", metaStr)
+	}
+	if !strings.Contains(metaStr, "Position = 123") {
+		t.Fatalf("metadata missing position: %s", metaStr)
+	}
+
+	schemaFile := filepath.Join(outputDir, "test.t1-schema.sql.gz")
+	if _, err := os.Stat(schemaFile); err != nil {
+		t.Fatalf("schema file missing: %v", err)
+	}
+
+	dataFile := filepath.Join(outputDir, "test.t1.00000.sql.gz")
+	if _, err := os.Stat(dataFile); err != nil {
+		t.Fatalf("data file missing: %v", err)
 	}
 }

--- a/clients/client_splitdump_test.go
+++ b/clients/client_splitdump_test.go
@@ -6,56 +6,36 @@ package clients
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
-func TestRunSplitdumpFromFile(t *testing.T) {
-	outputDir := t.TempDir()
-	inputFile := filepath.Join(t.TempDir(), "dump.sql")
+func TestRunSplitdumpRejectsNegativeStreamSize(t *testing.T) {
+	old := cliSplitDumpStreamSizeMax
+	cliSplitDumpStreamSizeMax = "-1"
+	t.Cleanup(func() {
+		cliSplitDumpStreamSizeMax = old
+	})
 
-	dump := strings.Join([]string{
-		"USE `test`;",
-		"-- Table structure for table `t1`",
-		"CREATE TABLE `t1` (",
-		"  `id` int",
-		");",
-		"CHANGE MASTER TO MASTER_LOG_FILE='bin.000001', MASTER_LOG_POS=123;",
-		"-- Dumping data for table `t1`",
-		"LOCK TABLES `t1` WRITE;",
-		"INSERT INTO `t1` VALUES (1);",
-		"UNLOCK TABLES;",
-		"",
-	}, "\n")
+	outputDir := filepath.Join(t.TempDir(), "splitdump")
+	if err := runSplitdump("", outputDir); err == nil {
+		t.Fatal("expected error for negative stream-size-max")
+	}
+}
 
-	if err := os.WriteFile(inputFile, []byte(dump), 0644); err != nil {
-		t.Fatalf("failed to write input dump: %v", err)
+func TestRunSplitdumpAcceptsZeroStreamSize(t *testing.T) {
+	old := cliSplitDumpStreamSizeMax
+	cliSplitDumpStreamSizeMax = "0"
+	t.Cleanup(func() {
+		cliSplitDumpStreamSizeMax = old
+	})
+
+	inputPath := filepath.Join(t.TempDir(), "empty.sql")
+	if err := os.WriteFile(inputPath, []byte(""), 0644); err != nil {
+		t.Fatalf("failed to write input file: %v", err)
 	}
 
-	if err := runSplitdump(inputFile, outputDir); err != nil {
-		t.Fatalf("runSplitdump error: %v", err)
-	}
-
-	metadataPath := filepath.Join(outputDir, "metadata")
-	metadata, err := os.ReadFile(metadataPath)
-	if err != nil {
-		t.Fatalf("failed to read metadata: %v", err)
-	}
-	metaStr := string(metadata)
-	if !strings.Contains(metaStr, "File = bin.000001") {
-		t.Fatalf("metadata missing binlog file: %s", metaStr)
-	}
-	if !strings.Contains(metaStr, "Position = 123") {
-		t.Fatalf("metadata missing position: %s", metaStr)
-	}
-
-	schemaFile := filepath.Join(outputDir, "test.t1-schema.sql.gz")
-	if _, err := os.Stat(schemaFile); err != nil {
-		t.Fatalf("schema file missing: %v", err)
-	}
-
-	dataFile := filepath.Join(outputDir, "test.t1.00000.sql.gz")
-	if _, err := os.Stat(dataFile); err != nil {
-		t.Fatalf("data file missing: %v", err)
+	outputDir := filepath.Join(t.TempDir(), "splitdump")
+	if err := runSplitdump(inputPath, outputDir); err != nil {
+		t.Fatalf("unexpected error for zero stream-size-max: %v", err)
 	}
 }

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -22,6 +22,7 @@ import (
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/backupmgr"
 	"github.com/signal18/replication-manager/utils/misc"
+	"github.com/signal18/replication-manager/utils/splitdump"
 	"github.com/signal18/replication-manager/utils/state"
 	"github.com/signal18/replication-manager/utils/version"
 )
@@ -1502,10 +1503,23 @@ func (cluster *Cluster) SplitDumpWithCli(ctx context.Context, destination *Serve
 
 	// Use parent context for cancellation control
 	// If caller wants a timeout, they should pass context.WithTimeout
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg,
-		"Executing splitdump command: %s splitdump --outputdir %s", cliPath, outputDir)
+	args := []string{"splitdump", "--outputdir", outputDir}
+	trimmedStreamSize := strings.TrimSpace(cluster.Conf.BackupSplitdumpStreamSizeMax)
+	if trimmedStreamSize != "" {
+		if sizeBytes, err := splitdump.ParseSizeBytes(trimmedStreamSize); err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn,
+				"Invalid backup-splitdump-stream-size-max %q, using default sharding: %v", trimmedStreamSize, err)
+		} else {
+			args = append(args, "--stream-size-max", trimmedStreamSize)
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
+				"Splitdump stream size max set to %q (%d bytes)", trimmedStreamSize, sizeBytes)
+		}
+	}
 
-	cmd := exec.CommandContext(ctx, cliPath, "splitdump", "--outputdir", outputDir)
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg,
+		"Executing splitdump command: %s %s", cliPath, strings.Join(args, " "))
+
+	cmd := exec.CommandContext(ctx, cliPath, args...)
 	cmd.Stdin = stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -1504,15 +1504,15 @@ func (cluster *Cluster) SplitDumpWithCli(ctx context.Context, destination *Serve
 	// Use parent context for cancellation control
 	// If caller wants a timeout, they should pass context.WithTimeout
 	args := []string{"splitdump", "--outputdir", outputDir}
-	trimmedStreamSize := strings.TrimSpace(cluster.Conf.BackupSplitdumpStreamSizeMax)
-	if trimmedStreamSize != "" {
-		if sizeBytes, err := splitdump.ParseSizeBytes(trimmedStreamSize); err != nil {
+	trimmedFileSize := strings.TrimSpace(cluster.Conf.BackupSplitdumpFileSize)
+	if trimmedFileSize != "" {
+		if sizeBytes, err := splitdump.ParseSizeBytes(trimmedFileSize); err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn,
-				"Invalid backup-splitdump-stream-size-max %q, using default sharding: %v", trimmedStreamSize, err)
+				"Invalid backup-splitdump-file-size %q, using default sharding: %v", trimmedFileSize, err)
 		} else {
-			args = append(args, "--stream-size-max", trimmedStreamSize)
+			args = append(args, "--stream-size-max", trimmedFileSize)
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
-				"Splitdump stream size max set to %q (%d bytes)", trimmedStreamSize, sizeBytes)
+				"Splitdump file size set to %q (%d bytes)", trimmedFileSize, sizeBytes)
 		}
 	}
 

--- a/cluster/srv_job_backup_splitdump_test.go
+++ b/cluster/srv_job_backup_splitdump_test.go
@@ -179,7 +179,7 @@ func TestSplitDumpWithCliAddsStreamSizeMax(t *testing.T) {
 	cluster, server := newSplitDumpTestServer(t)
 	argsPath := filepath.Join(t.TempDir(), "args.txt")
 	writeSplitDumpCliScriptWithArgs(t, cluster, argsPath, 0)
-	cluster.Conf.BackupSplitdumpStreamSizeMax = "16MiB"
+	cluster.Conf.BackupSplitdumpFileSize = "16MiB"
 
 	outputDir := prepareSplitDumpOutputDir(t, server)
 	runSplitDumpWithCli(t, cluster, server, outputDir, false)

--- a/cluster/srv_job_backup_splitdump_test.go
+++ b/cluster/srv_job_backup_splitdump_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -33,6 +34,18 @@ func newSplitDumpTestServer(t *testing.T) (*Cluster, *ServerMonitor) {
 func writeSplitDumpCliScript(t *testing.T, cluster *Cluster, exitCode int) {
 	cliPath := filepath.Join(t.TempDir(), "replication-manager-cli")
 	script := "#!/bin/sh\nexit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(cliPath, []byte(script), 0755); err != nil {
+		t.Fatalf("failed to write cli script: %v", err)
+	}
+	if err := os.Chmod(cliPath, 0755); err != nil {
+		t.Fatalf("failed to chmod cli script: %v", err)
+	}
+	cluster.Conf.ReplicationManagerCliPath = cliPath
+}
+
+func writeSplitDumpCliScriptWithArgs(t *testing.T, cluster *Cluster, argsPath string, exitCode int) {
+	cliPath := filepath.Join(t.TempDir(), "replication-manager-cli")
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %q\nexit %d\n", argsPath, exitCode)
 	if err := os.WriteFile(cliPath, []byte(script), 0755); err != nil {
 		t.Fatalf("failed to write cli script: %v", err)
 	}
@@ -157,6 +170,30 @@ func TestSplitDumpWithCliRotatesDirWhenEnabled(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Fatalf("expected empty splitdump dir after rotation, got %d entries", len(entries))
+	}
+}
+
+func TestSplitDumpWithCliAddsStreamSizeMax(t *testing.T) {
+	skipSplitDumpOnWindows(t)
+
+	cluster, server := newSplitDumpTestServer(t)
+	argsPath := filepath.Join(t.TempDir(), "args.txt")
+	writeSplitDumpCliScriptWithArgs(t, cluster, argsPath, 0)
+	cluster.Conf.BackupSplitdumpStreamSizeMax = "16MiB"
+
+	outputDir := prepareSplitDumpOutputDir(t, server)
+	runSplitDumpWithCli(t, cluster, server, outputDir, false)
+
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("failed to read args file: %v", err)
+	}
+	args := string(data)
+	if !strings.Contains(args, "--stream-size-max") {
+		t.Fatalf("expected stream-size-max arg, got: %s", args)
+	}
+	if !strings.Contains(args, "16MiB") {
+		t.Fatalf("expected stream-size-max value, got: %s", args)
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -706,6 +706,7 @@ type Config struct {
 	BackupReseedRemoteDecompress              bool   `mapstructure:"backup-reseed-remote-decompress" toml:"backup-reseed-remote-decompress" json:"backupReseedRemoteDecompress"`
 	BackupSplitMysqlUser                      bool   `mapstructure:"backup-split-mysql-user" toml:"backup-split-mysql-user" json:"backupSplitMysqlUser"`
 	BackupRestoreMysqlUser                    bool   `mapstructure:"backup-restore-mysql-user" toml:"backup-restore-mysql-user" json:"backupRestoreMysqlUser"`
+	BackupSplitdumpStreamSizeMax              string `mapstructure:"backup-splitdump-stream-size-max" toml:"backup-splitdump-stream-size-max" json:"backupSplitdumpStreamSizeMax"`
 	BackupCheckFreeSpace                      bool   `mapstructure:"backup-check-free-space" toml:"backup-check-free-space" json:"backupCheckFreeSpace"`
 	BackupDiskTresholdWarn                    int    `mapstructure:"backup-disk-treshold-warn" toml:"backup-disk-treshold-warn" json:"backupDiskTresholdWarn"`
 	BackupDiskTresholdCrit                    int    `mapstructure:"backup-disk-treshold-crit" toml:"backup-disk-treshold-crit" json:"backupDiskTresholdCrit"`

--- a/config/config.go
+++ b/config/config.go
@@ -706,7 +706,7 @@ type Config struct {
 	BackupReseedRemoteDecompress              bool   `mapstructure:"backup-reseed-remote-decompress" toml:"backup-reseed-remote-decompress" json:"backupReseedRemoteDecompress"`
 	BackupSplitMysqlUser                      bool   `mapstructure:"backup-split-mysql-user" toml:"backup-split-mysql-user" json:"backupSplitMysqlUser"`
 	BackupRestoreMysqlUser                    bool   `mapstructure:"backup-restore-mysql-user" toml:"backup-restore-mysql-user" json:"backupRestoreMysqlUser"`
-	BackupSplitdumpStreamSizeMax              string `mapstructure:"backup-splitdump-stream-size-max" toml:"backup-splitdump-stream-size-max" json:"backupSplitdumpStreamSizeMax"`
+	BackupSplitdumpFileSize                   string `mapstructure:"backup-splitdump-file-size" toml:"backup-splitdump-file-size" json:"backupSplitdumpFileSize"`
 	BackupCheckFreeSpace                      bool   `mapstructure:"backup-check-free-space" toml:"backup-check-free-space" json:"backupCheckFreeSpace"`
 	BackupDiskTresholdWarn                    int    `mapstructure:"backup-disk-treshold-warn" toml:"backup-disk-treshold-warn" json:"backupDiskTresholdWarn"`
 	BackupDiskTresholdCrit                    int    `mapstructure:"backup-disk-treshold-crit" toml:"backup-disk-treshold-crit" json:"backupDiskTresholdCrit"`

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -37,6 +37,7 @@ import (
 	"github.com/signal18/replication-manager/utils/dockerhelper"
 	"github.com/signal18/replication-manager/utils/misc"
 	"github.com/signal18/replication-manager/utils/s18log"
+	"github.com/signal18/replication-manager/utils/splitdump"
 )
 
 type LogLevelEnum string
@@ -2945,7 +2946,13 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 			return err
 		}
 	case "backup-splitdump-stream-size-max":
-		mycluster.Conf.BackupSplitdumpStreamSizeMax = value
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			if _, err := splitdump.ParseSizeBytes(trimmed); err != nil {
+				return fmt.Errorf("invalid value for backup-splitdump-stream-size-max: %q", value)
+			}
+		}
+		mycluster.Conf.BackupSplitdumpStreamSizeMax = trimmed
 	case "backup-keep-within-hourly":
 		err = mycluster.SetBackupKeepWithinHourly(value)
 		if err != nil {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2945,14 +2945,14 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		if err != nil {
 			return err
 		}
-	case "backup-splitdump-stream-size-max":
+	case "backup-splitdump-file-size":
 		trimmed := strings.TrimSpace(value)
 		if trimmed != "" {
 			if _, err := splitdump.ParseSizeBytes(trimmed); err != nil {
-				return fmt.Errorf("invalid value for backup-splitdump-stream-size-max: %q", value)
+				return fmt.Errorf("invalid value for backup-splitdump-file-size: %q", value)
 			}
 		}
-		mycluster.Conf.BackupSplitdumpStreamSizeMax = trimmed
+		mycluster.Conf.BackupSplitdumpFileSize = trimmed
 	case "backup-keep-within-hourly":
 		err = mycluster.SetBackupKeepWithinHourly(value)
 		if err != nil {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2944,6 +2944,8 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		if err != nil {
 			return err
 		}
+	case "backup-splitdump-stream-size-max":
+		mycluster.Conf.BackupSplitdumpStreamSizeMax = value
 	case "backup-keep-within-hourly":
 		err = mycluster.SetBackupKeepWithinHourly(value)
 		if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -894,7 +894,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.BackupMysqlclientPath, "backup-mysqlclient-path", "", "Path to mysql client binary")
 	flags.StringVar(&conf.BackupMysqlclientOptions, "backup-mysqlclient-options", "--force --batch", "Extra options")
 	flags.BoolVar(&conf.BackupMysqldumpSplitDump, "backup-mysqldump-splitdump", false, "Split mysqldump output using splitdump")
-	flags.StringVar(&conf.BackupSplitdumpStreamSizeMax, "backup-splitdump-stream-size-max", "1G", "Max stream size before sharding splitdump output (e.g. 16MiB, 1G; 0 disables sharding)")
+	flags.StringVar(&conf.BackupSplitdumpFileSize, "backup-splitdump-file-size", "1G", "Max file size before sharding splitdump output (e.g. 16MiB, 1G; 0 disables sharding)")
 	flags.StringVar(&conf.BackupMytopPath, "backup-mytop-path", "", "Path to mytop binary")
 	flags.StringVar(&conf.BackupGottyClientPath, "backup-gotty-client-path", "", "Path to gotty client binary")
 	flags.StringVar(&conf.ReplicationManagerCliPath, "replication-manager-cli-path", "", "Path to replication-manager-cli binary")

--- a/server/server.go
+++ b/server/server.go
@@ -894,6 +894,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.BackupMysqlclientPath, "backup-mysqlclient-path", "", "Path to mysql client binary")
 	flags.StringVar(&conf.BackupMysqlclientOptions, "backup-mysqlclient-options", "--force --batch", "Extra options")
 	flags.BoolVar(&conf.BackupMysqldumpSplitDump, "backup-mysqldump-splitdump", false, "Split mysqldump output using splitdump")
+	flags.StringVar(&conf.BackupSplitdumpStreamSizeMax, "backup-splitdump-stream-size-max", "", "Max stream size before sharding splitdump output (e.g. 16MiB, 1G; 0 disables sharding)")
 	flags.StringVar(&conf.BackupMytopPath, "backup-mytop-path", "", "Path to mytop binary")
 	flags.StringVar(&conf.BackupGottyClientPath, "backup-gotty-client-path", "", "Path to gotty client binary")
 	flags.StringVar(&conf.ReplicationManagerCliPath, "replication-manager-cli-path", "", "Path to replication-manager-cli binary")

--- a/server/server.go
+++ b/server/server.go
@@ -894,7 +894,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.BackupMysqlclientPath, "backup-mysqlclient-path", "", "Path to mysql client binary")
 	flags.StringVar(&conf.BackupMysqlclientOptions, "backup-mysqlclient-options", "--force --batch", "Extra options")
 	flags.BoolVar(&conf.BackupMysqldumpSplitDump, "backup-mysqldump-splitdump", false, "Split mysqldump output using splitdump")
-	flags.StringVar(&conf.BackupSplitdumpStreamSizeMax, "backup-splitdump-stream-size-max", "", "Max stream size before sharding splitdump output (e.g. 16MiB, 1G; 0 disables sharding)")
+	flags.StringVar(&conf.BackupSplitdumpStreamSizeMax, "backup-splitdump-stream-size-max", "1G", "Max stream size before sharding splitdump output (e.g. 16MiB, 1G; 0 disables sharding)")
 	flags.StringVar(&conf.BackupMytopPath, "backup-mytop-path", "", "Path to mytop binary")
 	flags.StringVar(&conf.BackupGottyClientPath, "backup-gotty-client-path", "", "Path to gotty client binary")
 	flags.StringVar(&conf.ReplicationManagerCliPath, "replication-manager-cli-path", "", "Path to replication-manager-cli binary")

--- a/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
@@ -355,13 +355,13 @@ Default: 1G. Select from list; 0 disables sharding.`
         <Dropdown
           options={splitdumpSizeOptions}
           className={styles.dropdownButton}
-          selectedValue={selectedCluster?.config?.backupSplitdumpStreamSizeMax || '1G'}
-          confirmTitle={`Confirm backup-splitdump-stream-size-max to `}
+          selectedValue={selectedCluster?.config?.backupSplitdumpFileSize || '1G'}
+          confirmTitle={`Confirm backup-splitdump-file-size to `}
           onChange={(value) =>
             dispatch(
               setSetting({
                 clusterName: selectedCluster?.name,
-                setting: 'backup-splitdump-stream-size-max',
+                setting: 'backup-splitdump-file-size',
                 value: value
               })
             )

--- a/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
@@ -93,6 +93,22 @@ Ensure the CLI is available in PATH or set a custom CLI path below.`
   const ReplicationManagerCliRequirement = `Path to replication-manager-cli used for splitdump processing.  
 Leave empty to use PATH lookup (replication-manager-cli).`
 
+  const SplitDumpStreamSizeRequirement = `Splitdump shard size limit for mysqldump splitdump output.  
+Default: 1G. Select from list; 0 disables sharding.`
+
+  const splitdumpSizeOptions = [
+    { name: '16 MiB', value: '16MiB' },
+    { name: '32 MiB', value: '32MiB' },
+    { name: '64 MiB', value: '64MiB' },
+    { name: '128 MiB', value: '128MiB' },
+    { name: '256 MiB', value: '256MiB' },
+    { name: '512 MiB', value: '512MiB' },
+    { name: '1 G', value: '1G' },
+    { name: '2 G', value: '2G' },
+    { name: '4 G', value: '4G' },
+    { name: 'No sharding', value: '0' }
+  ]
+
   const openCommonModal = () => {
     setIsCommonModalOpen(true)
   }
@@ -319,6 +335,34 @@ Leave empty to use PATH lookup (replication-manager-cli).`
               switchSetting({
                 clusterName: selectedCluster?.name,
                 setting: 'backup-mysqldump-splitdump'
+              })
+            )
+          }
+        />
+      )
+    },
+    {
+      key: (
+        <HStack spacing={2}>
+          <Text>Splitdump shard size</Text>
+          <RMIconButton
+            icon={HiQuestionMarkCircle}
+            onClick={() => openInfoModal('Splitdump shard size', SplitDumpStreamSizeRequirement)}
+          />
+        </HStack>
+      ),
+      value: (
+        <Dropdown
+          options={splitdumpSizeOptions}
+          className={styles.dropdownButton}
+          selectedValue={selectedCluster?.config?.backupSplitdumpStreamSizeMax || '1G'}
+          confirmTitle={`Confirm backup-splitdump-stream-size-max to `}
+          onChange={(value) =>
+            dispatch(
+              setSetting({
+                clusterName: selectedCluster?.name,
+                setting: 'backup-splitdump-stream-size-max',
+                value: value
               })
             )
           }

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -189,15 +189,11 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 		if streamSizeMax > 0 && streamSize > streamSizeMax {
 			if tableFile == nil {
 				streamSize = 0
-			} else {
+			} else if onTableData && dataTableName != "" {
 				shard++
 				closeTableFile()
 				shardpad = fmt.Sprintf(".%05d", shard)
-				baseTableName := dataTableName
-				if baseTableName == "" {
-					baseTableName = schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table ", "", 1), "`", "", -1))
-				}
-				tableName := baseTableName + shardpad
+				tableName := dataTableName + shardpad
 				fmt.Printf("Processing table data %s ", tableName)
 				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
 				f, err = os.Create(tablePath)
@@ -207,9 +203,10 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 				}
 				tableFile = gzip.NewWriter(f)
 				tableFile.Write([]byte(headerMetaData))
-				tableFile.Write([]byte("\n--\n" + line))
-				tableFile.Write([]byte("USE " + schema + ";\n"))
+				tableFile.Write([]byte("USE `" + schema + "`;\n"))
+				tableFile.Write([]byte(line))
 				streamSize = 0
+				continue
 			}
 		}
 		// The beginning of a mysqldump has some flags at the top of the file. Capture them into a variable.
@@ -266,6 +263,7 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 
 				}
 				closeTableFile()
+				shard = 0
 				shardpad = fmt.Sprintf(".%05d", shard)
 				dataTableName = schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table ", "", 1), "`", "", -1))
 				tableName := dataTableName + shardpad

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -173,22 +173,17 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 		return
 	}
 	streamSize := int64(0)
+	pendingSplit := false
+	splitReady := false
+	isStatementEnd := func(line string) bool {
+		trimmed := strings.TrimSpace(line)
+		return strings.HasSuffix(trimmed, ";")
+	}
 	for line := range bus.CurrentLine {
-		if !sourceDataDisabled {
-			lowerLine := strings.ToLower(line)
-			if strings.Contains(lowerLine, "source-data=0") {
-				sourceDataDisabled = true
-				bgtid = ""
-				bfile = ""
-				bpos = ""
-			}
-		}
-		//	fmt.Printf("%s %b %b %b", line, onTableScheme, onTableData)
-		streamSize += int64(len([]byte(line)))
-
-		if streamSizeMax > 0 && streamSize > streamSizeMax {
-			if tableFile == nil {
-				streamSize = 0
+		lineLen := int64(len([]byte(line)))
+		if splitReady {
+			if strings.HasPrefix(line, "UNLOCK TABLES;") {
+				splitReady = false
 			} else if onTableData && dataTableName != "" {
 				shard++
 				closeTableFile()
@@ -203,10 +198,30 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 				}
 				tableFile = gzip.NewWriter(f)
 				tableFile.Write([]byte(headerMetaData))
-				tableFile.Write([]byte("USE `" + schema + "`;\n"))
-				tableFile.Write([]byte(line))
+				if schema != "" {
+					tableFile.Write([]byte("USE `" + schema + "`;\n"))
+				}
 				streamSize = 0
-				continue
+				splitReady = false
+			}
+		}
+		if !sourceDataDisabled {
+			lowerLine := strings.ToLower(line)
+			if strings.Contains(lowerLine, "source-data=0") {
+				sourceDataDisabled = true
+				bgtid = ""
+				bfile = ""
+				bpos = ""
+			}
+		}
+		//	fmt.Printf("%s %b %b %b", line, onTableScheme, onTableData)
+		streamSize += lineLen
+
+		if streamSizeMax > 0 && streamSize > streamSizeMax {
+			if tableFile == nil {
+				streamSize = 0
+			} else if onTableData && dataTableName != "" {
+				pendingSplit = true
 			}
 		}
 		// The beginning of a mysqldump has some flags at the top of the file. Capture them into a variable.
@@ -219,6 +234,8 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 				onTableData = false
 				onTableScheme = false
 				dataTableName = ""
+				pendingSplit = false
+				splitReady = false
 				streamSize = 0
 				closeTableWriter()
 			}
@@ -336,6 +353,10 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 			if tableFile != nil {
 				tableFile.Write([]byte(line))
 			}
+		}
+		if pendingSplit && onTableData && isStatementEnd(line) {
+			splitReady = true
+			pendingSplit = false
 		}
 
 	}

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -175,6 +175,7 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 	streamSize := int64(0)
 	pendingSplit := false
 	splitReady := false
+	// mysqldump emits complete statements ending in ';' by default.
 	isStatementEnd := func(line string) bool {
 		trimmed := strings.TrimSpace(line)
 		return strings.HasSuffix(trimmed, ";")
@@ -189,7 +190,7 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 				closeTableFile()
 				shardpad = fmt.Sprintf(".%05d", shard)
 				tableName := dataTableName + shardpad
-				fmt.Printf("Processing table data %s ", tableName)
+				fmt.Printf("Processing table data %s\n", tableName)
 				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
 				f, err = os.Create(tablePath)
 				if err != nil {
@@ -202,6 +203,8 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 					tableFile.Write([]byte("USE `" + schema + "`;\n"))
 				}
 				streamSize = 0
+				splitReady = false
+			} else {
 				splitReady = false
 			}
 		}

--- a/utils/splitdump/split_test.go
+++ b/utils/splitdump/split_test.go
@@ -366,6 +366,26 @@ func TestSplitDumpLineParserShardsWithoutUse(t *testing.T) {
 	if len(matches) == 0 {
 		t.Fatalf("expected shard file for table without USE")
 	}
+	shardPath := matches[0]
+	file, err := os.Open(shardPath)
+	if err != nil {
+		t.Fatalf("failed to open shard file: %v", err)
+	}
+	defer file.Close()
+
+	reader, err := gzip.NewReader(file)
+	if err != nil {
+		t.Fatalf("failed to read shard gzip: %v", err)
+	}
+	defer reader.Close()
+
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("failed to read shard content: %v", err)
+	}
+	if strings.Contains(string(content), "USE ``;") {
+		t.Fatalf("did not expect empty USE statement in shard")
+	}
 }
 
 func TestSplitDumpLineParserAlternatingShardSizes(t *testing.T) {

--- a/utils/splitdump/split_test.go
+++ b/utils/splitdump/split_test.go
@@ -215,8 +215,15 @@ func TestSplitDumpLineParserShardsWithCustomStreamSize(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read shard content: %v", err)
 	}
-	if !strings.Contains(string(content), "INSERT INTO `mytable`") {
+	contentStr := string(content)
+	if !strings.Contains(contentStr, "USE `mydb`;") {
+		t.Fatalf("expected shard content to include USE for mydb")
+	}
+	if !strings.Contains(contentStr, "INSERT INTO `mytable`") {
 		t.Fatalf("expected shard content to include INSERTs for mytable")
+	}
+	if strings.Index(contentStr, "USE `mydb`;") > strings.Index(contentStr, "INSERT INTO `mytable`") {
+		t.Fatalf("expected USE to appear before INSERT in shard content")
 	}
 }
 
@@ -258,5 +265,221 @@ func TestSplitDumpLineParserNoShardingWhenZero(t *testing.T) {
 	}
 	if len(matches) != 0 {
 		t.Fatalf("expected no shard files when stream-size-max=0")
+	}
+}
+
+func TestSplitDumpLineParserResetsShardPerTable(t *testing.T) {
+	bus := NewSplitDumpChannelBus()
+	outputDir := filepath.Join(t.TempDir(), "splitdump")
+	streamSizeMax := int64(1024 * 16)
+	options := SplitDumpOptions{StreamSizeMax: &streamSizeMax}
+
+	go SplitDumpLineParser(bus, outputDir, options)
+
+	lines := []string{
+		"USE `mydb`\n",
+		"-- Table structure for table `table1`\n",
+		"CREATE TABLE `table1` (id int)\n",
+		"-- Dumping data for table `table1`\n",
+		"LOCK TABLES `table1` WRITE;\n",
+	}
+	baseSize := int64(0)
+	for _, line := range lines {
+		baseSize += int64(len(line))
+		bus.CurrentLine <- line
+	}
+
+	insertLine1 := "INSERT INTO `table1` VALUES (" + strings.Repeat("1,", 50) + "1);\n"
+	insertLen1 := int64(len(insertLine1))
+	count1 := int((streamSizeMax-baseSize)/insertLen1) + 2
+	for i := 0; i < count1; i++ {
+		bus.CurrentLine <- insertLine1
+	}
+	bus.CurrentLine <- "UNLOCK TABLES;\n"
+
+	lines2 := []string{
+		"-- Table structure for table `table2`\n",
+		"CREATE TABLE `table2` (id int)\n",
+		"-- Dumping data for table `table2`\n",
+		"LOCK TABLES `table2` WRITE;\n",
+		"INSERT INTO `table2` VALUES (1);\n",
+		"UNLOCK TABLES;\n",
+	}
+	for _, line := range lines2 {
+		bus.CurrentLine <- line
+	}
+	close(bus.CurrentLine)
+
+	select {
+	case <-bus.Finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for splitdump to finish")
+	}
+
+	if _, err := os.Stat(filepath.Join(outputDir, "mydb.table1.00001.sql.gz")); err != nil {
+		t.Fatalf("expected shard for table1: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "mydb.table2.00000.sql.gz")); err != nil {
+		t.Fatalf("expected table2 to start at shard 00000: %v", err)
+	}
+}
+
+func TestSplitDumpLineParserShardsWithoutUse(t *testing.T) {
+	bus := NewSplitDumpChannelBus()
+	outputDir := filepath.Join(t.TempDir(), "splitdump")
+	streamSizeMax := int64(1024 * 16)
+	options := SplitDumpOptions{StreamSizeMax: &streamSizeMax}
+
+	go SplitDumpLineParser(bus, outputDir, options)
+
+	lines := []string{
+		"-- Table structure for table `nouse`\n",
+		"CREATE TABLE `nouse` (id int)\n",
+		"-- Dumping data for table `nouse`\n",
+		"LOCK TABLES `nouse` WRITE;\n",
+	}
+	baseSize := int64(0)
+	for _, line := range lines {
+		baseSize += int64(len(line))
+		bus.CurrentLine <- line
+	}
+
+	insertLine := "INSERT INTO `nouse` VALUES (" + strings.Repeat("1,", 50) + "1);\n"
+	insertLen := int64(len(insertLine))
+	count := int((streamSizeMax-baseSize)/insertLen) + 2
+	for i := 0; i < count; i++ {
+		bus.CurrentLine <- insertLine
+	}
+	bus.CurrentLine <- "UNLOCK TABLES;\n"
+	close(bus.CurrentLine)
+
+	select {
+	case <-bus.Finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for splitdump to finish")
+	}
+
+	matches, err := filepath.Glob(filepath.Join(outputDir, "*nouse.00001.sql.gz"))
+	if err != nil {
+		t.Fatalf("failed to glob shard files: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("expected shard file for table without USE")
+	}
+}
+
+func TestSplitDumpLineParserAlternatingShardSizes(t *testing.T) {
+	bus := NewSplitDumpChannelBus()
+	outputDir := filepath.Join(t.TempDir(), "splitdump")
+	streamSizeMax := int64(1024 * 16)
+	options := SplitDumpOptions{StreamSizeMax: &streamSizeMax}
+
+	go SplitDumpLineParser(bus, outputDir, options)
+
+	lines := []string{
+		"USE `mydb`\n",
+		"-- Table structure for table `t1`\n",
+		"CREATE TABLE `t1` (id int)\n",
+		"-- Dumping data for table `t1`\n",
+		"LOCK TABLES `t1` WRITE;\n",
+	}
+	baseSize := int64(0)
+	for _, line := range lines {
+		baseSize += int64(len(line))
+		bus.CurrentLine <- line
+	}
+	insertLine1 := "INSERT INTO `t1` VALUES (" + strings.Repeat("1,", 50) + "1);\n"
+	insertLen1 := int64(len(insertLine1))
+	count1 := int((streamSizeMax-baseSize)/insertLen1) + 2
+	for i := 0; i < count1; i++ {
+		bus.CurrentLine <- insertLine1
+	}
+	bus.CurrentLine <- "UNLOCK TABLES;\n"
+
+	lines2 := []string{
+		"-- Table structure for table `t2`\n",
+		"CREATE TABLE `t2` (id int)\n",
+		"-- Dumping data for table `t2`\n",
+		"LOCK TABLES `t2` WRITE;\n",
+		"INSERT INTO `t2` VALUES (1);\n",
+		"UNLOCK TABLES;\n",
+	}
+	for _, line := range lines2 {
+		bus.CurrentLine <- line
+	}
+
+	lines3 := []string{
+		"-- Table structure for table `t3`\n",
+		"CREATE TABLE `t3` (id int)\n",
+		"-- Dumping data for table `t3`\n",
+		"LOCK TABLES `t3` WRITE;\n",
+	}
+	baseSize = 0
+	for _, line := range lines3 {
+		baseSize += int64(len(line))
+		bus.CurrentLine <- line
+	}
+	insertLine3 := "INSERT INTO `t3` VALUES (" + strings.Repeat("1,", 50) + "1);\n"
+	insertLen3 := int64(len(insertLine3))
+	count3 := int((streamSizeMax-baseSize)/insertLen3) + 2
+	for i := 0; i < count3; i++ {
+		bus.CurrentLine <- insertLine3
+	}
+	bus.CurrentLine <- "UNLOCK TABLES;\n"
+	close(bus.CurrentLine)
+
+	select {
+	case <-bus.Finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for splitdump to finish")
+	}
+
+	if _, err := os.Stat(filepath.Join(outputDir, "mydb.t1.00001.sql.gz")); err != nil {
+		t.Fatalf("expected shard for t1: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "mydb.t2.00000.sql.gz")); err != nil {
+		t.Fatalf("expected t2 to be unsharded: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "mydb.t3.00001.sql.gz")); err != nil {
+		t.Fatalf("expected shard for t3: %v", err)
+	}
+}
+
+func TestSplitDumpLineParserNoShardWhenLimitEqualsSize(t *testing.T) {
+	bus := NewSplitDumpChannelBus()
+	outputDir := filepath.Join(t.TempDir(), "splitdump")
+	streamSizeMax := int64(0)
+	options := SplitDumpOptions{StreamSizeMax: &streamSizeMax}
+
+	go SplitDumpLineParser(bus, outputDir, options)
+
+	lines := []string{
+		"USE `mydb`\n",
+		"-- Table structure for table `edge`\n",
+		"CREATE TABLE `edge` (id int)\n",
+		"-- Dumping data for table `edge`\n",
+		"LOCK TABLES `edge` WRITE;\n",
+	}
+	baseSize := int64(0)
+	for _, line := range lines {
+		baseSize += int64(len(line))
+		bus.CurrentLine <- line
+	}
+
+	insertLine := "INSERT INTO `edge` VALUES (1);\n"
+	insertLen := int64(len(insertLine))
+	streamSizeMax = baseSize + insertLen
+	bus.CurrentLine <- insertLine
+	bus.CurrentLine <- "UNLOCK TABLES;\n"
+	close(bus.CurrentLine)
+
+	select {
+	case <-bus.Finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for splitdump to finish")
+	}
+
+	if _, err := os.Stat(filepath.Join(outputDir, "mydb.edge.00001.sql.gz")); err == nil {
+		t.Fatal("expected no shard when stream size equals limit")
 	}
 }

--- a/utils/splitdump/split_test.go
+++ b/utils/splitdump/split_test.go
@@ -468,11 +468,6 @@ func TestSplitDumpLineParserAlternatingShardSizes(t *testing.T) {
 func TestSplitDumpLineParserNoShardWhenLimitEqualsSize(t *testing.T) {
 	bus := NewSplitDumpChannelBus()
 	outputDir := filepath.Join(t.TempDir(), "splitdump")
-	streamSizeMax := int64(0)
-	options := SplitDumpOptions{StreamSizeMax: &streamSizeMax}
-
-	go SplitDumpLineParser(bus, outputDir, options)
-
 	lines := []string{
 		"USE `mydb`\n",
 		"-- Table structure for table `edge`\n",
@@ -483,12 +478,19 @@ func TestSplitDumpLineParserNoShardWhenLimitEqualsSize(t *testing.T) {
 	baseSize := int64(0)
 	for _, line := range lines {
 		baseSize += int64(len(line))
-		bus.CurrentLine <- line
 	}
 
 	insertLine := "INSERT INTO `edge` VALUES (1);\n"
 	insertLen := int64(len(insertLine))
-	streamSizeMax = baseSize + insertLen
+	streamSizeMax := baseSize + insertLen
+	options := SplitDumpOptions{StreamSizeMax: &streamSizeMax}
+
+	go SplitDumpLineParser(bus, outputDir, options)
+
+	for _, line := range lines {
+		bus.CurrentLine <- line
+	}
+
 	bus.CurrentLine <- insertLine
 	bus.CurrentLine <- "UNLOCK TABLES;\n"
 	close(bus.CurrentLine)
@@ -501,5 +503,75 @@ func TestSplitDumpLineParserNoShardWhenLimitEqualsSize(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(outputDir, "mydb.edge.00001.sql.gz")); err == nil {
 		t.Fatal("expected no shard when stream size equals limit")
+	}
+}
+
+func TestSplitDumpLineParserSplitsAtStatementBoundary(t *testing.T) {
+	bus := NewSplitDumpChannelBus()
+	outputDir := filepath.Join(t.TempDir(), "splitdump")
+
+	lines := []string{
+		"USE `mydb`\n",
+		"-- Table structure for table `edge`\n",
+		"CREATE TABLE `edge` (id int)\n",
+		"-- Dumping data for table `edge`\n",
+		"LOCK TABLES `edge` WRITE;\n",
+		"INSERT INTO `edge` VALUES\n",
+		"(1),(2),(3)\n",
+		"(4),(5),(6);\n",
+		"INSERT INTO `edge` VALUES (7);\n",
+		"UNLOCK TABLES;\n",
+	}
+	baseSize := int64(0)
+	for i := 0; i < 7; i++ {
+		baseSize += int64(len(lines[i]))
+	}
+	streamSizeMax := baseSize - 1
+	options := SplitDumpOptions{StreamSizeMax: &streamSizeMax}
+
+	go SplitDumpLineParser(bus, outputDir, options)
+
+	for _, line := range lines {
+		bus.CurrentLine <- line
+	}
+	close(bus.CurrentLine)
+
+	select {
+	case <-bus.Finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for splitdump to finish")
+	}
+
+	shardPath := filepath.Join(outputDir, "mydb.edge.00001.sql.gz")
+	file, err := os.Open(shardPath)
+	if err != nil {
+		t.Fatalf("failed to open shard file: %v", err)
+	}
+	defer file.Close()
+
+	reader, err := gzip.NewReader(file)
+	if err != nil {
+		t.Fatalf("failed to read shard gzip: %v", err)
+	}
+	defer reader.Close()
+
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("failed to read shard content: %v", err)
+	}
+	contentStr := string(content)
+	useIndex := strings.Index(contentStr, "USE `mydb`;")
+	if useIndex == -1 {
+		t.Fatalf("expected USE statement in shard")
+	}
+	remaining := contentStr[useIndex+len("USE `mydb`;"):]
+	remaining = strings.TrimLeft(remaining, "\r\n")
+	firstLineEnd := strings.Index(remaining, "\n")
+	firstLine := remaining
+	if firstLineEnd != -1 {
+		firstLine = remaining[:firstLineEnd]
+	}
+	if !strings.HasPrefix(firstLine, "INSERT INTO `edge`") {
+		t.Fatalf("expected shard to start with INSERT statement, got: %s", firstLine)
 	}
 }


### PR DESCRIPTION
- Summary:
  - Defer shard creation until the end of an SQL statement to avoid tuple‑only shards and keep each shard self‑contained.
  - Reset shard numbering per table and require active table context before splitting to prevent incorrect filenames.
  - Expand splitdump tests for boundary conditions, missing USE, alternating shard/no‑shard tables, and CLI stream‑size validation.
- Proof:
  - Verified with mysqldump.sql.gz and 1 MiB shards; shard headers show USE <schema>; followed by complete statements.
- Tests:
  - go test ./utils/splitdump/...
  - go test -tags clients ./clients/...