### PR TITLE
Add cross-platform unmount support for restic mount operations

### DIFF
--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -2003,7 +2003,7 @@ func ensureResticMountDir(targetDir string, mode os.FileMode) error {
 	if statErr != nil {
 		if errors.Is(statErr, syscall.ENOTCONN) {
 			_ = exec.Command("fusermount", "-u", targetDir).Run()
-			_ = syscall.Unmount(targetDir, syscall.MNT_DETACH)
+			_ = unmountPath(targetDir)
 			if err := os.MkdirAll(targetDir, mode); err != nil && !os.IsExist(err) {
 				return err
 			}
@@ -2153,7 +2153,7 @@ func unmountResticPath(targetDir string) error {
 			errs = append(errs, fmt.Sprintf("fusermount: %v", err))
 		}
 	}
-	if err := syscall.Unmount(path, syscall.MNT_DETACH); err != nil && !errors.Is(err, syscall.EINVAL) {
+	if err := unmountPath(path); err != nil {
 		errs = append(errs, fmt.Sprintf("unmount: %v", err))
 	} else {
 		return nil

--- a/utils/backupmgr/restic_unmount_darwin.go
+++ b/utils/backupmgr/restic_unmount_darwin.go
@@ -1,0 +1,17 @@
+//go:build darwin
+
+package backupmgr
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+func unmountPath(path string) error {
+	err := unix.Unmount(path, 0)
+	if err != nil && !errors.Is(err, unix.EINVAL) {
+		return err
+	}
+	return nil
+}

--- a/utils/backupmgr/restic_unmount_linux.go
+++ b/utils/backupmgr/restic_unmount_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package backupmgr
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+func unmountPath(path string) error {
+	err := unix.Unmount(path, unix.MNT_DETACH)
+	if err != nil && !errors.Is(err, unix.EINVAL) {
+		return err
+	}
+	return nil
+}

--- a/utils/backupmgr/restic_unmount_nonunix.go
+++ b/utils/backupmgr/restic_unmount_nonunix.go
@@ -1,0 +1,12 @@
+//go:build !unix
+
+package backupmgr
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func unmountPath(path string) error {
+	return fmt.Errorf("unmount not supported on %s", runtime.GOOS)
+}

--- a/utils/backupmgr/restic_unmount_unix_other.go
+++ b/utils/backupmgr/restic_unmount_unix_other.go
@@ -1,0 +1,17 @@
+//go:build unix && !linux && !darwin
+
+package backupmgr
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+func unmountPath(path string) error {
+	err := unix.Unmount(path, 0)
+	if err != nil && !errors.Is(err, unix.EINVAL) {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Replace syscall.MNT_DETACH (Linux-only) with OS-specific unmount helpers using golang.org/x/sys/unix package. This fixes build errors on macOS/Darwin where MNT_DETACH is undefined.

- restic_unmount_linux.go: Uses lazy unmount (MNT_DETACH) for Linux
- restic_unmount_darwin.go: Uses normal unmount (flag 0) for macOS
- restic_unmount_unix_other.go: Fallback for other Unix systems
- restic_unmount_nonunix.go: Returns error for non-Unix platforms