### PR TITLE
fix(config/manager): prevent shutdown deadlocks and harden go-git metadata recovery

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/pelletier/go-toml"
 	"github.com/signal18/replication-manager/cluster/configurator"
+	"github.com/signal18/replication-manager/cluster/logplugin"
 	"github.com/signal18/replication-manager/cluster/nbc"
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/config/manager"
@@ -52,7 +53,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	logsql "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
-	"github.com/signal18/replication-manager/cluster/logplugin"
 )
 
 var clusterError = config.ClusterError
@@ -1072,11 +1072,12 @@ func (cluster *Cluster) SetIsSavingConfig(val bool) {
 }
 
 type ClusterState struct {
-	Servers    string      `json:"servers"`
-	Crashes    crashList   `json:"crashes"`
-	SLA        state.Sla   `json:"sla"`
-	SLAHistory []state.Sla `json:"slaHistory"`
-	IsAllDbUp  bool        `json:"provisioned"`
+	Servers       string      `json:"servers"`
+	Crashes       crashList   `json:"crashes"`
+	SLA           state.Sla   `json:"sla"`
+	SLAHistory    []state.Sla `json:"slaHistory"`
+	IsAllDbUp     bool        `json:"provisioned"`
+	RepmgrVersion string      `json:"repmgrVersion"`
 }
 
 func (cluster *Cluster) Save() error {
@@ -1092,6 +1093,7 @@ func (cluster *Cluster) Save() error {
 	clsave.SLA = cluster.StateMachine.GetSla()
 	clsave.IsAllDbUp = cluster.IsAllDbUp
 	clsave.SLAHistory = cluster.SLAHistory
+	clsave.RepmgrVersion = cluster.RepMgrVersion
 
 	saveJson, _ := json.MarshalIndent(clsave, "", "\t")
 	err := os.WriteFile(cluster.Conf.WorkingDir+"/"+cluster.Name+"/clusterstate.json", saveJson, 0644)

--- a/config/manager/manager.go
+++ b/config/manager/manager.go
@@ -121,6 +121,7 @@ func NewCommitManager(workerMin, workerLimit int, logger *config.LogrusWrapper) 
 }
 
 func (cmm *CommitManager) Start() {
+	cmm.wg.Add(1)
 	go cmm.processCommitQueue()
 }
 
@@ -162,6 +163,7 @@ func (cmm *CommitManager) processCommitQueue() {
 			cmm.commitQueue = cmm.commitQueue[1:]
 			cmm.mu.Unlock()
 
+			cmm.logger.Infof("none", config.ConstLogModGit, "CommitManager processing file: %s", task.Filename)
 			cmm.addFileToCommit(task)
 		}
 	}
@@ -511,6 +513,8 @@ func (cm *ConfigManager) Stop() {
 		cm.logger.Infof("none", config.ConstLogModGeneral, "[Shutdown] Waiting for active saves to finish...")
 		cm.configWg.Wait()
 
+		cm.gitManager.CommitManager.Stop()
+
 		close(cm.gitManager.stopCh) // Send stop signal to the push manager
 		cm.gitManager.cond.Signal() // Wake up the push manager
 		cm.logger.Infof("none", config.ConstLogModGeneral, "[Shutdown] Config manager stopped.")
@@ -806,6 +810,9 @@ func (cm *ConfigManager) PushConfigToGit(conf *config.Config, clusterList []stri
 		}
 	}
 
+	if errors.Is(err, git.NoErrAlreadyUpToDate) {
+		err = nil
+	}
 	return err
 }
 

--- a/config/manager/manager.go
+++ b/config/manager/manager.go
@@ -682,64 +682,65 @@ func (cm *ConfigManager) PushConfigToGit(conf *config.Config, clusterList []stri
 
 	// Check if .git directory exists
 	if _, err := os.Stat(filepath.Join(path, ".git")); os.IsNotExist(err) {
+		dirEntries, readErr := os.ReadDir(path)
+		if readErr != nil {
+			cm.logger.Errorf("none", config.ConstLogModGit, "Git error: cannot read workdir %s: %s", path, readErr)
+			return readErr
+		}
+
 		cloneopt := &git.CloneOptions{
 			URL:               url,
 			RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 			Auth:              auth,
 			Depth:             1, // Shallow clone
+			NoCheckout:        true,
+			SingleBranch:      true,
+			ReferenceName:     plumbing.NewBranchReferenceName("master"),
 		}
 
-		if !conf.ConfRestoreOnStart {
-			cloneopt.NoCheckout = true
+		cloneRepo := func(targetPath string) (*git.Repository, error) {
+			repo, cloneErr := git.PlainClone(targetPath, false, cloneopt)
+			if cloneErr == transport.ErrRepositoryNotFound {
+				conf.CreateGitlabProjects()
+				repo, cloneErr = git.PlainClone(targetPath, false, cloneopt)
+			}
+			return repo, cloneErr
 		}
 
-		// Perform shallow clone for better performance
-		r, err = git.PlainClone(path, false, cloneopt)
+		if len(dirEntries) == 0 {
+			// Empty dir: clone directly into working dir.
+			r, err = cloneRepo(path)
+		} else {
+			// Non-empty dir: preserve local files by cloning in a temp path and moving only .git.
+			tmpBase := filepath.Join(path, ".tmp")
+			if mkErr := os.MkdirAll(tmpBase, 0o755); mkErr != nil {
+				cm.logger.Errorf("none", config.ConstLogModGit, "Git error: cannot create temp dir %s: %s", tmpBase, mkErr)
+				return mkErr
+			}
+
+			tmpClonePath, mkErr := os.MkdirTemp(tmpBase, "repman-git-clone-*")
+			if mkErr != nil {
+				cm.logger.Errorf("none", config.ConstLogModGit, "Git error: cannot create temp clone dir: %s", mkErr)
+				return mkErr
+			}
+			defer os.RemoveAll(tmpClonePath)
+
+			if _, err = cloneRepo(tmpClonePath); err == nil {
+				renameErr := os.Rename(filepath.Join(tmpClonePath, ".git"), filepath.Join(path, ".git"))
+				if renameErr != nil {
+					cm.logger.Errorf("none", config.ConstLogModGit, "Git error: cannot move .git into workdir: %s", renameErr)
+					return renameErr
+				}
+				r, err = git.PlainOpen(path)
+			}
+		}
 
 		cm.logger.Debugf("none", config.ConstLogModGit, "Clone took: %s", time.Since(start))
 
 		// Handle repository not found
 		if err != nil {
-			if err == transport.ErrRepositoryNotFound {
-				conf.CreateGitlabProjects()
-				r, err = git.PlainClone(path, false, cloneopt)
-			}
-			if err != nil {
-				cm.logger.Errorf("none", config.ConstLogModGit, "Git error: cannot clone %s: %s", url, err)
-				return err
-			}
-		}
-
-		// After cloning with NoCheckout, create local master branch and checkout to fix push issues
-		if !conf.ConfRestoreOnStart && err == nil {
-			// Get remote master HEAD
-			remoteRef, refErr := r.Reference("refs/remotes/origin/master", true)
-			if refErr == nil {
-				// Create local master branch pointing to remote HEAD
-				localRef := plumbing.NewHashReference("refs/heads/master", remoteRef.Hash())
-				setErr := r.Storer.SetReference(localRef)
-				if setErr == nil {
-					w, wtErr := r.Worktree()
-					if wtErr == nil {
-						// Checkout to set HEAD to local master branch, Keep=true preserves local files
-						checkoutErr := w.Checkout(&git.CheckoutOptions{
-							Branch: "refs/heads/master",
-							Keep:   true,
-						})
-						if checkoutErr != nil {
-							cm.logger.Warnf("none", config.ConstLogModGit, "Git checkout warning (non-fatal): %s", checkoutErr)
-						} else {
-							cm.logger.Debugf("none", config.ConstLogModGit, "Created local master branch and checked out successfully")
-						}
-					} else {
-						cm.logger.Warnf("none", config.ConstLogModGit, "Git worktree warning (non-fatal): %s", wtErr)
-					}
-				} else {
-					cm.logger.Warnf("none", config.ConstLogModGit, "Git set reference warning (non-fatal): %s", setErr)
-				}
-			} else {
-				cm.logger.Warnf("none", config.ConstLogModGit, "Git remote reference warning (non-fatal): %s", refErr)
-			}
+			cm.logger.Errorf("none", config.ConstLogModGit, "Git error: cannot clone %s: %s", url, err)
+			return err
 		}
 	} else {
 		// Open existing repository

--- a/config/manager/manager.go
+++ b/config/manager/manager.go
@@ -163,7 +163,7 @@ func (cmm *CommitManager) processCommitQueue() {
 			cmm.commitQueue = cmm.commitQueue[1:]
 			cmm.mu.Unlock()
 
-			cmm.logger.Infof("none", config.ConstLogModGit, "CommitManager processing file: %s", task.Filename)
+			cmm.logger.Debugf("none", config.ConstLogModGit, "CommitManager processing file: %s", task.Filename)
 			cmm.addFileToCommit(task)
 		}
 	}

--- a/config/manager/manager.go
+++ b/config/manager/manager.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	git_obj "github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	git_https "github.com/go-git/go-git/v5/plumbing/transport/http"
@@ -706,6 +707,38 @@ func (cm *ConfigManager) PushConfigToGit(conf *config.Config, clusterList []stri
 			if err != nil {
 				cm.logger.Errorf("none", config.ConstLogModGit, "Git error: cannot clone %s: %s", url, err)
 				return err
+			}
+		}
+
+		// After cloning with NoCheckout, create local master branch and checkout to fix push issues
+		if !conf.ConfRestoreOnStart && err == nil {
+			// Get remote master HEAD
+			remoteRef, refErr := r.Reference("refs/remotes/origin/master", true)
+			if refErr == nil {
+				// Create local master branch pointing to remote HEAD
+				localRef := plumbing.NewHashReference("refs/heads/master", remoteRef.Hash())
+				setErr := r.Storer.SetReference(localRef)
+				if setErr == nil {
+					w, wtErr := r.Worktree()
+					if wtErr == nil {
+						// Checkout to set HEAD to local master branch, Keep=true preserves local files
+						checkoutErr := w.Checkout(&git.CheckoutOptions{
+							Branch: "refs/heads/master",
+							Keep:   true,
+						})
+						if checkoutErr != nil {
+							cm.logger.Warnf("none", config.ConstLogModGit, "Git checkout warning (non-fatal): %s", checkoutErr)
+						} else {
+							cm.logger.Debugf("none", config.ConstLogModGit, "Created local master branch and checked out successfully")
+						}
+					} else {
+						cm.logger.Warnf("none", config.ConstLogModGit, "Git worktree warning (non-fatal): %s", wtErr)
+					}
+				} else {
+					cm.logger.Warnf("none", config.ConstLogModGit, "Git set reference warning (non-fatal): %s", setErr)
+				}
+			} else {
+				cm.logger.Warnf("none", config.ConstLogModGit, "Git remote reference warning (non-fatal): %s", refErr)
 			}
 		}
 	} else {

--- a/config/manager/manager.go
+++ b/config/manager/manager.go
@@ -106,6 +106,7 @@ type CommitManager struct {
 	W           *git.Worktree
 	commitQueue []GitAddTask // Slice for commit tasks
 	mu          sync.Mutex   // Mutex to protect commitQueue
+	cond        *sync.Cond
 	stopCh      chan struct{}
 	wg          sync.WaitGroup
 	IsStopping  atomic.Bool
@@ -117,6 +118,7 @@ func NewCommitManager(workerMin, workerLimit int, logger *config.LogrusWrapper) 
 		commitQueue: []GitAddTask{},
 		stopCh:      make(chan struct{}),
 	}
+	cmm.cond = sync.NewCond(&cmm.mu)
 
 	cmm.Start()
 	return cmm
@@ -139,35 +141,43 @@ func (cmm *CommitManager) AddFileToCommit(task GitAddTask) {
 		}
 	default:
 		cmm.commitQueue = append(cmm.commitQueue, task)
+		cmm.cond.Signal()
 	}
 }
 
 func (cmm *CommitManager) processCommitQueue() {
-	defer LogPanic(cmm.logger)
+	defer LogPanic(cmm.logger, "CommitManager.processCommitQueue", "none", config.ConstLogModGit)
 	defer cmm.wg.Done()
 
 	for {
+		cmm.mu.Lock()
+		for len(cmm.commitQueue) == 0 {
+			select {
+			case <-cmm.stopCh:
+				cmm.mu.Unlock()
+				cmm.logger.Infof("none", config.ConstLogModGit, "CommitManager is stopping.")
+				return
+			default:
+			}
+			cmm.cond.Wait()
+		}
+
 		select {
 		case <-cmm.stopCh:
+			cmm.mu.Unlock()
 			cmm.logger.Infof("none", config.ConstLogModGit, "CommitManager is stopping.")
 			return
 		default:
-			cmm.mu.Lock()
-			if len(cmm.commitQueue) == 0 {
-				cmm.mu.Unlock()
-
-				time.Sleep(100 * time.Millisecond) // Avoid busy waiting
-				continue
-			}
-
-			// Fetch and remove the first task
-			task := cmm.commitQueue[0]
-			cmm.commitQueue = cmm.commitQueue[1:]
-			cmm.mu.Unlock()
-
-			cmm.logger.Debugf("none", config.ConstLogModGit, "CommitManager processing file: %s", task.Filename)
-			cmm.addFileToCommit(task)
 		}
+
+		// Invariant: addFileToCommit completes at most one in-flight dequeued task;
+		// Stop() drains and resolves all tasks still queued in commitQueue.
+		task := cmm.commitQueue[0]
+		cmm.commitQueue = cmm.commitQueue[1:]
+		cmm.mu.Unlock()
+
+		cmm.logger.Debugf("none", config.ConstLogModGit, "CommitManager processing file: %s", task.Filename)
+		cmm.addFileToCommit(task)
 	}
 }
 
