### PR TITLE
fix(terminal): Support OpenSVC container#jobs terminal

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -1796,6 +1796,7 @@ func logResponse(resp *http.Response) {
 // @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
 // @Param clusterName path string false "Cluster Name"
 // @Param serverName path string false "Server Name"
+// @Param rid query string false "OpenSVC server bash terminal container RID (allowed: container#db, container#jobs)"
 // @Success 200 {string} string "Connected successfully"
 // @Failure 400 {string} string "No user provided"
 // @Failure 500 {string} string "No valid node" or "No valid cluster"
@@ -1960,6 +1961,16 @@ func (repman *ReplicationManager) handlerTerminal(w http.ResponseWriter, r *http
 			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Error setting session values from node: %v", err)
 			session.SafeWriteMessage(websocket.TextMessage, []byte("Failed to set session values from node\n"))
 			return
+		}
+
+		selectedRID, shouldSetRID, err := resolveTerminalContainerRIDForSession(node != nil, session.CmdType, session.Orchestrator, r.URL.Query().Get("rid"))
+		if err != nil {
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Terminal session rid validation failed: %v", err)
+			session.SafeWriteMessage(websocket.TextMessage, []byte("Invalid rid parameter: "+err.Error()+"\n"))
+			return
+		}
+		if shouldSetRID {
+			session.ServiceContainerName = selectedRID
 		}
 
 		if session.CmdType == tty.TerminalBash {

--- a/server/server_tty.go
+++ b/server/server_tty.go
@@ -19,13 +19,9 @@ const (
 // resolveOpenSVCTerminalContainerRID validates and resolves the target OpenSVC
 // container resource for a terminal session.
 //
-// Existing server-terminal behavior is preserved by defaulting to
-// container#db when rid is empty.
+// Caller contract: rid must be non-empty. Empty/default behavior is handled by
+// resolveTerminalContainerRIDForSession.
 func resolveOpenSVCTerminalContainerRID(rid string) (string, error) {
-	if rid == "" {
-		return defaultServerServiceContainer, nil
-	}
-
 	switch rid {
 	case defaultServerServiceContainer, cluster.RestartRidJobsContainer:
 		return rid, nil

--- a/server/server_tty.go
+++ b/server/server_tty.go
@@ -11,6 +11,53 @@ import (
 	"github.com/signal18/replication-manager/utils/tty"
 )
 
+const (
+	defaultServerServiceContainer = "container#db"
+	defaultProxyServiceContainer  = "container#prx"
+)
+
+// resolveOpenSVCTerminalContainerRID validates and resolves the target OpenSVC
+// container resource for a terminal session.
+//
+// Existing server-terminal behavior is preserved by defaulting to
+// container#db when rid is empty.
+func resolveOpenSVCTerminalContainerRID(rid string) (string, error) {
+	if rid == "" {
+		return defaultServerServiceContainer, nil
+	}
+
+	switch rid {
+	case defaultServerServiceContainer, cluster.RestartRidJobsContainer:
+		return rid, nil
+	default:
+		return "", fmt.Errorf("invalid terminal rid: only '%s' or '%s' are allowed", defaultServerServiceContainer, cluster.RestartRidJobsContainer)
+	}
+}
+
+// resolveTerminalContainerRIDForSession validates whether rid is applicable for
+// the requested terminal type and returns the effective service container name.
+//
+// rid is only accepted for OpenSVC server bash terminals.
+func resolveTerminalContainerRIDForSession(isNodeTerminal bool, cmdType tty.TerminalCommandType, orchestrator string, rid string) (string, bool, error) {
+	if rid == "" {
+		if isNodeTerminal && cmdType == tty.TerminalBash && orchestrator == config.ConstOrchestratorOpenSVC {
+			return defaultServerServiceContainer, true, nil
+		}
+		return "", false, nil
+	}
+
+	if !isNodeTerminal || cmdType != tty.TerminalBash || orchestrator != config.ConstOrchestratorOpenSVC {
+		return "", false, fmt.Errorf("rid is only supported for OpenSVC server bash terminals")
+	}
+
+	selectedRID, err := resolveOpenSVCTerminalContainerRID(rid)
+	if err != nil {
+		return "", false, err
+	}
+
+	return selectedRID, true, nil
+}
+
 func (repman *ReplicationManager) InitWebTTY() {
 	// Initialize the session manager
 	stateFile := filepath.Join(repman.Conf.WorkingDir, "tty.state.json")
@@ -60,7 +107,7 @@ func (repman *ReplicationManager) SetSessionValuesFromNode(session *tty.Session,
 	mycluster := node.ClusterGroup
 	session.Orchestrator = mycluster.GetOrchestrator()
 	session.ServiceName = mycluster.Name + "/svc/" + node.Name
-	session.ServiceContainerName = "container#db"
+	session.ServiceContainerName = defaultServerServiceContainer
 	apiUser, ok := mycluster.APIUsers[session.Owner]
 	if !ok {
 		return fmt.Errorf("user %s not found in cluster %s", session.Owner, mycluster.Name)
@@ -123,7 +170,7 @@ func (repman *ReplicationManager) SetSessionValuesFromProxy(session *tty.Session
 	mycluster := proxy.GetCluster()
 	session.Orchestrator = mycluster.GetOrchestrator()
 	session.ServiceName = mycluster.Name + "/svc/" + proxy.GetName()
-	session.ServiceContainerName = "container#prx"
+	session.ServiceContainerName = defaultProxyServiceContainer
 	switch session.CmdType {
 	case tty.TerminalBash:
 		session.Port = strconv.Itoa(proxy.GetCluster().Conf.OnPremiseSSHPort)

--- a/server/server_tty_test.go
+++ b/server/server_tty_test.go
@@ -16,10 +16,10 @@ func TestResolveOpenSVCTerminalContainerRID(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "empty rid defaults to db container",
+			name:    "empty rid rejected by value validator",
 			rid:     "",
-			want:    defaultServerServiceContainer,
-			wantErr: false,
+			want:    "",
+			wantErr: true,
 		},
 		{
 			name:    "explicit db container accepted",

--- a/server/server_tty_test.go
+++ b/server/server_tty_test.go
@@ -1,0 +1,154 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/signal18/replication-manager/cluster"
+	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/tty"
+)
+
+func TestResolveOpenSVCTerminalContainerRID(t *testing.T) {
+	tests := []struct {
+		name    string
+		rid     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "empty rid defaults to db container",
+			rid:     "",
+			want:    defaultServerServiceContainer,
+			wantErr: false,
+		},
+		{
+			name:    "explicit db container accepted",
+			rid:     defaultServerServiceContainer,
+			want:    defaultServerServiceContainer,
+			wantErr: false,
+		},
+		{
+			name:    "explicit jobs container accepted",
+			rid:     cluster.RestartRidJobsContainer,
+			want:    cluster.RestartRidJobsContainer,
+			wantErr: false,
+		},
+		{
+			name:    "invalid rid rejected",
+			rid:     "container#prx",
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveOpenSVCTerminalContainerRID(tt.rid)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveOpenSVCTerminalContainerRID() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("resolveOpenSVCTerminalContainerRID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveTerminalContainerRIDForSession(t *testing.T) {
+	tests := []struct {
+		name           string
+		isNodeTerminal bool
+		cmdType        tty.TerminalCommandType
+		orchestrator   string
+		rid            string
+		wantRID        string
+		wantShouldSet  bool
+		wantErr        bool
+	}{
+		{
+			name:           "opensvc server bash defaults to db",
+			isNodeTerminal: true,
+			cmdType:        tty.TerminalBash,
+			orchestrator:   config.ConstOrchestratorOpenSVC,
+			rid:            "",
+			wantRID:        defaultServerServiceContainer,
+			wantShouldSet:  true,
+			wantErr:        false,
+		},
+		{
+			name:           "opensvc server bash jobs override accepted",
+			isNodeTerminal: true,
+			cmdType:        tty.TerminalBash,
+			orchestrator:   config.ConstOrchestratorOpenSVC,
+			rid:            cluster.RestartRidJobsContainer,
+			wantRID:        cluster.RestartRidJobsContainer,
+			wantShouldSet:  true,
+			wantErr:        false,
+		},
+		{
+			name:           "rid rejected for proxy bash terminal",
+			isNodeTerminal: false,
+			cmdType:        tty.TerminalBash,
+			orchestrator:   config.ConstOrchestratorOpenSVC,
+			rid:            cluster.RestartRidJobsContainer,
+			wantRID:        "",
+			wantShouldSet:  false,
+			wantErr:        true,
+		},
+		{
+			name:           "rid rejected for opensvc mysql terminal",
+			isNodeTerminal: true,
+			cmdType:        tty.TerminalMySQL,
+			orchestrator:   config.ConstOrchestratorOpenSVC,
+			rid:            cluster.RestartRidJobsContainer,
+			wantRID:        "",
+			wantShouldSet:  false,
+			wantErr:        true,
+		},
+		{
+			name:           "rid rejected for non-opensvc server bash",
+			isNodeTerminal: true,
+			cmdType:        tty.TerminalBash,
+			orchestrator:   config.ConstOrchestratorOnPremise,
+			rid:            cluster.RestartRidJobsContainer,
+			wantRID:        "",
+			wantShouldSet:  false,
+			wantErr:        true,
+		},
+		{
+			name:           "empty rid ignored for non-opensvc path",
+			isNodeTerminal: true,
+			cmdType:        tty.TerminalBash,
+			orchestrator:   config.ConstOrchestratorOnPremise,
+			rid:            "",
+			wantRID:        "",
+			wantShouldSet:  false,
+			wantErr:        false,
+		},
+		{
+			name:           "invalid opensvc rid rejected",
+			isNodeTerminal: true,
+			cmdType:        tty.TerminalBash,
+			orchestrator:   config.ConstOrchestratorOpenSVC,
+			rid:            "container#prx",
+			wantRID:        "",
+			wantShouldSet:  false,
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRID, gotShouldSet, err := resolveTerminalContainerRIDForSession(tt.isNodeTerminal, tt.cmdType, tt.orchestrator, tt.rid)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveTerminalContainerRIDForSession() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if gotRID != tt.wantRID {
+				t.Fatalf("resolveTerminalContainerRIDForSession() rid = %q, want %q", gotRID, tt.wantRID)
+			}
+			if gotShouldSet != tt.wantShouldSet {
+				t.Fatalf("resolveTerminalContainerRIDForSession() shouldSet = %v, want %v", gotShouldSet, tt.wantShouldSet)
+			}
+		})
+	}
+}

--- a/share/dashboard_react/package.json
+++ b/share/dashboard_react/package.json
@@ -7,7 +7,8 @@
     "dev": "vite --host=0.0.0.0 --port=3000",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:terminal-rid": "node src/Pages/Terminal/__tests__/ridUtils.test.js"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.10.5",

--- a/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
@@ -36,9 +36,7 @@ import {
 import { useState, useEffect, useCallback } from 'react'
 import { useHref } from 'react-router-dom'
 import { generateConfig } from '../../../../redux/configSlice'
-
-// Constants
-const JOBS_CONTAINER_RID = 'container#jobs'
+import { OpenSVCTerminalRID } from '../../../Terminal/ridUtils'
 
 /**
  * ServerMenu - Context menu for database server operations
@@ -415,7 +413,7 @@ function ServerMenu({
                               setConfirmTitle(`Confirm restart jobs container for ${serverName}?`)
                               setConfirmHandler(
                                 () => () =>
-                                  dispatch(restartDatabase({ clusterName, serverId: row.id, rid: JOBS_CONTAINER_RID }))
+                                  dispatch(restartDatabase({ clusterName, serverId: row.id, rid: OpenSVCTerminalRID.Jobs }))
                               )
                             }
                           }

--- a/share/dashboard_react/src/Pages/Terminal/__tests__/ridUtils.test.js
+++ b/share/dashboard_react/src/Pages/Terminal/__tests__/ridUtils.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+
+import {
+  normalizeRIDSearchParams,
+  OpenSVCTerminalRID,
+  resolveServiceContainerFromRID,
+  setRIDSearchParam,
+} from '../ridUtils.js'
+
+const runTests = () => {
+  assert.equal(resolveServiceContainerFromRID(null), OpenSVCTerminalRID.Default)
+  assert.equal(resolveServiceContainerFromRID('container#db'), OpenSVCTerminalRID.Default)
+  assert.equal(resolveServiceContainerFromRID('container#jobs'), OpenSVCTerminalRID.Jobs)
+  assert.equal(resolveServiceContainerFromRID('invalid'), OpenSVCTerminalRID.Default)
+
+  {
+    const { params, changed } = normalizeRIDSearchParams(new URLSearchParams('rid=container%23jobs'), false)
+    assert.equal(changed, true)
+    assert.equal(params.get('rid'), null)
+  }
+
+  {
+    const { params, changed } = normalizeRIDSearchParams(new URLSearchParams('rid=container%23jobs'), true)
+    assert.equal(changed, false)
+    assert.equal(params.get('rid'), OpenSVCTerminalRID.Jobs)
+  }
+
+  {
+    const { params, changed } = normalizeRIDSearchParams(new URLSearchParams('rid=container%23db'), true)
+    assert.equal(changed, true)
+    assert.equal(params.get('rid'), null)
+  }
+
+  {
+    const { params, changed } = normalizeRIDSearchParams(new URLSearchParams('rid=invalid'), true)
+    assert.equal(changed, true)
+    assert.equal(params.get('rid'), null)
+  }
+
+  {
+    const nextParams = setRIDSearchParam(new URLSearchParams('foo=bar'), OpenSVCTerminalRID.Jobs)
+    assert.equal(nextParams.get('foo'), 'bar')
+    assert.equal(nextParams.get('rid'), OpenSVCTerminalRID.Jobs)
+  }
+
+  {
+    const nextParams = setRIDSearchParam(new URLSearchParams('foo=bar&rid=container%23jobs'), OpenSVCTerminalRID.Default)
+    assert.equal(nextParams.get('foo'), 'bar')
+    assert.equal(nextParams.get('rid'), null)
+  }
+
+  console.log('ridUtils tests passed')
+}
+
+runTests()

--- a/share/dashboard_react/src/Pages/Terminal/index.jsx
+++ b/share/dashboard_react/src/Pages/Terminal/index.jsx
@@ -175,35 +175,51 @@ const TerminalComponent = () => {
   const handleDisconnect = () => {
     if (socketRef.current) {
       socketRef.current.close();
+      return;
     }
     setStatus('disconnected');
   };
 
   useEffect(() => {
     if (status === 'connecting' && url) {
+      if (socketRef.current && (socketRef.current.readyState === WebSocket.OPEN || socketRef.current.readyState === WebSocket.CONNECTING)) {
+        socketRef.current.close();
+      }
+
       // Once the WebSocket is connected, create the WebSocket instance
-      socketRef.current = new WebSocket(url);
+      const socket = new WebSocket(url);
+      socketRef.current = socket;
 
       // Attach the terminal to the WebSocket using AttachAddon
-      const attachAddon = new AttachAddon(socketRef.current);
+      const attachAddon = new AttachAddon(socket);
       terminalInstanceRef.current.loadAddon(attachAddon);
 
-      socketRef.current.onerror = () => {
+      socket.onerror = () => {
+        if (socketRef.current !== socket) {
+          return;
+        }
         console.error('WebSocket error');
         setStatus('error');
       };
 
-      socketRef.current.onopen = () => {
+      socket.onopen = () => {
+        if (socketRef.current !== socket) {
+          return;
+        }
         setStatus('connected');
-        socketRef.current.send(JSON.stringify({ type: 'auth', token: getTokenByBaseURL(baseURL) }));
+        socket.send(JSON.stringify({ type: 'auth', token: getTokenByBaseURL(baseURL) }));
       };
 
-      socketRef.current.onclose = () => {
+      socket.onclose = () => {
+        if (socketRef.current !== socket) {
+          return;
+        }
+        socketRef.current = null;
         setStatus('disconnected');
       };
 
     }
-  }, [status, url]);
+  }, [status, url, baseURL]);
 
   return (
     <PageContainer>

--- a/share/dashboard_react/src/Pages/Terminal/index.jsx
+++ b/share/dashboard_react/src/Pages/Terminal/index.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Box, chakra, HStack, Text } from '@chakra-ui/react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Box, chakra, HStack, Select, Text } from '@chakra-ui/react';
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import 'typeface-fira-code';
 import PageContainer from '../PageContainer';
 import { Terminal } from '@xterm/xterm';
@@ -12,6 +12,12 @@ import { useDispatch, useSelector } from 'react-redux';
 import { getClusterData } from '../../redux/clusterSlice';
 import RMButton from '../../components/RMButton';
 import { getTokenByBaseURL } from '../../services/apiHelper';
+import {
+  normalizeRIDSearchParams,
+  OpenSVCTerminalRID,
+  resolveServiceContainerFromRID,
+  setRIDSearchParam,
+} from './ridUtils';
 
 const ChakraLink = chakra(Link);
 
@@ -22,13 +28,44 @@ const TerminalComponent = () => {
   const terminalInstanceRef = useRef(null); // Store the terminal instance
   const socketRef = useRef(null); // Store the WebSocket connection in a ref for stability
   const { clusterName, serverName, proxyName, commandType } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
+  const [serviceContainer, setServiceContainer] = useState('container#db');
 
   const {
     cluster: { clusterData },
     auth: { baseURL },
   } = useSelector((state) => state);
   const dispatch = useDispatch();
+  const normalizedCommandType = (commandType || 'bash').toLowerCase();
+  const isOpenSVCServerShellTerminal = Boolean(clusterName && serverName) &&
+    normalizedCommandType === 'bash' &&
+    clusterData?.config?.provOrchestrator === 'opensvc';
+  const ridParam = searchParams.get('rid');
+
+  useEffect(() => {
+    if (!isOpenSVCServerShellTerminal) {
+      setServiceContainer(OpenSVCTerminalRID.Default);
+      return;
+    }
+
+    setServiceContainer(resolveServiceContainerFromRID(ridParam));
+  }, [isOpenSVCServerShellTerminal, ridParam]);
+
+  useEffect(() => {
+    const { params, changed } = normalizeRIDSearchParams(searchParams, isOpenSVCServerShellTerminal);
+    if (changed) {
+      setSearchParams(params, { replace: true });
+    }
+  }, [isOpenSVCServerShellTerminal, ridParam, searchParams, setSearchParams]);
+
+  const handleServiceContainerChange = (event) => {
+    const nextContainer = event.target.value;
+    setServiceContainer(nextContainer);
+
+    const nextParams = setRIDSearchParam(searchParams, nextContainer);
+    setSearchParams(nextParams, { replace: true });
+  };
 
   useEffect(() => {
     if (clusterName) {
@@ -126,6 +163,10 @@ const TerminalComponent = () => {
       websocketUrl += `/${commandType}`;
     }
 
+    if (isOpenSVCServerShellTerminal && serviceContainer === OpenSVCTerminalRID.Jobs) {
+      websocketUrl += `?rid=${encodeURIComponent(serviceContainer)}`;
+    }
+
     // Update state with the WebSocket URL
     setUrl(websocketUrl);
     setStatus('connecting');
@@ -187,6 +228,21 @@ const TerminalComponent = () => {
           </HStack>
         </HStack>
         <div ref={terminalRef} style={{ height: '75vh', width: '100%', border: '1px solid #000' }}></div>
+        {isOpenSVCServerShellTerminal && (
+          <HStack mt={3} spacing={3}>
+            <Text fontSize="sm">OpenSVC container</Text>
+            <Select
+              size="sm"
+              maxW="280px"
+              value={serviceContainer}
+              onChange={handleServiceContainerChange}
+              isDisabled={status === 'connected' || status === 'connecting'}
+            >
+              <option value={OpenSVCTerminalRID.Default}>container#db (default)</option>
+              <option value={OpenSVCTerminalRID.Jobs}>container#jobs</option>
+            </Select>
+          </HStack>
+        )}
         <div style={{ marginTop: '10px' }}>
           {status === 'connected' ? (
             <RMButton onClick={handleDisconnect}>Disconnect</RMButton>

--- a/share/dashboard_react/src/Pages/Terminal/index.jsx
+++ b/share/dashboard_react/src/Pages/Terminal/index.jsx
@@ -174,6 +174,8 @@ const TerminalComponent = () => {
 
   const handleDisconnect = () => {
     if (socketRef.current) {
+      // Intentionally defer status update to socket.onclose so UI reflects the
+      // actual websocket lifecycle (including any brief close handshake).
       socketRef.current.close();
       return;
     }

--- a/share/dashboard_react/src/Pages/Terminal/index.jsx
+++ b/share/dashboard_react/src/Pages/Terminal/index.jsx
@@ -30,7 +30,7 @@ const TerminalComponent = () => {
   const { clusterName, serverName, proxyName, commandType } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
-  const [serviceContainer, setServiceContainer] = useState('container#db');
+  const [serviceContainer, setServiceContainer] = useState(OpenSVCTerminalRID.Default);
 
   const {
     cluster: { clusterData },
@@ -38,26 +38,39 @@ const TerminalComponent = () => {
   } = useSelector((state) => state);
   const dispatch = useDispatch();
   const normalizedCommandType = (commandType || 'bash').toLowerCase();
-  const isOpenSVCServerShellTerminal = Boolean(clusterName && serverName) &&
-    normalizedCommandType === 'bash' &&
+  const isServerTerminal = Boolean(clusterName && serverName);
+  const isShellTerminal = normalizedCommandType === 'bash';
+  const requiresClusterContext = isServerTerminal && isShellTerminal;
+  const isTerminalContextKnown = !requiresClusterContext || clusterData?.name === clusterName;
+  const isOpenSVCServerShellTerminal = isTerminalContextKnown &&
+    isServerTerminal &&
+    isShellTerminal &&
     clusterData?.config?.provOrchestrator === 'opensvc';
   const ridParam = searchParams.get('rid');
 
   useEffect(() => {
+    if (!isTerminalContextKnown) {
+      return;
+    }
+
     if (!isOpenSVCServerShellTerminal) {
       setServiceContainer(OpenSVCTerminalRID.Default);
       return;
     }
 
     setServiceContainer(resolveServiceContainerFromRID(ridParam));
-  }, [isOpenSVCServerShellTerminal, ridParam]);
+  }, [isOpenSVCServerShellTerminal, isTerminalContextKnown, ridParam]);
 
   useEffect(() => {
+    if (!isTerminalContextKnown) {
+      return;
+    }
+
     const { params, changed } = normalizeRIDSearchParams(searchParams, isOpenSVCServerShellTerminal);
     if (changed) {
       setSearchParams(params, { replace: true });
     }
-  }, [isOpenSVCServerShellTerminal, ridParam, searchParams, setSearchParams]);
+  }, [isOpenSVCServerShellTerminal, isTerminalContextKnown, ridParam, searchParams, setSearchParams]);
 
   const handleServiceContainerChange = (event) => {
     const nextContainer = event.target.value;

--- a/share/dashboard_react/src/Pages/Terminal/ridUtils.js
+++ b/share/dashboard_react/src/Pages/Terminal/ridUtils.js
@@ -1,0 +1,45 @@
+const DEFAULT_RID = 'container#db'
+const JOBS_RID = 'container#jobs'
+
+export const OpenSVCTerminalRID = {
+  Default: DEFAULT_RID,
+  Jobs: JOBS_RID,
+}
+
+export const resolveServiceContainerFromRID = (rid) => {
+  return rid === JOBS_RID ? JOBS_RID : DEFAULT_RID
+}
+
+// Keep rid query parameter only when it carries a meaningful non-default
+// selection for OpenSVC server shell terminals.
+export const normalizeRIDSearchParams = (searchParams, isOpenSVCServerShellTerminal) => {
+  const nextParams = new URLSearchParams(searchParams)
+  const rid = nextParams.get('rid')
+
+  if (!isOpenSVCServerShellTerminal) {
+    if (rid !== null) {
+      nextParams.delete('rid')
+      return { params: nextParams, changed: true }
+    }
+    return { params: nextParams, changed: false }
+  }
+
+  if (rid === null || rid === JOBS_RID) {
+    return { params: nextParams, changed: false }
+  }
+
+  // Normalize unsupported/default values back to canonical default behavior
+  // represented by absence of rid query parameter.
+  nextParams.delete('rid')
+  return { params: nextParams, changed: true }
+}
+
+export const setRIDSearchParam = (searchParams, serviceContainer) => {
+  const nextParams = new URLSearchParams(searchParams)
+  if (serviceContainer === JOBS_RID) {
+    nextParams.set('rid', JOBS_RID)
+  } else {
+    nextParams.delete('rid')
+  }
+  return nextParams
+}


### PR DESCRIPTION
Summary
- add OpenSVC web terminal support for selecting container#jobs in addition to the default container#db
- validate rid server-side so it is only accepted for OpenSVC server bash terminals, with tests for valid and invalid paths
- fix terminal UI websocket state handling so stale socket events no longer show disconnected while the active session is connected