### PR TITLE
fix(app): debounce transient APPERR flapping

### DIFF
--- a/cluster/app.go
+++ b/cluster/app.go
@@ -49,6 +49,7 @@ type App struct {
 	Weight               string                 `json:"weight"`
 	FailCount            int                    `json:"failCount"`
 	AppErrConsecutiveCnt int                    `json:"-"`
+	AppErrConsecutiveMap map[string]int         `json:"-"`
 	ErrState             map[string]state.State `json:"-"`
 	ClusterGroup         *Cluster               `json:"-"`
 	Process              *os.Process            `json:"process"`
@@ -110,6 +111,7 @@ func NewApp(placement int, cluster *Cluster, appHost string) *App {
 
 	app.RouteStatus = make([]config.RouteStatus, 0)
 	app.ErrState = make(map[string]state.State)
+	app.AppErrConsecutiveMap = make(map[string]int)
 	app.CheckPrimaryRoute()
 	return app
 }
@@ -142,18 +144,33 @@ func (app *App) ClearAppError() {
 	app.ErrState = make(map[string]state.State)
 }
 
-func (app *App) IncAppErrConsecutiveCnt() int {
+func (app *App) IncAppErrConsecutiveCnt(routeKey string) int {
 	app.Lock()
 	defer app.Unlock()
 
-	app.AppErrConsecutiveCnt++
-	return app.AppErrConsecutiveCnt
+	if app.AppErrConsecutiveMap == nil {
+		app.AppErrConsecutiveMap = make(map[string]int)
+	}
+	app.AppErrConsecutiveMap[routeKey]++
+	app.AppErrConsecutiveCnt = app.AppErrConsecutiveMap[routeKey]
+	return app.AppErrConsecutiveMap[routeKey]
 }
 
-func (app *App) ResetAppErrConsecutiveCnt() {
+func (app *App) ResetAppErrConsecutiveCnt(routeKey string) {
 	app.Lock()
 	defer app.Unlock()
 
+	if app.AppErrConsecutiveMap != nil {
+		delete(app.AppErrConsecutiveMap, routeKey)
+	}
+	app.AppErrConsecutiveCnt = 0
+}
+
+func (app *App) ResetAllAppErrConsecutiveCnt() {
+	app.Lock()
+	defer app.Unlock()
+
+	app.AppErrConsecutiveMap = make(map[string]int)
 	app.AppErrConsecutiveCnt = 0
 }
 

--- a/cluster/app.go
+++ b/cluster/app.go
@@ -26,6 +26,7 @@ const (
 	ErrAppUnexpectedStatus = "APPERR002"
 	ErrAppTCPConnectFailed = "APPERR003"
 	ErrAppUnsupportedProto = "APPERR004"
+	appErrFailureThreshold = 3
 )
 
 // App defines a app
@@ -47,6 +48,7 @@ type App struct {
 	Agent                string                 `json:"agent"`
 	Weight               string                 `json:"weight"`
 	FailCount            int                    `json:"failCount"`
+	AppErrConsecutiveCnt int                    `json:"-"`
 	ErrState             map[string]state.State `json:"-"`
 	ClusterGroup         *Cluster               `json:"-"`
 	Process              *os.Process            `json:"process"`
@@ -138,6 +140,21 @@ func (app *App) ClearAppError() {
 	defer app.Unlock()
 
 	app.ErrState = make(map[string]state.State)
+}
+
+func (app *App) IncAppErrConsecutiveCnt() int {
+	app.Lock()
+	defer app.Unlock()
+
+	app.AppErrConsecutiveCnt++
+	return app.AppErrConsecutiveCnt
+}
+
+func (app *App) ResetAppErrConsecutiveCnt() {
+	app.Lock()
+	defer app.Unlock()
+
+	app.AppErrConsecutiveCnt = 0
 }
 
 func (app *App) AddFlags(flags *pflag.FlagSet, conf *config.AppConfig) {

--- a/cluster/app.go
+++ b/cluster/app.go
@@ -31,24 +31,24 @@ const (
 
 // App defines a app
 type App struct {
-	Id                   string                 `json:"id" groups:"apps"`
-	Name                 string                 `json:"name" groups:"apps"`
-	Type                 string                 `json:"type" groups:"apps"`
-	Host                 string                 `json:"host" groups:"apps"`
-	HostIPV6             string                 `json:"hostIPV6"`
-	Port                 string                 `json:"port" groups:"apps"`
-	User                 string                 `json:"-"`
-	Pass                 string                 `json:"-"`
-	Version              string                 `json:"version" groups:"apps"`
-	Datadir              string                 `json:"datadir"`
-	State                string                 `json:"state"`
-	PrevState            string                 `json:"prevState"`
-	SlapOSDatadir        string                 `json:"slaposDatadir"`
-	ServiceName          string                 `json:"serviceName"`
-	Agent                string                 `json:"agent"`
-	Weight               string                 `json:"weight"`
-	FailCount            int                    `json:"failCount"`
-	AppErrConsecutiveCnt int                    `json:"-"`
+	Id            string `json:"id" groups:"apps"`
+	Name          string `json:"name" groups:"apps"`
+	Type          string `json:"type" groups:"apps"`
+	Host          string `json:"host" groups:"apps"`
+	HostIPV6      string `json:"hostIPV6"`
+	Port          string `json:"port" groups:"apps"`
+	User          string `json:"-"`
+	Pass          string `json:"-"`
+	Version       string `json:"version" groups:"apps"`
+	Datadir       string `json:"datadir"`
+	State         string `json:"state"`
+	PrevState     string `json:"prevState"`
+	SlapOSDatadir string `json:"slaposDatadir"`
+	ServiceName   string `json:"serviceName"`
+	Agent         string `json:"agent"`
+	Weight        string `json:"weight"`
+	FailCount     int    `json:"failCount"`
+	// Route-scoped debounce counters are the single source of truth.
 	AppErrConsecutiveMap map[string]int         `json:"-"`
 	ErrState             map[string]state.State `json:"-"`
 	ClusterGroup         *Cluster               `json:"-"`
@@ -152,7 +152,6 @@ func (app *App) IncAppErrConsecutiveCnt(routeKey string) int {
 		app.AppErrConsecutiveMap = make(map[string]int)
 	}
 	app.AppErrConsecutiveMap[routeKey]++
-	app.AppErrConsecutiveCnt = app.AppErrConsecutiveMap[routeKey]
 	return app.AppErrConsecutiveMap[routeKey]
 }
 
@@ -163,7 +162,6 @@ func (app *App) ResetAppErrConsecutiveCnt(routeKey string) {
 	if app.AppErrConsecutiveMap != nil {
 		delete(app.AppErrConsecutiveMap, routeKey)
 	}
-	app.AppErrConsecutiveCnt = 0
 }
 
 func (app *App) ResetAllAppErrConsecutiveCnt() {
@@ -171,7 +169,6 @@ func (app *App) ResetAllAppErrConsecutiveCnt() {
 	defer app.Unlock()
 
 	app.AppErrConsecutiveMap = make(map[string]int)
-	app.AppErrConsecutiveCnt = 0
 }
 
 func (app *App) AddFlags(flags *pflag.FlagSet, conf *config.AppConfig) {

--- a/cluster/app_chk.go
+++ b/cluster/app_chk.go
@@ -32,7 +32,7 @@ func (app *App) GetMonitoringStatus() string {
 		}
 		return fmt.Sprintf("%s://%s:%s", route.Protocol, app.GetHost(), route.Port)
 	}
-	debouncedRecordAppErr := func(routeKey string, states []state.State, routeErr error) bool {
+	debouncedRecordAppErr := func(routeKey string, states []state.State, routeErr error) {
 		failCount := app.IncAppErrConsecutiveCnt(routeKey)
 		if failCount < failureThreshold {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlDbg,
@@ -43,13 +43,12 @@ func (app *App) GetMonitoringStatus() string {
 				failCount,
 				failureThreshold,
 			)
-			return false
+			return
 		}
 
 		for _, st := range states {
 			errStates[st.ErrKey] = st
 		}
-		return true
 	}
 	markSuccessfulRouteCheck := func(routeKey string) {
 		app.ResetAppErrConsecutiveCnt(routeKey)

--- a/cluster/app_chk.go
+++ b/cluster/app_chk.go
@@ -19,59 +19,65 @@ func (app *App) GetMonitoringStatus() string {
 	cluster := app.ClusterGroup
 	routes := app.GetAppConfig().Deployment.Routes
 	var primaryStatus = stateAppRunning
-	appErrKeys := []string{ErrAppConnectFailed, ErrAppUnexpectedStatus, ErrAppUnsupportedProto}
+	appErrKeys := []string{ErrAppConnectFailed, ErrAppUnexpectedStatus, ErrAppTCPConnectFailed, ErrAppUnsupportedProto}
 	errStates := make(map[string]state.State)
+	failureThreshold := cluster.Conf.AppErrorDebounceThreshold
+	if failureThreshold <= 0 {
+		// Keep legacy default when the cluster-level override is unset/invalid.
+		failureThreshold = appErrFailureThreshold
+	}
 	routeEndpoint := func(route config.Route) string {
 		if route.CName != "" {
 			return fmt.Sprintf("%s://%s:%s", route.Protocol, route.CName, route.Port)
 		}
 		return fmt.Sprintf("%s://%s:%s", route.Protocol, app.GetHost(), route.Port)
 	}
-	debouncedRecordAppErr := func(key string, st state.State, routeEndpoint string, routeErr error) bool {
-		failCount := app.IncAppErrConsecutiveCnt()
-		if failCount < appErrFailureThreshold {
+	debouncedRecordAppErr := func(routeKey string, states []state.State, routeErr error) bool {
+		failCount := app.IncAppErrConsecutiveCnt(routeKey)
+		if failCount < failureThreshold {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlDbg,
 				"Debounced app check failure for app %s endpoint %s: %s (fail count %d/%d)",
 				app.Name,
-				routeEndpoint,
+				routeKey,
 				routeErr,
 				failCount,
-				appErrFailureThreshold,
+				failureThreshold,
 			)
 			return false
 		}
 
-		errStates[key] = st
+		for _, st := range states {
+			errStates[st.ErrKey] = st
+		}
 		return true
 	}
-	markSuccessfulRouteCheck := func() {
-		app.ResetAppErrConsecutiveCnt()
+	markSuccessfulRouteCheck := func(routeKey string) {
+		app.ResetAppErrConsecutiveCnt(routeKey)
 	}
 
 	if len(routes) == 0 {
-		emitted := debouncedRecordAppErr(
-			ErrAppConnectFailed,
-			state.State{ErrType: "WARN", ErrKey: ErrAppConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), "no routes defined"), ServerUrl: app.Host},
-			"no-routes-defined",
-			errors.New("no routes defined"),
-		)
-		if emitted {
-			app.RecordAppError(ErrAppConnectFailed, state.State{ErrType: "WARN", ErrKey: ErrAppConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), "no routes defined"), ServerUrl: app.Host})
-		} else {
-			app.ResetAppError(ErrAppConnectFailed)
+		errStates[ErrAppConnectFailed] = state.State{ErrType: "WARN", ErrKey: ErrAppConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), "no routes defined"), ServerUrl: app.Host}
+		app.ResetAllAppErrConsecutiveCnt()
+		for _, key := range appErrKeys {
+			if st, ok := errStates[key]; ok {
+				app.RecordAppError(key, st)
+			} else {
+				app.ResetAppError(key)
+			}
 		}
-		app.ResetAppError(ErrAppUnexpectedStatus, ErrAppTCPConnectFailed, ErrAppUnsupportedProto)
+		app.SetRouteStatuses(nil)
 		return stateFailed
 	}
 
 	routeStatuses := make([]config.RouteStatus, 0, len(routes))
 	for _, route := range routes {
+		routeKey := routeEndpoint(route)
 		routeStatus := config.RouteStatus{Route: route, Status: stateAppRunning}
 		switch route.Protocol {
 		case "https":
 			httpStatus, _, err := app.GetAppHTTPStatus(route, false)
 			if err == nil {
-				markSuccessfulRouteCheck()
+				markSuccessfulRouteCheck(routeKey)
 			} else {
 				routeStatus.Status = stateAppWarning
 				primaryStatus = stateAppWarning
@@ -93,12 +99,7 @@ func (app *App) GetMonitoringStatus() string {
 						errDesc = fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), err)
 					}
 
-					debouncedRecordAppErr(
-						errKey,
-						state.State{ErrType: "WARN", ErrKey: errKey, ErrDesc: errDesc, ServerUrl: app.Host},
-						routeEndpoint(route),
-						err,
-					)
+					debouncedRecordAppErr(routeKey, []state.State{{ErrType: "WARN", ErrKey: errKey, ErrDesc: errDesc, ServerUrl: app.Host}}, err)
 
 					if route.Primary {
 						primaryStatus = stateFailed
@@ -107,41 +108,36 @@ func (app *App) GetMonitoringStatus() string {
 					}
 					routeStatus.Status = stateFailed
 				} else {
-					markSuccessfulRouteCheck()
+					markSuccessfulRouteCheck(routeKey)
 				}
 			}
 		case "tcp":
 			// For TCP routes, we assume the app is running if it can connect
 			err := app.GetAppTCPStatus(route)
 			if err == nil {
-				markSuccessfulRouteCheck()
+				markSuccessfulRouteCheck(routeKey)
 			} else {
 				routeStatus.Status = stateAppWarning
 				primaryStatus = stateAppWarning
 
 				if err := app.GetAppLocalTCPStatus(route); err != nil {
-					debouncedRecordAppErr(
-						ErrAppConnectFailed,
-						state.State{ErrType: "WARN", ErrKey: ErrAppConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), err), ServerUrl: app.Host},
-						routeEndpoint(route),
-						err,
-					)
+					// Temporary compatibility: emit APPERR003 (canonical) and APPERR001 together.
+					debouncedRecordAppErr(routeKey, []state.State{
+						{ErrType: "WARN", ErrKey: ErrAppTCPConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppTCPConnectFailed], app.GetId(), err), ServerUrl: app.Host},
+						{ErrType: "WARN", ErrKey: ErrAppConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), err), ServerUrl: app.Host},
+					}, err)
 
 					routeStatus.Status = stateFailed
 					if route.Primary {
 						primaryStatus = stateFailed
 					}
 				} else {
-					markSuccessfulRouteCheck()
+					markSuccessfulRouteCheck(routeKey)
 				}
 			}
 		default:
-			debouncedRecordAppErr(
-				ErrAppUnsupportedProto,
-				state.State{ErrType: "WARN", ErrKey: ErrAppUnsupportedProto, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppUnsupportedProto], app.GetId(), route.Protocol), ServerUrl: app.Host},
-				routeEndpoint(route),
-				fmt.Errorf("unsupported protocol %s", route.Protocol),
-			)
+			errStates[ErrAppUnsupportedProto] = state.State{ErrType: "WARN", ErrKey: ErrAppUnsupportedProto, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppUnsupportedProto], route.Protocol, app.GetId()), ServerUrl: app.Host}
+			app.ResetAppErrConsecutiveCnt(routeKey)
 			routeStatus.Status = stateFailed
 
 			if route.Primary {
@@ -161,9 +157,6 @@ func (app *App) GetMonitoringStatus() string {
 			app.ResetAppError(key)
 		}
 	}
