### PR TITLE
fix: guard checksum-all with schema cache and tune checksum wait logs

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -127,7 +127,7 @@ type Cluster struct {
 	IsNeedStagingChange           bool                       `json:"isNeedStagingChange" groups:"web"`
 	IsConfigPathChange            bool                       `json:"isConfigPathChange" groups:"web"`
 	IsResticQueuePaused           bool                       `json:"isResticQueuePaused" groups:"web"`
-	SchemaMonitorRequested        bool                       `json:"-"`
+	SchemaMonitorRequested        int32                      `json:"-"`
 	Conf                          *config.Config             `json:"config" groups:"apps"`
 	Confs                         *config.ConfVersion        `json:"-"`
 	CleanAll                      bool                       `json:"cleanReplication" groups:"web"` //used in testing
@@ -2040,7 +2040,7 @@ func (cluster *Cluster) MonitorTableSchemaDiff() {
 }
 
 func (cluster *Cluster) MonitorSchema() {
-	if !cluster.Conf.MonitorSchemaChange && !cluster.SchemaMonitorRequested {
+	if !cluster.Conf.MonitorSchemaChange && atomic.LoadInt32(&cluster.SchemaMonitorRequested) == 0 {
 		return
 	}
 
@@ -2048,7 +2048,7 @@ func (cluster *Cluster) MonitorSchema() {
 		return
 	}
 
-	if cluster.SchemaMonitorRequested {
+	if atomic.LoadInt32(&cluster.SchemaMonitorRequested) == 1 {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
 			"Schema monitoring requested; bypassing config gate for this run.")
 	}
@@ -2063,7 +2063,7 @@ func (cluster *Cluster) MonitorSchema() {
 	cluster.StateMachine.SetMonitorSchemaState()
 	defer func() {
 		cluster.StateMachine.RemoveMonitorSchemaState()
-		cluster.SchemaMonitorRequested = false
+		atomic.StoreInt32(&cluster.SchemaMonitorRequested, 0)
 	}()
 
 	err := cluster.MonitorMasterTableSchema()

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -127,6 +127,7 @@ type Cluster struct {
 	IsNeedStagingChange           bool                       `json:"isNeedStagingChange" groups:"web"`
 	IsConfigPathChange            bool                       `json:"isConfigPathChange" groups:"web"`
 	IsResticQueuePaused           bool                       `json:"isResticQueuePaused" groups:"web"`
+	SchemaMonitorRequested        bool                       `json:"-"`
 	Conf                          *config.Config             `json:"config" groups:"apps"`
 	Confs                         *config.ConfVersion        `json:"-"`
 	CleanAll                      bool                       `json:"cleanReplication" groups:"web"` //used in testing
@@ -2039,12 +2040,17 @@ func (cluster *Cluster) MonitorTableSchemaDiff() {
 }
 
 func (cluster *Cluster) MonitorSchema() {
-	if !cluster.Conf.MonitorSchemaChange {
+	if !cluster.Conf.MonitorSchemaChange && !cluster.SchemaMonitorRequested {
 		return
 	}
 
 	if cluster.StateMachine.IsInSchemaMonitor() {
 		return
+	}
+
+	if cluster.SchemaMonitorRequested {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+			"Schema monitoring requested; bypassing config gate for this run.")
 	}
 
 	loglevel := config.LvlInfo
@@ -2055,7 +2061,10 @@ func (cluster *Cluster) MonitorSchema() {
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, loglevel, "Starting schema monitoring")
 
 	cluster.StateMachine.SetMonitorSchemaState()
-	defer cluster.StateMachine.RemoveMonitorSchemaState()
+	defer func() {
+		cluster.StateMachine.RemoveMonitorSchemaState()
+		cluster.SchemaMonitorRequested = false
+	}()
 
 	err := cluster.MonitorMasterTableSchema()
 	if err != nil {

--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -728,9 +728,10 @@ func (cluster *Cluster) CheckTableChecksum(schema string, table string) {
 
 	for _, s := range cluster.slaves {
 		if !s.IsFailed() && !s.IsReplicationBroken() {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Wait sync on slave %s", s.URL)
 			for {
 				slaveSeq := s.SlaveGtid.GetSeqServerIdNos(uint64(cluster.master.ServerID))
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Wait sync on slave %s sequence %d", s.URL, slaveSeq)
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Wait sync on slave %s sequence %d", s.URL, slaveSeq)
 				if slaveSeq >= masterSeq {
 					break
 				} else {

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -1192,6 +1192,7 @@ func (cluster *Cluster) SetWaitSponsorCredCookie() {
 
 func (cluster *Cluster) SetWaitMonitorSchema() {
 	cluster.SetState("WARN0163", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(config.ClusterError["WARN0163"], cluster.Name), ErrFrom: "API"})
+	cluster.SchemaMonitorRequested = true
 }
 
 func (cluster *Cluster) SetDBDynamicConfig() {

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/signal18/replication-manager/config"
@@ -1192,7 +1193,7 @@ func (cluster *Cluster) SetWaitSponsorCredCookie() {
 
 func (cluster *Cluster) SetWaitMonitorSchema() {
 	cluster.SetState("WARN0163", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(config.ClusterError["WARN0163"], cluster.Name), ErrFrom: "API"})
-	cluster.SchemaMonitorRequested = true
+	atomic.StoreInt32(&cluster.SchemaMonitorRequested, 1)
 }
 
 func (cluster *Cluster) SetDBDynamicConfig() {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -5779,6 +5779,13 @@ func (repman *ReplicationManager) handlerMuxClusterSchemaChecksumAllTable(w http
 			http.Error(w, "No valid ACL", http.StatusForbidden)
 			return
 		}
+		master := mycluster.GetMaster()
+		if master == nil || len(master.Tables) == 0 {
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+				"Checksum all tables requested; schema cache empty. Triggered schema monitoring; re-run checksum after cache is ready.")
+			go mycluster.SetWaitMonitorSchema()
+			return
+		}
 		go mycluster.CheckAllTableChecksum()
 	} else {
 		http.Error(w, "No cluster", http.StatusInternalServerError)

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -5783,7 +5783,12 @@ func (repman *ReplicationManager) handlerMuxClusterSchemaChecksumAllTable(w http
 		if master == nil || len(master.Tables) == 0 {
 			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
 				"Checksum all tables requested; schema cache empty. Triggered schema monitoring; re-run checksum after cache is ready.")
-			go mycluster.SetWaitMonitorSchema()
+			mycluster.SetWaitMonitorSchema()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			json.NewEncoder(w).Encode(map[string]string{
+				"message": "schema cache empty; schema monitoring triggered; retry checksum after cache is populated",
+			})
 			return
 		}
 		go mycluster.CheckAllTableChecksum()

--- a/share/dashboard_react/src/Pages/Home/index.jsx
+++ b/share/dashboard_react/src/Pages/Home/index.jsx
@@ -234,6 +234,16 @@ function Home() {
     selectedClusterNameRef.current = cluster.name
     setSelectedTab(1)
   }
+
+  const openMaintenanceScheduler = () => {
+    localStorage.setItem('isSchedulerOpen', JSON.stringify(true))
+    const maintenanceIndex = dashboardTabsRef.current.indexOf('Maintenance')
+    if (maintenanceIndex >= 0) {
+      const tabIndex = maintenanceIndex + 1
+      selectedTabRef.current = tabIndex
+      setSelectedTab(tabIndex)
+    }
+  }
   const openNewClusterModal = (e) => {
     e.stopPropagation()
     setIsNewClusterModalOpen(true)
@@ -283,7 +293,7 @@ function Home() {
                 ...(selectedCluster?.config?.proxysql && user?.grants['cluster-show-agents']
                   ? [<QueryRules selectedCluster={selectedCluster} />]
                   : []),
-                ...(user?.grants['db-show-schema'] ? [<Shards selectedCluster={selectedCluster} />] : []),
+                ...(user?.grants['db-show-schema'] ? [<Shards selectedCluster={selectedCluster} user={user} onOpenSchedulerSettings={openMaintenanceScheduler} />] : []),
                 ...(user?.grants['cluster-grant'] ? [<Users selectedCluster={selectedCluster} user={user} />] : [])
               ]
               : globalTabsRef.current.includes('Clusters Peer') // monitor?.config?.cloud18 is false, do not show "Peer Clusters" tab

--- a/share/dashboard_react/src/Pages/Shards/index.jsx
+++ b/share/dashboard_react/src/Pages/Shards/index.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { checksumAllTables, checksumTable, getShardSchema } from '../../redux/clusterSlice'
+import { checksumAllTables, checksumTable, getShardSchema, monitorAllSchemas } from '../../redux/clusterSlice'
 import { createColumnHelper } from '@tanstack/react-table'
 import { DataTable } from '../../components/DataTable'
 import styles from './styles.module.scss'
@@ -11,16 +11,19 @@ import { getTablePct } from '../../utility/common'
 import Gauge from '../../components/Gauge'
 import AccordionComponent from '../../components/AccordionComponent'
 import  { GeneralLogs, TaskLogs } from '../Dashboard/components/Logs'
-import NotFound from '../../components/NotFound'
+import ConfirmModal from '../../components/Modals/ConfirmModal'
 
-function Shards({ selectedCluster }) {
+function Shards({ selectedCluster, user, onOpenSchedulerSettings }) {
   const dispatch = useDispatch()
 
   const {
-    cluster: { shardSchema }
+    cluster: { shardSchema },
   } = useSelector((state) => state)
   const [data, setData] = useState(shardSchema || [])
   const prevShardsRef = useRef(shardSchema)
+  const [isChecksumAllRunning, setIsChecksumAllRunning] = useState(false)
+  const [isSchemaConfirmOpen, setIsSchemaConfirmOpen] = useState(false)
+  const [pendingChecksumAll, setPendingChecksumAll] = useState(false)
 
   useEffect(() => {
     if (shardSchema?.length > 0) {
@@ -34,10 +37,49 @@ function Shards({ selectedCluster }) {
   const handleChecksum = (schema, table) => {
     dispatch(checksumTable({ clusterName: selectedCluster?.name, schema, table }))
   }
-  const handleChecksumAll = () => {
-    dispatch(checksumAllTables({ clusterName: selectedCluster?.name }))
+  const handleChecksumAll = async () => {
+    if (!selectedCluster?.name || isChecksumAllRunning) {
+      return
+    }
+    if (!shardSchema || shardSchema.length === 0) {
+      setPendingChecksumAll(true)
+      setIsSchemaConfirmOpen(true)
+      return
+    }
+    await runChecksumAllFlow()
   }
 
+  const runChecksumAllFlow = async () => {
+    if (!selectedCluster?.name || isChecksumAllRunning) {
+      return
+    }
+    setIsChecksumAllRunning(true)
+    try {
+      if (!shardSchema || shardSchema.length === 0) {
+        await dispatch(monitorAllSchemas({ clusterName: selectedCluster?.name }))
+        await waitForSchemaCache()
+      }
+      await dispatch(checksumAllTables({ clusterName: selectedCluster?.name }))
+    } finally {
+      setIsChecksumAllRunning(false)
+    }
+  }
+
+  const waitForSchemaCache = async () => {
+    if (!selectedCluster?.name) {
+      return
+    }
+    let hasSchema = false
+    while (!hasSchema) {
+      const action = await dispatch(getShardSchema({ clusterName: selectedCluster?.name }))
+      const payload = action?.payload?.data
+      if (Array.isArray(payload) && payload.length > 0) {
+        hasSchema = true
+        break
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5000))
+    }
+  }
   const columnHelper = createColumnHelper()
 
   const columns = useMemo(
@@ -96,13 +138,37 @@ function Shards({ selectedCluster }) {
     []
   )
   useEffect(() => {
-    dispatch(getShardSchema({ clusterName: selectedCluster?.name }))
-  }, [])
+    if (selectedCluster?.name) {
+      dispatch(getShardSchema({ clusterName: selectedCluster?.name }))
+    }
+  }, [dispatch, selectedCluster?.name])
   return (
     <VStack className={styles.shardsContainer}>
-      <RMButton className={`${styles.btnChecksumAll}`} onClick={handleChecksumAll}>
-        Checksum All Tables
-      </RMButton>
+      <Flex className={styles.section} direction='column'>
+        <Flex className={styles.sectionHeader} direction='column'>
+          <span className={styles.sectionTitle}>Schema Actions</span>
+          <span className={styles.sectionDescription}>
+            Run one-off checks or refresh schema metadata for the shard list.
+          </span>
+        </Flex>
+        <Flex className={styles.sectionBody} direction='column'>
+          <Flex className={styles.actionsRow}>
+            <RMButton
+              className={styles.btnChecksumAll}
+              onClick={handleChecksumAll}
+              isDisabled={!selectedCluster?.name || isChecksumAllRunning}
+              isLoading={isChecksumAllRunning}>
+              {isChecksumAllRunning ? 'Preparing schema cache...' : 'Checksum All Tables'}
+            </RMButton>
+            <RMButton
+              variant='outline'
+              onClick={onOpenSchedulerSettings}
+              isDisabled={!onOpenSchedulerSettings || user?.grants['cluster-show-backups'] == false}>
+              Open Scheduler Settings
+            </RMButton>
+          </Flex>
+        </Flex>
+      </Flex>
       <DataTable key="shards" data={data} columns={columns} className={styles.table} />
       <AccordionComponent
         className={styles.accordion}
@@ -114,6 +180,24 @@ function Shards({ selectedCluster }) {
         heading={'Job Logs'}
         body={<TaskLogs />}
       />
+      {isSchemaConfirmOpen && (
+        <ConfirmModal
+          isOpen={isSchemaConfirmOpen}
+          closeModal={() => {
+            setIsSchemaConfirmOpen(false)
+            setPendingChecksumAll(false)
+          }}
+          title='Schema cache required'
+          body='Schema cache is empty. Run a schema scan now and wait for it to complete before checksumming all tables?'
+          onConfirmClick={async () => {
+            setIsSchemaConfirmOpen(false)
+            if (pendingChecksumAll) {
+              setPendingChecksumAll(false)
+              await runChecksumAllFlow()
+            }
+          }}
+        />
+      )}
     </VStack>
   )
 }

--- a/share/dashboard_react/src/Pages/Shards/index.jsx
+++ b/share/dashboard_react/src/Pages/Shards/index.jsx
@@ -24,6 +24,14 @@ function Shards({ selectedCluster, user, onOpenSchedulerSettings }) {
   const [isChecksumAllRunning, setIsChecksumAllRunning] = useState(false)
   const [isSchemaConfirmOpen, setIsSchemaConfirmOpen] = useState(false)
   const [pendingChecksumAll, setPendingChecksumAll] = useState(false)
+  const [checksumTimeout, setChecksumTimeout] = useState(false)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   useEffect(() => {
     if (shardSchema?.length > 0) {
@@ -53,32 +61,48 @@ function Shards({ selectedCluster, user, onOpenSchedulerSettings }) {
     if (!selectedCluster?.name || isChecksumAllRunning) {
       return
     }
+    setChecksumTimeout(false)
     setIsChecksumAllRunning(true)
     try {
       if (!shardSchema || shardSchema.length === 0) {
         await dispatch(monitorAllSchemas({ clusterName: selectedCluster?.name }))
-        await waitForSchemaCache()
+        const schemaReady = await waitForSchemaCache()
+        if (!mountedRef.current) {
+          return
+        }
+        if (!schemaReady) {
+          setChecksumTimeout(true)
+          return
+        }
       }
       await dispatch(checksumAllTables({ clusterName: selectedCluster?.name }))
     } finally {
-      setIsChecksumAllRunning(false)
+      if (mountedRef.current) {
+        setIsChecksumAllRunning(false)
+      }
     }
   }
 
   const waitForSchemaCache = async () => {
     if (!selectedCluster?.name) {
-      return
+      return false
     }
-    let hasSchema = false
-    while (!hasSchema) {
+    const maxAttempts = 12
+    const intervalMs = 15000 // 15 seconds
+    let attempts = 0
+    while (attempts < maxAttempts) {
+      if (!mountedRef.current) {
+        return false
+      }
       const action = await dispatch(getShardSchema({ clusterName: selectedCluster?.name }))
       const payload = action?.payload?.data
       if (Array.isArray(payload) && payload.length > 0) {
-        hasSchema = true
-        break
+        return true
       }
-      await new Promise((resolve) => setTimeout(resolve, 5000))
+      attempts++
+      await new Promise((resolve) => setTimeout(resolve, intervalMs))
     }
+    return false
   }
   const columnHelper = createColumnHelper()
 
@@ -167,6 +191,11 @@ function Shards({ selectedCluster, user, onOpenSchedulerSettings }) {
               Open Scheduler Settings
             </RMButton>
           </Flex>
+          {checksumTimeout && (
+            <Flex className={styles.timeoutMessage}>
+              <span>Schema monitoring timed out. Check server logs or retry later.</span>
+            </Flex>
+          )}
         </Flex>
       </Flex>
       <DataTable key="shards" data={data} columns={columns} className={styles.table} />

--- a/share/dashboard_react/src/Pages/Shards/styles.module.scss
+++ b/share/dashboard_react/src/Pages/Shards/styles.module.scss
@@ -37,6 +37,19 @@
     flex-wrap: wrap;
     align-items: center;
   }
+  .timeoutMessage {
+    width: 100%;
+    padding: rem(8) rem(12);
+    margin-top: rem(8);
+    border-radius: rem(6);
+    background-color: rgba(229, 62, 62, 0.1);
+    border: 1px solid #e53e3e;
+    span {
+      font-size: rem(12);
+      color: #e53e3e;
+      font-weight: 500;
+    }
+  }
   .tablesSchemaCol {
     gap: rem(16);
   }

--- a/share/dashboard_react/src/Pages/Shards/styles.module.scss
+++ b/share/dashboard_react/src/Pages/Shards/styles.module.scss
@@ -1,12 +1,41 @@
 .shardsContainer {
   margin-top: rem(8);
   align-items: flex-start;
+  gap: rem(16);
 
   .accordion {
     width: 100%;
   }
-  .btnChecksumAll {
-    margin-right: auto;
+  .section {
+    width: 100%;
+    padding: rem(14);
+    border-radius: rem(12);
+    border: 1px solid var(--gray-color);
+    background-color: var(--secondary-gray-color);
+    gap: rem(12);
+  }
+  .sectionHeader {
+    gap: rem(4);
+  }
+  .sectionTitle {
+    font-size: rem(15);
+    font-weight: 700;
+    color: var(--text-color);
+  }
+  .sectionDescription {
+    font-size: rem(12);
+    color: var(--darkgray-color);
+    font-weight: 500;
+  }
+  .sectionBody {
+    width: 100%;
+  }
+  .actionsRow {
+    gap: rem(12);
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    align-items: center;
   }
   .tablesSchemaCol {
     gap: rem(16);
@@ -16,6 +45,12 @@
     margin: auto;
     div[class*='textOverlay'] {
       bottom: rem(12);
+    }
+  }
+
+  @media (max-width: 768px) {
+    .actionsRow {
+      align-items: flex-start;
     }
   }
 }


### PR DESCRIPTION
Summary
- Trigger schema monitoring when checksum-all is requested without a cached schema and skip checksum until the cache is ready.
- Add a schema-monitoring override flag to allow on-demand scans without toggling settings.
- Update the Shards page to guide users through schema warmup and link to scheduler settings.
- Reduce checksum wait log noise by emitting a single info line and moving per-iteration logs to debug.
Notes
- Checksum-all now logs and returns early if schema cache is empty; re-run after monitoring completes.
- Shards UI prompts for schema scan when cache is empty and blocks checksum until cache is populated.