### PR TITLE
Skip restic append guard for AWS

### DIFF
--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -34,21 +34,6 @@ func isS3ResticRepository(repoPath string) bool {
 	return strings.HasPrefix(strings.TrimSpace(repoPath), "s3:")
 }
 
-func isRemoteResticRepository(repoPath string) bool {
-	trimmed := strings.TrimSpace(repoPath)
-	if trimmed == "" {
-		return false
-	}
-	if strings.HasPrefix(trimmed, "s3:") {
-		return true
-	}
-	if strings.HasPrefix(trimmed, "sftp:") || strings.HasPrefix(trimmed, "rest:") || strings.HasPrefix(trimmed, "gs:") ||
-		strings.HasPrefix(trimmed, "azure:") || strings.HasPrefix(trimmed, "swift:") || strings.HasPrefix(trimmed, "b2:") {
-		return true
-	}
-	return strings.Contains(trimmed, "://")
-}
-
 func buildResticS3RepoSpec(endpoint, bucket, prefix, clusterName string, appendCluster bool) (string, string) {
 	bucket = strings.TrimSpace(bucket)
 	prefix = strings.Trim(prefix, "/")
@@ -163,7 +148,7 @@ func resolveResticRepoPolicy(conf *config.Config, localRepoPath string, cluster 
 		localRepoPath = ""
 	}
 	if !appendCluster && localRepoPath == "" {
-		if isRemoteResticRepository(conf.BackupResticRepository) {
+		if conf.BackupResticAws {
 			return localRepoPath, appendCluster
 		}
 		if cluster != nil {

--- a/cluster/cluster_bck_test.go
+++ b/cluster/cluster_bck_test.go
@@ -970,24 +970,16 @@ func TestResolveResticRepoAppendClusterGuards(t *testing.T) {
 		t.Fatalf("expected local repo to remain empty when not configured")
 	}
 
-	conf.BackupResticRepository = "https://example.com/restic"
-	localRepo, shouldAppend = resolveResticRepoPolicy(conf, conf.BackupResticLocalRepository, cluster)
-	if shouldAppend {
-		t.Fatalf("expected append to remain disabled with remote restic repository")
-	}
-	if localRepo != "" {
-		t.Fatalf("expected local repo to remain empty when remote repo is configured")
-	}
-
-	conf.BackupResticRepository = "s3:https://minio.local/bucket"
-	localRepo, shouldAppend = resolveResticRepoPolicy(conf, conf.BackupResticLocalRepository, cluster)
-	if shouldAppend {
-		t.Fatalf("expected append to remain disabled with remote s3 restic repository")
-	}
-	if localRepo != "" {
-		t.Fatalf("expected local repo to remain empty when remote s3 repo is configured")
-	}
 	conf.BackupResticRepository = ""
+	conf.BackupResticAws = true
+	localRepo, shouldAppend = resolveResticRepoPolicy(conf, conf.BackupResticLocalRepository, cluster)
+	if shouldAppend {
+		t.Fatalf("expected append to remain disabled when AWS restic is enabled")
+	}
+	if localRepo != "" {
+		t.Fatalf("expected local repo to remain empty when AWS restic is enabled")
+	}
+	conf.BackupResticAws = false
 
 	defaultParent := filepath.Join(cluster.Conf.WorkingDir, config.ConstStreamingSubDir, "archive")
 	conf.BackupResticLocalRepository = defaultParent


### PR DESCRIPTION
Skip checking local restic repo with append guard when AWS is enabled, since it will use aws instead.