### PR TITLE
Fix : Align GetTables query scans and add coverage

### DIFF
--- a/utils/dbhelper/schema.go
+++ b/utils/dbhelper/schema.go
@@ -229,8 +229,9 @@ func getTableDDLCRC(db *sqlx.DB, myver *version.Version, schema, table string, c
 		return 0, ""
 	}
 
+	var tbl string
 	var ddl string
-	if err := db.QueryRowx(query).Scan(&ddl); err != nil {
+	if err := db.QueryRowx(query).Scan(&tbl, &ddl); err != nil {
 		return 0, query + "\n"
 	}
 
@@ -309,15 +310,12 @@ func getTableColumns(db *sqlx.DB, myver *version.Version, schema string, tablema
 
 func columnDefQuery(myver *version.Version, schema string) string {
 	if myver.IsPostgreSQL() {
-		return fmt.Sprintf(`SELECT '%s', table_name, column_name, ordinal_position, column_default,
-			is_nullable, data_type, character_maximum_length, numeric_precision, numeric_scale,
-			'' AS character_set_name, '' AS collation_name, udt_name AS column_type,
-			'' AS column_key, '' AS extra
+		return fmt.Sprintf(`SELECT '%s' AS table_schema, table_name, ordinal_position, column_name, udt_name AS column_type,
+			is_nullable, column_default, '' AS extra, '' AS character_set_name, '' AS collation_name
 			FROM information_schema.columns WHERE table_schema = 'public' ORDER BY table_name, ordinal_position`, schema)
 	}
-	return fmt.Sprintf(`SELECT table_schema, table_name, column_name, ordinal_position, column_default,
-		is_nullable, data_type, character_maximum_length, numeric_precision, numeric_scale,
-		character_set_name, collation_name, column_type, column_key, extra
+	return fmt.Sprintf(`SELECT table_schema, table_name, ordinal_position, column_name, column_type,
+		is_nullable, column_default, extra, character_set_name, collation_name
 		FROM information_schema.COLUMNS WHERE table_schema = '%s' ORDER BY table_name, ordinal_position`, schema)
 }
 
@@ -407,8 +405,8 @@ func indexDefQuery(myver *version.Version, schema string) string {
 	if myver.IsPostgreSQL() {
 		return ""
 	}
-	return fmt.Sprintf(`SELECT table_schema, table_name, non_unique, index_name, seq_in_index,
-		column_name, nullable, index_type, sub_part
+	return fmt.Sprintf(`SELECT table_schema, table_name, index_name, non_unique, index_type, seq_in_index,
+		column_name, sub_part
 		FROM information_schema.STATISTICS WHERE table_schema = '%s'
 		ORDER BY table_name, index_name, seq_in_index`, schema)
 }

--- a/utils/dbhelper/schema_test.go
+++ b/utils/dbhelper/schema_test.go
@@ -5,6 +5,7 @@
 package dbhelper
 
 import (
+	"hash/crc64"
 	"regexp"
 	"strings"
 	"testing"
@@ -211,6 +212,102 @@ func TestAnalyzeTableRejectsInvalidTableName(t *testing.T) {
 	if !strings.Contains(err.Error(), "invalid table name") {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestGetTablesQueryAlignment(t *testing.T) {
+	ver, _ := version.NewVersionFromString("MariaDB", "10.4.1-MariaDB")
+	if ver == nil {
+		t.Fatalf("failed to build version")
+	}
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	sqlxdb := sqlx.NewDb(db, "sqlmock")
+
+	schema := "testdb"
+	table := "widgets"
+	ddl := "CREATE TABLE `widgets` (`id` int(11) NOT NULL) ENGINE=InnoDB"
+	crcTable := crc64.MakeTable(0xC96C5795D7870F42)
+	expectedCRC := crc64.Checksum([]byte(ddl), crcTable)
+
+	schemaSQL := schemaQuery(ver)
+	mock.ExpectQuery(regexp.QuoteMeta(schemaSQL)).
+		WillReturnRows(sqlmock.NewRows([]string{"SCHEMA_NAME"}).AddRow(schema))
+
+	tablesSQL := tablesQuery(sqlxdb, ver, schema)
+	mock.ExpectQuery(regexp.QuoteMeta(tablesSQL)).
+		WillReturnRows(sqlmock.NewRows([]string{"table_schema", "table_name", "engine", "table_rows", "data_length", "index_length", "table_crc"}).
+			AddRow(schema, table, "InnoDB", 1, 1024, 0, 0))
+
+	ddlSQL := ddlQuery(ver, schema, table)
+	mock.ExpectQuery(regexp.QuoteMeta(ddlSQL)).
+		WillReturnRows(sqlmock.NewRows([]string{"Table", "Create Table"}).AddRow(table, ddl))
+
+	columnsSQL := columnDefQuery(ver, schema)
+	mock.ExpectQuery(regexp.QuoteMeta(columnsSQL)).
+		WillReturnRows(sqlmock.NewRows([]string{"table_schema", "table_name", "ordinal_position", "column_name", "column_type", "is_nullable", "column_default", "extra", "character_set_name", "collation_name"}).
+			AddRow(schema, table, 1, "id", "INT(11)", "NO", nil, "", nil, nil))
+
+	indexesSQL := indexDefQuery(ver, schema)
+	mock.ExpectQuery(regexp.QuoteMeta(indexesSQL)).
+		WillReturnRows(sqlmock.NewRows([]string{"table_schema", "table_name", "index_name", "non_unique", "index_type", "seq_in_index", "column_name", "sub_part"}).
+			AddRow(schema, table, "PRIMARY", 0, "BTREE", 1, "id", nil))
+
+	mapTables, listTables, _, err := GetTables(sqlxdb, ver, true, true)
+	if err != nil {
+		t.Fatalf("GetTables returned error: %v", err)
+	}
+
+	if len(mapTables) != 1 {
+		t.Fatalf("expected 1 table in map, got %d", len(mapTables))
+	}
+	if len(listTables) != 1 {
+		t.Fatalf("expected 1 table in list, got %d", len(listTables))
+	}
+
+	tableKey := schema + "." + table
+	resultTable, ok := mapTables[tableKey]
+	if !ok {
+		t.Fatalf("expected table %s in map", tableKey)
+	}
+	if resultTable.TableCrc != expectedCRC {
+		t.Fatalf("expected crc %d, got %d", expectedCRC, resultTable.TableCrc)
+	}
+	if len(resultTable.TableColumns) != 1 {
+		t.Fatalf("expected 1 column, got %d", len(resultTable.TableColumns))
+	}
+	if resultTable.TableColumns[0].Name != "id" {
+		t.Fatalf("expected column name id, got %s", resultTable.TableColumns[0].Name)
+	}
+	if resultTable.TableColumns[0].Type != "int(11)" {
+		t.Fatalf("expected column type int(11), got %s", resultTable.TableColumns[0].Type)
+	}
+	if len(resultTable.TableIndexes) != 1 {
+		t.Fatalf("expected 1 index, got %d", len(resultTable.TableIndexes))
+	}
+	if resultTable.TableIndexes[0].Name != "PRIMARY" {
+		t.Fatalf("expected index name PRIMARY, got %s", resultTable.TableIndexes[0].Name)
+	}
+	if !resultTable.TableIndexes[0].Unique {
+		t.Fatalf("expected PRIMARY index to be unique")
+	}
+	if resultTable.TableIndexes[0].Type != "BTREE" {
+		t.Fatalf("expected index type BTREE, got %s", resultTable.TableIndexes[0].Type)
+	}
+	if len(resultTable.TableIndexes[0].Columns) != 1 {
+		t.Fatalf("expected 1 index column, got %d", len(resultTable.TableIndexes[0].Columns))
+	}
+	if resultTable.TableIndexes[0].Columns[0].Name != "id" {
+		t.Fatalf("expected index column name id, got %s", resultTable.TableIndexes[0].Columns[0].Name)
+	}
+
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sqlmock expectations: %v", err)
 	}


### PR DESCRIPTION
Summary
- Fix schema query scan alignment so GetTables logs and DDL CRCs are populated reliably.
- Align column/index query shapes with their scan order to avoid silent scan errors.
- Add sqlmock unit test covering the schema query/DDL CRC path.
Testing
- go test ./utils/dbhelper -run TestGetTablesQueryAlignment