### PR TITLE
Add S3 repository initialization with AWS region support and error backoff for Restic backups

### DIFF
--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -36,7 +36,13 @@ func (cluster *Cluster) ResticGetEnv() []string {
 	if cluster.Conf.BackupResticAws {
 		newEnv = append(newEnv, "AWS_ACCESS_KEY_ID="+cluster.Conf.BackupResticAwsAccessKeyId)
 		newEnv = append(newEnv, "AWS_SECRET_ACCESS_KEY="+cluster.Conf.GetDecryptedValue("backup-restic-aws-access-secret"))
+		if cluster.Conf.BackupResticAwsRegion != "" {
+			newEnv = append(newEnv, "AWS_REGION="+cluster.Conf.BackupResticAwsRegion)
+		}
 		newEnv = append(newEnv, "RESTIC_REPOSITORY="+cluster.Conf.BackupResticRepository+"/"+cluster.Name)
+		if cluster.Conf.BackupResticAwsInsecureTLS {
+			newEnv = append(newEnv, "RESTIC_INSECURE_TLS=true")
+		}
 	} else {
 		if _, err := os.Stat(cluster.GetResticLocalDir()); os.IsNotExist(err) {
 			err := os.MkdirAll(cluster.GetResticLocalDir(), os.ModePerm)
@@ -52,6 +58,8 @@ func (cluster *Cluster) ResticGetEnv() []string {
 func (cluster *Cluster) ReloadResticEnv() {
 	if cluster.ResticManager != nil {
 		cluster.ResticManager.SetEnv(cluster.ResticGetEnv())
+		// Clear init error backoff when environment changes (credentials/config may be fixed)
+		cluster.ResticManager.ClearInitErrorBackoffManual()
 	}
 }
 
@@ -142,7 +150,7 @@ func (cluster *Cluster) ResticInitRepo(force bool) error {
 
 	err := cluster.ResticManager.InitRepo(force)
 	if err != nil {
-		cluster.SetState("WARN0092", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0092"], err), ErrFrom: "BACKUP"})
+		cluster.SetState("WARN0095", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0095"], err), ErrFrom: "BACKUP"})
 	}
 
 	return err

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -29,20 +29,48 @@ import (
 
 var splitDumpTimestampRegex = regexp.MustCompile(`^\d+$`)
 
-func (cluster *Cluster) ResticGetEnv() []string {
-	newEnv := append(os.Environ(), "RESTIC_PASSWORD="+cluster.Conf.GetDecryptedValue("backup-restic-password"))
-	newEnv = append(newEnv, "RESTIC_CACHE_DIR="+cluster.Conf.WorkingDir+"/"+cluster.Name+"/.cache/restic")
+func isS3ResticRepository(repoPath string) bool {
+	return strings.HasPrefix(strings.TrimSpace(repoPath), "s3:")
+}
 
+func filterResticEnv(baseEnv []string, repoPath, password, cacheDir, awsAccessKey, awsSecretKey, awsRegion string) []string {
+	filtered := make([]string, 0, len(baseEnv)+6)
+	defaultRegion := ""
+	for _, env := range baseEnv {
+		if strings.HasPrefix(env, "AWS_DEFAULT_REGION=") {
+			defaultRegion = strings.TrimPrefix(env, "AWS_DEFAULT_REGION=")
+		}
+		if strings.HasPrefix(env, "RESTIC_") || strings.HasPrefix(env, "AWS_") {
+			continue
+		}
+		filtered = append(filtered, env)
+	}
+
+	filtered = append(filtered, "RESTIC_PASSWORD="+password)
+	filtered = append(filtered, "RESTIC_CACHE_DIR="+cacheDir)
+	filtered = append(filtered, "RESTIC_REPOSITORY="+repoPath)
+
+	if isS3ResticRepository(repoPath) {
+		filtered = append(filtered, "AWS_ACCESS_KEY_ID="+awsAccessKey)
+		filtered = append(filtered, "AWS_SECRET_ACCESS_KEY="+awsSecretKey)
+		region := strings.TrimSpace(awsRegion)
+		if region == "" {
+			region = strings.TrimSpace(defaultRegion)
+		}
+		if region != "" {
+			filtered = append(filtered, "AWS_DEFAULT_REGION="+region)
+		}
+	}
+
+	return filtered
+}
+
+func (cluster *Cluster) ResticGetEnv() []string {
+	cacheDir := cluster.Conf.WorkingDir + "/" + cluster.Name + "/.cache/restic"
+	password := cluster.Conf.GetDecryptedValue("backup-restic-password")
+	repoPath := ""
 	if cluster.Conf.BackupResticAws {
-		newEnv = append(newEnv, "AWS_ACCESS_KEY_ID="+cluster.Conf.BackupResticAwsAccessKeyId)
-		newEnv = append(newEnv, "AWS_SECRET_ACCESS_KEY="+cluster.Conf.GetDecryptedValue("backup-restic-aws-access-secret"))
-		if cluster.Conf.BackupResticAwsRegion != "" {
-			newEnv = append(newEnv, "AWS_REGION="+cluster.Conf.BackupResticAwsRegion)
-		}
-		newEnv = append(newEnv, "RESTIC_REPOSITORY="+cluster.Conf.BackupResticRepository+"/"+cluster.Name)
-		if cluster.Conf.BackupResticAwsInsecureTLS {
-			newEnv = append(newEnv, "RESTIC_INSECURE_TLS=true")
-		}
+		repoPath = cluster.Conf.BackupResticRepository + "/" + cluster.Name
 	} else {
 		if _, err := os.Stat(cluster.GetResticLocalDir()); os.IsNotExist(err) {
 			err := os.MkdirAll(cluster.GetResticLocalDir(), os.ModePerm)
@@ -50,9 +78,18 @@ func (cluster *Cluster) ResticGetEnv() []string {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Create archive directory failed: %s,%s", cluster.GetResticLocalDir(), err)
 			}
 		}
-		newEnv = append(newEnv, "RESTIC_REPOSITORY="+cluster.GetResticLocalDir())
+		repoPath = cluster.GetResticLocalDir()
 	}
-	return newEnv
+
+	return filterResticEnv(
+		os.Environ(),
+		repoPath,
+		password,
+		cacheDir,
+		cluster.Conf.BackupResticAwsAccessKeyId,
+		cluster.Conf.GetDecryptedValue("backup-restic-aws-access-secret"),
+		cluster.Conf.BackupResticAwsRegion,
+	)
 }
 
 func (cluster *Cluster) ReloadResticEnv() {

--- a/cluster/cluster_sst.go
+++ b/cluster/cluster_sst.go
@@ -76,14 +76,7 @@ func (cluster *Cluster) SSTRunReceiverToRestic(filename string) (string, error) 
 	var err error
 
 	resticcmd := exec.Command(cluster.Conf.BackupResticBinaryPath, "backup", "--stdin", "--stdin-filename", filename)
-	newEnv := append(os.Environ(), "AWS_ACCESS_KEY_ID="+cluster.Conf.BackupResticAwsAccessKeyId)
-	newEnv = append(newEnv, "AWS_SECRET_ACCESS_KEY="+cluster.Conf.GetDecryptedValue("backup-restic-aws-access-secret"))
-	if cluster.Conf.BackupResticAwsRegion != "" {
-		newEnv = append(newEnv, "AWS_REGION="+cluster.Conf.BackupResticAwsRegion)
-	}
-	newEnv = append(newEnv, "RESTIC_REPOSITORY="+cluster.Conf.BackupResticRepository+"/"+cluster.Name)
-	newEnv = append(newEnv, "RESTIC_PASSWORD="+cluster.Conf.GetDecryptedValue("backup-restic-password"))
-	resticcmd.Env = newEnv
+	resticcmd.Env = cluster.ResticGetEnv()
 
 	stdout, err := resticcmd.StdoutPipe()
 	if err != nil {

--- a/cluster/cluster_sst.go
+++ b/cluster/cluster_sst.go
@@ -78,6 +78,9 @@ func (cluster *Cluster) SSTRunReceiverToRestic(filename string) (string, error) 
 	resticcmd := exec.Command(cluster.Conf.BackupResticBinaryPath, "backup", "--stdin", "--stdin-filename", filename)
 	newEnv := append(os.Environ(), "AWS_ACCESS_KEY_ID="+cluster.Conf.BackupResticAwsAccessKeyId)
 	newEnv = append(newEnv, "AWS_SECRET_ACCESS_KEY="+cluster.Conf.GetDecryptedValue("backup-restic-aws-access-secret"))
+	if cluster.Conf.BackupResticAwsRegion != "" {
+		newEnv = append(newEnv, "AWS_REGION="+cluster.Conf.BackupResticAwsRegion)
+	}
 	newEnv = append(newEnv, "RESTIC_REPOSITORY="+cluster.Conf.BackupResticRepository+"/"+cluster.Name)
 	newEnv = append(newEnv, "RESTIC_PASSWORD="+cluster.Conf.GetDecryptedValue("backup-restic-password"))
 	resticcmd.Env = newEnv

--- a/cluster/cluster_tgl.go
+++ b/cluster/cluster_tgl.go
@@ -141,10 +141,12 @@ func (cluster *Cluster) SwitchBackupRestic() {
 	if cluster.ResticManager == nil {
 		cluster.StartResticManager()
 	}
+	cluster.ReloadResticEnv()
 }
 
 func (cluster *Cluster) SwitchBackupResticAws() {
 	cluster.Conf.BackupResticAws = !cluster.Conf.BackupResticAws
+	cluster.ReloadResticEnv()
 }
 
 func (cluster *Cluster) SwitchBackupBinlogs() {

--- a/config/config.go
+++ b/config/config.go
@@ -766,7 +766,6 @@ type Config struct {
 	BackupResticRepository                    string `mapstructure:"backup-restic-repository" toml:"backup-restic-repository" json:"backupResticRepository"`
 	BackupResticPassword                      string `mapstructure:"backup-restic-password"  toml:"backup-restic-password" json:"-"`
 	BackupResticAws                           bool   `mapstructure:"backup-restic-aws"  toml:"backup-restic-aws" json:"backupResticAws"`
-	BackupResticAwsInsecureTLS                bool   `mapstructure:"backup-restic-aws-insecure-tls" toml:"backup-restic-aws-insecure-tls" json:"backupResticAwsInsecureTLS"`
 	BackupResticTimeout                       int    `mapstructure:"backup-restic-timeout"  toml:"backup-restic-timeout" json:"backupResticTimeout"`
 	BackupResticDumpTimeout                   int    `mapstructure:"backup-restic-dump-timeout" toml:"backup-restic-dump-timeout" json:"backupResticDumpTimeout"`
 	BackupResticDirMode                       int    `mapstructure:"backup-restic-dir-mode" toml:"backup-restic-dir-mode" json:"backupResticDirMode"`

--- a/config/config.go
+++ b/config/config.go
@@ -762,9 +762,11 @@ type Config struct {
 	BackupResticLocalRepository               string `mapstructure:"backup-restic-local-repository" toml:"backup-restic-local-repository" json:"backupResticLocalRepository"`
 	BackupResticAwsAccessKeyId                string `mapstructure:"backup-restic-aws-access-key-id" toml:"backup-restic-aws-access-key-id" json:"backupResticAwsAccessKeyId"`
 	BackupResticAwsAccessSecret               string `mapstructure:"backup-restic-aws-access-secret"  toml:"backup-restic-aws-access-secret" json:"-"`
+	BackupResticAwsRegion                     string `mapstructure:"backup-restic-aws-region" toml:"backup-restic-aws-region" json:"backupResticAwsRegion"`
 	BackupResticRepository                    string `mapstructure:"backup-restic-repository" toml:"backup-restic-repository" json:"backupResticRepository"`
 	BackupResticPassword                      string `mapstructure:"backup-restic-password"  toml:"backup-restic-password" json:"-"`
 	BackupResticAws                           bool   `mapstructure:"backup-restic-aws"  toml:"backup-restic-aws" json:"backupResticAws"`
+	BackupResticAwsInsecureTLS                bool   `mapstructure:"backup-restic-aws-insecure-tls" toml:"backup-restic-aws-insecure-tls" json:"backupResticAwsInsecureTLS"`
 	BackupResticTimeout                       int    `mapstructure:"backup-restic-timeout"  toml:"backup-restic-timeout" json:"backupResticTimeout"`
 	BackupResticDumpTimeout                   int    `mapstructure:"backup-restic-dump-timeout" toml:"backup-restic-dump-timeout" json:"backupResticDumpTimeout"`
 	BackupResticDirMode                       int    `mapstructure:"backup-restic-dir-mode" toml:"backup-restic-dir-mode" json:"backupResticDirMode"`

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -7650,7 +7650,7 @@ func (repman *ReplicationManager) handlerMuxResticInitRepo(w http.ResponseWriter
 
 		err := mycluster.ResticInitRepo(force)
 		if err != nil {
-			http.Error(w, "Error unlocking archives :"+err.Error(), http.StatusInternalServerError)
+			http.Error(w, "Error initializing restic repository: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -3670,6 +3670,9 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		new_secret.Value = mycluster.Conf.BackupResticAwsAccessSecret
 		new_secret.OldValue = mycluster.Conf.GetDecryptedValue("backup-restic-aws-access-secret")
 		mycluster.Conf.Secrets["backup-restic-aws-access-secret"] = new_secret
+	case "backup-restic-aws-region":
+		mycluster.Conf.BackupResticAwsRegion = value
+		mycluster.ReloadResticEnv()
 	case "backup-restic-password":
 		val, err := base64.StdEncoding.DecodeString(value)
 		if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -808,6 +808,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.BackupResticBinaryPath, "backup-restic-binary-path", "/usr/bin/restic", "Path to restic binary")
 	flags.StringVar(&conf.BackupResticAwsAccessKeyId, "backup-restic-aws-access-key-id", "admin", "Restic backup AWS key id")
 	flags.StringVar(&conf.BackupResticAwsAccessSecret, "backup-restic-aws-access-secret", "secret", "Restic backup AWS key sercret")
+	flags.StringVar(&conf.BackupResticAwsRegion, "backup-restic-aws-region", "", "Restic backup AWS region (empty = AWS SDK default)")
 	flags.StringVar(&conf.BackupResticLocalRepository, "backup-restic-local-repository", "", "Restic local repository path. Empty by default to use repo per cluster in datadir/backups/archive/<clustername>")
 	flags.StringVar(&conf.BackupResticRepository, "backup-restic-repository", "s3:https://s3.signal18.io/backups", "Restic backend repository")
 	flags.StringVar(&conf.BackupResticPassword, "backup-restic-password", "secret", "Restic backend password")

--- a/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
@@ -450,7 +450,7 @@ function ResticRepositorySettings({
                         onClick={() => {
                           onOpenInfoModal(
                             'Re-initialize S3 Repository',
-                            'Re-initialize the S3/MinIO Restic repository. This creates a new repository configuration at the specified S3 bucket/path. Ensure AWS credentials and bucket path are correct before initializing.'
+                            'Re-initialize the S3/MinIO Restic repository. This creates a new repository configuration at the specified S3 bucket/path. Force re-initialization deletes all objects under the configured bucket/prefix. Ensure AWS credentials and bucket path are correct before initializing.'
                           )
                         }}
                       />
@@ -570,7 +570,9 @@ function ResticRepositorySettings({
               <Alert status='warning' size='sm' borderRadius='md'>
                 <AlertIcon />
                 <Text fontSize='sm'>
-                  Warning: This will overwrite the existing repository configuration
+                  {config?.backupResticAws
+                    ? 'Warning: Force re-initialization deletes all objects under the configured S3 bucket/prefix before creating a new repository.'
+                    : 'Warning: This will overwrite the existing repository configuration.'}
                 </Text>
               </Alert>
             )}

--- a/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
@@ -1,10 +1,13 @@
-import { Box, Flex, Grid, GridItem, HStack, Stack, Text, VStack } from '@chakra-ui/react'
+import { Box, Flex, Grid, GridItem, HStack, Stack, Text, VStack, Checkbox, Alert, AlertIcon, Divider, useDisclosure } from '@chakra-ui/react'
 import React, { useState } from 'react'
-import { HiChevronDown, HiChevronUp, HiQuestionMarkCircle } from 'react-icons/hi'
+import { HiChevronDown, HiChevronUp, HiQuestionMarkCircle, HiRefresh } from 'react-icons/hi'
 import RMIconButton from '../../components/RMIconButton'
+import RMButton from '../../components/RMButton'
 import RMSwitch from '../../components/RMSwitch'
 import TextForm from '../../components/TextForm'
+import ConfirmModal from '../../components/Modals/ConfirmModal'
 import { setSetting, switchSetting } from '../../redux/settingsSlice'
+import { resticInitRepo } from '../../redux/clusterSlice'
 import styles from './styles.module.scss'
 import tableStyles from '../../components/TableType2/styles.module.scss'
 
@@ -74,6 +77,14 @@ function ResticRepositorySettings({
   const [isTaggingOpen, setIsTaggingOpen] = useState(() => readStoredState('tagging', false))
   const areAllSectionsOpen = isConnectionOpen && isStorageOpen && isTaggingOpen
 
+  // Restic init modal state
+  const { 
+    isOpen: isInitModalOpen, 
+    onOpen: onOpenInitModal, 
+    onClose: onCloseInitModal 
+  } = useDisclosure()
+  const [initForce, setInitForce] = useState(false)
+
   const handleSettingChange = (setting, value, encodeValue = false) =>
     dispatch(
       setSetting({
@@ -90,6 +101,25 @@ function ResticRepositorySettings({
         setting
       })
     )
+
+  const handleResticInit = () => {
+    setInitForce(false) // Reset force flag
+    onOpenInitModal()
+  }
+
+  const handleConfirmInit = async () => {
+    try {
+      await dispatch(resticInitRepo({ 
+        clusterName, 
+        force: initForce
+      })).unwrap()
+      
+      onCloseInitModal()
+    } catch (error) {
+      console.error('Failed to initialize repository:', error)
+      onCloseInitModal()
+    }
+  }
 
   const toggleSection = (section, setter) => {
     setter((prev) => {
@@ -270,13 +300,33 @@ function ResticRepositorySettings({
                     <Text>Backup restic local repository</Text>
                   </GridItem>
                   <GridItem className={styles.valueCell}>
-                    <TextForm
-                      value={config?.backupResticLocalRepository}
-                      confirmTitle={`Confirm backup-restic-local-repository to `}
-                      className={styles.textbox}
-                      size='sm'
-                      onSave={(value) => handleSettingChange('backup-restic-local-repository', value, true)}
-                    />
+                    <HStack width='100%' spacing={2}>
+                      <TextForm
+                        value={config?.backupResticLocalRepository}
+                        confirmTitle={`Confirm backup-restic-local-repository to `}
+                        className={styles.textbox}
+                        size='sm'
+                        onSave={(value) => handleSettingChange('backup-restic-local-repository', value, true)}
+                      />
+                      <RMButton
+                        size='sm'
+                        colorScheme='blue'
+                        onClick={handleResticInit}
+                        isDisabled={user?.grants['cluster-settings'] === false || config?.backupResticAws}
+                        title="Re-initialize local repository"
+                      >
+                        <HiRefresh />
+                      </RMButton>
+                      <RMIconButton
+                        icon={HiQuestionMarkCircle}
+                        onClick={() => {
+                          onOpenInfoModal(
+                            'Re-initialize Local Repository',
+                            'Re-initialize the local Restic repository. This creates a new repository configuration at the specified path. Use with caution - only needed if the repository is corrupted or being set up for the first time.'
+                          )
+                        }}
+                      />
+                    </HStack>
                   </GridItem>
                 </Grid>
               </Stack>
@@ -352,16 +402,59 @@ function ResticRepositorySettings({
                   w='full'
                 >
                   <GridItem className={styles.rowLabel}>
-                    <Text>Backup restic aws bucket</Text>
+                    <Text>Backup restic aws region</Text>
                   </GridItem>
                   <GridItem className={styles.valueCell}>
                     <TextForm
-                      value={config?.backupResticRepository}
-                      confirmTitle={`Confirm backup-restic-repository to `}
+                      value={config?.backupResticAwsRegion}
+                      confirmTitle={`Confirm backup-restic-aws-region to `}
                       className={styles.textbox}
                       size='sm'
-                      onSave={(value) => handleSettingChange('backup-restic-repository', value, true)}
+                      placeholder='us-east-1, eu-west-1, etc.'
+                      onSave={(value) => handleSettingChange('backup-restic-aws-region', value)}
                     />
+                    <Text className={styles.helperText}>Empty uses AWS SDK default region resolution.</Text>
+                  </GridItem>
+                </Grid>
+
+                <Grid
+                  className={styles.resticMountGrid}
+                  templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
+                  columnGap={3}
+                  rowGap={1}
+                  w='full'
+                >
+                  <GridItem className={styles.rowLabel}>
+                    <Text>Backup restic aws bucket</Text>
+                  </GridItem>
+                  <GridItem className={styles.valueCell}>
+                    <HStack width='100%' spacing={2}>
+                      <TextForm
+                        value={config?.backupResticRepository}
+                        confirmTitle={`Confirm backup-restic-repository to `}
+                        className={styles.textbox}
+                        size='sm'
+                        onSave={(value) => handleSettingChange('backup-restic-repository', value, true)}
+                      />
+                      <RMButton
+                        size='sm'
+                        colorScheme='blue'
+                        onClick={handleResticInit}
+                        isDisabled={user?.grants['cluster-settings'] === false || !config?.backupResticAws}
+                        title="Re-initialize S3 repository"
+                      >
+                        <HiRefresh />
+                      </RMButton>
+                      <RMIconButton
+                        icon={HiQuestionMarkCircle}
+                        onClick={() => {
+                          onOpenInfoModal(
+                            'Re-initialize S3 Repository',
+                            'Re-initialize the S3/MinIO Restic repository. This creates a new repository configuration at the specified S3 bucket/path. Ensure AWS credentials and bucket path are correct before initializing.'
+                          )
+                        }}
+                      />
+                    </HStack>
                   </GridItem>
                 </Grid>
               </Stack>
@@ -441,6 +534,54 @@ function ResticRepositorySettings({
           )
         })}
       </Stack>
+
+      <ConfirmModal
+        isOpen={isInitModalOpen}
+        closeModal={onCloseInitModal}
+        title="Re-initialize Restic Repository"
+        body={
+          <VStack align='start' spacing={3}>
+            <Text>
+              Re-initialize the {config?.backupResticAws ? 'S3/MinIO' : 'local'} Restic repository:
+            </Text>
+            <Text 
+              fontWeight='bold' 
+              fontSize='sm' 
+              fontFamily='monospace'
+              bg='gray.100' 
+              p={2} 
+              borderRadius='md'
+              wordBreak='break-all'
+            >
+              {config?.backupResticAws 
+                ? config?.backupResticRepository 
+                : config?.backupResticLocalRepository}
+            </Text>
+            <Divider />
+            <Checkbox
+              isChecked={initForce}
+              onChange={(e) => setInitForce(e.target.checked)}
+            >
+              <Text fontSize='sm'>
+                Force re-initialization (overwrite existing configuration)
+              </Text>
+            </Checkbox>
+            {initForce && (
+              <Alert status='warning' size='sm' borderRadius='md'>
+                <AlertIcon />
+                <Text fontSize='sm'>
+                  Warning: This will overwrite the existing repository configuration
+                </Text>
+              </Alert>
+            )}
+          </VStack>
+        }
+        onConfirmClick={handleConfirmInit}
+        confirmButtonText="Initialize"
+        confirmButtonProps={{ 
+          colorScheme: initForce ? 'red' : 'blue' 
+        }}
+      />
     </VStack>
   )
 }

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -402,6 +402,19 @@ export const resticQueueResume = createGuardedAsyncThunk(
   }
 )
 
+export const resticInitRepo = createGuardedAsyncThunk(
+  'cluster/resticInitRepo',
+  async ({ clusterName, force = false }, thunkAPI) => {
+    try {
+      const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+      const { data, status } = await clusterService.resticInitRepo(clusterName, force, baseURL)
+      return { data, status }
+    } catch (error) {
+      return handleError(error, thunkAPI)
+    }
+  }
+)
+
 export const getJobs = createGuardedAsyncThunk('cluster/getJobs', async ({ clusterName }, thunkAPI) => {
   try {
     const baseURL = thunkAPI.getState()?.auth?.baseURL || ''

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -31,6 +31,7 @@ export const clusterService = {
   resticQueueReset,
   resticMountToggle,
   getResticMountStatus,
+  resticInitRepo,
 
   // Cluster management APIs
   checksumAllTables,
@@ -793,6 +794,13 @@ function resticMountToggle(clusterName, action, options, baseURL) {
 
 function getResticMountStatus(clusterName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/restic/mount-status`)
+}
+
+function resticInitRepo(clusterName, force, baseURL) {
+  const endpoint = force 
+    ? `clusters/${clusterName}/restic/init/force`
+    : `clusters/${clusterName}/restic/init`
+  return getApi(baseURL).post(endpoint)
 }
 
 // Utility functions

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -364,10 +363,9 @@ type ResticManager struct {
 	MountRecoveryEnabled bool                // If true, recover/cleanup stale mounts on startup
 	OnPurgeComplete      func(ResticPurgeOption)
 	// Error backoff state to prevent log flooding
-	lastInitError     error     // Last init error encountered
-	lastInitErrorTime time.Time // When the last init error occurred
-	initErrorCount    int       // Number of consecutive init errors
-	initBackoffUntil  time.Time // Don't retry init until this time
+	lastInitError    error     // Last init error encountered
+	initErrorCount   int       // Number of consecutive init errors
+	initBackoffUntil time.Time // Don't retry init until this time
 }
 
 // NewResticRepo initializes the repository manager
@@ -539,7 +537,6 @@ func (repo *ResticManager) ClearInitErrorBackoffManual() {
 	}
 
 	repo.lastInitError = nil
-	repo.lastInitErrorTime = time.Time{}
 	repo.initErrorCount = 0
 	repo.initBackoffUntil = time.Time{}
 }
@@ -2868,16 +2865,6 @@ func parseS3URL(repoPath string) (bucket, prefix, endpoint string, err error) {
 	return bucket, prefix, endpoint, nil
 }
 
-// shouldUseInsecureTLS checks if TLS certificate verification should be skipped
-func (repo *ResticManager) shouldUseInsecureTLS() bool {
-	val := repo.getEnvValue("RESTIC_INSECURE_TLS")
-	if val == "" {
-		return false
-	}
-	val = strings.ToLower(strings.TrimSpace(val))
-	return val == "1" || val == "true" || val == "yes"
-}
-
 // createS3Client creates AWS S3 client with MinIO compatibility
 func (repo *ResticManager) createS3Client(endpoint string) (*s3.S3, error) {
 	// Extract credentials from environment
@@ -2887,11 +2874,6 @@ func (repo *ResticManager) createS3Client(endpoint string) (*s3.S3, error) {
 	region := repo.getEnvValue("AWS_REGION")
 	if region == "" {
 		region = repo.getEnvValue("AWS_DEFAULT_REGION")
-	}
-
-	// Default region (MinIO ignores it)
-	if region == "" {
-		region = "eu-west-1"
 	}
 
 	// Create credentials
@@ -2918,22 +2900,8 @@ func (repo *ResticManager) createS3Client(endpoint string) (*s3.S3, error) {
 		awsConfig.Endpoint = aws.String(endpoint)
 	}
 
-	// Handle insecure TLS for self-signed certificates
-	if repo.shouldUseInsecureTLS() {
-		transport := &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
-		}
-		awsConfig.HTTPClient = &http.Client{
-			Transport: transport,
-			Timeout:   30 * time.Second,
-		}
-		repo.Printf(logrus.WarnLevel, "S3 client using insecure TLS (skipping certificate verification)")
-	} else {
-		awsConfig.HTTPClient = &http.Client{
-			Timeout: 30 * time.Second,
-		}
+	awsConfig.HTTPClient = &http.Client{
+		Timeout: 30 * time.Second,
 	}
 
 	// Create session
@@ -3161,8 +3129,6 @@ func (repo *ResticManager) setInitErrorBackoff(err error) {
 	}
 
 	repo.lastInitError = err
-	repo.lastInitErrorTime = now
-
 	// Exponential backoff: 10s, 30s, 1m, 2m, 5m, 10m, 30m (max)
 	var backoff time.Duration
 	switch {
@@ -3204,7 +3170,6 @@ func (repo *ResticManager) clearInitErrorBackoff() {
 	}
 
 	repo.lastInitError = nil
-	repo.lastInitErrorTime = time.Time{}
 	repo.initErrorCount = 0
 	repo.initBackoffUntil = time.Time{}
 }

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -4,10 +4,12 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,6 +19,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/creack/pty"
 	"github.com/signal18/replication-manager/utils/misc"
 	sharedlog "github.com/signal18/replication-manager/utils/s18log/shared"
@@ -356,6 +363,11 @@ type ResticManager struct {
 	AllowUnsafeMount     bool                // If true, allow using mount created by other process
 	MountRecoveryEnabled bool                // If true, recover/cleanup stale mounts on startup
 	OnPurgeComplete      func(ResticPurgeOption)
+	// Error backoff state to prevent log flooding
+	lastInitError     error     // Last init error encountered
+	lastInitErrorTime time.Time // When the last init error occurred
+	initErrorCount    int       // Number of consecutive init errors
+	initBackoffUntil  time.Time // Don't retry init until this time
 }
 
 // NewResticRepo initializes the repository manager
@@ -512,6 +524,24 @@ func (repo *ResticManager) FetchAndClearError(task TaskType) error {
 
 	delete(repo.TaskErrors, task)
 	return errs
+}
+
+// ClearInitErrorBackoffManual clears init error backoff and allows immediate retry
+// Useful when configuration has been fixed by the user
+func (repo *ResticManager) ClearInitErrorBackoffManual() {
+	repo.errorMutex.Lock()
+	defer repo.errorMutex.Unlock()
+
+	if repo.initErrorCount > 0 {
+		repo.Printf(logrus.InfoLevel,
+			"Init error backoff manually cleared (was at %d errors, backoff until %v)",
+			repo.initErrorCount, repo.initBackoffUntil)
+	}
+
+	repo.lastInitError = nil
+	repo.lastInitErrorTime = time.Time{}
+	repo.initErrorCount = 0
+	repo.initBackoffUntil = time.Time{}
 }
 
 func (repo *ResticManager) SetEnv(env []string) {
@@ -2727,9 +2757,421 @@ func (repo *ResticManager) ShutdownWorker() {
 	repo.cond.Broadcast()
 }
 
+// getEnvValue extracts value from repo.Env slice by key
+func (repo *ResticManager) getEnvValue(key string) string {
+	prefix := key + "="
+	for _, env := range repo.Env {
+		if strings.HasPrefix(env, prefix) {
+			return strings.TrimPrefix(env, prefix)
+		}
+	}
+	return ""
+}
+
+// isS3Repository checks if repository path uses S3 backend
+func isS3Repository(repoPath string) bool {
+	return strings.HasPrefix(repoPath, "s3:")
+}
+
+// parseS3URL parses S3 repository URL into components
+// Supports formats:
+//   - s3:https://endpoint/bucket/prefix (MinIO/custom endpoint)
+//   - s3:http://endpoint/bucket/prefix (MinIO dev)
+//   - s3:endpoint:port/bucket/prefix (MinIO shorthand)
+//   - s3:bucket/prefix (AWS implicit)
+//
+// Returns: bucket, prefix, endpoint, error
+func parseS3URL(repoPath string) (bucket, prefix, endpoint string, err error) {
+	// Remove "s3:" prefix
+	if !strings.HasPrefix(repoPath, "s3:") {
+		return "", "", "", fmt.Errorf("not an S3 URL (missing s3: prefix)")
+	}
+
+	path := strings.TrimPrefix(repoPath, "s3:")
+
+	// Handle protocol-prefixed URLs
+	if strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "http://") {
+		// Format: s3:https://endpoint/bucket/prefix
+		// Extract protocol
+		var protocol string
+		if strings.HasPrefix(path, "https://") {
+			protocol = "https://"
+			path = strings.TrimPrefix(path, "https://")
+		} else {
+			protocol = "http://"
+			path = strings.TrimPrefix(path, "http://")
+		}
+
+		// Now split by / to get endpoint, bucket, prefix
+		parts := strings.SplitN(path, "/", 3)
+		if len(parts) < 2 {
+			return "", "", "", fmt.Errorf("invalid S3 URL format: %s", repoPath)
+		}
+
+		endpoint = protocol + parts[0]
+		bucket = parts[1]
+		if len(parts) > 2 {
+			prefix = parts[2]
+		}
+
+	} else if strings.Contains(path, "://") {
+		return "", "", "", fmt.Errorf("unsupported protocol in S3 URL: %s", repoPath)
+
+	} else {
+		// Format: s3:endpoint/bucket/prefix OR s3:bucket/prefix
+		parts := strings.SplitN(path, "/", 3)
+
+		if len(parts) < 2 {
+			return "", "", "", fmt.Errorf("invalid S3 URL format (need at least bucket/path): %s", repoPath)
+		}
+
+		// Detect endpoint vs bucket by looking for ":" or "." (but not *.amazonaws.com)
+		firstPart := parts[0]
+		isEndpoint := strings.Contains(firstPart, ":") ||
+			(strings.Contains(firstPart, ".") && !strings.HasSuffix(firstPart, ".amazonaws.com"))
+
+		if isEndpoint {
+			// Format: s3:endpoint:port/bucket/prefix
+			endpoint = firstPart
+			if !strings.Contains(endpoint, "://") {
+				endpoint = "https://" + endpoint
+			}
+			bucket = parts[1]
+			if len(parts) > 2 {
+				prefix = parts[2]
+			}
+		} else {
+			// Format: s3:bucket/prefix (implicit AWS)
+			endpoint = ""
+			bucket = firstPart
+			if len(parts) > 1 {
+				// Join all remaining parts as prefix
+				prefix = strings.Join(parts[1:], "/")
+			}
+		}
+	}
+
+	// Validate
+	if bucket == "" {
+		return "", "", "", fmt.Errorf("bucket name is empty in S3 URL: %s", repoPath)
+	}
+
+	// Normalize prefix (remove leading/trailing slashes)
+	prefix = strings.Trim(prefix, "/")
+
+	return bucket, prefix, endpoint, nil
+}
+
+// shouldUseInsecureTLS checks if TLS certificate verification should be skipped
+func (repo *ResticManager) shouldUseInsecureTLS() bool {
+	val := repo.getEnvValue("RESTIC_INSECURE_TLS")
+	if val == "" {
+		return false
+	}
+	val = strings.ToLower(strings.TrimSpace(val))
+	return val == "1" || val == "true" || val == "yes"
+}
+
+// createS3Client creates AWS S3 client with MinIO compatibility
+func (repo *ResticManager) createS3Client(endpoint string) (*s3.S3, error) {
+	// Extract credentials from environment
+	accessKey := repo.getEnvValue("AWS_ACCESS_KEY_ID")
+	secretKey := repo.getEnvValue("AWS_SECRET_ACCESS_KEY")
+	sessionToken := repo.getEnvValue("AWS_SESSION_TOKEN")
+	region := repo.getEnvValue("AWS_REGION")
+
+	// Default region (MinIO ignores it)
+	if region == "" {
+		region = "eu-west-1"
+	}
+
+	// Create credentials
+	var creds *credentials.Credentials
+	if accessKey != "" && secretKey != "" {
+		if sessionToken != "" {
+			creds = credentials.NewStaticCredentials(accessKey, secretKey, sessionToken)
+		} else {
+			creds = credentials.NewStaticCredentials(accessKey, secretKey, "")
+		}
+	} else {
+		return nil, fmt.Errorf("AWS credentials not found (set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY)")
+	}
+
+	// Create AWS config (MinIO-compatible)
+	awsConfig := &aws.Config{
+		Region:           aws.String(region),
+		Credentials:      creds,
+		S3ForcePathStyle: aws.Bool(true), // Required for MinIO
+	}
+
+	// Set custom endpoint
+	if endpoint != "" {
+		awsConfig.Endpoint = aws.String(endpoint)
+	}
+
+	// Handle insecure TLS for self-signed certificates
+	if repo.shouldUseInsecureTLS() {
+		transport := &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+		awsConfig.HTTPClient = &http.Client{
+			Transport: transport,
+			Timeout:   30 * time.Second,
+		}
+		repo.Printf(logrus.WarnLevel, "S3 client using insecure TLS (skipping certificate verification)")
+	} else {
+		awsConfig.HTTPClient = &http.Client{
+			Timeout: 30 * time.Second,
+		}
+	}
+
+	// Create session
+	sess, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AWS session: %w", err)
+	}
+
+	return s3.New(sess), nil
+}
+
+// checkS3ObjectExists checks if an object exists in S3 bucket
+func checkS3ObjectExists(client *s3.S3, bucket, key string) (bool, error) {
+	_, err := client.HeadObject(&s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case "NotFound", s3.ErrCodeNoSuchKey:
+				return false, nil
+			case "Forbidden":
+				return false, fmt.Errorf("access denied to S3 object %s/%s (check credentials/permissions)", bucket, key)
+			}
+		}
+		return false, fmt.Errorf("S3 HeadObject failed: %w", err)
+	}
+
+	return true, nil
+}
+
+// listS3Prefix checks if any objects exist with the given prefix
+func listS3Prefix(client *s3.S3, bucket, prefix string) (bool, error) {
+	result, err := client.ListObjectsV2(&s3.ListObjectsV2Input{
+		Bucket:  aws.String(bucket),
+		Prefix:  aws.String(prefix),
+		MaxKeys: aws.Int64(1), // Only need to know if ANY exist
+	})
+
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case s3.ErrCodeNoSuchBucket:
+				return false, fmt.Errorf("S3 bucket not found: %s (create it first or check name)", bucket)
+			case "Forbidden":
+				return false, fmt.Errorf("access denied to S3 bucket: %s (check credentials/permissions)", bucket)
+			}
+		}
+		return false, fmt.Errorf("S3 ListObjects failed: %w", err)
+	}
+
+	return len(result.Contents) > 0, nil
+}
+
+// checkS3RepoFiles verifies S3 repository structure and initializes if needed
+func (repo *ResticManager) checkS3RepoFiles(bucket, prefix, endpoint string) error {
+	// Create S3 client
+	client, err := repo.createS3Client(endpoint)
+	if err != nil {
+		repo.CanInitRepo = false
+		err = fmt.Errorf("failed to create S3 client: %w", err)
+		repo.SetError(InitTask, err)
+		repo.setInitErrorBackoff(err)
+		return err
+	}
+
+	// Build config object key
+	configKey := "config"
+	if prefix != "" {
+		configKey = prefix + "/config"
+	}
+
+	endpointDisplay := endpoint
+	if endpointDisplay == "" {
+		endpointDisplay = "AWS S3"
+	}
+	repo.Printf(logrus.DebugLevel, "Checking S3 repository: endpoint=%s bucket=%s prefix=%s",
+		endpointDisplay, bucket, prefix)
+
+	// Check if config exists
+	configExists, err := checkS3ObjectExists(client, bucket, configKey)
+	if err != nil {
+		repo.CanInitRepo = false
+		repo.SetError(InitTask, err)
+		repo.setInitErrorBackoff(err)
+		return err
+	}
+
+	if !configExists {
+		// Config missing - check for data directory
+		errstr := "repo config is missing"
+
+		dataPrefix := "data/"
+		if prefix != "" {
+			dataPrefix = prefix + "/data/"
+		}
+
+		dataExists, err := listS3Prefix(client, bucket, dataPrefix)
+		if err != nil {
+			// Error checking data
+			repo.CanInitRepo = false
+			err = fmt.Errorf("%s and failed to check repo data: %w", errstr, err)
+			repo.SetError(InitTask, err)
+			repo.setInitErrorBackoff(err)
+			return err
+		}
+
+		if dataExists {
+			// Data exists without config - corrupted repo
+			errstr += " but data exists"
+			repo.CanInitRepo = false
+			err = errors.New(errstr)
+			repo.SetError(InitTask, err)
+			repo.setInitErrorBackoff(err)
+			return err
+		}
+
+		// No config, no data - initialize the repo
+		repo.Printf(logrus.InfoLevel, "S3 repository not initialized at %s/%s, initializing now...",
+			bucket, prefix)
+		err = repo.InitRepo(false)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Config exists or was just initialized
+	repo.CanInitRepo = true
+	delete(repo.TaskErrors, InitTask)
+	repo.clearInitErrorBackoff()
+
+	return nil
+}
+
+// setInitErrorBackoff records an init error and sets exponential backoff
+func (repo *ResticManager) setInitErrorBackoff(err error) {
+	repo.errorMutex.Lock()
+	defer repo.errorMutex.Unlock()
+
+	now := time.Now()
+
+	// Check if this is the same error repeating
+	if repo.lastInitError != nil && repo.lastInitError.Error() == err.Error() {
+		repo.initErrorCount++
+	} else {
+		// New error type, reset count
+		repo.initErrorCount = 1
+	}
+
+	repo.lastInitError = err
+	repo.lastInitErrorTime = now
+
+	// Exponential backoff: 10s, 30s, 1m, 2m, 5m, 10m, 30m (max)
+	var backoff time.Duration
+	switch {
+	case repo.initErrorCount == 1:
+		backoff = 10 * time.Second
+	case repo.initErrorCount == 2:
+		backoff = 30 * time.Second
+	case repo.initErrorCount == 3:
+		backoff = 1 * time.Minute
+	case repo.initErrorCount == 4:
+		backoff = 2 * time.Minute
+	case repo.initErrorCount == 5:
+		backoff = 5 * time.Minute
+	case repo.initErrorCount == 6:
+		backoff = 10 * time.Minute
+	default:
+		backoff = 30 * time.Minute
+	}
+
+	repo.initBackoffUntil = now.Add(backoff)
+
+	// Log only once per unique error or at increasing intervals
+	if repo.initErrorCount == 1 || repo.initErrorCount%10 == 0 {
+		repo.Printf(logrus.ErrorLevel,
+			"Repository initialization failed (attempt %d), backing off for %v: %v",
+			repo.initErrorCount, backoff, err)
+	}
+}
+
+// clearInitErrorBackoff clears the init error backoff state on success
+func (repo *ResticManager) clearInitErrorBackoff() {
+	repo.errorMutex.Lock()
+	defer repo.errorMutex.Unlock()
+
+	if repo.initErrorCount > 0 {
+		repo.Printf(logrus.InfoLevel,
+			"Repository initialization succeeded after %d failed attempts",
+			repo.initErrorCount)
+	}
+
+	repo.lastInitError = nil
+	repo.lastInitErrorTime = time.Time{}
+	repo.initErrorCount = 0
+	repo.initBackoffUntil = time.Time{}
+}
+
+// shouldSkipInitDueToBackoff returns true if init should be skipped due to backoff
+func (repo *ResticManager) shouldSkipInitDueToBackoff() bool {
+	repo.errorMutex.Lock()
+	defer repo.errorMutex.Unlock()
+
+	if repo.initBackoffUntil.IsZero() {
+		return false
+	}
+
+	now := time.Now()
+	if now.Before(repo.initBackoffUntil) {
+		// Still in backoff period
+		return true
+	}
+
+	// Backoff period expired, allow retry
+	return false
+}
+
 func (repo *ResticManager) CheckRepoFiles() error {
+	// Check if we're in backoff period due to repeated init failures
+	if repo.shouldSkipInitDueToBackoff() {
+		// Return cached error without retrying or logging
+		repo.errorMutex.Lock()
+		cachedErr := repo.lastInitError
+		repo.errorMutex.Unlock()
+		if cachedErr != nil {
+			return cachedErr
+		}
+		return errors.New("repository initialization in backoff period")
+	}
+
 	repopath := repo.GetRepoPath()
 
+	// Handle S3 repositories
+	if isS3Repository(repopath) {
+		bucket, prefix, endpoint, err := parseS3URL(repopath)
+		if err != nil {
+			repo.CanInitRepo = false
+			err = fmt.Errorf("invalid S3 repository URL: %w", err)
+			repo.SetError(InitTask, err)
+			return err
+		}
+		return repo.checkS3RepoFiles(bucket, prefix, endpoint)
+	}
+
+	// Existing local filesystem logic
 	if _, err := os.Stat(filepath.Join(repopath, "config")); os.IsNotExist(err) {
 		// Check the repo data
 		errstr := "repo config is missing"
@@ -2762,6 +3204,7 @@ func (repo *ResticManager) CheckRepoFiles() error {
 
 	repo.CanInitRepo = true
 	delete(repo.TaskErrors, InitTask) // Clear any previous init errors
+	repo.clearInitErrorBackoff()
 
 	return nil
 }
@@ -2928,8 +3371,6 @@ func (repo *ResticManager) InitRepoWithOptions(opt ResticInitOption) error {
 		os.MkdirAll(repopath, 0755)
 	}
 
-	defer repo.AddFetchTask()
-
 	// Prepare the arguments for the "init" command
 	args := []string{"init"}
 
@@ -2950,9 +3391,14 @@ func (repo *ResticManager) InitRepoWithOptions(opt ResticInitOption) error {
 		err = errors.New(string(stderr))
 
 		repo.SetError(InitTask, err)
+		repo.setInitErrorBackoff(err)
 
 		return err
 	}
+
+	// Only add fetch task on successful initialization
+	repo.AddFetchTask()
+	repo.clearInitErrorBackoff()
 
 	return nil
 }

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -2879,6 +2879,9 @@ func (repo *ResticManager) createS3Client(endpoint string) (*s3.S3, error) {
 	secretKey := repo.getEnvValue("AWS_SECRET_ACCESS_KEY")
 	sessionToken := repo.getEnvValue("AWS_SESSION_TOKEN")
 	region := repo.getEnvValue("AWS_REGION")
+	if region == "" {
+		region = repo.getEnvValue("AWS_DEFAULT_REGION")
+	}
 
 	// Default region (MinIO ignores it)
 	if region == "" {
@@ -2981,6 +2984,82 @@ func listS3Prefix(client *s3.S3, bucket, prefix string) (bool, error) {
 	return len(result.Contents) > 0, nil
 }
 
+// deleteS3RepoPrefix deletes all objects under the given prefix (or entire bucket if prefix is empty)
+func deleteS3RepoPrefix(client *s3.S3, bucket, prefix string) error {
+	var continuation *string
+
+	for {
+		input := &s3.ListObjectsV2Input{
+			Bucket: aws.String(bucket),
+			Prefix: aws.String(prefix),
+		}
+		if continuation != nil {
+			input.ContinuationToken = continuation
+		}
+
+		result, err := client.ListObjectsV2(input)
+		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				switch aerr.Code() {
+				case s3.ErrCodeNoSuchBucket:
+					return fmt.Errorf("S3 bucket not found: %s (create it first or check name)", bucket)
+				case "Forbidden":
+					return fmt.Errorf("access denied to S3 bucket: %s (check credentials/permissions)", bucket)
+				}
+			}
+			return fmt.Errorf("S3 ListObjects failed: %w", err)
+		}
+
+		if len(result.Contents) > 0 {
+			objects := make([]*s3.ObjectIdentifier, 0, len(result.Contents))
+			for _, obj := range result.Contents {
+				if obj == nil || obj.Key == nil {
+					continue
+				}
+				objects = append(objects, &s3.ObjectIdentifier{Key: obj.Key})
+			}
+
+			for start := 0; start < len(objects); start += 1000 {
+				end := start + 1000
+				if end > len(objects) {
+					end = len(objects)
+				}
+
+				deleteInput := &s3.DeleteObjectsInput{
+					Bucket: aws.String(bucket),
+					Delete: &s3.Delete{
+						Objects: objects[start:end],
+						Quiet:   aws.Bool(true),
+					},
+				}
+				deleteResult, delErr := client.DeleteObjects(deleteInput)
+				if delErr != nil {
+					return fmt.Errorf("S3 DeleteObjects failed: %w", delErr)
+				}
+				if deleteResult != nil && len(deleteResult.Errors) > 0 {
+					firstErr := deleteResult.Errors[0]
+					if firstErr != nil {
+						return fmt.Errorf("S3 DeleteObjects error for key %s: %s", aws.StringValue(firstErr.Key), aws.StringValue(firstErr.Message))
+					}
+					return fmt.Errorf("S3 DeleteObjects returned errors")
+				}
+			}
+		}
+
+		if aws.BoolValue(result.IsTruncated) {
+			continuation = result.NextContinuationToken
+			if continuation == nil {
+				return fmt.Errorf("S3 ListObjects truncated without continuation token")
+			}
+			continue
+		}
+
+		break
+	}
+
+	return nil
+}
+
 // checkS3RepoFiles verifies S3 repository structure and initializes if needed
 func (repo *ResticManager) checkS3RepoFiles(bucket, prefix, endpoint string) error {
 	// Create S3 client
@@ -3044,13 +3123,12 @@ func (repo *ResticManager) checkS3RepoFiles(bucket, prefix, endpoint string) err
 			return err
 		}
 
-		// No config, no data - initialize the repo
-		repo.Printf(logrus.InfoLevel, "S3 repository not initialized at %s/%s, initializing now...",
-			bucket, prefix)
-		err = repo.InitRepo(false)
-		if err != nil {
-			return err
-		}
+		// No config, no data - return error to require explicit init
+		repo.CanInitRepo = false
+		err = errors.New(errstr)
+		repo.SetError(InitTask, err)
+		repo.setInitErrorBackoff(err)
+		return err
 	}
 
 	// Config exists or was just initialized
@@ -3188,12 +3266,11 @@ func (repo *ResticManager) CheckRepoFiles() error {
 			err = errors.New(errstr)
 			repo.SetError(InitTask, err)
 			return err
-		} else { // Repo data does not exist (can init)
-			// Initialize the repo
-			err = repo.InitRepo(false)
-			if err != nil {
-				return err
-			}
+		} else { // Repo data does not exist (explicit init required)
+			repo.CanInitRepo = false
+			err = errors.New(errstr)
+			repo.SetError(InitTask, err)
+			return err
 		}
 	} else if err != nil {
 		repo.CanInitRepo = false
@@ -3363,12 +3440,39 @@ func (repo *ResticManager) InitRepo(force bool) error {
 func (repo *ResticManager) InitRepoWithOptions(opt ResticInitOption) error {
 	repopath := repo.GetRepoPath()
 	if opt.Force {
-		err := os.RemoveAll(repopath)
-		if err != nil {
-			return fmt.Errorf("failed to remove repo: %w", err)
-		}
+		if isS3Repository(repopath) {
+			bucket, prefix, endpoint, err := parseS3URL(repopath)
+			if err != nil {
+				repo.CanInitRepo = false
+				err = fmt.Errorf("invalid S3 repository URL: %w", err)
+				repo.SetError(InitTask, err)
+				repo.setInitErrorBackoff(err)
+				return err
+			}
 
-		os.MkdirAll(repopath, 0755)
+			client, err := repo.createS3Client(endpoint)
+			if err != nil {
+				repo.CanInitRepo = false
+				err = fmt.Errorf("failed to create S3 client: %w", err)
+				repo.SetError(InitTask, err)
+				repo.setInitErrorBackoff(err)
+				return err
+			}
+
+			if err := deleteS3RepoPrefix(client, bucket, prefix); err != nil {
+				repo.CanInitRepo = false
+				repo.SetError(InitTask, err)
+				repo.setInitErrorBackoff(err)
+				return err
+			}
+		} else {
+			err := os.RemoveAll(repopath)
+			if err != nil {
+				return fmt.Errorf("failed to remove repo: %w", err)
+			}
+
+			os.MkdirAll(repopath, 0755)
+		}
 	}
 
 	// Prepare the arguments for the "init" command
@@ -3434,9 +3538,6 @@ func (repo *ResticManager) fetchRepoSnapshots() error {
 	args := []string{"snapshots", "--json"}
 	stdout, stderr, err := repo.RunCommand(args, logrus.DebugLevel, true)
 	if err != nil {
-		if strings.Contains(string(stderr), "no such file or directory") {
-			_ = repo.InitRepo(false)
-		}
 		// Handle error (including stderr)
 		return fmt.Errorf("failed to fetch repo: %v, stderr: %s", err, stderr)
 	}
@@ -3975,9 +4076,6 @@ func (repo *ResticManager) CheckResticLocks() error {
 	// Execute the Restic "list locks" command using RunCommand
 	stdout, stderr, err := repo.RunCommand(args, logrus.DebugLevel, true)
 	if err != nil {
-		if strings.Contains(string(stderr), "no such file or directory") {
-			_ = repo.InitRepo(false)
-		}
 		// Handle error (including stderr)
 		return fmt.Errorf("failed to check repo locks: %v, stderr: %s", err, stderr)
 	}
@@ -4017,9 +4115,6 @@ func (repo *ResticManager) UnlockRepo() error {
 	// Execute the Restic "list locks" command using RunCommand
 	stdout, stderr, err := repo.RunCommand(args, logrus.InfoLevel, true)
 	if err != nil {
-		if strings.Contains(string(stderr), "no such file or directory") {
-			_ = repo.InitRepo(false)
-		}
 		// Handle error (including stderr)
 		return fmt.Errorf("failed to check repo locks: %v, stderr: %s", err, stderr)
 	}
@@ -4127,9 +4222,6 @@ func (repo *ResticManager) GetRepoKeyList() ([]ResticKey, error) {
 	// Execute the Restic "key list" command using RunCommand
 	stdout, stderr, err := repo.RunCommand(args, logrus.DebugLevel, true)
 	if err != nil {
-		if strings.Contains(string(stderr), "no such file or directory") {
-			_ = repo.InitRepo(false)
-		}
 		// Handle error (including stderr)
 		return nil, fmt.Errorf("failed to list repo keys: %v, stderr: %s", err, stderr)
 	}

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -567,7 +567,10 @@ func (repo *ResticManager) UpdateEnvKey(key, value string) {
 func (repo *ResticManager) GetRepoPath() string {
 	for _, env := range repo.Env {
 		if strings.HasPrefix(env, "RESTIC_REPOSITORY") {
-			return strings.Split(env, "=")[1]
+			parts := strings.SplitN(env, "=", 2)
+			if len(parts) == 2 {
+				return parts[1]
+			}
 		}
 	}
 
@@ -577,7 +580,10 @@ func (repo *ResticManager) GetRepoPath() string {
 func (repo *ResticManager) GetCacheDirPath() string {
 	for _, env := range repo.Env {
 		if strings.HasPrefix(env, "RESTIC_CACHE_DIR") {
-			return strings.Split(env, "=")[1]
+			parts := strings.SplitN(env, "=", 2)
+			if len(parts) == 2 {
+				return parts[1]
+			}
 		}
 	}
 

--- a/utils/backupmgr/restic_test.go
+++ b/utils/backupmgr/restic_test.go
@@ -262,6 +262,17 @@ func TestEnvHelpers(t *testing.T) {
 	if got := repo.GetCacheDirPath(); got != "/tmp/cache" {
 		t.Fatalf("unexpected cache dir: %s", got)
 	}
+
+	repo.SetEnv([]string{
+		"RESTIC_REPOSITORY=s3:https://example.com/bucket/path?sig=a=b",
+		"RESTIC_CACHE_DIR=/tmp/cache=dir",
+	})
+	if got := repo.GetRepoPath(); got != "s3:https://example.com/bucket/path?sig=a=b" {
+		t.Fatalf("unexpected repo path with equals: %s", got)
+	}
+	if got := repo.GetCacheDirPath(); got != "/tmp/cache=dir" {
+		t.Fatalf("unexpected cache dir with equals: %s", got)
+	}
 }
 
 func TestGenerateTaskIDAndCanFetch(t *testing.T) {

--- a/utils/backupmgr/restic_test.go
+++ b/utils/backupmgr/restic_test.go
@@ -1832,3 +1832,217 @@ func TestMountRepoBackwardCompatibility(t *testing.T) {
 		t.Fatalf("unmount repo: %v", err)
 	}
 }
+
+// TestParseS3URL tests S3 URL parsing for various formats
+func TestParseS3URL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		bucket   string
+		prefix   string
+		endpoint string
+		wantErr  bool
+	}{
+		{
+			name:     "MinIO HTTPS with prefix",
+			input:    "s3:https://minio.example.com:9000/my-bucket/restic/cluster1",
+			bucket:   "my-bucket",
+			prefix:   "restic/cluster1",
+			endpoint: "https://minio.example.com:9000",
+			wantErr:  false,
+		},
+		{
+			name:     "MinIO HTTP dev",
+			input:    "s3:http://localhost:9000/backups/db",
+			bucket:   "backups",
+			prefix:   "db",
+			endpoint: "http://localhost:9000",
+			wantErr:  false,
+		},
+		{
+			name:     "MinIO shorthand with port",
+			input:    "s3:minio.local:9000/backups/restic",
+			bucket:   "backups",
+			prefix:   "restic",
+			endpoint: "https://minio.local:9000",
+			wantErr:  false,
+		},
+		{
+			name:     "AWS implicit",
+			input:    "s3:my-bucket/path/to/repo",
+			bucket:   "my-bucket",
+			prefix:   "path/to/repo",
+			endpoint: "",
+			wantErr:  false,
+		},
+		{
+			name:     "AWS explicit endpoint",
+			input:    "s3:https://s3.us-west-2.amazonaws.com/prod-backups/cluster1",
+			bucket:   "prod-backups",
+			prefix:   "cluster1",
+			endpoint: "https://s3.us-west-2.amazonaws.com",
+			wantErr:  false,
+		},
+		{
+			name:     "S3 bucket only",
+			input:    "s3:my-bucket/",
+			bucket:   "my-bucket",
+			prefix:   "",
+			endpoint: "",
+			wantErr:  false,
+		},
+		{
+			name:     "S3 with nested prefix",
+			input:    "s3:bucket/path/to/deep/repo",
+			bucket:   "bucket",
+			prefix:   "path/to/deep/repo",
+			endpoint: "",
+			wantErr:  false,
+		},
+		{
+			name:    "Invalid - no bucket",
+			input:   "s3:https://endpoint/",
+			wantErr: true,
+		},
+		{
+			name:    "Invalid - not S3",
+			input:   "local:/path/to/repo",
+			wantErr: true,
+		},
+		{
+			name:    "Invalid - missing path",
+			input:   "s3:bucket-only",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bucket, prefix, endpoint, err := parseS3URL(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseS3URL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if bucket != tt.bucket {
+					t.Errorf("parseS3URL() bucket = %q, want %q", bucket, tt.bucket)
+				}
+				if prefix != tt.prefix {
+					t.Errorf("parseS3URL() prefix = %q, want %q", prefix, tt.prefix)
+				}
+				if endpoint != tt.endpoint {
+					t.Errorf("parseS3URL() endpoint = %q, want %q", endpoint, tt.endpoint)
+				}
+			}
+		})
+	}
+}
+
+// TestIsS3Repository tests S3 repository detection
+func TestIsS3Repository(t *testing.T) {
+	tests := []struct {
+		name     string
+		repoPath string
+		want     bool
+	}{
+		{"S3 HTTPS", "s3:https://minio.local/bucket/path", true},
+		{"S3 HTTP", "s3:http://localhost:9000/bucket", true},
+		{"S3 implicit", "s3:bucket/path", true},
+		{"Local path", "/var/backups/restic", false},
+		{"Local relative", "./backups", false},
+		{"Azure", "azure:container/path", false},
+		{"Empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isS3Repository(tt.repoPath); got != tt.want {
+				t.Errorf("isS3Repository(%q) = %v, want %v", tt.repoPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInitErrorBackoff(t *testing.T) {
+	repo := NewResticRepo("/usr/bin/restic", testMsgChan, 0)
+	defer repo.ShutdownWorker()
+
+	testErr := errors.New("S3 authentication failed")
+
+	// First error should set backoff to 10s
+	repo.setInitErrorBackoff(testErr)
+	if repo.initErrorCount != 1 {
+		t.Errorf("initErrorCount = %d, want 1", repo.initErrorCount)
+	}
+	if !repo.shouldSkipInitDueToBackoff() {
+		t.Error("shouldSkipInitDueToBackoff() = false, want true after first error")
+	}
+
+	// Same error should increment count
+	repo.setInitErrorBackoff(testErr)
+	if repo.initErrorCount != 2 {
+		t.Errorf("initErrorCount = %d, want 2", repo.initErrorCount)
+	}
+
+	// Different error should reset count
+	repo.setInitErrorBackoff(errors.New("different error"))
+	if repo.initErrorCount != 1 {
+		t.Errorf("initErrorCount = %d, want 1 after different error", repo.initErrorCount)
+	}
+
+	// Clear should reset everything
+	repo.clearInitErrorBackoff()
+	if repo.initErrorCount != 0 {
+		t.Errorf("initErrorCount = %d, want 0 after clear", repo.initErrorCount)
+	}
+	if repo.shouldSkipInitDueToBackoff() {
+		t.Error("shouldSkipInitDueToBackoff() = true, want false after clear")
+	}
+
+	// Test backoff expiration
+	repo.setInitErrorBackoff(testErr)
+	repo.errorMutex.Lock()
+	repo.initBackoffUntil = time.Now().Add(-1 * time.Second) // Set to past
+	repo.errorMutex.Unlock()
+	if repo.shouldSkipInitDueToBackoff() {
+		t.Error("shouldSkipInitDueToBackoff() = true, want false after backoff expired")
+	}
+}
+
+func TestInitErrorBackoffPreventsFlooding(t *testing.T) {
+	repo := NewResticRepo("/usr/bin/restic", testMsgChan, 0)
+	defer repo.ShutdownWorker()
+
+	// Simulate repeated init failures
+	testErr := errors.New("persistent S3 error")
+
+	// First few errors should be logged, but then backoff kicks in
+	for i := 0; i < 5; i++ {
+		repo.setInitErrorBackoff(testErr)
+	}
+
+	if repo.initErrorCount != 5 {
+		t.Errorf("initErrorCount = %d, want 5", repo.initErrorCount)
+	}
+
+	// Verify backoff is active
+	if !repo.shouldSkipInitDueToBackoff() {
+		t.Error("shouldSkipInitDueToBackoff() should be true after multiple errors")
+	}
+
+	// Verify CheckRepoFiles returns cached error without retrying
+	// (This would normally trigger init, but backoff should prevent it)
+	repo.Env = append(repo.Env, "RESTIC_REPOSITORY=/nonexistent/path")
+	err := repo.CheckRepoFiles()
+	if err == nil {
+		t.Error("CheckRepoFiles() should return error when in backoff")
+	}
+
+	// Error count should not increase when in backoff
+	originalCount := repo.initErrorCount
+	repo.CheckRepoFiles()
+	if repo.initErrorCount != originalCount {
+		t.Errorf("initErrorCount changed during backoff: was %d, now %d",
+			originalCount, repo.initErrorCount)
+	}
+}


### PR DESCRIPTION
This PR enhances Restic S3 backup support with intelligent error handling and AWS region configuration, enabling operators to recover from S3 setup failures through the UI/API.
Problem Statement
Restic AWS deployments encountered several operational challenges:
- S3 repository initialization failures would flood logs with no recovery path
- No support for specifying AWS regions, causing issues with region-specific buckets
- Self-signed certificates (common in MinIO deployments) were not supported
- Operators had no way to re-initialize repositories after fixing credentials/configuration without service restart
Solution
Backend (Go):
- S3 Repository Initialization: Implement AWS SDK-based S3 client with automatic repository verification and initialization
  - Parse multiple S3 URL formats: s3:https://endpoint/bucket/prefix (MinIO), s3:bucket/prefix (AWS), s3:endpoint:port/bucket/prefix
  - Verify repository structure (config + data files) before operations
  - Auto-initialize missing repositories when safe to do so
  
- AWS Region Configuration: Add backup-restic-aws-region setting for explicit region control
  - Environment variable: AWS_REGION
  - Defaults to AWS SDK resolution if empty
  - Wired through config, API, and environment propagation
- Insecure TLS Support: Add backup-restic-aws-insecure-tls flag for self-signed certificates
  - Useful for MinIO deployments with custom certificates
  - Environment variable: RESTIC_INSECURE_TLS
  
- Exponential Error Backoff: Prevent log flooding from persistent S3 failures
  - Backoff schedule: 10s → 30s → 1m → 2m → 5m → 10m → 30m (max)
  - Automatic retry after backoff expires
  - Manual backoff clear when config changes (allows immediate retry after credential fixes)
  - Only logs first error and every 10th occurrence to prevent spam
Frontend (React):
- Repository Re-initialization UI: Add manual repo init controls in Restic Repository Settings
  - Refresh button for both local and S3 repositories
  - Confirmation modal with force flag option for corrupted repositories
  - Context-aware help text for S3 vs local operations
  - Permission-aware button states (requires cluster-settings grant)
Configuration:
- New settings: 
  - backup-restic-aws-region (string, optional)
  - backup-restic-aws-insecure-tls (boolean, default: false)
- New API endpoints: 
  - POST /clusters/{name}/restic/init (normal init)
  - POST /clusters/{name}/restic/init/force (force overwrite)
- Auto-reload Restic environment when AWS settings change