-	// APPERR003 is no longer emitted by app checks. Always clear legacy state.
-	app.ResetAppError(ErrAppTCPConnectFailed)
-
 	app.SetRouteStatuses(routeStatuses)
 
 	return primaryStatus

--- a/cluster/app_chk.go
+++ b/cluster/app_chk.go
@@ -16,18 +16,52 @@ import (
 )
 
 func (app *App) GetMonitoringStatus() string {
+	cluster := app.ClusterGroup
 	routes := app.GetAppConfig().Deployment.Routes
 	var primaryStatus = stateAppRunning
-	appErrKeys := []string{ErrAppConnectFailed, ErrAppUnexpectedStatus, ErrAppTCPConnectFailed, ErrAppUnsupportedProto}
-	if len(routes) == 0 {
-		app.RecordAppError(ErrAppConnectFailed, state.State{ErrType: "WARN", ErrKey: ErrAppConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), "no routes defined"), ServerUrl: app.Host})
-		app.ResetAppError(ErrAppUnexpectedStatus, ErrAppTCPConnectFailed, ErrAppUnsupportedProto)
-		return stateFailed
+	appErrKeys := []string{ErrAppConnectFailed, ErrAppUnexpectedStatus, ErrAppUnsupportedProto}
+	errStates := make(map[string]state.State)
+	routeEndpoint := func(route config.Route) string {
+		if route.CName != "" {
+			return fmt.Sprintf("%s://%s:%s", route.Protocol, route.CName, route.Port)
+		}
+		return fmt.Sprintf("%s://%s:%s", route.Protocol, app.GetHost(), route.Port)
+	}
+	debouncedRecordAppErr := func(key string, st state.State, routeEndpoint string, routeErr error) bool {
+		failCount := app.IncAppErrConsecutiveCnt()
+		if failCount < appErrFailureThreshold {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlDbg,
+				"Debounced app check failure for app %s endpoint %s: %s (fail count %d/%d)",
+				app.Name,
+				routeEndpoint,
+				routeErr,
+				failCount,
+				appErrFailureThreshold,
+			)
+			return false
+		}
+
+		errStates[key] = st
+		return true
+	}
+	markSuccessfulRouteCheck := func() {
+		app.ResetAppErrConsecutiveCnt()
 	}
 
