### PR TITLE
Add concurrent app refresh with configurable concurrency

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -757,7 +757,7 @@ func (cluster *Cluster) Run() {
 
 					// Preserved server state in proxy during reload config
 					if !cluster.IsInFailover() {
-						wg.Add(1)
+						wg.Add(2)
 						go cluster.refreshProxies(wg)
 						go cluster.refreshApps(wg)
 						cluster.CheckAppsCredit()

--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -486,25 +486,34 @@ func (cluster *Cluster) GetAppHATopology(appcnf *config.AppConfig) string {
 }
 
 func (cluster *Cluster) refreshApps(wg *sync.WaitGroup) {
+	defer wg.Done()
 
-	// if !cluster.Conf.AppOn {
-	// 	return // If the app module is not enabled, do not refresh apps
-	// }
+	var workerWg sync.WaitGroup
+	appChan := make(chan *App)
 
-	// Refresh the apps
+	workerCount := cluster.Conf.AppRefreshConcurrency
+	if workerCount <= 0 {
+		workerCount = 1
+	}
+
+	for range workerCount {
+		workerWg.Add(1)
+		go func() {
+			defer workerWg.Done()
+			for app := range appChan {
+				app.FetchStats()
+			}
+		}()
+	}
+
 	for _, app := range cluster.Apps {
 		if app != nil {
-			wg.Add(1)
-			go func(app *App, wg *sync.WaitGroup) {
-				defer wg.Done()
-				defer cluster.LogPanicToFile("refreshApps")
-				err := app.Refresh()
-				if err != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlErr, "Error refreshing app %s: %s", app.Name, err)
-				}
-			}(app, wg)
+			appChan <- app
 		}
 	}
+	close(appChan)
+
+	workerWg.Wait()
 }
 
 func (cluster *Cluster) EmitAppErrors() {

--- a/config/config.go
+++ b/config/config.go
@@ -644,6 +644,7 @@ type Config struct {
 	AppOn                                     bool   `mapstructure:"app" toml:"app" json:"app"`
 	AppHosts                                  string `mapstructure:"app-hosts" toml:"app-hosts" json:"appHosts"`
 	AppHostsIPV6                              string `mapstructure:"app-hosts-ipv6" toml:"app-hosts-ipv6" json:"appHostsIpv6"`
+	AppRefreshConcurrency                     int    `mapstructure:"app-refresh-concurrency" toml:"app-refresh-concurrency" json:"appRefreshConcurrency"`
 	ProvAppMem                                string `measurement:"M,bytes,required" mapstructure:"prov-app-memory" toml:"prov-app-memory" json:"provAppMemory" groups:"apps"`
 	ProvAppDisk                               string `measurement:"G,bytes,required" mapstructure:"prov-app-disk-size" toml:"prov-app-disk-size" json:"provAppDiskSize" groups:"apps"`
 	ProvAppVolumePools                        string `mapstructure:"prov-app-volume-pools" toml:"prov-app-volume-pools" json:"provAppVolumePools" groups:"apps"`

--- a/server/server.go
+++ b/server/server.go
@@ -1164,6 +1164,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.ProvDockerRegistryCredentials, "prov-docker-registry-credentials", "", "Docker registry credentials for private registry. Format: url:port:user:password")
 
 	flags.BoolVar(&conf.AppOn, "app-on", false, "Enable application mode")
+	flags.IntVar(&conf.AppRefreshConcurrency, "app-refresh-concurrency", 2, "Number of concurrent refresh for deployed apps")
 	flags.IntVar(&conf.LogAppLevel, "app-log-level", 3, "Log level for application")
 	flags.StringVar(&conf.ProvAppAgents, "prov-app-agents", "", "App agents for micro services provisionning.")
 	flags.StringVar(&conf.ProvAppDisk, "prov-app-disk-size", "4", "Disk in g for micro service VM. When cloud18 credit system is used, this is the base for 1 credit")


### PR DESCRIPTION
Summary
- run app refresh in parallel with proxy refresh during cluster run loop
- add a worker pool for app stats refresh with configurable concurrency
- introduce app-refresh-concurrency config/flag (default 2)
Notes
- no changes to app enablement behavior; concurrency only applies when apps are present