### PR TITLE
feat(splitdump): Enhance restore with DEFINER handling, post-file support, and auto-create databases

### DIFF
--- a/clients/client_splitrestore.go
+++ b/clients/client_splitrestore.go
@@ -21,12 +21,13 @@ import (
 )
 
 var (
-	cliSplitRestoreDir           string
-	cliSplitRestoreMysql         string
-	cliSplitRestoreMysqlArg      string
-	cliSplitRestoreParallel      int
-	cliSplitRestoreUser          bool
-	cliSplitRestoreDisableBinlog bool
+	cliSplitRestoreDir              string
+	cliSplitRestoreMysql            string
+	cliSplitRestoreMysqlArg         string
+	cliSplitRestoreParallel         int
+	cliSplitRestoreUser             bool
+	cliSplitRestoreDisableBinlog    bool
+	cliSplitRestoreCreateDatabases  bool
 )
 
 var splitRestoreCmd = &cobra.Command{
@@ -48,6 +49,7 @@ func initSplitRestoreFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&cliSplitRestoreParallel, "parallel", 1, "Parallel workers for splitdump restore")
 	cmd.Flags().BoolVar(&cliSplitRestoreUser, "restore-user", true, "Restore mysql.system-all file when present")
 	cmd.Flags().BoolVar(&cliSplitRestoreDisableBinlog, "disable-binlog", false, "Disable binary logging for splitdump restore")
