### PR TITLE
Improve checksum chunk processing and expose chunk type for reuse

### DIFF
--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -9,6 +9,7 @@ package cluster
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -705,15 +706,15 @@ func (cluster *Cluster) CheckTableChecksum(schema string, table string) {
 			return
 		}
 
-		var count int
-		err3 := Conn.QueryRowx("SELECT count(*) FROM replication_manager_schema.table_chunk").Scan(&count)
-		if err3 != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Checksum can't fetch rows remaining", err)
-			return
-		}
-		if count == 0 {
+		var dummy int
+		err3 := Conn.QueryRowx("SELECT 1 FROM replication_manager_schema.table_chunk LIMIT 1").Scan(&dummy)
+		if err3 == sql.ErrNoRows {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Finished checksum table %s.%s", schema, table)
 			break
+		}
+		if err3 != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Checksum error checking remaining chunks: %s", err3)
+			return
 		}
 		/*	slave := cluster.GetFirstWorkingSlave()
 			if slave != nil {

--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -9,7 +9,6 @@ package cluster
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -667,6 +666,28 @@ func (cluster *Cluster) CheckTableChecksum(schema string, table string) {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "ERROR: Could not process chunck %s %s", query, err)
 		return
 	}
+
+	rows, err := Conn.Queryx("SELECT chunkId, chunkMinKey, chunkMaxKey FROM replication_manager_schema.table_chunk")
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "ERROR: Could not load chunks %s", err)
+		return
+	}
+	var chunks []dbhelper.Chunk
+	for rows.Next() {
+		var c dbhelper.Chunk
+		if err := rows.Scan(&c.ChunkId, &c.ChunkMinKey, &c.ChunkMaxKey); err != nil {
+			rows.Close()
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "ERROR: Could not scan chunk %s", err)
+			return
+		}
+		chunks = append(chunks, c)
+	}
+	rows.Close()
+	if len(chunks) == 0 {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Finished checksum table %s.%s (no chunks)", schema, table)
+		return
+	}
+
 	var md5Sum string
 	err = Conn.QueryRowx("SELECT CONCAT( \"SUM(CRC32(CONCAT(\" , GROUP_CONCAT( CONCAT( \"IFNULL(\" , COLUMN_NAME, \",'N')\")),\")))\") as fields FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA ='" + schema + "' AND TABLE_NAME='" + table + "'").Scan(&md5Sum)
 	if err != nil {
@@ -692,37 +713,21 @@ func (cluster *Cluster) CheckTableChecksum(schema string, table string) {
 		predicate = predicate + " AND A." + p + " >= SUBSTRING_INDEX(SUBSTRING_INDEX(B.chunkMinKey,'/*;*/'," + strconv.Itoa(i+1) + "),'/*;*/',-1) and A." + p + "<= SUBSTRING_INDEX(SUBSTRING_INDEX(B.chunkMaxKey,'/*;*/'," + strconv.Itoa(i+1) + "),'/*;*/',-1)"
 	}
 
-	for {
-		query := "INSERT INTO replication_manager_schema.table_checksum SELECT chunkId, chunkMinKey , chunkMaxKey," + md5Sum + " as chunkCheckSum FROM " + schema + "." + table + " A inner join (select * from replication_manager_schema.table_chunk limit 1) B on " + predicate + " GROUP BY chunkId, chunkMinKey, chunkMaxKey HAVING chunkId IS NOT NULL"
-		_, err := Conn.Exec(query)
+	for i, chunk := range chunks {
+		query := "INSERT INTO replication_manager_schema.table_checksum SELECT chunkId, chunkMinKey , chunkMaxKey," + md5Sum + " as chunkCheckSum FROM " + schema + "." + table + " A inner join (SELECT * FROM replication_manager_schema.table_chunk WHERE chunkId=? AND chunkMinKey=? AND chunkMaxKey=? LIMIT 1) B on " + predicate + " GROUP BY chunkId, chunkMinKey, chunkMaxKey HAVING chunkId IS NOT NULL"
+		_, err := Conn.Exec(query, chunk.ChunkId, chunk.ChunkMinKey, chunk.ChunkMaxKey)
 		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "ERROR: Could not process chunck %s %s", query, err)
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "ERROR: Could not process chunk %d %s %s", i, query, err)
 			return
 		}
 
