### PR TITLE
Allow remote restic repo without append

### DIFF
--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -34,6 +34,21 @@ func isS3ResticRepository(repoPath string) bool {
 	return strings.HasPrefix(strings.TrimSpace(repoPath), "s3:")
 }
 
+func isRemoteResticRepository(repoPath string) bool {
+	trimmed := strings.TrimSpace(repoPath)
+	if trimmed == "" {
+		return false
+	}
+	if strings.HasPrefix(trimmed, "s3:") {
+		return true
+	}
+	if strings.HasPrefix(trimmed, "sftp:") || strings.HasPrefix(trimmed, "rest:") || strings.HasPrefix(trimmed, "gs:") ||
+		strings.HasPrefix(trimmed, "azure:") || strings.HasPrefix(trimmed, "swift:") || strings.HasPrefix(trimmed, "b2:") {
+		return true
+	}
+	return strings.Contains(trimmed, "://")
+}
+
 func buildResticS3RepoSpec(endpoint, bucket, prefix, clusterName string, appendCluster bool) (string, string) {
 	bucket = strings.TrimSpace(bucket)
 	prefix = strings.Trim(prefix, "/")
@@ -148,6 +163,9 @@ func resolveResticRepoPolicy(conf *config.Config, localRepoPath string, cluster 
 		localRepoPath = ""
 	}
 	if !appendCluster && localRepoPath == "" {
+		if isRemoteResticRepository(conf.BackupResticRepository) {
+			return localRepoPath, appendCluster
+		}
 		if cluster != nil {
 			cluster.LogModulePrintf(conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
 				"backup-restic-repo-append-cluster=false ignored: backup-restic-local-repository is empty or invalid")

--- a/cluster/cluster_bck_test.go
+++ b/cluster/cluster_bck_test.go
@@ -970,6 +970,25 @@ func TestResolveResticRepoAppendClusterGuards(t *testing.T) {
 		t.Fatalf("expected local repo to remain empty when not configured")
 	}
 
+	conf.BackupResticRepository = "https://example.com/restic"
+	localRepo, shouldAppend = resolveResticRepoPolicy(conf, conf.BackupResticLocalRepository, cluster)
+	if shouldAppend {
+		t.Fatalf("expected append to remain disabled with remote restic repository")
+	}
+	if localRepo != "" {
+		t.Fatalf("expected local repo to remain empty when remote repo is configured")
+	}
+
+	conf.BackupResticRepository = "s3:https://minio.local/bucket"
+	localRepo, shouldAppend = resolveResticRepoPolicy(conf, conf.BackupResticLocalRepository, cluster)
+	if shouldAppend {
+		t.Fatalf("expected append to remain disabled with remote s3 restic repository")
+	}
+	if localRepo != "" {
+		t.Fatalf("expected local repo to remain empty when remote s3 repo is configured")
+	}
+	conf.BackupResticRepository = ""
+
 	defaultParent := filepath.Join(cluster.Conf.WorkingDir, config.ConstStreamingSubDir, "archive")
 	conf.BackupResticLocalRepository = defaultParent
 	localRepo, shouldAppend = resolveResticRepoPolicy(conf, conf.BackupResticLocalRepository, cluster)


### PR DESCRIPTION
Allow restic repo to use specific bucket or prefix without adding clustername as suffix