-	errStates := make(map[string]state.State)
-	setErrState := func(key string, desc string) {
-		errStates[key] = state.State{ErrType: "WARN", ErrKey: key, ErrDesc: desc, ServerUrl: app.Host}
+	if len(routes) == 0 {
+		emitted := debouncedRecordAppErr(
+			ErrAppConnectFailed,
+			state.State{ErrType: "WARN", ErrKey: ErrAppConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), "no routes defined"), ServerUrl: app.Host},
+			"no-routes-defined",
+			errors.New("no routes defined"),
+		)
+		if emitted {
+			app.RecordAppError(ErrAppConnectFailed, state.State{ErrType: "WARN", ErrKey: ErrAppConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), "no routes defined"), ServerUrl: app.Host})
+		} else {
+			app.ResetAppError(ErrAppConnectFailed)
+		}
+		app.ResetAppError(ErrAppUnexpectedStatus, ErrAppTCPConnectFailed, ErrAppUnsupportedProto)
+		return stateFailed
 	}
 
 	routeStatuses := make([]config.RouteStatus, 0, len(routes))
@@ -36,50 +70,78 @@ func (app *App) GetMonitoringStatus() string {
 		switch route.Protocol {
 		case "https":
 			httpStatus, _, err := app.GetAppHTTPStatus(route, false)
-			if err != nil {
+			if err == nil {
+				markSuccessfulRouteCheck()
+			} else {
 				routeStatus.Status = stateAppWarning
 				primaryStatus = stateAppWarning
+
+				errKey := ErrAppConnectFailed
+				errDesc := fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), err)
 				if strings.HasPrefix(err.Error(), "unexpected status code") {
-					setErrState(ErrAppUnexpectedStatus, fmt.Sprintf(config.ClusterError[ErrAppUnexpectedStatus], app.GetId(), httpStatus))
-				} else {
-					setErrState(ErrAppConnectFailed, fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), err))
+					errKey = ErrAppUnexpectedStatus
+					errDesc = fmt.Sprintf(config.ClusterError[ErrAppUnexpectedStatus], app.GetId(), httpStatus)
 				}
 
 				httpStatus, _, err := app.GetAppLocalHTTPStatus(route, false)
 				if err != nil {
 					if strings.HasPrefix(err.Error(), "unexpected status code") {
-						setErrState(ErrAppUnexpectedStatus, fmt.Sprintf(config.ClusterError[ErrAppUnexpectedStatus], app.GetId(), httpStatus))
+						errKey = ErrAppUnexpectedStatus
+						errDesc = fmt.Sprintf(config.ClusterError[ErrAppUnexpectedStatus], app.GetId(), httpStatus)
 					} else {
-						setErrState(ErrAppConnectFailed, fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), err))
+						errKey = ErrAppConnectFailed
+						errDesc = fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), err)
 					}
 
