### PR TITLE
fix(server): expose git push/pull failures through global state-machine alerts

### DIFF
--- a/config/error.go
+++ b/config/error.go
@@ -258,9 +258,9 @@ var AppError = map[string]string{}
 // server-level supervision workflows.
 var GlobalError = map[string]string{
 	"GWARN001": "ReplicationManager detected stalled cluster heartbeat for %s",
+	"GWARN002": "ReplicationManager git push reported warning-level failure: %s",
+	"GWARN003": "ReplicationManager git pull reported warning-level failure: %s",
 	"GERR001":  "ReplicationManager detected prolonged stalled cluster heartbeat for %s",
-	"GWARN002": "ReplicationManager git %s reported warning-level failure: %s",
-	"GERR002":  "ReplicationManager git %s reported persistent failure: %s",
-	"GWARN003": "ReplicationManager git %s reported warning-level failure: %s",
-	"GERR003":  "ReplicationManager git %s reported persistent failure: %s",
+	"GERR002":  "ReplicationManager git push reported persistent failure: %s",
+	"GERR003":  "ReplicationManager git pull reported persistent failure: %s",
 }

--- a/config/error.go
+++ b/config/error.go
@@ -259,4 +259,8 @@ var AppError = map[string]string{}
 var GlobalError = map[string]string{
 	"GWARN001": "ReplicationManager detected stalled cluster heartbeat for %s",
 	"GERR001":  "ReplicationManager detected prolonged stalled cluster heartbeat for %s",
+	"GWARN002": "ReplicationManager git %s reported warning-level failure: %s",
+	"GERR002":  "ReplicationManager git %s reported persistent failure: %s",
+	"GWARN003": "ReplicationManager git %s reported warning-level failure: %s",
+	"GERR003":  "ReplicationManager git %s reported persistent failure: %s",
 }

