### PR TITLE
Harden app monitor creation validation and improve New Server modal defaults

### DIFF
--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -300,6 +301,27 @@ func (cluster *Cluster) AddSeededApp(srv, port, dockerImg, template string) erro
 	var newViper *viper.Viper
 	var content []byte
 	var err error
+
+	srv = strings.TrimSpace(srv)
+	port = strings.TrimSpace(port)
+	dockerImg = strings.TrimSpace(dockerImg)
+	template = strings.TrimSpace(template)
+
+	if srv == "" {
+		return errors.New("app host is required")
+	}
+
+	if dockerImg == "" && template == "" {
+		return errors.New("docker image or template is required")
+	}
+
+	if port != "" && port != "0" {
+		portNumber, convErr := strconv.Atoi(port)
+		if convErr != nil || portNumber < 1 || portNumber > 65535 {
+			return errors.New("app port must be between 1 and 65535")
+		}
+	}
+
 	if template != "" {
 		content, err = cluster.GetTemplateContent(template)
 		if err != nil {
@@ -324,6 +346,15 @@ func (cluster *Cluster) AddSeededApp(srv, port, dockerImg, template string) erro
 				return errors.New("Docker image is required in the template")
 			}
 		}
+	}
+
+	if port == "" || port == "0" {
+		return errors.New("app port is required")
+	}
+
+	portNumber, convErr := strconv.Atoi(port)
+	if convErr != nil || portNumber < 1 || portNumber > 65535 {
+		return errors.New("app port must be between 1 and 65535")
 	}
 
 	for _, app := range cluster.Conf.Apps {

--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -30,7 +30,7 @@ func (cluster *Cluster) NewAppConfig(apphost, port string) *config.AppConfig {
 		ProvAppDisk:       cluster.GetAppDisk(nil),
 		ProvAppAgents:     cluster.GetAppAgents(nil),
 		ProvAppHATopology: cluster.GetAppHATopology(nil),
-		Deployment:        new(config.Deployment),
+		Deployment:        config.NewDeploymentConfig(),
 	}
 }
 
@@ -75,7 +75,7 @@ func (cluster *Cluster) LoadAppConfig(dirname, appname string) error {
 
 	// Create a new configuration struct
 	var appcnf config.AppConfig
-	appcnf.Deployment = new(config.Deployment)
+	appcnf.Deployment = config.NewDeploymentConfig()
 
 	filename := filepath.Join(dirname, appname+".toml")
 

--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -315,13 +315,6 @@ func (cluster *Cluster) AddSeededApp(srv, port, dockerImg, template string) erro
 		return errors.New("docker image or template is required")
 	}
 