-					routeStatus.Status = stateFailed
+					debouncedRecordAppErr(
+						errKey,
+						state.State{ErrType: "WARN", ErrKey: errKey, ErrDesc: errDesc, ServerUrl: app.Host},
+						routeEndpoint(route),
+						err,
+					)
+
 					if route.Primary {
 						primaryStatus = stateFailed
 					} else {
 						primaryStatus = stateAppWarning
 					}
+					routeStatus.Status = stateFailed
+				} else {
+					markSuccessfulRouteCheck()
 				}
 			}
 		case "tcp":
 			// For TCP routes, we assume the app is running if it can connect
 			err := app.GetAppTCPStatus(route)
-			if err != nil {
+			if err == nil {
+				markSuccessfulRouteCheck()
+			} else {
 				routeStatus.Status = stateAppWarning
 				primaryStatus = stateAppWarning
 
-				setErrState(ErrAppTCPConnectFailed, fmt.Sprintf(config.ClusterError[ErrAppTCPConnectFailed], app.GetId(), err))
-
 				if err := app.GetAppLocalTCPStatus(route); err != nil {
-					setErrState(ErrAppTCPConnectFailed, fmt.Sprintf(config.ClusterError[ErrAppTCPConnectFailed], app.GetId(), err))
+					debouncedRecordAppErr(
+						ErrAppConnectFailed,
+						state.State{ErrType: "WARN", ErrKey: ErrAppConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), err), ServerUrl: app.Host},
+						routeEndpoint(route),
+						err,
+					)
+
 					routeStatus.Status = stateFailed
 					if route.Primary {
 						primaryStatus = stateFailed
 					}
+				} else {
+					markSuccessfulRouteCheck()
 				}
 			}
 		default:
-			setErrState(ErrAppUnsupportedProto, fmt.Sprintf(config.ClusterError[ErrAppUnsupportedProto], app.GetId(), route.Protocol))
+			debouncedRecordAppErr(
+				ErrAppUnsupportedProto,
+				state.State{ErrType: "WARN", ErrKey: ErrAppUnsupportedProto, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppUnsupportedProto], app.GetId(), route.Protocol), ServerUrl: app.Host},
+				routeEndpoint(route),
+				fmt.Errorf("unsupported protocol %s", route.Protocol),
+			)
 			routeStatus.Status = stateFailed
 
 			if route.Primary {
@@ -99,6 +161,8 @@ func (app *App) GetMonitoringStatus() string {
 			app.ResetAppError(key)
 		}
 	}
+	// APPERR003 is no longer emitted by app checks. Always clear legacy state.
+	app.ResetAppError(ErrAppTCPConnectFailed)
 
 	app.SetRouteStatuses(routeStatuses)
 

--- a/cluster/app_chk.go
+++ b/cluster/app_chk.go
@@ -136,6 +136,7 @@ func (app *App) GetMonitoringStatus() string {
 				}
 			}
 		default:
+			// Keep APPERR004 argument order aligned with config.ClusterError format string.
 			errStates[ErrAppUnsupportedProto] = state.State{ErrType: "WARN", ErrKey: ErrAppUnsupportedProto, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppUnsupportedProto], route.Protocol, app.GetId()), ServerUrl: app.Host}
 			app.ResetAppErrConsecutiveCnt(routeKey)
 			routeStatus.Status = stateFailed

--- a/cluster/app_error_test.go
+++ b/cluster/app_error_test.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -11,6 +13,23 @@ import (
 
 func newTestApp() *App {
 	return &App{Mutex: &sync.Mutex{}}
+}
+
+func newMonitoringTestApp(routes []config.Route) *App {
+	return &App{
+		Id:       "app-test",
+		Name:     "app-test",
+		Host:     "127.0.0.1",
+		Mutex:    &sync.Mutex{},
+		ErrState: make(map[string]state.State),
+		AppConfig: &config.AppConfig{
+			Deployment: &config.Deployment{Routes: routes},
+		},
+		ClusterGroup: &Cluster{
+			Name: "test-cluster",
+			Conf: &config.Config{Timeout: 1},
+		},
+	}
 }
 
 func TestRecordAppErrorThreadSafe(t *testing.T) {
@@ -112,5 +131,100 @@ func TestSetRouteStatusesThreadSafe(t *testing.T) {
 	}
 	if app.RouteStatus[0].Route.CName != "final" {
 		t.Fatalf("expected final route status to be stored")
+	}
+}
+
+func TestGetMonitoringStatusDebouncesAppErrorsAtThreeFailures(t *testing.T) {
+	app := newMonitoringTestApp(nil)
+
+	for i := 1; i <= 2; i++ {
+		state := app.GetMonitoringStatus()
+		if state != stateFailed {
+			t.Fatalf("expected state %s on iteration %d, got %s", stateFailed, i, state)
+		}
+		if _, ok := app.ErrState[ErrAppConnectFailed]; ok {
+			t.Fatalf("did not expect %s before threshold, iteration %d", ErrAppConnectFailed, i)
+		}
+	}
+
+	state := app.GetMonitoringStatus()
+	if state != stateFailed {
+		t.Fatalf("expected state %s on threshold iteration, got %s", stateFailed, state)
+	}
+	if _, ok := app.ErrState[ErrAppConnectFailed]; !ok {
+		t.Fatalf("expected %s at threshold", ErrAppConnectFailed)
+	}
+}
+
+func TestGetMonitoringStatusResetsFailureCounterOnSuccessfulRouteCheck(t *testing.T) {
+	app := newMonitoringTestApp([]config.Route{{Protocol: "bad", CName: "invalid", Port: "80", Primary: true}})
+
+	app.GetMonitoringStatus()
+	app.GetMonitoringStatus()
+	if app.AppErrConsecutiveCnt != 2 {
+		t.Fatalf("expected debounce counter to be 2, got %d", app.AppErrConsecutiveCnt)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test tcp listener: %v", err)
+	}
+	defer ln.Close()
+
+	port := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+	app.AppConfig.Deployment.Routes = []config.Route{{Protocol: "tcp", CName: "127.0.0.1", Port: port, Primary: true}}
+
+	state := app.GetMonitoringStatus()
+	if state != stateAppRunning {
+		t.Fatalf("expected state %s after successful check, got %s", stateAppRunning, state)
+	}
+	if app.AppErrConsecutiveCnt != 0 {
+		t.Fatalf("expected debounce counter reset after success, got %d", app.AppErrConsecutiveCnt)
+	}
+
+	app.AppConfig.Deployment.Routes = []config.Route{{Protocol: "bad", CName: "invalid", Port: "80", Primary: true}}
+	app.GetMonitoringStatus()
+	if app.AppErrConsecutiveCnt != 1 {
+		t.Fatalf("expected debounce counter restart from 1 after success reset, got %d", app.AppErrConsecutiveCnt)
+	}
+	if _, ok := app.ErrState[ErrAppUnsupportedProto]; ok {
+		t.Fatalf("did not expect %s immediately after reset", ErrAppUnsupportedProto)
+	}
+}
+
+func TestGetMonitoringStatusMapsTCPConnectFailureToAPPERR001(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to allocate test tcp port: %v", err)
+	}
+	port := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+	ln.Close()
+
+	app := newMonitoringTestApp([]config.Route{{Protocol: "tcp", CName: "127.0.0.1", Port: port, Primary: true}})
+	// Seed legacy key to ensure app checks clear it under the new mapping.
+	app.RecordAppError(ErrAppTCPConnectFailed, state.State{ErrType: "WARN", ErrKey: ErrAppTCPConnectFailed})
+
+	for i := 1; i <= 2; i++ {
+		status := app.GetMonitoringStatus()
+		if status != stateFailed {
+			t.Fatalf("expected state %s on iteration %d, got %s", stateFailed, i, status)
+		}
+		if _, ok := app.ErrState[ErrAppConnectFailed]; ok {
+			t.Fatalf("did not expect %s before threshold, iteration %d", ErrAppConnectFailed, i)
+		}
+		if _, ok := app.ErrState[ErrAppTCPConnectFailed]; ok {
+			t.Fatalf("did not expect legacy key %s to persist, iteration %d", ErrAppTCPConnectFailed, i)
+		}
+	}
+
+	status := app.GetMonitoringStatus()
+	if status != stateFailed {
+		t.Fatalf("expected state %s on threshold iteration, got %s", stateFailed, status)
+	}
+	if _, ok := app.ErrState[ErrAppConnectFailed]; !ok {
+		t.Fatalf("expected %s at threshold", ErrAppConnectFailed)
+	}
+	if _, ok := app.ErrState[ErrAppTCPConnectFailed]; ok {
+		t.Fatalf("did not expect %s to be emitted for tcp failures", ErrAppTCPConnectFailed)
 	}
 }