--- a/config/manager/manager.go
+++ b/config/manager/manager.go
@@ -69,8 +69,28 @@ type GitManager struct {
 	cond          *sync.Cond       // Condition variable for waiting and notifying tasks
 	stopCh        chan struct{}    // Stop channel to signal the goroutine to stop
 	PullCh        chan struct{}    // Signal to start pull
-	DonePullCh    chan struct{}    // Signal to finish pull
-	CommitManager *CommitManager   // Commit manager
+	DonePullCh    chan struct{}    // Signal pull completion
+	pullResultMu  *sync.Mutex
+	pullResultErr error
+	CommitManager *CommitManager // Commit manager
+}
+
+type GitOperationHealth struct {
+	HasFailure  bool
+	Recoverable bool
+	Reason      string
+	Details     string
+	UpdatedAt   time.Time
+}
+
+const (
+	gitOperationPush = "push"
+	gitOperationPull = "pull"
+)
+
+type GitHealthSnapshot struct {
+	Push GitOperationHealth
+	Pull GitOperationHealth
 }
 
 func NewGitManager(logger *config.LogrusWrapper) *GitManager {
@@ -81,8 +101,23 @@ func NewGitManager(logger *config.LogrusWrapper) *GitManager {
 		stopCh:        make(chan struct{}), // Initialize stop channel for the push manager
 		PullCh:        make(chan struct{}),
 		DonePullCh:    make(chan struct{}),
+		pullResultMu:  &sync.Mutex{},
 		CommitManager: NewCommitManager(1, 10, logger),
 	}
+}
+
+func (gm *GitManager) SetPullResult(err error) {
+	gm.pullResultMu.Lock()
+	defer gm.pullResultMu.Unlock()
+	gm.pullResultErr = err
+}
+
+func (gm *GitManager) ConsumePullResult() error {
+	gm.pullResultMu.Lock()
+	defer gm.pullResultMu.Unlock()
+	err := gm.pullResultErr
+	gm.pullResultErr = nil
+	return err
 }
 
 func (gm *GitManager) SplitTaskQueue() (*ConfigGitTask, []*ConfigGitTask, []*ConfigGitTask) {
@@ -226,6 +261,8 @@ type ConfigManager struct {
 	logger      *config.LogrusWrapper
 	configWg    *sync.WaitGroup            // Tracks ongoing config saves
 	gitMutex    *sync.Mutex                // Blocks new saves during Git push
+	gitStatusMu sync.RWMutex               // Protects gitStatus
+	gitStatus   GitHealthSnapshot          // Latest git health snapshot
 	stopOnce    sync.Once                  // Ensures Stop() runs only once
 	isStopping  atomic.Bool                // Prevents new saves after stopping
 	clusterMu   *sync.RWMutex              // Protects clusterData map access
@@ -253,6 +290,72 @@ func NewConfigManager(logger *config.LogrusWrapper) *ConfigManager {
 
 func (cm *ConfigManager) GetGitManager() *GitManager {
 	return cm.gitManager
+}
+
+func (cm *ConfigManager) GetGitHealthSnapshot() GitHealthSnapshot {
+	cm.gitStatusMu.RLock()
+	defer cm.gitStatusMu.RUnlock()
+
+	return cm.gitStatus
+}
+
+func (cm *ConfigManager) setGitOperationSuccess(operation string) {
+	cm.gitStatusMu.Lock()
+	defer cm.gitStatusMu.Unlock()
+
+	now := time.Now()
+	switch operation {
+	case "push":
+		cm.gitStatus.Push = GitOperationHealth{UpdatedAt: now}
+	case "pull":
+		cm.gitStatus.Pull = GitOperationHealth{UpdatedAt: now}
+	}
+}
+
+func (cm *ConfigManager) setGitOperationFailure(operation string, recoverable bool, reason string, err error) {
+	cm.gitStatusMu.Lock()
+	defer cm.gitStatusMu.Unlock()
+
+	status := GitOperationHealth{
+		HasFailure:  true,
+		Recoverable: recoverable,
+		Reason:      reason,
+		UpdatedAt:   time.Now(),
+	}
+	if err != nil {
+		status.Details = err.Error()
+	}
+
+	switch operation {
+	case "push":
+		cm.gitStatus.Push = status
+	case "pull":
+		cm.gitStatus.Pull = status
+	}
+}
+
+func (cm *ConfigManager) UpdateGitOperationStatus(operation string, err error) {
+	if err == nil {
+		cm.setGitOperationSuccess(operation)
+		return
+	}
+
+	recoverable := false
+	reason := ""
+
+	switch operation {
+	case gitOperationPush:
+		recoverable, reason = cm.classifyRecoverablePushError(err)
+		if !recoverable {
+			recoverable, reason = classifyRecoverableGitSyncError(err)
+		}
+	case gitOperationPull:
+		recoverable, reason = classifyRecoverableGitSyncError(err)
+	default:
+		return
+	}
+
+	cm.setGitOperationFailure(operation, recoverable, reason, err)
 }
 
 func (cm *ConfigManager) UpdateLoggerConfig(clustername string, conf *config.Config) {
@@ -605,16 +708,37 @@ func (cm *ConfigManager) processGitPush() {
 
 				// Wait for the pull process to finish
 				<-cm.gitManager.DonePullCh
-
-				cm.logger.Infof("none", config.ConstLogModGit, "[Git] Git pull completed successfully.")
+				pullErr := cm.gitManager.ConsumePullResult()
+				if pullErr != nil {
+					cm.UpdateGitOperationStatus(gitOperationPull, pullErr)
+					recoverable, reason := classifyRecoverableGitSyncError(pullErr)
+					if recoverable {
+						cm.logger.Warnf("none", config.ConstLogModGit, "[Git] Warning-class pull failure (%s): %v", reason, pullErr)
+					} else {
+						cm.logger.Errorf("none", config.ConstLogModGit, "[Git] Persistent pull failure (%s): %v", reason, pullErr)
+					}
+				} else {
+					cm.UpdateGitOperationStatus(gitOperationPull, nil)
+					cm.logger.Infof("none", config.ConstLogModGit, "[Git] Git pull completed successfully.")
+				}
 
 			} else {
 				cm.logger.Debugf("none", config.ConstLogModGit, "[Git] Starting Git push...")
 				// Execute the save function and handle potential errors
 				if err := cm.PushAllConfigsToGit(configGitTask.conf, configGitTask.clusterList); err != nil {
+					cm.UpdateGitOperationStatus(gitOperationPush, err)
+					recoverable, reason := cm.classifyRecoverablePushError(err)
+					if !recoverable {
+						recoverable, reason = classifyRecoverableGitSyncError(err)
+					}
 					// Execute the Git push function and handle potential errors
-					cm.logger.Errorf("none", config.ConstLogModGit, "[Git] Error during push: %v\n", err)
+					if recoverable {
+						cm.logger.Warnf("none", config.ConstLogModGit, "[Git] Warning-class push failure (%s): %v", reason, err)
+					} else {
+						cm.logger.Errorf("none", config.ConstLogModGit, "[Git] Error during push: %v\n", err)
+					}
 				} else {
+					cm.UpdateGitOperationStatus(gitOperationPush, nil)
 					cm.logger.Infof("none", config.ConstLogModGit, "[Git] Git push completed successfully.")
 				}
 			}
@@ -765,6 +889,76 @@ func (cm *ConfigManager) classifyRecoverablePushError(err error) (bool, string) 
 		if strings.Contains(msg, candidate.match) {
 			return true, candidate.reason
 		}
+	}
+
+	return false, ""
+}
+
+func classifyRecoverableGitSyncError(err error) (bool, string) {
+	if err == nil {
+		return false, ""
+	}
+
+	if errors.Is(err, io.EOF) {
+		return true, "unexpected EOF"
+	}
+	if errors.Is(err, plumbing.ErrObjectNotFound) {
+		return true, "object not found"
+	}
+	if errors.Is(err, plumbing.ErrReferenceNotFound) {
+		return true, "reference not found"
+	}
+
+	msg := strings.ToLower(err.Error())
+
+	persistentSubstrings := []string{
+		"authentication required",
+		"authorization failed",
+		"unauthorized",
+		"permission denied",
+		"rejected",
+		"non-fast-forward",
+		"fetch first",
+	}
+	for _, sub := range persistentSubstrings {
+		if strings.Contains(msg, sub) {
+			return false, sub
+		}
+	}
+
+	recoverableSubstrings := []string{
+		"object not found",
+		"missing object",
+		"reference not found",
+		"couldn't find remote ref",
+		"reference does not exist",
+		"unable to resolve reference",
+		"connection reset",
+		"connection refused",
+		"connection timed out",
+		"timeout",
+		"temporary",
+		"eof",
+		"tls handshake timeout",
+		"network is unreachable",
+		"no route to host",
+	}
+	for _, sub := range recoverableSubstrings {
+		if strings.Contains(msg, sub) {
+			return true, sub
+		}
+	}
+
+	if errors.Is(err, transport.ErrRepositoryNotFound) {
+		return false, "repository not found"
+	}
+
+	if errors.Is(err, transport.ErrEmptyRemoteRepository) {
+		return true, "empty remote repository"
+	}
+
+	if errors.Is(err, transport.ErrAuthenticationRequired) || errors.Is(err, transport.ErrAuthorizationFailed) {
+		return false, "authentication/authorization"
 	}
 
 	return false, ""

--- a/config/manager/manager.go
+++ b/config/manager/manager.go
@@ -80,7 +80,6 @@ type GitOperationHealth struct {
 	Recoverable bool
 	Reason      string
 	Details     string
-	UpdatedAt   time.Time
 }
 
 const (
@@ -303,28 +302,17 @@ func (cm *ConfigManager) setGitOperationSuccess(operation string) {
 	cm.gitStatusMu.Lock()
 	defer cm.gitStatusMu.Unlock()
 
-	now := time.Now()
 	switch operation {
 	case "push":
-		cm.gitStatus.Push = GitOperationHealth{UpdatedAt: now}
+		cm.gitStatus.Push = GitOperationHealth{}
 	case "pull":
-		cm.gitStatus.Pull = GitOperationHealth{UpdatedAt: now}
+		cm.gitStatus.Pull = GitOperationHealth{}
 	}
 }
 
-func (cm *ConfigManager) setGitOperationFailure(operation string, recoverable bool, reason string, err error) {
+func (cm *ConfigManager) setGitOperationFailure(operation string, status GitOperationHealth) {
 	cm.gitStatusMu.Lock()
 	defer cm.gitStatusMu.Unlock()
-
-	status := GitOperationHealth{
-		HasFailure:  true,
-		Recoverable: recoverable,
-		Reason:      reason,
-		UpdatedAt:   time.Now(),
-	}
-	if err != nil {
-		status.Details = err.Error()
-	}
 
 	switch operation {
 	case "push":
@@ -334,28 +322,41 @@ func (cm *ConfigManager) setGitOperationFailure(operation string, recoverable bo
 	}
 }
 
-func (cm *ConfigManager) UpdateGitOperationStatus(operation string, err error) {
-	if err == nil {
-		cm.setGitOperationSuccess(operation)
-		return
+func (cm *ConfigManager) classifyGitOperationError(operation string, err error) GitOperationHealth {
+	status := GitOperationHealth{HasFailure: true}
+	if err != nil {
+		status.Details = err.Error()
 	}
-
-	recoverable := false
-	reason := ""
 
 	switch operation {
 	case gitOperationPush:
-		recoverable, reason = cm.classifyRecoverablePushError(err)
-		if !recoverable {
-			recoverable, reason = classifyRecoverableGitSyncError(err)
+		status.Recoverable, status.Reason = cm.classifyRecoverablePushError(err)
+		if !status.Recoverable {
+			status.Recoverable, status.Reason = classifyRecoverableGitSyncError(err)
 		}
 	case gitOperationPull:
-		recoverable, reason = classifyRecoverableGitSyncError(err)
-	default:
-		return
+		status.Recoverable, status.Reason = classifyRecoverableGitSyncError(err)
 	}
 
-	cm.setGitOperationFailure(operation, recoverable, reason, err)
+	if status.Reason == "" {
+		status.Reason = status.Details
+	}
+
+	return status
+}
+
+func (cm *ConfigManager) UpdateGitOperationStatus(operation string, err error) GitOperationHealth {
+	if err == nil {
+		cm.setGitOperationSuccess(operation)
+		return GitOperationHealth{}
+	}
+	if operation != gitOperationPush && operation != gitOperationPull {
+		return GitOperationHealth{}
+	}
+
+	status := cm.classifyGitOperationError(operation, err)
+	cm.setGitOperationFailure(operation, status)
+	return status
 }
 
 func (cm *ConfigManager) UpdateLoggerConfig(clustername string, conf *config.Config) {
@@ -710,12 +711,11 @@ func (cm *ConfigManager) processGitPush() {
 				<-cm.gitManager.DonePullCh
 				pullErr := cm.gitManager.ConsumePullResult()
 				if pullErr != nil {
-					cm.UpdateGitOperationStatus(gitOperationPull, pullErr)
-					recoverable, reason := classifyRecoverableGitSyncError(pullErr)
-					if recoverable {
-						cm.logger.Warnf("none", config.ConstLogModGit, "[Git] Warning-class pull failure (%s): %v", reason, pullErr)
+					status := cm.UpdateGitOperationStatus(gitOperationPull, pullErr)
+					if status.Recoverable {
+						cm.logger.Warnf("none", config.ConstLogModGit, "[Git] Warning-class pull failure (%s): %v", status.Reason, pullErr)
 					} else {
-						cm.logger.Errorf("none", config.ConstLogModGit, "[Git] Persistent pull failure (%s): %v", reason, pullErr)
+						cm.logger.Errorf("none", config.ConstLogModGit, "[Git] Persistent pull failure (%s): %v", status.Reason, pullErr)
 					}
 				} else {
 					cm.UpdateGitOperationStatus(gitOperationPull, nil)
@@ -726,14 +726,10 @@ func (cm *ConfigManager) processGitPush() {
 				cm.logger.Debugf("none", config.ConstLogModGit, "[Git] Starting Git push...")
 				// Execute the save function and handle potential errors
 				if err := cm.PushAllConfigsToGit(configGitTask.conf, configGitTask.clusterList); err != nil {
-					cm.UpdateGitOperationStatus(gitOperationPush, err)
-					recoverable, reason := cm.classifyRecoverablePushError(err)
-					if !recoverable {
-						recoverable, reason = classifyRecoverableGitSyncError(err)
-					}
+					status := cm.UpdateGitOperationStatus(gitOperationPush, err)
 					// Execute the Git push function and handle potential errors
-					if recoverable {
-						cm.logger.Warnf("none", config.ConstLogModGit, "[Git] Warning-class push failure (%s): %v", reason, err)
+					if status.Recoverable {
+						cm.logger.Warnf("none", config.ConstLogModGit, "[Git] Warning-class push failure (%s): %v", status.Reason, err)
 					} else {
 						cm.logger.Errorf("none", config.ConstLogModGit, "[Git] Error during push: %v\n", err)
 					}
@@ -899,6 +895,18 @@ func classifyRecoverableGitSyncError(err error) (bool, string) {
 		return false, ""
 	}
 
+	if errors.Is(err, transport.ErrAuthenticationRequired) || errors.Is(err, transport.ErrAuthorizationFailed) {
+		return false, "authentication/authorization"
+	}
+
+	if errors.Is(err, transport.ErrRepositoryNotFound) {
+		return false, "repository not found"
+	}
+
+	if errors.Is(err, transport.ErrEmptyRemoteRepository) {
+		return true, "empty remote repository"
+	}
+
 	if errors.Is(err, io.EOF) {
 		return true, "unexpected EOF"
 	}
@@ -947,18 +955,6 @@ func classifyRecoverableGitSyncError(err error) (bool, string) {
 		if strings.Contains(msg, sub) {
 			return true, sub
 		}
-	}
-
-	if errors.Is(err, transport.ErrRepositoryNotFound) {
-		return false, "repository not found"
-	}
-
-	if errors.Is(err, transport.ErrEmptyRemoteRepository) {
-		return true, "empty remote repository"
-	}
-
-	if errors.Is(err, transport.ErrAuthenticationRequired) || errors.Is(err, transport.ErrAuthorizationFailed) {
-		return false, "authentication/authorization"
 	}
 
 	return false, ""

--- a/server/server.go
+++ b/server/server.go
@@ -2599,6 +2599,7 @@ func (repman *ReplicationManager) Run() error {
 		}
 
 		repman.ProduceClusterHeartbeatSupervisionStates()
+		repman.ProduceGitSupervisionStates()
 		repman.ProcessAlertStateLifecycle()
 
 		counter++

--- a/server/server_git.go
+++ b/server/server_git.go
@@ -259,8 +259,11 @@ func (repman *ReplicationManager) PullCloud18Configs() {
 	<-gm.PullCh
 	repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Pulling Cloud18 Configs")
 
+	var pullErr error
+
 	defer func() {
 		// Inform the GitManager that the pull is done
+		gm.SetPullResult(pullErr)
 		gm.DonePullCh <- struct{}{}
 	}()
 
@@ -271,7 +274,12 @@ func (repman *ReplicationManager) PullCloud18Configs() {
 		err := repman.Conf.CloneConfigFromGit(repman.Conf.GitUrlPull, repman.Conf.GitUsername, repman.Conf.Secrets["git-acces-token"].Value, pullDir)
 		if err != nil {
 			os.RemoveAll(pullDir + "/.git")
-			repman.Conf.CloneConfigFromGit(repman.Conf.GitUrlPull, repman.Conf.GitUsername, repman.Conf.Secrets["git-acces-token"].Value, pullDir)
+			err = repman.Conf.CloneConfigFromGit(repman.Conf.GitUrlPull, repman.Conf.GitUsername, repman.Conf.Secrets["git-acces-token"].Value, pullDir)
+			if err != nil {
+				pullErr = err
+				repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlErr, "Error pulling cloud18 git config: %v", err)
+				return
+			}
 		}
 
 		//to check cloud18.toml for the first time

--- a/server/server_state.go
+++ b/server/server_state.go
@@ -12,12 +12,17 @@ import (
 
 	"github.com/signal18/replication-manager/cluster"
 	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/config/manager"
 	"github.com/signal18/replication-manager/utils/state"
 )
 
 const (
 	clusterHeartbeatWarnErrKey                  = "GWARN001"
 	clusterHeartbeatCriticalErrKey              = "GERR001"
+	gitPushWarnErrKey                           = "GWARN002"
+	gitPushErrErrKey                            = "GERR002"
+	gitPullWarnErrKey                           = "GWARN003"
+	gitPullErrErrKey                            = "GERR003"
 	defaultMonitorGlobalHeartbeatStallThreshold = 5
 	heartbeatCriticalThresholdMultiplier        = int64(3)
 )
@@ -115,6 +120,41 @@ func (repman *ReplicationManager) ProcessAlertStateLifecycle() {
 	}
 
 	repman.StateMachine.ClearState()
+}
+
+func (repman *ReplicationManager) ProduceGitSupervisionStates() {
+	if repman == nil || repman.StateMachine == nil || repman.ConfigManager == nil {
+		return
+	}
+
+	snapshot := repman.ConfigManager.GetGitHealthSnapshot()
+	repman.produceGitOperationSupervisionState("git", "push", snapshot.Push, gitPushWarnErrKey, gitPushErrErrKey)
+	repman.produceGitOperationSupervisionState("git", "pull", snapshot.Pull, gitPullWarnErrKey, gitPullErrErrKey)
+}
+
+func (repman *ReplicationManager) produceGitOperationSupervisionState(scope string, operation string, operationStatus manager.GitOperationHealth, warnErrKey, errErrKey string) {
+	if !operationStatus.HasFailure {
+		return
+	}
+
+	severity := "ERROR"
+	errKey := errErrKey
+	if operationStatus.Recoverable {
+		severity = "WARNING"
+		errKey = warnErrKey
+	}
+
+	reason := operationStatus.Reason
+	if reason == "" {
+		reason = operationStatus.Details
+	}
+	errDesc := fmt.Sprintf(config.GlobalError[errKey], operation, reason)
+	repman.SetState(fmt.Sprintf("%s@%s", errKey, scope), state.State{
+		ErrType: severity,
+		ErrKey:  errKey,
+		ErrDesc: errDesc,
+		ErrFrom: "REPMAN",
+	})
 }
 
 // ProduceClusterHeartbeatSupervisionStates inspects per-cluster state-machine

--- a/server/server_state.go
+++ b/server/server_state.go
@@ -128,11 +128,11 @@ func (repman *ReplicationManager) ProduceGitSupervisionStates() {
 	}
 
 	snapshot := repman.ConfigManager.GetGitHealthSnapshot()
-	repman.produceGitOperationSupervisionState("git", "push", snapshot.Push, gitPushWarnErrKey, gitPushErrErrKey)
-	repman.produceGitOperationSupervisionState("git", "pull", snapshot.Pull, gitPullWarnErrKey, gitPullErrErrKey)
+	repman.produceGitOperationSupervisionState("git", snapshot.Push, gitPushWarnErrKey, gitPushErrErrKey)
+	repman.produceGitOperationSupervisionState("git", snapshot.Pull, gitPullWarnErrKey, gitPullErrErrKey)
 }
 
-func (repman *ReplicationManager) produceGitOperationSupervisionState(scope string, operation string, operationStatus manager.GitOperationHealth, warnErrKey, errErrKey string) {
+func (repman *ReplicationManager) produceGitOperationSupervisionState(scope string, operationStatus manager.GitOperationHealth, warnErrKey, errErrKey string) {
 	if !operationStatus.HasFailure {
 		return
 	}
@@ -148,7 +148,7 @@ func (repman *ReplicationManager) produceGitOperationSupervisionState(scope stri
 	if reason == "" {
 		reason = operationStatus.Details
 	}
-	errDesc := fmt.Sprintf(config.GlobalError[errKey], operation, reason)
+	errDesc := fmt.Sprintf(config.GlobalError[errKey], reason)
 	repman.SetState(fmt.Sprintf("%s@%s", errKey, scope), state.State{
 		ErrType: severity,
 		ErrKey:  errKey,

--- a/server/server_state.go
+++ b/server/server_state.go
@@ -128,11 +128,13 @@ func (repman *ReplicationManager) ProduceGitSupervisionStates() {
 	}
 
 	snapshot := repman.ConfigManager.GetGitHealthSnapshot()
-	repman.produceGitOperationSupervisionState("git", snapshot.Push, gitPushWarnErrKey, gitPushErrErrKey)
-	repman.produceGitOperationSupervisionState("git", snapshot.Pull, gitPullWarnErrKey, gitPullErrErrKey)
+	// Keep a single global key scope (@git) and distinguish push vs pull
+	// with dedicated error codes (GWARN/GERR 002 for push, 003 for pull).
+	repman.produceGitOperationSupervisionState("push", snapshot.Push, gitPushWarnErrKey, gitPushErrErrKey)
+	repman.produceGitOperationSupervisionState("pull", snapshot.Pull, gitPullWarnErrKey, gitPullErrErrKey)
 }
 
-func (repman *ReplicationManager) produceGitOperationSupervisionState(scope string, operationStatus manager.GitOperationHealth, warnErrKey, errErrKey string) {
+func (repman *ReplicationManager) produceGitOperationSupervisionState(operation string, operationStatus manager.GitOperationHealth, warnErrKey, errErrKey string) {
 	if !operationStatus.HasFailure {
 		return
 	}
@@ -148,8 +150,23 @@ func (repman *ReplicationManager) produceGitOperationSupervisionState(scope stri
 	if reason == "" {
 		reason = operationStatus.Details
 	}
-	errDesc := fmt.Sprintf(config.GlobalError[errKey], reason)
-	repman.SetState(fmt.Sprintf("%s@%s", errKey, scope), state.State{
+	// Guard template lookup so alert descriptions stay valid even if a future
+	// refactor removes/renames a GlobalError key. When mapping exists, use the
+	// operation-specific template from config/error.go; otherwise fall back.
+	tmpl, ok := config.GlobalError[errKey]
+	errDesc := ""
+	if ok && tmpl != "" {
+		errDesc = fmt.Sprintf(tmpl, reason)
+	} else {
+		if operationStatus.Recoverable {
+			tmpl = "ReplicationManager git %s reported warning-level failure: %s"
+		} else {
+			tmpl = "ReplicationManager git %s reported persistent failure: %s"
+		}
+		errDesc = fmt.Sprintf(tmpl, operation, reason)
+	}
+
+	repman.SetState(fmt.Sprintf("%s@git", errKey), state.State{
 		ErrType: severity,
 		ErrKey:  errKey,
 		ErrDesc: errDesc,

--- a/server/server_state_supervision_test.go
+++ b/server/server_state_supervision_test.go
@@ -300,7 +300,7 @@ func TestProduceGitSupervisionStatesErrorForPersistentPushFailure(t *testing.T) 
 	}
 }
 
-func TestProduceGitSupervisionStatesUsesSeparatePullKeys(t *testing.T) {
+func TestProduceGitSupervisionStatesUsesDistinctPushPullErrorCodes(t *testing.T) {
 	cm := newGitSupervisionTestConfigManager(t)
 	cm.UpdateGitOperationStatus("pull", io.EOF)
 
@@ -312,10 +312,10 @@ func TestProduceGitSupervisionStatesUsesSeparatePullKeys(t *testing.T) {
 	pullWarnKey := fmt.Sprintf("%s@git", gitPullWarnErrKey)
 	pushWarnKey := fmt.Sprintf("%s@git", gitPushWarnErrKey)
 	if !repman.StateMachine.IsInState(pullWarnKey) {
-		t.Fatalf("expected pull warning state %s", pullWarnKey)
+		t.Fatalf("expected pull warning state using pull-specific code %s", pullWarnKey)
 	}
 	if repman.StateMachine.IsInState(pushWarnKey) {
-		t.Fatalf("did not expect push warning key %s when only pull failed", pushWarnKey)
+		t.Fatalf("did not expect push warning state code %s when only pull failed", pushWarnKey)
 	}
 }
 

--- a/server/server_state_supervision_test.go
+++ b/server/server_state_supervision_test.go
@@ -2,11 +2,15 @@ package server
 
 import (
 	"fmt"
+	"io"
 	"testing"
 
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/signal18/replication-manager/cluster"
 	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/config/manager"
 	"github.com/signal18/replication-manager/utils/state"
+	"github.com/sirupsen/logrus"
 )
 
 func newHeartbeatTestCluster(heartbeats int) *cluster.Cluster {
@@ -252,5 +256,91 @@ func TestProduceClusterHeartbeatSupervisionStatesEscalatesToCritical(t *testing.
 	}
 	if repman.StateMachine.IsInState(warnKey) {
 		t.Fatalf("expected warning key %s to resolve after critical escalation", warnKey)
+	}
+}
+
+func newGitSupervisionTestConfigManager(t *testing.T) *manager.ConfigManager {
+	t.Helper()
+	cm := manager.NewConfigManager(config.NewLogrusWrapper(&config.Config{}, logrus.New()))
+	t.Cleanup(cm.Stop)
+	return cm
+}
+
+func TestProduceGitSupervisionStatesWarningForTransientPushFailure(t *testing.T) {
+	cm := newGitSupervisionTestConfigManager(t)
+	cm.UpdateGitOperationStatus("push", io.EOF)
+
+	repman := &ReplicationManager{Conf: &config.Config{}, ConfigManager: cm}
+	repman.InitAlertStateMachine()
+	repman.ProduceGitSupervisionStates()
+	repman.ProcessAlertStateLifecycle()
+
+	warnKey := fmt.Sprintf("%s@git", gitPushWarnErrKey)
+	errKey := fmt.Sprintf("%s@git", gitPushErrErrKey)
+	if !repman.StateMachine.IsInState(warnKey) {
+		t.Fatalf("expected warning git push supervision state %s", warnKey)
+	}
+	if repman.StateMachine.IsInState(errKey) {
+		t.Fatalf("did not expect persistent git push supervision state %s", errKey)
+	}
+}
+
+func TestProduceGitSupervisionStatesErrorForPersistentPushFailure(t *testing.T) {
+	cm := newGitSupervisionTestConfigManager(t)
+	cm.UpdateGitOperationStatus("push", transport.ErrAuthenticationRequired)
+
+	repman := &ReplicationManager{Conf: &config.Config{}, ConfigManager: cm}
+	repman.InitAlertStateMachine()
+	repman.ProduceGitSupervisionStates()
+	repman.ProcessAlertStateLifecycle()
+
+	errKey := fmt.Sprintf("%s@git", gitPushErrErrKey)
+	if !repman.StateMachine.IsInState(errKey) {
+		t.Fatalf("expected persistent git push supervision state %s", errKey)
+	}
+}
+
+func TestProduceGitSupervisionStatesUsesSeparatePullKeys(t *testing.T) {
+	cm := newGitSupervisionTestConfigManager(t)
+	cm.UpdateGitOperationStatus("pull", io.EOF)
+
+	repman := &ReplicationManager{Conf: &config.Config{}, ConfigManager: cm}
+	repman.InitAlertStateMachine()
+	repman.ProduceGitSupervisionStates()
+	repman.ProcessAlertStateLifecycle()
+
+	pullWarnKey := fmt.Sprintf("%s@git", gitPullWarnErrKey)
+	pushWarnKey := fmt.Sprintf("%s@git", gitPushWarnErrKey)
+	if !repman.StateMachine.IsInState(pullWarnKey) {
+		t.Fatalf("expected pull warning state %s", pullWarnKey)
+	}
+	if repman.StateMachine.IsInState(pushWarnKey) {
+		t.Fatalf("did not expect push warning key %s when only pull failed", pushWarnKey)
+	}
+}
+
+func TestProduceGitSupervisionStatesResolvesAfterSuccess(t *testing.T) {
+	cm := newGitSupervisionTestConfigManager(t)
+	cm.UpdateGitOperationStatus("push", io.EOF)
+
+	repman := &ReplicationManager{Conf: &config.Config{}, ConfigManager: cm}
+	repman.InitAlertStateMachine()
+
+	warnKey := fmt.Sprintf("%s@git", gitPushWarnErrKey)
+	repman.ProduceGitSupervisionStates()
+	repman.ProcessAlertStateLifecycle()
+	if !repman.StateMachine.IsInState(warnKey) {
+		t.Fatalf("expected active warning state %s before recovery", warnKey)
+	}
+
+	cm.UpdateGitOperationStatus("push", nil)
+	repman.ProduceGitSupervisionStates()
+	if got := len(repman.StateMachine.GetLastResolvedStates()); got == 0 {
+		t.Fatalf("expected resolved transition after successful git push status")
+	}
+	repman.ProcessAlertStateLifecycle()
+
+	if repman.StateMachine.IsInState(warnKey) {
+		t.Fatalf("expected warning state %s to resolve after success", warnKey)
 	}
 }


### PR DESCRIPTION
## Summary
- Add git supervision state production to the server global state-machine so git sync problems are visible via global alerts.
- Track push and pull outcomes in `ConfigManager` with a thread-safe health snapshot, then map warning/error classes to `GWARN/GERR` states.
- Add global error templates and tests covering warning/error emission, push vs pull separation, and alert resolution after successful sync.

## Why
Git sync failures were only logged, which made them easy to miss operationally.  
This change surfaces those failures as first-class global alerts so operators can detect and react faster.