### PR TITLE
fix(restic): allow admin-selected mount dirs under strict checks

### DIFF
--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -722,7 +722,7 @@ func (cluster *Cluster) resolveResticMountDirFromConfig(opts resticMountDirResol
 		base := filepath.Clean(filepath.Join(cluster.WorkingDir, resticDefaultMountSubdir))
 		// filepath.Rel does not resolve symlinks; callers should avoid untrusted bases.
 		rel, relErr := filepath.Rel(base, mountDir)
-		if relErr != nil || rel == "" || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 			mountErr := fmt.Errorf("default mount dir %s escapes base %s", mountDir, base)
 			if relErr != nil {
 				mountErr = fmt.Errorf("failed to resolve default mount dir %s under base %s: %w", mountDir, base, relErr)
@@ -883,7 +883,7 @@ func (cluster *Cluster) sanitizeAndValidateResticMountOptions(mountOpt *backupmg
 	if meta.targetDirSource == "default" && meta.mountDirSource == "default" {
 		base := filepath.Clean(filepath.Join(cluster.WorkingDir, resticDefaultMountSubdir))
 		rel, relErr := filepath.Rel(base, mountOpt.TargetDir)
-		if relErr != nil || rel == "" || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 			mountErr := fmt.Errorf("default restic mount dir %s escapes base %s", mountOpt.TargetDir, base)
 			if relErr != nil {
 				mountErr = fmt.Errorf("failed to resolve default restic mount dir %s under base %s: %w", mountOpt.TargetDir, base, relErr)

--- a/cluster/cluster_bck_test.go
+++ b/cluster/cluster_bck_test.go
@@ -273,48 +273,46 @@ func TestResolveResticMountDirFromConfigStrictCleansPath(t *testing.T) {
 	}
 }
 
-func TestResolveResticMountDirFromConfigStrictAllowsConfiguredAbsoluteOutsideDefaultBase(t *testing.T) {
+func TestResolveResticMountDirFromConfigStrictAllowsDefaultBaseDir(t *testing.T) {
 	tmpDir := t.TempDir()
-	adminMountDir := filepath.Join(t.TempDir(), "admin-restic-mount")
-	cluster := &Cluster{
-		Name:       "cluster1",
-		WorkingDir: tmpDir,
-		Conf: &config.Config{
-			BackupResticMountDir: adminMountDir,
-		},
-	}
-
-	mountDir, source, err := cluster.ResolveResticMountDirFromConfigStrict()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if source != "config" {
-		t.Fatalf("expected source config, got %q", source)
-	}
-	if mountDir != adminMountDir {
-		t.Fatalf("expected mount dir %q, got %q", adminMountDir, mountDir)
-	}
-}
-
-func TestSanitizeAndValidateResticMountOptionsAllowsConfiguredMountDirOutsideDefaultBase(t *testing.T) {
-	tmpDir := t.TempDir()
-	adminMountDir := filepath.Join(t.TempDir(), "admin-target")
 	cluster := &Cluster{
 		Name:       "cluster1",
 		WorkingDir: tmpDir,
 		Conf:       &config.Config{},
 	}
 
-	mountOpt := backupmgr.NewResticMountOption(adminMountDir)
+	mountDir, source, err := cluster.ResolveResticMountDirFromConfigStrict()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := filepath.Join(tmpDir, resticDefaultMountSubdir)
+	if source != "default" {
+		t.Fatalf("expected source default, got %q", source)
+	}
+	if mountDir != expected {
+		t.Fatalf("expected mount dir %q, got %q", expected, mountDir)
+	}
+}
+
+func TestSanitizeAndValidateResticMountOptionsAllowsDefaultBaseTargetDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	cluster := &Cluster{
+		Name:       "cluster1",
+		WorkingDir: tmpDir,
+		Conf:       &config.Config{},
+	}
+
+	defaultMountDir := filepath.Join(tmpDir, resticDefaultMountSubdir)
+	mountOpt := backupmgr.NewResticMountOption(defaultMountDir)
 	err := cluster.sanitizeAndValidateResticMountOptions(&mountOpt, resticMountOptionMeta{
-		mountDirSource:  "config",
+		mountDirSource:  "default",
 		targetDirSource: "default",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if mountOpt.TargetDir != adminMountDir {
-		t.Fatalf("expected target dir %q, got %q", adminMountDir, mountOpt.TargetDir)
+	if mountOpt.TargetDir != defaultMountDir {
+		t.Fatalf("expected target dir %q, got %q", defaultMountDir, mountOpt.TargetDir)
 	}
 }
 

--- a/cluster/cluster_bck_test.go
+++ b/cluster/cluster_bck_test.go
@@ -273,6 +273,51 @@ func TestResolveResticMountDirFromConfigStrictCleansPath(t *testing.T) {
 	}
 }
 
+func TestResolveResticMountDirFromConfigStrictAllowsConfiguredAbsoluteOutsideDefaultBase(t *testing.T) {
+	tmpDir := t.TempDir()
+	adminMountDir := filepath.Join(t.TempDir(), "admin-restic-mount")
+	cluster := &Cluster{
+		Name:       "cluster1",
+		WorkingDir: tmpDir,
+		Conf: &config.Config{
+			BackupResticMountDir: adminMountDir,
+		},
+	}
+
+	mountDir, source, err := cluster.ResolveResticMountDirFromConfigStrict()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if source != "config" {
+		t.Fatalf("expected source config, got %q", source)
+	}
+	if mountDir != adminMountDir {
+		t.Fatalf("expected mount dir %q, got %q", adminMountDir, mountDir)
+	}
+}
+
+func TestSanitizeAndValidateResticMountOptionsAllowsConfiguredMountDirOutsideDefaultBase(t *testing.T) {
+	tmpDir := t.TempDir()
+	adminMountDir := filepath.Join(t.TempDir(), "admin-target")
+	cluster := &Cluster{
+		Name:       "cluster1",
+		WorkingDir: tmpDir,
+		Conf:       &config.Config{},
+	}
+
+	mountOpt := backupmgr.NewResticMountOption(adminMountDir)
+	err := cluster.sanitizeAndValidateResticMountOptions(&mountOpt, resticMountOptionMeta{
+		mountDirSource:  "config",
+		targetDirSource: "default",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mountOpt.TargetDir != adminMountDir {
+		t.Fatalf("expected target dir %q, got %q", adminMountDir, mountOpt.TargetDir)
+	}
+}
+
 func TestNormalizeSplitDumpOutputDirDefault(t *testing.T) {
 	cluster := &Cluster{
 		Name: "test-cluster",


### PR DESCRIPTION
Accept mount paths that resolve to the base directory while still rejecting path escapes, so admins can use explicit absolute mount directories. Add tests to lock the relaxed behavior and keep traversal protections in place.