### PR TITLE
Add sysbench version discovery and storage

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -671,7 +671,7 @@ var pstates30 = []string{
 var pstates3600 = []string{
 	"WARN0094",             // Restic
 	"WARN0132", "WARN0137", // App templates
-	"WARN0117", "WARN0118", "WARN0119", "WARN0120", "WARN0121", "WARN0156", "WARN0157", // Tools versions
+	"WARN0117", "WARN0118", "WARN0119", "WARN0120", "WARN0121", "WARN0156", "WARN0157", "WARN0167", // Tools versions
 }
 
 func (cluster *Cluster) Run() {

--- a/cluster/cluster_tst.go
+++ b/cluster/cluster_tst.go
@@ -173,6 +173,19 @@ func (cluster *Cluster) prepareTpccParams(prx DatabaseProxy, command string, ove
 	return append(params, command)
 }
 
+func (cluster *Cluster) shouldUseSysbenchV1Syntax() bool {
+	tool, ok := cluster.GetToolsVersion("sysbench")
+	if ok && tool != nil {
+		// Defensive fallback for invalid placeholder version objects.
+		if tool.Major == 0 && tool.Minor == 0 && tool.Release == 0 {
+			return cluster.Conf.SysbenchV1 // deprecated
+		}
+		// Detected sysbench version takes precedence; config flag is fallback only.
+		return !tool.Lower("1.0")
+	}
+	return cluster.Conf.SysbenchV1
+}
+
 func (cluster *Cluster) PrepareBench() error {
 	prx := cluster.GetProxies()[0]
 	if prx == nil {
@@ -188,7 +201,7 @@ func (cluster *Cluster) PrepareBench() error {
 		var cmdprep *exec.Cmd
 		cmdprep = exec.Command(cluster.Conf.SysbenchBinaryPath, test, tablesize, "--db-driver=mysql", "--mysql-db=replication_manager_schema", "--mysql-user="+cluster.GetDbUser(), "--mysql-password="+cluster.GetDbPass(), "--mysql-host="+prx.GetHost(), "--mysql-port="+strconv.Itoa(prx.GetWritePort()), time, mode, requests, threads, "prepare")
 
-		if cluster.Conf.SysbenchV1 {
+		if cluster.shouldUseSysbenchV1Syntax() {
 			test = cluster.Conf.SysbenchTest
 			time = "--time=" + strconv.Itoa(cluster.Conf.SysbenchTime)
 			tablesize = "--table-size=1000000"
@@ -230,7 +243,7 @@ func (cluster *Cluster) CleanupBench() error {
 	prx := proxies[0]
 	if cluster.benchmarkType == "sysbench" {
 		test := "--test=oltp"
-		if cluster.Conf.SysbenchV1 {
+		if cluster.shouldUseSysbenchV1Syntax() {
 			test = cluster.Conf.SysbenchTest
 		}
 		var cleanup = cluster.Conf.SysbenchBinaryPath + test + " --db-driver=mysql --mysql-db=replication_manager_schema --mysql-user=" + cluster.GetDbUser() + " --mysql-password=" + cluster.GetDbPass() + " --mysql-host=" + prx.GetHost() + " --mysql-port=" + strconv.Itoa(prx.GetWritePort()) + " cleanup"
@@ -291,7 +304,7 @@ func (cluster *Cluster) RunSysBench(myTest string, myThreads string, mySize stri
 
 	var cmdrun *exec.Cmd
 	cmdrun = exec.Command(cluster.Conf.SysbenchBinaryPath, test, tablesize, "--db-driver=mysql", "--mysql-db=replication_manager_schema", "--mysql-user="+cluster.GetDbUser(), "--mysql-password="+cluster.GetDbPass(), "--mysql-host="+prx.GetHost(), "--mysql-port="+strconv.Itoa(prx.GetWritePort()), time, mode, requests, threads, "run")
-	if cluster.Conf.SysbenchV1 {
+	if cluster.shouldUseSysbenchV1Syntax() {
 		test = cluster.Conf.SysbenchTest
 		tablesize = "--table-size=" + mySize
 		threads = "--threads=" + myThreads

--- a/cluster/cluster_tst.go
+++ b/cluster/cluster_tst.go
@@ -173,17 +173,27 @@ func (cluster *Cluster) prepareTpccParams(prx DatabaseProxy, command string, ove
 	return append(params, command)
 }
 
-func (cluster *Cluster) shouldUseSysbenchV1Syntax() bool {
+func (cluster *Cluster) shouldUseSysbenchV1Syntax() (bool, error) {
+	tool, ok := cluster.GetToolsVersion("sysbench")
+	if !ok || tool == nil {
+		return false, fmt.Errorf("sysbench version not available")
+	}
+	return !tool.Lower("1.0"), nil
+}
+
+func (cluster *Cluster) ensureSysbenchVersionAvailable() error {
 	tool, ok := cluster.GetToolsVersion("sysbench")
 	if ok && tool != nil {
-		// Defensive fallback for invalid placeholder version objects.
-		if tool.Major == 0 && tool.Minor == 0 && tool.Release == 0 {
-			return cluster.Conf.SysbenchV1 // deprecated
-		}
-		// Detected sysbench version takes precedence; config flag is fallback only.
-		return !tool.Lower("1.0")
+		return nil
 	}
-	return cluster.Conf.SysbenchV1
+	if err := cluster.RefreshSysbenchVersion(); err != nil {
+		return err
+	}
+	tool, ok = cluster.GetToolsVersion("sysbench")
+	if !ok || tool == nil {
+		return fmt.Errorf("sysbench version not available after refresh")
+	}
+	return nil
 }
 
 func (cluster *Cluster) PrepareBench() error {
@@ -201,7 +211,18 @@ func (cluster *Cluster) PrepareBench() error {
 		var cmdprep *exec.Cmd
 		cmdprep = exec.Command(cluster.Conf.SysbenchBinaryPath, test, tablesize, "--db-driver=mysql", "--mysql-db=replication_manager_schema", "--mysql-user="+cluster.GetDbUser(), "--mysql-password="+cluster.GetDbPass(), "--mysql-host="+prx.GetHost(), "--mysql-port="+strconv.Itoa(prx.GetWritePort()), time, mode, requests, threads, "prepare")
 
-		if cluster.shouldUseSysbenchV1Syntax() {
+		if err := cluster.ensureSysbenchVersionAvailable(); err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Sysbench version check failed: %s", err)
+			return err
+		}
+
+		useV1Syntax, err := cluster.shouldUseSysbenchV1Syntax()
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Sysbench syntax selection failed: %s", err)
+			return err
+		}
+
+		if useV1Syntax {
 			test = cluster.Conf.SysbenchTest
 			time = "--time=" + strconv.Itoa(cluster.Conf.SysbenchTime)
 			tablesize = "--table-size=1000000"
@@ -242,8 +263,19 @@ func (cluster *Cluster) CleanupBench() error {
 
 	prx := proxies[0]
 	if cluster.benchmarkType == "sysbench" {
+		if err := cluster.ensureSysbenchVersionAvailable(); err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Sysbench version check failed: %s", err)
+			return err
+		}
+
+		useV1Syntax, err := cluster.shouldUseSysbenchV1Syntax()
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Sysbench syntax selection failed: %s", err)
+			return err
+		}
+
 		test := "--test=oltp"
-		if cluster.shouldUseSysbenchV1Syntax() {
+		if useV1Syntax {
 			test = cluster.Conf.SysbenchTest
 		}
 		var cleanup = cluster.Conf.SysbenchBinaryPath + test + " --db-driver=mysql --mysql-db=replication_manager_schema --mysql-user=" + cluster.GetDbUser() + " --mysql-password=" + cluster.GetDbPass() + " --mysql-host=" + prx.GetHost() + " --mysql-port=" + strconv.Itoa(prx.GetWritePort()) + " cleanup"
@@ -304,7 +336,19 @@ func (cluster *Cluster) RunSysBench(myTest string, myThreads string, mySize stri
 
 	var cmdrun *exec.Cmd
 	cmdrun = exec.Command(cluster.Conf.SysbenchBinaryPath, test, tablesize, "--db-driver=mysql", "--mysql-db=replication_manager_schema", "--mysql-user="+cluster.GetDbUser(), "--mysql-password="+cluster.GetDbPass(), "--mysql-host="+prx.GetHost(), "--mysql-port="+strconv.Itoa(prx.GetWritePort()), time, mode, requests, threads, "run")
-	if cluster.shouldUseSysbenchV1Syntax() {
+
+	if err := cluster.ensureSysbenchVersionAvailable(); err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Sysbench version check failed: %s", err)
+		return err
+	}
+
+	useV1Syntax, err := cluster.shouldUseSysbenchV1Syntax()
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Sysbench syntax selection failed: %s", err)
+		return err
+	}
+
+	if useV1Syntax {
 		test = cluster.Conf.SysbenchTest
 		tablesize = "--table-size=" + mySize
 		threads = "--threads=" + myThreads

--- a/cluster/cluster_tst_sysbench_version_test.go
+++ b/cluster/cluster_tst_sysbench_version_test.go
@@ -9,41 +9,46 @@ import (
 
 func TestShouldUseSysbenchV1Syntax(t *testing.T) {
 	tests := []struct {
-		name              string
-		detected          string
-		flagSysbenchV1    bool
-		injectZeroVersion bool
-		want              bool
+		name     string
+		detected string
+		want     bool
+		wantErr  bool
 	}{
-		{"detected <1.0 uses legacy syntax", "0.5.0", true, false, false},
-		{"detected >=1.0 uses v1 syntax", "1.0.20", false, false, true},
-		{"detected 1.1.0 uses v1 syntax", "1.1.0", true, false, true},
-		{"detected 1.0.0 uses v1 syntax", "1.0.0", false, false, true},
-		{"detected 0.14.0 uses legacy syntax", "0.14.0", true, false, false},
-		{"no detected version falls back to flag false", "", false, false, false},
-		{"no detected version falls back to flag true", "", true, false, true},
-		{"zero detected version falls back to flag false", "", false, true, false},
-		{"zero detected version falls back to flag true", "", true, true, true},
+		{"detected <1.0 uses legacy syntax", "0.5.0", false, false},
+		{"detected >=1.0 uses v1 syntax", "1.0.20", true, false},
+		{"detected 1.1.0 uses v1 syntax", "1.1.0", true, false},
+		{"detected 1.0.0 uses v1 syntax", "1.0.0", true, false},
+		{"detected 0.14.0 uses legacy syntax", "0.14.0", false, false},
+		{"no detected version returns error", "", false, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Cluster{
-				Conf:        &config.Config{SysbenchV1: tt.flagSysbenchV1},
+				Conf:        &config.Config{},
 				VersionsMap: config.NewVersionsMap(),
 			}
 
 			if tt.detected != "" {
-				v, _ := version.NewVersionFromString("sysbench", tt.detected)
+				v, tokens := version.NewVersionFromString("sysbench", tt.detected)
+				if v == nil || tokens == 0 {
+					t.Fatalf("failed to parse test version %q", tt.detected)
+				}
 				c.VersionsMap.Set("sysbench", v)
 			}
-			if tt.injectZeroVersion {
-				c.VersionsMap.Set("sysbench", &version.Version{Flavor: "sysbench"})
-			}
 
-			got := c.shouldUseSysbenchV1Syntax()
-			if got != tt.want {
-				t.Fatalf("got %v, want %v", got, tt.want)
+			got, err := c.shouldUseSysbenchV1Syntax()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != tt.want {
+					t.Fatalf("got %v, want %v", got, tt.want)
+				}
 			}
 		})
 	}

--- a/cluster/cluster_tst_sysbench_version_test.go
+++ b/cluster/cluster_tst_sysbench_version_test.go
@@ -1,0 +1,50 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/version"
+)
+
+func TestShouldUseSysbenchV1Syntax(t *testing.T) {
+	tests := []struct {
+		name              string
+		detected          string
+		flagSysbenchV1    bool
+		injectZeroVersion bool
+		want              bool
+	}{
+		{"detected <1.0 uses legacy syntax", "0.5.0", true, false, false},
+		{"detected >=1.0 uses v1 syntax", "1.0.20", false, false, true},
+		{"detected 1.1.0 uses v1 syntax", "1.1.0", true, false, true},
+		{"detected 1.0.0 uses v1 syntax", "1.0.0", false, false, true},
+		{"detected 0.14.0 uses legacy syntax", "0.14.0", true, false, false},
+		{"no detected version falls back to flag false", "", false, false, false},
+		{"no detected version falls back to flag true", "", true, false, true},
+		{"zero detected version falls back to flag false", "", false, true, false},
+		{"zero detected version falls back to flag true", "", true, true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Cluster{
+				Conf:        &config.Config{SysbenchV1: tt.flagSysbenchV1},
+				VersionsMap: config.NewVersionsMap(),
+			}
+
+			if tt.detected != "" {
+				v, _ := version.NewVersionFromString("sysbench", tt.detected)
+				c.VersionsMap.Set("sysbench", v)
+			}
+			if tt.injectZeroVersion {
+				c.VersionsMap.Set("sysbench", &version.Version{Flavor: "sysbench"})
+			}
+
+			got := c.shouldUseSysbenchV1Syntax()
+			if got != tt.want {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cluster/cluster_version.go
+++ b/cluster/cluster_version.go
@@ -26,6 +26,10 @@ func (cluster *Cluster) RefreshToolVersions() {
 		cluster.SetState("WARN0120", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0120"], err), ErrFrom: "CLUSTER"})
 	}
 
+	if err := cluster.RefreshSysbenchVersion(); err != nil {
+		cluster.SetState("WARN0167", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0167"], err), ErrFrom: "CLUSTER"})
+	}
+
 	if cluster.Conf.BackupRestic {
 		if err := cluster.RefreshResticVersion(); err != nil {
 			cluster.SetState("WARN0121", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0121"], err), ErrFrom: "CLUSTER"})
@@ -238,6 +242,51 @@ func (cluster *Cluster) RefreshMyDumperVersion() error {
 			return err
 		}
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "MyDumper version %s: %s", cstring, v.ToFullString())
+	}
+
+	return nil
+}
+
+func (cluster *Cluster) SetSysbenchVersion(v *version.Version) error {
+	if v == nil {
+		return fmt.Errorf("nil version provided")
+	}
+	cluster.VersionsMap.Set("sysbench", v)
+	cluster.GetStateMachine().DeleteState("WARN0167")
+
+	return nil
+}
+
+func (cluster *Cluster) RefreshSysbenchVersion() error {
+	cstring := "changed"
+	oldV, _ := cluster.GetToolsVersion("sysbench")
+	if oldV == nil {
+		cstring = "discovered"
+	}
+
+	out, err := exec.Command(cluster.Conf.SysbenchBinaryPath, "--version").Output()
+	if err != nil {
+		return err
+	}
+
+	rawOutput := string(out)
+	vstring := version.ExtractVersionFromOutput(rawOutput)
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Sysbench raw output: %s", rawOutput)
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Sysbench cleaned version string: %s", vstring)
+
+	v, _ := version.NewVersionFromString("sysbench", vstring)
+
+	hasChanged, err := version.HasVersionChanged(oldV, v)
+	if err != nil {
+		return err
+	}
+
+	if hasChanged {
+		if err := cluster.SetSysbenchVersion(v); err != nil {
+			return err
+		}
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Sysbench version %s: %s", cstring, v.ToFullString())
 	}
 
 	return nil

--- a/cluster/cluster_version.go
+++ b/cluster/cluster_version.go
@@ -275,7 +275,10 @@ func (cluster *Cluster) RefreshSysbenchVersion() error {
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Sysbench raw output: %s", rawOutput)
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Sysbench cleaned version string: %s", vstring)
 
-	v, _ := version.NewVersionFromString("sysbench", vstring)
+	v, tokens := version.NewVersionFromString("sysbench", vstring)
+	if tokens == 0 {
+		return fmt.Errorf("unable to parse sysbench version from string: %s (raw: %s)", vstring, rawOutput)
+	}
 
 	hasChanged, err := version.HasVersionChanged(oldV, v)
 	if err != nil {

--- a/cluster/cluster_version.go
+++ b/cluster/cluster_version.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/state"
@@ -26,8 +27,10 @@ func (cluster *Cluster) RefreshToolVersions() {
 		cluster.SetState("WARN0120", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0120"], err), ErrFrom: "CLUSTER"})
 	}
 
-	if err := cluster.RefreshSysbenchVersion(); err != nil {
-		cluster.SetState("WARN0167", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0167"], err), ErrFrom: "CLUSTER"})
+	if cluster.shouldRefreshSysbenchVersionPeriodically() {
+		if err := cluster.RefreshSysbenchVersion(); err != nil {
+			cluster.SetState("WARN0167", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0167"], err), ErrFrom: "CLUSTER"})
+		}
 	}
 
 	if cluster.Conf.BackupRestic {
@@ -257,6 +260,20 @@ func (cluster *Cluster) SetSysbenchVersion(v *version.Version) error {
 	return nil
 }
 
+func (cluster *Cluster) shouldRefreshSysbenchVersionPeriodically() bool {
+	path := strings.TrimSpace(cluster.Conf.SysbenchBinaryPath)
+
+	if path != "" && path != "/usr/bin/sysbench" {
+		return true
+	}
+
+	if cluster.Conf.Test || cluster.Conf.TestInjectTraffic || cluster.Conf.TestInjectTrafficStaging {
+		return true
+	}
+
+	return false
+}
+
 func (cluster *Cluster) RefreshSysbenchVersion() error {
 	cstring := "changed"
 	oldV, _ := cluster.GetToolsVersion("sysbench")
@@ -264,7 +281,7 @@ func (cluster *Cluster) RefreshSysbenchVersion() error {
 		cstring = "discovered"
 	}
 
-	out, err := exec.Command(cluster.Conf.SysbenchBinaryPath, "--version").Output()
+	out, err := exec.Command(cluster.Conf.SysbenchBinaryPath, "--version").CombinedOutput()
 	if err != nil {
 		return err
 	}

--- a/cluster/cluster_version_sysbench_gate_test.go
+++ b/cluster/cluster_version_sysbench_gate_test.go
@@ -1,0 +1,85 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+)
+
+func TestShouldRefreshSysbenchVersionPeriodically(t *testing.T) {
+	tests := []struct {
+		name                     string
+		sysbenchBinaryPath       string
+		test                     bool
+		testInjectTraffic        bool
+		testInjectTrafficStaging bool
+		want                     bool
+	}{
+		{
+			name:                     "default path no test flags",
+			sysbenchBinaryPath:       "/usr/bin/sysbench",
+			test:                     false,
+			testInjectTraffic:        false,
+			testInjectTrafficStaging: false,
+			want:                     false,
+		},
+		{
+			name:                     "empty path no test flags",
+			sysbenchBinaryPath:       "",
+			test:                     false,
+			testInjectTraffic:        false,
+			testInjectTrafficStaging: false,
+			want:                     false,
+		},
+		{
+			name:                     "non-default path",
+			sysbenchBinaryPath:       "/usr/local/bin/sysbench",
+			test:                     false,
+			testInjectTraffic:        false,
+			testInjectTrafficStaging: false,
+			want:                     true,
+		},
+		{
+			name:                     "default path with Test enabled",
+			sysbenchBinaryPath:       "/usr/bin/sysbench",
+			test:                     true,
+			testInjectTraffic:        false,
+			testInjectTrafficStaging: false,
+			want:                     true,
+		},
+		{
+			name:                     "default path with TestInjectTraffic enabled",
+			sysbenchBinaryPath:       "/usr/bin/sysbench",
+			test:                     false,
+			testInjectTraffic:        true,
+			testInjectTrafficStaging: false,
+			want:                     true,
+		},
+		{
+			name:                     "default path with TestInjectTrafficStaging enabled",
+			sysbenchBinaryPath:       "/usr/bin/sysbench",
+			test:                     false,
+			testInjectTraffic:        false,
+			testInjectTrafficStaging: true,
+			want:                     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Cluster{
+				Conf: &config.Config{
+					SysbenchBinaryPath:       tt.sysbenchBinaryPath,
+					Test:                     tt.test,
+					TestInjectTraffic:        tt.testInjectTraffic,
+					TestInjectTrafficStaging: tt.testInjectTrafficStaging,
+				},
+			}
+
+			got := c.shouldRefreshSysbenchVersionPeriodically()
+			if got != tt.want {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -486,7 +486,7 @@ type Config struct {
 	GraphiteCarbonPprofPort                   int    `scope:"server" mapstructure:"graphite-carbon-pprof-port" toml:"graphite-carbon-pprof-port" json:"graphiteCarbonPprofPort"`
 	SysbenchBinaryPath                        string `scope:"server" mapstructure:"sysbench-binary-path" toml:"sysbench-binary-path" json:"sysbenchBinaryPath"`
 	SysbenchTest                              string `mapstructure:"sysbench-test" toml:"sysbench-test" json:"sysbenchBinaryTest"`
-	SysbenchV1                                bool   `scope:"server" mapstructure:"sysbench-v1" toml:"sysbench-v1" json:"sysbenchV1"`
+	SysbenchV1                                bool   `scope:"server" mapstructure:"sysbench-v1" toml:"sysbench-v1" json:"sysbenchV1"` // deprecated, version is now detected by binary
 	SysbenchTime                              int    `mapstructure:"sysbench-time" toml:"sysbench-time" json:"sysbenchTime"`
 	SysbenchThreads                           int    `mapstructure:"sysbench-threads" toml:"sysbench-threads" json:"sysbenchThreads"`
 	SysbenchTables                            int    `mapstructure:"sysbench-tables" toml:"sysbench-tables" json:"sysbenchTables"`

--- a/config/error.go
+++ b/config/error.go
@@ -238,6 +238,7 @@ var ClusterError = map[string]string{
 	"WARN0164":  "Cluster %s has schema differences between master and slaves: %v",
 	"WARN0165":  "Restart container cookie deferred on %s: %s",
 	"WARN0166":  "Restic reseed queued on server %s (snapshot %s, method %s, strategy %s)",
+	"WARN0167":  "Failed to get sysbench version on repman: %s",
 	"MDEV20821": "MariaDB version has replication issue https://jira.mariadb.org/browse/MDEV-20821",
 	"MDEV28310": "MariaDB version has replication issue for non row format https://jira.mariadb.org/browse/MDEV-28310",
 	"MDEV19577": "MariaDB version has replication issue for non row format https://jira.mariadb.org/browse/MDEV-19577",

--- a/utils/version/version.go
+++ b/utils/version/version.go
@@ -86,7 +86,7 @@ func ExtractVersionFromOutput(output string) string {
 	// This handles outputs like "mydumper 0.11.5" or "restic 0.15.0"
 	// We only do this if no version marker was found, to avoid double-processing
 	if !foundMarker {
-		toolNames := []string{"mydumper ", "restic ", "mysql ", "mysqldump ", "mysqlbinlog "}
+		toolNames := []string{"mydumper ", "restic ", "mysql ", "mysqldump ", "mysqlbinlog ", "sysbench "}
 		for _, tool := range toolNames {
 			if strings.HasPrefix(output, tool) {
 				output = strings.TrimPrefix(output, tool)

--- a/utils/version/version_test.go
+++ b/utils/version/version_test.go
@@ -650,6 +650,16 @@ func TestExtractVersionFromOutput(t *testing.T) {
 			expected: "0.15.0 compiled with go1.19.5 on linux/amd64",
 		},
 		{
+			name:     "sysbench output",
+			input:    "sysbench 1.1.0 (using system LuaJIT 2.1.0-beta3)",
+			expected: "1.1.0 (using system LuaJIT 2.1.0-beta3)",
+		},
+		{
+			name:     "sysbench with path and version keyword",
+			input:    "/usr/local/bin/sysbench version 1.0.20 (using system LuaJIT 2.1.0-beta3)",
+			expected: "1.0.20 (using system LuaJIT 2.1.0-beta3)",
+		},
+		{
 			name:     "multiline output",
 			input:    "/usr/bin/mysql  Ver 8.0.28 for Linux on x86_64\nCopyright (c) 2000, 2023, Oracle",
 			expected: "8.0.28 for Linux on x86_64",


### PR DESCRIPTION
- Add RefreshSysbenchVersion() and SetSysbenchVersion() to cluster package
- Add WARN0167 warning for sysbench version detection failures
- Add sysbench to version extraction tool prefixes
- Add unit tests for sysbench version output parsing