### PR TITLE
fix: use correct TLS config name in mysql.RegisterTLSConfig

### DIFF
--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -287,6 +287,8 @@ const (
 	ConstTLSNoConfig      string = ""
 	ConstTLSOldConfig     string = "&tls=tlsconfigold"
 	ConstTLSCurrentConfig string = "&tls=tlsconfig"
+    ConstTLSCurrentConfigName string = "tlsconfig"
+    ConstTLSOldConfigName     string = "tlsconfigold"
 )
 
 /* Initializes a server object compute if spider node*/

--- a/cluster/srv_set.go
+++ b/cluster/srv_set.go
@@ -239,9 +239,9 @@ func (server *ServerMonitor) SetDSN() {
 	} else {
 		server.DSN = mydsn()
 		if cluster.HaveDBTLSCert {
-			mysql.RegisterTLSConfig(ConstTLSCurrentConfig, cluster.tlsconf)
+			mysql.RegisterTLSConfig(ConstTLSCurrentConfigName, cluster.tlsconf)
 			if cluster.HaveDBTLSOldCert {
-				mysql.RegisterTLSConfig(ConstTLSOldConfig, cluster.tlsoldconf)
+				mysql.RegisterTLSConfig(ConstTLSOldConfigName, cluster.tlsoldconf)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Fix TLS config name mismatch in `mysql.RegisterTLSConfig()` that silently disables TLS
- `RegisterTLSConfig("&tls=tlsconfig", ...)` registers under wrong name — driver looks up `"tlsconfig"` from DSN but can't find it
- Splits `ConstTLSCurrentConfig`/`ConstTLSOldConfig` into separate DSN fragment and registration name constants

## Impact
- **All MySQL 8.4+ users affected** — `caching_sha2_password` (default auth) requires TLS for initial handshake
- Without this fix, repman silently connects without TLS, causing `Access denied` or `Authentication requires secure connection` errors
- Workaround: switch users to `mysql_native_password` + `REQUIRE NONE`

## Test plan
- [ ] Connect repman to MySQL 8.4 with `caching_sha2_password` + `REQUIRE SSL` users
- [ ] Verify `SHOW STATUS LIKE 'Ssl_cipher'` shows active TLS on repman's connection
- [ ] Verify failover/switchover works with TLS-required users