+	cmd.Flags().BoolVar(&cliSplitRestoreCreateDatabases, "splitdump-create-databases", false, "Create databases before restore (opt-in for manual CLI use)")
 }
 
 func runSplitrestore(ctx context.Context) error {
@@ -116,6 +118,31 @@ func runSplitrestore(ctx context.Context) error {
 			return fmt.Errorf("mysql restore failed for %s: %s", path, errOutput)
 		}
 		return nil
+	}
+
+	if cliSplitRestoreCreateDatabases {
+		schemas, schemaErr := splitdump.ListSchemas(cliSplitRestoreDir)
+		if schemaErr != nil {
+			logger(splitdump.LogWarn, "Could not list schemas for CREATE DATABASE: %v", schemaErr)
+		} else {
+			createArgs, argErr := splitMysqlArgs(cliSplitRestoreMysqlArg)
+			if argErr != nil {
+				logger(splitdump.LogWarn, "Invalid mysql-args, skipping CREATE DATABASE: %v", argErr)
+			} else {
+				for _, schema := range schemas {
+					escaped := strings.ReplaceAll(schema, "`", "``")
+					sql := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`;\n", escaped)
+					createCmd := exec.CommandContext(ctx, cliSplitRestoreMysql, createArgs...)
+					createCmd.Stdin = strings.NewReader(sql)
+					var createStderr bytes.Buffer
+					createCmd.Stderr = &createStderr
+					if err := createCmd.Run(); err != nil {
+						logger(splitdump.LogWarn, "CREATE DATABASE failed for %s: %s",
+							schema, strings.TrimSpace(createStderr.String()))
+					}
+				}
+			}
+		}
 	}
 
 	if err := splitdump.Restore(cliSplitRestoreDir, splitdump.RestoreOptions{

--- a/clients/client_splitrestore.go
+++ b/clients/client_splitrestore.go
@@ -28,6 +28,7 @@ var (
 	cliSplitRestoreUser             bool
 	cliSplitRestoreDisableBinlog    bool
 	cliSplitRestoreCreateDatabases  bool
+	cliSplitRestoreDefinerStrict    bool
 )
 
 var splitRestoreCmd = &cobra.Command{
@@ -50,6 +51,7 @@ func initSplitRestoreFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&cliSplitRestoreUser, "restore-user", true, "Restore mysql.system-all file when present")
 	cmd.Flags().BoolVar(&cliSplitRestoreDisableBinlog, "disable-binlog", false, "Disable binary logging for splitdump restore")
 	cmd.Flags().BoolVar(&cliSplitRestoreCreateDatabases, "splitdump-create-databases", false, "Create databases before restore (opt-in for manual CLI use)")
+	cmd.Flags().BoolVar(&cliSplitRestoreDefinerStrict, "definer-strict", false, "Fail the restore when an incompatible DEFINER clause is encountered instead of retrying without it")
 }
 
 func runSplitrestore(ctx context.Context) error {
@@ -207,6 +209,7 @@ func runSplitrestore(ctx context.Context) error {
 		Context:                   ctx,
 		RestoreFileWithContext:    restoreFile,
 		RestoreFileWithoutDefiner: restoreFileWithoutDefiner,
+		DefinerStrict:             cliSplitRestoreDefinerStrict,
 	}); err != nil {
 		return err
 	}

--- a/clients/client_splitrestore.go
+++ b/clients/client_splitrestore.go
@@ -120,6 +120,61 @@ func runSplitrestore(ctx context.Context) error {
 		return nil
 	}
 
+	// restoreFileWithoutDefiner is the non-strict DEFINER fallback: it re-opens the file,
+	// strips DEFINER clauses while streaming, and re-runs the mysql client. Without this, a
+	// DEFINER error would cause the file to be silently skipped, losing views, routines,
+	// triggers, or events without any indication to the user.
+	// splitdump.NewDefinerStrippingReader uses bufio.Reader.ReadString (no token ceiling)
+	// so lines of arbitrary length — including multi-megabyte INSERT rows — are handled
+	// correctly, unlike bufio.Scanner which returns ErrTooLong beyond its buffer limit.
+	restoreFileWithoutDefiner := func(ctx context.Context, path string) error {
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		var reader io.Reader = file
+		if strings.HasSuffix(strings.ToLower(path), ".gz") {
+			gzReader, err := gzip.NewReader(file)
+			if err != nil {
+				return err
+			}
+			defer gzReader.Close()
+			reader = gzReader
+		}
+
+		strippedReader, done := splitdump.NewDefinerStrippingReader(reader)
+
+		args, err := splitMysqlArgs(cliSplitRestoreMysqlArg)
+		if err != nil {
+			done(fmt.Errorf("arg parse failed"))
+			return fmt.Errorf("invalid mysql-args: %w", err)
+		}
+		preamble := splitdump.RestorePreamble(path)
+		if cliSplitRestoreDisableBinlog {
+			preamble = "SET sql_log_bin=0;\n" + preamble
+		}
+		var finalReader io.Reader = strippedReader
+		if preamble != "" {
+			finalReader = io.MultiReader(bytes.NewBufferString(preamble), strippedReader)
+		}
+		cmd := exec.CommandContext(ctx, cliSplitRestoreMysql, args...)
+		cmd.Stdin = finalReader
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		execErr := cmd.Run()
+		done(execErr) // unblock goroutine and wait for it before deferred file.Close runs
+		if execErr != nil {
+			errOutput := strings.TrimSpace(stderr.String())
+			if errOutput == "" {
+				errOutput = execErr.Error()
+			}
+			return fmt.Errorf("mysql restore (no-definer) failed for %s: %s", path, errOutput)
+		}
+		return nil
+	}
+
 	if cliSplitRestoreCreateDatabases {
 		schemas, schemaErr := splitdump.ListSchemas(cliSplitRestoreDir)
 		if schemaErr != nil {
@@ -146,11 +201,12 @@ func runSplitrestore(ctx context.Context) error {
 	}
 
 	if err := splitdump.Restore(cliSplitRestoreDir, splitdump.RestoreOptions{
-		Parallel:               cliSplitRestoreParallel,
-		RestoreUser:            cliSplitRestoreUser,
-		Logger:                 logger,
-		Context:                ctx,
-		RestoreFileWithContext: restoreFile,
+		Parallel:                  cliSplitRestoreParallel,
+		RestoreUser:               cliSplitRestoreUser,
+		Logger:                    logger,
+		Context:                   ctx,
+		RestoreFileWithContext:    restoreFile,
+		RestoreFileWithoutDefiner: restoreFileWithoutDefiner,
 	}); err != nil {
 		return err
 	}

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -965,9 +965,6 @@ func resolveLogicalBackupPathFromMeta(server *ServerMonitor, backtype string) (s
 	return dest, true
 }
 
-// definerStripRegex matches DEFINER=`user`@`host` clauses (case-insensitive) in SQL output.
-var definerStripRegex = regexp.MustCompile("(?i)DEFINER\\s*=\\s*`[^`]+`@`[^`]+`")
-
 func isSplitDumpDir(path string) (bool, error) {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -1069,8 +1066,9 @@ func (server *ServerMonitor) restoreSplitdumpFileContextWithPreamble(ctx context
 			return nil
 		}
 
-		// We need force in system-all to prevent failed plugins
-		if splitdump.IsMysqlSystemAll(path) {
+		// We need force in system-all to prevent failed plugins.
+		// IsMysqlSystemAll compares basename only, so pass filepath.Base(path).
+		if splitdump.IsMysqlSystemAll(filepath.Base(path)) {
 			force = true
 		}
 
@@ -1098,9 +1096,12 @@ func (server *ServerMonitor) restoreSplitdumpFileContextWithPreamble(ctx context
 }
 
 // restoreSplitdumpFileContextStripDefiner opens path (handling gzip), strips DEFINER clauses
-// line-by-line using definerStripRegex, prepends preamble, and pipes the result to the mysql
-// client. Streaming avoids loading the full decompressed file into memory.
-// It is used as the non-strict DEFINER fallback when backup-restore-definer-strict=false.
+// while streaming via splitdump.NewDefinerStrippingReader, prepends preamble, and pipes the
+// result to the mysql client. It is used as the non-strict DEFINER fallback when
+// backup-restore-definer-strict=false.
+// splitdump.NewDefinerStrippingReader uses bufio.Reader.ReadString (no fixed token ceiling)
+// so lines of arbitrary length — including multi-megabyte INSERT rows — are handled without
+// the bufio.ErrTooLong failure that the old bufio.Scanner approach was susceptible to.
 func (server *ServerMonitor) restoreSplitdumpFileContextStripDefiner(ctx context.Context, path, preamble string) error {
 	file, err := os.Open(path)
 	if err != nil {
@@ -1121,34 +1122,17 @@ func (server *ServerMonitor) restoreSplitdumpFileContextStripDefiner(ctx context
 		reader = gzReader
 	}
 
-	// Stream line-by-line through an io.Pipe so we never buffer the whole file.
-	// DEFINER clauses in mysqldump output never span lines, so per-line replacement is safe.
-	pr, pw := io.Pipe()
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		scanner := bufio.NewScanner(reader)
-		// Use a 4 MiB buffer to handle long INSERT lines in trigger/routine files.
-		scanner.Buffer(make([]byte, 4*1024*1024), 4*1024*1024)
-		for scanner.Scan() {
-			line := definerStripRegex.ReplaceAllString(scanner.Text(), "") + "\n"
-			if _, writeErr := pw.Write([]byte(line)); writeErr != nil {
-				return // pr was closed (error path); goroutine exits without blocking
-			}
-		}
-		pw.CloseWithError(scanner.Err())
-	}()
+	strippedReader, done := splitdump.NewDefinerStrippingReader(reader)
 
-	var finalReader io.Reader = pr
+	var finalReader io.Reader = strippedReader
 	if preamble != "" {
-		finalReader = io.MultiReader(bytes.NewBufferString(preamble), pr)
+		finalReader = io.MultiReader(bytes.NewBufferString(preamble), strippedReader)
 	}
 
-	force := splitdump.IsMysqlSystemAll(path)
+	// IsMysqlSystemAll compares basename only, so pass filepath.Base(path).
+	force := splitdump.IsMysqlSystemAll(filepath.Base(path))
 	execErr := server.executeMysqlRestoreContext(ctx, finalReader, force)
-	pr.CloseWithError(execErr) // unblock goroutine if blocked in pw.Write
-	wg.Wait()                  // wait for goroutine before deferred file.Close fires
+	done(execErr) // unblock goroutine and wait for it before deferred file.Close fires
 	return execErr
 }
 

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -965,6 +965,9 @@ func resolveLogicalBackupPathFromMeta(server *ServerMonitor, backtype string) (s
 	return dest, true
 }
 
+// definerStripRegex matches DEFINER=`user`@`host` clauses (case-insensitive) in SQL output.
+var definerStripRegex = regexp.MustCompile("(?i)DEFINER\\s*=\\s*`[^`]+`@`[^`]+`")
+
 func isSplitDumpDir(path string) (bool, error) {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -1071,7 +1074,7 @@ func (server *ServerMonitor) restoreSplitdumpFileContextWithPreamble(ctx context
 			force = true
 		}
 
-		if table != "" {
+		if table != "" && splitdump.IsMysqlTableCheckEligible(path) {
 			// Server path proactively checks information_schema; CLI path reacts to mysql error output instead.
 			exists, err := server.tableExists(schema, table)
 			if err != nil {
@@ -1092,6 +1095,44 @@ func (server *ServerMonitor) restoreSplitdumpFileContextWithPreamble(ctx context
 	}
 
 	return server.executeMysqlRestoreContext(ctx, reader, force)
+}
+
+// restoreSplitdumpFileContextStripDefiner reads path (handling gzip), strips DEFINER clauses
+// using definerStripRegex, prepends preamble, and pipes the result to the mysql client.
+// It is used as the non-strict DEFINER fallback when backup-restore-definer-strict=false.
+func (server *ServerMonitor) restoreSplitdumpFileContextStripDefiner(ctx context.Context, path, preamble string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	cluster := server.ClusterGroup
+	var reader io.Reader = file
+	if strings.HasSuffix(strings.ToLower(path), ".gz") {
+		parallelBlocks := cluster.getSanitizedParallelBlocks(config.ConstLogModTask)
+		bufferSize := cluster.getSanitizedDecompressBufferSize(config.ConstLogModTask)
+		gzReader, err := gzip.NewReaderN(file, bufferSize, parallelBlocks)
+		if err != nil {
+			return err
+		}
+		defer gzReader.Close()
+		reader = gzReader
+	}
+
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	stripped := definerStripRegex.ReplaceAll(content, nil)
+
+	var finalReader io.Reader = bytes.NewReader(stripped)
+	if preamble != "" {
+		finalReader = io.MultiReader(bytes.NewBufferString(preamble), finalReader)
+	}
+
+	force := splitdump.IsMysqlSystemAll(path)
+	return server.executeMysqlRestoreContext(ctx, finalReader, force)
 }
 
 func (server *ServerMonitor) tableExists(schema, table string) (bool, error) {
@@ -1213,9 +1254,30 @@ func (server *ServerMonitor) restoreSplitdumpWithMysql(ctx context.Context, back
 
 	defer server.SetInReseedBackup("")
 
+	if cluster.Conf.BackupSplitdumpCreateDatabases {
+		schemas, schemaErr := splitdump.ListSchemas(backupPath)
+		if schemaErr != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModBackupStream,
+				config.LvlWarn, "Could not list schemas for CREATE DATABASE: %v", schemaErr)
+		} else {
+			for _, schema := range schemas {
+				escaped := strings.ReplaceAll(schema, "`", "``")
+				sql := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`;\n", escaped)
+				if err := server.executeMysqlRestoreContext(ctx, strings.NewReader(sql), false); err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModBackupStream,
+						config.LvlWarn, "CREATE DATABASE failed for %s: %v", schema, err)
+				}
+			}
+		}
+	}
+
 	restoreFile := func(ctx context.Context, path string) error {
 		preamble := server.buildSplitdumpRestorePreamble(path, sqlLogBin)
 		return server.restoreSplitdumpFileContextWithPreamble(ctx, path, preamble)
+	}
+	restoreFileWithoutDefiner := func(ctx context.Context, path string) error {
+		preamble := server.buildSplitdumpRestorePreamble(path, sqlLogBin)
+		return server.restoreSplitdumpFileContextStripDefiner(ctx, path, preamble)
 	}
 
 	restoreErr := splitdump.Restore(backupPath, splitdump.RestoreOptions{
@@ -1224,8 +1286,10 @@ func (server *ServerMonitor) restoreSplitdumpWithMysql(ctx context.Context, back
 		Logger: func(level, format string, args ...any) {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModBackupStream, level, format, args...)
 		},
-		Context:                ctx,
-		RestoreFileWithContext: restoreFile,
+		Context:                   ctx,
+		RestoreFileWithContext:     restoreFile,
+		RestoreFileWithoutDefiner: restoreFileWithoutDefiner,
+		DefinerStrict:             cluster.Conf.BackupRestoreDefinerStrict,
 	})
 	if restoreErr != nil {
 		return restoreErr

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -1097,8 +1097,9 @@ func (server *ServerMonitor) restoreSplitdumpFileContextWithPreamble(ctx context
 	return server.executeMysqlRestoreContext(ctx, reader, force)
 }
 
-// restoreSplitdumpFileContextStripDefiner reads path (handling gzip), strips DEFINER clauses
-// using definerStripRegex, prepends preamble, and pipes the result to the mysql client.
+// restoreSplitdumpFileContextStripDefiner opens path (handling gzip), strips DEFINER clauses
+// line-by-line using definerStripRegex, prepends preamble, and pipes the result to the mysql
+// client. Streaming avoids loading the full decompressed file into memory.
 // It is used as the non-strict DEFINER fallback when backup-restore-definer-strict=false.
 func (server *ServerMonitor) restoreSplitdumpFileContextStripDefiner(ctx context.Context, path, preamble string) error {
 	file, err := os.Open(path)
@@ -1120,19 +1121,35 @@ func (server *ServerMonitor) restoreSplitdumpFileContextStripDefiner(ctx context
 		reader = gzReader
 	}
 
-	content, err := io.ReadAll(reader)
-	if err != nil {
-		return err
-	}
-	stripped := definerStripRegex.ReplaceAll(content, nil)
+	// Stream line-by-line through an io.Pipe so we never buffer the whole file.
+	// DEFINER clauses in mysqldump output never span lines, so per-line replacement is safe.
+	pr, pw := io.Pipe()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		scanner := bufio.NewScanner(reader)
+		// Use a 4 MiB buffer to handle long INSERT lines in trigger/routine files.
+		scanner.Buffer(make([]byte, 4*1024*1024), 4*1024*1024)
+		for scanner.Scan() {
+			line := definerStripRegex.ReplaceAllString(scanner.Text(), "") + "\n"
+			if _, writeErr := pw.Write([]byte(line)); writeErr != nil {
+				return // pr was closed (error path); goroutine exits without blocking
+			}
+		}
+		pw.CloseWithError(scanner.Err())
+	}()
 
-	var finalReader io.Reader = bytes.NewReader(stripped)
+	var finalReader io.Reader = pr
 	if preamble != "" {
-		finalReader = io.MultiReader(bytes.NewBufferString(preamble), finalReader)
+		finalReader = io.MultiReader(bytes.NewBufferString(preamble), pr)
 	}
 
 	force := splitdump.IsMysqlSystemAll(path)
-	return server.executeMysqlRestoreContext(ctx, finalReader, force)
+	execErr := server.executeMysqlRestoreContext(ctx, finalReader, force)
+	pr.CloseWithError(execErr) // unblock goroutine if blocked in pw.Write
+	wg.Wait()                  // wait for goroutine before deferred file.Close fires
+	return execErr
 }
 
 func (server *ServerMonitor) tableExists(schema, table string) (bool, error) {

--- a/cluster/srv_job_backup_splitdump_test.go
+++ b/cluster/srv_job_backup_splitdump_test.go
@@ -1,6 +1,8 @@
 package cluster
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -12,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	gzip "github.com/klauspost/pgzip"
 	"github.com/signal18/replication-manager/config"
 	"github.com/sirupsen/logrus"
 )
@@ -260,5 +263,74 @@ func TestIsSplitDumpDir(t *testing.T) {
 	}
 	if ok, err := isSplitDumpDir(emptyDir); err != nil || ok {
 		t.Fatalf("expected empty dir to be false, err=%v", err)
+	}
+}
+
+// TestDefinerStripRegexStreaming verifies that restoreSplitdumpFileContextStripDefiner actually
+// removes DEFINER clauses from the byte stream delivered to the mysql client. It writes a gzip
+// SQL file with DEFINER= clauses, pipes it through the stripping logic, and checks that the
+// output contains no DEFINER clause while preserving non-DEFINER content.
+func TestDefinerStripRegexStreaming(t *testing.T) {
+	// Build a SQL file that mimics mysqldump output for a view or routine.
+	sqlContent := strings.Join([]string{
+		"SET FOREIGN_KEY_CHECKS=0;",
+		"CREATE DEFINER=`root`@`localhost` VIEW `v1` AS SELECT 1;",
+		"CREATE DEFINER=`app_user`@`%` PROCEDURE `p1`() BEGIN SELECT 1; END;",
+		"-- plain comment without definer",
+		"CREATE TABLE `t` (`id` INT);",
+	}, "\n") + "\n"
+
+	// Write as gzip.
+	dir := t.TempDir()
+	gzPath := filepath.Join(dir, "db.v1-schema-view.sql.gz")
+	f, err := os.Create(gzPath)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	gzw := gzip.NewWriter(f)
+	if _, err := gzw.Write([]byte(sqlContent)); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	f.Close()
+
+	// Apply definerStripRegex line-by-line (same logic as restoreSplitdumpFileContextStripDefiner).
+	rf, err := os.Open(gzPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer rf.Close()
+	gzr, err := gzip.NewReader(rf)
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	defer gzr.Close()
+
+	var out bytes.Buffer
+	scanner := bufio.NewScanner(gzr)
+	for scanner.Scan() {
+		line := definerStripRegex.ReplaceAllString(scanner.Text(), "") + "\n"
+		out.WriteString(line)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	result := out.String()
+	if strings.Contains(strings.ToUpper(result), "DEFINER=") {
+		t.Fatalf("DEFINER clause still present after strip:\n%s", result)
+	}
+	// Non-DEFINER content must be preserved.
+	if !strings.Contains(result, "SELECT 1") {
+		t.Fatalf("expected SELECT 1 to be preserved, got:\n%s", result)
+	}
+	if !strings.Contains(result, "plain comment") {
+		t.Fatalf("expected comment to be preserved, got:\n%s", result)
+	}
+	// Verify CREATE statements are retained (without the DEFINER clause).
+	if !strings.Contains(result, "CREATE") {
+		t.Fatalf("expected CREATE statements to be preserved, got:\n%s", result)
 	}
 }

--- a/cluster/srv_job_backup_splitdump_test.go
+++ b/cluster/srv_job_backup_splitdump_test.go
@@ -1,8 +1,6 @@
 package cluster
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -16,6 +14,7 @@ import (
 
 	gzip "github.com/klauspost/pgzip"
 	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/splitdump"
 	"github.com/sirupsen/logrus"
 )
 
@@ -296,7 +295,8 @@ func TestDefinerStripRegexStreaming(t *testing.T) {
 	}
 	f.Close()
 
-	// Apply definerStripRegex line-by-line (same logic as restoreSplitdumpFileContextStripDefiner).
+	// Stream through splitdump.NewDefinerStrippingReader (same code path as
+	// restoreSplitdumpFileContextStripDefiner) to verify DEFINER stripping.
 	rf, err := os.Open(gzPath)
 	if err != nil {
 		t.Fatalf("open: %v", err)
@@ -308,17 +308,14 @@ func TestDefinerStripRegexStreaming(t *testing.T) {
 	}
 	defer gzr.Close()
 
-	var out bytes.Buffer
-	scanner := bufio.NewScanner(gzr)
-	for scanner.Scan() {
-		line := definerStripRegex.ReplaceAllString(scanner.Text(), "") + "\n"
-		out.WriteString(line)
-	}
-	if err := scanner.Err(); err != nil {
-		t.Fatalf("scan: %v", err)
+	strippedReader, done := splitdump.NewDefinerStrippingReader(gzr)
+	outBytes, readErr := io.ReadAll(strippedReader)
+	done(readErr)
+	if readErr != nil {
+		t.Fatalf("read stripped: %v", readErr)
 	}
 
-	result := out.String()
+	result := string(outBytes)
 	if strings.Contains(strings.ToUpper(result), "DEFINER=") {
 		t.Fatalf("DEFINER clause still present after strip:\n%s", result)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -845,6 +845,7 @@ type Config struct {
 	BackupMysqlclientPath                  string                 `mapstructure:"backup-mysqlclient-path" toml:"backup-mysqlclient-path" json:"backupMysqlclientPath"`
 	BackupMysqlclientOptions               string                 `mapstructure:"backup-mysqlclient-options" toml:"backup-mysqlclient-options" json:"backupMysqlclientOptions"`
 	BackupMysqldumpSplitDump               bool                   `mapstructure:"backup-mysqldump-splitdump" toml:"backup-mysqldump-splitdump" json:"backupMysqldumpSplitDump"`
+	BackupSplitdumpCreateDatabases         bool                   `mapstructure:"backup-splitdump-create-databases" toml:"backup-splitdump-create-databases" json:"backupSplitdumpCreateDatabases"`
 	BackupMytopPath                        string                 `mapstructure:"backup-mytop-path" toml:"backup-mytop-path" json:"backupMytopPath"`
 	BackupGottyClientPath                  string                 `mapstructure:"backup-gotty-client-path" toml:"backup-gotty-client-path" json:"backupGottyClientPath"`
 	ReplicationManagerCliPath              string                 `mapstructure:"replication-manager-cli-path" toml:"replication-manager-cli-path" json:"replicationManagerCliPath"`
@@ -852,6 +853,7 @@ type Config struct {
 	BackupBinlogsKeep                      int                    `mapstructure:"backup-binlogs-keep" toml:"backup-binlogs-keep" json:"backupBinlogsKeep"`
 	BackupLockDDL                          bool                   `mapstructure:"backup-lockddl" toml:"backup-lockddl" json:"backupLockDDL"`
 	BackupRestoreVersionStrict             bool                   `mapstructure:"backup-restore-version-strict" toml:"backup-restore-version-strict" json:"backupRestoreVersionStrict"`
+	BackupRestoreDefinerStrict             bool                   `mapstructure:"backup-restore-definer-strict" toml:"backup-restore-definer-strict" json:"backupRestoreDefinerStrict"`
 	BinlogCopyMode                         string                 `mapstructure:"binlog-copy-mode" toml:"binlog-copy-mode" json:"binlogCopyMode"`
 	BinlogCopyScript                       string                 `mapstructure:"binlog-copy-script" toml:"binlog-copy-script" json:"binlogCopyScript"`
 	BinlogRotationScript                   string                 `mapstructure:"binlog-rotation-script" toml:"binlog-rotation-script" json:"binlogRotationScript"`

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2560,6 +2560,8 @@ func (repman *ReplicationManager) switchClusterSettings(mycluster *cluster.Clust
 		mycluster.Conf.BackupRestoreMysqlUser = !mycluster.Conf.BackupRestoreMysqlUser
 	case "backup-mysqldump-splitdump":
 		mycluster.Conf.BackupMysqldumpSplitDump = !mycluster.Conf.BackupMysqldumpSplitDump
+	case "backup-splitdump-create-databases":
+		mycluster.Conf.BackupSplitdumpCreateDatabases = !mycluster.Conf.BackupSplitdumpCreateDatabases
 	case "backup-check-free-space":
 		mycluster.Conf.BackupCheckFreeSpace = !mycluster.Conf.BackupCheckFreeSpace
 	case "backup-estimate-size":
@@ -3132,6 +3134,8 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 			}
 		}
 		mycluster.Conf.BackupSplitdumpFileSize = trimmed
+	case "backup-splitdump-create-databases":
+		mycluster.Conf.BackupSplitdumpCreateDatabases = applyIsActive(mycluster.Conf.BackupSplitdumpCreateDatabases, isactive)
 	case "backup-keep-within-hourly":
 		err = mycluster.SetBackupKeepWithinHourly(value)
 		if err != nil {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2562,6 +2562,8 @@ func (repman *ReplicationManager) switchClusterSettings(mycluster *cluster.Clust
 		mycluster.Conf.BackupMysqldumpSplitDump = !mycluster.Conf.BackupMysqldumpSplitDump
 	case "backup-splitdump-create-databases":
 		mycluster.Conf.BackupSplitdumpCreateDatabases = !mycluster.Conf.BackupSplitdumpCreateDatabases
+	case "backup-restore-definer-strict":
+		mycluster.Conf.BackupRestoreDefinerStrict = !mycluster.Conf.BackupRestoreDefinerStrict
 	case "backup-check-free-space":
 		mycluster.Conf.BackupCheckFreeSpace = !mycluster.Conf.BackupCheckFreeSpace
 	case "backup-estimate-size":
@@ -3136,6 +3138,8 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		mycluster.Conf.BackupSplitdumpFileSize = trimmed
 	case "backup-splitdump-create-databases":
 		mycluster.Conf.BackupSplitdumpCreateDatabases = applyIsActive(mycluster.Conf.BackupSplitdumpCreateDatabases, isactive)
+	case "backup-restore-definer-strict":
+		mycluster.Conf.BackupRestoreDefinerStrict = applyIsActive(mycluster.Conf.BackupRestoreDefinerStrict, isactive)
 	case "backup-keep-within-hourly":
 		err = mycluster.SetBackupKeepWithinHourly(value)
 		if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -922,10 +922,12 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.BackupMysqlclientOptions, "backup-mysqlclient-options", "--force --batch", "Extra options")
 	flags.BoolVar(&conf.BackupMysqldumpSplitDump, "backup-mysqldump-splitdump", false, "Split mysqldump output using splitdump")
 	flags.StringVar(&conf.BackupSplitdumpFileSize, "backup-splitdump-file-size", "1G", "Max file size before sharding splitdump output (e.g. 16MiB, 1G; 0 disables sharding)")
+	flags.BoolVar(&conf.BackupSplitdumpCreateDatabases, "backup-splitdump-create-databases", true, "Auto-create databases before splitdump restore (server-orchestrated)")
 	flags.StringVar(&conf.BackupMytopPath, "backup-mytop-path", "", "Path to mytop binary")
 	flags.StringVar(&conf.BackupGottyClientPath, "backup-gotty-client-path", "", "Path to gotty client binary")
 	flags.StringVar(&conf.ReplicationManagerCliPath, "replication-manager-cli-path", "", "Path to replication-manager-cli binary")
 	flags.BoolVar(&conf.BackupRestoreVersionStrict, "backup-restore-version-strict", false, "During restore, check backup version against tools version. False will just issue a warning. True will abort restore")
+	flags.BoolVar(&conf.BackupRestoreDefinerStrict, "backup-restore-definer-strict", false, "During restore, fail closed when an incompatible DEFINER clause is encountered. False (default) applies non-strict fallback and continues.")
 
 	flags.BoolVar(&conf.BackupBinlogs, "backup-binlogs", false, "Archive binlogs")
 	flags.IntVar(&conf.BackupBinlogsKeep, "backup-binlogs-keep", 10, "Number of master binlog to keep")

--- a/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
@@ -121,6 +121,7 @@ function BackupSettings({ selectedCluster, user }) {
   const hMysqldumpOptions = `**Mysqldump Options**\n\nAdditional command-line flags passed to mysqldump.\nExample: \`--single-transaction --triggers --routines\`\n\nConfig: \`backup-mysqldump-options\``
   const hSplitDump = `**Mysqldump Splitdump Output**\n\nSends mysqldump output through replication-manager-cli splitdump instead of a single .sql.gz file.\nOutput is written to a splitdump directory (uncompressed).\nRequires the CLI to be available in PATH or configured below.\n\nConfig: \`backup-mysqldump-splitdump\``
   const hSplitDumpSize = `**Splitdump Shard Size**\n\nMaximum shard size for splitdump output. Default: 1G. Set to 0 to disable sharding.\n\nConfig: \`backup-splitdump-file-size\``
+  const hSplitDumpCreateDatabases = `**Auto-create databases for splitdump restore**\n\nWhen enabled, missing databases are automatically created before applying splitdump schema files during restore.\n\nConfig: \`backup-splitdump-create-databases\``
   const hCliPath = `**Replication Manager CLI Path**\n\nPath to the replication-manager-cli binary used for splitdump processing.\nLeave empty to use PATH lookup.\n\nConfig: \`replication-manager-cli-path\``
   const hMydumperOptions = `**Mydumper Options**\n\nAdditional command-line flags passed to mydumper.\n\nConfig: \`backup-mydumper-options\``
   const hMydumperRegex = `**Mydumper Regex**\n\nRegular expression to filter which tables mydumper includes in the backup.\n\nConfig: \`backup-mydumper-regex\``
@@ -231,6 +232,22 @@ function BackupSettings({ selectedCluster, user }) {
           selectedValue={selectedCluster?.config?.backupSplitdumpFileSize || '1G'}
           confirmTitle={`Confirm backup-splitdump-file-size to `}
           onChange={(value) => dispatch(setSetting({ clusterName: selectedCluster?.name, setting: 'backup-splitdump-file-size', value }))} />
+      )
+    },
+    {
+      key: 'Auto-create databases for splitdump restore',
+      help: h(hSplitDumpCreateDatabases, 'Auto-create databases for splitdump restore'),
+      value: (
+        <RMSwitch
+          isChecked={selectedCluster?.config?.backupSplitdumpCreateDatabases}
+          isDisabled={user?.grants['cluster-settings'] == false}
+          confirmTitle={'Confirm switch settings for backup-splitdump-create-databases?'}
+          onChange={() =>
+            dispatch(
+              switchSetting({ clusterName: selectedCluster?.name, setting: 'backup-splitdump-create-databases' })
+            )
+          }
+        />
       )
     },
     {

--- a/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
@@ -122,6 +122,7 @@ function BackupSettings({ selectedCluster, user }) {
   const hSplitDump = `**Mysqldump Splitdump Output**\n\nSends mysqldump output through replication-manager-cli splitdump instead of a single .sql.gz file.\nOutput is written to a splitdump directory (uncompressed).\nRequires the CLI to be available in PATH or configured below.\n\nConfig: \`backup-mysqldump-splitdump\``
   const hSplitDumpSize = `**Splitdump Shard Size**\n\nMaximum shard size for splitdump output. Default: 1G. Set to 0 to disable sharding.\n\nConfig: \`backup-splitdump-file-size\``
   const hSplitDumpCreateDatabases = `**Auto-create databases for splitdump restore**\n\nWhen enabled, missing databases are automatically created before applying splitdump schema files during restore.\n\nConfig: \`backup-splitdump-create-databases\``
+  const hRestoreDefinerStrict = `**Strict DEFINER enforcement on restore**\n\nWhen enabled, restore fails if an incompatible DEFINER clause is detected (e.g. the definer user does not exist on the target). When disabled (default), the file is re-imported with DEFINER clauses stripped and a warning is logged.\n\nConfig: \`backup-restore-definer-strict\``
   const hCliPath = `**Replication Manager CLI Path**\n\nPath to the replication-manager-cli binary used for splitdump processing.\nLeave empty to use PATH lookup.\n\nConfig: \`replication-manager-cli-path\``
   const hMydumperOptions = `**Mydumper Options**\n\nAdditional command-line flags passed to mydumper.\n\nConfig: \`backup-mydumper-options\``
   const hMydumperRegex = `**Mydumper Regex**\n\nRegular expression to filter which tables mydumper includes in the backup.\n\nConfig: \`backup-mydumper-regex\``
@@ -245,6 +246,22 @@ function BackupSettings({ selectedCluster, user }) {
           onChange={() =>
             dispatch(
               switchSetting({ clusterName: selectedCluster?.name, setting: 'backup-splitdump-create-databases' })
+            )
+          }
+        />
+      )
+    },
+    {
+      key: 'Strict DEFINER enforcement on restore',
+      help: h(hRestoreDefinerStrict, 'Strict DEFINER enforcement on restore'),
+      value: (
+        <RMSwitch
+          isChecked={selectedCluster?.config?.backupRestoreDefinerStrict}
+          isDisabled={user?.grants['cluster-settings'] == false}
+          confirmTitle={'Confirm switch settings for backup-restore-definer-strict?'}
+          onChange={() =>
+            dispatch(
+              switchSetting({ clusterName: selectedCluster?.name, setting: 'backup-restore-definer-strict' })
             )
           }
         />

--- a/utils/splitdump/definer.go
+++ b/utils/splitdump/definer.go
@@ -1,0 +1,52 @@
+package splitdump
+
+import (
+	"bufio"
+	"io"
+	"regexp"
+	"sync"
+)
+
+// DefinerStripRe matches DEFINER=`user`@`host` clauses in SQL output.
+// It is exported so all restore paths (CLI, server) share identical stripping semantics.
+var DefinerStripRe = regexp.MustCompile("(?i)DEFINER\\s*=\\s*`[^`]+`@`[^`]+`")
+
+// NewDefinerStrippingReader returns a reader that transparently strips DEFINER=`user`@`host`
+// clauses from every line in src. It uses bufio.Reader.ReadString so lines of arbitrary
+// length (including multi-megabyte INSERT rows) are handled without error — unlike
+// bufio.Scanner which returns bufio.ErrTooLong when its fixed token buffer is exceeded.
+//
+// A background goroutine performs the stripping. The caller MUST call done after consuming
+// the reader (or abandoning it on error) and BEFORE any deferred Close on the underlying
+// source. Passing nil to done signals clean completion; passing a non-nil error propagates
+// it. done blocks until the goroutine has fully exited, making it safe to close src.
+func NewDefinerStrippingReader(src io.Reader) (r io.Reader, done func(error)) {
+	pr, pw := io.Pipe()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		br := bufio.NewReaderSize(src, 64*1024)
+		for {
+			line, err := br.ReadString('\n')
+			if line != "" {
+				stripped := DefinerStripRe.ReplaceAllString(line, "")
+				if _, writeErr := pw.Write([]byte(stripped)); writeErr != nil {
+					return // pipe read-end closed; discard remaining input
+				}
+			}
+			if err != nil {
+				if err == io.EOF {
+					pw.Close()
+				} else {
+					pw.CloseWithError(err)
+				}
+				return
+			}
+		}
+	}()
+	return pr, func(err error) {
+		_ = pr.CloseWithError(err) // unblock goroutine if blocked in pw.Write
+		wg.Wait()                  // wait until goroutine exits before src is closed
+	}
+}

--- a/utils/splitdump/definer_test.go
+++ b/utils/splitdump/definer_test.go
@@ -1,0 +1,152 @@
+package splitdump
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestNewDefinerStrippingReaderPlainSQL verifies that DEFINER clauses are removed and all
+// other content is passed through unchanged on a plain (non-compressed) reader.
+func TestNewDefinerStrippingReaderPlainSQL(t *testing.T) {
+	input := strings.Join([]string{
+		"CREATE DEFINER=`root`@`localhost` VIEW `v` AS SELECT 1;",
+		"-- plain comment",
+		"CREATE TABLE `t` (`id` INT);",
+	}, "\n") + "\n"
+
+	r, done := NewDefinerStrippingReader(strings.NewReader(input))
+	got, err := io.ReadAll(r)
+	done(err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result := string(got)
+	if strings.Contains(strings.ToUpper(result), "DEFINER=") {
+		t.Fatalf("DEFINER clause still present:\n%s", result)
+	}
+	if !strings.Contains(result, "SELECT 1") {
+		t.Fatalf("expected SELECT 1 to be preserved:\n%s", result)
+	}
+	if !strings.Contains(result, "plain comment") {
+		t.Fatalf("expected comment to be preserved:\n%s", result)
+	}
+	if !strings.Contains(result, "CREATE TABLE") {
+		t.Fatalf("expected CREATE TABLE to be preserved:\n%s", result)
+	}
+}
+
+// TestNewDefinerStrippingReaderGzip verifies that DEFINER stripping works transparently on
+// a gzip-compressed reader (the caller decompresses before passing to the helper).
+func TestNewDefinerStrippingReaderGzip(t *testing.T) {
+	input := "CREATE DEFINER=`u`@`h` PROCEDURE `p`() BEGIN SELECT 42; END;\n"
+	expected := "CREATE  PROCEDURE `p`() BEGIN SELECT 42; END;\n"
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if _, err := gz.Write([]byte(input)); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+
+	gzr, err := gzip.NewReader(&buf)
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	defer gzr.Close()
+
+	r, done := NewDefinerStrippingReader(gzr)
+	got, readErr := io.ReadAll(r)
+	done(readErr)
+	if readErr != nil {
+		t.Fatalf("unexpected error: %v", readErr)
+	}
+
+	if string(got) != expected {
+		t.Fatalf("got %q, want %q", string(got), expected)
+	}
+}
+
+// TestNewDefinerStrippingReaderLargeLine verifies that a line larger than bufio.Scanner's
+// default token limit (64 KiB) and the old 4 MiB limit does not cause an error.
+// This is the core regression test for the ErrTooLong failure that bufio.Scanner would produce.
+func TestNewDefinerStrippingReaderLargeLine(t *testing.T) {
+	// Build a line that exceeds 4 MiB — the limit used by the old bufio.Scanner approach.
+	bigPayload := strings.Repeat("x", 5*1024*1024) // 5 MiB of 'x'
+	input := "DEFINER=`admin`@`%` " + bigPayload + "\n"
+	// After stripping: the DEFINER prefix is removed, leaving " " + bigPayload + "\n"
+	wantLen := 1 + len(bigPayload) + 1 // space + payload + newline
+
+	r, done := NewDefinerStrippingReader(strings.NewReader(input))
+	got, err := io.ReadAll(r)
+	done(err)
+	if err != nil {
+		t.Fatalf("unexpected error reading large line: %v", err)
+	}
+	if len(got) != wantLen {
+		t.Fatalf("unexpected output length: got %d, want %d", len(got), wantLen)
+	}
+	if strings.Contains(strings.ToUpper(string(got)), "DEFINER=") {
+		t.Fatalf("DEFINER clause still present in large-line output")
+	}
+}
+
+// TestNewDefinerStrippingReaderMultipleDefiners verifies that multiple DEFINER clauses on
+// separate lines are each stripped independently.
+func TestNewDefinerStrippingReaderMultipleDefiners(t *testing.T) {
+	input := "DEFINER=`a`@`b` VIEW v1 AS SELECT 1;\nDEFINER=`c`@`d` VIEW v2 AS SELECT 2;\n"
+	r, done := NewDefinerStrippingReader(strings.NewReader(input))
+	got, err := io.ReadAll(r)
+	done(err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result := string(got)
+	if strings.Contains(strings.ToUpper(result), "DEFINER=") {
+		t.Fatalf("DEFINER clause still present:\n%s", result)
+	}
+	if !strings.Contains(result, "SELECT 1") || !strings.Contains(result, "SELECT 2") {
+		t.Fatalf("expected both SELECT statements preserved:\n%s", result)
+	}
+}
+
+// TestNewDefinerStrippingReaderEmptyInput verifies correct behavior on an empty reader.
+func TestNewDefinerStrippingReaderEmptyInput(t *testing.T) {
+	r, done := NewDefinerStrippingReader(strings.NewReader(""))
+	got, err := io.ReadAll(r)
+	done(err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty output, got %q", string(got))
+	}
+}
+
+// TestIsMysqlSystemAllBaseNameRequired verifies that IsMysqlSystemAll only matches
+// the base filename, not a full path. Callers must pass filepath.Base(path).
+func TestIsMysqlSystemAllBaseNameRequired(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{"mysql.system-all.sql.gz", true},
+		{"mysql.system-all.sql", true},
+		{"mysql.system-all", true},
+		{"MYSQL.SYSTEM-ALL.SQL.GZ", true}, // case-insensitive
+		{"/some/dir/mysql.system-all.sql.gz", false}, // full path must not match
+		{"other.system-all.sql.gz", false},
+		{"mysql.system-all.sql.gz.bak", false},
+	}
+	for _, tc := range cases {
+		got := IsMysqlSystemAll(tc.input)
+		if got != tc.want {
+			t.Errorf("IsMysqlSystemAll(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}

--- a/utils/splitdump/restore.go
+++ b/utils/splitdump/restore.go
@@ -21,6 +21,23 @@ const (
 
 var ErrMetadataInvalid = errors.New("splitdump metadata invalid")
 
+// ErrNotSplitdump is returned by BuildRestorePlan when the backup directory
+// does not contain a splitdump-compatible artifact layout.
+var ErrNotSplitdump = errors.New("not a splitdump backup layout")
+
+// ErrDefinerStrict is returned when strict DEFINER enforcement blocks a restore.
+var ErrDefinerStrict = errors.New("strict DEFINER enforcement blocked restore")
+
+// IsDefinerError reports whether err indicates a MySQL/MariaDB DEFINER compatibility failure
+// (typically error 1449: the definer user does not exist on the target server).
+func IsDefinerError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "1449") || strings.Contains(s, "definer")
+}
+
 type Metadata struct {
 	File       string
 	Position   uint64
@@ -32,21 +49,38 @@ type RestoreOptions struct {
 	Parallel               int
 	RestoreUser            bool
 	StrictMetadata         bool
-	Logger                 func(level, format string, args ...any)
-	RestoreFile            func(path string) error
-	Context                context.Context
-	RestoreFileWithContext func(ctx context.Context, path string) error
+	// DefinerStrict causes restore to fail closed when an incompatible DEFINER clause is
+	// encountered. When false (default), non-strict fallback is applied: RestoreFileWithoutDefiner
+	// is called if provided, otherwise the file is skipped with a warning.
+	DefinerStrict             bool
+	Logger                    func(level, format string, args ...any)
+	RestoreFile               func(path string) error
+	Context                   context.Context
+	RestoreFileWithContext     func(ctx context.Context, path string) error
+	// RestoreFileWithoutDefiner is called instead of RestoreFileWithContext when a DEFINER
+	// error is detected and DefinerStrict is false. The implementation is responsible for
+	// stripping DEFINER clauses before execution.
+	RestoreFileWithoutDefiner func(ctx context.Context, path string) error
 }
 
 type FileSet struct {
 	Schema []string
 	Data   []string
+	Post   []string
 }
 
 type dataGroup struct {
 	key   string
 	paths []string
 }
+
+type fileCategory int
+
+const (
+	fileCategorySchema fileCategory = iota
+	fileCategoryData
+	fileCategoryPost
+)
 
 func ReadMetadata(backupPath string) (*Metadata, error) {
 	metadataPath := filepath.Join(backupPath, "metadata")
@@ -117,20 +151,56 @@ func ListFiles(backupPath string, restoreUser bool) (FileSet, error) {
 			continue
 		}
 		name := entry.Name()
-		isSchema, ok := classifyFile(name, restoreUser)
+		category, ok := classifyFile(name, restoreUser)
 		if !ok {
 			continue
 		}
 		fullPath := filepath.Join(backupPath, name)
-		if isSchema {
+		switch category {
+		case fileCategorySchema:
 			set.Schema = append(set.Schema, fullPath)
-		} else {
+		case fileCategoryPost:
+			set.Post = append(set.Post, fullPath)
+		default:
 			set.Data = append(set.Data, fullPath)
 		}
 	}
-	sort.Strings(set.Schema)
+	sortSplitdumpSchemaFiles(set.Schema)
 	sortSplitdumpDataFiles(set.Data)
+	sortSplitdumpPostFiles(set.Post)
 	return set, nil
+}
+
+var systemSchemas = map[string]bool{
+	"mysql":              true,
+	"information_schema": true,
+	"performance_schema": true,
+	"sys":                true,
+}
+
+// ListSchemas returns the sorted list of unique user-defined schema names found
+// in the backup directory, excluding system schemas (mysql, information_schema,
+// performance_schema, sys).
+func ListSchemas(backupPath string) ([]string, error) {
+	files, err := ListFiles(backupPath, false)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]bool)
+	var schemas []string
+	allFiles := append(append(files.Schema, files.Data...), files.Post...)
+	for _, path := range allFiles {
+		schema := SchemaFromFilename(path)
+		if schema == "" || systemSchemas[strings.ToLower(schema)] {
+			continue
+		}
+		if !seen[schema] {
+			seen[schema] = true
+			schemas = append(schemas, schema)
+		}
+	}
+	sort.Strings(schemas)
+	return schemas, nil
 }
 
 func Restore(backupPath string, opts RestoreOptions) error {
@@ -165,23 +235,46 @@ func Restore(backupPath string, opts RestoreOptions) error {
 		logf(LogInfo, "Splitdump metadata loaded (file=%s pos=%d)", meta.File, meta.Position)
 	}
 
-	files, err := ListFiles(backupPath, opts.RestoreUser)
+	plan, err := BuildRestorePlan(backupPath, opts.RestoreUser)
 	if err != nil {
 		return err
 	}
-	logf(LogInfo, "Splitdump restore files listed (schema=%d data=%d)", len(files.Schema), len(files.Data))
+	files := *plan
+	logf(LogInfo, "Splitdump detection: compatible backup layout confirmed at %s", backupPath)
+	logf(LogInfo, "Splitdump restore files listed (schema=%d data=%d post=%d)", len(files.Schema), len(files.Data), len(files.Post))
 
+	restoreOneFile := func(path string) error {
+		var restoreErr error
+		if opts.RestoreFileWithContext != nil {
+			restoreErr = opts.RestoreFileWithContext(ctx, path)
+		} else {
+			restoreErr = opts.RestoreFile(path)
+		}
+		if restoreErr == nil || !IsDefinerError(restoreErr) {
+			return restoreErr
+		}
+		// DEFINER compatibility error detected.
+		if opts.DefinerStrict {
+			logf(LogError, "Splitdump strict DEFINER enforcement blocked restore of %s: %v", filepath.Base(path), restoreErr)
+			return fmt.Errorf("%w: %s: %v", ErrDefinerStrict, filepath.Base(path), restoreErr)
+		}
+		// Non-strict fallback: try without DEFINER if a fallback function is provided.
+		if opts.RestoreFileWithoutDefiner != nil {
+			logf(LogWarn, "Splitdump DEFINER fallback for %s (retrying without DEFINER)", filepath.Base(path))
+			return opts.RestoreFileWithoutDefiner(ctx, path)
+		}
+		// No fallback function — skip the file and log the omission.
+		logf(LogWarn, "Splitdump DEFINER skipped for %s: incompatible DEFINER clause, no fallback function provided", filepath.Base(path))
+		return nil
+	}
+
+	logf(LogInfo, "Splitdump restore phase: schema (%d files)", len(files.Schema))
 	for _, schemaFile := range files.Schema {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 		logf(LogDebug, "Splitdump restoring schema (%s)", filepath.Base(schemaFile))
-		var err error
-		if opts.RestoreFileWithContext != nil {
-			err = opts.RestoreFileWithContext(ctx, schemaFile)
-		} else {
-			err = opts.RestoreFile(schemaFile)
-		}
+		err := restoreOneFile(schemaFile)
 		if err != nil {
 			logf(LogError, "Splitdump schema restore failed (%s): %v", filepath.Base(schemaFile), err)
 			cancel()
@@ -197,114 +290,130 @@ func Restore(backupPath string, opts RestoreOptions) error {
 		parallel = len(files.Data)
 	}
 
-	if len(files.Data) == 0 {
-		logf(LogInfo, "Splitdump restore completed (no data files)")
-		return nil
-	}
-
+	logf(LogInfo, "Splitdump restore phase: data (%d files)", len(files.Data))
 	dataGroups := groupSplitdumpDataFiles(files.Data)
 	if len(dataGroups) == 0 {
-		logf(LogInfo, "Splitdump restore completed (no data files)")
-		return nil
-	}
+		logf(LogInfo, "Splitdump restoring data files skipped (none)")
+	} else {
+		var wg sync.WaitGroup
+		var firstErr error
+		var errOnce sync.Once
 
-	var wg sync.WaitGroup
-	var firstErr error
-	var errOnce sync.Once
+		setErr := func(err error) {
+			errOnce.Do(func() {
+				firstErr = err
+				cancel()
+			})
+		}
 
-	setErr := func(err error) {
-		errOnce.Do(func() {
-			firstErr = err
-			cancel()
-		})
-	}
-
-	groupJobs := make(chan dataGroup)
-	groupWorker := func() {
-		defer wg.Done()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case group, ok := <-groupJobs:
-				if !ok {
+		groupJobs := make(chan dataGroup)
+		groupWorker := func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
 					return
-				}
-				for _, path := range group.paths {
-					select {
-					case <-ctx.Done():
+				case group, ok := <-groupJobs:
+					if !ok {
 						return
-					default:
 					}
-					logf(LogDebug, "Splitdump restoring data (%s)", filepath.Base(path))
-					var err error
-					if opts.RestoreFileWithContext != nil {
-						err = opts.RestoreFileWithContext(ctx, path)
-					} else {
-						err = opts.RestoreFile(path)
-					}
-					if err != nil {
-						logf(LogError, "Splitdump data restore failed (%s): %v", filepath.Base(path), err)
-						setErr(err)
-						return
+					for _, path := range group.paths {
+						select {
+						case <-ctx.Done():
+							return
+						default:
+						}
+						logf(LogDebug, "Splitdump restoring data (%s)", filepath.Base(path))
+						err := restoreOneFile(path)
+						if err != nil {
+							logf(LogError, "Splitdump data restore failed (%s): %v", filepath.Base(path), err)
+							setErr(err)
+							return
+						}
 					}
 				}
 			}
 		}
-	}
 
-	if parallel > len(dataGroups) {
-		parallel = len(dataGroups)
-	}
-
-	for i := 0; i < parallel; i++ {
-		wg.Add(1)
-		go groupWorker()
-	}
-
-	logf(LogInfo, "Splitdump restoring data files (count=%d parallel=%d)", len(files.Data), parallel)
-
-sendLoop:
-	for _, group := range dataGroups {
-		select {
-		case <-ctx.Done():
-			break sendLoop
-		case groupJobs <- group:
+		if parallel > len(dataGroups) {
+			parallel = len(dataGroups)
 		}
-	}
-	close(groupJobs)
-	wg.Wait()
 
-	if firstErr == nil {
+		for i := 0; i < parallel; i++ {
+			wg.Add(1)
+			go groupWorker()
+		}
+
+		logf(LogInfo, "Splitdump restoring data files (count=%d parallel=%d)", len(files.Data), parallel)
+
+	sendLoop:
+		for _, group := range dataGroups {
+			select {
+			case <-ctx.Done():
+				break sendLoop
+			case groupJobs <- group:
+			}
+		}
+		close(groupJobs)
+		wg.Wait()
+
+		if firstErr != nil {
+			return firstErr
+		}
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		logf(LogInfo, "Splitdump restore completed")
 	}
-	return firstErr
+
+	logf(LogInfo, "Splitdump restore phase: post-data (%d files)", len(files.Post))
+	for _, postFile := range files.Post {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		logf(LogDebug, "Splitdump restoring post-data (%s)", filepath.Base(postFile))
+		err := restoreOneFile(postFile)
+		if err != nil {
+			logf(LogError, "Splitdump post-data restore failed (%s): %v", filepath.Base(postFile), err)
+			cancel()
+			return err
+		}
+	}
+
+	logf(LogInfo, "Splitdump restore completed")
+	return nil
 }
 
-func classifyFile(name string, restoreUser bool) (isSchema bool, ok bool) {
+func classifyFile(name string, restoreUser bool) (category fileCategory, ok bool) {
 	lower := strings.ToLower(name)
 	if lower == "metadata" {
-		return false, false
+		return fileCategoryData, false
 	}
 	if strings.HasSuffix(lower, ".sql.gz") || strings.HasSuffix(lower, ".sql") {
 		switch {
 		case strings.HasSuffix(lower, "-schema.sql.gz") || strings.HasSuffix(lower, "-schema.sql"):
-			return true, true
+			return fileCategorySchema, true
 		case strings.HasSuffix(lower, "-schema-view.sql.gz") || strings.HasSuffix(lower, "-schema-view.sql"):
-			return true, true
+			return fileCategorySchema, true
+		case strings.HasSuffix(lower, "-schema-routine.sql.gz") || strings.HasSuffix(lower, "-schema-routine.sql"):
+			return fileCategorySchema, true
+		case strings.HasSuffix(lower, "-schema-function.sql.gz") || strings.HasSuffix(lower, "-schema-function.sql"):
+			return fileCategorySchema, true
+		case strings.HasSuffix(lower, "-schema-procedure.sql.gz") || strings.HasSuffix(lower, "-schema-procedure.sql"):
+			return fileCategorySchema, true
+		case strings.HasSuffix(lower, "-schema-trigger.sql.gz") || strings.HasSuffix(lower, "-schema-trigger.sql"):
+			return fileCategoryPost, true
+		case strings.HasSuffix(lower, "-schema-event.sql.gz") || strings.HasSuffix(lower, "-schema-event.sql"):
+			return fileCategoryPost, true
 		case lower == "mysql.system-all.sql.gz" || lower == "mysql.system-all.sql":
 			if !restoreUser {
-				return false, false
+				return fileCategoryData, false
 			}
-			return true, true
+			return fileCategorySchema, true
 		default:
-			return false, true
+			return fileCategoryData, true
 		}
 	}
-	return false, false
+	return fileCategoryData, false
 }
 
 func sortSplitdumpDataFiles(paths []string) {
@@ -318,6 +427,62 @@ func sortSplitdumpDataFiles(paths []string) {
 		}
 		return leftKey < rightKey
 	})
+}
+
+func sortSplitdumpSchemaFiles(paths []string) {
+	sort.SliceStable(paths, func(i, j int) bool {
+		left := filepath.Base(paths[i])
+		right := filepath.Base(paths[j])
+		leftPriority := splitdumpSchemaPriority(left)
+		rightPriority := splitdumpSchemaPriority(right)
+		if leftPriority == rightPriority {
+			return left < right
+		}
+		return leftPriority < rightPriority
+	})
+}
+
+func splitdumpSchemaPriority(name string) int {
+	lower := strings.ToLower(filepath.Base(name))
+	switch {
+	case strings.HasSuffix(lower, "-schema.sql.gz") || strings.HasSuffix(lower, "-schema.sql"):
+		return 0
+	case IsMysqlSystemAll(lower):
+		return 1
+	case strings.HasSuffix(lower, "-schema-routine.sql.gz") || strings.HasSuffix(lower, "-schema-routine.sql") ||
+		strings.HasSuffix(lower, "-schema-function.sql.gz") || strings.HasSuffix(lower, "-schema-function.sql") ||
+		strings.HasSuffix(lower, "-schema-procedure.sql.gz") || strings.HasSuffix(lower, "-schema-procedure.sql"):
+		return 2
+	case strings.HasSuffix(lower, "-schema-view.sql.gz") || strings.HasSuffix(lower, "-schema-view.sql"):
+		return 3
+	default:
+		return 4
+	}
+}
+
+func sortSplitdumpPostFiles(paths []string) {
+	sort.SliceStable(paths, func(i, j int) bool {
+		left := filepath.Base(paths[i])
+		right := filepath.Base(paths[j])
+		leftPriority := splitdumpPostPriority(left)
+		rightPriority := splitdumpPostPriority(right)
+		if leftPriority == rightPriority {
+			return left < right
+		}
+		return leftPriority < rightPriority
+	})
+}
+
+func splitdumpPostPriority(name string) int {
+	lower := strings.ToLower(filepath.Base(name))
+	switch {
+	case strings.HasSuffix(lower, "-schema-trigger.sql.gz") || strings.HasSuffix(lower, "-schema-trigger.sql"):
+		return 0
+	case strings.HasSuffix(lower, "-schema-event.sql.gz") || strings.HasSuffix(lower, "-schema-event.sql"):
+		return 1
+	default:
+		return 2
+	}
 }
 
 func groupSplitdumpDataFiles(paths []string) []dataGroup {
@@ -378,7 +543,17 @@ func IsSchemaFile(name string) bool {
 	return strings.HasSuffix(lower, "-schema.sql.gz") ||
 		strings.HasSuffix(lower, "-schema.sql") ||
 		strings.HasSuffix(lower, "-schema-view.sql.gz") ||
-		strings.HasSuffix(lower, "-schema-view.sql")
+		strings.HasSuffix(lower, "-schema-view.sql") ||
+		strings.HasSuffix(lower, "-schema-routine.sql.gz") ||
+		strings.HasSuffix(lower, "-schema-routine.sql") ||
+		strings.HasSuffix(lower, "-schema-function.sql.gz") ||
+		strings.HasSuffix(lower, "-schema-function.sql") ||
+		strings.HasSuffix(lower, "-schema-procedure.sql.gz") ||
+		strings.HasSuffix(lower, "-schema-procedure.sql") ||
+		strings.HasSuffix(lower, "-schema-trigger.sql.gz") ||
+		strings.HasSuffix(lower, "-schema-trigger.sql") ||
+		strings.HasSuffix(lower, "-schema-event.sql.gz") ||
+		strings.HasSuffix(lower, "-schema-event.sql")
 }
 
 func IsGtidSlavePosDataFile(name string) bool {
@@ -415,6 +590,11 @@ func splitdumpSchemaTable(name string) (string, string) {
 
 	trimmed := strings.TrimSuffix(base, ".sql.gz")
 	trimmed = strings.TrimSuffix(trimmed, ".sql")
+	trimmed = strings.TrimSuffix(trimmed, "-schema-event")
+	trimmed = strings.TrimSuffix(trimmed, "-schema-trigger")
+	trimmed = strings.TrimSuffix(trimmed, "-schema-routine")
+	trimmed = strings.TrimSuffix(trimmed, "-schema-function")
+	trimmed = strings.TrimSuffix(trimmed, "-schema-procedure")
 	trimmed = strings.TrimSuffix(trimmed, "-schema-view")
 	trimmed = strings.TrimSuffix(trimmed, "-schema")
 	trimmed, _ = splitdumpDataKey(trimmed)
@@ -431,4 +611,73 @@ func splitdumpSchemaTable(name string) (string, string) {
 func IsMysqlSystemAll(name string) bool {
 	lower := strings.ToLower(name)
 	return lower == "mysql.system-all.sql.gz" || lower == "mysql.system-all.sql" || lower == "mysql.system-all"
+}
+
+// Detect reports whether backupPath contains a splitdump-compatible artifact layout.
+// A directory is splitdump-compatible if it contains at least one file whose name
+// follows the schema.table naming convention used by splitdump (e.g. db.tbl-schema.sql.gz,
+// mysql.system-all.sql.gz). Directories with only generic SQL files (no schema.table prefix)
+// or only non-SQL files are not considered splitdump-compatible.
+// Returns (true, nil) for compatible layouts, (false, nil) for incompatible layouts,
+// and (false, err) for I/O errors.
+func Detect(backupPath string) (bool, error) {
+	entries, err := os.ReadDir(backupPath)
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if SchemaFromFilename(entry.Name()) != "" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// BuildRestorePlan classifies the files in backupPath into typed restore phases:
+// schema (tables, mysql.system-all, routines, views), data, and post-data (triggers, events).
+// Phase ordering is fixed before any replay begins: schema files are ordered by type priority,
+// data files by table and shard, post-data files with triggers before events.
+// Returns ErrNotSplitdump if the directory does not contain a splitdump-compatible layout.
+func BuildRestorePlan(backupPath string, restoreUser bool) (*FileSet, error) {
+	ok, err := Detect(backupPath)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNotSplitdump
+	}
+	fs, err := ListFiles(backupPath, restoreUser)
+	if err != nil {
+		return nil, err
+	}
+	return &fs, nil
+}
+
+func IsMysqlTableCheckEligible(name string) bool {
+	lower := strings.ToLower(filepath.Base(name))
+	if !strings.HasSuffix(lower, ".sql.gz") && !strings.HasSuffix(lower, ".sql") {
+		return false
+	}
+	if IsMysqlSystemAll(lower) {
+		return false
+	}
+	if strings.HasSuffix(lower, "-schema-view.sql.gz") || strings.HasSuffix(lower, "-schema-view.sql") {
+		return false
+	}
+	if strings.HasSuffix(lower, "-schema-routine.sql.gz") || strings.HasSuffix(lower, "-schema-routine.sql") {
+		return false
+	}
+	if strings.HasSuffix(lower, "-schema-function.sql.gz") || strings.HasSuffix(lower, "-schema-function.sql") {
+		return false
+	}
+	if strings.HasSuffix(lower, "-schema-procedure.sql.gz") || strings.HasSuffix(lower, "-schema-procedure.sql") {
+		return false
+	}
+	if strings.HasSuffix(lower, "-schema-event.sql.gz") || strings.HasSuffix(lower, "-schema-event.sql") {
+		return false
+	}
+	return true
 }

--- a/utils/splitdump/restore.go
+++ b/utils/splitdump/restore.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -28,14 +29,16 @@ var ErrNotSplitdump = errors.New("not a splitdump backup layout")
 // ErrDefinerStrict is returned when strict DEFINER enforcement blocks a restore.
 var ErrDefinerStrict = errors.New("strict DEFINER enforcement blocked restore")
 
+// definerErrRe matches the MySQL/MariaDB DEFINER compatibility error. The pattern targets the
+// canonical error number (1449) and the distinctive phrase in the error message, avoiding false
+// positives from passwords, row counts, or unrelated messages that happen to contain "1449" or
+// "definer" as substrings.
+var definerErrRe = regexp.MustCompile(`(?i)(ERROR 1449|the user specified as a definer)`)
+
 // IsDefinerError reports whether err indicates a MySQL/MariaDB DEFINER compatibility failure
 // (typically error 1449: the definer user does not exist on the target server).
 func IsDefinerError(err error) bool {
-	if err == nil {
-		return false
-	}
-	s := strings.ToLower(err.Error())
-	return strings.Contains(s, "1449") || strings.Contains(s, "definer")
+	return err != nil && definerErrRe.MatchString(err.Error())
 }
 
 type Metadata struct {
@@ -188,7 +191,12 @@ func ListSchemas(backupPath string) ([]string, error) {
 	}
 	seen := make(map[string]bool)
 	var schemas []string
-	allFiles := append(append(files.Schema, files.Data...), files.Post...)
+	// Explicit allocation avoids the append-aliasing pitfall where a first append with spare
+	// capacity in files.Schema would write files.Data entries into its backing array.
+	allFiles := make([]string, 0, len(files.Schema)+len(files.Data)+len(files.Post))
+	allFiles = append(allFiles, files.Schema...)
+	allFiles = append(allFiles, files.Data...)
+	allFiles = append(allFiles, files.Post...)
 	for _, path := range allFiles {
 		schema := SchemaFromFilename(path)
 		if schema == "" || systemSchemas[strings.ToLower(schema)] {
@@ -534,6 +542,10 @@ func TableFromFilename(name string) string {
 	return table
 }
 
+// IsSchemaFile reports whether name is a schema-phase file (tables, mysql.system-all, routines,
+// views). Trigger and event files are post-phase artifacts (see IsPostFile) and are intentionally
+// excluded here so that callers gating schema-phase behaviour (table existence checks, ordering)
+// do not accidentally include them.
 func IsSchemaFile(name string) bool {
 	base := filepath.Base(name)
 	if IsMysqlSystemAll(base) {
@@ -549,8 +561,14 @@ func IsSchemaFile(name string) bool {
 		strings.HasSuffix(lower, "-schema-function.sql.gz") ||
 		strings.HasSuffix(lower, "-schema-function.sql") ||
 		strings.HasSuffix(lower, "-schema-procedure.sql.gz") ||
-		strings.HasSuffix(lower, "-schema-procedure.sql") ||
-		strings.HasSuffix(lower, "-schema-trigger.sql.gz") ||
+		strings.HasSuffix(lower, "-schema-procedure.sql")
+}
+
+// IsPostFile reports whether name is a post-data-phase file (triggers or events).
+// These are distinct from schema-phase files even though their filenames carry a "-schema-" infix.
+func IsPostFile(name string) bool {
+	lower := strings.ToLower(filepath.Base(name))
+	return strings.HasSuffix(lower, "-schema-trigger.sql.gz") ||
 		strings.HasSuffix(lower, "-schema-trigger.sql") ||
 		strings.HasSuffix(lower, "-schema-event.sql.gz") ||
 		strings.HasSuffix(lower, "-schema-event.sql")
@@ -656,12 +674,19 @@ func BuildRestorePlan(backupPath string, restoreUser bool) (*FileSet, error) {
 	return &fs, nil
 }
 
+// IsMysqlTableCheckEligible reports whether a tableExists check makes sense before restoring name.
+// Trigger files reference a table but are post-phase objects: running a table-existence guard on
+// them would skip legitimate trigger restores. Views, routines, events, and mysql.system-all are
+// also excluded because they have their own ordering or existence semantics.
 func IsMysqlTableCheckEligible(name string) bool {
 	lower := strings.ToLower(filepath.Base(name))
 	if !strings.HasSuffix(lower, ".sql.gz") && !strings.HasSuffix(lower, ".sql") {
 		return false
 	}
 	if IsMysqlSystemAll(lower) {
+		return false
+	}
+	if strings.HasSuffix(lower, "-schema-trigger.sql.gz") || strings.HasSuffix(lower, "-schema-trigger.sql") {
 		return false
 	}
 	if strings.HasSuffix(lower, "-schema-view.sql.gz") || strings.HasSuffix(lower, "-schema-view.sql") {

--- a/utils/splitdump/restore.go
+++ b/utils/splitdump/restore.go
@@ -67,9 +67,12 @@ type RestoreOptions struct {
 }
 
 type FileSet struct {
-	Schema []string
-	Data   []string
-	Post   []string
+	Schema     []string
+	Data       []string
+	Post       []string
+	// PrunedData holds data-phase files removed during conflict resolution.
+	// Callers can inspect this to understand what was excluded and why.
+	PrunedData []string
 }
 
 type dataGroup struct {
@@ -249,6 +252,9 @@ func Restore(backupPath string, opts RestoreOptions) error {
 	}
 	files := *plan
 	logf(LogInfo, "Splitdump detection: compatible backup layout confirmed at %s", backupPath)
+	if len(files.PrunedData) > 0 {
+		logf(LogWarn, "Splitdump mysql.proc data phase excluded (%d file(s)): mysql routines artifact present (restoring both causes duplicate-key errors)", len(files.PrunedData))
+	}
 	logf(LogInfo, "Splitdump restore files listed (schema=%d data=%d post=%d)", len(files.Schema), len(files.Data), len(files.Post))
 
 	restoreOneFile := func(path string) error {
@@ -654,11 +660,50 @@ func Detect(backupPath string) (bool, error) {
 	return false, nil
 }
 
+// isMysqlRoutinesSchemaPresent reports whether any path in schema is a mysql-schema
+// routine artifact. It recognises all three suffix variants that the restore classifier
+// accepts (-schema-routine, -schema-function, -schema-procedure), constrained to the
+// mysql schema, so dump tools that separate procedures from functions are covered.
+func isMysqlRoutinesSchemaPresent(schema []string) bool {
+	for _, p := range schema {
+		lower := strings.ToLower(filepath.Base(p))
+		if !strings.HasPrefix(lower, "mysql.") {
+			continue
+		}
+		if strings.HasSuffix(lower, "-schema-routine.sql.gz") ||
+			strings.HasSuffix(lower, "-schema-routine.sql") ||
+			strings.HasSuffix(lower, "-schema-function.sql.gz") ||
+			strings.HasSuffix(lower, "-schema-function.sql") ||
+			strings.HasSuffix(lower, "-schema-procedure.sql.gz") ||
+			strings.HasSuffix(lower, "-schema-procedure.sql") {
+			return true
+		}
+	}
+	return false
+}
+
+// isMysqlProcDataFile reports whether path is a data-phase artifact for the mysql.proc
+// table (mysql.proc.sql[.gz] or sharded variants mysql.proc.NNNNN.sql[.gz]).
+// Schema-phase files (mysql.proc-schema.sql.gz) are excluded.
+func isMysqlProcDataFile(path string) bool {
+	if IsSchemaFile(path) {
+		return false
+	}
+	return strings.ToLower(SchemaFromFilename(path)) == "mysql" &&
+		strings.ToLower(TableFromFilename(path)) == "proc"
+}
+
 // BuildRestorePlan classifies the files in backupPath into typed restore phases:
 // schema (tables, mysql.system-all, routines, views), data, and post-data (triggers, events).
 // Phase ordering is fixed before any replay begins: schema files are ordered by type priority,
 // data files by table and shard, post-data files with triggers before events.
 // Returns ErrNotSplitdump if the directory does not contain a splitdump-compatible layout.
+//
+// Conflict pruning: when any mysql routine artifact (-schema-routine, -schema-function, or
+// -schema-procedure) is present in the schema phase, all mysql.proc data-phase files are
+// removed from the plan and recorded in FileSet.PrunedData. mysqldump emits both a routines
+// DDL artifact and a raw mysql.proc table dump; restoring both causes duplicate-key errors
+// because the CREATE PROCEDURE/FUNCTION statements implicitly populate mysql.proc.
 func BuildRestorePlan(backupPath string, restoreUser bool) (*FileSet, error) {
 	ok, err := Detect(backupPath)
 	if err != nil {
@@ -670,6 +715,18 @@ func BuildRestorePlan(backupPath string, restoreUser bool) (*FileSet, error) {
 	fs, err := ListFiles(backupPath, restoreUser)
 	if err != nil {
 		return nil, err
+	}
+	if isMysqlRoutinesSchemaPresent(fs.Schema) {
+		var kept, pruned []string
+		for _, path := range fs.Data {
+			if isMysqlProcDataFile(path) {
+				pruned = append(pruned, path)
+			} else {
+				kept = append(kept, path)
+			}
+		}
+		fs.Data = kept
+		fs.PrunedData = pruned
 	}
 	return &fs, nil
 }

--- a/utils/splitdump/restore_test.go
+++ b/utils/splitdump/restore_test.go
@@ -1442,3 +1442,255 @@ func TestIsMysqlTableCheckEligible(t *testing.T) {
 		})
 	}
 }
+
+// ---- mysql.proc / routines-schema conflict pruning tests ----
+
+// TestBuildRestorePlanPrunesMysqlProcWhenMysqlRoutineSchemaPresent is a table-driven test
+// covering all three mysql routine artifact suffixes (-schema-routine, -schema-function,
+// -schema-procedure). Each variant should independently trigger pruning of mysql.proc data
+// files and populate FileSet.PrunedData.
+func TestBuildRestorePlanPrunesMysqlProcWhenMysqlRoutineSchemaPresent(t *testing.T) {
+	routineArtifacts := []string{
+		"mysql.__routines-schema-routine.sql.gz",  // standard splitdump artifact
+		"mysql.__routines-schema-routine.sql",     // uncompressed variant
+		"mysql.__funcs-schema-function.sql.gz",    // function-only variant (mydumper style)
+		"mysql.__procs-schema-procedure.sql.gz",   // procedure-only variant (mydumper style)
+	}
+
+	for _, artifact := range routineArtifacts {
+		artifact := artifact
+		t.Run(artifact, func(t *testing.T) {
+			dir := t.TempDir()
+			fixtures := []string{
+				artifact,                  // trigger artifact — must trigger pruning
+				"mysql.proc.00000.sql.gz", // sharded mysql.proc data — must be pruned
+				"mysql.proc.sql.gz",       // unsharded mysql.proc data — must be pruned
+				"db.tbl.sql.gz",           // normal user data — must be kept
+				"db.tbl-schema.sql.gz",    // schema file — must be kept
+			}
+			for _, f := range fixtures {
+				if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+					t.Fatalf("write %s: %v", f, err)
+				}
+			}
+
+			plan, err := BuildRestorePlan(dir, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// mysql.proc files must not appear in the data phase.
+			for _, p := range plan.Data {
+				base := filepath.Base(p)
+				if strings.HasPrefix(strings.ToLower(base), "mysql.proc") {
+					t.Errorf("mysql.proc file should have been pruned but found in data phase: %s", base)
+				}
+			}
+
+			// PrunedData must record the removed files (both sharded and unsharded).
+			if len(plan.PrunedData) != 2 {
+				t.Fatalf("expected 2 pruned files, got %d: %v", len(plan.PrunedData), plan.PrunedData)
+			}
+			for _, p := range plan.PrunedData {
+				base := strings.ToLower(filepath.Base(p))
+				if !strings.HasPrefix(base, "mysql.proc") {
+					t.Errorf("PrunedData contains unexpected file: %s", base)
+				}
+			}
+
+			// Normal user data must still be present.
+			foundUserData := false
+			for _, p := range plan.Data {
+				if filepath.Base(p) == "db.tbl.sql.gz" {
+					foundUserData = true
+					break
+				}
+			}
+			if !foundUserData {
+				t.Fatalf("db.tbl.sql.gz should remain in data phase after pruning, got: %v", plan.Data)
+			}
+		})
+	}
+}
+
+// TestBuildRestorePlanKeepsMysqlProcWithoutMysqlRoutineSchema verifies that mysql.proc
+// data files are NOT pruned when no mysql routines schema artifact is present. This is
+// the common case for backups generated without --routines, where mysql.proc is the only
+// representation of stored procedures. PrunedData must be empty.
+func TestBuildRestorePlanKeepsMysqlProcWithoutMysqlRoutineSchema(t *testing.T) {
+	dir := t.TempDir()
+	fixtures := []string{
+		"mysql.proc.00000.sql.gz",
+		"db.tbl.sql.gz",
+		"db.tbl-schema.sql.gz",
+	}
+	for _, f := range fixtures {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("write %s: %v", f, err)
+		}
+	}
+
+	plan, err := BuildRestorePlan(dir, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	foundProc := false
+	for _, p := range plan.Data {
+		if filepath.Base(p) == "mysql.proc.00000.sql.gz" {
+			foundProc = true
+			break
+		}
+	}
+	if !foundProc {
+		t.Fatalf("mysql.proc.00000.sql.gz should remain in data phase when no routines artifact present, got: %v", plan.Data)
+	}
+	if len(plan.PrunedData) != 0 {
+		t.Fatalf("PrunedData must be empty when no pruning occurred, got: %v", plan.PrunedData)
+	}
+}
+
+// TestRestoreSkipsMysqlProcWhenRoutinesSchemaPresent is an end-to-end test through
+// Restore() that verifies:
+//   - the mysql routines schema artifact IS restored (in schema phase)
+//   - mysql.proc data files are NOT passed to the restore callback
+//   - normal user data IS restored
+//   - a warning log is emitted identifying the exclusion
+func TestRestoreSkipsMysqlProcWhenRoutinesSchemaPresent(t *testing.T) {
+	dir := t.TempDir()
+	// Write a valid metadata file so Restore() does not log a metadata warning.
+	meta := "[source]\nFile = mysql-bin.000001\nPosition = 4\n"
+	if err := os.WriteFile(filepath.Join(dir, "metadata"), []byte(meta), 0644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+	fixtures := []string{
+		"mysql.__routines-schema-routine.sql.gz",
+		"mysql.proc.00000.sql.gz",
+		"db.tbl-schema.sql.gz",
+		"db.tbl.sql.gz",
+	}
+	for _, f := range fixtures {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("write %s: %v", f, err)
+		}
+	}
+
+	var mu sync.Mutex
+	var restored []string
+	var warnLogs []string
+
+	logger := func(level, format string, args ...any) {
+		mu.Lock()
+		defer mu.Unlock()
+		if level == LogWarn {
+			warnLogs = append(warnLogs, fmt.Sprintf(format, args...))
+		}
+	}
+	restoreFile := func(path string) error {
+		mu.Lock()
+		restored = append(restored, filepath.Base(path))
+		mu.Unlock()
+		return nil
+	}
+
+	if err := Restore(dir, RestoreOptions{Parallel: 1, Logger: logger, RestoreFile: restoreFile}); err != nil {
+		t.Fatalf("unexpected restore error: %v", err)
+	}
+
+	mu.Lock()
+	gotRestored := append([]string(nil), restored...)
+	gotWarn := append([]string(nil), warnLogs...)
+	mu.Unlock()
+
+	// mysql.proc must not appear in restored files.
+	for _, name := range gotRestored {
+		if strings.HasPrefix(strings.ToLower(name), "mysql.proc") {
+			t.Errorf("mysql.proc should not have been restored, but got: %s", name)
+		}
+	}
+
+	// Routines schema artifact must have been restored.
+	foundRoutines := false
+	for _, name := range gotRestored {
+		if strings.Contains(strings.ToLower(name), "routines-schema-routine") {
+			foundRoutines = true
+			break
+		}
+	}
+	if !foundRoutines {
+		t.Fatalf("mysql.__routines-schema-routine was not restored, got: %v", gotRestored)
+	}
+
+	// Normal user data must have been restored.
+	foundUserData := false
+	for _, name := range gotRestored {
+		if name == "db.tbl.sql.gz" {
+			foundUserData = true
+			break
+		}
+	}
+	if !foundUserData {
+		t.Fatalf("db.tbl.sql.gz was not restored, got: %v", gotRestored)
+	}
+
+	// A warning log must identify the exclusion with a count.
+	foundWarn := false
+	for _, l := range gotWarn {
+		lower := strings.ToLower(l)
+		if strings.Contains(lower, "mysql.proc") && strings.Contains(lower, "excluded") {
+			foundWarn = true
+			break
+		}
+	}
+	if !foundWarn {
+		t.Fatalf("expected warning log about mysql.proc exclusion, got: %v", gotWarn)
+	}
+}
+
+// TestRestoreNoSpuriousWarnWhenNoMysqlProcFiles verifies that no mysql.proc warning is
+// emitted when a mysql routines artifact is present but no mysql.proc data files exist.
+// The log was previously gated on isMysqlRoutinesSchemaPresent (always true when artifact
+// exists); now it is gated on len(PrunedData) > 0 so no misleading log appears.
+func TestRestoreNoSpuriousWarnWhenNoMysqlProcFiles(t *testing.T) {
+	dir := t.TempDir()
+	meta := "[source]\nFile = mysql-bin.000001\nPosition = 4\n"
+	if err := os.WriteFile(filepath.Join(dir, "metadata"), []byte(meta), 0644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+	// Routines artifact present, but NO mysql.proc data files.
+	fixtures := []string{
+		"mysql.__routines-schema-routine.sql.gz",
+		"db.tbl-schema.sql.gz",
+		"db.tbl.sql.gz",
+	}
+	for _, f := range fixtures {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("write %s: %v", f, err)
+		}
+	}
+
+	var mu sync.Mutex
+	var warnLogs []string
+	logger := func(level, format string, args ...any) {
+		mu.Lock()
+		defer mu.Unlock()
+		if level == LogWarn {
+			warnLogs = append(warnLogs, fmt.Sprintf(format, args...))
+		}
+	}
+
+	if err := Restore(dir, RestoreOptions{Parallel: 1, Logger: logger, RestoreFile: func(string) error { return nil }}); err != nil {
+		t.Fatalf("unexpected restore error: %v", err)
+	}
+
+	mu.Lock()
+	gotWarn := append([]string(nil), warnLogs...)
+	mu.Unlock()
+
+	for _, l := range gotWarn {
+		lower := strings.ToLower(l)
+		if strings.Contains(lower, "mysql.proc") && strings.Contains(lower, "excluded") {
+			t.Fatalf("spurious mysql.proc exclusion warning when no mysql.proc files existed: %s", l)
+		}
+	}
+}

--- a/utils/splitdump/restore_test.go
+++ b/utils/splitdump/restore_test.go
@@ -514,8 +514,9 @@ func TestIsSchemaFile(t *testing.T) {
 		{name: "db.tbl-schema-view.sql.gz", want: true},
 		{name: "db.tbl-schema-view.sql", want: true},
 		{name: "db.__routines-schema-routine.sql.gz", want: true},
-		{name: "db.tbl-schema-trigger.sql.gz", want: true},
-		{name: "db.__events-schema-event.sql.gz", want: true},
+		// triggers and events are post-phase, not schema-phase
+		{name: "db.tbl-schema-trigger.sql.gz", want: false},
+		{name: "db.__events-schema-event.sql.gz", want: false},
 		{name: "mysql.system-all.sql.gz", want: true},
 		{name: "mysql.system-all.sql", want: true},
 		{name: "mysql.system-all", want: true},
@@ -758,8 +759,12 @@ func TestIsDefinerError(t *testing.T) {
 		want bool
 	}{
 		{name: "nil", err: nil, want: false},
-		{name: "error 1449", err: fmt.Errorf("mysql restore failed: ERROR 1449 (HY000): The user specified as a definer ('bad'@'localhost') does not exist"), want: true},
-		{name: "definer text", err: fmt.Errorf("definer 'user'@'host' problem"), want: true},
+		{name: "error 1449 full", err: fmt.Errorf("mysql restore failed: ERROR 1449 (HY000): The user specified as a definer ('bad'@'localhost') does not exist"), want: true},
+		{name: "error 1449 number only", err: fmt.Errorf("ERROR 1449 something"), want: true},
+		{name: "the user specified as a definer phrase", err: fmt.Errorf("The user specified as a definer does not exist"), want: true},
+		// bare "definer" or "1449" as substring must not trigger false positives
+		{name: "definer in column name", err: fmt.Errorf("column 'definer_id' not found"), want: false},
+		{name: "1449 in row count", err: fmt.Errorf("inserted 1449 rows"), want: false},
 		{name: "other mysql error", err: fmt.Errorf("mysql restore failed: ERROR 1146 (42S02): Table does not exist"), want: false},
 		{name: "context canceled", err: context.Canceled, want: false},
 		{name: "generic error", err: fmt.Errorf("connection refused"), want: false},
@@ -1421,7 +1426,8 @@ func TestIsMysqlTableCheckEligible(t *testing.T) {
 	}{
 		{name: "mysql.tbl-schema.sql.gz", want: true},
 		{name: "mysql.tbl.sql.gz", want: true},
-		{name: "mysql.tbl-schema-trigger.sql.gz", want: true},
+		// trigger files reference a table but are post-phase; table-existence guard is wrong for them
+		{name: "mysql.tbl-schema-trigger.sql.gz", want: false},
 		{name: "mysql.tbl-schema-view.sql.gz", want: false},
 		{name: "mysql.__routines-schema-routine.sql.gz", want: false},
 		{name: "mysql.__events-schema-event.sql.gz", want: false},

--- a/utils/splitdump/restore_test.go
+++ b/utils/splitdump/restore_test.go
@@ -1,6 +1,7 @@
 package splitdump
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -208,7 +209,10 @@ func TestListFilesOrderingAndClassification(t *testing.T) {
 	dir := t.TempDir()
 	files := []string{
 		"db.tbl-schema.sql.gz",
+		"db.__routines-schema-routine.sql.gz",
 		"db.tbl-schema-view.sql.gz",
+		"db.tbl-schema-trigger.sql.gz",
+		"db.__events-schema-event.sql.gz",
 		"mysql.system-all.sql.gz",
 		"db.tbl.sql.gz",
 		"db.tbl.00002.sql.gz",
@@ -238,12 +242,21 @@ func TestListFilesOrderingAndClassification(t *testing.T) {
 	}
 
 	wantSchema := []string{
-		filepath.Join(dir, "db.tbl-schema-view.sql.gz"),
 		filepath.Join(dir, "db.tbl-schema.sql.gz"),
 		filepath.Join(dir, "mysql.system-all.sql.gz"),
+		filepath.Join(dir, "db.__routines-schema-routine.sql.gz"),
+		filepath.Join(dir, "db.tbl-schema-view.sql.gz"),
 	}
 	if !reflect.DeepEqual(set.Schema, wantSchema) {
 		t.Fatalf("unexpected schema list: %#v", set.Schema)
+	}
+
+	wantPost := []string{
+		filepath.Join(dir, "db.tbl-schema-trigger.sql.gz"),
+		filepath.Join(dir, "db.__events-schema-event.sql.gz"),
+	}
+	if !reflect.DeepEqual(set.Post, wantPost) {
+		t.Fatalf("unexpected post-data list: %#v", set.Post)
 	}
 
 	setNoUser, err := ListFiles(dir, false)
@@ -257,6 +270,120 @@ func TestListFilesOrderingAndClassification(t *testing.T) {
 	}
 }
 
+func TestListFilesSchemaOrderingTableBeforeViewAlphabeticalConflict(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		"db.a_view-schema-view.sql.gz",
+		"db.z_table-schema.sql.gz",
+		"mysql.system-all.sql.gz",
+	}
+	for _, name := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to write file %s: %v", name, err)
+		}
+	}
+
+	set, err := ListFiles(dir, true)
+	if err != nil {
+		t.Fatalf("ListFiles error: %v", err)
+	}
+
+	wantSchema := []string{
+		filepath.Join(dir, "db.z_table-schema.sql.gz"),
+		filepath.Join(dir, "mysql.system-all.sql.gz"),
+		filepath.Join(dir, "db.a_view-schema-view.sql.gz"),
+	}
+	if !reflect.DeepEqual(set.Schema, wantSchema) {
+		t.Fatalf("unexpected schema order: %#v", set.Schema)
+	}
+}
+
+func TestRestoreAppliesExpandedObjectOrdering(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		"db.a_view-schema-view.sql.gz",
+		"db.z_table-schema.sql.gz",
+		"mysql.system-all.sql.gz",
+		"db.__routines-schema-routine.sql.gz",
+		"db.tbl.00000.sql.gz",
+		"db.tbl-schema-trigger.sql.gz",
+		"db.__events-schema-event.sql.gz",
+	}
+	for _, name := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to write file %s: %v", name, err)
+		}
+	}
+
+	var mu sync.Mutex
+	var restored []string
+	restoreFile := func(path string) error {
+		mu.Lock()
+		restored = append(restored, filepath.Base(path))
+		mu.Unlock()
+		return nil
+	}
+
+	if err := Restore(dir, RestoreOptions{Parallel: 1, RestoreUser: true, RestoreFile: restoreFile}); err != nil {
+		t.Fatalf("unexpected restore error: %v", err)
+	}
+
+	mu.Lock()
+	gotRestored := append([]string(nil), restored...)
+	mu.Unlock()
+
+	want := []string{
+		"db.z_table-schema.sql.gz",
+		"mysql.system-all.sql.gz",
+		"db.__routines-schema-routine.sql.gz",
+		"db.a_view-schema-view.sql.gz",
+		"db.tbl.00000.sql.gz",
+		"db.tbl-schema-trigger.sql.gz",
+		"db.__events-schema-event.sql.gz",
+	}
+	if !reflect.DeepEqual(gotRestored, want) {
+		t.Fatalf("unexpected restore order: %#v", gotRestored)
+	}
+}
+
+func TestRestoreAppliesSchemaTableBeforeView(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		"db.a_view-schema-view.sql.gz",
+		"db.z_table-schema.sql.gz",
+	}
+	for _, name := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to write file %s: %v", name, err)
+		}
+	}
+
+	var mu sync.Mutex
+	var restored []string
+	restoreFile := func(path string) error {
+		mu.Lock()
+		restored = append(restored, filepath.Base(path))
+		mu.Unlock()
+		return nil
+	}
+
+	if err := Restore(dir, RestoreOptions{Parallel: 1, RestoreFile: restoreFile}); err != nil {
+		t.Fatalf("unexpected restore error: %v", err)
+	}
+
+	mu.Lock()
+	gotRestored := append([]string(nil), restored...)
+	mu.Unlock()
+
+	want := []string{
+		"db.z_table-schema.sql.gz",
+		"db.a_view-schema-view.sql.gz",
+	}
+	if !reflect.DeepEqual(gotRestored, want) {
+		t.Fatalf("unexpected restore order: %#v", gotRestored)
+	}
+}
+
 func TestSchemaFromFilename(t *testing.T) {
 	tests := []struct {
 		name string
@@ -266,6 +393,9 @@ func TestSchemaFromFilename(t *testing.T) {
 		{name: "db.tbl.sql.gz", want: "db"},
 		{name: "db.tbl.sql", want: "db"},
 		{name: "db.tbl-schema-view.sql.gz", want: "db"},
+		{name: "db.__routines-schema-routine.sql.gz", want: "db"},
+		{name: "db.tbl-schema-trigger.sql.gz", want: "db"},
+		{name: "db.__events-schema-event.sql.gz", want: "db"},
 		{name: "db.tbl.00001.sql.gz", want: "db"},
 		{name: filepath.Join("dir", "sub", "db.tbl-schema.sql"), want: "db"},
 		{name: "mysql.system-all.sql.gz", want: "mysql"},
@@ -292,7 +422,9 @@ func TestTableFromFilename(t *testing.T) {
 		{name: "db.tbl.sql.gz", want: "tbl"},
 		{name: "db.tbl.00001.sql.gz", want: "tbl"},
 		{name: "db.tbl-schema-view.sql", want: "tbl"},
+		{name: "db.tbl-schema-trigger.sql.gz", want: "tbl"},
 		{name: "mysql.system-all.sql.gz", want: ""},
+		{name: "db.__routines-schema-routine.sql.gz", want: "__routines"},
 		{name: "no-dot.sql", want: ""},
 		{name: "not-a-splitdump.txt", want: ""},
 	}
@@ -315,6 +447,8 @@ func TestRestorePreamble(t *testing.T) {
 		{name: "mysql.system-all.sql.gz", want: "SET FOREIGN_KEY_CHECKS=0;\nUSE `mysql`;\n"},
 		{name: "db.tbl.00001.sql.gz", want: "SET FOREIGN_KEY_CHECKS=0;\nUSE `db`;\n"},
 		{name: "db.tbl-schema-view.sql", want: "SET FOREIGN_KEY_CHECKS=0;\nUSE `db`;\n"},
+		{name: "db.__routines-schema-routine.sql.gz", want: "SET FOREIGN_KEY_CHECKS=0;\nUSE `db`;\n"},
+		{name: "db.tbl-schema-trigger.sql.gz", want: "SET FOREIGN_KEY_CHECKS=0;\nUSE `db`;\n"},
 		{name: "no-dot.sql", want: "SET FOREIGN_KEY_CHECKS=0;\n"},
 		{name: "not-a-splitdump.txt", want: "SET FOREIGN_KEY_CHECKS=0;\n"},
 	}
@@ -379,6 +513,9 @@ func TestIsSchemaFile(t *testing.T) {
 		{name: "db.tbl-schema.sql", want: true},
 		{name: "db.tbl-schema-view.sql.gz", want: true},
 		{name: "db.tbl-schema-view.sql", want: true},
+		{name: "db.__routines-schema-routine.sql.gz", want: true},
+		{name: "db.tbl-schema-trigger.sql.gz", want: true},
+		{name: "db.__events-schema-event.sql.gz", want: true},
 		{name: "mysql.system-all.sql.gz", want: true},
 		{name: "mysql.system-all.sql", want: true},
 		{name: "mysql.system-all", want: true},
@@ -401,5 +538,901 @@ func TestRestorePreambleEscapesSchema(t *testing.T) {
 	want := "SET FOREIGN_KEY_CHECKS=0;\nUSE `db``name`;\n"
 	if got := RestorePreamble(name); got != want {
 		t.Fatalf("RestorePreamble(%q) = %q, want %q", name, got, want)
+	}
+}
+
+func TestRestoreFailsForNonSplitdumpDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "backup.sql.gz"), []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	err := Restore(dir, RestoreOptions{Parallel: 1, RestoreFile: func(string) error { return nil }})
+	if err == nil {
+		t.Fatalf("expected ErrNotSplitdump for non-splitdump dir, got nil")
+	}
+	if !errors.Is(err, ErrNotSplitdump) {
+		t.Fatalf("expected ErrNotSplitdump, got: %v", err)
+	}
+}
+
+// ---- Phase ordering and phase-log tests (story 4.2) ----
+
+func TestRestorePhaseOrderAllSevenTypes(t *testing.T) {
+	dir := t.TempDir()
+	// All 7 artifact types: tables, mysql.system-all, routines, views, data, triggers, events
+	files := []string{
+		"db.tbl-schema-trigger.sql.gz",    // post: trigger
+		"db.__events-schema-event.sql.gz", // post: event
+		"db.tbl.00000.sql.gz",             // data
+		"db.tbl-schema.sql.gz",            // schema: table
+		"mysql.system-all.sql.gz",         // schema: system-all
+		"db.__routines-schema-routine.sql.gz", // schema: routine
+		"db.a_view-schema-view.sql.gz",    // schema: view
+	}
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to write file %s: %v", f, err)
+		}
+	}
+
+	var mu sync.Mutex
+	var restored []string
+	restoreFile := func(path string) error {
+		mu.Lock()
+		restored = append(restored, filepath.Base(path))
+		mu.Unlock()
+		return nil
+	}
+
+	if err := Restore(dir, RestoreOptions{Parallel: 1, RestoreUser: true, RestoreFile: restoreFile}); err != nil {
+		t.Fatalf("unexpected restore error: %v", err)
+	}
+
+	mu.Lock()
+	got := append([]string(nil), restored...)
+	mu.Unlock()
+
+	want := []string{
+		"db.tbl-schema.sql.gz",
+		"mysql.system-all.sql.gz",
+		"db.__routines-schema-routine.sql.gz",
+		"db.a_view-schema-view.sql.gz",
+		"db.tbl.00000.sql.gz",
+		"db.tbl-schema-trigger.sql.gz",
+		"db.__events-schema-event.sql.gz",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected restore order:\n  got:  %v\n  want: %v", got, want)
+	}
+}
+
+func TestRestoreSchemaPhaseCompletesBeforeData(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		"db.tbl-schema.sql.gz",
+		"db.tbl.sql.gz",
+		"db.other.sql.gz",
+		"db.a_view-schema-view.sql.gz",
+	}
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to write file %s: %v", f, err)
+		}
+	}
+
+	var mu sync.Mutex
+	var schemaRestored []string
+	var dataStarted []string
+	restoreFile := func(path string) error {
+		base := filepath.Base(path)
+		mu.Lock()
+		defer mu.Unlock()
+		if strings.Contains(base, "-schema") {
+			schemaRestored = append(schemaRestored, base)
+		} else {
+			// Data file: at this point all schema files must already be restored
+			dataStarted = append(dataStarted, base)
+		}
+		return nil
+	}
+
+	if err := Restore(dir, RestoreOptions{Parallel: 1, RestoreFile: restoreFile}); err != nil {
+		t.Fatalf("unexpected restore error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(schemaRestored) == 0 {
+		t.Fatalf("expected schema files to be restored")
+	}
+	if len(dataStarted) == 0 {
+		t.Fatalf("expected data files to be restored")
+	}
+	// All schema files must appear before any data file in the restore sequence
+	// (validated by the fact that the schema phase runs sequentially before data phase)
+	if len(schemaRestored) != 2 { // tbl-schema and a_view-schema-view
+		t.Fatalf("expected 2 schema files, got %d: %v", len(schemaRestored), schemaRestored)
+	}
+}
+
+func TestRestoreDataPhaseCompletesBeforePost(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		"db.tbl-schema.sql.gz",
+		"db.tbl.sql.gz",
+		"db.tbl-schema-trigger.sql.gz",
+		"db.__events-schema-event.sql.gz",
+	}
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to write file %s: %v", f, err)
+		}
+	}
+
+	var mu sync.Mutex
+	var order []string
+	restoreFile := func(path string) error {
+		mu.Lock()
+		order = append(order, filepath.Base(path))
+		mu.Unlock()
+		return nil
+	}
+
+	if err := Restore(dir, RestoreOptions{Parallel: 1, RestoreFile: restoreFile}); err != nil {
+		t.Fatalf("unexpected restore error: %v", err)
+	}
+
+	mu.Lock()
+	got := append([]string(nil), order...)
+	mu.Unlock()
+
+	want := []string{
+		"db.tbl-schema.sql.gz",
+		"db.tbl.sql.gz",
+		"db.tbl-schema-trigger.sql.gz",
+		"db.__events-schema-event.sql.gz",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected restore order:\n  got:  %v\n  want: %v", got, want)
+	}
+}
+
+func TestRestorePhaseStartLogsEmitted(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		"db.tbl-schema.sql.gz",
+		"db.tbl.sql.gz",
+		"db.tbl-schema-trigger.sql.gz",
+	}
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to write file %s: %v", f, err)
+		}
+	}
+
+	var mu sync.Mutex
+	var infoLogs []string
+	logger := func(level, format string, args ...any) {
+		mu.Lock()
+		if level == LogInfo {
+			infoLogs = append(infoLogs, fmt.Sprintf(format, args...))
+		}
+		mu.Unlock()
+	}
+	restoreFile := func(path string) error { return nil }
+
+	if err := Restore(dir, RestoreOptions{Parallel: 1, Logger: logger, RestoreFile: restoreFile}); err != nil {
+		t.Fatalf("unexpected restore error: %v", err)
+	}
+
+	mu.Lock()
+	logs := append([]string(nil), infoLogs...)
+	mu.Unlock()
+
+	hasPhaseLog := func(phase string) bool {
+		for _, l := range logs {
+			if strings.Contains(l, "phase: "+phase) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !hasPhaseLog("schema") {
+		t.Fatalf("expected schema phase-start log, got: %v", logs)
+	}
+	if !hasPhaseLog("data") {
+		t.Fatalf("expected data phase-start log, got: %v", logs)
+	}
+	if !hasPhaseLog("post-data") {
+		t.Fatalf("expected post-data phase-start log, got: %v", logs)
+	}
+}
+
+// ---- DEFINER compatibility tests (story 4.3) ----
+
+func TestIsDefinerError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "error 1449", err: fmt.Errorf("mysql restore failed: ERROR 1449 (HY000): The user specified as a definer ('bad'@'localhost') does not exist"), want: true},
+		{name: "definer text", err: fmt.Errorf("definer 'user'@'host' problem"), want: true},
+		{name: "other mysql error", err: fmt.Errorf("mysql restore failed: ERROR 1146 (42S02): Table does not exist"), want: false},
+		{name: "context canceled", err: context.Canceled, want: false},
+		{name: "generic error", err: fmt.Errorf("connection refused"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsDefinerError(tt.err); got != tt.want {
+				t.Fatalf("IsDefinerError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRestoreDefinerNonStrictFallback(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "db.v_foo-schema-view.sql.gz"), []byte("test"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	definerErr := fmt.Errorf("mysql restore failed: ERROR 1449 (HY000): The user specified as a definer ('bad_user'@'localhost') does not exist")
+
+	var mu sync.Mutex
+	var fallbackCalled []string
+	var warnLogs []string
+
+	err := Restore(dir, RestoreOptions{
+		Parallel: 1,
+		Logger: func(level, format string, args ...any) {
+			mu.Lock()
+			if level == LogWarn {
+				warnLogs = append(warnLogs, fmt.Sprintf(format, args...))
+			}
+			mu.Unlock()
+		},
+		Context: context.Background(),
+		RestoreFileWithContext: func(ctx context.Context, path string) error {
+			return definerErr
+		},
+		RestoreFileWithoutDefiner: func(ctx context.Context, path string) error {
+			mu.Lock()
+			fallbackCalled = append(fallbackCalled, filepath.Base(path))
+			mu.Unlock()
+			return nil
+		},
+		DefinerStrict: false,
+	})
+
+	if err != nil {
+		t.Fatalf("expected non-strict fallback to succeed, got: %v", err)
+	}
+
+	mu.Lock()
+	fc := append([]string(nil), fallbackCalled...)
+	wl := append([]string(nil), warnLogs...)
+	mu.Unlock()
+
+	if len(fc) != 1 || fc[0] != "db.v_foo-schema-view.sql.gz" {
+		t.Fatalf("expected fallback called for view file, got: %v", fc)
+	}
+	foundFallbackLog := false
+	for _, l := range wl {
+		if strings.Contains(l, "DEFINER fallback") {
+			foundFallbackLog = true
+			break
+		}
+	}
+	if !foundFallbackLog {
+		t.Fatalf("expected DEFINER fallback warning in logs, got: %v", wl)
+	}
+}
+
+func TestRestoreDefinerStrictFails(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "db.v_foo-schema-view.sql.gz"), []byte("test"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	definerErr := fmt.Errorf("mysql restore failed: ERROR 1449 (HY000): The user specified as a definer ('bad_user'@'localhost') does not exist")
+
+	var mu sync.Mutex
+	var errLogs []string
+
+	err := Restore(dir, RestoreOptions{
+		Parallel: 1,
+		Logger: func(level, format string, args ...any) {
+			mu.Lock()
+			if level == LogError {
+				errLogs = append(errLogs, fmt.Sprintf(format, args...))
+			}
+			mu.Unlock()
+		},
+		Context: context.Background(),
+		RestoreFileWithContext: func(ctx context.Context, path string) error {
+			return definerErr
+		},
+		DefinerStrict: true,
+	})
+
+	if err == nil {
+		t.Fatalf("expected strict DEFINER error, got nil")
+	}
+	if !errors.Is(err, ErrDefinerStrict) {
+		t.Fatalf("expected ErrDefinerStrict, got: %v", err)
+	}
+
+	mu.Lock()
+	el := append([]string(nil), errLogs...)
+	mu.Unlock()
+
+	foundStrictLog := false
+	for _, l := range el {
+		if strings.Contains(strings.ToLower(l), "strict") && strings.Contains(strings.ToLower(l), "definer") {
+			foundStrictLog = true
+			break
+		}
+	}
+	if !foundStrictLog {
+		t.Fatalf("expected strict DEFINER error log, got: %v", el)
+	}
+}
+
+func TestRestoreDefinerNotTriggeredOnOtherErrors(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "db.tbl-schema.sql.gz"), []byte("test"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	someErr := fmt.Errorf("mysql restore failed: ERROR 1146 (42S02): Table doesn't exist")
+	var fallbackCalled bool
+
+	err := Restore(dir, RestoreOptions{
+		Parallel: 1,
+		Context:  context.Background(),
+		RestoreFileWithContext: func(ctx context.Context, path string) error {
+			return someErr
+		},
+		RestoreFileWithoutDefiner: func(ctx context.Context, path string) error {
+			fallbackCalled = true
+			return nil
+		},
+		DefinerStrict: false,
+	})
+
+	if err == nil {
+		t.Fatalf("expected error for non-DEFINER failure, got nil")
+	}
+	if errors.Is(err, ErrDefinerStrict) {
+		t.Fatalf("expected non-DEFINER error, got ErrDefinerStrict")
+	}
+	if fallbackCalled {
+		t.Fatalf("DEFINER fallback should not be triggered for non-DEFINER errors")
+	}
+}
+
+func TestRestoreDefinerNonStrictNoFallbackFunctionLogs(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "db.v_foo-schema-view.sql.gz"), []byte("test"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	definerErr := fmt.Errorf("mysql restore failed: ERROR 1449 (HY000): The user specified as a definer ('bad_user'@'localhost') does not exist")
+
+	var mu sync.Mutex
+	var warnLogs []string
+
+	err := Restore(dir, RestoreOptions{
+		Parallel: 1,
+		Logger: func(level, format string, args ...any) {
+			mu.Lock()
+			if level == LogWarn {
+				warnLogs = append(warnLogs, fmt.Sprintf(format, args...))
+			}
+			mu.Unlock()
+		},
+		Context: context.Background(),
+		RestoreFileWithContext: func(ctx context.Context, path string) error {
+			return definerErr
+		},
+		// No RestoreFileWithoutDefiner — non-strict should skip with a warning
+		DefinerStrict: false,
+	})
+
+	if err != nil {
+		t.Fatalf("expected non-strict with no fallback to skip file (not fail), got: %v", err)
+	}
+
+	mu.Lock()
+	wl := append([]string(nil), warnLogs...)
+	mu.Unlock()
+
+	foundWarn := false
+	for _, l := range wl {
+		if strings.Contains(strings.ToLower(l), "definer") {
+			foundWarn = true
+			break
+		}
+	}
+	if !foundWarn {
+		t.Fatalf("expected DEFINER warning log when no fallback function, got: %v", wl)
+	}
+}
+
+func TestRestoreNormalBehaviorUnchangedWithoutDefinerError(t *testing.T) {
+	// AC 4: files without DEFINER issues restore normally with no extra transformation
+	dir := t.TempDir()
+	for _, f := range []string{"db.tbl-schema.sql.gz", "db.tbl.sql.gz"} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	var mu sync.Mutex
+	var restored []string
+	var fallbackCalled bool
+
+	err := Restore(dir, RestoreOptions{
+		Parallel: 1,
+		Context:  context.Background(),
+		RestoreFileWithContext: func(ctx context.Context, path string) error {
+			mu.Lock()
+			restored = append(restored, filepath.Base(path))
+			mu.Unlock()
+			return nil
+		},
+		RestoreFileWithoutDefiner: func(ctx context.Context, path string) error {
+			fallbackCalled = true
+			return nil
+		},
+		DefinerStrict: false,
+	})
+
+	if err != nil {
+		t.Fatalf("expected clean restore, got: %v", err)
+	}
+	if fallbackCalled {
+		t.Fatalf("DEFINER fallback must not be called when no DEFINER error occurs")
+	}
+	mu.Lock()
+	r := append([]string(nil), restored...)
+	mu.Unlock()
+	if len(r) != 2 {
+		t.Fatalf("expected 2 files restored, got %d: %v", len(r), r)
+	}
+}
+
+// ---- Detect and BuildRestorePlan tests ----
+
+func TestDetectReturnsTrueForSplitdumpDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "db.tbl-schema.sql.gz"), []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	ok, err := Detect(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected splitdump-compatible, got false")
+	}
+}
+
+func TestDetectReturnsFalseForNonSplitdumpDir(t *testing.T) {
+	dir := t.TempDir()
+	// A single file with no schema.table pattern (no dot before .sql extension)
+	if err := os.WriteFile(filepath.Join(dir, "backup.sql.gz"), []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	ok, err := Detect(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected not splitdump-compatible, got true")
+	}
+}
+
+func TestDetectReturnsFalseForEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	ok, err := Detect(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected false for empty dir, got true")
+	}
+}
+
+func TestDetectReturnsFalseForOnlyMetadata(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "metadata"), []byte("[source]\nFile=x\n"), 0644); err != nil {
+		t.Fatalf("failed to write metadata: %v", err)
+	}
+	ok, err := Detect(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected false for only-metadata dir, got true")
+	}
+}
+
+func TestDetectReturnsTrueForMysqlSystemAll(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "mysql.system-all.sql.gz"), []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	ok, err := Detect(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected splitdump-compatible for mysql.system-all.sql.gz, got false")
+	}
+}
+
+func TestDetectReturnsErrorForNonExistentDir(t *testing.T) {
+	_, err := Detect("/this/path/does/not/exist/splitdump-test")
+	if err == nil {
+		t.Fatalf("expected error for non-existent dir, got nil")
+	}
+}
+
+func TestDetectReturnsFalseForNonSplitdumpSqlFile(t *testing.T) {
+	dir := t.TempDir()
+	// Files with no dot-separated schema.table prefix are not splitdump
+	for _, name := range []string{"nodot.sql", "alsono.sql.gz"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to write %s: %v", name, err)
+		}
+	}
+	ok, err := Detect(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected false for non-splitdump sql files, got true")
+	}
+}
+
+func TestBuildRestorePlanReturnsPlanForSplitdumpDir(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		"db.tbl-schema.sql.gz",
+		"db.tbl.sql.gz",
+		"db.tbl-schema-trigger.sql.gz",
+	}
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to write file %s: %v", f, err)
+		}
+	}
+	plan, err := BuildRestorePlan(dir, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if plan == nil {
+		t.Fatalf("expected non-nil plan")
+	}
+	if len(plan.Schema) == 0 {
+		t.Fatalf("expected schema files in plan")
+	}
+	if len(plan.Data) == 0 {
+		t.Fatalf("expected data files in plan")
+	}
+	if len(plan.Post) == 0 {
+		t.Fatalf("expected post-data files in plan")
+	}
+}
+
+func TestBuildRestorePlanReturnsErrNotSplitdump(t *testing.T) {
+	dir := t.TempDir()
+	// A file with no schema.table naming pattern
+	if err := os.WriteFile(filepath.Join(dir, "backup.sql.gz"), []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	_, err := BuildRestorePlan(dir, false)
+	if err == nil {
+		t.Fatalf("expected ErrNotSplitdump, got nil")
+	}
+	if !errors.Is(err, ErrNotSplitdump) {
+		t.Fatalf("expected ErrNotSplitdump, got: %v", err)
+	}
+}
+
+func TestBuildRestorePlanReturnsErrNotSplitdumpForEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	_, err := BuildRestorePlan(dir, false)
+	if err == nil {
+		t.Fatalf("expected ErrNotSplitdump for empty dir, got nil")
+	}
+	if !errors.Is(err, ErrNotSplitdump) {
+		t.Fatalf("expected ErrNotSplitdump, got: %v", err)
+	}
+}
+
+func TestBuildRestorePlanPhaseOrdering(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		"db.tbl-schema-event.sql.gz",
+		"db.tbl-schema-trigger.sql.gz",
+		"db.tbl.sql.gz",
+		"db.tbl-schema.sql.gz",
+		"mysql.system-all.sql.gz",
+		"db.__routines-schema-routine.sql.gz",
+	}
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to write file %s: %v", f, err)
+		}
+	}
+
+	plan, err := BuildRestorePlan(dir, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Schema phase: table schema first, then mysql.system-all, then routines
+	if len(plan.Schema) < 3 {
+		t.Fatalf("expected at least 3 schema files, got %d: %v", len(plan.Schema), plan.Schema)
+	}
+	schemaBase := filepath.Base(plan.Schema[0])
+	if schemaBase != "db.tbl-schema.sql.gz" {
+		t.Fatalf("expected table schema first in schema phase, got %q", schemaBase)
+	}
+	systemAllBase := filepath.Base(plan.Schema[1])
+	if systemAllBase != "mysql.system-all.sql.gz" {
+		t.Fatalf("expected mysql.system-all second in schema phase, got %q", systemAllBase)
+	}
+
+	// Post phase: triggers before events
+	if len(plan.Post) < 2 {
+		t.Fatalf("expected at least 2 post-data files, got %d", len(plan.Post))
+	}
+	triggerBase := filepath.Base(plan.Post[0])
+	if !strings.Contains(triggerBase, "trigger") {
+		t.Fatalf("expected trigger first in post phase, got %q", triggerBase)
+	}
+	eventBase := filepath.Base(plan.Post[1])
+	if !strings.Contains(eventBase, "event") {
+		t.Fatalf("expected event second in post phase, got %q", eventBase)
+	}
+}
+
+func TestBuildRestorePlanRespectsRestoreUser(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		"db.tbl-schema.sql.gz",
+		"db.tbl.sql.gz",
+		"mysql.system-all.sql.gz",
+	}
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to write file %s: %v", f, err)
+		}
+	}
+
+	// With restoreUser=false, mysql.system-all should be excluded from schema phase
+	planNoUser, err := BuildRestorePlan(dir, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, p := range planNoUser.Schema {
+		if strings.Contains(filepath.Base(p), "system-all") {
+			t.Fatalf("expected mysql.system-all excluded when restoreUser=false")
+		}
+	}
+
+	// With restoreUser=true, mysql.system-all should be included in schema phase
+	planWithUser, err := BuildRestorePlan(dir, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := false
+	for _, p := range planWithUser.Schema {
+		if strings.Contains(filepath.Base(p), "system-all") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected mysql.system-all in schema phase when restoreUser=true")
+	}
+}
+
+// ---- Detection outcome and log distinguishability tests (story 4.4) ----
+
+func TestRestoreDetectionOutcomeLogged(t *testing.T) {
+	dir := t.TempDir()
+	for _, f := range []string{"db.tbl-schema.sql.gz", "db.tbl.sql.gz"} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	var mu sync.Mutex
+	var infoLogs []string
+	logger := func(level, format string, args ...any) {
+		mu.Lock()
+		if level == LogInfo {
+			infoLogs = append(infoLogs, fmt.Sprintf(format, args...))
+		}
+		mu.Unlock()
+	}
+
+	if err := Restore(dir, RestoreOptions{Parallel: 1, Logger: logger, RestoreFile: func(string) error { return nil }}); err != nil {
+		t.Fatalf("unexpected restore error: %v", err)
+	}
+
+	mu.Lock()
+	logs := append([]string(nil), infoLogs...)
+	mu.Unlock()
+
+	found := false
+	for _, l := range logs {
+		lower := strings.ToLower(l)
+		if strings.Contains(lower, "detection") && strings.Contains(lower, "confirmed") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected detection outcome log containing 'detection' and 'confirmed', got: %v", logs)
+	}
+}
+
+func TestRestoreOrderingFailureDistinguishableFromDefinerFailure(t *testing.T) {
+	// Schema restore failures should log differently from DEFINER strict failures,
+	// allowing operators to distinguish ordering errors from DEFINER enforcement errors.
+
+	// --- Schema ordering failure ---
+	dir1 := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir1, "db.tbl-schema.sql.gz"), []byte("test"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	schemaErr := fmt.Errorf("mysqldump restore error: connection refused")
+	var mu1 sync.Mutex
+	var errLogs1 []string
+	Restore(dir1, RestoreOptions{ //nolint:errcheck
+		Parallel: 1,
+		Logger: func(level, format string, args ...any) {
+			mu1.Lock()
+			if level == LogError {
+				errLogs1 = append(errLogs1, fmt.Sprintf(format, args...))
+			}
+			mu1.Unlock()
+		},
+		RestoreFile: func(string) error { return schemaErr },
+	})
+
+	// --- DEFINER strict failure ---
+	dir2 := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir2, "db.v_foo-schema-view.sql.gz"), []byte("test"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	definerErr := fmt.Errorf("mysql restore failed: ERROR 1449 (HY000): The user specified as a definer does not exist")
+	var mu2 sync.Mutex
+	var errLogs2 []string
+	Restore(dir2, RestoreOptions{ //nolint:errcheck
+		Parallel: 1,
+		Logger: func(level, format string, args ...any) {
+			mu2.Lock()
+			if level == LogError {
+				errLogs2 = append(errLogs2, fmt.Sprintf(format, args...))
+			}
+			mu2.Unlock()
+		},
+		Context: context.Background(),
+		RestoreFileWithContext: func(ctx context.Context, path string) error { return definerErr },
+		DefinerStrict: true,
+	})
+
+	mu1.Lock()
+	el1 := append([]string(nil), errLogs1...)
+	mu1.Unlock()
+
+	mu2.Lock()
+	el2 := append([]string(nil), errLogs2...)
+	mu2.Unlock()
+
+	if len(el1) == 0 {
+		t.Fatalf("expected schema error logs, got none")
+	}
+	if len(el2) == 0 {
+		t.Fatalf("expected DEFINER error logs, got none")
+	}
+
+	// Schema failure log must not mention "definer" or "strict"
+	for _, l := range el1 {
+		lower := strings.ToLower(l)
+		if strings.Contains(lower, "definer") || strings.Contains(lower, "strict") {
+			t.Fatalf("schema restore failure log should not mention definer/strict: %v", el1)
+		}
+	}
+
+	// DEFINER strict failure log must contain both "definer" and "strict"
+	found := false
+	for _, l := range el2 {
+		lower := strings.ToLower(l)
+		if strings.Contains(lower, "definer") && strings.Contains(lower, "strict") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected DEFINER strict log to contain 'definer' and 'strict', got: %v", el2)
+	}
+}
+
+func TestListSchemas(t *testing.T) {
+	dir := t.TempDir()
+	// User schemas
+	for _, name := range []string{
+		"app.tbl-schema.sql.gz",
+		"app.tbl.sql.gz",
+		"logs.events-schema.sql.gz",
+		"logs.events.sql.gz",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(""), 0644); err != nil {
+			t.Fatalf("failed to write %s: %v", name, err)
+		}
+	}
+	// System schemas that must be excluded
+	for _, name := range []string{
+		"mysql.system-all.sql.gz",
+		"sys.sys_config-schema.sql.gz",
+		"information_schema.tables-schema.sql.gz",
+		"performance_schema.events-schema.sql.gz",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(""), 0644); err != nil {
+			t.Fatalf("failed to write %s: %v", name, err)
+		}
+	}
+
+	got, err := ListSchemas(dir)
+	if err != nil {
+		t.Fatalf("ListSchemas returned error: %v", err)
+	}
+	want := []string{"app", "logs"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ListSchemas = %v, want %v", got, want)
+	}
+}
+
+func TestListSchemasEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	got, err := ListSchemas(dir)
+	if err != nil {
+		t.Fatalf("ListSchemas returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %v", got)
+	}
+}
+
+func TestIsMysqlTableCheckEligible(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "mysql.tbl-schema.sql.gz", want: true},
+		{name: "mysql.tbl.sql.gz", want: true},
+		{name: "mysql.tbl-schema-trigger.sql.gz", want: true},
+		{name: "mysql.tbl-schema-view.sql.gz", want: false},
+		{name: "mysql.__routines-schema-routine.sql.gz", want: false},
+		{name: "mysql.__events-schema-event.sql.gz", want: false},
+		{name: "mysql.system-all.sql.gz", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsMysqlTableCheckEligible(tt.name); got != tt.want {
+				t.Fatalf("IsMysqlTableCheckEligible(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
 	}
 }

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -137,6 +137,8 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 	shardpad, schema := "", ""
 	shard := 0
 	dataTableName := ""
+	currentOutputName := ""
+	openedOutputs := make(map[string]bool)
 	binlogRegexMariaDB := regexp.MustCompile(`CHANGE MASTER TO MASTER_LOG_FILE='(.+)', MASTER_LOG_POS=(\d+)`)
 	gtidRegexMariaDB := regexp.MustCompile(`SET GLOBAL gtid_slave_pos='(.+)'`)
 	binlogRegexMySQL := regexp.MustCompile(`CHANGE REPLICATION SOURCE TO SOURCE_LOG_FILE='(.+)', SOURCE_LOG_POS=(\d+)`)
@@ -153,6 +155,15 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 	var tableFile *gzip.Writer
 	var bgtid, bfile, bpos string
 	sourceDataDisabled := false
+	extractDumpSectionName := func(line, marker string) string {
+		trimmed := strings.TrimSpace(line)
+		if len(trimmed) < len(marker) || !strings.EqualFold(trimmed[:len(marker)], marker) {
+			return ""
+		}
+		name := strings.TrimSpace(trimmed[len(marker):])
+		name = strings.Trim(name, "`'\"")
+		return strings.TrimSpace(name)
+	}
 	closeTableWriter := func() {
 		if tableFile != nil {
 			_ = tableFile.Flush()
@@ -166,6 +177,30 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 			_ = f.Close()
 			f = nil
 		}
+		currentOutputName = ""
+	}
+	openOutputFile := func(tableName string, appendMode bool) error {
+		if tableFile != nil && currentOutputName == tableName {
+			return nil
+		}
+		closeTableFile()
+		tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
+		flags := os.O_CREATE | os.O_WRONLY
+		if appendMode && openedOutputs[tableName] {
+			flags |= os.O_APPEND
+		} else {
+			flags |= os.O_TRUNC
+		}
+		var openErr error
+		f, openErr = os.OpenFile(tablePath, flags, 0644)
+		if openErr != nil {
+			return fmt.Errorf("splitdump: create file %s: %w", tablePath, openErr)
+		}
+		tableFile = gzip.NewWriter(f)
+		currentOutputName = tableName
+		openedOutputs[tableName] = true
+		pastHeader = true
+		return nil
 	}
 
 	streamSizeMax, err := normalizeSplitDumpOptions(opts)
@@ -188,17 +223,13 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 				splitReady = false
 			} else if onTableData && dataTableName != "" {
 				shard++
-				closeTableFile()
 				shardpad = fmt.Sprintf(".%05d", shard)
 				tableName := dataTableName + shardpad
 				fmt.Printf("Processing table data %s\n", tableName)
-				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-				f, err = os.Create(tablePath)
-				if err != nil {
-					finishWithError(fmt.Errorf("splitdump: create file %s: %w", tablePath, err))
+				if err = openOutputFile(tableName, false); err != nil {
+					finishWithError(err)
 					return
 				}
-				tableFile = gzip.NewWriter(f)
 				tableFile.Write([]byte(headerMetaData))
 				if schema != "" {
 					tableFile.Write([]byte("USE `" + schema + "`;\n"))
@@ -256,14 +287,10 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 				onTableScheme, onTableData = true, false
 				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Table structure for table ", "", 1), "`", "", -1)) + "-schema"
 				fmt.Printf("Processing table schema %s\n", tableName)
-				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-				f, err = os.Create(tablePath)
-				if err != nil {
-					finishWithError(fmt.Errorf("splitdump: create file %s: %w", tablePath, err))
+				if err = openOutputFile(tableName, false); err != nil {
+					finishWithError(err)
 					return
 				}
-				tableFile = gzip.NewWriter(f)
-				pastHeader = true
 			} else if strings.HasPrefix(line, "LOCK TABLES `") {
 				onTableData, onTableScheme = true, false
 			} else if strings.HasPrefix(line, "-- Dumping data for table") {
@@ -272,15 +299,11 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 					closeTableWriter()
 					tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table", "", 1), "`", "", -1)) + "-schema"
 					fmt.Printf("Processing table schema %s\n", tableName)
-					tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-					f, err = os.Create(tablePath)
-					if err != nil {
-						finishWithError(fmt.Errorf("splitdump: create file %s: %w", tablePath, err))
+					if err = openOutputFile(tableName, false); err != nil {
+						finishWithError(err)
 						return
 					}
-					tableFile = gzip.NewWriter(f)
 					tableFile.Write([]byte("\n--\n" + line))
-					pastHeader = true
 
 				}
 				closeTableFile()
@@ -289,13 +312,10 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 				dataTableName = schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Dumping data for table ", "", 1), "`", "", -1))
 				tableName := dataTableName + shardpad
 				fmt.Printf("Processing table data %s\n", tableName)
-				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-				f, err = os.Create(tablePath)
-				if err != nil {
-					finishWithError(fmt.Errorf("splitdump: create file %s: %w", tablePath, err))
+				if err = openOutputFile(tableName, false); err != nil {
+					finishWithError(err)
 					return
 				}
-				tableFile = gzip.NewWriter(f)
 				tableFile.Write([]byte(headerMetaData))
 				onTableScheme = false
 				onTableData = true
@@ -305,31 +325,65 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 				onTableScheme = false
 				dataTableName = ""
 				//	onView = true
-				closeTableFile()
 				tableName := schema + "." + strings.TrimSpace(strings.Replace(strings.Replace(line, "-- Final view structure for view ", "", 1), "`", "", -1)) + "-schema-view"
 				fmt.Printf("Processing view schema %s\n", tableName)
-				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-				f, err = os.Create(tablePath)
-				if err != nil {
-					finishWithError(fmt.Errorf("splitdump: create file %s: %w", tablePath, err))
+				if err = openOutputFile(tableName, false); err != nil {
+					finishWithError(err)
 					return
 				}
-				tableFile = gzip.NewWriter(f)
 				//-- Dumping routines
+			} else if strings.HasPrefix(line, "-- Dumping routines for database ") {
+				onTableData = false
+				onTableScheme = false
+				dataTableName = ""
+				routineSchema := extractDumpSectionName(line, "-- Dumping routines for database ")
+				if routineSchema == "" {
+					routineSchema = schema
+				}
+				tableName := routineSchema + ".__routines-schema-routine"
+				fmt.Printf("Processing routines schema %s\n", tableName)
+				if err = openOutputFile(tableName, true); err != nil {
+					finishWithError(err)
+					return
+				}
+			} else if strings.HasPrefix(line, "-- Dumping events for database ") {
+				onTableData = false
+				onTableScheme = false
+				dataTableName = ""
+				eventSchema := extractDumpSectionName(line, "-- Dumping events for database ")
+				if eventSchema == "" {
+					eventSchema = schema
+				}
+				tableName := eventSchema + ".__events-schema-event"
+				fmt.Printf("Processing events schema %s\n", tableName)
+				if err = openOutputFile(tableName, true); err != nil {
+					finishWithError(err)
+					return
+				}
+			} else if strings.HasPrefix(line, "-- Dumping triggers for table ") {
+				onTableData = false
+				onTableScheme = false
+				dataTableName = ""
+				triggerTable := extractDumpSectionName(line, "-- Dumping triggers for table ")
+				if triggerTable == "" {
+					triggerTable = "__triggers"
+				}
+				tableName := schema + "." + triggerTable + "-schema-trigger"
+				fmt.Printf("Processing trigger schema %s\n", tableName)
+				if err = openOutputFile(tableName, true); err != nil {
+					finishWithError(err)
+					return
+				}
 			} else if strings.HasPrefix(line, "INSTALL PLUGIN") || strings.HasPrefix(line, "CREATE USER") {
 				onTableData = false
 				onTableScheme = false
 				dataTableName = ""
-				closeTableFile()
 				tableName := "mysql.system-all"
 				fmt.Printf("Processing system schema %s\n", tableName)
-				tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
-				f, err = os.Create(tablePath)
-				if err != nil {
-					finishWithError(fmt.Errorf("splitdump: create file %s: %w", tablePath, err))
+				if err = openOutputFile(tableName, true); err != nil {
+					finishWithError(err)
 					return
 				}
-				tableFile = gzip.NewWriter(f)
 			}
 			if !sourceDataDisabled {
 				if matches := gtidRegexMariaDB.FindStringSubmatch(line); matches != nil {

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -161,6 +161,10 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 			return ""
 		}
 		name := strings.TrimSpace(trimmed[len(marker):])
+		// strings.Trim removes any mix of backtick/single/double-quote characters from
+		// both ends. This is correct for mysqldump output: identifiers are wrapped in a
+		// single consistent quote style and do not contain literal unescaped trailing
+		// quote characters (e.g. `db name` → db name, not `db name`` → db name).
 		name = strings.Trim(name, "`'\"")
 		return strings.TrimSpace(name)
 	}

--- a/utils/splitdump/split_test.go
+++ b/utils/splitdump/split_test.go
@@ -575,3 +575,150 @@ func TestSplitDumpLineParserSplitsAtStatementBoundary(t *testing.T) {
 		t.Fatalf("expected shard to start with INSERT statement, got: %s", firstLine)
 	}
 }
+
+func TestSplitDumpLineParserWritesRoutinesTriggersEventsAndSystemFiles(t *testing.T) {
+	bus := NewSplitDumpChannelBus()
+	outputDir := filepath.Join(t.TempDir(), "splitdump")
+
+	go SplitDumpLineParser(bus, outputDir, SplitDumpOptions{})
+
+	lines := []string{
+		"USE `db`\n",
+		"-- Table structure for table `tbl`\n",
+		"CREATE TABLE `tbl` (id int);\n",
+		"-- Final view structure for view `v_tbl`\n",
+		"CREATE VIEW `v_tbl` AS SELECT `tbl`.`id` AS `id` FROM `tbl`;\n",
+		"-- Dumping routines for database 'db'\n",
+		"CREATE FUNCTION `f_tbl`() RETURNS int RETURN 1;\n",
+		"-- Dumping data for table `tbl`\n",
+		"LOCK TABLES `tbl` WRITE;\n",
+		"INSERT INTO `tbl` VALUES (1);\n",
+		"UNLOCK TABLES;\n",
+		"-- Dumping triggers for table `tbl`\n",
+		"CREATE TRIGGER `trg_tbl` BEFORE INSERT ON `tbl` FOR EACH ROW SET NEW.id = NEW.id;\n",
+		"-- Dumping events for database 'db'\n",
+		"CREATE EVENT `ev_tbl` ON SCHEDULE EVERY 1 DAY DO SELECT 1;\n",
+		"CREATE USER 'app'@'%' IDENTIFIED BY 'x';\n",
+		"INSTALL PLUGIN validate_password SONAME 'validate_password.so';\n",
+	}
+	for _, line := range lines {
+		bus.CurrentLine <- line
+	}
+	close(bus.CurrentLine)
+
+	select {
+	case <-bus.Finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for splitdump to finish")
+	}
+
+	readGzip := func(path string) string {
+		file, err := os.Open(path)
+		if err != nil {
+			t.Fatalf("failed to open %s: %v", path, err)
+		}
+		defer file.Close()
+		reader, err := gzip.NewReader(file)
+		if err != nil {
+			t.Fatalf("failed to open gzip %s: %v", path, err)
+		}
+		defer reader.Close()
+		content, err := io.ReadAll(reader)
+		if err != nil {
+			t.Fatalf("failed to read gzip %s: %v", path, err)
+		}
+		return string(content)
+	}
+
+	routinePath := filepath.Join(outputDir, "db.__routines-schema-routine.sql.gz")
+	if _, err := os.Stat(routinePath); err != nil {
+		t.Fatalf("expected routines file: %v", err)
+	}
+	if got := readGzip(routinePath); !strings.Contains(got, "CREATE FUNCTION") {
+		t.Fatalf("expected routines file to contain function definition")
+	}
+
+	triggerPath := filepath.Join(outputDir, "db.tbl-schema-trigger.sql.gz")
+	if _, err := os.Stat(triggerPath); err != nil {
+		t.Fatalf("expected trigger file: %v", err)
+	}
+	if got := readGzip(triggerPath); !strings.Contains(got, "CREATE TRIGGER") {
+		t.Fatalf("expected trigger file to contain trigger definition")
+	}
+
+	eventPath := filepath.Join(outputDir, "db.__events-schema-event.sql.gz")
+	if _, err := os.Stat(eventPath); err != nil {
+		t.Fatalf("expected event file: %v", err)
+	}
+	if got := readGzip(eventPath); !strings.Contains(got, "CREATE EVENT") {
+		t.Fatalf("expected event file to contain event definition")
+	}
+
+	systemPath := filepath.Join(outputDir, "mysql.system-all.sql.gz")
+	if _, err := os.Stat(systemPath); err != nil {
+		t.Fatalf("expected mysql system file: %v", err)
+	}
+	systemContent := readGzip(systemPath)
+	if !strings.Contains(systemContent, "CREATE USER") {
+		t.Fatalf("expected system file to contain CREATE USER")
+	}
+	if !strings.Contains(systemContent, "INSTALL PLUGIN") {
+		t.Fatalf("expected system file to contain INSTALL PLUGIN")
+	}
+}
+
+func TestSplitDumpLineParserTruncatesSystemFileOnFirstWriteInRun(t *testing.T) {
+	bus := NewSplitDumpChannelBus()
+	outputDir := filepath.Join(t.TempDir(), "splitdump")
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		t.Fatalf("failed to create output dir: %v", err)
+	}
+
+	preexisting := filepath.Join(outputDir, "mysql.system-all.sql.gz")
+	func() {
+		f, err := os.Create(preexisting)
+		if err != nil {
+			t.Fatalf("failed to create preexisting file: %v", err)
+		}
+		defer f.Close()
+		zw := gzip.NewWriter(f)
+		if _, err := zw.Write([]byte("OLD SYSTEM CONTENT\n")); err != nil {
+			t.Fatalf("failed to write preexisting gzip content: %v", err)
+		}
+		if err := zw.Close(); err != nil {
+			t.Fatalf("failed to close preexisting gzip writer: %v", err)
+		}
+	}()
+
+	go SplitDumpLineParser(bus, outputDir, SplitDumpOptions{})
+	bus.CurrentLine <- "CREATE USER 'new'@'%' IDENTIFIED BY 'x';\n"
+	close(bus.CurrentLine)
+
+	select {
+	case <-bus.Finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for splitdump to finish")
+	}
+
+	f, err := os.Open(preexisting)
+	if err != nil {
+		t.Fatalf("failed to open system file: %v", err)
+	}
+	defer f.Close()
+	r, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("failed to open system gzip: %v", err)
+	}
+	defer r.Close()
+	content, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("failed to read system gzip: %v", err)
+	}
+	got := string(content)
+	if strings.Contains(got, "OLD SYSTEM CONTENT") {
+		t.Fatalf("expected old system content to be truncated, got: %s", got)
+	}
+	if !strings.Contains(got, "CREATE USER") {
+		t.Fatalf("expected new system content in file, got: %s", got)
+	}
+}


### PR DESCRIPTION
### **Summary**
This PR improves the reliability and usability of splitdump-based logical restores by adding three major capabilities: graceful DEFINER clause fallback, post-schema file execution, and automatic database creation before restore.

### **What Changed**
1. DEFINER Error Handling (backup-restore-definer-strict)
- Added a new config flag backup-restore-definer-strict (default: false).
- When a restore hits a MySQL/MariaDB DEFINER error (e.g., error 1449 — user does not exist), the default non-strict mode now:
  - Strips DEFINER= clauses via regex fallback.
  - Retries the file without failing the entire restore.
- Strict mode (true) preserves the old fail-closed behavior.
- The fallback is implemented server-side in srv_job_backup.go via restoreSplitdumpFileContextStripDefiner.
2. Post-File Support
- Extended FileSet and classifyFile to recognize a new post category (e.g., routines, events, triggers).
- Post files are sorted and executed after schema and data files, ensuring proper dependency ordering during restore.
3. Auto-Create Databases (backup-splitdump-create-databases)
- Added backup-splitdump-create-databases config flag (default true for server-orchestrated restores, opt-in for CLI).
- Server-initiated splitdump restores now automatically run CREATE DATABASE IF NOT EXISTS for every user schema found in the backup before importing data.
- The CLI splitrestore command gained a new --splitdump-create-databases flag for manual use.
4. File Classification & Sorting Improvements
- Replaced boolean schema/data classification with a typed fileCategory enum.
- Added sortSplitdumpSchemaFiles and sortSplitdumpPostFiles for deterministic ordering.
- Added ListSchemas() helper to extract unique non-system schemas from a splitdump directory.
5. Test Coverage
- Added comprehensive unit tests in restore_test.go and split_test.go covering:
  - DEFINER strict vs. non-strict paths
  - Post-file ordering
  - Schema listing and file classification
  - Metadata parsing edge cases
6. Dashboard Settings
- Updated BackupSettings.jsx to expose the new configuration options in the React GUI.

### **Files Changed**
- utils/splitdump/restore.go / restore_test.go
- utils/splitdump/split.go / split_test.go
- cluster/srv_job_backup.go
- clients/client_splitrestore.go
- config/config.go
- server/server.go
- server/api_cluster.go
- share/dashboard_react/src/Pages/Settings/BackupSettings.jsx