### PR TITLE
feat: add functions to retrieve absolute path of replication-manager executable and CLI script

### DIFF
--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -262,7 +262,7 @@ func (cluster *Cluster) GetRepManAbsolutePath() (string, error) {
 		return filepath.Abs(path)
 	}
 
-	truepath, err := os.Readlink(path)
+	truepath, err := filepath.EvalSymlinks(path)
 	if err != nil {
 		return "", err
 	}

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -277,6 +277,10 @@ func (cluster *Cluster) GetReplicationManagerCliPath() string {
 		if dirpath, err := cluster.GetRepManAbsolutePath(); err == nil {
 			return filepath.Join(filepath.Dir(dirpath), "replication-manager-cli")
 		}
+		// Fall back to PATH lookup
+		if path, err := exec.LookPath("replication-manager-cli"); err == nil {
+			return path
+		}
 		return "replication-manager-cli"
 	}
 	return cluster.Conf.ReplicationManagerCliPath

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -275,7 +275,10 @@ func (cluster *Cluster) GetRepManAbsolutePath() (string, error) {
 func (cluster *Cluster) GetReplicationManagerCliPath() string {
 	if strings.TrimSpace(cluster.Conf.ReplicationManagerCliPath) == "" {
 		if dirpath, err := cluster.GetRepManAbsolutePath(); err == nil {
-			return filepath.Join(filepath.Dir(dirpath), "replication-manager-cli")
+			clipath := filepath.Join(filepath.Dir(dirpath), "replication-manager-cli")
+			if _, err := os.Stat(clipath); err == nil {
+				return clipath
+			}
 		}
 		// Fall back to PATH lookup
 		if path, err := exec.LookPath("replication-manager-cli"); err == nil {

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -14,6 +14,7 @@ import (
 	"hash/crc64"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"sort"
@@ -245,10 +246,37 @@ func (cluster *Cluster) GetGottyClientPath() string {
 	return cluster.Conf.BackupGottyClientPath
 }
 
+// GetRepManAbsoluteDirPath returns the absolute path of the directory where the replication-manager executable is located.
+// It resolves symlinks if the executable is a symlink.
+func (cluster *Cluster) GetRepManAbsoluteDirPath() (string, error) {
+	path, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+
+	finfo, err := os.Lstat(path)
+	if err != nil {
+		return "", err
+	}
+
+	if finfo.Mode()&os.ModeSymlink == 0 {
+		return filepath.Abs(filepath.Dir(path))
+	}
+
+	truepath, err := os.Readlink(path)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Abs(filepath.Dir(truepath))
+}
+
+// GetReplicationManagerCliPath returns the path to the replication-manager-cli script.
+// It will return the path defined in the configuration file if set, otherwise it will return the path of the script in the same directory as the executable
 func (cluster *Cluster) GetReplicationManagerCliPath() string {
 	if strings.TrimSpace(cluster.Conf.ReplicationManagerCliPath) == "" {
-		if path, err := exec.LookPath("replication-manager-cli"); err == nil {
-			return path
+		if dirpath, err := cluster.GetRepManAbsoluteDirPath(); err == nil {
+			return filepath.Join(dirpath, "replication-manager-cli")
 		}
 		return "replication-manager-cli"
 	}

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -246,7 +246,7 @@ func (cluster *Cluster) GetGottyClientPath() string {
 	return cluster.Conf.BackupGottyClientPath
 }
 
-// GetRepManAbsoluteDirPath returns the absolute path of the directory where the replication-manager executable is located
+// GetRepManAbsolutePath returns the absolute path of the replication-manager executable, resolving any symlinks if necessary
 func (cluster *Cluster) GetRepManAbsolutePath() (string, error) {
 	path, err := os.Executable()
 	if err != nil {

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -246,9 +246,8 @@ func (cluster *Cluster) GetGottyClientPath() string {
 	return cluster.Conf.BackupGottyClientPath
 }
 
-// GetRepManAbsoluteDirPath returns the absolute path of the directory where the replication-manager executable is located.
-// It resolves symlinks if the executable is a symlink.
-func (cluster *Cluster) GetRepManAbsoluteDirPath() (string, error) {
+// GetRepManAbsoluteDirPath returns the absolute path of the directory where the replication-manager executable is located
+func (cluster *Cluster) GetRepManAbsolutePath() (string, error) {
 	path, err := os.Executable()
 	if err != nil {
 		return "", err
@@ -260,7 +259,7 @@ func (cluster *Cluster) GetRepManAbsoluteDirPath() (string, error) {
 	}
 
 	if finfo.Mode()&os.ModeSymlink == 0 {
-		return filepath.Abs(filepath.Dir(path))
+		return filepath.Abs(path)
 	}
 
 	truepath, err := os.Readlink(path)
@@ -268,15 +267,15 @@ func (cluster *Cluster) GetRepManAbsoluteDirPath() (string, error) {
 		return "", err
 	}
 
-	return filepath.Abs(filepath.Dir(truepath))
+	return filepath.Abs(truepath)
 }
 
 // GetReplicationManagerCliPath returns the path to the replication-manager-cli script.
 // It will return the path defined in the configuration file if set, otherwise it will return the path of the script in the same directory as the executable
 func (cluster *Cluster) GetReplicationManagerCliPath() string {
 	if strings.TrimSpace(cluster.Conf.ReplicationManagerCliPath) == "" {
-		if dirpath, err := cluster.GetRepManAbsoluteDirPath(); err == nil {
-			return filepath.Join(dirpath, "replication-manager-cli")
+		if dirpath, err := cluster.GetRepManAbsolutePath(); err == nil {
+			return filepath.Join(filepath.Dir(dirpath), "replication-manager-cli")
 		}
 		return "replication-manager-cli"
 	}

--- a/cluster/cluster_get_test.go
+++ b/cluster/cluster_get_test.go
@@ -1,0 +1,74 @@
+package cluster
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+)
+
+func expectedExecutablePath(t *testing.T) string {
+	t.Helper()
+
+	path, err := os.Executable()
+	if err != nil {
+		t.Fatalf("failed to get executable path: %v", err)
+	}
+
+	finfo, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("failed to lstat executable path: %v", err)
+	}
+
+	if finfo.Mode()&os.ModeSymlink != 0 {
+		path, err = filepath.EvalSymlinks(path)
+		if err != nil {
+			t.Fatalf("failed to eval symlink: %v", err)
+		}
+	}
+
+	path, err = filepath.Abs(path)
+	if err != nil {
+		t.Fatalf("failed to get absolute path: %v", err)
+	}
+
+	return path
+}
+
+func TestGetRepManAbsolutePath(t *testing.T) {
+	cluster := &Cluster{}
+
+	got, err := cluster.GetRepManAbsolutePath()
+	if err != nil {
+		t.Fatalf("GetRepManAbsolutePath error: %v", err)
+	}
+
+	if !filepath.IsAbs(got) {
+		t.Fatalf("expected absolute path, got %q", got)
+	}
+
+	expected := expectedExecutablePath(t)
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestGetReplicationManagerCliPathUsesConfiguredValue(t *testing.T) {
+	cluster := &Cluster{Conf: &config.Config{ReplicationManagerCliPath: "/custom/replication-manager-cli"}}
+
+	got := cluster.GetReplicationManagerCliPath()
+	if got != cluster.Conf.ReplicationManagerCliPath {
+		t.Fatalf("expected configured path %q, got %q", cluster.Conf.ReplicationManagerCliPath, got)
+	}
+}
+
+func TestGetReplicationManagerCliPathUsesExecutableDir(t *testing.T) {
+	cluster := &Cluster{Conf: &config.Config{ReplicationManagerCliPath: "  "}}
+
+	got := cluster.GetReplicationManagerCliPath()
+	expected := filepath.Join(filepath.Dir(expectedExecutablePath(t)), "replication-manager-cli")
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}


### PR DESCRIPTION
This feature allow repman to auto-detect correct binary, since replication-manager-cli usually in one directory with the server