-	if port != "" && port != "0" {
-		portNumber, convErr := strconv.Atoi(port)
-		if convErr != nil || portNumber < 1 || portNumber > 65535 {
-			return errors.New("app port must be between 1 and 65535")
-		}
-	}
-
 	if template != "" {
 		content, err = cluster.GetTemplateContent(template)
 		if err != nil {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -5439,6 +5439,11 @@ func (repman *ReplicationManager) handlerMuxServerAdd(w http.ResponseWriter, r *
 				return
 			}
 
+			if port == "" || port == "0" {
+				http.Error(w, "Port is required for app monitor", http.StatusBadRequest)
+				return
+			}
+
 			if port != "" && port != "0" {
 				portNumber, convErr := strconv.Atoi(port)
 				if convErr != nil || portNumber < 1 || portNumber > 65535 {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -5444,12 +5444,10 @@ func (repman *ReplicationManager) handlerMuxServerAdd(w http.ResponseWriter, r *
 				return
 			}
 
-			if port != "" && port != "0" {
-				portNumber, convErr := strconv.Atoi(port)
-				if convErr != nil || portNumber < 1 || portNumber > 65535 {
-					http.Error(w, "Port must be between 1 and 65535", http.StatusBadRequest)
-					return
-				}
+			portNumber, convErr := strconv.Atoi(port)
+			if convErr != nil || portNumber < 1 || portNumber > 65535 {
+				http.Error(w, "Port must be between 1 and 65535", http.StatusBadRequest)
+				return
 			}
 
 			var formData DockerRegistryLoginForm

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -3018,7 +3018,7 @@ var base64LogValueSettings = map[string]struct{}{
 
 func GetApiChangeLogFormat(name, value string) (string, []interface{}) {
 	switch name {
-	case "replication-credential", "db-servers-credential", "proxysql-servers-credential", "proxy-servers-backend-max-connections", "proxy-servers-backend-max-replication-lag", "maxscale-servers-credential", "shardproxy-servers-credential", "mail-smtp-password", "mail-smtp-user", "mail-to", "mail-from", "cloud18-gitlab-user", "cloud18-gitlab-password", "backup-restic-aws-access-key-id", "backup-restic-aws-access-secret", "backup-restic-password", "cloud18-dba-user-credentials", "cloud18-sponsor-user-credentials":
+	case "replication-credential", "db-servers-credential", "proxysql-servers-credential", "proxy-servers-backend-max-connections", "proxy-servers-backend-max-replication-lag", "maxscale-servers-credential", "shardproxy-servers-credential", "mail-smtp-password", "mail-smtp-user", "mail-to", "mail-from", "cloud18-gitlab-user", "cloud18-gitlab-password", "cloud18-domain-secret", "backup-restic-aws-access-key-id", "backup-restic-aws-access-secret", "backup-restic-password", "cloud18-dba-user-credentials", "cloud18-sponsor-user-credentials":
 		return "API receive set setting %s to ****", []interface{}{name}
 	default:
 		logValue := value
@@ -3683,6 +3683,16 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		new_secret.Value = mycluster.Conf.Cloud18GitPassword
 		new_secret.OldValue = mycluster.Conf.GetDecryptedValue("cloud18-gitlab-password")
 		mycluster.Conf.Secrets["cloud18-gitlab-password"] = new_secret
+	case "cloud18-domain-secret":
+		val, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return errors.New("unable to decode")
+		}
+		mycluster.Conf.Cloud18DomainSecret = string(val)
+		var new_secret config.Secret
+		new_secret.Value = mycluster.Conf.Cloud18DomainSecret
+		new_secret.OldValue = mycluster.Conf.GetDecryptedValue("cloud18-domain-secret")
+		mycluster.Conf.Secrets["cloud18-domain-secret"] = new_secret
 	case "cloud18-platform-description":
 		mycluster.Conf.Cloud18PlatformDescription = value
 	case "log-level-file":
@@ -4566,6 +4576,26 @@ func (repman *ReplicationManager) setRepmanSetting(name string, value string) er
 		new_secret.Value = repman.Conf.Cloud18GitPassword
 		new_secret.OldValue = repman.Conf.GetDecryptedValue("cloud18-gitlab-password")
 		repman.Conf.Secrets["cloud18-gitlab-password"] = new_secret
+	case "cloud18-gateway-domain-name":
+		repman.Conf.Cloud18GatewayDomainName = value
+	case "cloud18-gateway-service":
+		repman.Conf.Cloud18GatewayService = value
+	case "cloud18-domain-add-script":
+		repman.Conf.Cloud18DomainAddScript = value
+	case "cloud18-domain-drop-script":
+		repman.Conf.Cloud18DomainDropScript = value
+	case "cloud18-domain-user":
+		repman.Conf.Cloud18DomainUser = value
+	case "cloud18-domain-secret":
+		val, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return errors.New("unable to decode")
+		}
+		repman.Conf.Cloud18DomainSecret = string(val)
+		var new_secret config.Secret
+		new_secret.Value = repman.Conf.Cloud18DomainSecret
+		new_secret.OldValue = repman.Conf.GetDecryptedValue("cloud18-domain-secret")
+		repman.Conf.Secrets["cloud18-domain-secret"] = new_secret
 	case "api-bind":
 		repman.Conf.APIBind = value
 	case "api-port ":

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -5423,9 +5423,9 @@ func (repman *ReplicationManager) handlerMuxServerAdd(w http.ResponseWriter, r *
 		mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Rest API receive new %s monitor to be added %s", vars["type"], vars["host"]+":"+vars["port"])
 		var srvtype, host, port, tag, template string
 		srvtype = vars["type"]
-		host = vars["host"]
-		port = vars["port"]
-		tag = vars["tag"]
+		host = strings.TrimSpace(vars["host"])
+		port = strings.TrimSpace(vars["port"])
+		tag = strings.TrimSpace(vars["tag"])
 
 		if srvtype == "" {
 			if port == "0" || port == "" {
@@ -5434,6 +5434,19 @@ func (repman *ReplicationManager) handlerMuxServerAdd(w http.ResponseWriter, r *
 			err = mycluster.AddSeededServer(host + ":" + port)
 		} else if srvtype == "app" {
 			// Add app monitor
+			if host == "" {
+				http.Error(w, "Host is required for app monitor", http.StatusBadRequest)
+				return
+			}
+
+			if port != "" && port != "0" {
+				portNumber, convErr := strconv.Atoi(port)
+				if convErr != nil || portNumber < 1 || portNumber > 65535 {
+					http.Error(w, "Port must be between 1 and 65535", http.StatusBadRequest)
+					return
+				}
+			}
+
 			var formData DockerRegistryLoginForm
 			if r.Body != nil {
 				decoder := json.NewDecoder(r.Body)
@@ -5446,6 +5459,17 @@ func (repman *ReplicationManager) handlerMuxServerAdd(w http.ResponseWriter, r *
 				}
 
 				if formData.IsPrivate {
+					formData.URL = strings.TrimSpace(formData.URL)
+					formData.Username = strings.TrimSpace(formData.Username)
+					if formData.URL == "" {
+						http.Error(w, "Registry URL is required for private registry", http.StatusBadRequest)
+						return
+					}
+					if formData.Password == "" {
+						http.Error(w, "Registry credential is required for private registry", http.StatusBadRequest)
+						return
+					}
+
 					err := mycluster.AddDockerPrivateRegistryCredentials(formData.URL, formData.Username, formData.Password, formData.Update)
 					if err != nil {
 						// Only warn don't exit if error is not nil
@@ -5454,7 +5478,7 @@ func (repman *ReplicationManager) handlerMuxServerAdd(w http.ResponseWriter, r *
 				}
 
 				if formData.Template != "" {
-					template = formData.Template
+					template = strings.TrimSpace(formData.Template)
 				}
 			}
 

--- a/share/app/deployments/dummy.toml.sample
+++ b/share/app/deployments/dummy.toml.sample
@@ -5,8 +5,6 @@ prov-app-ha-topology = "flex"
 
 [deployment]
 
-  [deployment.Mutex]
-
   [[deployment.routes]]
     cname = "{{app.name}}.{{name}}.{{config.cloud18SubDomain}}-{{config.cloud18SubDomainZone}}.{{config.cloud18Domain}}.cloud18.io"
     port = "{{app.port}}"

--- a/share/app/deployments/dummy.toml.sample
+++ b/share/app/deployments/dummy.toml.sample
@@ -1,12 +1,28 @@
+app-host = "{{app.name}}"
+app-port = "80"
+prov-app-docker-img = "phpmyadmin:latest"
+prov-app-ha-topology = "flex"
+
 [deployment]
+
+  [deployment.Mutex]
+
+  [[deployment.routes]]
+    cname = "{{app.name}}.{{name}}.{{config.cloud18SubDomain}}-{{config.cloud18SubDomainZone}}.{{config.cloud18Domain}}.cloud18.io"
+    port = "{{app.port}}"
+    primary = true
+    protocol = "https"
+
+  [deployment.storages]
+
   [[deployment.variables]]
     locked = false
     name = "PMA_HOSTS"
     type = "env"
-    value = "{{ proxies.#.host }}"
+    value = "{{proxies.#.name}}"
 
   [[deployment.variables]]
     locked = false
     name = "PMA_ABSOLUTE_URI"
     type = "env"
-    value = "https://{{ app.config.deployment.primaryRoute.cname }}/"
+    value = "https://{{app.name}}.{{name}}.{{config.cloud18SubDomain}}-{{config.cloud18SubDomainZone}}.{{config.cloud18Domain}}.cloud18.io/"

--- a/share/dashboard_react/src/Pages/ClustersGlobalSettings/CloudSettings.jsx
+++ b/share/dashboard_react/src/Pages/ClustersGlobalSettings/CloudSettings.jsx
@@ -98,6 +98,7 @@ Start create an account in https://gitlab.signal18.io
       key: 'Gitlab Password',
       value: (
         <TextForm
+          type={"password"}
           value={config?.cloud18GitlabPassword}
           confirmTitle={`Confirm gitlab password to `}
           onSave={(value) => {
@@ -150,6 +151,79 @@ Start create an account in https://gitlab.signal18.io
           confirmTitle={`Confirm platform description to `}
           onSave={(value) => {
             dispatch(setGlobalSetting({ setting: 'cloud18-platform-description', value }))
+          }}
+        />
+      )
+    },
+    {
+      key: 'Gateway Domain Name',
+      value: (
+        <TextForm
+          value={config?.cloud18GatewayDomainName}
+          confirmTitle={`Confirm gateway domain name to `}
+          onSave={(value) => {
+            dispatch(setGlobalSetting({ setting: 'cloud18-gateway-domain-name', value }))
+          }}
+        />
+      )
+    },
+    {
+      key: 'Gateway Service',
+      value: (
+        <TextForm
+          value={config?.cloud18GatewayService}
+          confirmTitle={`Confirm gateway service to `}
+          onSave={(value) => {
+            dispatch(setGlobalSetting({ setting: 'cloud18-gateway-service', value }))
+          }}
+        />
+      )
+    },
+    {
+      key: 'Domain Add Script',
+      value: (
+        <TextForm
+          value={config?.cloud18DomainAddScript}
+          confirmTitle={`Confirm domain add script to `}
+          onSave={(value) => {
+            dispatch(setGlobalSetting({ setting: 'cloud18-domain-add-script', value }))
+          }}
+        />
+      )
+    },
+    {
+      key: 'Domain Drop Script',
+      value: (
+        <TextForm
+          value={config?.cloud18DomainDropScript}
+          confirmTitle={`Confirm domain drop script to `}
+          onSave={(value) => {
+            dispatch(setGlobalSetting({ setting: 'cloud18-domain-drop-script', value }))
+          }}
+        />
+      )
+    },
+    {
+      key: 'Domain User',
+      value: (
+        <TextForm
+          value={config?.cloud18DomainUser}
+          confirmTitle={`Confirm domain user to `}
+          onSave={(value) => {
+            dispatch(setGlobalSetting({ setting: 'cloud18-domain-user', value }))
+          }}
+        />
+      )
+    },
+    {
+      key: 'Domain Secret',
+      value: (
+        <TextForm
+          type={"password"}
+          value={config?.cloud18DomainSecret}
+          confirmTitle={`Confirm domain secret to `}
+          onSave={(value) => {
+            dispatch(setGlobalSetting({ setting: 'cloud18-domain-secret', value: btoa(value) }))
           }}
         />
       )

--- a/share/dashboard_react/src/components/Modals/NewServerModal.jsx
+++ b/share/dashboard_react/src/components/Modals/NewServerModal.jsx
@@ -1,7 +1,9 @@
 import {
   Checkbox,
+  Flex,
   FormControl,
   FormErrorMessage,
+  FormHelperText,
   FormLabel,
   Input,
   Modal,
@@ -13,7 +15,7 @@ import {
   ModalOverlay,
   Stack
 } from '@chakra-ui/react'
-import React, { useEffect, useReducer, useState } from 'react'
+import { useEffect, useReducer } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { addServer, connectDockerRegistry } from '../../redux/clusterSlice'
 import Dropdown from '../Dropdown'
@@ -21,18 +23,37 @@ import RMButton from '../RMButton'
 import { useTheme } from '../../ThemeProvider'
 import parentStyles from './styles.module.scss'
 import PasswordControl from '../PasswordControl'
-import { showSuccessToast } from '../../redux/toastSlice'
 import RMIconButton from '../RMIconButton'
 import { HiRefresh } from 'react-icons/hi'
 import { refreshAppTemplateRepo } from '../../redux/globalClustersSlice'
+import PropTypes from 'prop-types'
+
+const parsePortValue = (value) => {
+  if (value === undefined || value === null || value === '') return null
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 && parsed <= 65535 ? parsed : null
+}
+
+const parseFirstHostPort = (hosts) => {
+  if (!hosts || typeof hosts !== 'string') return null
+  const firstHost = hosts.split(',').map((item) => item.trim()).find(Boolean)
+  if (!firstHost) return null
+
+  const match = firstHost.match(/:(\d+)$/)
+  if (!match) return null
+
+  return parsePortValue(match[1])
+}
 
 const initialState = {
   formData: {
+    name: '',
     host: '',
-    port: 0,
+    port: '',
     monitorType: '',
     dockerImage: '',
     tag: '',
+    hostTouched: false,
     dockerRegistry: {
       private: false,
       authType: 'password',
@@ -46,8 +67,12 @@ const initialState = {
   templateOptions: [],
   tagOptions: [],
   errors: {
+    monitorType: '',
+    name: '',
     host: '',
     port: '',
+    dockerImage: '',
+    registryUrl: '',
     dockerUser: '',
     dockerPassword: '',
   }
@@ -63,27 +88,51 @@ const formReducer = (state, action) => {
       return { ...state, templateOptions: action.payload }
     case 'SET_TAG_OPTIONS':
       return { ...state, tagOptions: action.payload }
-    case 'FILL_VERSION_DROPDOWN':
-      const repolist = action.payload === 'shardproxy' ? 'mariadb' : action.payload
-      const repo = state.serviceRepos.find((r) => r.name === repolist)
-      const tmpValue = action.payload === 'app' ? state.formData.template : ''
+    case 'SET_APP_NAME':
       return {
         ...state,
         formData: {
           ...state.formData,
-          monitorType: action.payload,
-          dockerImage: repo?.image || '',
+          name: action.payload,
+          host: state.formData.hostTouched ? state.formData.host : action.payload
+        }
+      }
+    case 'SET_APP_HOST':
+      return {
+        ...state,
+        formData: {
+          ...state.formData,
+          host: action.payload,
+          hostTouched: true
+        }
+      }
+    case 'FILL_VERSION_DROPDOWN': {
+      const selectedType = action.payload?.type || ''
+      const defaultPort = action.payload?.defaultPort
+      const repolist = selectedType === 'shardproxy' ? 'mariadb' : selectedType
+      const repo = state.serviceRepos.find((r) => r.name === repolist)
+      const template = selectedType === 'app' ? state.formData.dockerRegistry.template : ''
+
+      return {
+        ...state,
+        formData: {
+          ...state.formData,
+          monitorType: selectedType,
+          dockerImage: selectedType === 'app' ? state.formData.dockerImage : (repo?.image || ''),
           tag: '',
+          name: selectedType === 'app' ? state.formData.name : '',
+          port: defaultPort ?? state.formData.port,
+          hostTouched: selectedType === 'app' ? state.formData.hostTouched : false,
           dockerRegistry: {
             ...state.formData.dockerRegistry,
-            template: tmpValue
+            template
           }
         },
         tagOptions: repo?.options || []
       }
+    }
     case 'SET_ERRORS':
       return { ...state, errors: { ...state.errors, ...action.payload } }
-    // inside your formReducer add cases to handle new fields:
     case 'SET_PRIVATE_REGISTRY_USAGE':
       return {
         ...state,
@@ -121,7 +170,11 @@ const formReducer = (state, action) => {
         }
       }
     case 'RESET_FORM':
-      return { ...initialState, serviceRepos: state.serviceRepos, tagOptions: state.tagOptions }
+      return {
+        ...initialState,
+        serviceRepos: state.serviceRepos,
+        templateOptions: state.templateOptions,
+      }
     case 'RESET':
       return initialState
     default:
@@ -150,20 +203,47 @@ const authTypes = [
 function NewServerModal({ clusterName, isOpen, closeModal }) {
   const dispatch = useDispatch()
   const { theme } = useTheme()
-  const { globalClusters: { monitor } } = useSelector((state) => state)
+  const { globalClusters: { monitor, clusters } } = useSelector((state) => state)
   const [formState, formDispatch] = useReducer(formReducer, initialState)
   const { formData, tagOptions, templateOptions, errors } = formState
-  const { host, port, monitorType, dockerImage, tag, dockerRegistry } = formData
+  const { name, host, port, monitorType, dockerImage, tag, dockerRegistry } = formData
   const { private: isPrivateRegistry, url, username, password, authType, template } = dockerRegistry
+  const isAppMonitor = monitorType === 'app'
+  const isPortReadOnly = Boolean(monitorType) && !isAppMonitor
+  const selectedCluster = clusters?.find((cluster) => cluster?.name === clusterName)
+  const clusterConfig = selectedCluster?.config || {}
+
+  const getDefaultPortForType = (type) => {
+    switch (type) {
+      case 'mariadb':
+      case 'mysql':
+      case 'percona':
+        return parseFirstHostPort(clusterConfig?.dbServersHosts) ?? 3306
+      case 'proxysql':
+        return parsePortValue(clusterConfig?.proxysqlPort) ?? 3306
+      case 'maxscale':
+        return parsePortValue(clusterConfig?.maxscalePort) ?? 6603
+      case 'haproxy':
+        return parsePortValue(clusterConfig?.haproxyWritePort) ?? parsePortValue(clusterConfig?.haproxyReadPort) ?? 3306
+      case 'shardproxy':
+        return parseFirstHostPort(clusterConfig?.shardproxyServers) ?? 3306
+      case 'sphinx':
+        return parsePortValue(clusterConfig?.sphinxSqlPort) ?? parsePortValue(clusterConfig?.sphinxPort) ?? 9306
+      case 'extvip':
+        return parsePortValue(clusterConfig?.provProxyRoutePort) ?? 3306
+      default:
+        return null
+    }
+  }
 
   useEffect(() => {
     if (monitor?.serviceRepos?.length > 0) {
       const repos = monitor?.serviceRepos.map(entry => ({
         name: entry.name,
         image: entry.image,
-        options: entry.tags?.results?.map(tag => ({
-          name: tag.name,
-          value: `${entry.image}:${tag.name}`
+        options: entry.tags?.results?.map(tagItem => ({
+          name: tagItem.name,
+          value: `${entry.image}:${tagItem.name}`
         }))
       }))
 
@@ -182,67 +262,79 @@ function NewServerModal({ clusterName, isOpen, closeModal }) {
     }
   }, [monitor?.serviceTemplates])
 
-  // useEffect(() => {
-  //   console.log("::formState::", formState)
-  // },[formState])
-
   const handleCreateNewServer = () => {
-    const hostError = host ? '' : 'Host is required'
-    const portError = port >= 0 && port <= 65535 ? '' : 'Port is required'
+    const monitorTypeError = monitorType?.length > 0 ? '' : 'Monitor type is required'
+    const appNameError = isAppMonitor && name?.trim().length === 0 ? 'Name is required' : ''
+    const hostError = host?.trim().length > 0 ? '' : 'Host is required'
+    const parsedPort = Number(port)
+    const portError = Number.isInteger(parsedPort) && parsedPort >= 1 && parsedPort <= 65535 ? '' : 'Port is required (1-65535)'
 
-    formDispatch({ type: 'SET_ERRORS', payload: { host: hostError, port: portError } })
-    if (hostError || portError) {
-      return
+    const nextErrors = {
+      monitorType: monitorTypeError,
+      name: appNameError,
+      host: hostError,
+      port: portError,
+      dockerImage: '',
+      registryUrl: '',
+      dockerUser: '',
+      dockerPassword: ''
     }
 
-    if (monitorType === 'app') {
-      if (!template || template.length === 0) {
-        if (monitorType === 'app' && (!dockerImage || dockerImage.length === 0)) {
-          formDispatch({ type: 'SET_ERRORS', payload: { dockerImage: 'Docker image is required' } })
-          return
-        }
+    if (isAppMonitor) {
+      if (!template && (!dockerImage || dockerImage.trim().length === 0)) {
+        nextErrors.dockerImage = 'Docker image is required'
       }
 
-      if (isPrivateRegistry && (!url || url.length === 0)) {
-        formDispatch({ type: 'SET_ERRORS', payload: { dockerPassword: 'Registry URL is required' } })
-        return
+      if (isPrivateRegistry && (!url || url.trim().length === 0)) {
+        nextErrors.registryUrl = 'Registry URL is required'
       }
 
-      if (isPrivateRegistry && (!username || username.length === 0)) {
-        formDispatch({ type: 'SET_ERRORS', payload: { dockerUser: 'Username is required' } })
-        return
+      if (isPrivateRegistry && (!username || username.trim().length === 0)) {
+        nextErrors.dockerUser = 'Username is required'
       }
 
       if (isPrivateRegistry && (!password || password.length === 0)) {
-        formDispatch({ type: 'SET_ERRORS', payload: { dockerPassword: 'Password is required' } })
-        return
+        nextErrors.dockerPassword = authType === 'token' ? 'Token is required' : 'Password is required'
       }
-    } else {
-
     }
 
-    let finalTag = ""
-    if (monitorType === 'app' && dockerImage && dockerImage.length > 0) {
-      finalTag = dockerImage
+    formDispatch({ type: 'SET_ERRORS', payload: nextErrors })
+
+    if (Object.values(nextErrors).some((err) => Boolean(err))) {
+      return
+    }
+
+    let finalTag = ''
+    if (isAppMonitor && dockerImage && dockerImage.trim().length > 0) {
+      finalTag = dockerImage.trim()
     } else if (tag && tag.length > 0) {
       finalTag = tag
     }
 
-    dispatch(addServer({ clusterName, host, port, monitorType, tag: finalTag, dockerRegistry }))
+    dispatch(addServer({
+      clusterName,
+      host: host.trim(),
+      port: parsedPort,
+      monitorType,
+      tag: finalTag,
+      dockerRegistry
+    }))
+
     closeModal()
   }
 
   const handleDockerAuth = () => {
-    const userError = username?.length == 0 && isPrivateRegistry ? 'User is required' : ''
-    const passError = password?.length == 0 && isPrivateRegistry ? 'Password is required' : ''
+    const urlError = url?.length === 0 && isPrivateRegistry ? 'Registry URL is required' : ''
+    const userError = username?.length === 0 && isPrivateRegistry ? 'User is required' : ''
+    const passError = password?.length === 0 && isPrivateRegistry ? (authType === 'token' ? 'Token is required' : 'Password is required') : ''
 
-    formDispatch({ type: 'SET_ERRORS', payload: { dockerUser: userError, dockerPassword: passError } })
-    if (userError || passError) {
+    formDispatch({ type: 'SET_ERRORS', payload: { registryUrl: urlError, dockerUser: userError, dockerPassword: passError } })
+    if (urlError || userError || passError) {
       return
     }
 
-    dispatch(connectDockerRegistry({ clusterName, dockerRegistry })).then((response) => {
-      // console.log("::response::", response)
+    dispatch(connectDockerRegistry({ clusterName, dockerRegistry })).then(() => {
+      // no-op
     }, (error) => {
       formDispatch({ type: 'SET_ERRORS', payload: { dockerPassword: error.message } })
     })
@@ -258,7 +350,6 @@ function NewServerModal({ clusterName, isOpen, closeModal }) {
     }
   }, [isOpen])
 
-
   return (
     <Modal isOpen={isOpen} onClose={closeModal}>
       <ModalOverlay />
@@ -267,64 +358,134 @@ function NewServerModal({ clusterName, isOpen, closeModal }) {
         <ModalCloseButton />
         <ModalBody>
           <Stack spacing='5'>
-            <FormControl>
+            <FormControl isInvalid={Boolean(errors.monitorType)}>
               <FormLabel htmlFor='monitorType'>Monitor type</FormLabel>
               <Dropdown
                 id='monitorType'
                 isMenuPortalTarget={false}
-                onChange={(option) => formDispatch({ type: 'FILL_VERSION_DROPDOWN', payload: option.value })}
+                onChange={(option) => {
+                  const selectedType = option?.value || ''
+                  const defaultPort = getDefaultPortForType(selectedType)
+                  formDispatch({ type: 'FILL_VERSION_DROPDOWN', payload: { type: selectedType, defaultPort } })
+                }}
                 options={serviceTypes}
                 selectedValue={monitorType}
               />
+              <FormErrorMessage>{errors.monitorType}</FormErrorMessage>
             </FormControl>
 
-            {monitorType === 'app' ? (
+            {isAppMonitor ? (
               <>
+                <FormControl isInvalid={Boolean(errors.name)}>
+                  <FormLabel htmlFor='name'>Name</FormLabel>
+                  <Input
+                    id='name'
+                    type='text'
+                    isRequired={true}
+                    value={name}
+                    onChange={(e) => {
+                      formDispatch({ type: 'SET_APP_NAME', payload: e.target.value })
+                      if (errors.name || errors.host) {
+                        formDispatch({ type: 'SET_ERRORS', payload: { name: '', host: '' } })
+                      }
+                    }}
+                  />
+                  <FormErrorMessage>{errors.name}</FormErrorMessage>
+                </FormControl>
+
                 <FormControl>
-                  <FormLabel htmlFor='template'>Template</FormLabel>
+                  <Flex className={parentStyles.modalFieldWithAction}>
+                    <FormLabel htmlFor='template' mb={0}>Template</FormLabel>
+                    <RMIconButton onClick={handleRefreshAppTemplates} icon={HiRefresh} tooltip='Refresh templates from repository' />
+                  </Flex>
                   <Dropdown
                     id='template'
                     isMenuPortalTarget={false}
-                    onChange={(option) => { formDispatch({ type: 'SET_DOCKER_TEMPLATE', payload: option.value }) }}
+                    onChange={(option) => { formDispatch({ type: 'SET_DOCKER_TEMPLATE', payload: option?.value }) }}
                     options={templateOptions}
                     selectedValue={template}
                   />
-                  <RMIconButton onClick={handleRefreshAppTemplates} icon={HiRefresh} tooltip='Refresh templates from repository' />
                 </FormControl>
 
                 {!template && (
-                  <FormControl>
+                  <FormControl isInvalid={Boolean(errors.dockerImage)}>
                     <FormLabel htmlFor='dockerImage'>Docker image</FormLabel>
-                    <Input id='dockerImage' type='text' isRequired={true} value={dockerImage} onChange={(e) => formDispatch({ type: 'SET_FORM_DATA', payload: { dockerImage: e.target.value } })} />
+                    <Input
+                      id='dockerImage'
+                      type='text'
+                      isRequired={true}
+                      value={dockerImage}
+                      onChange={(e) => {
+                        formDispatch({ type: 'SET_FORM_DATA', payload: { dockerImage: e.target.value } })
+                        if (errors.dockerImage) {
+                          formDispatch({ type: 'SET_ERRORS', payload: { dockerImage: '' } })
+                        }
+                      }}
+                    />
+                    <FormErrorMessage>{errors.dockerImage}</FormErrorMessage>
                   </FormControl>
                 )}
               </>
             ) : (
-              <FormControl >
+              <FormControl>
                 <FormLabel htmlFor='tag'>Docker Version</FormLabel>
                 <Dropdown
                   id='tag'
                   isMenuPortalTarget={false}
-                  onChange={(option) => { formDispatch({ type: 'SET_FORM_DATA', payload: { tag: option.value } }) }}
+                  onChange={(option) => { formDispatch({ type: 'SET_FORM_DATA', payload: { tag: option?.value } }) }}
                   options={tagOptions}
                   selectedValue={tag}
                 />
               </FormControl>
             )}
-            <FormControl isInvalid={errors.host}>
+
+            <FormControl isInvalid={Boolean(errors.host)}>
               <FormLabel htmlFor='host'>Host</FormLabel>
-              <Input id='host' type='text' isRequired={true} value={host} onChange={(e) => formDispatch({ type: 'SET_FORM_DATA', payload: { host: e.target.value } })} />
+              <Input
+                id='host'
+                type='text'
+                isRequired={true}
+                value={host}
+                onChange={(e) => {
+                  if (isAppMonitor) {
+                    formDispatch({ type: 'SET_APP_HOST', payload: e.target.value })
+                  } else {
+                    formDispatch({ type: 'SET_FORM_DATA', payload: { host: e.target.value } })
+                  }
+
+                  if (errors.host) {
+                    formDispatch({ type: 'SET_ERRORS', payload: { host: '' } })
+                  }
+                }}
+              />
               <FormErrorMessage>{errors.host}</FormErrorMessage>
             </FormControl>
-            <FormControl isInvalid={errors.port}>
-              <FormLabel htmlFor='port'>Port {template ? "(Optional)" : ""}</FormLabel>
-              <Input id='port' type='number' max={65535} value={port} onChange={(e) => formDispatch({ type: 'SET_FORM_DATA', payload: { port: e.target.value ? parseInt(e.target.value, 10) : 0 } })} />
+
+            <FormControl isInvalid={Boolean(errors.port)}>
+              <FormLabel htmlFor='port'>Port {isPortReadOnly ? '(From config)' : ''}</FormLabel>
+              <Input
+                id='port'
+                type='number'
+                min={1}
+                max={65535}
+                isRequired={true}
+                value={port}
+                isReadOnly={isPortReadOnly}
+                className={isPortReadOnly ? parentStyles.readOnlyPortInput : ''}
+                onChange={(e) => {
+                  if (isPortReadOnly) return
+                  formDispatch({ type: 'SET_FORM_DATA', payload: { port: e.target.value ? parseInt(e.target.value, 10) : '' } })
+                  if (errors.port) {
+                    formDispatch({ type: 'SET_ERRORS', payload: { port: '' } })
+                  }
+                }}
+              />
               <FormErrorMessage>{errors.port}</FormErrorMessage>
+              {isPortReadOnly && <FormHelperText className={parentStyles.portHintText}>Using cluster configured default port for this monitor type.</FormHelperText>}
             </FormControl>
 
-            {monitorType === 'app' && (
+            {isAppMonitor && (
               <>
-                {/* Private Docker Registry Checkbox */}
                 <FormControl>
                   <Checkbox
                     isChecked={isPrivateRegistry}
@@ -336,10 +497,9 @@ function NewServerModal({ clusterName, isOpen, closeModal }) {
                   </Checkbox>
                 </FormControl>
 
-                {/* Conditionally render Docker Registry inputs */}
                 {isPrivateRegistry && (
                   <>
-                    <FormControl>
+                    <FormControl isInvalid={Boolean(errors.registryUrl)}>
                       <FormLabel htmlFor='dockerRegistryUrl'>Registry URL</FormLabel>
                       <Input
                         id='dockerRegistryUrl'
@@ -352,8 +512,10 @@ function NewServerModal({ clusterName, isOpen, closeModal }) {
                           })
                         }
                       />
+                      <FormErrorMessage>{errors.registryUrl}</FormErrorMessage>
                     </FormControl>
-                    <FormControl>
+
+                    <FormControl isInvalid={Boolean(errors.dockerUser)}>
                       <FormLabel htmlFor='dockerRegistryUsername'>Username</FormLabel>
                       <Input
                         id='dockerRegistryUsername'
@@ -368,26 +530,29 @@ function NewServerModal({ clusterName, isOpen, closeModal }) {
                       />
                       <FormErrorMessage>{errors.dockerUser}</FormErrorMessage>
                     </FormControl>
+
                     <FormControl>
                       <FormLabel htmlFor='dockerPassword'>Auth Type</FormLabel>
                       <Dropdown
                         id='type'
                         isMenuPortalTarget={false}
-                        onChange={(option) => formDispatch({ type: 'SET_REGISTRY_CREDENTIALS', payload: { authType: option.value } })}
+                        onChange={(option) => formDispatch({ type: 'SET_REGISTRY_CREDENTIALS', payload: { authType: option?.value } })}
                         options={authTypes}
                         selectedValue={authType}
                       />
                     </FormControl>
-                    <FormControl>
-                      <PasswordControl passwordError={errors.dockerPassword} inputClassName={theme === 'dark' ? parentStyles.darkLoginText : ""} labelClassName={theme === 'dark' ? parentStyles.darkLoginText : ""} className={`${parentStyles.revealButton} ${parentStyles.errorMessage} ${theme === 'dark' ? parentStyles.darkLoginText : ""}`} onChange={(e) => formDispatch({ type: 'SET_REGISTRY_CREDENTIALS', payload: { password: e.target.value } })} />
+
+                    <FormControl isInvalid={Boolean(errors.dockerPassword)}>
+                      <PasswordControl passwordError={errors.dockerPassword} inputClassName={theme === 'dark' ? parentStyles.darkLoginText : ''} labelClassName={theme === 'dark' ? parentStyles.darkLoginText : ''} className={`${parentStyles.revealButton} ${parentStyles.errorMessage} ${theme === 'dark' ? parentStyles.darkLoginText : ''}`} onChange={(e) => formDispatch({ type: 'SET_REGISTRY_CREDENTIALS', payload: { password: e.target.value } })} />
                     </FormControl>
+
                     <RMButton onClick={handleDockerAuth} size='medium'>
                       Connect
                     </RMButton>
                   </>
                 )}
               </>
-              )}
+            )}
           </Stack>
         </ModalBody>
 
@@ -405,3 +570,9 @@ function NewServerModal({ clusterName, isOpen, closeModal }) {
 }
 
 export default NewServerModal
+
+NewServerModal.propTypes = {
+  clusterName: PropTypes.string.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  closeModal: PropTypes.func.isRequired,
+}

--- a/share/dashboard_react/src/components/Modals/NewServerModal.jsx
+++ b/share/dashboard_react/src/components/Modals/NewServerModal.jsx
@@ -174,6 +174,7 @@ const formReducer = (state, action) => {
         ...initialState,
         serviceRepos: state.serviceRepos,
         templateOptions: state.templateOptions,
+        tagOptions: state.tagOptions,
       }
     case 'RESET':
       return initialState
@@ -267,7 +268,12 @@ function NewServerModal({ clusterName, isOpen, closeModal }) {
     const appNameError = isAppMonitor && name?.trim().length === 0 ? 'Name is required' : ''
     const hostError = host?.trim().length > 0 ? '' : 'Host is required'
     const parsedPort = Number(port)
-    const portError = Number.isInteger(parsedPort) && parsedPort >= 1 && parsedPort <= 65535 ? '' : 'Port is required (1-65535)'
+    const hasValidPort = Number.isInteger(parsedPort) && parsedPort >= 1 && parsedPort <= 65535
+    const portError = hasValidPort
+      ? ''
+      : (isPortReadOnly
+        ? 'Port could not be resolved from cluster config for this monitor type'
+        : 'Port is required (1-65535)')
 
     const nextErrors = {
       monitorType: monitorTypeError,
@@ -391,6 +397,7 @@ function NewServerModal({ clusterName, isOpen, closeModal }) {
                     }}
                   />
                   <FormErrorMessage>{errors.name}</FormErrorMessage>
+                  <FormHelperText className={parentStyles.portHintText}>Used to prefill host. Host is saved as app identity.</FormHelperText>
                 </FormControl>
 
                 <FormControl>

--- a/share/dashboard_react/src/components/Modals/styles.module.scss
+++ b/share/dashboard_react/src/components/Modals/styles.module.scss
@@ -243,3 +243,22 @@
   flex-direction: column;
   gap: var(--info-modal-body-gap, #{rem(8)});
 }
+
+.modalFieldWithAction {
+  align-items: center;
+  justify-content: space-between;
+  gap: rem(8);
+  margin-bottom: rem(6);
+}
+
+.readOnlyPortInput {
+  background-color: var(--secondary-gray-color) !important;
+  border-color: var(--tertiary-color) !important;
+  cursor: not-allowed;
+}
+
+.portHintText {
+  font-size: rem(12);
+  color: var(--text-color);
+  opacity: 0.8;
+}


### PR DESCRIPTION
### **Summary**
- improve the New Server modal UX for app monitors with clearer validation, name-to-host autofill, and config-based default ports for non-app types
- make config-driven DB/proxy ports read-only in the modal to better reflect backend behavior
- harden backend app creation validation so invalid host, port, and registry inputs are rejected before initiation

### **Why**
App initiation was working, but the frontend and backend allowed a few ambiguous or unsafe cases:
- the modal could submit empty or misleading port values
- app setup lacked a dedicated helper flow for name/host entry
- DB/proxy/app behavior was mixed together in one form, which made it easier to misconfigure fields
- backend app creation relied too heavily on frontend correctness and did not explicitly reject some invalid inputs
These changes reduce operator error and make the form behavior match how the backend actually treats each monitor type, while preserving the current initiation flow for valid requests

### **Details**
**Frontend**
- add app-specific helper input for name and auto-fill host from it
- keep host editable for app monitors
- require valid ports in the modal
- auto-fill DB/proxy ports from cluster config/backend defaults
- make non-app ports read-only because they are config-driven
- improve field validation and error display
- improve modal styling and clarity around template/port behavior

**Backend**
- trim and validate app add inputs before initiation
- reject empty app host
- reject invalid app port values
- require docker image or template
- validate private registry input more explicitly
- keep template-based fallback behavior intact so valid app initiation still works as before

### **Notes**
- no backend contract change was introduced for app creation
- valid existing app initiation paths are preserved
- stricter validation only blocks clearly invalid requests