### PR TITLE
Enable safe deletion of local backups while guarding active jobs

### DIFF
--- a/cluster/backup_helpers.go
+++ b/cluster/backup_helpers.go
@@ -8,6 +8,7 @@ package cluster
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -33,6 +34,7 @@ type BackupRunOptions struct {
 }
 
 var adhocMetaFilePattern = regexp.MustCompile(`\.(\d+)\.meta\.json$`)
+var ErrBackupInProgress = errors.New("backup is still running")
 
 func normalizeBackupLine(value string) string {
 	normalized := strings.ToLower(strings.TrimSpace(value))
@@ -481,6 +483,87 @@ func (server *ServerMonitor) GetLatestMetaForLine(method, line string) (int64, *
 	return latest, meta
 }
 
+func isActiveBackupMeta(target, active *backupmgr.BackupMetadata) bool {
+	if target == nil || active == nil {
+		return false
+	}
+	if target.BackupSessionID != "" && active.BackupSessionID != "" {
+		if target.BackupSessionID == active.BackupSessionID {
+			return true
+		}
+	}
+	if target.Id > 0 && active.Id > 0 && target.Id == active.Id {
+		return true
+	}
+	if target.Dest != "" && active.Dest != "" {
+		return filepath.Clean(target.Dest) == filepath.Clean(active.Dest)
+	}
+	return false
+}
+
+func (cluster *Cluster) isBackupMetaInProgress(meta *backupmgr.BackupMetadata, server *ServerMonitor) bool {
+	if cluster == nil || server == nil || meta == nil {
+		return false
+	}
+
+	server.backupMetaMutex.Lock()
+	var logicalCopy *backupmgr.BackupMetadata
+	var physicalCopy *backupmgr.BackupMetadata
+	if server.LastBackupMeta.Logical != nil {
+		metaCopy := *server.LastBackupMeta.Logical
+		logicalCopy = &metaCopy
+	}
+	if server.LastBackupMeta.Physical != nil {
+		metaCopy := *server.LastBackupMeta.Physical
+		physicalCopy = &metaCopy
+	}
+	server.backupMetaMutex.Unlock()
+
+	knownLogical := false
+	knownPhysical := false
+	switch meta.BackupTool {
+	case config.ConstBackupLogicalTypeMysqldump,
+		config.ConstBackupLogicalTypeMydumper,
+		config.ConstBackupLogicalTypeDumpling,
+		"script":
+		knownLogical = true
+	case config.ConstBackupPhysicalTypeXtrabackup,
+		config.ConstBackupPhysicalTypeMariaBackup:
+		knownPhysical = true
+	}
+
+	method := inferBackupMethod(meta)
+	if knownLogical {
+		method = backupmgr.BackupMethodLogical
+	} else if knownPhysical {
+		method = backupmgr.BackupMethodPhysical
+	}
+	if !knownLogical && !knownPhysical {
+		if !cluster.IsInBackup() {
+			return false
+		}
+		return isActiveBackupMeta(meta, logicalCopy) || isActiveBackupMeta(meta, physicalCopy)
+	}
+
+	switch method {
+	case backupmgr.BackupMethodLogical:
+		if !cluster.InLogicalBackup && !cluster.IsInResticBackupForMethod(backupmgr.BackupMethodLogical) {
+			return false
+		}
+		return isActiveBackupMeta(meta, logicalCopy)
+	case backupmgr.BackupMethodPhysical:
+		if !cluster.InPhysicalBackup && !cluster.IsInResticBackupForMethod(backupmgr.BackupMethodPhysical) {
+			return false
+		}
+		return isActiveBackupMeta(meta, physicalCopy)
+	default:
+		if !cluster.IsInBackup() {
+			return false
+		}
+		return isActiveBackupMeta(meta, logicalCopy) || isActiveBackupMeta(meta, physicalCopy)
+	}
+}
+
 func (cluster *Cluster) DeleteBackupByID(backupID int64) (*backupmgr.BackupMetadata, error) {
 	if cluster == nil || cluster.BackupMetaMap == nil {
 		return nil, fmt.Errorf("cluster backups not available")
@@ -501,15 +584,24 @@ func (cluster *Cluster) DeleteBackupByID(backupID int64) (*backupmgr.BackupMetad
 	if server == nil {
 		return nil, fmt.Errorf("source server %s not found", meta.Source)
 	}
+	if cluster.isBackupMetaInProgress(meta, server) {
+		return nil, fmt.Errorf("%w: %d", ErrBackupInProgress, backupID)
+	}
 
 	if meta.Dest != "" {
 		backupDir := server.GetMyBackupDirectory()
 		if !isPathWithinBase(backupDir, meta.Dest) {
 			return nil, fmt.Errorf("backup path %s is outside %s", meta.Dest, backupDir)
 		}
+		if cluster.isBackupMetaInProgress(meta, server) {
+			return nil, fmt.Errorf("%w: %d", ErrBackupInProgress, backupID)
+		}
 		if err := os.RemoveAll(meta.Dest); err != nil {
 			return nil, err
 		}
+	}
+	if cluster.isBackupMetaInProgress(meta, server) {
+		return nil, fmt.Errorf("%w: %d", ErrBackupInProgress, backupID)
 	}
 
 	metaPath := server.backupMetaFilePath(meta)

--- a/cluster/backup_helpers.go
+++ b/cluster/backup_helpers.go
@@ -481,6 +481,48 @@ func (server *ServerMonitor) GetLatestMetaForLine(method, line string) (int64, *
 	return latest, meta
 }
 
+func (cluster *Cluster) DeleteBackupByID(backupID int64) (*backupmgr.BackupMetadata, error) {
+	if cluster == nil || cluster.BackupMetaMap == nil {
+		return nil, fmt.Errorf("cluster backups not available")
+	}
+	if backupID <= 0 {
+		return nil, fmt.Errorf("invalid backup id %d", backupID)
+	}
+
+	meta := cluster.BackupMetaMap.Get(backupID)
+	if meta == nil {
+		return nil, fmt.Errorf("backup %d not found", backupID)
+	}
+	if meta.Source == "" {
+		return nil, fmt.Errorf("backup %d has no source server", backupID)
+	}
+
+	server := cluster.GetServerFromURL(meta.Source)
+	if server == nil {
+		return nil, fmt.Errorf("source server %s not found", meta.Source)
+	}
+
+	if meta.Dest != "" {
+		backupDir := server.GetMyBackupDirectory()
+		if !isPathWithinBase(backupDir, meta.Dest) {
+			return nil, fmt.Errorf("backup path %s is outside %s", meta.Dest, backupDir)
+		}
+		if err := os.RemoveAll(meta.Dest); err != nil {
+			return nil, err
+		}
+	}
+
+	metaPath := server.backupMetaFilePath(meta)
+	if metaPath != "" {
+		if err := os.Remove(metaPath); err != nil && !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+
+	cluster.BackupMetaMap.Delete(meta.Id)
+	return meta, nil
+}
+
 func (cluster *Cluster) PurgeExpiredAdhocBackups() {
 	if cluster == nil {
 		return

--- a/cluster/backup_helpers.go
+++ b/cluster/backup_helpers.go
@@ -34,7 +34,11 @@ type BackupRunOptions struct {
 }
 
 var adhocMetaFilePattern = regexp.MustCompile(`\.(\d+)\.meta\.json$`)
-var ErrBackupInProgress = errors.New("backup is still running")
+var (
+	ErrBackupInProgress = errors.New("backup is still running")
+	ErrBackupInvalidID  = errors.New("invalid backup id")
+	ErrBackupNotFound   = errors.New("backup not found")
+)
 
 func normalizeBackupLine(value string) string {
 	normalized := strings.ToLower(strings.TrimSpace(value))
@@ -491,6 +495,7 @@ func isActiveBackupMeta(target, active *backupmgr.BackupMetadata) bool {
 		if target.BackupSessionID == active.BackupSessionID {
 			return true
 		}
+		return false
 	}
 	if target.Id > 0 && active.Id > 0 && target.Id == active.Id {
 		return true
@@ -569,12 +574,12 @@ func (cluster *Cluster) DeleteBackupByID(backupID int64) (*backupmgr.BackupMetad
 		return nil, fmt.Errorf("cluster backups not available")
 	}
 	if backupID <= 0 {
-		return nil, fmt.Errorf("invalid backup id %d", backupID)
+		return nil, fmt.Errorf("%w: %d", ErrBackupInvalidID, backupID)
 	}
 
 	meta := cluster.BackupMetaMap.Get(backupID)
 	if meta == nil {
-		return nil, fmt.Errorf("backup %d not found", backupID)
+		return nil, fmt.Errorf("%w: %d", ErrBackupNotFound, backupID)
 	}
 	if meta.Source == "" {
 		return nil, fmt.Errorf("backup %d has no source server", backupID)
@@ -600,10 +605,6 @@ func (cluster *Cluster) DeleteBackupByID(backupID int64) (*backupmgr.BackupMetad
 			return nil, err
 		}
 	}
-	if cluster.isBackupMetaInProgress(meta, server) {
-		return nil, fmt.Errorf("%w: %d", ErrBackupInProgress, backupID)
-	}
-
 	metaPath := server.backupMetaFilePath(meta)
 	if metaPath != "" {
 		if err := os.Remove(metaPath); err != nil && !os.IsNotExist(err) {

--- a/cluster/backup_helpers_test.go
+++ b/cluster/backup_helpers_test.go
@@ -8,6 +8,7 @@ package cluster
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -852,6 +853,150 @@ func TestPurgeExpiredAdhocBackupsConcurrent(t *testing.T) {
 			t.Errorf("expected dest dir %s to be removed", entry.destDir)
 		}
 	}
+}
+
+func TestIsActiveBackupMetaSessionMismatch(t *testing.T) {
+	target := &backupmgr.BackupMetadata{
+		Id:              10,
+		Dest:            "/tmp/backup",
+		BackupSessionID: "session-a",
+	}
+	active := &backupmgr.BackupMetadata{
+		Id:              11,
+		Dest:            "/tmp/backup",
+		BackupSessionID: "session-b",
+	}
+	if isActiveBackupMeta(target, active) {
+		t.Fatalf("expected session mismatch to be inactive")
+	}
+}
+
+func TestIsBackupMetaInProgressUnknownTool(t *testing.T) {
+	cluster, server := newTestClusterServer(t)
+	cluster.InLogicalBackup = true
+
+	active := &backupmgr.BackupMetadata{
+		Id:              101,
+		BackupTool:      config.ConstBackupLogicalTypeMysqldump,
+		Dest:            filepath.Join(server.GetMyBackupDirectory(), "mysqldump.sql.gz"),
+		BackupSessionID: "session-101",
+		Source:          server.URL,
+	}
+	server.backupMetaMutex.Lock()
+	server.LastBackupMeta.Logical = active
+	server.backupMetaMutex.Unlock()
+
+	meta := &backupmgr.BackupMetadata{
+		Id:              101,
+		BackupTool:      "customtool",
+		Dest:            active.Dest,
+		BackupSessionID: "session-101",
+		Source:          server.URL,
+	}
+	if !cluster.isBackupMetaInProgress(meta, server) {
+		t.Fatalf("expected unknown tool backup to be detected as in progress")
+	}
+
+	meta.Dest = filepath.Join(server.GetMyBackupDirectory(), "other.sql.gz")
+	meta.BackupSessionID = "session-102"
+	if cluster.isBackupMetaInProgress(meta, server) {
+		t.Fatalf("expected non-matching backup to be inactive")
+	}
+}
+
+func TestDeleteBackupByIDSuccess(t *testing.T) {
+	cluster, server := newTestClusterServer(t)
+	backupDir := server.GetMyBackupDirectory()
+	dest := filepath.Join(backupDir, "mysqldump.sql.gz")
+	if err := os.WriteFile(dest, []byte("payload"), 0644); err != nil {
+		t.Fatalf("failed to create backup payload: %v", err)
+	}
+
+	meta := &backupmgr.BackupMetadata{
+		Id:         time.Now().Unix(),
+		BackupTool: config.ConstBackupLogicalTypeMysqldump,
+		BackupLine: backupmgr.BackupLineDefault,
+		Source:     server.URL,
+		Dest:       dest,
+	}
+	cluster.BackupMetaMap.Set(meta.Id, meta)
+
+	metaPath := server.backupMetaFilePath(meta)
+	if err := os.WriteFile(metaPath, []byte("{}"), 0644); err != nil {
+		t.Fatalf("failed to create backup metadata: %v", err)
+	}
+
+	if _, err := cluster.DeleteBackupByID(meta.Id); err != nil {
+		t.Fatalf("unexpected error deleting backup: %v", err)
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatalf("expected backup payload to be removed")
+	}
+	if _, err := os.Stat(metaPath); !os.IsNotExist(err) {
+		t.Fatalf("expected metadata file to be removed")
+	}
+	if got := cluster.BackupMetaMap.Get(meta.Id); got != nil {
+		t.Fatalf("expected backup metadata to be removed from map")
+	}
+}
+
+func TestDeleteBackupByIDInProgress(t *testing.T) {
+	cluster, server := newTestClusterServer(t)
+	cluster.InLogicalBackup = true
+	backupDir := server.GetMyBackupDirectory()
+	dest := filepath.Join(backupDir, "mysqldump.sql.gz")
+	if err := os.WriteFile(dest, []byte("payload"), 0644); err != nil {
+		t.Fatalf("failed to create backup payload: %v", err)
+	}
+
+	meta := &backupmgr.BackupMetadata{
+		Id:         123,
+		BackupTool: config.ConstBackupLogicalTypeMysqldump,
+		BackupLine: backupmgr.BackupLineDefault,
+		Source:     server.URL,
+		Dest:       dest,
+	}
+	cluster.BackupMetaMap.Set(meta.Id, meta)
+	server.backupMetaMutex.Lock()
+	server.LastBackupMeta.Logical = meta
+	server.backupMetaMutex.Unlock()
+
+	if _, err := cluster.DeleteBackupByID(meta.Id); !errors.Is(err, ErrBackupInProgress) {
+		t.Fatalf("expected ErrBackupInProgress, got %v", err)
+	}
+	if _, err := os.Stat(dest); err != nil {
+		t.Fatalf("expected backup payload to remain, got %v", err)
+	}
+}
+
+func TestDeleteBackupByIDInvalidOrMissing(t *testing.T) {
+	cluster, _ := newTestClusterServer(t)
+	if _, err := cluster.DeleteBackupByID(0); !errors.Is(err, ErrBackupInvalidID) {
+		t.Fatalf("expected ErrBackupInvalidID, got %v", err)
+	}
+	if _, err := cluster.DeleteBackupByID(999); !errors.Is(err, ErrBackupNotFound) {
+		t.Fatalf("expected ErrBackupNotFound, got %v", err)
+	}
+}
+
+func newTestClusterServer(t *testing.T) (*Cluster, *ServerMonitor) {
+	t.Helper()
+	cluster := &Cluster{
+		Name:          "test-cluster",
+		Conf:          &config.Config{WorkingDir: t.TempDir()},
+		StateMachine:  &state.StateMachine{},
+		Logrus:        logrus.New(),
+		BackupMetaMap: backupmgr.NewBackupMetaMap(),
+	}
+	cluster.StateMachine.Init()
+	server := &ServerMonitor{
+		Host:         "127.0.0.1",
+		Port:         "3306",
+		URL:          "127.0.0.1:3306",
+		ClusterGroup: cluster,
+	}
+	cluster.Servers = serverList{server}
+	return cluster, server
 }
 
 // Helper function

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2052,6 +2052,7 @@ func (repman *ReplicationManager) handlerMuxClusterBackupReconcile(w http.Respon
 // @Param backupID path string true "Backup ID"
 // @Success 200 {object} map[string]interface{} "Backup deleted"
 // @Failure 400 {string} string "Invalid request"
+// @Failure 409 {string} string "Backup running"
 // @Failure 403 {string} string "No valid ACL"
 // @Failure 500 {string} string "Delete failed"
 // @Router /api/clusters/{clusterName}/backups/{backupID}/delete [post]
@@ -2081,6 +2082,10 @@ func (repman *ReplicationManager) handlerMuxClusterBackupDelete(w http.ResponseW
 
 	meta, err := mycluster.DeleteBackupByID(backupIDInt)
 	if err != nil {
+		if errors.Is(err, cluster.ErrBackupInProgress) {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2082,12 +2082,17 @@ func (repman *ReplicationManager) handlerMuxClusterBackupDelete(w http.ResponseW
 
 	meta, err := mycluster.DeleteBackupByID(backupIDInt)
 	if err != nil {
-		if errors.Is(err, cluster.ErrBackupInProgress) {
+		switch {
+		case errors.Is(err, cluster.ErrBackupInProgress):
 			http.Error(w, err.Error(), http.StatusConflict)
 			return
+		case errors.Is(err, cluster.ErrBackupInvalidID), errors.Is(err, cluster.ErrBackupNotFound):
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -119,6 +119,11 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterBackupReconcile)),
 	))
 
+	router.Handle("/api/clusters/{clusterName}/backups/{backupID}/delete", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterBackupDelete)),
+	))
+
 	router.Handle("/api/clusters/{clusterName}/terminals", negroni.New(
 		negroni.Wrap(http.HandlerFunc(repman.handlerGetTerminalSessionList)),
 	))
@@ -2034,6 +2039,61 @@ func (repman *ReplicationManager) handlerMuxClusterBackupReconcile(w http.Respon
 	err = e.Encode(report)
 	if err != nil {
 		mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "API encoding error %s", err)
+	}
+}
+
+// handlerMuxClusterBackupDelete handles deletion of a non-restic backup by ID.
+// @Summary Delete a backup by ID
+// @Description Deletes a non-restic backup for the specified cluster.
+// @Tags ClusterBackups
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Param backupID path string true "Backup ID"
+// @Success 200 {object} map[string]interface{} "Backup deleted"
+// @Failure 400 {string} string "Invalid request"
+// @Failure 403 {string} string "No valid ACL"
+// @Failure 500 {string} string "Delete failed"
+// @Router /api/clusters/{clusterName}/backups/{backupID}/delete [post]
+func (repman *ReplicationManager) handlerMuxClusterBackupDelete(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster == nil {
+		http.Error(w, "No cluster", http.StatusInternalServerError)
+		return
+	}
+	if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+		http.Error(w, "No valid ACL", http.StatusForbidden)
+		return
+	}
+
+	backupID := strings.TrimSpace(vars["backupID"])
+	if backupID == "" {
+		http.Error(w, "No backup ID", http.StatusBadRequest)
+		return
+	}
+	backupIDInt, err := strconv.ParseInt(backupID, 10, 64)
+	if err != nil {
+		http.Error(w, "Invalid backup ID", http.StatusBadRequest)
+		return
+	}
+
+	meta, err := mycluster.DeleteBackupByID(backupIDInt)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	e := json.NewEncoder(w)
+	e.SetIndent("", "\t")
+	if err := e.Encode(map[string]interface{}{
+		"id":      meta.Id,
+		"message": "Local backup deleted; restic snapshots retained",
+	}); err != nil {
+		http.Error(w, "Encoding error", http.StatusInternalServerError)
+		return
 	}
 }
 

--- a/share/dashboard_react/src/Pages/Maintenance/index.jsx
+++ b/share/dashboard_react/src/Pages/Maintenance/index.jsx
@@ -375,21 +375,18 @@ function Maintenance({ selectedCluster, user }) {
         header: 'Completed',
         id: 'completed'
       }),
-      columnHelper.accessor(
-        (row) => (
+      columnHelper.display({
+        id: 'actions',
+        header: 'Actions',
+        cell: (info) => (
           <RMIconButton
             icon={HiTrash}
             tooltip='Delete backup'
-            onClick={() => openConfirmModal('Do you want to delete this backup?', { action: 'backupDelete', data: { backupId: row.id } })}
+            onClick={() => openConfirmModal('Do you want to delete this backup?', { action: 'backupDelete', data: { backupId: info.row.original.id } })}
             isDisabled={user?.grants['cluster-settings'] == false}
           />
-        ),
-        {
-          cell: (info) => info.getValue(),
-          header: 'Actions',
-          id: 'actions'
-        }
-      )
+        )
+      })
     ]
   )
 
@@ -426,12 +423,15 @@ function Maintenance({ selectedCluster, user }) {
       header: 'Tags'
     }),
     // Added Purge action column
-    columnHelper.accessor((row) => (
-      <RMIconButton icon={HiTrash} onClick={() => openConfirmModal('Do you want to purge this snapshot?', { action: 'snapshotPurge', data: { snapshotId: row.id } })} />
-    ), {
-      cell: (info) => info.getValue(),
-      header: 'Actions',
+    columnHelper.display({
       id: 'actions',
+      header: 'Actions',
+      cell: (info) => (
+        <RMIconButton
+          icon={HiTrash}
+          onClick={() => openConfirmModal('Do you want to purge this snapshot?', { action: 'snapshotPurge', data: { snapshotId: info.row.original.id } })}
+        />
+      )
     })
   ])
 
@@ -470,12 +470,15 @@ function Maintenance({ selectedCluster, user }) {
       minWidth: 200
     }),
     // Added Purge action column
-    columnHelper.accessor((row) => (
-      <RMIconButton icon={HiTrash} onClick={() => openConfirmModal('Cancel Queued Task', { action: 'queueCancel', data: { taskId: row.task_id } })} />
-    ), {
-      cell: (info) => info.getValue(),
-      header: 'Actions',
+    columnHelper.display({
       id: 'actions',
+      header: 'Actions',
+      cell: (info) => (
+        <RMIconButton
+          icon={HiTrash}
+          onClick={() => openConfirmModal('Cancel Queued Task', { action: 'queueCancel', data: { taskId: info.row.original.task_id } })}
+        />
+      )
     })
   ])
 

--- a/share/dashboard_react/src/Pages/Maintenance/index.jsx
+++ b/share/dashboard_react/src/Pages/Maintenance/index.jsx
@@ -11,7 +11,7 @@ import BackupSettings from '../Settings/BackupSettings'
 import SchedulerSettings from '../Settings/SchedulerSettings'
 import { TaskLogs } from '../Dashboard/components/Logs'
 import DatabaseJobs from './DatabaseJobs'
-import { purgeResticSnapshot, resticQueueCancel, resticQueueMove, resticQueuePause, resticQueueResume } from '../../redux/clusterSlice'
+import { deleteBackup, purgeResticSnapshot, resticQueueCancel, resticQueueMove, resticQueuePause, resticQueueResume } from '../../redux/clusterSlice'
 import RMIconButton from '../../components/RMIconButton'
 import ConfirmModal from '../../components/Modals/ConfirmModal'
 import { HiPause, HiPlay, HiTrash } from 'react-icons/hi'
@@ -168,6 +168,9 @@ function Maintenance({ selectedCluster, user }) {
   const handleConfirm = () => {
     if (payload && payload.action) {
       switch (payload.action) {
+        case 'backupDelete':
+          dispatch(deleteBackup({ clusterName: selectedCluster.name, backupId: payload.data.backupId }))
+          break
         case 'snapshotPurge':
           dispatch(purgeResticSnapshot({ clusterName: selectedCluster.name, snapshotId: payload.data.snapshotId }))
           break
@@ -371,7 +374,22 @@ function Maintenance({ selectedCluster, user }) {
         cell: (info) => info.getValue(),
         header: 'Completed',
         id: 'completed'
-      })
+      }),
+      columnHelper.accessor(
+        (row) => (
+          <RMIconButton
+            icon={HiTrash}
+            tooltip='Delete backup'
+            onClick={() => openConfirmModal('Do you want to delete this backup?', { action: 'backupDelete', data: { backupId: row.id } })}
+            isDisabled={user?.grants['cluster-settings'] == false}
+          />
+        ),
+        {
+          cell: (info) => info.getValue(),
+          header: 'Actions',
+          id: 'actions'
+        }
+      )
     ]
   )
 
@@ -409,7 +427,7 @@ function Maintenance({ selectedCluster, user }) {
     }),
     // Added Purge action column
     columnHelper.accessor((row) => (
-      <RMIconButton icon={HiTrash} onClick={() => openConfirmModal('Purge Snapshot', { action: 'snapshotPurge', data: { snapshotId: row.id } })} />
+      <RMIconButton icon={HiTrash} onClick={() => openConfirmModal('Do you want to purge this snapshot?', { action: 'snapshotPurge', data: { snapshotId: row.id } })} />
     ), {
       cell: (info) => info.getValue(),
       header: 'Actions',

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -277,6 +277,20 @@ export const getBackupStats = createGuardedAsyncThunk('cluster/getBackupStats', 
   }
 })
 
+export const deleteBackup = createGuardedAsyncThunk('cluster/deleteBackup', async ({ clusterName, backupId }, thunkAPI) => {
+  try {
+    const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+    const { data, status } = await clusterService.deleteBackup(clusterName, backupId, baseURL)
+    if (status === 200) {
+      thunkAPI.dispatch(getBackups({ clusterName }))
+      thunkAPI.dispatch(getBackupStats({ clusterName }))
+    }
+    return { data, status }
+  } catch (error) {
+    return handleError(error, thunkAPI)
+  }
+})
+
 export const getResticSnapshot = createGuardedAsyncThunk(
   'cluster/getResticSnapshot',
   async ({ clusterName, filter = 'latest-per-session' }, thunkAPI) => {

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -13,6 +13,7 @@ export const clusterService = {
   getOpenSVCStats,
   getBackups,
   getBackupStats,
+  deleteBackup,
   getJobs,
   getShardSchema,
   getQueryRules,
@@ -204,6 +205,10 @@ function getBackups(clusterName, baseURL) {
 
 function getBackupStats(clusterName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/backups/stats`)
+}
+
+function deleteBackup(clusterName, backupId, baseURL) {
+  return getApi(baseURL).post(`clusters/${clusterName}/backups/${backupId}/delete`)
 }
 
 function getResticSnapshot(clusterName, baseURL, filter) {


### PR DESCRIPTION
Summary
This PR adds a first-class delete path for non‑restic backups, wires it into the Maintenance UI, and hardens the backend to prevent deleting a backup while its job is still running. It keeps restic snapshots untouched and focuses on reclaiming local disk space safely.
What changed
- Backend delete API: Adds /api/clusters/{clusterName}/backups/{backupID}/delete with ACL enforcement and JSON response.  
- Cluster delete logic: Deletes the backup payload and metadata file, with a strict path‑within‑backup‑directory guard.  
- Active job guard: Prevents deleting a backup that matches the currently running backup metadata.  
  - Uses BackupSessionID/ID/dest matching.
  - Treats unknown backup tools as “check both logical/physical” to avoid false negatives.
  - Rechecks before deletion to reduce TOCTOU windows.
- Client + UI: Adds delete action in “Current Backups” with confirm prompt and auto‑refresh of list/stats after success.  
- Restic behavior: Deleting local backups does not purge restic snapshots.
Why
- Operators need to free local disk space even after a restic snapshot exists.
- Deleting the wrong file during an active backup can corrupt the running job; the new guard blocks that safely.
Behavior notes
- If a matching backup is still running, the API returns 409 Conflict and deletion is blocked.
- Restic snapshots are managed by their own purge flow and are not affected by delete‑backup.