### PR TITLE
fix: reduce stale Database Jobs reads in dashboard and cluster API

### DIFF
--- a/cluster/cluster_job.go
+++ b/cluster/cluster_job.go
@@ -24,6 +24,8 @@ import (
 	"github.com/signal18/replication-manager/utils/state"
 )
 
+const jobsAPIDBRefreshMinInterval = 5 * time.Second
+
 func (cluster *Cluster) JobAnalyzeSQL(persistent bool) error {
 	var err error
 	var logs string
@@ -112,9 +114,9 @@ func (cluster *Cluster) JobsGetEntries() (config.JobEntries, error) {
 			continue
 		}
 		// When scheduler monitoring is disabled, there is no periodic invoker that
-		// reconciles runtime job cache with DB state. In that mode, refresh on API
-		// reads to keep entries aligned.
-		if !s.JobsHasEntries() || s.NeedRefreshJobs || !cluster.Conf.MonitorScheduler {
+		// reconciles runtime job cache with DB state. In that mode, allow API reads
+		// to refresh with a short minimum interval to avoid DB pressure under polling.
+		if !s.JobsHasEntries() || s.NeedRefreshJobsPending() || (!cluster.Conf.MonitorScheduler && s.HasJobsRefreshTTLExpired(jobsAPIDBRefreshMinInterval)) {
 			if err := s.JobsRefreshEntries(); err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "Jobs refresh skipped for %s: %s", s.URL, err)
 			}

--- a/cluster/cluster_job.go
+++ b/cluster/cluster_job.go
@@ -111,7 +111,10 @@ func (cluster *Cluster) JobsGetEntries() (config.JobEntries, error) {
 		if s == nil {
 			continue
 		}
-		if !s.JobsHasEntries() {
+		// When scheduler monitoring is disabled, there is no periodic invoker that
+		// reconciles runtime job cache with DB state. In that mode, refresh on API
+		// reads to keep entries aligned.
+		if !s.JobsHasEntries() || s.NeedRefreshJobs || !cluster.Conf.MonitorScheduler {
 			if err := s.JobsRefreshEntries(); err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "Jobs refresh skipped for %s: %s", s.URL, err)
 			}

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -215,6 +215,7 @@ type ServerMonitor struct {
 	IsRefreshingBinlogMeta      bool
 	IsLoadingJobList            bool
 	NeedRefreshJobs             bool
+	lastJobsRefreshAttempt      time.Time
 	PointInTimeMeta             backupmgr.PointInTimeMeta
 	BinaryLogDir                string
 	BinaryLogName               string
@@ -242,6 +243,7 @@ type ServerMonitor struct {
 	resticReseedCleanup      map[string]*ResticReseedCleanupEntry
 	jobCancelMutex           sync.Mutex
 	jobCancelEntries         map[string]*jobCancelEntry
+	jobRefreshStateMutex     sync.RWMutex
 }
 
 type ServerBackupMeta struct {
@@ -313,7 +315,7 @@ func (cluster *Cluster) newServerMonitor(url string, user string, pass string, c
 	server.LastBackupMeta.Logical = new(backupmgr.BackupMetadata)
 	server.BinaryLogMetaToWrite = make([]string, 0)
 	server.BinaryLogMetaToRemove = make([]string, 0)
-	server.NeedRefreshJobs = true
+	server.SetNeedRefreshJobs(true)
 
 	// Set source cluster name, set cluster name as source if not specified
 	// This is needed to make check more simple

--- a/cluster/srv_has.go
+++ b/cluster/srv_has.go
@@ -24,6 +24,34 @@ func (server *ServerMonitor) IsSemiSyncMaster() bool {
 	return server.Status.Get("RPL_SEMI_SYNC_MASTER_STATUS") == "ON" || server.Status.Get("RPL_SEMI_SYNC_SOURCE_STATUS") == "ON"
 }
 
+func (server *ServerMonitor) IsLoadingJobListActive() bool {
+	server.jobRefreshStateMutex.RLock()
+	defer server.jobRefreshStateMutex.RUnlock()
+	return server.IsLoadingJobList
+}
+
+func (server *ServerMonitor) NeedRefreshJobsPending() bool {
+	server.jobRefreshStateMutex.RLock()
+	defer server.jobRefreshStateMutex.RUnlock()
+	return server.NeedRefreshJobs
+}
+
+func (server *ServerMonitor) HasJobsRefreshTTLExpired(ttl time.Duration) bool {
+	if ttl <= 0 {
+		return true
+	}
+
+	server.jobRefreshStateMutex.RLock()
+	lastAttempt := server.lastJobsRefreshAttempt
+	server.jobRefreshStateMutex.RUnlock()
+
+	if lastAttempt.IsZero() {
+		return true
+	}
+
+	return time.Since(lastAttempt) >= ttl
+}
+
 func (server *ServerMonitor) IsSemiSyncReplica() bool {
 	// If MySQL or Percona 8.0 or greater
 	if server.DBVersion.IsMySQLOrPercona() && server.DBVersion.GreaterEqual("8.0") {

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -232,6 +232,10 @@ func jobTaskHasMeaningfulChanges(cached *config.Task, dbTask *config.Task) bool 
 }
 
 func shouldUpdateCachedJobTask(cached *config.Task, dbTask *config.Task) bool {
+	if dbTask == nil {
+		return false
+	}
+
 	if cached == nil {
 		return true
 	}
@@ -319,12 +323,11 @@ func (server *ServerMonitor) JobsRefreshEntries() error {
 	if server.Conn == nil {
 		return fmt.Errorf("No connection pool on %s", server.URL)
 	}
-	if server.IsLoadingJobList {
+	if !server.TryStartLoadingJobList() {
 		return errors.New("Waiting for previous update")
 	}
-
-	server.SetLoadingJobList(true)
 	defer server.SetLoadingJobList(false)
+	server.MarkJobsRefreshAttempt(time.Now())
 
 	conn, err := server.GetConnNoBinlog(server.Conn)
 	if err != nil {
@@ -838,11 +841,9 @@ func (server *ServerMonitor) JobsCheckStates() error {
 		return fmt.Errorf("No connection pool on %s", server.URL)
 	}
 
-	if server.IsLoadingJobList {
+	if !server.TryStartLoadingJobList() {
 		return errors.New("Waiting for previous update")
 	}
-
-	server.SetLoadingJobList(true)
 	defer server.SetLoadingJobList(false)
 
 	conn, err := server.GetConnNoBinlog(server.Conn)
@@ -861,7 +862,7 @@ func (server *ServerMonitor) JobsCheckStates() error {
 	server.JobsCheckErrors(conn)
 	server.JobsCheckPending(conn)
 
-	if server.NeedRefreshJobs {
+	if server.NeedRefreshJobsPending() {
 		err = server.JobsUpdateEntries(conn)
 		return err
 	}

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -202,6 +202,54 @@ func (server *ServerMonitor) jobsCreateTable() error {
 	return nil
 }
 
+func jobTaskFreshnessTimestamp(task *config.Task) int64 {
+	if task == nil {
+		return 0
+	}
+
+	if task.End > 0 {
+		return task.End
+	}
+
+	return task.Start
+}
+
+func jobTaskHasMeaningfulChanges(cached *config.Task, dbTask *config.Task) bool {
+	if cached == nil || dbTask == nil {
+		return cached != dbTask
+	}
+
+	return cached.Id != dbTask.Id ||
+		cached.Task != dbTask.Task ||
+		cached.Port != dbTask.Port ||
+		cached.Server != dbTask.Server ||
+		cached.Done != dbTask.Done ||
+		cached.State != dbTask.State ||
+		cached.Result != dbTask.Result ||
+		cached.Payload != dbTask.Payload ||
+		cached.Start != dbTask.Start ||
+		cached.End != dbTask.End
+}
+
+func shouldUpdateCachedJobTask(cached *config.Task, dbTask *config.Task) bool {
+	if cached == nil {
+		return true
+	}
+
+	dbFreshness := jobTaskFreshnessTimestamp(dbTask)
+	cachedFreshness := jobTaskFreshnessTimestamp(cached)
+
+	if dbFreshness > cachedFreshness {
+		return true
+	}
+
+	if dbFreshness < cachedFreshness {
+		return false
+	}
+
+	return jobTaskHasMeaningfulChanges(cached, dbTask)
+}
+
 func (server *ServerMonitor) JobsUpdateEntries(Conn *sqlx.Conn) error {
 	query := "SELECT id, task, port, server, done, state, result, payload, floor(UNIX_TIMESTAMP(start)) start, floor(UNIX_TIMESTAMP(end)) end FROM replication_manager_schema.jobs"
 
@@ -236,7 +284,9 @@ func (server *ServerMonitor) JobsUpdateEntries(Conn *sqlx.Conn) error {
 		t.Result = res.String
 		t.Payload = payload.String
 		t.End = end.Int64
-		if v, exists := server.JobResults.LoadOrStore(t.Task, &t); exists {
+		if v, exists := server.JobResults.LoadOrStore(t.Task, &t); !exists {
+			continue
+		} else if shouldUpdateCachedJobTask(v, &t) {
 			v.Set(t)
 		}
 	}

--- a/cluster/srv_job_helpers_test.go
+++ b/cluster/srv_job_helpers_test.go
@@ -1,0 +1,55 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+)
+
+func TestJobTaskFreshnessTimestamp(t *testing.T) {
+	tests := []struct {
+		name string
+		task *config.Task
+		want int64
+	}{
+		{name: "nil task", task: nil, want: 0},
+		{name: "use start when end not set", task: &config.Task{Start: 10, End: 0}, want: 10},
+		{name: "prefer end when present", task: &config.Task{Start: 10, End: 42}, want: 42},
+		{name: "zero timestamps", task: &config.Task{}, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := jobTaskFreshnessTimestamp(tt.task); got != tt.want {
+				t.Fatalf("jobTaskFreshnessTimestamp() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldUpdateCachedJobTask(t *testing.T) {
+	base := &config.Task{Task: "backup", Start: 100, End: 0, State: 1, Done: 0}
+
+	tests := []struct {
+		name   string
+		cached *config.Task
+		dbTask *config.Task
+		want   bool
+	}{
+		{name: "nil db task is ignored", cached: base, dbTask: nil, want: false},
+		{name: "missing cache should store db row", cached: nil, dbTask: &config.Task{Task: "backup", Start: 100}, want: true},
+		{name: "newer db timestamp updates cache", cached: &config.Task{Task: "backup", Start: 100, End: 0}, dbTask: &config.Task{Task: "backup", Start: 100, End: 101}, want: true},
+		{name: "older db timestamp does not overwrite", cached: &config.Task{Task: "backup", Start: 100, End: 150}, dbTask: &config.Task{Task: "backup", Start: 100, End: 120}, want: false},
+		{name: "equal timestamp unchanged payload", cached: &config.Task{Task: "backup", Start: 100, State: 1, Done: 0}, dbTask: &config.Task{Task: "backup", Start: 100, State: 1, Done: 0}, want: false},
+		{name: "equal timestamp with field change updates", cached: &config.Task{Task: "backup", Start: 100, State: 1, Done: 0}, dbTask: &config.Task{Task: "backup", Start: 100, State: 3, Done: 1}, want: true},
+		{name: "end beats start for freshness", cached: &config.Task{Task: "backup", Start: 100, End: 0}, dbTask: &config.Task{Task: "backup", Start: 50, End: 120}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldUpdateCachedJobTask(tt.cached, tt.dbTask); got != tt.want {
+				t.Fatalf("shouldUpdateCachedJobTask() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cluster/srv_set.go
+++ b/cluster/srv_set.go
@@ -420,7 +420,25 @@ func (server *ServerMonitor) SetWaitRunJobSSHCookie() error {
 }
 
 func (server *ServerMonitor) SetLoadingJobList(val bool) {
+	server.jobRefreshStateMutex.Lock()
 	server.IsLoadingJobList = val
+	server.jobRefreshStateMutex.Unlock()
+}
+
+func (server *ServerMonitor) TryStartLoadingJobList() bool {
+	server.jobRefreshStateMutex.Lock()
+	defer server.jobRefreshStateMutex.Unlock()
+	if server.IsLoadingJobList {
+		return false
+	}
+	server.IsLoadingJobList = true
+	return true
+}
+
+func (server *ServerMonitor) MarkJobsRefreshAttempt(at time.Time) {
+	server.jobRefreshStateMutex.Lock()
+	server.lastJobsRefreshAttempt = at
+	server.jobRefreshStateMutex.Unlock()
 }
 
 func (server *ServerMonitor) SetReplicationCredentialsRotation(ss *dbhelper.SlaveStatus) {
@@ -491,7 +509,9 @@ func (server *ServerMonitor) TrySetInReseedBackup(task string) (bool, string) {
 }
 
 func (server *ServerMonitor) SetNeedRefreshJobs(value bool) {
+	server.jobRefreshStateMutex.Lock()
 	server.NeedRefreshJobs = value
+	server.jobRefreshStateMutex.Unlock()
 }
 
 func (server *ServerMonitor) SetRestartNode(value string) {

--- a/share/dashboard_react/src/Pages/Home/index.jsx
+++ b/share/dashboard_react/src/Pages/Home/index.jsx
@@ -155,6 +155,14 @@ function Home() {
     )
   }
 
+  const refreshMaintenanceData = (clusterName) => {
+    dispatch(getResticSnapshot({ clusterName, filter: 'latest-per-session' }))
+    dispatch(getBackups({ clusterName }))
+    dispatch(getBackupStats({ clusterName }))
+    dispatch(getResticCurrentTask({ clusterName }))
+    dispatch(getJobs({ clusterName }))
+  }
+
   const callServices = () => {
     const isAutoReloadPaused = localStorage.getItem('pause_auto_reload')
 
@@ -192,11 +200,7 @@ function Home() {
         dispatch(getClusterCertificates({ clusterName: selectedClusterNameRef.current }))
       }
       if (dashboardTabsRef.current[selectedTabRef.current - 1] === 'Maintenance') {
-        dispatch(getResticSnapshot({ clusterName: selectedClusterNameRef.current, filter: 'latest-per-session' }))
-        dispatch(getBackups({ clusterName: selectedClusterNameRef.current }))
-        dispatch(getBackupStats({ clusterName: selectedClusterNameRef.current }))
-        dispatch(getResticCurrentTask({ clusterName: selectedClusterNameRef.current }))
-        dispatch(getJobs({ clusterName: selectedClusterNameRef.current }))
+        refreshMaintenanceData(selectedClusterNameRef.current)
       }
       if (dashboardTabsRef.current[selectedTabRef.current - 1] === 'Tops') {
         dispatch(getTopProcess({ clusterName: selectedClusterNameRef.current }))
@@ -220,6 +224,12 @@ function Home() {
       dispatch(setCluster({ data: null }))
       dispatch(setBaseURL({ baseURL: '' }))
       selectedClusterNameRef.current = ''
+    } else if (
+      isClusterOpenRef.current &&
+      selectedClusterNameRef.current &&
+      dashboardTabsRef.current[tabIndex - 1] === 'Maintenance'
+    ) {
+      refreshMaintenanceData(selectedClusterNameRef.current)
     }
   }
 
@@ -240,6 +250,9 @@ function Home() {
       const tabIndex = maintenanceIndex + 1
       selectedTabRef.current = tabIndex
       setSelectedTab(tabIndex)
+      if (selectedClusterNameRef.current) {
+        refreshMaintenanceData(selectedClusterNameRef.current)
+      }
     }
   }
   const openNewClusterModal = (e) => {

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -4,6 +4,7 @@ import { handleError, showErrorBanner, showSuccessBanner } from '../utility/comm
 import { get, isEqual } from 'lodash'
 
 const pendingKeySelectors = {
+  'cluster/getJobs': (arg) => arg?.clusterName,
   'cluster/getDatabaseService': (arg) => arg?.serviceName,
   'cluster/getAppService': (arg) => arg?.serviceName
 }
@@ -105,7 +106,9 @@ const fulfilledHandlers = {
     state.queryRules = action.payload.data
   },
   'cluster/getJobs': (state, action) => {
-    state.jobs = action.payload.data
+    if (action.meta?.arg?.clusterName === state.clusterData?.name) {
+      state.jobs = action.payload.data
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- refresh Maintenance job data immediately when entering the tab instead of waiting for the next poll
- prevent cross-cluster job response bleed in the React store
- refresh cluster job entries on API reads when scheduler-driven invokers lag, while only merging newer DB task state into cache
## Why
Database Jobs could appear stale even when the underlying job state had already advanced. The issue was a mix of delayed frontend fetch timing and server-side cache refresh behavior that depended too heavily on background invokers.
## Changes
- Dashboard:
  - trigger immediate Maintenance data fetch on tab entry
  - scope `getJobs` request de-duplication per cluster
  - guard Redux job updates so only the active cluster can overwrite job state
- Cluster:
  - refresh job entries when cache is empty, marked dirty, or scheduler monitoring is disabled
  - update cached job records from DB only when the DB row is newer, with same-timestamp field-change fallback
## Impact
- reduces stale Job views in Maintenance
- improves correctness when switching clusters
- makes cluster job entry reads more resilient when scheduler update timing lags