@@ -186,14 +196,16 @@ func (cmm *CommitManager) addFileToCommit(task GitAddTask) {
 
 func (cmm *CommitManager) Stop() {
 	cmm.IsStopping.Store(true)
+
+	cmm.mu.Lock()
 	select {
 	case <-cmm.stopCh:
 		// already closed
 	default:
 		close(cmm.stopCh)
 	}
+	cmm.cond.Broadcast()
 
-	cmm.mu.Lock()
 	pending := cmm.commitQueue
 	cmm.commitQueue = make([]GitAddTask, 0)
 	cmm.mu.Unlock()
@@ -214,6 +226,7 @@ type ConfigManager struct {
 	gitMutex    *sync.Mutex                // Blocks new saves during Git push
 	stopOnce    sync.Once                  // Ensures Stop() runs only once
 	isStopping  atomic.Bool                // Prevents new saves after stopping
+	clusterMu   *sync.RWMutex              // Protects clusterData map access
 	clusterData map[string]*ClusterManager // Map of clusters and their respective managers
 	gitManager  *GitManager                // Pull Push manager
 }
@@ -223,6 +236,7 @@ func NewConfigManager(logger *config.LogrusWrapper) *ConfigManager {
 	newcm := &ConfigManager{
 		logger:      logger,
 		clusterData: make(map[string]*ClusterManager),
+		clusterMu:   &sync.RWMutex{},
 		gitMutex:    &sync.Mutex{},
 		configWg:    &sync.WaitGroup{},
 		gitManager:  NewGitManager(logger),
@@ -244,7 +258,8 @@ func (cm *ConfigManager) UpdateLoggerConfig(clustername string, conf *config.Con
 }
 
 func (cm *ConfigManager) CountTasksForCluster(cluster string) int {
-	if clusterManager, exists := cm.clusterData[cluster]; exists {
+	clusterManager, exists := cm.getClusterManager(cluster)
+	if exists {
 		clusterManager.mutex.Lock()
 		defer clusterManager.mutex.Unlock()
 		return len(clusterManager.tasks)
@@ -252,59 +267,83 @@ func (cm *ConfigManager) CountTasksForCluster(cluster string) int {
 	return 0
 }
 
+func (cm *ConfigManager) getClusterManager(cluster string) (*ClusterManager, bool) {
+	cm.clusterMu.RLock()
+	clusterManager, exists := cm.clusterData[cluster]
+	cm.clusterMu.RUnlock()
+	return clusterManager, exists
+}
+
+func (cm *ConfigManager) getOrCreateClusterManager(cluster string) (*ClusterManager, bool) {
+	cm.clusterMu.Lock()
+	if cm.isStopping.Load() {
+		cm.clusterMu.Unlock()
+		return nil, false
+	}
+
+	clusterManager, exists := cm.clusterData[cluster]
+	if !exists {
+		clusterManager = &ClusterManager{
+			tasks:  []*ConfigSaveTask{},
+			mutex:  &sync.Mutex{},
+			stopCh: make(chan struct{}),
+		}
+		clusterManager.cond = sync.NewCond(clusterManager.mutex)
+		cm.clusterData[cluster] = clusterManager
+	}
+	cm.clusterMu.Unlock()
+
+	if !exists {
+		go cm.processClusterQueue(cluster, clusterManager)
+	}
+
+	return clusterManager, true
+}
+
 // SaveConfig allows concurrent saves but respects stopping
 func (cm *ConfigManager) SaveConfig(cluster ClusterConfig, wait bool) {
-	configSaveTask := &ConfigSaveTask{Cluster: cluster}
 	clustername := cluster.GetName()
 
 	if cm.isStopping.Load() {
-		cm.logger.Debugf(clustername, config.ConstLogModGeneral, "[%s] Save blocked: system is stopping.\n", configSaveTask.Cluster)
-		return
-	}
-	if wait {
-		wg := sync.WaitGroup{}
-		configSaveTask.WaitGroup = &wg
-		configSaveTask.WaitGroup.Add(1)
-		cm.logger.Debugf(clustername, config.ConstLogModConfigLoad, "[%s] Save with wait requested.\n", configSaveTask.Cluster)
-	}
-
-	if cm.isStopping.Load() {
-		cm.logger.Debugf(clustername, config.ConstLogModConfigLoad, "[%s] Save blocked: system is stopping.\n", configSaveTask.Cluster)
+		cm.logger.Debugf(clustername, config.ConstLogModGeneral, "[%s] Save blocked: system is stopping.\n", cluster)
 		return
 	}
 
-	// Ensure each cluster has a ClusterManager (with tasks, mutex, stop channel)
-	if _, exists := cm.clusterData[clustername]; !exists {
-		cm.clusterData[clustername] = &ClusterManager{
-			tasks:  []*ConfigSaveTask{},
-			mutex:  &sync.Mutex{},
-			stopCh: make(chan struct{}), // Initialize stop channel for the cluster
-		}
-		// Initialize the condition variable with the mutex
-		cm.clusterData[clustername].cond = sync.NewCond(cm.clusterData[clustername].mutex)
-		go cm.processClusterQueue(clustername) // Start the persistent goroutine for the cluster
+	clusterManager, ok := cm.getOrCreateClusterManager(clustername)
+	if !ok {
+		cm.logger.Debugf(clustername, config.ConstLogModConfigLoad, "[%s] Save blocked while creating queue: system is stopping.\n", cluster)
+		return
 	}
+	configSaveTask := &ConfigSaveTask{Cluster: cluster}
 
 	// Lock the cluster's mutex to safely add to the task slice
-	cm.clusterData[clustername].mutex.Lock()
+	clusterManager.mutex.Lock()
 	if cm.isStopping.Load() {
-		cm.clusterData[clustername].mutex.Unlock()
+		clusterManager.mutex.Unlock()
 		cm.logger.Debugf(clustername, config.ConstLogModConfigLoad, "[%s] Save blocked while queueing: system is stopping.\n", configSaveTask.Cluster)
 		return
 	}
 	select {
-	case <-cm.clusterData[clustername].stopCh:
-		cm.clusterData[clustername].mutex.Unlock()
+	case <-clusterManager.stopCh:
+		clusterManager.mutex.Unlock()
 		cm.logger.Debugf(clustername, config.ConstLogModConfigLoad, "[%s] Save blocked: cluster manager is stopping.\n", configSaveTask.Cluster)
 		return
 	default:
 	}
+
+	if wait {
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		configSaveTask.WaitGroup = wg
+		cm.logger.Debugf(clustername, config.ConstLogModConfigLoad, "[%s] Save with wait requested.\n", configSaveTask.Cluster)
+	}
+
 	cm.logger.Debugf(clustername, config.ConstLogModConfigLoad, "[%s] Appending to save queue.\n", clustername)
 
-	cm.clusterData[clustername].tasks = append(cm.clusterData[clustername].tasks, configSaveTask)
+	clusterManager.tasks = append(clusterManager.tasks, configSaveTask)
 	// Signal the goroutine that a new task is available
-	cm.clusterData[clustername].cond.Signal()
-	cm.clusterData[clustername].mutex.Unlock()
+	clusterManager.cond.Signal()
+	clusterManager.mutex.Unlock()
 
 	// If a WaitGroup pointer is provided, add to the wait group
 	if configSaveTask.WaitGroup != nil {
@@ -317,76 +356,112 @@ func (cm *ConfigManager) SaveConfig(cluster ClusterConfig, wait bool) {
 }
 
 // processClusterQueue processes the tasks in the slice for a given cluster
-func (cm *ConfigManager) processClusterQueue(cluster string) {
-	defer LogPanic(cm.logger)
+func (cm *ConfigManager) processClusterQueue(cluster string, clusterManager *ClusterManager) {
+	defer LogPanic(cm.logger, fmt.Sprintf("ConfigManager.processClusterQueue[%s]", cluster), cluster, config.ConstLogModConfigLoad)
 
 	for {
 		// Lock the cluster's mutex to safely check for tasks
-		cm.clusterData[cluster].mutex.Lock()
+		clusterManager.mutex.Lock()
 
 		// Wait until there is at least one task in the queue
-		for len(cm.clusterData[cluster].tasks) == 0 {
+		for len(clusterManager.tasks) == 0 {
 			select {
-			case <-cm.clusterData[cluster].stopCh: // Stop signal for the goroutine
+			case <-clusterManager.stopCh: // Stop signal for the goroutine
 				cm.logger.Infof(cluster, config.ConstLogModGeneral, "[%s] Stopping goroutine.\n", cluster)
-				cm.clusterData[cluster].mutex.Unlock()
+				clusterManager.mutex.Unlock()
 				return
 			default:
 			}
 
-			cm.clusterData[cluster].cond.Wait()
+			clusterManager.cond.Wait()
 		}
 
 		cm.logger.Debugf(cluster, config.ConstLogModConfigLoad, "[%s] Waking up goroutine.\n", cluster)
 
 		// Check for the stop signal before processing
 		select {
-		case <-cm.clusterData[cluster].stopCh: // Stop signal for the goroutine
-			cm.clusterData[cluster].isStopping = true
+		case <-clusterManager.stopCh: // Stop signal for the goroutine
+			clusterManager.isStopping = true
 			drained := 0
-			for _, task := range cm.clusterData[cluster].tasks {
+			for _, task := range clusterManager.tasks {
 				if task.WaitGroup != nil {
 					task.WaitGroup.Done()
 				}
 				drained++
 			}
-			cm.clusterData[cluster].tasks = make([]*ConfigSaveTask, 0)
+			clusterManager.tasks = make([]*ConfigSaveTask, 0)
 			cm.logger.Infof(cluster, config.ConstLogModGeneral, "[%s] Stop observed, drained %d queued save task(s).", cluster, drained)
-			cm.clusterData[cluster].mutex.Unlock()
+			clusterManager.mutex.Unlock()
 			return
 		default:
 			// Process the first task in the queue
-			configSaveTask := cm.clusterData[cluster].tasks[0]
-			skippedTasks := cm.clusterData[cluster].tasks[1:]
-			cm.clusterData[cluster].tasks = make([]*ConfigSaveTask, 0) // remove the current batch since they doing the same thing
-			cm.clusterData[cluster].mutex.Unlock()
+			configSaveTask := clusterManager.tasks[0]
+			skippedTasks := clusterManager.tasks[1:]
+			clusterManager.tasks = make([]*ConfigSaveTask, 0) // remove the current batch since they doing the same thing
+			clusterManager.mutex.Unlock()
 
 			cm.gitMutex.Lock() // Prevent Git push conflict
+			if cm.isStopping.Load() {
+				cm.gitMutex.Unlock()
+				if configSaveTask.WaitGroup != nil {
+					configSaveTask.WaitGroup.Done()
+				}
+				for _, task := range skippedTasks {
+					if task.WaitGroup != nil {
+						task.WaitGroup.Done()
+					}
+				}
+				cm.logger.Infof(cluster, config.ConstLogModConfigLoad, "[%s] Save aborted: system is stopping.", cluster)
+				return
+			}
+			select {
+			case <-clusterManager.stopCh:
+				cm.gitMutex.Unlock()
+				if configSaveTask.WaitGroup != nil {
+					configSaveTask.WaitGroup.Done()
+				}
+				for _, task := range skippedTasks {
+					if task.WaitGroup != nil {
+						task.WaitGroup.Done()
+					}
+				}
+				cm.logger.Infof(cluster, config.ConstLogModConfigLoad, "[%s] Save aborted: cluster manager is stopping.", cluster)
+				return
+			default:
+			}
 			cm.configWg.Add(1)
 			cm.gitMutex.Unlock()
 
-			// Execute the save function and handle potential errors
-			if err := configSaveTask.Cluster.Save(); err != nil {
-				cm.logger.Errorf(cluster, config.ConstLogModConfigLoad, "Error during save: %v", err)
-			} else {
-				cm.logger.Infof(cluster, config.ConstLogModConfigLoad, "Config saved successfully.")
-			}
+			func() {
+				defer cm.configWg.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						cm.logger.Errorf(cluster, config.ConstLogModConfigLoad, "Panic during save: %v", r)
+					}
+				}()
+				defer func() {
+					if configSaveTask.WaitGroup != nil {
+						configSaveTask.WaitGroup.Done()
+						cm.logger.Debugf(cluster, config.ConstLogModConfigLoad, "[%s] Save completed.\n", configSaveTask.Cluster)
+					}
 
-			// If a WaitGroup pointer is provided, mark the task as done
-			if configSaveTask.WaitGroup != nil {
-				configSaveTask.WaitGroup.Done()
-				cm.logger.Debugf(cluster, config.ConstLogModConfigLoad, "[%s] Save completed.\n", configSaveTask.Cluster)
-			}
+					for _, task := range skippedTasks {
+						if task.WaitGroup != nil {
+							task.WaitGroup.Done()
+							cm.logger.Debugf(cluster, config.ConstLogModConfigLoad, "[%s] Skipped save completed.\n", task.Cluster)
+						}
+					}
+				}()
 
-			for _, task := range skippedTasks {
-				if task.WaitGroup != nil {
-					task.WaitGroup.Done()
-					cm.logger.Debugf(cluster, config.ConstLogModConfigLoad, "[%s] Skipped save completed.\n", task.Cluster)
+				// Execute the save function and handle potential errors
+				if err := configSaveTask.Cluster.Save(); err != nil {
+					cm.logger.Errorf(cluster, config.ConstLogModConfigLoad, "Error during save: %v", err)
+				} else {
+					cm.logger.Infof(cluster, config.ConstLogModConfigLoad, "Config saved successfully.")
 				}
-			}
+			}()
 
-			cm.configWg.Done()
-			if cm.clusterData[cluster].isStopping {
+			if clusterManager.isStopping {
 				cm.logger.Infof(cluster, config.ConstLogModGeneral, "[%s] Cluster manager is stopping, exiting goroutine.", cluster)
 				return
 			}
@@ -468,7 +543,7 @@ func (cm *ConfigManager) GitPullDir() {
 
 // processClusterQueue processes the tasks in the slice for a given cluster
 func (cm *ConfigManager) processGitPush() {
-	defer LogPanic(cm.logger)
+	defer LogPanic(cm.logger, "ConfigManager.processGitPush", "none", config.ConstLogModGit)
 
 	for {
 		cm.gitManager.mutex.Lock()
@@ -573,9 +648,21 @@ func (cm *ConfigManager) Stop() {
 		cm.gitMutex.Lock()
 		defer cm.gitMutex.Unlock()
 
-		// Send stop signal to all cluster goroutines
+		cm.clusterMu.RLock()
+		clusterManagers := make([]*ClusterManager, 0, len(cm.clusterData))
 		for _, clmgr := range cm.clusterData {
-			close(clmgr.stopCh)
+			clusterManagers = append(clusterManagers, clmgr)
+		}
+		cm.clusterMu.RUnlock()
+
+		// Send stop signal to all cluster goroutines
+		for _, clmgr := range clusterManagers {
+			select {
+			case <-clmgr.stopCh:
+				// already closed
+			default:
+				close(clmgr.stopCh)
+			}
 			clmgr.cond.Signal() // Wake up the cluster goroutine
 		}
 
@@ -681,9 +768,13 @@ func (cm *ConfigManager) classifyRecoverablePushError(err error) (bool, string) 
 	return false, ""
 }
 
+func isRepositoryNotFoundError(err error) bool {
+	return errors.Is(err, transport.ErrRepositoryNotFound)
+}
+
 func (cm *ConfigManager) cloneRepositoryWithBootstrap(path string, conf *config.Config, cloneopt *git.CloneOptions) (*git.Repository, error) {
 	repo, cloneErr := git.PlainClone(path, false, cloneopt)
-	if cloneErr == transport.ErrRepositoryNotFound {
+	if isRepositoryNotFoundError(cloneErr) {
 		cm.logger.Warnf("none", config.ConstLogModGit, "Remote repository not found. Attempting project bootstrap before retrying clone")
 		conf.CreateGitlabProjects()
 		repo, cloneErr = git.PlainClone(path, false, cloneopt)
@@ -1132,13 +1223,15 @@ func (cm *ConfigManager) RotateGitAccessToken(conf *config.Config) error {
 	return nil
 }
 
-func LogPanic(clogger *config.LogrusWrapper) {
+func LogPanic(clogger *config.LogrusWrapper, component, cluster string, module int) {
 	if r := recover(); r != nil {
-		fields := logrus.Fields{
-			"cluster":    "none",
-			"panic":      r,
+		clogger.Logger.WithFields(logrus.Fields{
+			"cluster":    cluster,
+			"module":     config.GetTagsForLog(module),
+			"component":  component,
+			"panic":      fmt.Sprintf("%v", r),
+			"panic_type": fmt.Sprintf("%T", r),
 			"stacktrace": string(debug.Stack()),
-		}
-		clogger.Print(fields, "Panic recovered in processClusterQueue")
+		}).Error("Recovered panic in manager worker")
 	}
 }

--- a/config/manager/manager.go
+++ b/config/manager/manager.go
@@ -10,6 +10,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-git/go-git/v5"
@@ -107,7 +108,7 @@ type CommitManager struct {
 	mu          sync.Mutex   // Mutex to protect commitQueue
 	stopCh      chan struct{}
 	wg          sync.WaitGroup
-	IsStopping  bool
+	IsStopping  atomic.Bool
 }
 
 func NewCommitManager(workerMin, workerLimit int, logger *config.LogrusWrapper) *CommitManager {
@@ -184,9 +185,20 @@ func (cmm *CommitManager) addFileToCommit(task GitAddTask) {
 }
 
 func (cmm *CommitManager) Stop() {
-	close(cmm.stopCh)
-	cmm.IsStopping = true
-	for _, task := range cmm.commitQueue {
+	cmm.IsStopping.Store(true)
+	select {
+	case <-cmm.stopCh:
+		// already closed
+	default:
+		close(cmm.stopCh)
+	}
+
+	cmm.mu.Lock()
+	pending := cmm.commitQueue
+	cmm.commitQueue = make([]GitAddTask, 0)
+	cmm.mu.Unlock()
+
+	for _, task := range pending {
 		if task.WaitGroup != nil {
 			task.WaitGroup.Done()
 		}
@@ -201,7 +213,7 @@ type ConfigManager struct {
 	configWg    *sync.WaitGroup            // Tracks ongoing config saves
 	gitMutex    *sync.Mutex                // Blocks new saves during Git push
 	stopOnce    sync.Once                  // Ensures Stop() runs only once
-	isStopping  bool                       // Prevents new saves after stopping
+	isStopping  atomic.Bool                // Prevents new saves after stopping
 	clusterData map[string]*ClusterManager // Map of clusters and their respective managers
 	gitManager  *GitManager                // Pull Push manager
 }
@@ -245,7 +257,7 @@ func (cm *ConfigManager) SaveConfig(cluster ClusterConfig, wait bool) {
 	configSaveTask := &ConfigSaveTask{Cluster: cluster}
 	clustername := cluster.GetName()
 
-	if cm.isStopping {
+	if cm.isStopping.Load() {
 		cm.logger.Debugf(clustername, config.ConstLogModGeneral, "[%s] Save blocked: system is stopping.\n", configSaveTask.Cluster)
 		return
 	}
@@ -256,7 +268,7 @@ func (cm *ConfigManager) SaveConfig(cluster ClusterConfig, wait bool) {
 		cm.logger.Debugf(clustername, config.ConstLogModConfigLoad, "[%s] Save with wait requested.\n", configSaveTask.Cluster)
 	}
 
-	if cm.isStopping {
+	if cm.isStopping.Load() {
 		cm.logger.Debugf(clustername, config.ConstLogModConfigLoad, "[%s] Save blocked: system is stopping.\n", configSaveTask.Cluster)
 		return
 	}
@@ -275,6 +287,18 @@ func (cm *ConfigManager) SaveConfig(cluster ClusterConfig, wait bool) {
 
 	// Lock the cluster's mutex to safely add to the task slice
 	cm.clusterData[clustername].mutex.Lock()
+	if cm.isStopping.Load() {
+		cm.clusterData[clustername].mutex.Unlock()
+		cm.logger.Debugf(clustername, config.ConstLogModConfigLoad, "[%s] Save blocked while queueing: system is stopping.\n", configSaveTask.Cluster)
+		return
+	}
+	select {
+	case <-cm.clusterData[clustername].stopCh:
+		cm.clusterData[clustername].mutex.Unlock()
+		cm.logger.Debugf(clustername, config.ConstLogModConfigLoad, "[%s] Save blocked: cluster manager is stopping.\n", configSaveTask.Cluster)
+		return
+	default:
+	}
 	cm.logger.Debugf(clustername, config.ConstLogModConfigLoad, "[%s] Appending to save queue.\n", clustername)
 
 	cm.clusterData[clustername].tasks = append(cm.clusterData[clustername].tasks, configSaveTask)
@@ -319,7 +343,17 @@ func (cm *ConfigManager) processClusterQueue(cluster string) {
 		select {
 		case <-cm.clusterData[cluster].stopCh: // Stop signal for the goroutine
 			cm.clusterData[cluster].isStopping = true
+			drained := 0
+			for _, task := range cm.clusterData[cluster].tasks {
+				if task.WaitGroup != nil {
+					task.WaitGroup.Done()
+				}
+				drained++
+			}
+			cm.clusterData[cluster].tasks = make([]*ConfigSaveTask, 0)
+			cm.logger.Infof(cluster, config.ConstLogModGeneral, "[%s] Stop observed, drained %d queued save task(s).", cluster, drained)
 			cm.clusterData[cluster].mutex.Unlock()
+			return
 		default:
 			// Process the first task in the queue
 			configSaveTask := cm.clusterData[cluster].tasks[0]
@@ -375,6 +409,18 @@ func (cm *ConfigManager) GitPush(conf *config.Config, clusterList []string, wait
 	cm.logger.Debugln("none", config.ConstLogModGit, "Locking push mutex")
 	// Lock the cluster's mutex to safely add to the task slice
 	cm.gitManager.mutex.Lock()
+	if cm.isStopping.Load() {
+		cm.logger.Debugln("none", config.ConstLogModGit, "Rejecting push queue append: manager is stopping")
+		cm.gitManager.mutex.Unlock()
+		return
+	}
+	select {
+	case <-cm.gitManager.stopCh:
+		cm.logger.Debugln("none", config.ConstLogModGit, "Rejecting push queue append: git manager is stopped")
+		cm.gitManager.mutex.Unlock()
+		return
+	default:
+	}
 	cm.logger.Debugln("none", config.ConstLogModGit, "Appending to push queue")
 	cm.gitManager.tasks = append(cm.gitManager.tasks, configGitTask)
 	// Signal the goroutine that a new task is available
@@ -399,6 +445,18 @@ func (cm *ConfigManager) GitPullDir() {
 	cm.logger.Debugln("none", config.ConstLogModGit, "Locking pull mutex")
 	// Lock the cluster's mutex to safely add to the task slice
 	cm.gitManager.mutex.Lock()
+	if cm.isStopping.Load() {
+		cm.logger.Debugln("none", config.ConstLogModGit, "Rejecting pull queue append: manager is stopping")
+		cm.gitManager.mutex.Unlock()
+		return
+	}
+	select {
+	case <-cm.gitManager.stopCh:
+		cm.logger.Debugln("none", config.ConstLogModGit, "Rejecting pull queue append: git manager is stopped")
+		cm.gitManager.mutex.Unlock()
+		return
+	default:
+	}
 	cm.logger.Debugln("none", config.ConstLogModGit, "Appending to pull queue")
 	cm.gitManager.tasks = append(cm.gitManager.tasks, configGitTask)
 	// Signal the goroutine that a new task is available
@@ -432,8 +490,18 @@ func (cm *ConfigManager) processGitPush() {
 		select {
 		case <-cm.gitManager.stopCh: // Stop signal for the goroutine
 			cm.gitManager.isStopping = true
+			drained := 0
+			for _, task := range cm.gitManager.tasks {
+				if task.WaitGroup != nil {
+					task.WaitGroup.Done()
+				}
+				drained++
+			}
+			cm.gitManager.tasks = make([]*ConfigGitTask, 0)
+			cm.logger.Infof("none", config.ConstLogModGit, "[Git] Stop observed, drained %d queued git task(s).", drained)
 			cm.logger.Debugf("none", config.ConstLogModGit, "[Git] Stopping goroutine.")
 			cm.gitManager.mutex.Unlock()
+			return
 		default:
 			// Process the first task in the queue and skip same type tasks
 			configGitTask, pull, push := cm.gitManager.SplitTaskQueue()
@@ -500,7 +568,7 @@ func (cm *ConfigManager) Stop() {
 	cm.stopOnce.Do(func() {
 		cm.logger.Infof("none", config.ConstLogModGeneral, "[Shutdown] Stopping...")
 
-		cm.isStopping = true // Prevent new saves
+		cm.isStopping.Store(true) // Prevent new saves
 
 		cm.gitMutex.Lock()
 		defer cm.gitMutex.Unlock()
@@ -540,8 +608,12 @@ func (cm *ConfigManager) PushAllConfigsToGit(conf *config.Config, clusterList []
 
 	err := cm.PushConfigToGit(conf, clusterList)
 	if err != nil {
-		if err == transport.ErrRepositoryNotFound || err == io.EOF {
-			os.RemoveAll(conf.WorkingDir + "/.git")
+		if recoverable, reason := cm.classifyRecoverablePushError(err); recoverable {
+			cm.logger.Warnf("none", config.ConstLogModGit, "Recoverable git push failure (%s): %v. Refreshing repository metadata and retrying once.", reason, err)
+			if refreshErr := cm.RefreshGitMetadata(conf); refreshErr != nil {
+				cm.logger.Errorf("none", config.ConstLogModGit, "Git metadata refresh failed after recoverable push error: %v", refreshErr)
+				return refreshErr
+			}
 			err = cm.PushConfigToGit(conf, clusterList)
 		}
 		if err != nil {
@@ -558,14 +630,155 @@ func (cm *ConfigManager) PushAllConfigsToGit(conf *config.Config, clusterList []
 	}
 
 	if commits >= 10 {
-		os.RemoveAll(conf.WorkingDir + "/.git")
-		err := cm.ShallowClone(conf)
+		cm.logger.Infof("none", config.ConstLogModGit, "Refreshing git metadata after %d commits to keep repository shallow", commits)
+		err := cm.RefreshGitMetadata(conf)
 		if err != nil {
-			cm.logger.Errorf("none", config.ConstLogModGit, "Error shallow cloning: %v", err)
+			cm.logger.Errorf("none", config.ConstLogModGit, "Error refreshing git metadata: %v", err)
 			return err
 		}
 	}
 
+	return nil
+}
+
+func (cm *ConfigManager) classifyRecoverablePushError(err error) (bool, string) {
+	if err == nil {
+		return false, ""
+	}
+
+	if errors.Is(err, transport.ErrRepositoryNotFound) {
+		return true, "repository not found"
+	}
+	if errors.Is(err, io.EOF) {
+		return true, "unexpected EOF"
+	}
+	if errors.Is(err, plumbing.ErrObjectNotFound) {
+		return true, "object not found"
+	}
+	if errors.Is(err, plumbing.ErrReferenceNotFound) {
+		return true, "reference not found"
+	}
+
+	msg := strings.ToLower(err.Error())
+	recoverableSubstrings := []struct {
+		reason string
+		match  string
+	}{
+		{reason: "object not found", match: "object not found"},
+		{reason: "missing object", match: "missing object"},
+		{reason: "reference not found", match: "reference not found"},
+		{reason: "missing remote ref", match: "couldn't find remote ref"},
+		{reason: "reference does not exist", match: "reference does not exist"},
+		{reason: "cannot resolve reference", match: "unable to resolve reference"},
+	}
+
+	for _, candidate := range recoverableSubstrings {
+		if strings.Contains(msg, candidate.match) {
+			return true, candidate.reason
+		}
+	}
+
+	return false, ""
+}
+
+func (cm *ConfigManager) cloneRepositoryWithBootstrap(path string, conf *config.Config, cloneopt *git.CloneOptions) (*git.Repository, error) {
+	repo, cloneErr := git.PlainClone(path, false, cloneopt)
+	if cloneErr == transport.ErrRepositoryNotFound {
+		cm.logger.Warnf("none", config.ConstLogModGit, "Remote repository not found. Attempting project bootstrap before retrying clone")
+		conf.CreateGitlabProjects()
+		repo, cloneErr = git.PlainClone(path, false, cloneopt)
+	}
+
+	return repo, cloneErr
+}
+
+func (cm *ConfigManager) swapGitMetadata(workDir, stagedGitDir string) error {
+	activeGitDir := filepath.Join(workDir, ".git")
+
+	if _, err := os.Stat(stagedGitDir); err != nil {
+		return fmt.Errorf("staged git metadata missing at %s: %w", stagedGitDir, err)
+	}
+
+	backupGitDir := filepath.Join(workDir, fmt.Sprintf(".git.backup.%d", time.Now().UnixNano()))
+	hasOriginalMetadata := false
+
+	if _, err := os.Stat(activeGitDir); err == nil {
+		hasOriginalMetadata = true
+		cm.logger.Infof("none", config.ConstLogModGit, "Backing up existing .git metadata to %s", backupGitDir)
+		if err := os.Rename(activeGitDir, backupGitDir); err != nil {
+			return fmt.Errorf("cannot backup existing git metadata: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("cannot inspect current git metadata: %w", err)
+	}
+
+	cm.logger.Infof("none", config.ConstLogModGit, "Installing refreshed .git metadata into %s", activeGitDir)
+	if err := os.Rename(stagedGitDir, activeGitDir); err != nil {
+		if hasOriginalMetadata {
+			cm.logger.Warnf("none", config.ConstLogModGit, "Failed to install refreshed metadata, rolling back .git backup: %v", err)
+			if rollbackErr := os.Rename(backupGitDir, activeGitDir); rollbackErr != nil {
+				cm.logger.Errorf("none", config.ConstLogModGit, "Rollback failed: original .git backup still at %s: %v", backupGitDir, rollbackErr)
+			} else {
+				cm.logger.Infof("none", config.ConstLogModGit, "Rollback succeeded. Original .git metadata restored")
+			}
+		}
+		return fmt.Errorf("cannot install refreshed git metadata: %w", err)
+	}
+
+	if hasOriginalMetadata {
+		if err := os.RemoveAll(backupGitDir); err != nil {
+			cm.logger.Warnf("none", config.ConstLogModGit, "Refreshed .git installed but cleanup of backup metadata failed (%s): %v", backupGitDir, err)
+		}
+	}
+
+	return nil
+}
+
+func (cm *ConfigManager) RefreshGitMetadata(conf *config.Config) error {
+	url := conf.GitUrl
+	tok := conf.GetDecryptedValue("git-acces-token")
+	user := conf.GitUsername
+	path := conf.WorkingDir
+
+	if url == "" {
+		return nil
+	}
+
+	auth := &git_https.BasicAuth{
+		Username: user,
+		Password: tok,
+	}
+
+	tmpBase := filepath.Join(path, ".tmp")
+	if err := os.MkdirAll(tmpBase, 0o755); err != nil {
+		return fmt.Errorf("cannot create metadata temp base %s: %w", tmpBase, err)
+	}
+
+	tmpClonePath, err := os.MkdirTemp(tmpBase, "repman-git-refresh-*")
+	if err != nil {
+		return fmt.Errorf("cannot create metadata temp clone dir: %w", err)
+	}
+	defer os.RemoveAll(tmpClonePath)
+
+	cloneopt := &git.CloneOptions{
+		URL:               url,
+		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
+		Auth:              auth,
+		Depth:             1,
+		NoCheckout:        true,
+		SingleBranch:      true,
+	}
+
+	cm.logger.Infof("none", config.ConstLogModGit, "Cloning fresh git metadata into temporary directory for in-place refresh")
+	if _, err := cm.cloneRepositoryWithBootstrap(tmpClonePath, conf, cloneopt); err != nil {
+		return fmt.Errorf("cannot clone refreshed metadata: %w", err)
+	}
+
+	if err := cm.swapGitMetadata(path, filepath.Join(tmpClonePath, ".git")); err != nil {
+		return err
+	}
+
+	cm.logger.Infof("none", config.ConstLogModGit, "Git metadata refresh complete. Working tree files preserved in place")
 	return nil
 }
 
@@ -695,21 +908,11 @@ func (cm *ConfigManager) PushConfigToGit(conf *config.Config, clusterList []stri
 			Depth:             1, // Shallow clone
 			NoCheckout:        true,
 			SingleBranch:      true,
-			ReferenceName:     plumbing.NewBranchReferenceName("master"),
-		}
-
-		cloneRepo := func(targetPath string) (*git.Repository, error) {
-			repo, cloneErr := git.PlainClone(targetPath, false, cloneopt)
-			if cloneErr == transport.ErrRepositoryNotFound {
-				conf.CreateGitlabProjects()
-				repo, cloneErr = git.PlainClone(targetPath, false, cloneopt)
-			}
-			return repo, cloneErr
 		}
 
 		if len(dirEntries) == 0 {
 			// Empty dir: clone directly into working dir.
-			r, err = cloneRepo(path)
+			r, err = cm.cloneRepositoryWithBootstrap(path, conf, cloneopt)
 		} else {
 			// Non-empty dir: preserve local files by cloning in a temp path and moving only .git.
 			tmpBase := filepath.Join(path, ".tmp")
@@ -725,11 +928,10 @@ func (cm *ConfigManager) PushConfigToGit(conf *config.Config, clusterList []stri
 			}
 			defer os.RemoveAll(tmpClonePath)
 
-			if _, err = cloneRepo(tmpClonePath); err == nil {
-				renameErr := os.Rename(filepath.Join(tmpClonePath, ".git"), filepath.Join(path, ".git"))
-				if renameErr != nil {
-					cm.logger.Errorf("none", config.ConstLogModGit, "Git error: cannot move .git into workdir: %s", renameErr)
-					return renameErr
+			if _, err = cm.cloneRepositoryWithBootstrap(tmpClonePath, conf, cloneopt); err == nil {
+				if swapErr := cm.swapGitMetadata(path, filepath.Join(tmpClonePath, ".git")); swapErr != nil {
+					cm.logger.Errorf("none", config.ConstLogModGit, "Git error: cannot install cloned .git metadata: %s", swapErr)
+					return swapErr
 				}
 				r, err = git.PlainOpen(path)
 			}
@@ -810,7 +1012,7 @@ func (cm *ConfigManager) PushConfigToGit(conf *config.Config, clusterList []stri
 
 	cm.logger.Debugf("none", config.ConstLogModGit, "Total file add took: %s", time.Since(allstart))
 
-	if cm.gitManager.CommitManager.IsStopping {
+	if cm.gitManager.CommitManager.IsStopping.Load() {
 		cm.logger.Info("none", config.ConstLogModGit, "CommitManager is stopping, cancelling commit")
 		return nil
 	}

--- a/config/manager/manager.go
+++ b/config/manager/manager.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/go-git/go-git/v5"
@@ -784,6 +786,10 @@ func (cm *ConfigManager) cloneRepositoryWithBootstrap(path string, conf *config.
 }
 
 func (cm *ConfigManager) swapGitMetadata(workDir, stagedGitDir string) error {
+	return cm.swapGitMetadataWithRenamer(workDir, stagedGitDir, os.Rename)
+}
+
+func (cm *ConfigManager) swapGitMetadataWithRenamer(workDir, stagedGitDir string, renameFn func(oldpath, newpath string) error) error {
 	activeGitDir := filepath.Join(workDir, ".git")
 
 	if _, err := os.Stat(stagedGitDir); err != nil {
@@ -796,7 +802,7 @@ func (cm *ConfigManager) swapGitMetadata(workDir, stagedGitDir string) error {
 	if _, err := os.Stat(activeGitDir); err == nil {
 		hasOriginalMetadata = true
 		cm.logger.Infof("none", config.ConstLogModGit, "Backing up existing .git metadata to %s", backupGitDir)
-		if err := os.Rename(activeGitDir, backupGitDir); err != nil {
+		if err := renameFn(activeGitDir, backupGitDir); err != nil {
 			return fmt.Errorf("cannot backup existing git metadata: %w", err)
 		}
 	} else if !os.IsNotExist(err) {
@@ -804,10 +810,29 @@ func (cm *ConfigManager) swapGitMetadata(workDir, stagedGitDir string) error {
 	}
 
 	cm.logger.Infof("none", config.ConstLogModGit, "Installing refreshed .git metadata into %s", activeGitDir)
-	if err := os.Rename(stagedGitDir, activeGitDir); err != nil {
+	if err := renameFn(stagedGitDir, activeGitDir); err != nil {
+		if errors.Is(err, syscall.EXDEV) {
+			cm.logger.Warnf("none", config.ConstLogModGit, "Cross-filesystem install detected while moving refreshed .git (%v). Falling back to recursive copy", err)
+			if copyErr := copyDirRecursive(stagedGitDir, activeGitDir); copyErr != nil {
+				if hasOriginalMetadata {
+					if rollbackErr := rollbackGitMetadata(backupGitDir, activeGitDir, renameFn); rollbackErr != nil {
+						cm.logger.Errorf("none", config.ConstLogModGit, "Rollback failed after EXDEV fallback failure. Backup retained at %s: %v", backupGitDir, rollbackErr)
+					}
+				}
+				return fmt.Errorf("cannot install refreshed git metadata via EXDEV fallback copy: %w", copyErr)
+			}
+
+			if hasOriginalMetadata {
+				if rmErr := os.RemoveAll(backupGitDir); rmErr != nil {
+					cm.logger.Warnf("none", config.ConstLogModGit, "Refreshed .git copied successfully after EXDEV, but cleanup of backup metadata failed (%s): %v", backupGitDir, rmErr)
+				}
+			}
+			return nil
+		}
+
 		if hasOriginalMetadata {
 			cm.logger.Warnf("none", config.ConstLogModGit, "Failed to install refreshed metadata, rolling back .git backup: %v", err)
-			if rollbackErr := os.Rename(backupGitDir, activeGitDir); rollbackErr != nil {
+			if rollbackErr := rollbackGitMetadata(backupGitDir, activeGitDir, renameFn); rollbackErr != nil {
 				cm.logger.Errorf("none", config.ConstLogModGit, "Rollback failed: original .git backup still at %s: %v", backupGitDir, rollbackErr)
 			} else {
 				cm.logger.Infof("none", config.ConstLogModGit, "Rollback succeeded. Original .git metadata restored")
@@ -823,6 +848,119 @@ func (cm *ConfigManager) swapGitMetadata(workDir, stagedGitDir string) error {
 	}
 
 	return nil
+}
+
+func rollbackGitMetadata(backupGitDir, activeGitDir string, renameFn func(oldpath, newpath string) error) error {
+	if _, statErr := os.Stat(activeGitDir); statErr == nil {
+		if rmErr := os.RemoveAll(activeGitDir); rmErr != nil {
+			return fmt.Errorf("cannot remove partial active git metadata before rollback: %w", rmErr)
+		}
+	} else if !os.IsNotExist(statErr) {
+		return fmt.Errorf("cannot inspect active git metadata before rollback: %w", statErr)
+	}
+
+	if err := renameFn(backupGitDir, activeGitDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func copyDirRecursive(src, dst string) error {
+	if err := os.RemoveAll(dst); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("cannot prepare destination %s: %w", dst, err)
+	}
+
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			return os.MkdirAll(target, info.Mode().Perm())
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		if info.Mode()&os.ModeSymlink != 0 {
+			linkTarget, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			return os.Symlink(linkTarget, target)
+		}
+
+		return copyFile(path, target, info.Mode().Perm())
+	})
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+
+	return out.Sync()
+}
+
+func resolveCurrentLocalBranch(workDir string) (plumbing.ReferenceName, bool) {
+	r, err := git.PlainOpen(workDir)
+	if err != nil {
+		return "", false
+	}
+
+	headRef, err := r.Head()
+	if err == nil && headRef.Name().IsBranch() {
+		return headRef.Name(), true
+	}
+
+	if _, err := r.Reference(plumbing.NewBranchReferenceName("master"), true); err == nil {
+		return plumbing.NewBranchReferenceName("master"), true
+	}
+
+	return "", false
+}
+
+func isReferenceNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, plumbing.ErrReferenceNotFound) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "couldn't find remote ref") || strings.Contains(msg, "reference not found")
 }
 
 func (cm *ConfigManager) RefreshGitMetadata(conf *config.Config) error {
@@ -860,9 +998,35 @@ func (cm *ConfigManager) RefreshGitMetadata(conf *config.Config) error {
 		SingleBranch:      true,
 	}
 
+	if refName, ok := resolveCurrentLocalBranch(path); ok {
+		cloneopt.ReferenceName = refName
+		cloneopt.SingleBranch = true
+		cm.logger.Infof("none", config.ConstLogModGit, "Refreshing git metadata using current local branch reference %s", refName)
+	} else {
+		fallbackRef := plumbing.NewBranchReferenceName("master")
+		cloneopt.ReferenceName = fallbackRef
+		cloneopt.SingleBranch = true
+		cm.logger.Warnf("none", config.ConstLogModGit, "Could not determine current local branch for metadata refresh, falling back to %s", fallbackRef)
+	}
+
 	cm.logger.Infof("none", config.ConstLogModGit, "Cloning fresh git metadata into temporary directory for in-place refresh")
 	if _, err := cm.cloneRepositoryWithBootstrap(tmpClonePath, conf, cloneopt); err != nil {
-		return fmt.Errorf("cannot clone refreshed metadata: %w", err)
+		if cloneopt.ReferenceName != "" && isReferenceNotFoundError(err) {
+			cm.logger.Warnf("none", config.ConstLogModGit, "Refresh metadata clone with reference %s failed (%v). Retrying with remote default branch", cloneopt.ReferenceName, err)
+			if rmErr := os.RemoveAll(tmpClonePath); rmErr != nil {
+				return fmt.Errorf("cannot reset temporary clone dir before refresh retry: %w", rmErr)
+			}
+			if mkErr := os.MkdirAll(tmpClonePath, 0o755); mkErr != nil {
+				return fmt.Errorf("cannot recreate temporary clone dir before refresh retry: %w", mkErr)
+			}
+			cloneopt.ReferenceName = ""
+			cloneopt.SingleBranch = false
+			if _, retryErr := cm.cloneRepositoryWithBootstrap(tmpClonePath, conf, cloneopt); retryErr != nil {
+				return fmt.Errorf("cannot clone refreshed metadata: %w", retryErr)
+			}
+		} else {
+			return fmt.Errorf("cannot clone refreshed metadata: %w", err)
+		}
 	}
 
 	if err := cm.swapGitMetadata(path, filepath.Join(tmpClonePath, ".git")); err != nil {
@@ -997,7 +1161,7 @@ func (cm *ConfigManager) PushConfigToGit(conf *config.Config, clusterList []stri
 			RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 			Auth:              auth,
 			Depth:             1, // Shallow clone
-			NoCheckout:        true,
+			NoCheckout:        !conf.ConfRestoreOnStart,
 			SingleBranch:      true,
 		}
 
@@ -1152,7 +1316,10 @@ func (cm *ConfigManager) CountAllCommits(conf *config.Config) (int, error) {
 		return 0, fmt.Errorf("failed to open repository at %s: %w", mainPath, err)
 	}
 
-	r.Fetch(&git.FetchOptions{Force: true, Auth: &git_https.BasicAuth{Username: conf.GitUsername, Password: conf.GetDecryptedValue("git-acces-token")}})
+	fetchErr := r.Fetch(&git.FetchOptions{Force: true, Auth: &git_https.BasicAuth{Username: conf.GitUsername, Password: conf.GetDecryptedValue("git-acces-token")}})
+	if fetchErr != nil && !errors.Is(fetchErr, git.NoErrAlreadyUpToDate) {
+		cm.logger.Warnf("none", config.ConstLogModGit, "CountAllCommits: fetch failed, counting local commits only: %v", fetchErr)
+	}
 
 	commitIter, err := r.Log(&git.LogOptions{All: true})
 	if err != nil {

--- a/config/manager/manager_test.go
+++ b/config/manager/manager_test.go
@@ -9,11 +9,14 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/go-git/go-git/v5"
+	git_config "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	git_obj "github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	git_https "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/signal18/replication-manager/config"
@@ -571,6 +574,242 @@ func TestSaveConfigConcurrentStopAndCreateDoesNotBlock(t *testing.T) {
 	case <-done:
 	case <-time.After(3 * time.Second):
 		t.Fatalf("concurrent SaveConfig + Stop blocked")
+	}
+}
+
+func TestRefreshGitMetadata_PreservesCurrentBranchReference(t *testing.T) {
+	remoteBare := filepath.Join(t.TempDir(), "remote.git")
+	if _, err := git.PlainInit(remoteBare, true); err != nil {
+		t.Fatalf("failed to initialize bare remote repo: %v", err)
+	}
+
+	seedDir := t.TempDir()
+	seedRepo, err := git.PlainInit(seedDir, false)
+	if err != nil {
+		t.Fatalf("failed to initialize seed repo: %v", err)
+	}
+
+	seedWorktree, err := seedRepo.Worktree()
+	if err != nil {
+		t.Fatalf("failed to open seed worktree: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(seedDir, "README.md"), []byte("master\n"), 0o644); err != nil {
+		t.Fatalf("failed to write seed README: %v", err)
+	}
+	if _, err := seedWorktree.Add("README.md"); err != nil {
+		t.Fatalf("failed to add README: %v", err)
+	}
+	if _, err := seedWorktree.Commit("initial", &git.CommitOptions{Author: &git_obj.Signature{Name: "tester", Email: "tester@example.com", When: time.Now()}}); err != nil {
+		t.Fatalf("failed to commit initial master commit: %v", err)
+	}
+
+	if _, err := seedRepo.CreateRemote(&git_config.RemoteConfig{Name: "origin", URLs: []string{remoteBare}}); err != nil {
+		t.Fatalf("failed to add seed remote: %v", err)
+	}
+	if err := seedRepo.Push(&git.PushOptions{RefSpecs: []git_config.RefSpec{"refs/heads/master:refs/heads/master"}}); err != nil {
+		t.Fatalf("failed to push master branch: %v", err)
+	}
+
+	featureRef := plumbing.NewBranchReferenceName("feature")
+	if err := seedWorktree.Checkout(&git.CheckoutOptions{Branch: featureRef, Create: true}); err != nil {
+		t.Fatalf("failed to checkout feature branch in seed repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(seedDir, "FEATURE.txt"), []byte("feature\n"), 0o644); err != nil {
+		t.Fatalf("failed to write feature file: %v", err)
+	}
+	if _, err := seedWorktree.Add("FEATURE.txt"); err != nil {
+		t.Fatalf("failed to add feature file: %v", err)
+	}
+	if _, err := seedWorktree.Commit("feature commit", &git.CommitOptions{Author: &git_obj.Signature{Name: "tester", Email: "tester@example.com", When: time.Now()}}); err != nil {
+		t.Fatalf("failed to commit feature branch commit: %v", err)
+	}
+	if err := seedRepo.Push(&git.PushOptions{RefSpecs: []git_config.RefSpec{"refs/heads/feature:refs/heads/feature"}}); err != nil {
+		t.Fatalf("failed to push feature branch: %v", err)
+	}
+
+	workDir := t.TempDir()
+	if _, err := git.PlainClone(workDir, false, &git.CloneOptions{URL: remoteBare, ReferenceName: featureRef, SingleBranch: true}); err != nil {
+		t.Fatalf("failed to clone working repository on feature branch: %v", err)
+	}
+
+	conf := &config.Config{
+		WorkingDir:  workDir,
+		GitUrl:      remoteBare,
+		GitUsername: "local",
+		Secrets: map[string]config.Secret{
+			"git-acces-token": {Value: ""},
+		},
+	}
+	logger := logrus.New()
+	cm := NewConfigManager(config.NewLogrusWrapper(conf, logger))
+	defer cm.Stop()
+
+	if err := cm.RefreshGitMetadata(conf); err != nil {
+		t.Fatalf("RefreshGitMetadata failed: %v", err)
+	}
+
+	r, err := git.PlainOpen(workDir)
+	if err != nil {
+		t.Fatalf("failed to open refreshed workdir: %v", err)
+	}
+	headRef, err := r.Head()
+	if err != nil {
+		t.Fatalf("failed to resolve refreshed HEAD: %v", err)
+	}
+	if headRef.Name() != featureRef {
+		t.Fatalf("expected refreshed HEAD branch %s, got %s", featureRef, headRef.Name())
+	}
+}
+
+func TestCountAllCommits_FetchErrorContinuesWithLocalCount(t *testing.T) {
+	workDir := t.TempDir()
+	r, err := git.PlainInit(workDir, false)
+	if err != nil {
+		t.Fatalf("failed to initialize repository: %v", err)
+	}
+	w, err := r.Worktree()
+	if err != nil {
+		t.Fatalf("failed to open worktree: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(workDir, "local.txt"), []byte("local\n"), 0o644); err != nil {
+		t.Fatalf("failed to write local commit file: %v", err)
+	}
+	if _, err := w.Add("local.txt"); err != nil {
+		t.Fatalf("failed to add local commit file: %v", err)
+	}
+	if _, err := w.Commit("local commit", &git.CommitOptions{Author: &git_obj.Signature{Name: "tester", Email: "tester@example.com", When: time.Now()}}); err != nil {
+		t.Fatalf("failed to create local commit: %v", err)
+	}
+
+	if _, err := r.CreateRemote(&git_config.RemoteConfig{Name: "origin", URLs: []string{"https://127.0.0.1:1/invalid.git"}}); err != nil {
+		t.Fatalf("failed to add invalid origin remote: %v", err)
+	}
+
+	conf := &config.Config{
+		WorkingDir:  workDir,
+		GitUsername: "user",
+		LogGit:      true,
+		LogGitLevel: config.NumLvlWarn,
+		Secrets: map[string]config.Secret{
+			"git-acces-token": {Value: "token"},
+		},
+	}
+
+	var logs bytes.Buffer
+	logger := logrus.New()
+	logger.SetOutput(&logs)
+	logger.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true, DisableColors: true})
+	cm := NewConfigManager(config.NewLogrusWrapper(conf, logger))
+	defer cm.Stop()
+
+	count, err := cm.CountAllCommits(conf)
+	if err != nil {
+		t.Fatalf("CountAllCommits returned unexpected error on fetch failure: %v", err)
+	}
+	if count < 1 {
+		t.Fatalf("expected at least one local commit to be counted, got %d", count)
+	}
+	if !strings.Contains(logs.String(), "fetch failed") {
+		t.Fatalf("expected warning log about fetch failure, got logs: %s", logs.String())
+	}
+}
+
+func TestSwapGitMetadataWithRenamer_EXDEVFallbackCopiesMetadata(t *testing.T) {
+	workDir := t.TempDir()
+	activeGitDir := filepath.Join(workDir, ".git")
+	if err := os.MkdirAll(activeGitDir, 0o755); err != nil {
+		t.Fatalf("failed to create active .git dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(activeGitDir, "HEAD"), []byte("old-head\n"), 0o644); err != nil {
+		t.Fatalf("failed to write active HEAD: %v", err)
+	}
+
+	stagedRoot := t.TempDir()
+	stagedGitDir := filepath.Join(stagedRoot, ".git")
+	if err := os.MkdirAll(filepath.Join(stagedGitDir, "refs", "heads"), 0o755); err != nil {
+		t.Fatalf("failed to create staged .git structure: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stagedGitDir, "HEAD"), []byte("ref: refs/heads/feature\n"), 0o644); err != nil {
+		t.Fatalf("failed to write staged HEAD: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stagedGitDir, "refs", "heads", "feature"), []byte("deadbeef\n"), 0o644); err != nil {
+		t.Fatalf("failed to write staged feature ref: %v", err)
+	}
+
+	conf := &config.Config{LogGit: true, LogGitLevel: config.NumLvlWarn}
+	logger := logrus.New()
+	cm := NewConfigManager(config.NewLogrusWrapper(conf, logger))
+	defer cm.Stop()
+
+	renamer := func(oldpath, newpath string) error {
+		if oldpath == stagedGitDir && newpath == activeGitDir {
+			return &os.LinkError{Op: "rename", Old: oldpath, New: newpath, Err: syscall.EXDEV}
+		}
+		return os.Rename(oldpath, newpath)
+	}
+
+	if err := cm.swapGitMetadataWithRenamer(workDir, stagedGitDir, renamer); err != nil {
+		t.Fatalf("swapGitMetadataWithRenamer EXDEV fallback failed: %v", err)
+	}
+
+	headRaw, err := os.ReadFile(filepath.Join(activeGitDir, "HEAD"))
+	if err != nil {
+		t.Fatalf("failed to read active HEAD after fallback: %v", err)
+	}
+	if string(headRaw) != "ref: refs/heads/feature\n" {
+		t.Fatalf("active HEAD not copied from staged metadata, got %q", string(headRaw))
+	}
+
+	entries, err := os.ReadDir(workDir)
+	if err != nil {
+		t.Fatalf("failed to read workdir entries: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".git.backup.") {
+			t.Fatalf("unexpected leftover backup directory after successful fallback: %s", entry.Name())
+		}
+	}
+}
+
+func TestRollbackGitMetadata_RemovesPartialActiveThenRestoresBackup(t *testing.T) {
+	workDir := t.TempDir()
+	activeGitDir := filepath.Join(workDir, ".git")
+	backupGitDir := filepath.Join(workDir, ".git.backup.test")
+
+	if err := os.MkdirAll(activeGitDir, 0o755); err != nil {
+		t.Fatalf("failed to create active .git dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(activeGitDir, "PARTIAL"), []byte("partial\n"), 0o644); err != nil {
+		t.Fatalf("failed to write partial marker: %v", err)
+	}
+
+	if err := os.MkdirAll(backupGitDir, 0o755); err != nil {
+		t.Fatalf("failed to create backup .git dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(backupGitDir, "HEAD"), []byte("ref: refs/heads/master\n"), 0o644); err != nil {
+		t.Fatalf("failed to write backup HEAD: %v", err)
+	}
+
+	if err := rollbackGitMetadata(backupGitDir, activeGitDir, os.Rename); err != nil {
+		t.Fatalf("rollbackGitMetadata failed: %v", err)
+	}
+
+	if _, err := os.Stat(backupGitDir); !os.IsNotExist(err) {
+		t.Fatalf("expected backup dir to be moved away, got err=%v", err)
+	}
+
+	headRaw, err := os.ReadFile(filepath.Join(activeGitDir, "HEAD"))
+	if err != nil {
+		t.Fatalf("failed reading restored HEAD: %v", err)
+	}
+	if string(headRaw) != "ref: refs/heads/master\n" {
+		t.Fatalf("unexpected restored HEAD content: %q", string(headRaw))
+	}
+
+	if _, err := os.Stat(filepath.Join(activeGitDir, "PARTIAL")); !os.IsNotExist(err) {
+		t.Fatalf("expected partial marker to be removed during rollback")
 	}
 }
 

--- a/config/manager/manager_test.go
+++ b/config/manager/manager_test.go
@@ -2,20 +2,39 @@ package manager
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	git_https "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/signal18/replication-manager/config"
 	"github.com/sirupsen/logrus"
 )
+
+type testClusterConfig struct {
+	name   string
+	saveFn func() error
+}
+
+func (tc *testClusterConfig) GetName() string {
+	return tc.name
+}
+
+func (tc *testClusterConfig) Save() error {
+	if tc.saveFn != nil {
+		return tc.saveFn()
+	}
+	return nil
+}
 
 func testWorkDir(t *testing.T) string {
 	t.Helper()
@@ -341,5 +360,228 @@ func TestCommitManagerStop_DrainsPendingTasksAndRejectsNewOnes(t *testing.T) {
 	case <-rejectedDone:
 	case <-time.After(2 * time.Second):
 		t.Fatalf("post-stop task was not rejected/done promptly")
+	}
+}
+
+func TestSaveConfigWaitDuringStoppingReturnsPromptly(t *testing.T) {
+	conf := &config.Config{}
+	logger := logrus.New()
+	cm := NewConfigManager(config.NewLogrusWrapper(conf, logger))
+
+	cluster := &testClusterConfig{name: "stopping-cluster"}
+
+	cm.Stop()
+
+	done := make(chan struct{})
+	go func() {
+		cm.SaveConfig(cluster, true)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatalf("SaveConfig(wait=true) blocked while manager is stopping")
+	}
+}
+
+func TestSaveConfigWaitWhenClusterQueueStoppedReturnsPromptly(t *testing.T) {
+	conf := &config.Config{}
+	logger := logrus.New()
+	cm := NewConfigManager(config.NewLogrusWrapper(conf, logger))
+	t.Cleanup(cm.Stop)
+
+	cluster := &testClusterConfig{name: "queue-stop-cluster"}
+	clmgr, ok := cm.getOrCreateClusterManager(cluster.GetName())
+	if !ok {
+		t.Fatalf("expected cluster manager creation to succeed")
+	}
+
+	close(clmgr.stopCh)
+	clmgr.cond.Signal()
+
+	done := make(chan struct{})
+	go func() {
+		cm.SaveConfig(cluster, true)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatalf("SaveConfig(wait=true) blocked when cluster queue is stopped")
+	}
+}
+
+func TestSaveConfigConcurrentClusterCreateAndAccess(t *testing.T) {
+	conf := &config.Config{}
+	logger := logrus.New()
+	cm := NewConfigManager(config.NewLogrusWrapper(conf, logger))
+	t.Cleanup(cm.Stop)
+
+	const clusters = 8
+	const requests = 200
+
+	clusterList := make([]*testClusterConfig, 0, clusters)
+	counters := make([]*atomic.Int64, 0, clusters)
+	for i := 0; i < clusters; i++ {
+		counter := &atomic.Int64{}
+		counters = append(counters, counter)
+		clusterName := fmt.Sprintf("cluster-%d", i)
+		clusterList = append(clusterList, &testClusterConfig{
+			name: clusterName,
+			saveFn: func() error {
+				counter.Add(1)
+				time.Sleep(2 * time.Millisecond)
+				return nil
+			},
+		})
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(requests)
+	for i := 0; i < requests; i++ {
+		cluster := clusterList[i%clusters]
+		go func(c *testClusterConfig) {
+			defer wg.Done()
+			cm.SaveConfig(c, true)
+		}(cluster)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("concurrent SaveConfig calls timed out")
+	}
+
+	totalSaves := int64(0)
+	for _, counter := range counters {
+		totalSaves += counter.Load()
+	}
+	if totalSaves == 0 {
+		t.Fatalf("expected at least one successful save")
+	}
+}
+
+func TestSaveConfigWaitWithSavePanicReturnsPromptly(t *testing.T) {
+	conf := &config.Config{}
+	logger := logrus.New()
+	cm := NewConfigManager(config.NewLogrusWrapper(conf, logger))
+	t.Cleanup(cm.Stop)
+
+	cluster := &testClusterConfig{
+		name: "panic-cluster",
+		saveFn: func() error {
+			panic("save panic")
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		cm.SaveConfig(cluster, true)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("SaveConfig(wait=true) blocked when Save panicked")
+	}
+}
+
+func TestSaveConfigWorkerSurvivesSavePanic(t *testing.T) {
+	conf := &config.Config{}
+	logger := logrus.New()
+	cm := NewConfigManager(config.NewLogrusWrapper(conf, logger))
+	t.Cleanup(cm.Stop)
+
+	var calls atomic.Int64
+	cluster := &testClusterConfig{
+		name: "panic-recover-cluster",
+		saveFn: func() error {
+			if calls.Add(1) == 1 {
+				panic("first save panic")
+			}
+			return nil
+		},
+	}
+
+	firstDone := make(chan struct{})
+	go func() {
+		cm.SaveConfig(cluster, true)
+		close(firstDone)
+	}()
+
+	select {
+	case <-firstDone:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("first SaveConfig(wait=true) blocked when Save panicked")
+	}
+
+	secondDone := make(chan struct{})
+	go func() {
+		cm.SaveConfig(cluster, true)
+		close(secondDone)
+	}()
+
+	select {
+	case <-secondDone:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("second SaveConfig(wait=true) blocked after panic")
+	}
+
+	if calls.Load() < 2 {
+		t.Fatalf("expected save worker to continue processing after panic")
+	}
+}
+
+func TestSaveConfigConcurrentStopAndCreateDoesNotBlock(t *testing.T) {
+	conf := &config.Config{}
+	logger := logrus.New()
+	cm := NewConfigManager(config.NewLogrusWrapper(conf, logger))
+
+	const requests = 100
+	var wg sync.WaitGroup
+	wg.Add(requests)
+
+	for i := 0; i < requests; i++ {
+		idx := i
+		go func() {
+			defer wg.Done()
+			cluster := &testClusterConfig{name: fmt.Sprintf("stop-race-%d", idx)}
+			cm.SaveConfig(cluster, true)
+		}()
+	}
+
+	cm.Stop()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("concurrent SaveConfig + Stop blocked")
+	}
+}
+
+func TestIsRepositoryNotFoundError_MatchesWrappedError(t *testing.T) {
+	err := fmt.Errorf("clone failed: %w", transport.ErrRepositoryNotFound)
+	if !isRepositoryNotFoundError(err) {
+		t.Fatalf("expected wrapped ErrRepositoryNotFound to match")
+	}
+
+	nonMatchErr := errors.New("different error")
+	if isRepositoryNotFoundError(nonMatchErr) {
+		t.Fatalf("unexpected match for unrelated error")
 	}
 }

--- a/config/manager/manager_test.go
+++ b/config/manager/manager_test.go
@@ -1,0 +1,255 @@
+package manager
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	git_https "github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/signal18/replication-manager/config"
+	"github.com/sirupsen/logrus"
+)
+
+func testWorkDir(t *testing.T) string {
+	t.Helper()
+
+	if wd := os.Getenv("REPMAN_GIT_TEST_WORKDIR"); wd != "" {
+		if err := os.RemoveAll(wd); err != nil {
+			t.Fatalf("failed resetting static test workdir %s: %v", wd, err)
+		}
+		if err := os.MkdirAll(wd, 0o755); err != nil {
+			t.Fatalf("failed creating static test workdir %s: %v", wd, err)
+		}
+		t.Logf("using static test workdir: %s", wd)
+		return wd
+	}
+
+	return t.TempDir()
+}
+
+func snapshotLocalFiles(t *testing.T, root string) map[string][]byte {
+	t.Helper()
+
+	files := make(map[string][]byte)
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if rel == ".git" || rel == ".tmp" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		files[rel] = raw
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to snapshot local files: %v", err)
+	}
+
+	return files
+}
+
+func testGitCredentialsFromEnv(t *testing.T) (string, string, string) {
+	t.Helper()
+
+	gitURL := os.Getenv("REPMAN_GIT_TEST_URL")
+	gitToken := os.Getenv("REPMAN_GIT_TEST_TOKEN")
+	gitUser := os.Getenv("REPMAN_GIT_TEST_USERNAME")
+
+	if gitURL == "" || gitToken == "" || gitUser == "" {
+		t.Skip("set REPMAN_GIT_TEST_URL, REPMAN_GIT_TEST_TOKEN, and REPMAN_GIT_TEST_USERNAME to run this integration test")
+	}
+
+	return gitURL, gitToken, gitUser
+}
+
+func TestPushConfigToGit_WithEnvCredentials(t *testing.T) {
+	gitURL, gitToken, gitUser := testGitCredentialsFromEnv(t)
+
+	workDir := testWorkDir(t)
+	clusterName := "cluster1"
+
+	conf := &config.Config{
+		WorkingDir:  workDir,
+		GitUrl:      gitURL,
+		GitUsername: gitUser,
+		Secrets: map[string]config.Secret{
+			"git-acces-token": {Value: gitToken},
+		},
+	}
+
+	logger := logrus.New()
+	cm := NewConfigManager(config.NewLogrusWrapper(conf, logger))
+	defer cm.Stop()
+
+	// First call: clone/open repository into empty temp working dir.
+	if err := cm.PushConfigToGit(conf, nil); err != nil {
+		t.Fatalf("initial PushConfigToGit (clone/open) failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(workDir, ".git")); err != nil {
+		t.Fatalf("expected .git directory after initial push call: %v", err)
+	}
+
+	// Second phase: create files so we produce an actual commit and push.
+	if err := os.MkdirAll(filepath.Join(workDir, clusterName), 0o755); err != nil {
+		t.Fatalf("failed creating cluster directory: %v", err)
+	}
+
+	defaultToml := []byte("# repman integration test\nupdated-at = \"" + time.Now().UTC().Format(time.RFC3339Nano) + "\"\n")
+	if err := os.WriteFile(filepath.Join(workDir, "default.toml"), defaultToml, 0o644); err != nil {
+		t.Fatalf("failed writing default.toml: %v", err)
+	}
+
+	clusterState := []byte("{\"servers\":\"\",\"crashes\":[],\"sla\":{},\"slaHistory\":[],\"provisioned\":false,\"repmgrVersion\":\"test\"}\n")
+	if err := os.WriteFile(filepath.Join(workDir, clusterName, "clusterstate.json"), clusterState, 0o644); err != nil {
+		t.Fatalf("failed writing clusterstate.json: %v", err)
+	}
+
+	if err := cm.PushConfigToGit(conf, []string{clusterName}); err != nil {
+		t.Fatalf("second PushConfigToGit (commit+push) failed: %v", err)
+	}
+}
+
+func TestPushConfigToGit_ShallowClonePreservesLocalFilesThenPushMaster(t *testing.T) {
+	gitURL, gitToken, gitUser := testGitCredentialsFromEnv(t)
+
+	workDir := testWorkDir(t)
+	clusterName := "cluster1"
+
+	conf := &config.Config{
+		WorkingDir:  workDir,
+		GitUrl:      gitURL,
+		GitUsername: gitUser,
+		Secrets: map[string]config.Secret{
+			"git-acces-token": {Value: gitToken},
+		},
+	}
+
+	logger := logrus.New()
+	cm := NewConfigManager(config.NewLogrusWrapper(conf, logger))
+	defer cm.Stop()
+
+	preservedFile := filepath.Join(workDir, "local-preserved.txt")
+	preservedContent := "preserve-me"
+	if err := os.WriteFile(preservedFile, []byte(preservedContent), 0o644); err != nil {
+		t.Fatalf("failed writing local preserved file: %v", err)
+	}
+
+	preservedNestedDir := filepath.Join(workDir, "local-dir")
+	if err := os.MkdirAll(preservedNestedDir, 0o755); err != nil {
+		t.Fatalf("failed creating nested preserved dir: %v", err)
+	}
+	preservedNestedFile := filepath.Join(preservedNestedDir, "keep.txt")
+	preservedNestedContent := "keep-nested"
+	if err := os.WriteFile(preservedNestedFile, []byte(preservedNestedContent), 0o644); err != nil {
+		t.Fatalf("failed writing nested preserved file: %v", err)
+	}
+
+	t.Logf("snapshotting pre-clone local files")
+	beforeClone := snapshotLocalFiles(t, workDir)
+
+	// 1) Shallow clone into non-empty directory.
+	t.Logf("step 1: shallow clone (non-empty workdir)")
+	if err := cm.PushConfigToGit(conf, nil); err != nil {
+		t.Fatalf("initial PushConfigToGit (shallow clone) failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(workDir, ".git", "shallow")); err != nil {
+		t.Fatalf("expected shallow clone metadata in .git/shallow: %v", err)
+	}
+
+	// 2) Pre-existing local files are preserved.
+	t.Logf("step 2: verify pre-existing files remain intact")
+	afterClone := snapshotLocalFiles(t, workDir)
+	if len(beforeClone) != len(afterClone) {
+		t.Fatalf("file count changed after clone, before=%d after=%d", len(beforeClone), len(afterClone))
+	}
+	for name, beforeRaw := range beforeClone {
+		afterRaw, ok := afterClone[name]
+		if !ok {
+			t.Fatalf("file missing after clone: %s", name)
+		}
+		if !bytes.Equal(beforeRaw, afterRaw) {
+			t.Fatalf("file content changed after clone: %s", name)
+		}
+	}
+
+	raw, err := os.ReadFile(preservedFile)
+	if err != nil {
+		t.Fatalf("failed reading preserved file after clone: %v", err)
+	}
+	if string(raw) != preservedContent {
+		t.Fatalf("preserved file content changed after clone, got=%q want=%q", string(raw), preservedContent)
+	}
+	rawNested, err := os.ReadFile(preservedNestedFile)
+	if err != nil {
+		t.Fatalf("failed reading nested preserved file after clone: %v", err)
+	}
+	if string(rawNested) != preservedNestedContent {
+		t.Fatalf("nested preserved file content changed after clone, got=%q want=%q", string(rawNested), preservedNestedContent)
+	}
+
+	// 3) Commit local files.
+	t.Logf("step 3: create tracked files and commit+push")
+	if err := os.MkdirAll(filepath.Join(workDir, clusterName), 0o755); err != nil {
+		t.Fatalf("failed creating cluster directory: %v", err)
+	}
+
+	marker := "integration-marker=" + time.Now().UTC().Format(time.RFC3339Nano)
+	if err := os.WriteFile(filepath.Join(workDir, "default.toml"), []byte("# repman integration test\n"+marker+"\n"), 0o644); err != nil {
+		t.Fatalf("failed writing default.toml: %v", err)
+	}
+
+	clusterState := "{\"integrationMarker\":\"" + marker + "\"}\n"
+	if err := os.WriteFile(filepath.Join(workDir, clusterName, "clusterstate.json"), []byte(clusterState), 0o644); err != nil {
+		t.Fatalf("failed writing clusterstate.json: %v", err)
+	}
+
+	if err := cm.PushConfigToGit(conf, []string{clusterName}); err != nil {
+		t.Fatalf("second PushConfigToGit (commit+push) failed: %v", err)
+	}
+
+	// 4) Push succeeded: verify remote master contains marker.
+	t.Logf("step 4: verify marker exists on remote master")
+	verifyDir := t.TempDir()
+	_, err = git.PlainClone(verifyDir, false, &git.CloneOptions{
+		URL:           gitURL,
+		Depth:         1,
+		SingleBranch:  true,
+		ReferenceName: plumbing.NewBranchReferenceName("master"),
+		Auth: &git_https.BasicAuth{
+			Username: gitUser,
+			Password: gitToken,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to clone remote master for verification: %v", err)
+	}
+
+	remoteState, err := os.ReadFile(filepath.Join(verifyDir, clusterName, "clusterstate.json"))
+	if err != nil {
+		t.Fatalf("failed reading clusterstate.json from remote clone: %v", err)
+	}
+	if !strings.Contains(string(remoteState), marker) {
+		t.Fatalf("remote clusterstate.json does not contain marker %q", marker)
+	}
+}

--- a/config/manager/manager_test.go
+++ b/config/manager/manager_test.go
@@ -2,9 +2,11 @@ package manager
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -251,5 +253,93 @@ func TestPushConfigToGit_ShallowClonePreservesLocalFilesThenPushMaster(t *testin
 	}
 	if !strings.Contains(string(remoteState), marker) {
 		t.Fatalf("remote clusterstate.json does not contain marker %q", marker)
+	}
+}
+
+func TestCommitManagerStop_DrainsPendingTasksAndRejectsNewOnes(t *testing.T) {
+	workDir := t.TempDir()
+
+	r, err := git.PlainInit(workDir, false)
+	if err != nil {
+		t.Fatalf("failed to init repo: %v", err)
+	}
+
+	w, err := r.Worktree()
+	if err != nil {
+		t.Fatalf("failed to get worktree: %v", err)
+	}
+
+	conf := &config.Config{}
+	logger := logrus.New()
+	cm := NewConfigManager(config.NewLogrusWrapper(conf, logger))
+	t.Cleanup(cm.Stop)
+
+	cmm := cm.gitManager.CommitManager
+
+	const taskCount = 200
+	var waitQueued sync.WaitGroup
+	waitQueued.Add(taskCount)
+
+	for i := 0; i < taskCount; i++ {
+		fileName := filepath.Join(workDir, fmt.Sprintf("file-%03d.txt", i))
+		if err := os.WriteFile(fileName, []byte("payload"), 0o644); err != nil {
+			t.Fatalf("failed to create file %s: %v", fileName, err)
+		}
+
+		relPath, err := filepath.Rel(workDir, fileName)
+		if err != nil {
+			t.Fatalf("failed to create relative path: %v", err)
+		}
+
+		cmm.AddFileToCommit(GitAddTask{Filename: relPath, W: w, WaitGroup: &waitQueued})
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		cmm.Stop()
+		close(stopDone)
+	}()
+
+	select {
+	case <-stopDone:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("CommitManager.Stop() timed out")
+	}
+
+	queuedDone := make(chan struct{})
+	go func() {
+		waitQueued.Wait()
+		close(queuedDone)
+	}()
+
+	select {
+	case <-queuedDone:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("queued commit waiters were not released")
+	}
+
+	postStopFile := filepath.Join(workDir, "post-stop.txt")
+	if err := os.WriteFile(postStopFile, []byte("after-stop"), 0o644); err != nil {
+		t.Fatalf("failed to create post-stop file: %v", err)
+	}
+	postStopRel, err := filepath.Rel(workDir, postStopFile)
+	if err != nil {
+		t.Fatalf("failed to create post-stop relative path: %v", err)
+	}
+
+	var waitRejected sync.WaitGroup
+	waitRejected.Add(1)
+	cmm.AddFileToCommit(GitAddTask{Filename: postStopRel, W: w, WaitGroup: &waitRejected})
+
+	rejectedDone := make(chan struct{})
+	go func() {
+		waitRejected.Wait()
+		close(rejectedDone)
+	}()
+
+	select {
+	case <-rejectedDone:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("post-stop task was not rejected/done promptly")
 	}
 }


### PR DESCRIPTION
## Summary
This PR hardens `config/manager` around failure seen in production:
- go-git push failures such as `object not found` could leave the local repo metadata in a bad state, previously requiring manual `.git` removal to recover
The changes make shutdown behavior deterministic, prevent new work from being queued once shutdown begins, and replace destructive `.git` deletion with a safer metadata refresh flow that preserves dirty working-tree files in place.

## Changes
### Shutdown / queue handling
- drain queued save tasks and queued git tasks when stop is observed
- release waiting callers before worker exit instead of spinning on closed stop channels
- prevent new save/push/pull tasks from being enqueued once shutdown has started
- make shutdown state checks concurrency-safe with atomic stop flags
### Commit manager hardening
- synchronize `CommitManager.Stop()` with the commit queue
- clear pending commit tasks under lock before releasing waiters
- guard stop-channel close and make stop-state reads/writes safe across goroutines
### go-git recovery
- detect recoverable push failures including missing object/reference style errors
- replace `os.RemoveAll(<workdir>/.git)` recovery with in-place metadata refresh
- clone fresh repo metadata into a temp directory, then swap only `.git`
- preserve dirty working-tree files in place for running processes
- keep rollback behavior if metadata swap fails
- remove the hardcoded `master` branch assumption during clone setup

## Why
We observed intermittent go-git errors like `cannot push: object not found`, where the practical recovery had been deleting `.git` and recloning. That approach is unsafe when the working tree contains dirty files or is actively used by other processes.
We also identified shutdown paths where workers could stop with queued tasks still present, leaving waiters blocked indefinitely. This PR makes shutdown best-effort and non-blocking by draining queued work and exiting cleanly.

## Behavior impact
- active work still follows the existing save/push sequencing
- git metadata refresh now preserves local files instead of deleting `.git` outright

## Validation
- `go test ./config/manager`
- `go test ./config/...`