-		_, err2 := Conn.Exec("DELETE FROM replication_manager_schema.table_chunk limit 1")
+		_, err2 := Conn.Exec("DELETE FROM replication_manager_schema.table_chunk WHERE chunkId=? AND chunkMinKey=? AND chunkMaxKey=?", chunk.ChunkId, chunk.ChunkMinKey, chunk.ChunkMaxKey)
 		if err2 != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Checksum error deleting chunck %s", err)
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Checksum error deleting chunk %d %s", i, err)
 			return
 		}
-
-		var dummy int
-		err3 := Conn.QueryRowx("SELECT 1 FROM replication_manager_schema.table_chunk LIMIT 1").Scan(&dummy)
-		if err3 == sql.ErrNoRows {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Finished checksum table %s.%s", schema, table)
-			break
-		}
-		if err3 != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Checksum error checking remaining chunks: %s", err3)
-			return
-		}
-		/*	slave := cluster.GetFirstWorkingSlave()
-			if slave != nil {
-				if slave.GetReplicationDelay() > 5 {
-					time.Sleep(time.Duration(slave.GetReplicationDelay()) * time.Second)
-				}
-			}*/
 	}
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Finished checksum table %s.%s", schema, table)
 	cluster.master.Refresh()
 	masterSeq := cluster.master.CurrentGtid.GetSeqServerIdNos(uint64(cluster.master.ServerID))
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Wait sync: Master sequence %d", masterSeq)

--- a/utils/dbhelper/schema.go
+++ b/utils/dbhelper/schema.go
@@ -99,8 +99,8 @@ func SetEventStatus(db *sqlx.DB, ev Event, status int64) (string, error) {
 }
 
 // GetTableChecksumResult retrieves table checksum results
-func GetTableChecksumResult(db *sqlx.DB) (map[uint64]chunk, string, error) {
-	vars := make(map[uint64]chunk)
+func GetTableChecksumResult(db *sqlx.DB) (map[uint64]Chunk, string, error) {
+	vars := make(map[uint64]Chunk)
 	query := "SELECT /*replication-manager*/ * FROM replication_manager_schema.table_checksum"
 	rows, err := db.Queryx(query)
 	if err != nil {
@@ -108,7 +108,7 @@ func GetTableChecksumResult(db *sqlx.DB) (map[uint64]chunk, string, error) {
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var v chunk
+		var v Chunk
 		err = rows.Scan(&v.ChunkId, &v.ChunkMinKey, &v.ChunkMaxKey, &v.ChunkCheckSum)
 		if err != nil {
 			return vars, query, err

--- a/utils/dbhelper/types.go
+++ b/utils/dbhelper/types.go
@@ -40,7 +40,7 @@ type Plugin struct {
 }
 
 // chunk represents a table checksum chunk
-type chunk struct {
+type Chunk struct {
 	ChunkId       uint64 `json:"chunkId"`
 	ChunkMinKey   string `json:"chunkMinKey"`
 	ChunkMaxKey   string `json:"chunkMaxKey"`


### PR DESCRIPTION
**## Why**
Checksum execution was repeatedly querying and deleting `table_chunk` rows one-by-one (`LIMIT 1` flow), which adds avoidable overhead and makes chunk handling less explicit. We also needed the checksum chunk struct to be reusable across package boundaries.

**## What changed**
- Refactored checksum chunk processing in `CheckTableChecksum` to:
  - preload chunk metadata from `replication_manager_schema.table_chunk`,
  - process each chunk with parameterized predicates (`chunkId`, `chunkMinKey`, `chunkMaxKey`),
  - delete processed chunks by exact key tuple instead of `DELETE ... LIMIT 1`.
- Added explicit finish logging for the no-chunk case and normal completion path.
- Exported `dbhelper.Chunk` (formerly unexported `chunk`) and updated checksum result retrieval to return `map[uint64]Chunk`.

**## Impact**
- Reduces repeated chunk-table round trips during checksum runs.
- Makes per-chunk execution/deletion deterministic and easier to reason about.
- Improves type reuse for checksum-related logic in `dbhelper`.