--- a/cluster/app_error_test.go
+++ b/cluster/app_error_test.go
@@ -17,17 +17,18 @@ func newTestApp() *App {
 
 func newMonitoringTestApp(routes []config.Route) *App {
 	return &App{
-		Id:       "app-test",
-		Name:     "app-test",
-		Host:     "127.0.0.1",
-		Mutex:    &sync.Mutex{},
-		ErrState: make(map[string]state.State),
+		Id:                   "app-test",
+		Name:                 "app-test",
+		Host:                 "127.0.0.1",
+		Mutex:                &sync.Mutex{},
+		ErrState:             make(map[string]state.State),
+		AppErrConsecutiveMap: make(map[string]int),
 		AppConfig: &config.AppConfig{
 			Deployment: &config.Deployment{Routes: routes},
 		},
 		ClusterGroup: &Cluster{
 			Name: "test-cluster",
-			Conf: &config.Config{Timeout: 1},
+			Conf: &config.Config{Timeout: 1, AppErrorDebounceThreshold: 3},
 		},
 	}
 }
@@ -134,75 +135,8 @@ func TestSetRouteStatusesThreadSafe(t *testing.T) {
 	}
 }
 
-func TestGetMonitoringStatusDebouncesAppErrorsAtThreeFailures(t *testing.T) {
-	app := newMonitoringTestApp(nil)
-
-	for i := 1; i <= 2; i++ {
-		state := app.GetMonitoringStatus()
-		if state != stateFailed {
-			t.Fatalf("expected state %s on iteration %d, got %s", stateFailed, i, state)
-		}
-		if _, ok := app.ErrState[ErrAppConnectFailed]; ok {
-			t.Fatalf("did not expect %s before threshold, iteration %d", ErrAppConnectFailed, i)
-		}
-	}
-
-	state := app.GetMonitoringStatus()
-	if state != stateFailed {
-		t.Fatalf("expected state %s on threshold iteration, got %s", stateFailed, state)
-	}
-	if _, ok := app.ErrState[ErrAppConnectFailed]; !ok {
-		t.Fatalf("expected %s at threshold", ErrAppConnectFailed)
-	}
-}
-
-func TestGetMonitoringStatusResetsFailureCounterOnSuccessfulRouteCheck(t *testing.T) {
-	app := newMonitoringTestApp([]config.Route{{Protocol: "bad", CName: "invalid", Port: "80", Primary: true}})
-
-	app.GetMonitoringStatus()
-	app.GetMonitoringStatus()
-	if app.AppErrConsecutiveCnt != 2 {
-		t.Fatalf("expected debounce counter to be 2, got %d", app.AppErrConsecutiveCnt)
-	}
-
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("failed to start test tcp listener: %v", err)
-	}
-	defer ln.Close()
-
-	port := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
-	app.AppConfig.Deployment.Routes = []config.Route{{Protocol: "tcp", CName: "127.0.0.1", Port: port, Primary: true}}
-
-	state := app.GetMonitoringStatus()
-	if state != stateAppRunning {
-		t.Fatalf("expected state %s after successful check, got %s", stateAppRunning, state)
-	}
-	if app.AppErrConsecutiveCnt != 0 {
-		t.Fatalf("expected debounce counter reset after success, got %d", app.AppErrConsecutiveCnt)
-	}
-
-	app.AppConfig.Deployment.Routes = []config.Route{{Protocol: "bad", CName: "invalid", Port: "80", Primary: true}}
-	app.GetMonitoringStatus()
-	if app.AppErrConsecutiveCnt != 1 {
-		t.Fatalf("expected debounce counter restart from 1 after success reset, got %d", app.AppErrConsecutiveCnt)
-	}
-	if _, ok := app.ErrState[ErrAppUnsupportedProto]; ok {
-		t.Fatalf("did not expect %s immediately after reset", ErrAppUnsupportedProto)
-	}
-}
-
-func TestGetMonitoringStatusMapsTCPConnectFailureToAPPERR001(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("failed to allocate test tcp port: %v", err)
-	}
-	port := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
-	ln.Close()
-
-	app := newMonitoringTestApp([]config.Route{{Protocol: "tcp", CName: "127.0.0.1", Port: port, Primary: true}})
-	// Seed legacy key to ensure app checks clear it under the new mapping.
-	app.RecordAppError(ErrAppTCPConnectFailed, state.State{ErrType: "WARN", ErrKey: ErrAppTCPConnectFailed})
+func TestGetMonitoringStatusDebouncesOncePerRouteInvocation(t *testing.T) {
+	app := newMonitoringTestApp([]config.Route{{Protocol: "https", CName: "127.0.0.1:1", Port: "443", Primary: true}})
 
 	for i := 1; i <= 2; i++ {
 		status := app.GetMonitoringStatus()
@@ -211,9 +145,6 @@ func TestGetMonitoringStatusMapsTCPConnectFailureToAPPERR001(t *testing.T) {
 		}
 		if _, ok := app.ErrState[ErrAppConnectFailed]; ok {
 			t.Fatalf("did not expect %s before threshold, iteration %d", ErrAppConnectFailed, i)
-		}
-		if _, ok := app.ErrState[ErrAppTCPConnectFailed]; ok {
-			t.Fatalf("did not expect legacy key %s to persist, iteration %d", ErrAppTCPConnectFailed, i)
 		}
 	}
 
@@ -224,7 +155,127 @@ func TestGetMonitoringStatusMapsTCPConnectFailureToAPPERR001(t *testing.T) {
 	if _, ok := app.ErrState[ErrAppConnectFailed]; !ok {
 		t.Fatalf("expected %s at threshold", ErrAppConnectFailed)
 	}
+}
+
+func TestGetMonitoringStatusNoRoutesEmitsImmediately(t *testing.T) {
+	app := newMonitoringTestApp(nil)
+
+	status := app.GetMonitoringStatus()
+	if status != stateFailed {
+		t.Fatalf("expected state %s, got %s", stateFailed, status)
+	}
+	if _, ok := app.ErrState[ErrAppConnectFailed]; !ok {
+		t.Fatalf("expected immediate %s for no routes", ErrAppConnectFailed)
+	}
+}
+
+func TestGetMonitoringStatusUnsupportedProtocolEmitsImmediately(t *testing.T) {
+	app := newMonitoringTestApp([]config.Route{{Protocol: "bad", CName: "invalid", Port: "80", Primary: true}})
+
+	status := app.GetMonitoringStatus()
+	if status != stateFailed {
+		t.Fatalf("expected state %s, got %s", stateFailed, status)
+	}
+	if _, ok := app.ErrState[ErrAppUnsupportedProto]; !ok {
+		t.Fatalf("expected immediate %s", ErrAppUnsupportedProto)
+	}
+}
+
+func TestGetMonitoringStatusSuccessOnOneRouteDoesNotResetOtherRouteDebounce(t *testing.T) {
+	app := newMonitoringTestApp(nil)
+	app.ClusterGroup.Conf.AppErrorDebounceThreshold = 3
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test tcp listener: %v", err)
+	}
+	defer ln.Close()
+
+	port := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+	app.AppConfig.Deployment.Routes = []config.Route{
+		{Protocol: "tcp", CName: "127.0.0.1", Port: "1", Primary: true},
+		{Protocol: "tcp", CName: "127.0.0.1", Port: port, Primary: false},
+	}
+
+	for i := 1; i <= 2; i++ {
+		status := app.GetMonitoringStatus()
+		if status != stateFailed {
+			t.Fatalf("expected state %s on iteration %d, got %s", stateFailed, i, status)
+		}
+		if _, ok := app.ErrState[ErrAppTCPConnectFailed]; ok {
+			t.Fatalf("did not expect %s before threshold, iteration %d", ErrAppTCPConnectFailed, i)
+		}
+	}
+
+	status := app.GetMonitoringStatus()
+	if status != stateFailed {
+		t.Fatalf("expected state %s on threshold iteration, got %s", stateFailed, status)
+	}
+	if _, ok := app.ErrState[ErrAppTCPConnectFailed]; !ok {
+		t.Fatalf("expected %s at threshold", ErrAppTCPConnectFailed)
+	}
+}
+
+func TestGetMonitoringStatusTCPFailureDualEmissionWithConfigurableThreshold(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to allocate test tcp port: %v", err)
+	}
+	port := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+	ln.Close()
+
+	app := newMonitoringTestApp([]config.Route{{Protocol: "tcp", CName: "127.0.0.1", Port: port, Primary: true}})
+	app.ClusterGroup.Conf.AppErrorDebounceThreshold = 2
+
+	status := app.GetMonitoringStatus()
+	if status != stateFailed {
+		t.Fatalf("expected state %s on first iteration, got %s", stateFailed, status)
+	}
 	if _, ok := app.ErrState[ErrAppTCPConnectFailed]; ok {
-		t.Fatalf("did not expect %s to be emitted for tcp failures", ErrAppTCPConnectFailed)
+		t.Fatalf("did not expect %s before threshold", ErrAppTCPConnectFailed)
+	}
+	if _, ok := app.ErrState[ErrAppConnectFailed]; ok {
+		t.Fatalf("did not expect %s before threshold", ErrAppConnectFailed)
+	}
+
+	status = app.GetMonitoringStatus()
+	if status != stateFailed {
+		t.Fatalf("expected state %s on threshold iteration, got %s", stateFailed, status)
+	}
+	if _, ok := app.ErrState[ErrAppTCPConnectFailed]; !ok {
+		t.Fatalf("expected canonical %s at threshold", ErrAppTCPConnectFailed)
+	}
+	if _, ok := app.ErrState[ErrAppConnectFailed]; !ok {
+		t.Fatalf("expected compatibility %s at threshold", ErrAppConnectFailed)
+	}
+}
+
+func TestGetMonitoringStatusDefaultDebounceThresholdIsThree(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to allocate test tcp port: %v", err)
+	}
+	port := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+	ln.Close()
+
+	app := newMonitoringTestApp([]config.Route{{Protocol: "tcp", CName: "127.0.0.1", Port: port, Primary: true}})
+	app.ClusterGroup.Conf.AppErrorDebounceThreshold = 0
+
+	for i := 1; i <= 2; i++ {
+		status := app.GetMonitoringStatus()
+		if status != stateFailed {
+			t.Fatalf("expected state %s on iteration %d, got %s", stateFailed, i, status)
+		}
+		if _, ok := app.ErrState[ErrAppTCPConnectFailed]; ok {
+			t.Fatalf("did not expect %s before default threshold, iteration %d", ErrAppTCPConnectFailed, i)
+		}
+	}
+
+	status := app.GetMonitoringStatus()
+	if status != stateFailed {
+		t.Fatalf("expected state %s on threshold iteration, got %s", stateFailed, status)
+	}
+	if _, ok := app.ErrState[ErrAppTCPConnectFailed]; !ok {
+		t.Fatalf("expected %s at default threshold", ErrAppTCPConnectFailed)
 	}
 }

