### PR TITLE
Disable S3 restic repo checks and force-init; add optional env overrides

### DIFF
--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -33,12 +33,15 @@ func isS3ResticRepository(repoPath string) bool {
 	return strings.HasPrefix(strings.TrimSpace(repoPath), "s3:")
 }
 
-func splitResticAdditionalEnvTokens(value string) ([]string, bool) {
+func splitResticAdditionalEnvTokens(value string) ([]string, error) {
 	parts := make([]string, 0)
 	var current strings.Builder
 	var quote rune
 	escaped := false
 	hadUnmatched := false
+	hadInvalid := false
+	seenEquals := false
+	justClosedQuote := false
 
 	for _, r := range value {
 		if quote != 0 {
@@ -54,9 +57,27 @@ func splitResticAdditionalEnvTokens(value string) ([]string, bool) {
 			}
 			if r == quote {
 				quote = 0
+				justClosedQuote = true
 			}
 			current.WriteRune(r)
 			continue
+		}
+
+		if justClosedQuote {
+			switch r {
+			case ',', ' ', '\t', '\n', '\r':
+				// ok: delimiter after quoted token
+			case '=':
+				if seenEquals {
+					hadInvalid = true
+				}
+			default:
+				hadInvalid = true
+			}
+			justClosedQuote = false
+			if hadInvalid {
+				break
+			}
 		}
 
 		switch r {
@@ -67,27 +88,40 @@ func splitResticAdditionalEnvTokens(value string) ([]string, bool) {
 			if current.Len() > 0 {
 				parts = append(parts, current.String())
 				current.Reset()
+				seenEquals = false
 			}
+		case '=':
+			seenEquals = true
+			current.WriteRune(r)
 		default:
 			current.WriteRune(r)
 		}
 	}
 
+	if hadInvalid {
+		return nil, errors.New("restic additional env has invalid characters after quoted value")
+	}
 	if quote != 0 {
 		hadUnmatched = true
+	}
+	if hadUnmatched {
+		return nil, errors.New("restic additional env has unmatched quotes")
 	}
 	if current.Len() > 0 {
 		parts = append(parts, current.String())
 	}
 
-	return parts, hadUnmatched
+	return parts, nil
 }
 
-func parseResticAdditionalEnvOverrides(raw string) (map[string]string, map[string]struct{}) {
+func parseResticAdditionalEnvOverrides(raw string) (map[string]string, map[string]struct{}, error) {
 	overrides := make(map[string]string)
 	allowlist := make(map[string]struct{})
 
-	parts, _ := splitResticAdditionalEnvTokens(raw)
+	parts, err := splitResticAdditionalEnvTokens(raw)
+	if err != nil {
+		return overrides, allowlist, err
+	}
 	for _, part := range parts {
 		trimmed := strings.TrimSpace(part)
 		if trimmed == "" {
@@ -111,14 +145,24 @@ func parseResticAdditionalEnvOverrides(raw string) (map[string]string, map[strin
 		}
 	}
 
-	return overrides, allowlist
+	return overrides, allowlist, nil
 }
 
-func filterResticEnv(baseEnv []string, repoPath, password, cacheDir, awsAccessKey, awsSecretKey, awsRegion, additionalEnv string) []string {
+func filterResticEnv(cluster *Cluster, baseEnv []string, repoPath, password, cacheDir, awsAccessKey, awsSecretKey, awsRegion, additionalEnv string) []string {
 	filtered := make([]string, 0, len(baseEnv)+6)
-	overrides, allowlist := parseResticAdditionalEnvOverrides(additionalEnv)
+	overrides, allowlist, err := parseResticAdditionalEnvOverrides(additionalEnv)
+	if err != nil {
+		if cluster != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Ignoring restic additional env override: %s", err)
+		}
+		overrides = make(map[string]string)
+		allowlist = make(map[string]struct{})
+	}
+	isS3 := isS3ResticRepository(repoPath)
 	defaultRegion := ""
 	optionalAwsEnv := make(map[string]string)
+	// Reserved env vars cannot be overridden via backup-restic-additional-env.
+	// Add any new sensitive env vars here to prevent unintended injection.
 	reserved := map[string]struct{}{
 		"RESTIC_REPOSITORY":     {},
 		"RESTIC_PASSWORD":       {},
@@ -138,12 +182,19 @@ func filterResticEnv(baseEnv []string, repoPath, password, cacheDir, awsAccessKe
 			if _, blocked := reserved[key]; blocked {
 				continue
 			}
+			if strings.HasPrefix(key, "AWS_") && !isS3 {
+				continue
+			}
+			// AWS_DEFAULT_REGION from additional env is ignored for S3 repos; base env is used as fallback.
+			if key == "AWS_DEFAULT_REGION" && isS3 {
+				continue
+			}
 			if override, exists := overrides[key]; exists {
 				optionalAwsEnv[key] = override
 			} else {
 				optionalAwsEnv[key] = val
 			}
-			if key == "AWS_DEFAULT_REGION" {
+			if key == "AWS_DEFAULT_REGION" && !isS3 {
 				defaultRegion = optionalAwsEnv[key]
 			}
 			continue
@@ -158,11 +209,17 @@ func filterResticEnv(baseEnv []string, repoPath, password, cacheDir, awsAccessKe
 		if _, blocked := reserved[key]; blocked {
 			continue
 		}
+		if strings.HasPrefix(key, "AWS_") && !isS3 {
+			continue
+		}
+		if key == "AWS_DEFAULT_REGION" && isS3 {
+			continue
+		}
 		if _, exists := optionalAwsEnv[key]; exists {
 			continue
 		}
 		optionalAwsEnv[key] = override
-		if key == "AWS_DEFAULT_REGION" {
+		if key == "AWS_DEFAULT_REGION" && !isS3 {
 			defaultRegion = override
 		}
 	}
@@ -171,7 +228,7 @@ func filterResticEnv(baseEnv []string, repoPath, password, cacheDir, awsAccessKe
 	filtered = append(filtered, "RESTIC_CACHE_DIR="+cacheDir)
 	filtered = append(filtered, "RESTIC_REPOSITORY="+repoPath)
 
-	if isS3ResticRepository(repoPath) {
+	if isS3 {
 		filtered = append(filtered, "AWS_ACCESS_KEY_ID="+awsAccessKey)
 		filtered = append(filtered, "AWS_SECRET_ACCESS_KEY="+awsSecretKey)
 		region := strings.TrimSpace(awsRegion)
@@ -187,7 +244,7 @@ func filterResticEnv(baseEnv []string, repoPath, password, cacheDir, awsAccessKe
 		if _, blocked := reserved[key]; blocked {
 			continue
 		}
-		if key == "AWS_DEFAULT_REGION" && isS3ResticRepository(repoPath) {
+		if key == "AWS_DEFAULT_REGION" && isS3 {
 			continue
 		}
 		filtered = append(filtered, key+"="+value)
@@ -213,6 +270,7 @@ func (cluster *Cluster) ResticGetEnv() []string {
 	}
 
 	return filterResticEnv(
+		cluster,
 		os.Environ(),
 		repoPath,
 		password,

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -148,6 +148,11 @@ func parseResticAdditionalEnvOverrides(raw string) (map[string]string, map[strin
 	return overrides, allowlist, nil
 }
 
+func ValidateResticAdditionalEnvOverrides(raw string) error {
+	_, _, err := parseResticAdditionalEnvOverrides(raw)
+	return err
+}
+
 func filterResticEnv(cluster *Cluster, baseEnv []string, repoPath, password, cacheDir, awsAccessKey, awsSecretKey, awsRegion, additionalEnv string) []string {
 	filtered := make([]string, 0, len(baseEnv)+6)
 	overrides, allowlist, err := parseResticAdditionalEnvOverrides(additionalEnv)

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -262,6 +262,7 @@ func (cluster *Cluster) ResticGetEnv() []string {
 	cacheDir := cluster.Conf.WorkingDir + "/" + cluster.Name + "/.cache/restic"
 	password := cluster.Conf.GetDecryptedValue("backup-restic-password")
 	repoPath := ""
+	// backup-restic-aws controls whether the repo path is remote; otherwise local repo is used.
 	if cluster.Conf.BackupResticAws {
 		repoPath = cluster.Conf.BackupResticRepository + "/" + cluster.Name
 	} else {

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -33,17 +33,138 @@ func isS3ResticRepository(repoPath string) bool {
 	return strings.HasPrefix(strings.TrimSpace(repoPath), "s3:")
 }
 
-func filterResticEnv(baseEnv []string, repoPath, password, cacheDir, awsAccessKey, awsSecretKey, awsRegion string) []string {
-	filtered := make([]string, 0, len(baseEnv)+6)
-	defaultRegion := ""
-	for _, env := range baseEnv {
-		if strings.HasPrefix(env, "AWS_DEFAULT_REGION=") {
-			defaultRegion = strings.TrimPrefix(env, "AWS_DEFAULT_REGION=")
+func splitResticAdditionalEnvTokens(value string) ([]string, bool) {
+	parts := make([]string, 0)
+	var current strings.Builder
+	var quote rune
+	escaped := false
+	hadUnmatched := false
+
+	for _, r := range value {
+		if quote != 0 {
+			if quote == '"' && !escaped && r == '\\' {
+				escaped = true
+				current.WriteRune(r)
+				continue
+			}
+			if quote == '"' && escaped {
+				current.WriteRune(r)
+				escaped = false
+				continue
+			}
+			if r == quote {
+				quote = 0
+			}
+			current.WriteRune(r)
+			continue
 		}
-		if strings.HasPrefix(env, "RESTIC_") || strings.HasPrefix(env, "AWS_") {
+
+		switch r {
+		case '"', '\'':
+			quote = r
+			current.WriteRune(r)
+		case ',', ' ', '\t', '\n', '\r':
+			if current.Len() > 0 {
+				parts = append(parts, current.String())
+				current.Reset()
+			}
+		default:
+			current.WriteRune(r)
+		}
+	}
+
+	if quote != 0 {
+		hadUnmatched = true
+	}
+	if current.Len() > 0 {
+		parts = append(parts, current.String())
+	}
+
+	return parts, hadUnmatched
+}
+
+func parseResticAdditionalEnvOverrides(raw string) (map[string]string, map[string]struct{}) {
+	overrides := make(map[string]string)
+	allowlist := make(map[string]struct{})
+
+	parts, _ := splitResticAdditionalEnvTokens(raw)
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		key, value, hasValue := strings.Cut(trimmed, "=")
+		key = strings.TrimSpace(key)
+		if unquotedKey, ok := unquoteResticTagLiteral(key); ok {
+			key = strings.TrimSpace(unquotedKey)
+		}
+		if key == "" {
+			continue
+		}
+		allowlist[key] = struct{}{}
+		if hasValue {
+			value = strings.TrimSpace(value)
+			if unquotedValue, ok := unquoteResticTagLiteral(value); ok {
+				value = unquotedValue
+			}
+			overrides[key] = value
+		}
+	}
+
+	return overrides, allowlist
+}
+
+func filterResticEnv(baseEnv []string, repoPath, password, cacheDir, awsAccessKey, awsSecretKey, awsRegion, additionalEnv string) []string {
+	filtered := make([]string, 0, len(baseEnv)+6)
+	overrides, allowlist := parseResticAdditionalEnvOverrides(additionalEnv)
+	defaultRegion := ""
+	optionalAwsEnv := make(map[string]string)
+	reserved := map[string]struct{}{
+		"RESTIC_REPOSITORY":     {},
+		"RESTIC_PASSWORD":       {},
+		"RESTIC_CACHE_DIR":      {},
+		"AWS_ACCESS_KEY_ID":     {},
+		"AWS_SECRET_ACCESS_KEY": {},
+	}
+	for _, env := range baseEnv {
+		key, val, hasValue := strings.Cut(env, "=")
+		if !hasValue {
+			continue
+		}
+		if key == "AWS_DEFAULT_REGION" {
+			defaultRegion = val
+		}
+		if _, ok := allowlist[key]; ok {
+			if _, blocked := reserved[key]; blocked {
+				continue
+			}
+			if override, exists := overrides[key]; exists {
+				optionalAwsEnv[key] = override
+			} else {
+				optionalAwsEnv[key] = val
+			}
+			if key == "AWS_DEFAULT_REGION" {
+				defaultRegion = optionalAwsEnv[key]
+			}
+			continue
+		}
+		if strings.HasPrefix(key, "RESTIC_") || strings.HasPrefix(key, "AWS_") {
 			continue
 		}
 		filtered = append(filtered, env)
+	}
+
+	for key, override := range overrides {
+		if _, blocked := reserved[key]; blocked {
+			continue
+		}
+		if _, exists := optionalAwsEnv[key]; exists {
+			continue
+		}
+		optionalAwsEnv[key] = override
+		if key == "AWS_DEFAULT_REGION" {
+			defaultRegion = override
+		}
 	}
 
 	filtered = append(filtered, "RESTIC_PASSWORD="+password)
@@ -60,6 +181,16 @@ func filterResticEnv(baseEnv []string, repoPath, password, cacheDir, awsAccessKe
 		if region != "" {
 			filtered = append(filtered, "AWS_DEFAULT_REGION="+region)
 		}
+	}
+
+	for key, value := range optionalAwsEnv {
+		if _, blocked := reserved[key]; blocked {
+			continue
+		}
+		if key == "AWS_DEFAULT_REGION" && isS3ResticRepository(repoPath) {
+			continue
+		}
+		filtered = append(filtered, key+"="+value)
 	}
 
 	return filtered
@@ -89,6 +220,7 @@ func (cluster *Cluster) ResticGetEnv() []string {
 		cluster.Conf.BackupResticAwsAccessKeyId,
 		cluster.Conf.GetDecryptedValue("backup-restic-aws-access-secret"),
 		cluster.Conf.BackupResticAwsRegion,
+		cluster.Conf.BackupResticAdditionalEnv,
 	)
 }
 

--- a/cluster/cluster_bck_test.go
+++ b/cluster/cluster_bck_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -36,6 +37,85 @@ func TestSplitResticKeepTagTemplates(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSplitResticAdditionalEnvTokensValid(t *testing.T) {
+	input := `AWS_SESSION_TOKEN="abc",AWS_DEFAULT_REGION=us-east-1 OTHER=value`
+	got, err := splitResticAdditionalEnvTokens(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []string{`AWS_SESSION_TOKEN="abc"`, `AWS_DEFAULT_REGION=us-east-1`, `OTHER=value`}
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("unexpected split result: got %v, want %v", got, expected)
+	}
+}
+
+func TestSplitResticAdditionalEnvTokensUnmatchedQuotes(t *testing.T) {
+	_, err := splitResticAdditionalEnvTokens(`AWS_SESSION_TOKEN="abc`)
+	if err == nil {
+		t.Fatalf("expected error for unmatched quotes")
+	}
+}
+
+func TestSplitResticAdditionalEnvTokensInvalidTrailingChars(t *testing.T) {
+	_, err := splitResticAdditionalEnvTokens(`KEY='single'extra`)
+	if err == nil {
+		t.Fatalf("expected error for trailing characters after closing quote")
+	}
+}
+
+func TestParseResticAdditionalEnvOverridesValid(t *testing.T) {
+	overrides, allowlist, err := parseResticAdditionalEnvOverrides(`AWS_SESSION_TOKEN="abc" AWS_DEFAULT_REGION=us-east-1 AWS_PROFILE`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if overrides["AWS_SESSION_TOKEN"] != "abc" {
+		t.Fatalf("expected session token override, got %q", overrides["AWS_SESSION_TOKEN"])
+	}
+	if overrides["AWS_DEFAULT_REGION"] != "us-east-1" {
+		t.Fatalf("expected default region override, got %q", overrides["AWS_DEFAULT_REGION"])
+	}
+	if _, ok := allowlist["AWS_PROFILE"]; !ok {
+		t.Fatalf("expected allowlist to include AWS_PROFILE")
+	}
+}
+
+func TestParseResticAdditionalEnvOverridesInvalid(t *testing.T) {
+	_, _, err := parseResticAdditionalEnvOverrides(`KEY='single'extra`)
+	if err == nil {
+		t.Fatalf("expected error for invalid additional env")
+	}
+}
+
+func TestFilterResticEnvSkipsAwsForNonS3(t *testing.T) {
+	baseEnv := []string{
+		"PATH=/bin",
+		"AWS_DEFAULT_REGION=us-west-2",
+		"OTHER=base",
+	}
+	env := filterResticEnv(nil, baseEnv, "/tmp/repo", "pw", "/tmp/cache", "ak", "sk", "", "AWS_PROFILE=dev AWS_DEFAULT_REGION=us-east-1 OTHER=override")
+	if containsEnvPrefix(env, "AWS_PROFILE=") {
+		t.Fatalf("expected AWS_PROFILE to be filtered for non-S3 repo")
+	}
+	if containsEnvPrefix(env, "AWS_DEFAULT_REGION=") {
+		t.Fatalf("expected AWS_DEFAULT_REGION to be filtered for non-S3 repo")
+	}
+	if containsEnvPrefix(env, "AWS_ACCESS_KEY_ID=") || containsEnvPrefix(env, "AWS_SECRET_ACCESS_KEY=") {
+		t.Fatalf("expected AWS credentials to be omitted for non-S3 repo")
+	}
+	if !containsEnvPrefix(env, "OTHER=override") {
+		t.Fatalf("expected override for OTHER to be applied")
+	}
+}
+
+func containsEnvPrefix(env []string, prefix string) bool {
+	for _, item := range env {
+		if strings.HasPrefix(item, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestSplitResticKeepTagTemplates_UnmatchedQuotes(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -763,6 +763,7 @@ type Config struct {
 	BackupResticAwsAccessKeyId                string `mapstructure:"backup-restic-aws-access-key-id" toml:"backup-restic-aws-access-key-id" json:"backupResticAwsAccessKeyId"`
 	BackupResticAwsAccessSecret               string `mapstructure:"backup-restic-aws-access-secret"  toml:"backup-restic-aws-access-secret" json:"-"`
 	BackupResticAwsRegion                     string `mapstructure:"backup-restic-aws-region" toml:"backup-restic-aws-region" json:"backupResticAwsRegion"`
+	BackupResticAdditionalEnv                 string `mapstructure:"backup-restic-additional-env" toml:"backup-restic-additional-env" json:"backupResticAdditionalEnv"`
 	BackupResticRepository                    string `mapstructure:"backup-restic-repository" toml:"backup-restic-repository" json:"backupResticRepository"`
 	BackupResticPassword                      string `mapstructure:"backup-restic-password"  toml:"backup-restic-password" json:"-"`
 	BackupResticAws                           bool   `mapstructure:"backup-restic-aws"  toml:"backup-restic-aws" json:"backupResticAws"`

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -3673,6 +3673,9 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 	case "backup-restic-aws-region":
 		mycluster.Conf.BackupResticAwsRegion = value
 		mycluster.ReloadResticEnv()
+	case "backup-restic-additional-env":
+		mycluster.Conf.BackupResticAdditionalEnv = value
+		mycluster.ReloadResticEnv()
 	case "backup-restic-password":
 		val, err := base64.StdEncoding.DecodeString(value)
 		if err != nil {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -3674,6 +3674,9 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		mycluster.Conf.BackupResticAwsRegion = value
 		mycluster.ReloadResticEnv()
 	case "backup-restic-additional-env":
+		if err := cluster.ValidateResticAdditionalEnvOverrides(value); err != nil {
+			return fmt.Errorf("invalid backup-restic-additional-env: %w", err)
+		}
 		mycluster.Conf.BackupResticAdditionalEnv = value
 		mycluster.ReloadResticEnv()
 	case "backup-restic-password":

--- a/server/server.go
+++ b/server/server.go
@@ -809,6 +809,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.BackupResticAwsAccessKeyId, "backup-restic-aws-access-key-id", "admin", "Restic backup AWS key id")
 	flags.StringVar(&conf.BackupResticAwsAccessSecret, "backup-restic-aws-access-secret", "secret", "Restic backup AWS key sercret")
 	flags.StringVar(&conf.BackupResticAwsRegion, "backup-restic-aws-region", "", "Restic backup AWS region (empty = AWS SDK default)")
+	flags.StringVar(&conf.BackupResticAdditionalEnv, "backup-restic-additional-env", "", "Optional restic env vars (comma/space separated KEY or KEY=VALUE)")
 	flags.StringVar(&conf.BackupResticLocalRepository, "backup-restic-local-repository", "", "Restic local repository path. Empty by default to use repo per cluster in datadir/backups/archive/<clustername>")
 	flags.StringVar(&conf.BackupResticRepository, "backup-restic-repository", "s3:https://s3.signal18.io/backups", "Restic backend repository")
 	flags.StringVar(&conf.BackupResticPassword, "backup-restic-password", "secret", "Restic backend password")

--- a/server/server.go
+++ b/server/server.go
@@ -809,7 +809,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.BackupResticAwsAccessKeyId, "backup-restic-aws-access-key-id", "admin", "Restic backup AWS key id")
 	flags.StringVar(&conf.BackupResticAwsAccessSecret, "backup-restic-aws-access-secret", "secret", "Restic backup AWS key sercret")
 	flags.StringVar(&conf.BackupResticAwsRegion, "backup-restic-aws-region", "", "Restic backup AWS region (empty = AWS SDK default)")
-	flags.StringVar(&conf.BackupResticAdditionalEnv, "backup-restic-additional-env", "", "Optional restic env vars (comma/space separated KEY or KEY=VALUE)")
+	flags.StringVar(&conf.BackupResticAdditionalEnv, "backup-restic-additional-env", "", "Optional restic env vars (comma/space separated KEY or KEY=VALUE). AWS_* entries apply only for S3 repos. In double quotes, only \\\\ and \\\" are escapes.")
 	flags.StringVar(&conf.BackupResticLocalRepository, "backup-restic-local-repository", "", "Restic local repository path. Empty by default to use repo per cluster in datadir/backups/archive/<clustername>")
 	flags.StringVar(&conf.BackupResticRepository, "backup-restic-repository", "s3:https://s3.signal18.io/backups", "Restic backend repository")
 	flags.StringVar(&conf.BackupResticPassword, "backup-restic-password", "secret", "Restic backend password")

--- a/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
@@ -593,9 +593,14 @@ function ResticRepositorySettings({
               </Text>
             </Checkbox>
             {config?.backupResticAws && (
-              <Text fontSize='sm' color='gray.600'>
-                Force re-initialization is disabled when backup-restic-aws is enabled (S3/MinIO mode).
-              </Text>
+              <>
+                <Text fontSize='sm' color='gray.600'>
+                  Force re-initialization is disabled when backup-restic-aws is enabled (S3/MinIO mode).
+                </Text>
+                <Text fontSize='xs' color='gray.500'>
+                  Local repositories are used when backup-restic-aws is off, regardless of repository URL.
+                </Text>
+              </>
             )}
             {initForce && (
               <Alert status='warning' size='sm' borderRadius='md'>

--- a/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
@@ -594,7 +594,7 @@ function ResticRepositorySettings({
             </Checkbox>
             {config?.backupResticAws && (
               <Text fontSize='sm' color='gray.600'>
-                Force re-initialization is disabled for S3 repositories.
+                Force re-initialization is disabled when backup-restic-aws is enabled (S3/MinIO mode).
               </Text>
             )}
             {initForce && (

--- a/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
@@ -424,6 +424,31 @@ function ResticRepositorySettings({
                   rowGap={1}
                   w='full'
                 >
+                <GridItem className={styles.rowLabel}>
+                    <Text>Backup restic additional env</Text>
+                  </GridItem>
+                  <GridItem className={styles.valueCell}>
+                    <TextForm
+                      value={config?.backupResticAdditionalEnv}
+                      confirmTitle={`Confirm backup-restic-additional-env to `}
+                      className={styles.textbox}
+                      size='sm'
+                      placeholder='AWS_SESSION_TOKEN, NO_PROXY="host1,host2"'
+                      onSave={(value) => handleSettingChange('backup-restic-additional-env', value)}
+                    />
+                    <Text className={styles.helperText}>
+                      Optional env vars to pass to restic (comma or space separated KEY or KEY=VALUE). Quote values with commas.
+                    </Text>
+                  </GridItem>
+                </Grid>
+
+                <Grid
+                  className={styles.resticMountGrid}
+                  templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
+                  columnGap={3}
+                  rowGap={1}
+                  w='full'
+                >
                   <GridItem className={styles.rowLabel}>
                     <Text>Backup restic aws bucket</Text>
                   </GridItem>
@@ -560,12 +585,18 @@ function ResticRepositorySettings({
             <Divider />
             <Checkbox
               isChecked={initForce}
+              isDisabled={config?.backupResticAws}
               onChange={(e) => setInitForce(e.target.checked)}
             >
               <Text fontSize='sm'>
                 Force re-initialization (overwrite existing configuration)
               </Text>
             </Checkbox>
+            {config?.backupResticAws && (
+              <Text fontSize='sm' color='gray.600'>
+                Force re-initialization is disabled for S3 repositories.
+              </Text>
+            )}
             {initForce && (
               <Alert status='warning' size='sm' borderRadius='md'>
                 <AlertIcon />

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -3207,17 +3207,9 @@ func (repo *ResticManager) CheckRepoFiles() error {
 	}
 
 	repopath := repo.GetRepoPath()
-
-	// Handle S3 repositories
 	if isS3Repository(repopath) {
-		bucket, prefix, endpoint, err := parseS3URL(repopath)
-		if err != nil {
-			repo.CanInitRepo = false
-			err = fmt.Errorf("invalid S3 repository URL: %w", err)
-			repo.SetError(InitTask, err)
-			return err
-		}
-		return repo.checkS3RepoFiles(bucket, prefix, endpoint)
+		// S3 repository file checks are not supported yet.
+		return nil
 	}
 
 	// Existing local filesystem logic
@@ -3412,30 +3404,11 @@ func (repo *ResticManager) InitRepoWithOptions(opt ResticInitOption) error {
 	repopath := repo.GetRepoPath()
 	if opt.Force {
 		if isS3Repository(repopath) {
-			bucket, prefix, endpoint, err := parseS3URL(repopath)
-			if err != nil {
-				repo.CanInitRepo = false
-				err = fmt.Errorf("invalid S3 repository URL: %w", err)
-				repo.SetError(InitTask, err)
-				repo.setInitErrorBackoff(err)
-				return err
-			}
-
-			client, err := repo.createS3Client(endpoint)
-			if err != nil {
-				repo.CanInitRepo = false
-				err = fmt.Errorf("failed to create S3 client: %w", err)
-				repo.SetError(InitTask, err)
-				repo.setInitErrorBackoff(err)
-				return err
-			}
-
-			if err := deleteS3RepoPrefix(client, bucket, prefix); err != nil {
-				repo.CanInitRepo = false
-				repo.SetError(InitTask, err)
-				repo.setInitErrorBackoff(err)
-				return err
-			}
+			err := errors.New("force init is disabled for S3 repositories")
+			repo.CanInitRepo = false
+			repo.SetError(InitTask, err)
+			repo.setInitErrorBackoff(err)
+			return err
 		} else {
 			err := os.RemoveAll(repopath)
 			if err != nil {

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -3404,7 +3404,8 @@ func (repo *ResticManager) InitRepoWithOptions(opt ResticInitOption) error {
 	repopath := repo.GetRepoPath()
 	if opt.Force {
 		if isS3Repository(repopath) {
-			err := errors.New("force init is disabled for S3 repositories")
+			// Avoid force init on S3 to prevent accidental data loss or conflicts on shared buckets/prefixes.
+			err := errors.New("force init is disabled for S3 repositories to prevent accidental data loss")
 			repo.CanInitRepo = false
 			repo.SetError(InitTask, err)
 			repo.setInitErrorBackoff(err)


### PR DESCRIPTION
Summary
- Disable S3 repository file checks and block force-init for S3 to avoid unsupported operations (main change).
- Add configurable backup-restic-additional-env parsing to pass optional restic/AWS env vars.
- Wire the new setting through API, flags, and dashboard UI with guidance.