### PR TITLE
fix: suppress per-file orphaned metadata warnings

### DIFF
--- a/cluster/cluster_bck_meta.go
+++ b/cluster/cluster_bck_meta.go
@@ -1310,7 +1310,7 @@ func (cluster *Cluster) ReconcileSnapshotMetadata() (*ReconciliationReport, erro
 		// Check if snapshot exists
 		if !snapshotIDs[snapshotID] {
 			report.OrphanedMetadata = append(report.OrphanedMetadata, metaFile)
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlWarn, "Orphaned metadata: %s references deleted snapshot %s", base, snapshotID)
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlDbg, "Orphaned metadata: %s references deleted snapshot %s", base, snapshotID)
 
 			// Auto-cleanup if enabled
 			if cluster.Conf.BackupReconcileAutoCleanup {


### PR DESCRIPTION
Change per-orphan log level from WARN to DEBUG to reduce log noise while keeping the reconciliation summary.