--- a/cluster/app_error_test.go
+++ b/cluster/app_error_test.go
@@ -241,14 +241,7 @@ func TestGetMonitoringStatusNoRoutesClearsAllRouteDebounceCounters(t *testing.T)
 }
 
 func TestGetMonitoringStatusTCPFailureDualEmissionWithConfigurableThreshold(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("failed to allocate test tcp port: %v", err)
-	}
-	port := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
-	ln.Close()
-
-	app := newMonitoringTestApp([]config.Route{{Protocol: "tcp", CName: "127.0.0.1", Port: port, Primary: true}})
+	app := newMonitoringTestApp([]config.Route{{Protocol: "tcp", CName: "127.0.0.1", Port: "1", Primary: true}})
 	app.ClusterGroup.Conf.AppErrorDebounceThreshold = 2
 
 	status := app.GetMonitoringStatus()
@@ -275,14 +268,7 @@ func TestGetMonitoringStatusTCPFailureDualEmissionWithConfigurableThreshold(t *t
 }
 
 func TestGetMonitoringStatusDefaultDebounceThresholdIsThree(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("failed to allocate test tcp port: %v", err)
-	}
-	port := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
-	ln.Close()
-
-	app := newMonitoringTestApp([]config.Route{{Protocol: "tcp", CName: "127.0.0.1", Port: port, Primary: true}})
+	app := newMonitoringTestApp([]config.Route{{Protocol: "tcp", CName: "127.0.0.1", Port: "1", Primary: true}})
 	app.ClusterGroup.Conf.AppErrorDebounceThreshold = 0
 
 	for i := 1; i <= 2; i++ {

--- a/cluster/app_error_test.go
+++ b/cluster/app_error_test.go
@@ -179,6 +179,10 @@ func TestGetMonitoringStatusUnsupportedProtocolEmitsImmediately(t *testing.T) {
 	if _, ok := app.ErrState[ErrAppUnsupportedProto]; !ok {
 		t.Fatalf("expected immediate %s", ErrAppUnsupportedProto)
 	}
+	expected := fmt.Sprintf(config.ClusterError[ErrAppUnsupportedProto], "bad", app.GetId())
+	if got := app.ErrState[ErrAppUnsupportedProto].ErrDesc; got != expected {
+		t.Fatalf("unexpected %s description: got %q want %q", ErrAppUnsupportedProto, got, expected)
+	}
 }
 
 func TestGetMonitoringStatusSuccessOnOneRouteDoesNotResetOtherRouteDebounce(t *testing.T) {
@@ -205,6 +209,12 @@ func TestGetMonitoringStatusSuccessOnOneRouteDoesNotResetOtherRouteDebounce(t *t
 		if _, ok := app.ErrState[ErrAppTCPConnectFailed]; ok {
 			t.Fatalf("did not expect %s before threshold, iteration %d", ErrAppTCPConnectFailed, i)
 		}
+		if got := app.AppErrConsecutiveMap["tcp://127.0.0.1:1"]; got != i {
+			t.Fatalf("expected failing route counter=%d, got %d", i, got)
+		}
+		if _, ok := app.AppErrConsecutiveMap[fmt.Sprintf("tcp://127.0.0.1:%s", port)]; ok {
+			t.Fatalf("did not expect successful route counter to be tracked")
+		}
 	}
 
 	status := app.GetMonitoringStatus()
@@ -213,6 +223,20 @@ func TestGetMonitoringStatusSuccessOnOneRouteDoesNotResetOtherRouteDebounce(t *t
 	}
 	if _, ok := app.ErrState[ErrAppTCPConnectFailed]; !ok {
 		t.Fatalf("expected %s at threshold", ErrAppTCPConnectFailed)
+	}
+}
+
+func TestGetMonitoringStatusNoRoutesClearsAllRouteDebounceCounters(t *testing.T) {
+	app := newMonitoringTestApp([]config.Route{{Protocol: "tcp", CName: "127.0.0.1", Port: "1", Primary: true}})
+	app.GetMonitoringStatus()
+	if len(app.AppErrConsecutiveMap) == 0 {
+		t.Fatalf("expected route debounce counters to be populated before reset")
+	}
+
+	app.AppConfig.Deployment.Routes = nil
+	app.GetMonitoringStatus()
+	if len(app.AppErrConsecutiveMap) != 0 {
+		t.Fatalf("expected all route debounce counters to be cleared, got %d", len(app.AppErrConsecutiveMap))
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -650,6 +650,7 @@ type Config struct {
 	AppOn                                     bool   `mapstructure:"app" toml:"app" json:"app"`
 	AppHosts                                  string `mapstructure:"app-hosts" toml:"app-hosts" json:"appHosts"`
 	AppHostsIPV6                              string `mapstructure:"app-hosts-ipv6" toml:"app-hosts-ipv6" json:"appHostsIpv6"`
+	AppErrorDebounceThreshold                 int    `mapstructure:"app-error-debounce-threshold" toml:"app-error-debounce-threshold" json:"appErrorDebounceThreshold"`
 	AppRefreshConcurrency                     int    `mapstructure:"app-refresh-concurrency" toml:"app-refresh-concurrency" json:"appRefreshConcurrency"`
 	ProvAppMem                                string `measurement:"M,bytes,required" mapstructure:"prov-app-memory" toml:"prov-app-memory" json:"provAppMemory" groups:"apps"`
 	ProvAppDisk                               string `measurement:"G,bytes,required" mapstructure:"prov-app-disk-size" toml:"prov-app-disk-size" json:"provAppDiskSize" groups:"apps"`

--- a/server/server.go
+++ b/server/server.go
@@ -1174,6 +1174,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.ProvDockerRegistryCredentials, "prov-docker-registry-credentials", "", "Docker registry credentials for private registry. Format: url:port:user:password")
 
 	flags.BoolVar(&conf.AppOn, "app-on", false, "Enable application mode")
+	flags.IntVar(&conf.AppErrorDebounceThreshold, "app-error-debounce-threshold", 3, "Consecutive app route failures before emitting runtime app errors")
 	flags.IntVar(&conf.AppRefreshConcurrency, "app-refresh-concurrency", 2, "Number of concurrent refresh for deployed apps")
 	flags.IntVar(&conf.LogAppLevel, "app-log-level", 3, "Log level for application")
 	flags.StringVar(&conf.ProvAppAgents, "prov-app-agents", "", "App agents for micro services provisionning.")


### PR DESCRIPTION
Only emit APPERR after three consecutive app check failures to reduce intermittent timeout noise, and map TCP connectivity failures to APPERR001 to keep connection diagnostics consistent.

## Contributor Agreement

By submitting this pull request, I agree to the terms outlined in the [Contributor Agreement](CONTRIBUTING.md).
