### PR TITLE
fix splitdump restore ordering with manifest and FK-aware fallback

### DIFF
--- a/utils/splitdump/fkorder.go
+++ b/utils/splitdump/fkorder.go
@@ -67,8 +67,11 @@ func splitSchemaBuckets(paths []string) (tableSchemas, mysqlSystemAll, routineSc
 func appendReferencedTablesFromSQL(sqlText, defaultSchema string, seen map[string]bool, refs *[]string) {
 	// Fast path: mysqldump always emits REFERENCES in uppercase, so a case-sensitive
 	// check avoids allocating a full-text uppercase copy — especially important in the
-	// large-parser path where sqlText can be several megabytes. The regex handles any
-	// edge case where case differs via its (?i) flag.
+	// large-parser path where sqlText can be several megabytes.
+	// NOTE: This is a mysqldump-specific optimisation. If the SQL was produced by a tool
+	// that emits lowercase "references", this early return will fire and FK dependencies
+	// will be silently missed (the regex is never reached). Only use this function with
+	// mysqldump output.
 	if !strings.Contains(sqlText, "REFERENCES") {
 		return
 	}
@@ -317,17 +320,20 @@ func orderTableSchemasByForeignKeys(paths []string, logf func(level, format stri
 	}
 
 	// Any unprocessed node is part of a dependency cycle.
-	hasCycle := false
+	var cycleKeys []string
 	for i := range nodes {
 		if !processed[i] {
-			if !hasCycle {
-				hasCycle = true
-				if logf != nil {
-					logf(LogWarn, "Splitdump FK ordering: unresolvable dependency cycle detected; affected tables appended in original input order")
-				}
+			if nodes[i].key != "" {
+				cycleKeys = append(cycleKeys, nodes[i].key)
+			} else {
+				cycleKeys = append(cycleKeys, filepath.Base(nodes[i].path))
 			}
 			result = append(result, nodes[i].path)
 		}
+	}
+	if len(cycleKeys) > 0 && logf != nil {
+		logf(LogWarn, "Splitdump FK ordering: unresolvable dependency cycle detected; affected tables appended in original input order: %s",
+			strings.Join(cycleKeys, ", "))
 	}
 
 	return result

--- a/utils/splitdump/fkorder.go
+++ b/utils/splitdump/fkorder.go
@@ -65,8 +65,11 @@ func splitSchemaBuckets(paths []string) (tableSchemas, mysqlSystemAll, routineSc
 // SQL text and appends newly-seen "schema.table" keys to *refs, deduplicating via seen.
 // defaultSchema is used when no explicit schema qualifier is present.
 func appendReferencedTablesFromSQL(sqlText, defaultSchema string, seen map[string]bool, refs *[]string) {
-	// Fast path: skip text that cannot contain a REFERENCES keyword.
-	if !strings.Contains(strings.ToUpper(sqlText), "REFERENCES") {
+	// Fast path: mysqldump always emits REFERENCES in uppercase, so a case-sensitive
+	// check avoids allocating a full-text uppercase copy — especially important in the
+	// large-parser path where sqlText can be several megabytes. The regex handles any
+	// edge case where case differs via its (?i) flag.
+	if !strings.Contains(sqlText, "REFERENCES") {
 		return
 	}
 	for _, m := range referencesRe.FindAllStringSubmatch(sqlText, -1) {
@@ -97,12 +100,14 @@ func appendReferencedTablesFromSQL(sqlText, defaultSchema string, seen map[strin
 }
 
 // openAndDecompress opens path and, if the content is gzip-compressed, wraps it in a
-// gzip.Reader. Returns (reader, closer, nil) on success; (nil, nil, nil) when the file
-// cannot be opened or decompressed (caller treats as dependency-free).
-func openAndDecompress(path string) (io.Reader, func(), error) {
+// gzip.Reader. Returns (reader, closer) on success; (nil, nil) when the file cannot be
+// opened or decompressed — caller treats that as dependency-free. Errors are intentionally
+// swallowed here because both callers want the same nil-means-skip behaviour and a separate
+// error return would always be discarded.
+func openAndDecompress(path string) (io.Reader, func()) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, nil, nil //nolint:nilerr // treat unreadable file as dependency-free
+		return nil, nil //nolint:nilerr // treat unreadable file as dependency-free
 	}
 	bufR := bufio.NewReaderSize(f, 32*1024)
 	peek, peekErr := bufR.Peek(2)
@@ -110,11 +115,11 @@ func openAndDecompress(path string) (io.Reader, func(), error) {
 		gz, gzErr := gzip.NewReader(bufR)
 		if gzErr != nil {
 			f.Close()
-			return nil, nil, nil //nolint:nilerr // corrupt gzip header — treat as dependency-free
+			return nil, nil //nolint:nilerr // corrupt gzip header — treat as dependency-free
 		}
-		return gz, func() { gz.Close(); f.Close() }, nil
+		return gz, func() { gz.Close(); f.Close() }
 	}
-	return bufR, func() { f.Close() }, nil
+	return bufR, func() { f.Close() }
 }
 
 // parseReferencedTablesScanner reads a SQL file line-by-line using bufio.Scanner and
@@ -122,7 +127,7 @@ func openAndDecompress(path string) (io.Reader, func(), error) {
 // when a single line exceeds the 4 MiB token limit so the caller can retry via the
 // statement-accumulation path. On file-open or decompression errors it returns (nil, nil).
 func parseReferencedTablesScanner(path string, defaultSchema string) ([]string, error) {
-	r, closeAll, _ := openAndDecompress(path)
+	r, closeAll := openAndDecompress(path)
 	if r == nil {
 		return nil, nil
 	}
@@ -153,7 +158,7 @@ func parseReferencedTablesScanner(path string, defaultSchema string) ([]string, 
 // statement and searched for REFERENCES clauses. On file-open or decompression errors it
 // returns (nil, nil).
 func parseReferencedTablesLarge(path string, defaultSchema string) ([]string, error) {
-	r, closeAll, _ := openAndDecompress(path)
+	r, closeAll := openAndDecompress(path)
 	if r == nil {
 		return nil, nil
 	}

--- a/utils/splitdump/fkorder.go
+++ b/utils/splitdump/fkorder.go
@@ -1,0 +1,346 @@
+package splitdump
+
+import (
+	"bufio"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// referencesRe matches a FOREIGN KEY REFERENCES clause in mysqldump SQL output and
+// captures the referenced schema and table name. It handles four identifier forms:
+//
+//	`schema`.`table`  — backtick-quoted explicit (groups 1, 2)
+//	`table`           — backtick-quoted implicit  (group 3)
+//	schema.table      — unquoted explicit          (groups 4, 5)
+//	table             — unquoted implicit           (group 4 only)
+//
+// The trailing \s*\( requires the column list to follow, which is always present
+// in mysqldump output and significantly reduces false positives from comments.
+var referencesRe = regexp.MustCompile(
+	"(?i)REFERENCES\\s+" +
+		"(?:" +
+		"`([^`]+)`\\.`([^`]+)`" + // groups 1=schema, 2=table (backtick explicit)
+		"|`([^`]+)`" + // group 3=table        (backtick implicit)
+		"|([A-Za-z_][A-Za-z0-9_$]*)(?:\\.([A-Za-z_][A-Za-z0-9_$]*))?" + // groups 4,5 unquoted
+		")\\s*\\(")
+
+// splitSchemaBuckets partitions a schema-phase file list into four ordered sub-lists:
+//   - tableSchemas: plain table definitions (-schema.sql[.gz])
+//   - mysqlSystemAll: the mysql.system-all artifact
+//   - routineSchemas: stored procedures, functions, and routine bundles
+//   - viewSchemas: view definitions (-schema-view.sql[.gz])
+//
+// The relative order within each sub-list matches the input order.
+func splitSchemaBuckets(paths []string) (tableSchemas, mysqlSystemAll, routineSchemas, viewSchemas []string) {
+	for _, p := range paths {
+		lower := strings.ToLower(filepath.Base(p))
+		switch {
+		case IsMysqlSystemAll(lower):
+			mysqlSystemAll = append(mysqlSystemAll, p)
+		case strings.HasSuffix(lower, "-schema-routine.sql.gz") ||
+			strings.HasSuffix(lower, "-schema-routine.sql") ||
+			strings.HasSuffix(lower, "-schema-function.sql.gz") ||
+			strings.HasSuffix(lower, "-schema-function.sql") ||
+			strings.HasSuffix(lower, "-schema-procedure.sql.gz") ||
+			strings.HasSuffix(lower, "-schema-procedure.sql"):
+			routineSchemas = append(routineSchemas, p)
+		case strings.HasSuffix(lower, "-schema-view.sql.gz") ||
+			strings.HasSuffix(lower, "-schema-view.sql"):
+			viewSchemas = append(viewSchemas, p)
+		default:
+			// Includes plain -schema.sql[.gz] and any unrecognised schema artifact.
+			tableSchemas = append(tableSchemas, p)
+		}
+	}
+	return
+}
+
+// appendReferencedTablesFromSQL extracts FOREIGN KEY REFERENCES clauses from arbitrary
+// SQL text and appends newly-seen "schema.table" keys to *refs, deduplicating via seen.
+// defaultSchema is used when no explicit schema qualifier is present.
+func appendReferencedTablesFromSQL(sqlText, defaultSchema string, seen map[string]bool, refs *[]string) {
+	// Fast path: skip text that cannot contain a REFERENCES keyword.
+	if !strings.Contains(strings.ToUpper(sqlText), "REFERENCES") {
+		return
+	}
+	for _, m := range referencesRe.FindAllStringSubmatch(sqlText, -1) {
+		var refSchema, refTable string
+		switch {
+		case m[1] != "" && m[2] != "": // `schema`.`table`
+			refSchema = strings.ToLower(m[1])
+			refTable = strings.ToLower(m[2])
+		case m[3] != "": // `table`
+			refSchema = defaultSchema
+			refTable = strings.ToLower(m[3])
+		case m[4] != "" && m[5] != "": // schema.table unquoted
+			refSchema = strings.ToLower(m[4])
+			refTable = strings.ToLower(m[5])
+		case m[4] != "": // table unquoted
+			refSchema = defaultSchema
+			refTable = strings.ToLower(m[4])
+		}
+		if refTable == "" {
+			continue
+		}
+		key := refSchema + "." + refTable
+		if !seen[key] {
+			seen[key] = true
+			*refs = append(*refs, key)
+		}
+	}
+}
+
+// openAndDecompress opens path and, if the content is gzip-compressed, wraps it in a
+// gzip.Reader. Returns (reader, closer, nil) on success; (nil, nil, nil) when the file
+// cannot be opened or decompressed (caller treats as dependency-free).
+func openAndDecompress(path string) (io.Reader, func(), error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, nil //nolint:nilerr // treat unreadable file as dependency-free
+	}
+	bufR := bufio.NewReaderSize(f, 32*1024)
+	peek, peekErr := bufR.Peek(2)
+	if peekErr == nil && len(peek) >= 2 && peek[0] == 0x1f && peek[1] == 0x8b {
+		gz, gzErr := gzip.NewReader(bufR)
+		if gzErr != nil {
+			f.Close()
+			return nil, nil, nil //nolint:nilerr // corrupt gzip header — treat as dependency-free
+		}
+		return gz, func() { gz.Close(); f.Close() }, nil
+	}
+	return bufR, func() { f.Close() }, nil
+}
+
+// parseReferencedTablesScanner reads a SQL file line-by-line using bufio.Scanner and
+// returns all FOREIGN KEY REFERENCES found. It returns (partial-refs, bufio.ErrTooLong)
+// when a single line exceeds the 4 MiB token limit so the caller can retry via the
+// statement-accumulation path. On file-open or decompression errors it returns (nil, nil).
+func parseReferencedTablesScanner(path string, defaultSchema string) ([]string, error) {
+	r, closeAll, _ := openAndDecompress(path)
+	if r == nil {
+		return nil, nil
+	}
+	defer closeAll()
+
+	scanner := bufio.NewScanner(r)
+	// Allow up to 4 MiB per line. mysqldump schema files are typically well under
+	// this limit; the cap prevents unbounded memory use on pathological inputs while
+	// being large enough to handle any realistic CREATE TABLE statement.
+	const maxTokenSize = 4 * 1024 * 1024
+	scanner.Buffer(make([]byte, 0, 64*1024), maxTokenSize)
+
+	defaultSchema = strings.ToLower(defaultSchema)
+	seen := make(map[string]bool)
+	var refs []string
+
+	for scanner.Scan() {
+		appendReferencedTablesFromSQL(scanner.Text(), defaultSchema, seen, &refs)
+	}
+	// Return partial refs alongside the error so the caller can decide whether to
+	// use what was extracted before the failure.
+	return refs, scanner.Err()
+}
+
+// parseReferencedTablesLarge reads a SQL file using semicolon-delimited statement
+// accumulation rather than line-by-line scanning. This handles DDL files where a single
+// logical line exceeds the scanner token limit. Each chunk up to ';' is treated as one
+// statement and searched for REFERENCES clauses. On file-open or decompression errors it
+// returns (nil, nil).
+func parseReferencedTablesLarge(path string, defaultSchema string) ([]string, error) {
+	r, closeAll, _ := openAndDecompress(path)
+	if r == nil {
+		return nil, nil
+	}
+	defer closeAll()
+
+	stmtReader := bufio.NewReaderSize(r, 64*1024)
+	defaultSchema = strings.ToLower(defaultSchema)
+	seen := make(map[string]bool)
+	var refs []string
+
+	for {
+		stmt, readErr := stmtReader.ReadString(';')
+		if len(stmt) > 0 {
+			appendReferencedTablesFromSQL(stmt, defaultSchema, seen, &refs)
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				break
+			}
+			return refs, readErr
+		}
+	}
+	return refs, nil
+}
+
+// parseReferencedTables reads a SQL file (plain or gzip-compressed) and returns the
+// normalised "schema.table" keys of every table referenced via FOREIGN KEY REFERENCES
+// clauses. defaultSchema is used for references that omit an explicit schema qualifier.
+//
+// It first attempts line-by-line scanning (fast path). If bufio.ErrTooLong is returned
+// because a single line exceeds the 4 MiB token limit, it transparently retries using
+// statement-accumulation (reading up to the next semicolon) so that oversized DDL
+// statements are still correctly parsed.
+//
+// On file-open or decompression errors the function returns (nil, nil) so the caller
+// treats the file as dependency-free without surfacing an I/O error.
+func parseReferencedTables(path string, defaultSchema string) ([]string, error) {
+	refs, err := parseReferencedTablesScanner(path, defaultSchema)
+	if err == nil {
+		return refs, nil
+	}
+	if !errors.Is(err, bufio.ErrTooLong) {
+		// Non-ErrTooLong scan failure: return whatever partial refs were collected.
+		return refs, err
+	}
+	// Retry with the statement-accumulation large parser.
+	largeRefs, largeErr := parseReferencedTablesLarge(path, defaultSchema)
+	if largeErr == nil {
+		return largeRefs, nil
+	}
+	if len(largeRefs) > 0 {
+		return largeRefs, largeErr
+	}
+	return refs, largeErr
+}
+
+// orderTableSchemasByForeignKeys reorders paths so that any table referenced by a
+// FOREIGN KEY constraint appears before the table that declares the constraint.
+// Stable tie-breaking by original input index preserves the existing order for tables
+// that have no ordering constraint relative to each other.
+//
+// When unresolvable cycles are detected the remaining nodes are appended in their
+// original input order. If logf is non-nil a warning is emitted for each cycle group.
+func orderTableSchemasByForeignKeys(paths []string, logf func(level, format string, args ...any)) []string {
+	if len(paths) <= 1 {
+		return paths
+	}
+
+	type tableNode struct {
+		path    string
+		key     string // "schema.table" (lower-cased), empty for unparseable filenames
+		origIdx int
+	}
+
+	nodes := make([]tableNode, len(paths))
+	keyToIdx := make(map[string]int, len(paths))
+	for i, p := range paths {
+		schema := strings.ToLower(SchemaFromFilename(p))
+		table := strings.ToLower(TableFromFilename(p))
+		key := ""
+		if schema != "" && table != "" {
+			key = schema + "." + table
+		}
+		nodes[i] = tableNode{path: p, key: key, origIdx: i}
+		if key != "" {
+			keyToIdx[key] = i
+		}
+	}
+
+	// Build Kahn's algorithm structures.
+	// indegree[i] = number of not-yet-satisfied parent dependencies for node i.
+	// children[i] = indices of nodes that list i as a dependency.
+	indegree := make([]int, len(nodes))
+	children := make([][]int, len(nodes))
+
+	for i, n := range nodes {
+		refs, scanErr := parseReferencedTables(n.path, SchemaFromFilename(n.path))
+		if scanErr != nil && logf != nil {
+			logf(LogWarn, "Splitdump FK parser: scan error reading %s; FK dependencies may be incomplete: %v",
+				filepath.Base(n.path), scanErr)
+		}
+		added := make(map[int]bool)
+		for _, ref := range refs {
+			ref = strings.ToLower(ref)
+			if ref == n.key { // self-reference — no ordering pressure
+				continue
+			}
+			parentIdx, ok := keyToIdx[ref]
+			if !ok { // referenced table not in backup set — ignore
+				continue
+			}
+			if added[parentIdx] { // deduplicate edges
+				continue
+			}
+			added[parentIdx] = true
+			indegree[i]++
+			children[parentIdx] = append(children[parentIdx], i)
+		}
+	}
+
+	// Initialise the eligible set (nodes with no unsatisfied dependencies).
+	eligible := make([]int, 0, len(nodes))
+	for i, deg := range indegree {
+		if deg == 0 {
+			eligible = append(eligible, i)
+		}
+	}
+	sort.Slice(eligible, func(a, b int) bool {
+		return nodes[eligible[a]].origIdx < nodes[eligible[b]].origIdx
+	})
+
+	result := make([]string, 0, len(paths))
+	processed := make([]bool, len(nodes))
+
+	for len(eligible) > 0 {
+		// Pick the eligible node with the lowest original index.
+		idx := eligible[0]
+		eligible = eligible[1:]
+		processed[idx] = true
+		result = append(result, nodes[idx].path)
+
+		// Unlock any nodes that depended solely on idx.
+		var newlyEligible []int
+		for _, child := range children[idx] {
+			indegree[child]--
+			if indegree[child] == 0 {
+				newlyEligible = append(newlyEligible, child)
+			}
+		}
+		if len(newlyEligible) > 0 {
+			eligible = append(eligible, newlyEligible...)
+			sort.Slice(eligible, func(a, b int) bool {
+				return nodes[eligible[a]].origIdx < nodes[eligible[b]].origIdx
+			})
+		}
+	}
+
+	// Any unprocessed node is part of a dependency cycle.
+	hasCycle := false
+	for i := range nodes {
+		if !processed[i] {
+			if !hasCycle {
+				hasCycle = true
+				if logf != nil {
+					logf(LogWarn, "Splitdump FK ordering: unresolvable dependency cycle detected; affected tables appended in original input order")
+				}
+			}
+			result = append(result, nodes[i].path)
+		}
+	}
+
+	return result
+}
+
+// orderSchemaPhaseByForeignKeys partitions a schema-phase file list into sub-buckets,
+// applies FK-based reordering to plain table schemas only, then reassembles in the
+// canonical phase order: table schemas → mysql.system-all → routines → views.
+//
+// mysql.system-all, routine, and view artifacts are never reordered; only the plain
+// table schema sub-list is modified. logf may be nil to suppress cycle warnings.
+func orderSchemaPhaseByForeignKeys(schemaFiles []string, logf func(level, format string, args ...any)) []string {
+	tables, systemAll, routines, views := splitSchemaBuckets(schemaFiles)
+	ordered := orderTableSchemasByForeignKeys(tables, logf)
+	result := make([]string, 0, len(schemaFiles))
+	result = append(result, ordered...)
+	result = append(result, systemAll...)
+	result = append(result, routines...)
+	result = append(result, views...)
+	return result
+}

--- a/utils/splitdump/fkorder_test.go
+++ b/utils/splitdump/fkorder_test.go
@@ -1,0 +1,711 @@
+package splitdump
+
+import (
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// writeSQLGzip creates a gzip-compressed SQL file at dir/name with the given SQL content.
+func writeSQLGzip(t *testing.T, dir, name, sql string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("writeSQLGzip: create %s: %v", name, err)
+	}
+	defer f.Close()
+	gz := gzip.NewWriter(f)
+	if _, err := gz.Write([]byte(sql)); err != nil {
+		t.Fatalf("writeSQLGzip: write %s: %v", name, err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("writeSQLGzip: close gzip %s: %v", name, err)
+	}
+	return path
+}
+
+// writeSQLPlain creates a plain (non-compressed) SQL file at dir/name.
+func writeSQLPlain(t *testing.T, dir, name, sql string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(sql), 0644); err != nil {
+		t.Fatalf("writeSQLPlain: write %s: %v", name, err)
+	}
+	return path
+}
+
+// ---- splitSchemaBuckets ----
+
+func TestSplitSchemaBuckets(t *testing.T) {
+	paths := []string{
+		"db.tbl-schema.sql.gz",
+		"mysql.system-all.sql.gz",
+		"db.__routines-schema-routine.sql.gz",
+		"db.__funcs-schema-function.sql.gz",
+		"db.__procs-schema-procedure.sql",
+		"db.v_tbl-schema-view.sql.gz",
+		"db.other-schema.sql",
+	}
+	tables, systemAll, routines, views := splitSchemaBuckets(paths)
+
+	wantTables := []string{"db.tbl-schema.sql.gz", "db.other-schema.sql"}
+	if !reflect.DeepEqual(tables, wantTables) {
+		t.Fatalf("tableSchemas = %v, want %v", tables, wantTables)
+	}
+	if !reflect.DeepEqual(systemAll, []string{"mysql.system-all.sql.gz"}) {
+		t.Fatalf("mysqlSystemAll = %v", systemAll)
+	}
+	wantRoutines := []string{
+		"db.__routines-schema-routine.sql.gz",
+		"db.__funcs-schema-function.sql.gz",
+		"db.__procs-schema-procedure.sql",
+	}
+	if !reflect.DeepEqual(routines, wantRoutines) {
+		t.Fatalf("routineSchemas = %v, want %v", routines, wantRoutines)
+	}
+	if !reflect.DeepEqual(views, []string{"db.v_tbl-schema-view.sql.gz"}) {
+		t.Fatalf("viewSchemas = %v", views)
+	}
+}
+
+// ---- parseReferencedTables ----
+
+func TestParseReferencedTablesBacktickImplicit(t *testing.T) {
+	dir := t.TempDir()
+	sql := "CREATE TABLE `child` (\n" +
+		"  `id` INT,\n" +
+		"  `pid` INT,\n" +
+		"  CONSTRAINT `fk1` FOREIGN KEY (`pid`) REFERENCES `parent` (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+	path := writeSQLGzip(t, dir, "db.child-schema.sql.gz", sql)
+
+	refs, err := parseReferencedTables(path, "db")
+	if err != nil {
+		t.Fatalf("unexpected scan error: %v", err)
+	}
+	if len(refs) != 1 || refs[0] != "db.parent" {
+		t.Fatalf("expected [db.parent], got %v", refs)
+	}
+}
+
+func TestParseReferencedTablesBacktickExplicit(t *testing.T) {
+	dir := t.TempDir()
+	sql := "CREATE TABLE `child` (\n" +
+		"  `id` INT,\n" +
+		"  `pid` INT,\n" +
+		"  CONSTRAINT `fk1` FOREIGN KEY (`pid`) REFERENCES `mydb`.`parent` (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+	path := writeSQLGzip(t, dir, "mydb.child-schema.sql.gz", sql)
+
+	refs, err := parseReferencedTables(path, "mydb")
+	if err != nil {
+		t.Fatalf("unexpected scan error: %v", err)
+	}
+	if len(refs) != 1 || refs[0] != "mydb.parent" {
+		t.Fatalf("expected [mydb.parent], got %v", refs)
+	}
+}
+
+func TestParseReferencedTablesUnquoted(t *testing.T) {
+	dir := t.TempDir()
+	// Some MySQL versions and tools emit unquoted identifiers.
+	sql := "CREATE TABLE child (\n" +
+		"  id INT,\n" +
+		"  pid INT,\n" +
+		"  CONSTRAINT fk1 FOREIGN KEY (pid) REFERENCES parent (id)\n" +
+		") ENGINE=InnoDB;\n"
+	path := writeSQLPlain(t, dir, "db.child-schema.sql", sql)
+
+	refs, err := parseReferencedTables(path, "db")
+	if err != nil {
+		t.Fatalf("unexpected scan error: %v", err)
+	}
+	if len(refs) != 1 || refs[0] != "db.parent" {
+		t.Fatalf("expected [db.parent], got %v", refs)
+	}
+}
+
+func TestParseReferencedTablesUnquotedExplicitSchema(t *testing.T) {
+	dir := t.TempDir()
+	sql := "CREATE TABLE child (\n" +
+		"  id INT,\n" +
+		"  CONSTRAINT fk1 FOREIGN KEY (pid) REFERENCES other_db.parent (id)\n" +
+		") ENGINE=InnoDB;\n"
+	path := writeSQLPlain(t, dir, "db.child-schema.sql", sql)
+
+	refs, err := parseReferencedTables(path, "db")
+	if err != nil {
+		t.Fatalf("unexpected scan error: %v", err)
+	}
+	if len(refs) != 1 || refs[0] != "other_db.parent" {
+		t.Fatalf("expected [other_db.parent], got %v", refs)
+	}
+}
+
+func TestParseReferencedTablesMissingFile(t *testing.T) {
+	refs, err := parseReferencedTables("/no/such/path/db.tbl-schema.sql.gz", "db")
+	if refs != nil {
+		t.Fatalf("expected nil for missing file, got %v", refs)
+	}
+	if err != nil {
+		t.Fatalf("expected nil error for missing file (treated as dependency-free), got %v", err)
+	}
+}
+
+func TestParseReferencedTablesMultipleRefs(t *testing.T) {
+	dir := t.TempDir()
+	sql := "CREATE TABLE `order_item` (\n" +
+		"  `id` INT,\n" +
+		"  `order_id` INT,\n" +
+		"  `product_id` INT,\n" +
+		"  CONSTRAINT `fk_order` FOREIGN KEY (`order_id`) REFERENCES `orders` (`id`),\n" +
+		"  CONSTRAINT `fk_product` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+	path := writeSQLGzip(t, dir, "db.order_item-schema.sql.gz", sql)
+
+	refs, err := parseReferencedTables(path, "db")
+	if err != nil {
+		t.Fatalf("unexpected scan error: %v", err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 references, got %v", refs)
+	}
+	refSet := map[string]bool{}
+	for _, r := range refs {
+		refSet[r] = true
+	}
+	if !refSet["db.orders"] || !refSet["db.products"] {
+		t.Fatalf("expected db.orders and db.products, got %v", refs)
+	}
+}
+
+func TestParseReferencedTablesDeduplicated(t *testing.T) {
+	dir := t.TempDir()
+	// Same table referenced twice (composite FK or two separate columns).
+	sql := "CREATE TABLE `t` (\n" +
+		"  `a` INT,\n" +
+		"  `b` INT,\n" +
+		"  CONSTRAINT `fk1` FOREIGN KEY (`a`) REFERENCES `parent` (`x`),\n" +
+		"  CONSTRAINT `fk2` FOREIGN KEY (`b`) REFERENCES `parent` (`y`)\n" +
+		") ENGINE=InnoDB;\n"
+	path := writeSQLGzip(t, dir, "db.t-schema.sql.gz", sql)
+
+	refs, err := parseReferencedTables(path, "db")
+	if err != nil {
+		t.Fatalf("unexpected scan error: %v", err)
+	}
+	if len(refs) != 1 || refs[0] != "db.parent" {
+		t.Fatalf("expected single deduplicated [db.parent], got %v", refs)
+	}
+}
+
+// TestParseReferencedTablesLineTooLong verifies that a file with a comment line
+// exceeding the 4 MiB scanner token limit is handled gracefully via the large-parser
+// retry: no error is returned and refs is empty (comment contains no REFERENCES).
+func TestParseReferencedTablesLineTooLong(t *testing.T) {
+	dir := t.TempDir()
+	// Build a SQL file where a single comment line is 5 MiB.
+	// The scanner fails with bufio.ErrTooLong; the large parser retries via
+	// ReadString(';') and succeeds (no REFERENCES in the comment → nil refs).
+	const lineSize = 5 * 1024 * 1024
+	giant := "-- " + strings.Repeat("x", lineSize) + "\n"
+	path := writeSQLPlain(t, dir, "db.huge-schema.sql", giant)
+
+	refs, err := parseReferencedTables(path, "db")
+	if err != nil {
+		t.Fatalf("expected successful retry for oversized comment, got error: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Fatalf("expected no refs from a comment-only file, got %v", refs)
+	}
+}
+
+// TestParseReferencedTablesOversizedPlain verifies that a plain SQL file where the
+// entire CREATE TABLE statement is a single >4 MiB line is still parsed correctly via
+// the large-parser retry path.
+func TestParseReferencedTablesOversizedPlain(t *testing.T) {
+	dir := t.TempDir()
+	// Embed a valid REFERENCES clause inside a statement padded to >4 MiB.
+	// The scanner will fail on this line; the large parser retries via ReadString(';').
+	const padSize = 5 * 1024 * 1024
+	sql := "CREATE TABLE `child` (`id` INT, `pid` INT, CONSTRAINT `fk` FOREIGN KEY (`pid`) REFERENCES `parent` (`id`) -- " +
+		strings.Repeat("x", padSize) +
+		") ENGINE=InnoDB;"
+	path := writeSQLPlain(t, dir, "db.child-schema.sql", sql)
+
+	refs, err := parseReferencedTables(path, "db")
+	if err != nil {
+		t.Fatalf("unexpected error from large-parser retry: %v", err)
+	}
+	if len(refs) != 1 || refs[0] != "db.parent" {
+		t.Fatalf("expected [db.parent] from oversized plain DDL, got %v", refs)
+	}
+}
+
+// TestParseReferencedTablesOversizedGzip verifies the large-parser retry path for a
+// gzip-compressed file whose content contains a single >4 MiB DDL statement.
+func TestParseReferencedTablesOversizedGzip(t *testing.T) {
+	dir := t.TempDir()
+	const padSize = 5 * 1024 * 1024
+	sql := "CREATE TABLE `child` (`id` INT, `pid` INT, CONSTRAINT `fk` FOREIGN KEY (`pid`) REFERENCES `myparent` (`id`) -- " +
+		strings.Repeat("z", padSize) +
+		") ENGINE=InnoDB;"
+	path := writeSQLGzip(t, dir, "db.child-schema.sql.gz", sql)
+
+	refs, err := parseReferencedTables(path, "db")
+	if err != nil {
+		t.Fatalf("unexpected error from large-parser retry (gzip): %v", err)
+	}
+	if len(refs) != 1 || refs[0] != "db.myparent" {
+		t.Fatalf("expected [db.myparent] from oversized gzip DDL, got %v", refs)
+	}
+}
+
+// TestOrderTableSchemasByFKOversizedChildDDL verifies end-to-end that FK ordering
+// works correctly when one of the schema files has an oversized DDL statement that
+// requires the large-parser retry path to extract its REFERENCES clause.
+func TestOrderTableSchemasByFKOversizedChildDDL(t *testing.T) {
+	dir := t.TempDir()
+
+	// achild's CREATE TABLE is a single >4 MiB line — scanner will fail and retry.
+	const padSize = 5 * 1024 * 1024
+	childSQL := "CREATE TABLE `achild` (`id` INT, `pid` INT, CONSTRAINT `fk` FOREIGN KEY (`pid`) REFERENCES `zparent` (`id`) -- " +
+		strings.Repeat("p", padSize) +
+		") ENGINE=InnoDB;"
+	parentSQL := "CREATE TABLE `zparent` (`id` INT PRIMARY KEY) ENGINE=InnoDB;\n"
+
+	childPath := writeSQLGzip(t, dir, "db.achild-schema.sql.gz", childSQL)
+	parentPath := writeSQLGzip(t, dir, "db.zparent-schema.sql.gz", parentSQL)
+
+	// Input in alphabetical (wrong) order.
+	result := orderTableSchemasByForeignKeys([]string{childPath, parentPath}, nil)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(result))
+	}
+	if filepath.Base(result[0]) != "db.zparent-schema.sql.gz" {
+		t.Fatalf("expected zparent first (FK ordering via large-parser retry), got: %s", filepath.Base(result[0]))
+	}
+	if filepath.Base(result[1]) != "db.achild-schema.sql.gz" {
+		t.Fatalf("expected achild second, got: %s", filepath.Base(result[1]))
+	}
+}
+
+// ---- orderTableSchemasByForeignKeys ----
+
+func TestOrderTableSchemasByFKParentBeforeChild(t *testing.T) {
+	dir := t.TempDir()
+
+	// achild sorts before zparent alphabetically, but achild depends on zparent.
+	childSQL := "CREATE TABLE `achild` (\n" +
+		"  `id` INT,\n" +
+		"  `pid` INT,\n" +
+		"  CONSTRAINT `fk` FOREIGN KEY (`pid`) REFERENCES `zparent` (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+	parentSQL := "CREATE TABLE `zparent` (`id` INT PRIMARY KEY) ENGINE=InnoDB;\n"
+
+	childPath := writeSQLGzip(t, dir, "db.achild-schema.sql.gz", childSQL)
+	parentPath := writeSQLGzip(t, dir, "db.zparent-schema.sql.gz", parentSQL)
+
+	// Input in alphabetical (wrong) order.
+	paths := []string{childPath, parentPath}
+	result := orderTableSchemasByForeignKeys(paths, nil)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(result))
+	}
+	if filepath.Base(result[0]) != "db.zparent-schema.sql.gz" {
+		t.Fatalf("expected zparent first (FK ordering), got: %s", filepath.Base(result[0]))
+	}
+	if filepath.Base(result[1]) != "db.achild-schema.sql.gz" {
+		t.Fatalf("expected achild second, got: %s", filepath.Base(result[1]))
+	}
+}
+
+func TestOrderTableSchemasByFKSameSchemaImplicit(t *testing.T) {
+	dir := t.TempDir()
+
+	// Reference using just backtick-quoted table name (no schema qualifier).
+	childSQL := "CREATE TABLE `child` (\n" +
+		"  `id` INT,\n" +
+		"  `pid` INT,\n" +
+		"  CONSTRAINT `fk` FOREIGN KEY (`pid`) REFERENCES `parent` (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+	parentSQL := "CREATE TABLE `parent` (`id` INT PRIMARY KEY) ENGINE=InnoDB;\n"
+
+	childPath := writeSQLGzip(t, dir, "app.child-schema.sql.gz", childSQL)
+	parentPath := writeSQLGzip(t, dir, "app.parent-schema.sql.gz", parentSQL)
+
+	// Input: child before parent (wrong).
+	result := orderTableSchemasByForeignKeys([]string{childPath, parentPath}, nil)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(result))
+	}
+	if filepath.Base(result[0]) != "app.parent-schema.sql.gz" {
+		t.Fatalf("expected parent first, got: %s", filepath.Base(result[0]))
+	}
+}
+
+func TestOrderTableSchemasByFKExplicitSchemaRef(t *testing.T) {
+	dir := t.TempDir()
+
+	// Reference using `schema`.`table` explicit form.
+	childSQL := "CREATE TABLE `child` (\n" +
+		"  `id` INT,\n" +
+		"  `pid` INT,\n" +
+		"  CONSTRAINT `fk` FOREIGN KEY (`pid`) REFERENCES `app`.`parent` (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+	parentSQL := "CREATE TABLE `parent` (`id` INT PRIMARY KEY) ENGINE=InnoDB;\n"
+
+	childPath := writeSQLGzip(t, dir, "app.child-schema.sql.gz", childSQL)
+	parentPath := writeSQLGzip(t, dir, "app.parent-schema.sql.gz", parentSQL)
+
+	result := orderTableSchemasByForeignKeys([]string{childPath, parentPath}, nil)
+
+	if filepath.Base(result[0]) != "app.parent-schema.sql.gz" {
+		t.Fatalf("expected parent first via explicit schema ref, got: %s", filepath.Base(result[0]))
+	}
+}
+
+func TestOrderTableSchemasByFKSelfReferenceIgnored(t *testing.T) {
+	dir := t.TempDir()
+
+	// Adjacency / parent-of table that references itself.
+	sql := "CREATE TABLE `category` (\n" +
+		"  `id` INT PRIMARY KEY,\n" +
+		"  `parent_id` INT,\n" +
+		"  CONSTRAINT `fk_self` FOREIGN KEY (`parent_id`) REFERENCES `category` (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+	path := writeSQLGzip(t, dir, "db.category-schema.sql.gz", sql)
+
+	// Single-item list — trivially returned unchanged, but self-reference must not
+	// cause the node to be treated as having an unsatisfied dependency.
+	result := orderTableSchemasByForeignKeys([]string{path}, nil)
+	if len(result) != 1 || filepath.Base(result[0]) != "db.category-schema.sql.gz" {
+		t.Fatalf("expected [db.category-schema.sql.gz], got %v", result)
+	}
+
+	// Two items: category and another table with no deps. Self-ref must not reorder.
+	otherSQL := "CREATE TABLE `other` (`id` INT) ENGINE=InnoDB;\n"
+	otherPath := writeSQLGzip(t, dir, "db.other-schema.sql.gz", otherSQL)
+	result2 := orderTableSchemasByForeignKeys([]string{path, otherPath}, nil)
+	if len(result2) != 2 {
+		t.Fatalf("expected 2 results, got %d: %v", len(result2), result2)
+	}
+	// Original order should be preserved since there is no dependency between them.
+	if filepath.Base(result2[0]) != "db.category-schema.sql.gz" {
+		t.Fatalf("expected category first (original order), got: %s", filepath.Base(result2[0]))
+	}
+}
+
+func TestOrderTableSchemasByFKMissingRefIgnored(t *testing.T) {
+	dir := t.TempDir()
+
+	// Table references a table not in the backup set.
+	sql := "CREATE TABLE `orphan` (\n" +
+		"  `id` INT,\n" +
+		"  `rid` INT,\n" +
+		"  CONSTRAINT `fk` FOREIGN KEY (`rid`) REFERENCES `nonexistent` (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+	path := writeSQLGzip(t, dir, "db.orphan-schema.sql.gz", sql)
+
+	result := orderTableSchemasByForeignKeys([]string{path}, nil)
+	if len(result) != 1 || filepath.Base(result[0]) != "db.orphan-schema.sql.gz" {
+		t.Fatalf("expected [db.orphan-schema.sql.gz], got %v", result)
+	}
+}
+
+func TestOrderTableSchemasByFKCycleFallbackPreservesOriginalOrder(t *testing.T) {
+	dir := t.TempDir()
+
+	// A → B (A depends on B) and B → A (B depends on A) — true cycle.
+	aSQL := "CREATE TABLE `a` (\n" +
+		"  `id` INT,\n" +
+		"  `bid` INT,\n" +
+		"  CONSTRAINT `fk_ab` FOREIGN KEY (`bid`) REFERENCES `b` (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+	bSQL := "CREATE TABLE `b` (\n" +
+		"  `id` INT,\n" +
+		"  `aid` INT,\n" +
+		"  CONSTRAINT `fk_ba` FOREIGN KEY (`aid`) REFERENCES `a` (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+
+	aPath := writeSQLGzip(t, dir, "db.a-schema.sql.gz", aSQL)
+	bPath := writeSQLGzip(t, dir, "db.b-schema.sql.gz", bSQL)
+
+	var warnLogs []string
+	logf := func(level, format string, args ...any) {
+		if level == LogWarn {
+			warnLogs = append(warnLogs, format)
+		}
+	}
+
+	// Input: a, b (original order).
+	result := orderTableSchemasByForeignKeys([]string{aPath, bPath}, logf)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(result))
+	}
+	// Original order must be preserved for cycled nodes.
+	if filepath.Base(result[0]) != "db.a-schema.sql.gz" || filepath.Base(result[1]) != "db.b-schema.sql.gz" {
+		t.Fatalf("expected original order [a, b] for cycle fallback, got: %v",
+			[]string{filepath.Base(result[0]), filepath.Base(result[1])})
+	}
+	// A cycle warning must have been emitted.
+	if len(warnLogs) == 0 {
+		t.Fatalf("expected cycle warning to be logged, got none")
+	}
+	foundCycleWarn := false
+	for _, l := range warnLogs {
+		if strings.Contains(strings.ToLower(l), "cycle") {
+			foundCycleWarn = true
+			break
+		}
+	}
+	if !foundCycleWarn {
+		t.Fatalf("expected log containing 'cycle', got: %v", warnLogs)
+	}
+}
+
+func TestOrderTableSchemasByFKStableOriginalOrder(t *testing.T) {
+	dir := t.TempDir()
+
+	// Three independent tables with no FK relationships.
+	// Result must preserve input order (stable sort).
+	for _, name := range []string{"db.alpha-schema.sql.gz", "db.beta-schema.sql.gz", "db.gamma-schema.sql.gz"} {
+		writeSQLGzip(t, dir, name,
+			"CREATE TABLE `t` (`id` INT) ENGINE=InnoDB;\n")
+	}
+
+	paths := []string{
+		filepath.Join(dir, "db.alpha-schema.sql.gz"),
+		filepath.Join(dir, "db.beta-schema.sql.gz"),
+		filepath.Join(dir, "db.gamma-schema.sql.gz"),
+	}
+	result := orderTableSchemasByForeignKeys(paths, nil)
+
+	for i, want := range paths {
+		if result[i] != want {
+			t.Fatalf("stable order broken at index %d: got %s, want %s", i, filepath.Base(result[i]), filepath.Base(want))
+		}
+	}
+}
+
+// ---- orderSchemaPhaseByForeignKeys ----
+
+func TestOrderSchemaPhasePreservesNonTableBuckets(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write proper SQL so FK ordering can parse them.
+	childSQL := "CREATE TABLE `child` (\n" +
+		"  `id` INT,\n" +
+		"  `pid` INT,\n" +
+		"  CONSTRAINT `fk` FOREIGN KEY (`pid`) REFERENCES `parent` (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+	parentSQL := "CREATE TABLE `parent` (`id` INT) ENGINE=InnoDB;\n"
+
+	writeSQLGzip(t, dir, "db.child-schema.sql.gz", childSQL)
+	writeSQLGzip(t, dir, "db.parent-schema.sql.gz", parentSQL)
+
+	// Add non-table schema files — their relative order and bucket must be unchanged.
+	systemAll := filepath.Join(dir, "mysql.system-all.sql.gz")
+	routines := filepath.Join(dir, "db.__routines-schema-routine.sql.gz")
+	views := filepath.Join(dir, "db.v_tbl-schema-view.sql.gz")
+	for _, p := range []string{systemAll, routines, views} {
+		if err := os.WriteFile(p, []byte("test"), 0644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	// Input in the order produced by sortSplitdumpSchemaFiles:
+	// table schemas (alphabetical), then system-all, then routines, then views.
+	input := []string{
+		filepath.Join(dir, "db.child-schema.sql.gz"),
+		filepath.Join(dir, "db.parent-schema.sql.gz"),
+		systemAll,
+		routines,
+		views,
+	}
+
+	result := orderSchemaPhaseByForeignKeys(input, nil)
+
+	if len(result) != 5 {
+		t.Fatalf("expected 5 files, got %d: %v", len(result), result)
+	}
+	// Table schemas: parent must precede child after FK ordering.
+	if filepath.Base(result[0]) != "db.parent-schema.sql.gz" {
+		t.Fatalf("expected parent first in schema phase, got: %s", filepath.Base(result[0]))
+	}
+	if filepath.Base(result[1]) != "db.child-schema.sql.gz" {
+		t.Fatalf("expected child second in schema phase, got: %s", filepath.Base(result[1]))
+	}
+	// Non-table artifacts must appear in the expected phase order at the end.
+	if filepath.Base(result[2]) != "mysql.system-all.sql.gz" {
+		t.Fatalf("expected mysql.system-all third, got: %s", filepath.Base(result[2]))
+	}
+	if filepath.Base(result[3]) != "db.__routines-schema-routine.sql.gz" {
+		t.Fatalf("expected routines fourth, got: %s", filepath.Base(result[3]))
+	}
+	if filepath.Base(result[4]) != "db.v_tbl-schema-view.sql.gz" {
+		t.Fatalf("expected view fifth, got: %s", filepath.Base(result[4]))
+	}
+}
+
+// ---- BuildRestorePlan integration: FK ordering in legacy path ----
+
+func TestBuildRestorePlanFKOrderParentBeforeChild(t *testing.T) {
+	dir := t.TempDir()
+
+	// child depends on parent but sorts alphabetically before it.
+	childSQL := "CREATE TABLE `achild` (\n" +
+		"  `id` INT,\n" +
+		"  `pid` INT,\n" +
+		"  CONSTRAINT `fk` FOREIGN KEY (`pid`) REFERENCES `zparent` (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+	parentSQL := "CREATE TABLE `zparent` (`id` INT PRIMARY KEY) ENGINE=InnoDB;\n"
+
+	writeSQLGzip(t, dir, "db.achild-schema.sql.gz", childSQL)
+	writeSQLGzip(t, dir, "db.zparent-schema.sql.gz", parentSQL)
+	// Data file to make the directory splitdump-detectable.
+	if err := os.WriteFile(filepath.Join(dir, "db.achild.sql.gz"), []byte("test"), 0644); err != nil {
+		t.Fatalf("write data: %v", err)
+	}
+
+	plan, err := BuildRestorePlan(dir, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(plan.Schema) < 2 {
+		t.Fatalf("expected at least 2 schema files, got %d: %v", len(plan.Schema), plan.Schema)
+	}
+	if filepath.Base(plan.Schema[0]) != "db.zparent-schema.sql.gz" {
+		t.Fatalf("expected zparent first in plan (FK ordering), got: %s", filepath.Base(plan.Schema[0]))
+	}
+	if filepath.Base(plan.Schema[1]) != "db.achild-schema.sql.gz" {
+		t.Fatalf("expected achild second in plan, got: %s", filepath.Base(plan.Schema[1]))
+	}
+}
+
+func TestBuildRestorePlanManifestWinsOverFKOrdering(t *testing.T) {
+	dir := t.TempDir()
+
+	// Files on disk — parent sorts after child alphabetically.
+	childSQL := "CREATE TABLE `achild` (\n" +
+		"  `id` INT,\n" +
+		"  `pid` INT,\n" +
+		"  CONSTRAINT `fk` FOREIGN KEY (`pid`) REFERENCES `zparent` (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+	parentSQL := "CREATE TABLE `zparent` (`id` INT PRIMARY KEY) ENGINE=InnoDB;\n"
+
+	writeSQLGzip(t, dir, "db.achild-schema.sql.gz", childSQL)
+	writeSQLGzip(t, dir, "db.zparent-schema.sql.gz", parentSQL)
+	if err := os.WriteFile(filepath.Join(dir, "db.achild.sql.gz"), []byte("test"), 0644); err != nil {
+		t.Fatalf("write data: %v", err)
+	}
+
+	// Manifest records the correct FK-safe order (parent first).
+	writeManifestFile(t, dir, &Manifest{
+		Version: 1,
+		Schema:  []string{"db.zparent-schema.sql.gz", "db.achild-schema.sql.gz"},
+		Data:    []string{"db.achild.sql.gz"},
+		Post:    nil,
+	})
+
+	plan, err := BuildRestorePlan(dir, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Manifest order must be used — FK parsing is not invoked for the manifest path.
+	if filepath.Base(plan.Schema[0]) != "db.zparent-schema.sql.gz" {
+		t.Fatalf("expected manifest order (zparent first), got: %s", filepath.Base(plan.Schema[0]))
+	}
+}
+
+func TestBuildRestorePlanFKOrderEmptyFiles(t *testing.T) {
+	// Existing tests write files with content "test" (no SQL). FK ordering must
+	// tolerate empty/non-SQL content without error and preserve alphabetical order.
+	dir := t.TempDir()
+	for _, f := range []string{"db.b_tbl-schema.sql.gz", "db.a_tbl-schema.sql.gz", "db.b_tbl.sql.gz"} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("write %s: %v", f, err)
+		}
+	}
+
+	plan, err := BuildRestorePlan(dir, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// No FK deps found (dummy content) → alphabetical order preserved.
+	if len(plan.Schema) != 2 {
+		t.Fatalf("expected 2 schema files, got %d: %v", len(plan.Schema), plan.Schema)
+	}
+	// sortSplitdumpSchemaFiles puts a_tbl before b_tbl alphabetically.
+	if filepath.Base(plan.Schema[0]) != "db.a_tbl-schema.sql.gz" {
+		t.Fatalf("expected a_tbl first (alphabetical fallback), got: %s", filepath.Base(plan.Schema[0]))
+	}
+}
+
+func TestBuildRestorePlanFKChain(t *testing.T) {
+	// Three-level chain: grandparent ← parent ← child.
+	// Input order: child, parent, grandparent (all wrong).
+	dir := t.TempDir()
+
+	grandSQL := "CREATE TABLE `grandparent` (`id` INT PRIMARY KEY) ENGINE=InnoDB;\n"
+	parentSQL := "CREATE TABLE `parent` (\n" +
+		"  `id` INT PRIMARY KEY,\n" +
+		"  `gid` INT,\n" +
+		"  CONSTRAINT `fk_g` FOREIGN KEY (`gid`) REFERENCES `grandparent` (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+	childSQL := "CREATE TABLE `child` (\n" +
+		"  `id` INT,\n" +
+		"  `pid` INT,\n" +
+		"  CONSTRAINT `fk_p` FOREIGN KEY (`pid`) REFERENCES `parent` (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+
+	writeSQLGzip(t, dir, "db.child-schema.sql.gz", childSQL)
+	writeSQLGzip(t, dir, "db.parent-schema.sql.gz", parentSQL)
+	writeSQLGzip(t, dir, "db.grandparent-schema.sql.gz", grandSQL)
+	// Need a data file for Detect() to recognise the layout.
+	if err := os.WriteFile(filepath.Join(dir, "db.child.sql.gz"), []byte("test"), 0644); err != nil {
+		t.Fatalf("write data: %v", err)
+	}
+
+	plan, err := BuildRestorePlan(dir, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(plan.Schema) < 3 {
+		t.Fatalf("expected 3 schema files, got %d", len(plan.Schema))
+	}
+
+	bases := make([]string, len(plan.Schema))
+	for i, p := range plan.Schema {
+		bases[i] = filepath.Base(p)
+	}
+
+	grandIdx := -1
+	parentIdx := -1
+	childIdx := -1
+	for i, b := range bases {
+		switch b {
+		case "db.grandparent-schema.sql.gz":
+			grandIdx = i
+		case "db.parent-schema.sql.gz":
+			parentIdx = i
+		case "db.child-schema.sql.gz":
+			childIdx = i
+		}
+	}
+	if grandIdx < 0 || parentIdx < 0 || childIdx < 0 {
+		t.Fatalf("missing schema files in plan: %v", bases)
+	}
+	if !(grandIdx < parentIdx && parentIdx < childIdx) {
+		t.Fatalf("expected grandparent < parent < child order, got indices grand=%d parent=%d child=%d in %v",
+			grandIdx, parentIdx, childIdx, bases)
+	}
+}

--- a/utils/splitdump/fkorder_test.go
+++ b/utils/splitdump/fkorder_test.go
@@ -576,7 +576,7 @@ func TestBuildRestorePlanFKOrderParentBeforeChild(t *testing.T) {
 		t.Fatalf("write data: %v", err)
 	}
 
-	plan, err := BuildRestorePlan(dir, false)
+	plan, err := BuildRestorePlan(dir, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -616,7 +616,7 @@ func TestBuildRestorePlanManifestWinsOverFKOrdering(t *testing.T) {
 		Post:    nil,
 	})
 
-	plan, err := BuildRestorePlan(dir, false)
+	plan, err := BuildRestorePlan(dir, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -636,7 +636,7 @@ func TestBuildRestorePlanFKOrderEmptyFiles(t *testing.T) {
 		}
 	}
 
-	plan, err := BuildRestorePlan(dir, false)
+	plan, err := BuildRestorePlan(dir, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -675,7 +675,7 @@ func TestBuildRestorePlanFKChain(t *testing.T) {
 		t.Fatalf("write data: %v", err)
 	}
 
-	plan, err := BuildRestorePlan(dir, false)
+	plan, err := BuildRestorePlan(dir, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/utils/splitdump/manifest.go
+++ b/utils/splitdump/manifest.go
@@ -74,7 +74,7 @@ func parseManifest(content string) (*Manifest, error) {
 			section = strings.ToLower(line[1 : len(line)-1])
 			continue
 		}
-		if strings.HasPrefix(line, "version") {
+		if section == "" && strings.HasPrefix(line, "version") {
 			parts := strings.SplitN(line, "=", 2)
 			if len(parts) == 2 {
 				v := strings.TrimSpace(parts[1])

--- a/utils/splitdump/manifest.go
+++ b/utils/splitdump/manifest.go
@@ -1,0 +1,161 @@
+package splitdump
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const manifestVersion = 1
+const manifestFileName = "manifest"
+
+// ErrManifestInvalid is returned when a manifest file exists but fails validation.
+var ErrManifestInvalid = errors.New("splitdump manifest invalid")
+
+// Manifest records the artifact creation order produced by a split operation.
+// Phase slices use basename-only entries (no directory component).
+// Schema holds table/view/routine/system artifacts; Data holds row-data artifacts
+// (including shards); Post holds trigger and event artifacts.
+type Manifest struct {
+	Version int
+	Schema  []string
+	Data    []string
+	Post    []string
+}
+
+// ReadManifest reads and parses the manifest file inside backupPath.
+// Returns os.ErrNotExist (wrapped) when no manifest file is present.
+func ReadManifest(backupPath string) (*Manifest, error) {
+	manifestPath := filepath.Join(backupPath, manifestFileName)
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+	return parseManifest(string(data))
+}
+
+// WriteManifest serialises m to backupPath/manifest, creating the file if needed.
+func WriteManifest(outputDir string, m *Manifest) error {
+	manifestPath := filepath.Join(outputDir, manifestFileName)
+	f, err := os.Create(manifestPath)
+	if err != nil {
+		return fmt.Errorf("splitdump: create manifest %s: %w", manifestPath, err)
+	}
+	defer f.Close()
+	w := bufio.NewWriter(f)
+	fmt.Fprintf(w, "version = %d\n\n", m.Version)
+	writeManifestSection(w, "schema", m.Schema)
+	writeManifestSection(w, "data", m.Data)
+	writeManifestSection(w, "post", m.Post)
+	return w.Flush()
+}
+
+func writeManifestSection(w *bufio.Writer, section string, entries []string) {
+	fmt.Fprintf(w, "[%s]\n", section)
+	for _, e := range entries {
+		fmt.Fprintf(w, "%s\n", e)
+	}
+	fmt.Fprintf(w, "\n")
+}
+
+func parseManifest(content string) (*Manifest, error) {
+	m := &Manifest{}
+	section := ""
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section = strings.ToLower(line[1 : len(line)-1])
+			continue
+		}
+		if strings.HasPrefix(line, "version") {
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) == 2 {
+				v := strings.TrimSpace(parts[1])
+				var n int
+				if _, scanErr := fmt.Sscanf(v, "%d", &n); scanErr == nil {
+					m.Version = n
+				}
+			}
+			continue
+		}
+		switch section {
+		case "schema":
+			m.Schema = append(m.Schema, line)
+		case "data":
+			m.Data = append(m.Data, line)
+		case "post":
+			m.Post = append(m.Post, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("%w: scan error: %v", ErrManifestInvalid, err)
+	}
+	return m, nil
+}
+
+// ValidateManifest checks that m is internally consistent and references only
+// basename-only, unique, non-cross-phase entries at a supported version.
+// Each entry is also classified via classifyFile to ensure it is placed in the
+// correct phase: schema entries must classify as fileCategorySchema, data entries
+// as fileCategoryData, and post entries as fileCategoryPost.
+func ValidateManifest(m *Manifest) error {
+	if m == nil {
+		return fmt.Errorf("%w: nil manifest", ErrManifestInvalid)
+	}
+	if m.Version != manifestVersion {
+		return fmt.Errorf("%w: unsupported version %d (want %d)", ErrManifestInvalid, m.Version, manifestVersion)
+	}
+	seen := make(map[string]string) // basename → phase name
+	phases := []struct {
+		name        string
+		entries     []string
+		expectedCat fileCategory
+	}{
+		{"schema", m.Schema, fileCategorySchema},
+		{"data", m.Data, fileCategoryData},
+		{"post", m.Post, fileCategoryPost},
+	}
+	for _, phase := range phases {
+		for _, entry := range phase.entries {
+			if entry != filepath.Base(entry) {
+				return fmt.Errorf("%w: entry %q is not a basename (contains path separator)", ErrManifestInvalid, entry)
+			}
+			if prev, ok := seen[entry]; ok {
+				return fmt.Errorf("%w: entry %q appears in both %q and %q phases", ErrManifestInvalid, entry, prev, phase.name)
+			}
+			seen[entry] = phase.name
+			// Classify with restoreUser=true so mysql.system-all is accepted in the schema
+			// phase (the splitter always records it there).
+			cat, ok := classifyFile(entry, true)
+			if !ok {
+				return fmt.Errorf("%w: entry %q in phase %q is not a recognised splitdump artifact", ErrManifestInvalid, entry, phase.name)
+			}
+			if cat != phase.expectedCat {
+				return fmt.Errorf("%w: entry %q is declared in phase %q but classifies as phase %q",
+					ErrManifestInvalid, entry, phase.name, categoryName(cat))
+			}
+		}
+	}
+	return nil
+}
+
+// categoryName returns a human-readable label for a fileCategory, used in error messages.
+func categoryName(cat fileCategory) string {
+	switch cat {
+	case fileCategorySchema:
+		return "schema"
+	case fileCategoryData:
+		return "data"
+	case fileCategoryPost:
+		return "post"
+	default:
+		return "unknown"
+	}
+}

--- a/utils/splitdump/restore.go
+++ b/utils/splitdump/restore.go
@@ -716,9 +716,9 @@ func applyRestorePlanPruning(fs *FileSet) {
 
 // buildFileSetFromManifest constructs a FileSet from a validated Manifest, preserving the
 // emission order recorded at split time. Files listed in the manifest but absent from disk
-// are silently skipped. mysql.system-all is filtered when restoreUser is false, matching the
-// behaviour of ListFiles.
-func buildFileSetFromManifest(backupPath string, m *Manifest, restoreUser bool) (*FileSet, error) {
+// are skipped with a warning via logf. mysql.system-all is filtered when restoreUser is false,
+// matching the behaviour of ListFiles.
+func buildFileSetFromManifest(backupPath string, m *Manifest, restoreUser bool, logf func(level, format string, args ...any)) (*FileSet, error) {
 	fs := &FileSet{}
 	for _, name := range m.Schema {
 		_, ok := classifyFile(name, restoreUser)
@@ -727,13 +727,15 @@ func buildFileSetFromManifest(backupPath string, m *Manifest, restoreUser bool) 
 		}
 		fullPath := filepath.Join(backupPath, name)
 		if _, statErr := os.Stat(fullPath); statErr != nil {
-			continue // file missing — skip silently
+			logf(LogWarn, "Splitdump manifest: schema file listed in manifest but missing on disk, skipping: %s", name)
+			continue
 		}
 		fs.Schema = append(fs.Schema, fullPath)
 	}
 	for _, name := range m.Data {
 		fullPath := filepath.Join(backupPath, name)
 		if _, statErr := os.Stat(fullPath); statErr != nil {
+			logf(LogWarn, "Splitdump manifest: data file listed in manifest but missing on disk, skipping: %s", name)
 			continue
 		}
 		fs.Data = append(fs.Data, fullPath)
@@ -741,6 +743,7 @@ func buildFileSetFromManifest(backupPath string, m *Manifest, restoreUser bool) 
 	for _, name := range m.Post {
 		fullPath := filepath.Join(backupPath, name)
 		if _, statErr := os.Stat(fullPath); statErr != nil {
+			logf(LogWarn, "Splitdump manifest: post file listed in manifest but missing on disk, skipping: %s", name)
 			continue
 		}
 		fs.Post = append(fs.Post, fullPath)
@@ -781,7 +784,7 @@ func BuildRestorePlan(backupPath string, restoreUser bool, logf func(level, form
 	manifest, readErr := ReadManifest(backupPath)
 	if readErr == nil {
 		if validateErr := ValidateManifest(manifest); validateErr == nil {
-			mfs, buildErr := buildFileSetFromManifest(backupPath, manifest, restoreUser)
+			mfs, buildErr := buildFileSetFromManifest(backupPath, manifest, restoreUser, logf)
 			if buildErr == nil {
 				applyRestorePlanPruning(mfs)
 				return mfs, nil

--- a/utils/splitdump/restore.go
+++ b/utils/splitdump/restore.go
@@ -693,17 +693,75 @@ func isMysqlProcDataFile(path string) bool {
 		strings.ToLower(TableFromFilename(path)) == "proc"
 }
 
+// applyRestorePlanPruning removes mysql.proc data-phase files from fs when a mysql routine
+// artifact is present in the schema phase, recording the removed files in fs.PrunedData.
+// mysqldump emits both a routines DDL artifact and a raw mysql.proc table dump; restoring
+// both causes duplicate-key errors because CREATE PROCEDURE/FUNCTION implicitly populates
+// mysql.proc.
+func applyRestorePlanPruning(fs *FileSet) {
+	if !isMysqlRoutinesSchemaPresent(fs.Schema) {
+		return
+	}
+	var kept, pruned []string
+	for _, path := range fs.Data {
+		if isMysqlProcDataFile(path) {
+			pruned = append(pruned, path)
+		} else {
+			kept = append(kept, path)
+		}
+	}
+	fs.Data = kept
+	fs.PrunedData = pruned
+}
+
+// buildFileSetFromManifest constructs a FileSet from a validated Manifest, preserving the
+// emission order recorded at split time. Files listed in the manifest but absent from disk
+// are silently skipped. mysql.system-all is filtered when restoreUser is false, matching the
+// behaviour of ListFiles.
+func buildFileSetFromManifest(backupPath string, m *Manifest, restoreUser bool) (*FileSet, error) {
+	fs := &FileSet{}
+	for _, name := range m.Schema {
+		_, ok := classifyFile(name, restoreUser)
+		if !ok {
+			continue // filtered (e.g. mysql.system-all when restoreUser=false)
+		}
+		fullPath := filepath.Join(backupPath, name)
+		if _, statErr := os.Stat(fullPath); statErr != nil {
+			continue // file missing — skip silently
+		}
+		fs.Schema = append(fs.Schema, fullPath)
+	}
+	for _, name := range m.Data {
+		fullPath := filepath.Join(backupPath, name)
+		if _, statErr := os.Stat(fullPath); statErr != nil {
+			continue
+		}
+		fs.Data = append(fs.Data, fullPath)
+	}
+	for _, name := range m.Post {
+		fullPath := filepath.Join(backupPath, name)
+		if _, statErr := os.Stat(fullPath); statErr != nil {
+			continue
+		}
+		fs.Post = append(fs.Post, fullPath)
+	}
+	return fs, nil
+}
+
 // BuildRestorePlan classifies the files in backupPath into typed restore phases:
 // schema (tables, mysql.system-all, routines, views), data, and post-data (triggers, events).
-// Phase ordering is fixed before any replay begins: schema files are ordered by type priority,
-// data files by table and shard, post-data files with triggers before events.
+//
+// When a manifest file is present and valid the artifact order it records is used directly,
+// preserving the FK-safe emission order produced by the splitter. For old backups without a
+// manifest, or when the manifest is missing or malformed, the function falls back to the
+// legacy directory-scan behaviour (alphabetical within each phase, type-priority ordering).
+//
 // Returns ErrNotSplitdump if the directory does not contain a splitdump-compatible layout.
 //
 // Conflict pruning: when any mysql routine artifact (-schema-routine, -schema-function, or
 // -schema-procedure) is present in the schema phase, all mysql.proc data-phase files are
-// removed from the plan and recorded in FileSet.PrunedData. mysqldump emits both a routines
-// DDL artifact and a raw mysql.proc table dump; restoring both causes duplicate-key errors
-// because the CREATE PROCEDURE/FUNCTION statements implicitly populate mysql.proc.
+// removed from the plan and recorded in FileSet.PrunedData regardless of which path was used
+// to build the file set.
 func BuildRestorePlan(backupPath string, restoreUser bool) (*FileSet, error) {
 	ok, err := Detect(backupPath)
 	if err != nil {
@@ -712,22 +770,31 @@ func BuildRestorePlan(backupPath string, restoreUser bool) (*FileSet, error) {
 	if !ok {
 		return nil, ErrNotSplitdump
 	}
+
+	// Try manifest-based plan first.
+	manifest, readErr := ReadManifest(backupPath)
+	if readErr == nil {
+		if validateErr := ValidateManifest(manifest); validateErr == nil {
+			mfs, buildErr := buildFileSetFromManifest(backupPath, manifest, restoreUser)
+			if buildErr == nil {
+				applyRestorePlanPruning(mfs)
+				return mfs, nil
+			}
+		}
+		// Manifest present but invalid — fall through to legacy path.
+	}
+	// readErr != nil covers both os.ErrNotExist (no manifest) and other I/O errors;
+	// either way we fall back to the directory scan.
+
 	fs, err := ListFiles(backupPath, restoreUser)
 	if err != nil {
 		return nil, err
 	}
-	if isMysqlRoutinesSchemaPresent(fs.Schema) {
-		var kept, pruned []string
-		for _, path := range fs.Data {
-			if isMysqlProcDataFile(path) {
-				pruned = append(pruned, path)
-			} else {
-				kept = append(kept, path)
-			}
-		}
-		fs.Data = kept
-		fs.PrunedData = pruned
-	}
+	// Re-order plain table schemas by FK dependency graph so that parents are
+	// restored before children. This is a best-effort analysis: unresolvable cycles
+	// and references to tables outside the backup are silently tolerated.
+	fs.Schema = orderSchemaPhaseByForeignKeys(fs.Schema, nil)
+	applyRestorePlanPruning(&fs)
 	return &fs, nil
 }
 

--- a/utils/splitdump/restore.go
+++ b/utils/splitdump/restore.go
@@ -246,7 +246,7 @@ func Restore(backupPath string, opts RestoreOptions) error {
 		logf(LogInfo, "Splitdump metadata loaded (file=%s pos=%d)", meta.File, meta.Position)
 	}
 
-	plan, err := BuildRestorePlan(backupPath, opts.RestoreUser)
+	plan, err := BuildRestorePlan(backupPath, opts.RestoreUser, logf)
 	if err != nil {
 		return err
 	}
@@ -756,13 +756,19 @@ func buildFileSetFromManifest(backupPath string, m *Manifest, restoreUser bool) 
 // manifest, or when the manifest is missing or malformed, the function falls back to the
 // legacy directory-scan behaviour (alphabetical within each phase, type-priority ordering).
 //
+// logf is used to emit operational warnings (manifest validation failures, FK cycle
+// detection). Pass nil to suppress all logging.
+//
 // Returns ErrNotSplitdump if the directory does not contain a splitdump-compatible layout.
 //
 // Conflict pruning: when any mysql routine artifact (-schema-routine, -schema-function, or
 // -schema-procedure) is present in the schema phase, all mysql.proc data-phase files are
 // removed from the plan and recorded in FileSet.PrunedData regardless of which path was used
 // to build the file set.
-func BuildRestorePlan(backupPath string, restoreUser bool) (*FileSet, error) {
+func BuildRestorePlan(backupPath string, restoreUser bool, logf func(level, format string, args ...any)) (*FileSet, error) {
+	if logf == nil {
+		logf = func(_, _ string, _ ...any) {}
+	}
 	ok, err := Detect(backupPath)
 	if err != nil {
 		return nil, err
@@ -780,11 +786,13 @@ func BuildRestorePlan(backupPath string, restoreUser bool) (*FileSet, error) {
 				applyRestorePlanPruning(mfs)
 				return mfs, nil
 			}
+			logf(LogWarn, "Splitdump manifest: buildFileSetFromManifest failed (%v); falling back to directory scan", buildErr)
+		} else {
+			logf(LogWarn, "Splitdump manifest: validation failed (%v); falling back to directory scan with FK ordering", validateErr)
 		}
-		// Manifest present but invalid — fall through to legacy path.
 	}
-	// readErr != nil covers both os.ErrNotExist (no manifest) and other I/O errors;
-	// either way we fall back to the directory scan.
+	// readErr != nil covers both os.ErrNotExist (no manifest, expected for old backups)
+	// and other I/O errors — either way fall back to the directory scan.
 
 	fs, err := ListFiles(backupPath, restoreUser)
 	if err != nil {
@@ -793,7 +801,7 @@ func BuildRestorePlan(backupPath string, restoreUser bool) (*FileSet, error) {
 	// Re-order plain table schemas by FK dependency graph so that parents are
 	// restored before children. This is a best-effort analysis: unresolvable cycles
 	// and references to tables outside the backup are silently tolerated.
-	fs.Schema = orderSchemaPhaseByForeignKeys(fs.Schema, nil)
+	fs.Schema = orderSchemaPhaseByForeignKeys(fs.Schema, logf)
 	applyRestorePlanPruning(&fs)
 	return &fs, nil
 }

--- a/utils/splitdump/restore_test.go
+++ b/utils/splitdump/restore_test.go
@@ -1916,6 +1916,68 @@ func TestRestoreUsesManifestParentBeforeChild(t *testing.T) {
 	}
 }
 
+// TestBuildRestorePlanManifestWarnsMissingFiles verifies that when a manifest lists files
+// that are absent from disk, BuildRestorePlan emits a LogWarn for each missing file and
+// still returns a valid plan containing only the files that are present.
+func TestBuildRestorePlanManifestWarnsMissingFiles(t *testing.T) {
+	dir := t.TempDir()
+	// Write only the schema file; data and post files are intentionally absent.
+	if err := os.WriteFile(filepath.Join(dir, "db.tbl-schema.sql.gz"), []byte("test"), 0644); err != nil {
+		t.Fatalf("write schema file: %v", err)
+	}
+	writeManifestFile(t, dir, &Manifest{
+		Version: 1,
+		Schema:  []string{"db.tbl-schema.sql.gz", "db.missing-schema.sql.gz"},
+		Data:    []string{"db.tbl.00000.sql.gz"},
+		Post:    []string{"db.tbl-schema-trigger.sql.gz"},
+	})
+
+	var mu sync.Mutex
+	var warnings []string
+	logf := func(level, format string, args ...any) {
+		if level == LogWarn {
+			mu.Lock()
+			warnings = append(warnings, fmt.Sprintf(format, args...))
+			mu.Unlock()
+		}
+	}
+
+	plan, err := BuildRestorePlan(dir, false, logf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Only the present schema file should appear in the plan.
+	if len(plan.Schema) != 1 || filepath.Base(plan.Schema[0]) != "db.tbl-schema.sql.gz" {
+		t.Fatalf("unexpected schema files in plan: %v", plan.Schema)
+	}
+	if len(plan.Data) != 0 {
+		t.Fatalf("expected no data files in plan, got: %v", plan.Data)
+	}
+	if len(plan.Post) != 0 {
+		t.Fatalf("expected no post files in plan, got: %v", plan.Post)
+	}
+
+	// A warning must have been emitted for each missing file.
+	mu.Lock()
+	got := append([]string(nil), warnings...)
+	mu.Unlock()
+
+	wantSubstrings := []string{"db.missing-schema.sql.gz", "db.tbl.00000.sql.gz", "db.tbl-schema-trigger.sql.gz"}
+	for _, sub := range wantSubstrings {
+		found := false
+		for _, w := range got {
+			if strings.Contains(w, sub) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected warning mentioning %q; warnings were: %v", sub, got)
+		}
+	}
+}
+
 // ---- ValidateManifest phase-classification tests ----
 
 func TestValidateManifestAcceptsWellFormedManifest(t *testing.T) {

--- a/utils/splitdump/restore_test.go
+++ b/utils/splitdump/restore_test.go
@@ -1116,7 +1116,7 @@ func TestBuildRestorePlanReturnsPlanForSplitdumpDir(t *testing.T) {
 			t.Fatalf("failed to write file %s: %v", f, err)
 		}
 	}
-	plan, err := BuildRestorePlan(dir, false)
+	plan, err := BuildRestorePlan(dir, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1140,7 +1140,7 @@ func TestBuildRestorePlanReturnsErrNotSplitdump(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "backup.sql.gz"), []byte("test"), 0644); err != nil {
 		t.Fatalf("failed to write file: %v", err)
 	}
-	_, err := BuildRestorePlan(dir, false)
+	_, err := BuildRestorePlan(dir, false, nil)
 	if err == nil {
 		t.Fatalf("expected ErrNotSplitdump, got nil")
 	}
@@ -1151,7 +1151,7 @@ func TestBuildRestorePlanReturnsErrNotSplitdump(t *testing.T) {
 
 func TestBuildRestorePlanReturnsErrNotSplitdumpForEmptyDir(t *testing.T) {
 	dir := t.TempDir()
-	_, err := BuildRestorePlan(dir, false)
+	_, err := BuildRestorePlan(dir, false, nil)
 	if err == nil {
 		t.Fatalf("expected ErrNotSplitdump for empty dir, got nil")
 	}
@@ -1176,7 +1176,7 @@ func TestBuildRestorePlanPhaseOrdering(t *testing.T) {
 		}
 	}
 
-	plan, err := BuildRestorePlan(dir, true)
+	plan, err := BuildRestorePlan(dir, true, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1222,7 +1222,7 @@ func TestBuildRestorePlanRespectsRestoreUser(t *testing.T) {
 	}
 
 	// With restoreUser=false, mysql.system-all should be excluded from schema phase
-	planNoUser, err := BuildRestorePlan(dir, false)
+	planNoUser, err := BuildRestorePlan(dir, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1233,7 +1233,7 @@ func TestBuildRestorePlanRespectsRestoreUser(t *testing.T) {
 	}
 
 	// With restoreUser=true, mysql.system-all should be included in schema phase
-	planWithUser, err := BuildRestorePlan(dir, true)
+	planWithUser, err := BuildRestorePlan(dir, true, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1474,7 +1474,7 @@ func TestBuildRestorePlanPrunesMysqlProcWhenMysqlRoutineSchemaPresent(t *testing
 				}
 			}
 
-			plan, err := BuildRestorePlan(dir, false)
+			plan, err := BuildRestorePlan(dir, false, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -1530,7 +1530,7 @@ func TestBuildRestorePlanKeepsMysqlProcWithoutMysqlRoutineSchema(t *testing.T) {
 		}
 	}
 
-	plan, err := BuildRestorePlan(dir, false)
+	plan, err := BuildRestorePlan(dir, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1723,7 +1723,7 @@ func TestBuildRestorePlanPrefersManifestOrder(t *testing.T) {
 		Post:    nil,
 	})
 
-	plan, err := BuildRestorePlan(dir, false)
+	plan, err := BuildRestorePlan(dir, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1749,7 +1749,7 @@ func TestBuildRestorePlanFallsBackWithoutManifest(t *testing.T) {
 		}
 	}
 
-	plan, err := BuildRestorePlan(dir, false)
+	plan, err := BuildRestorePlan(dir, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error for backup without manifest: %v", err)
 	}
@@ -1780,7 +1780,7 @@ func TestBuildRestorePlanFallsBackOnInvalidManifest(t *testing.T) {
 	}
 
 	// BuildRestorePlan must not return an error — it should silently fall back.
-	plan, err := BuildRestorePlan(dir, false)
+	plan, err := BuildRestorePlan(dir, false, nil)
 	if err != nil {
 		t.Fatalf("expected fallback on invalid manifest, got error: %v", err)
 	}
@@ -1814,7 +1814,7 @@ func TestManifestPlanStillPrunesMysqlProcOverlap(t *testing.T) {
 		Post:    nil,
 	})
 
-	plan, err := BuildRestorePlan(dir, false)
+	plan, err := BuildRestorePlan(dir, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1845,7 +1845,7 @@ func TestBuildRestorePlanManifestRespectsRestoreUser(t *testing.T) {
 	})
 
 	// restoreUser=false — mysql.system-all must be excluded.
-	planNoUser, err := BuildRestorePlan(dir, false)
+	planNoUser, err := BuildRestorePlan(dir, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1856,7 +1856,7 @@ func TestBuildRestorePlanManifestRespectsRestoreUser(t *testing.T) {
 	}
 
 	// restoreUser=true — mysql.system-all must be included.
-	planWithUser, err := BuildRestorePlan(dir, true)
+	planWithUser, err := BuildRestorePlan(dir, true, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2030,7 +2030,7 @@ func TestBuildRestorePlanFallsBackOnPhaseMismatchManifest(t *testing.T) {
 	writeManifestFile(t, dir, badManifest)
 
 	// BuildRestorePlan must not return an error — it must silently fall back.
-	plan, err := BuildRestorePlan(dir, false)
+	plan, err := BuildRestorePlan(dir, false, nil)
 	if err != nil {
 		t.Fatalf("expected fallback on phase-mismatch manifest, got error: %v", err)
 	}
@@ -2047,5 +2047,70 @@ func TestBuildRestorePlanFallsBackOnPhaseMismatchManifest(t *testing.T) {
 	}
 	if !triggerFound {
 		t.Fatalf("expected trigger file in post phase after fallback, got post=%v", plan.Post)
+	}
+}
+
+// TestBuildRestorePlanLogsManifestValidationFailure verifies that when a manifest is
+// present but fails validation, BuildRestorePlan emits a WARN-level log message before
+// falling back to the legacy directory scan.
+func TestBuildRestorePlanLogsManifestValidationFailure(t *testing.T) {
+	dir := t.TempDir()
+	// Write a minimal splitdump layout.
+	if err := os.WriteFile(filepath.Join(dir, "db.tbl-schema.sql.gz"), []byte("test"), 0644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "db.tbl.sql.gz"), []byte("test"), 0644); err != nil {
+		t.Fatalf("write data: %v", err)
+	}
+	// Manifest with a trigger in the schema phase — ValidateManifest will reject it.
+	writeManifestFile(t, dir, &Manifest{
+		Version: 1,
+		Schema:  []string{"db.tbl-schema.sql.gz", "db.tbl-schema-trigger.sql.gz"},
+		Data:    []string{"db.tbl.sql.gz"},
+	})
+
+	var warnLogs []string
+	logf := func(level, format string, args ...any) {
+		if level == LogWarn {
+			warnLogs = append(warnLogs, fmt.Sprintf(format, args...))
+		}
+	}
+
+	plan, err := BuildRestorePlan(dir, false, logf)
+	if err != nil {
+		t.Fatalf("expected fallback, got error: %v", err)
+	}
+	if plan == nil {
+		t.Fatalf("expected non-nil plan")
+	}
+	if len(warnLogs) == 0 {
+		t.Fatalf("expected a WARN log about manifest validation failure, got none")
+	}
+	found := false
+	for _, msg := range warnLogs {
+		if strings.Contains(strings.ToLower(msg), "manifest") && strings.Contains(strings.ToLower(msg), "valid") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected WARN log mentioning 'manifest' and 'valid', got: %v", warnLogs)
+	}
+}
+
+// TestParseManifestVersionTableNotDropped verifies that an artifact whose basename starts
+// with "version" (e.g. from a table named "versioncontrol") is correctly recorded in the
+// schema section and not misidentified as the version header line.
+func TestParseManifestVersionTableNotDropped(t *testing.T) {
+	content := "version = 1\n\n[schema]\nversioncontrol-schema.sql.gz\n\n[data]\n\n[post]\n"
+	m, err := parseManifest(content)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if m.Version != 1 {
+		t.Fatalf("expected version 1, got %d", m.Version)
+	}
+	if len(m.Schema) != 1 || m.Schema[0] != "versioncontrol-schema.sql.gz" {
+		t.Fatalf("expected versioncontrol-schema.sql.gz in Schema, got %v", m.Schema)
 	}
 }

--- a/utils/splitdump/restore_test.go
+++ b/utils/splitdump/restore_test.go
@@ -1694,3 +1694,358 @@ func TestRestoreNoSpuriousWarnWhenNoMysqlProcFiles(t *testing.T) {
 		}
 	}
 }
+
+// ---- Manifest-based restore plan tests ----
+
+// writeManifestFile is a test helper that writes a manifest file directly to dir.
+func writeManifestFile(t *testing.T, dir string, m *Manifest) {
+	t.Helper()
+	if err := WriteManifest(dir, m); err != nil {
+		t.Fatalf("failed to write test manifest: %v", err)
+	}
+}
+
+// TestBuildRestorePlanPrefersManifestOrder verifies that when a valid manifest is present,
+// the restore plan uses manifest order rather than alphabetical directory ordering.
+func TestBuildRestorePlanPrefersManifestOrder(t *testing.T) {
+	dir := t.TempDir()
+	// Files on disk — alphabetical order would put achild before zparent.
+	for _, f := range []string{"db.zparent-schema.sql.gz", "db.achild-schema.sql.gz", "db.achild.00000.sql.gz"} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("write %s: %v", f, err)
+		}
+	}
+	// Manifest records zparent before achild (FK-safe emission order).
+	writeManifestFile(t, dir, &Manifest{
+		Version: 1,
+		Schema:  []string{"db.zparent-schema.sql.gz", "db.achild-schema.sql.gz"},
+		Data:    []string{"db.achild.00000.sql.gz"},
+		Post:    nil,
+	})
+
+	plan, err := BuildRestorePlan(dir, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(plan.Schema) < 2 {
+		t.Fatalf("expected 2 schema files, got %d: %v", len(plan.Schema), plan.Schema)
+	}
+	if filepath.Base(plan.Schema[0]) != "db.zparent-schema.sql.gz" {
+		t.Fatalf("expected zparent first (manifest order), got: %s", filepath.Base(plan.Schema[0]))
+	}
+	if filepath.Base(plan.Schema[1]) != "db.achild-schema.sql.gz" {
+		t.Fatalf("expected achild second (manifest order), got: %s", filepath.Base(plan.Schema[1]))
+	}
+}
+
+// TestBuildRestorePlanFallsBackWithoutManifest verifies that old backups without a manifest
+// file still work correctly using the legacy directory-scan path.
+func TestBuildRestorePlanFallsBackWithoutManifest(t *testing.T) {
+	dir := t.TempDir()
+	// No manifest file — only the artifact files.
+	for _, f := range []string{"db.tbl-schema.sql.gz", "db.tbl.00000.sql.gz"} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("write %s: %v", f, err)
+		}
+	}
+
+	plan, err := BuildRestorePlan(dir, false)
+	if err != nil {
+		t.Fatalf("unexpected error for backup without manifest: %v", err)
+	}
+	if plan == nil {
+		t.Fatalf("expected non-nil plan")
+	}
+	if len(plan.Schema) == 0 {
+		t.Fatalf("expected schema files in fallback plan, got none")
+	}
+	if len(plan.Data) == 0 {
+		t.Fatalf("expected data files in fallback plan, got none")
+	}
+}
+
+// TestBuildRestorePlanFallsBackOnInvalidManifest verifies that a malformed manifest does not
+// hard-fail the restore — the plan falls back to legacy directory scanning instead.
+func TestBuildRestorePlanFallsBackOnInvalidManifest(t *testing.T) {
+	dir := t.TempDir()
+	for _, f := range []string{"db.tbl-schema.sql.gz", "db.tbl.00000.sql.gz"} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("write %s: %v", f, err)
+		}
+	}
+	// Write a manifest with an unsupported version — ValidateManifest must reject it.
+	badManifest := "version = 999\n\n[schema]\ndb.tbl-schema.sql.gz\n\n[data]\n\n[post]\n\n"
+	if err := os.WriteFile(filepath.Join(dir, manifestFileName), []byte(badManifest), 0644); err != nil {
+		t.Fatalf("write bad manifest: %v", err)
+	}
+
+	// BuildRestorePlan must not return an error — it should silently fall back.
+	plan, err := BuildRestorePlan(dir, false)
+	if err != nil {
+		t.Fatalf("expected fallback on invalid manifest, got error: %v", err)
+	}
+	if plan == nil {
+		t.Fatalf("expected non-nil plan")
+	}
+	if len(plan.Schema) == 0 {
+		t.Fatalf("expected schema files in fallback plan, got none")
+	}
+}
+
+// TestManifestPlanStillPrunesMysqlProcOverlap verifies that mysql.proc pruning is applied
+// even when the plan is built from a manifest. A manifest that lists both a mysql routine
+// artifact and a mysql.proc data file must still have the data file removed.
+func TestManifestPlanStillPrunesMysqlProcOverlap(t *testing.T) {
+	dir := t.TempDir()
+	for _, f := range []string{
+		"mysql.__routines-schema-routine.sql.gz",
+		"mysql.proc.00000.sql.gz",
+		"db.tbl-schema.sql.gz",
+		"db.tbl.sql.gz",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("write %s: %v", f, err)
+		}
+	}
+	writeManifestFile(t, dir, &Manifest{
+		Version: 1,
+		Schema:  []string{"mysql.__routines-schema-routine.sql.gz", "db.tbl-schema.sql.gz"},
+		Data:    []string{"mysql.proc.00000.sql.gz", "db.tbl.sql.gz"},
+		Post:    nil,
+	})
+
+	plan, err := BuildRestorePlan(dir, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, p := range plan.Data {
+		if strings.HasPrefix(strings.ToLower(filepath.Base(p)), "mysql.proc") {
+			t.Fatalf("mysql.proc should have been pruned from manifest plan, but found in data: %s", filepath.Base(p))
+		}
+	}
+	if len(plan.PrunedData) == 0 {
+		t.Fatalf("expected PrunedData to record the pruned mysql.proc file")
+	}
+}
+
+// TestBuildRestorePlanManifestRespectsRestoreUser verifies that mysql.system-all is filtered
+// from a manifest-based plan when restoreUser is false.
+func TestBuildRestorePlanManifestRespectsRestoreUser(t *testing.T) {
+	dir := t.TempDir()
+	for _, f := range []string{"db.tbl-schema.sql.gz", "mysql.system-all.sql.gz", "db.tbl.sql.gz"} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("write %s: %v", f, err)
+		}
+	}
+	writeManifestFile(t, dir, &Manifest{
+		Version: 1,
+		Schema:  []string{"db.tbl-schema.sql.gz", "mysql.system-all.sql.gz"},
+		Data:    []string{"db.tbl.sql.gz"},
+		Post:    nil,
+	})
+
+	// restoreUser=false — mysql.system-all must be excluded.
+	planNoUser, err := BuildRestorePlan(dir, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, p := range planNoUser.Schema {
+		if IsMysqlSystemAll(filepath.Base(p)) {
+			t.Fatalf("mysql.system-all must be excluded when restoreUser=false, got: %s", filepath.Base(p))
+		}
+	}
+
+	// restoreUser=true — mysql.system-all must be included.
+	planWithUser, err := BuildRestorePlan(dir, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := false
+	for _, p := range planWithUser.Schema {
+		if IsMysqlSystemAll(filepath.Base(p)) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("mysql.system-all must be included when restoreUser=true, got schema: %v", planWithUser.Schema)
+	}
+}
+
+// TestRestoreUsesManifestParentBeforeChild is an end-to-end test through Restore() that
+// verifies FK-safe parent-before-child schema ordering recorded in the manifest is preserved
+// during the actual restore callback sequence.
+func TestRestoreUsesManifestParentBeforeChild(t *testing.T) {
+	dir := t.TempDir()
+	for _, f := range []string{"db.zparent-schema.sql.gz", "db.achild-schema.sql.gz", "db.achild.sql.gz"} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("write %s: %v", f, err)
+		}
+	}
+	writeManifestFile(t, dir, &Manifest{
+		Version: 1,
+		Schema:  []string{"db.zparent-schema.sql.gz", "db.achild-schema.sql.gz"},
+		Data:    []string{"db.achild.sql.gz"},
+		Post:    nil,
+	})
+
+	var mu sync.Mutex
+	var order []string
+	restoreFile := func(path string) error {
+		mu.Lock()
+		order = append(order, filepath.Base(path))
+		mu.Unlock()
+		return nil
+	}
+
+	if err := Restore(dir, RestoreOptions{Parallel: 1, RestoreFile: restoreFile}); err != nil {
+		t.Fatalf("unexpected restore error: %v", err)
+	}
+
+	mu.Lock()
+	got := append([]string(nil), order...)
+	mu.Unlock()
+
+	want := []string{
+		"db.zparent-schema.sql.gz",
+		"db.achild-schema.sql.gz",
+		"db.achild.sql.gz",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected restore order:\n  got:  %v\n  want: %v", got, want)
+	}
+}
+
+// ---- ValidateManifest phase-classification tests ----
+
+func TestValidateManifestAcceptsWellFormedManifest(t *testing.T) {
+	m := &Manifest{
+		Version: 1,
+		Schema:  []string{"db.tbl-schema.sql.gz", "mysql.system-all.sql.gz", "db.__routines-schema-routine.sql.gz"},
+		Data:    []string{"db.tbl.00000.sql.gz", "db.other.sql.gz"},
+		Post:    []string{"db.tbl-schema-trigger.sql.gz", "db.__events-schema-event.sql.gz"},
+	}
+	if err := ValidateManifest(m); err != nil {
+		t.Fatalf("expected valid manifest to pass, got: %v", err)
+	}
+}
+
+func TestValidateManifestRejectsTriggerInSchemaPhase(t *testing.T) {
+	m := &Manifest{
+		Version: 1,
+		Schema:  []string{"db.tbl-schema-trigger.sql.gz"}, // triggers are post-phase
+		Data:    nil,
+		Post:    nil,
+	}
+	err := ValidateManifest(m)
+	if err == nil {
+		t.Fatalf("expected error for trigger in schema phase, got nil")
+	}
+	if !errors.Is(err, ErrManifestInvalid) {
+		t.Fatalf("expected ErrManifestInvalid, got: %v", err)
+	}
+}
+
+func TestValidateManifestRejectsSchemaFileInDataPhase(t *testing.T) {
+	m := &Manifest{
+		Version: 1,
+		Schema:  nil,
+		Data:    []string{"db.tbl-schema.sql.gz"}, // schema files belong in schema phase
+		Post:    nil,
+	}
+	err := ValidateManifest(m)
+	if err == nil {
+		t.Fatalf("expected error for schema file in data phase, got nil")
+	}
+	if !errors.Is(err, ErrManifestInvalid) {
+		t.Fatalf("expected ErrManifestInvalid, got: %v", err)
+	}
+}
+
+func TestValidateManifestRejectsDataFileInPostPhase(t *testing.T) {
+	m := &Manifest{
+		Version: 1,
+		Schema:  nil,
+		Data:    nil,
+		Post:    []string{"db.tbl.00000.sql.gz"}, // data files don't belong in post
+	}
+	err := ValidateManifest(m)
+	if err == nil {
+		t.Fatalf("expected error for data file in post phase, got nil")
+	}
+	if !errors.Is(err, ErrManifestInvalid) {
+		t.Fatalf("expected ErrManifestInvalid, got: %v", err)
+	}
+}
+
+func TestValidateManifestRejectsUnrecognisedEntry(t *testing.T) {
+	m := &Manifest{
+		Version: 1,
+		Schema:  []string{"metadata"}, // not a recognised splitdump artifact
+		Data:    nil,
+		Post:    nil,
+	}
+	err := ValidateManifest(m)
+	if err == nil {
+		t.Fatalf("expected error for unrecognised entry in schema phase, got nil")
+	}
+	if !errors.Is(err, ErrManifestInvalid) {
+		t.Fatalf("expected ErrManifestInvalid, got: %v", err)
+	}
+}
+
+func TestValidateManifestRejectsEventInSchemaPhase(t *testing.T) {
+	m := &Manifest{
+		Version: 1,
+		Schema:  []string{"db.__events-schema-event.sql.gz"}, // events are post-phase
+		Data:    nil,
+		Post:    nil,
+	}
+	err := ValidateManifest(m)
+	if err == nil {
+		t.Fatalf("expected error for event in schema phase, got nil")
+	}
+	if !errors.Is(err, ErrManifestInvalid) {
+		t.Fatalf("expected ErrManifestInvalid, got: %v", err)
+	}
+}
+
+// TestBuildRestorePlanFallsBackOnPhaseMismatchManifest verifies that a manifest where an
+// entry is in the wrong phase (e.g. trigger declared under [schema]) causes BuildRestorePlan
+// to fall back to the legacy directory scan rather than trusting the bad manifest.
+func TestBuildRestorePlanFallsBackOnPhaseMismatchManifest(t *testing.T) {
+	dir := t.TempDir()
+	for _, f := range []string{"db.tbl-schema.sql.gz", "db.tbl.00000.sql.gz", "db.tbl-schema-trigger.sql.gz"} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("write %s: %v", f, err)
+		}
+	}
+	// Manifest incorrectly places the trigger in the schema phase.
+	badManifest := &Manifest{
+		Version: 1,
+		Schema:  []string{"db.tbl-schema.sql.gz", "db.tbl-schema-trigger.sql.gz"},
+		Data:    []string{"db.tbl.00000.sql.gz"},
+		Post:    nil,
+	}
+	writeManifestFile(t, dir, badManifest)
+
+	// BuildRestorePlan must not return an error — it must silently fall back.
+	plan, err := BuildRestorePlan(dir, false)
+	if err != nil {
+		t.Fatalf("expected fallback on phase-mismatch manifest, got error: %v", err)
+	}
+	if plan == nil {
+		t.Fatalf("expected non-nil plan after fallback")
+	}
+	// The legacy path correctly places the trigger in the post phase.
+	triggerFound := false
+	for _, p := range plan.Post {
+		if strings.Contains(filepath.Base(p), "trigger") {
+			triggerFound = true
+			break
+		}
+	}
+	if !triggerFound {
+		t.Fatalf("expected trigger file in post phase after fallback, got post=%v", plan.Post)
+	}
+}

--- a/utils/splitdump/split.go
+++ b/utils/splitdump/split.go
@@ -139,6 +139,30 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 	dataTableName := ""
 	currentOutputName := ""
 	openedOutputs := make(map[string]bool)
+
+	// Manifest tracking: record each artifact on its first creation, preserving emission order.
+	var manifestSchema, manifestData, manifestPost []string
+	manifestSeen := make(map[string]bool)
+	recordManifestEntry := func(tableName string) {
+		sanitized := sanitizefilename.Sanitize(tableName) + ".sql.gz"
+		if manifestSeen[sanitized] {
+			return
+		}
+		manifestSeen[sanitized] = true
+		// Classify with restoreUser=true so mysql.system-all is recorded as schema.
+		cat, ok := classifyFile(sanitized, true)
+		if !ok {
+			return
+		}
+		switch cat {
+		case fileCategorySchema:
+			manifestSchema = append(manifestSchema, sanitized)
+		case fileCategoryPost:
+			manifestPost = append(manifestPost, sanitized)
+		default:
+			manifestData = append(manifestData, sanitized)
+		}
+	}
 	binlogRegexMariaDB := regexp.MustCompile(`CHANGE MASTER TO MASTER_LOG_FILE='(.+)', MASTER_LOG_POS=(\d+)`)
 	gtidRegexMariaDB := regexp.MustCompile(`SET GLOBAL gtid_slave_pos='(.+)'`)
 	binlogRegexMySQL := regexp.MustCompile(`CHANGE REPLICATION SOURCE TO SOURCE_LOG_FILE='(.+)', SOURCE_LOG_POS=(\d+)`)
@@ -190,6 +214,7 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 		closeTableFile()
 		tablePath := filepath.Join(outputDir, sanitizefilename.Sanitize(tableName)+".sql.gz")
 		flags := os.O_CREATE | os.O_WRONLY
+		isFirstOpen := !openedOutputs[tableName]
 		if appendMode && openedOutputs[tableName] {
 			flags |= os.O_APPEND
 		} else {
@@ -203,6 +228,9 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 		tableFile = gzip.NewWriter(f)
 		currentOutputName = tableName
 		openedOutputs[tableName] = true
+		if isFirstOpen {
+			recordManifestEntry(tableName)
+		}
 		pastHeader = true
 		return nil
 	}
@@ -435,6 +463,17 @@ func SplitDumpLineParser(bus *SplitDumpChannelBus, outputDir string, opts SplitD
 	line := strings.Join(metaLines, "\n")
 	_, _ = f.Write([]byte(line))
 	f.Close()
+
+	manifest := &Manifest{
+		Version: manifestVersion,
+		Schema:  manifestSchema,
+		Data:    manifestData,
+		Post:    manifestPost,
+	}
+	if err = WriteManifest(outputDir, manifest); err != nil {
+		finishWithError(err)
+		return
+	}
 
 	bus.Finished <- true
 }

--- a/utils/splitdump/split_test.go
+++ b/utils/splitdump/split_test.go
@@ -722,3 +722,206 @@ func TestSplitDumpLineParserTruncatesSystemFileOnFirstWriteInRun(t *testing.T) {
 		t.Fatalf("expected new system content in file, got: %s", got)
 	}
 }
+
+// ---- Manifest emission tests ----
+
+// TestSplitDumpWritesManifest verifies that a split run produces a manifest file.
+func TestSplitDumpWritesManifest(t *testing.T) {
+	bus := NewSplitDumpChannelBus()
+	outputDir := filepath.Join(t.TempDir(), "splitdump")
+
+	go SplitDumpLineParser(bus, outputDir, SplitDumpOptions{})
+
+	lines := []string{
+		"USE `db`\n",
+		"-- Table structure for table `tbl`\n",
+		"CREATE TABLE `tbl` (id int);\n",
+		"-- Dumping data for table `tbl`\n",
+		"LOCK TABLES `tbl` WRITE;\n",
+		"INSERT INTO `tbl` VALUES (1);\n",
+		"UNLOCK TABLES;\n",
+	}
+	for _, l := range lines {
+		bus.CurrentLine <- l
+	}
+	close(bus.CurrentLine)
+
+	select {
+	case <-bus.Finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	m, err := ReadManifest(outputDir)
+	if err != nil {
+		t.Fatalf("expected manifest to be readable: %v", err)
+	}
+	if err := ValidateManifest(m); err != nil {
+		t.Fatalf("expected manifest to be valid: %v", err)
+	}
+	if m.Version != 1 {
+		t.Fatalf("expected version 1, got %d", m.Version)
+	}
+}
+
+// TestSplitDumpManifestPreservesEmissionOrder verifies that the manifest records artifacts
+// in the order they were emitted rather than sorted alphabetically. When the splitter
+// processes parent before child (FK ordering), the manifest must reflect that order.
+func TestSplitDumpManifestPreservesEmissionOrder(t *testing.T) {
+	bus := NewSplitDumpChannelBus()
+	outputDir := filepath.Join(t.TempDir(), "splitdump")
+
+	go SplitDumpLineParser(bus, outputDir, SplitDumpOptions{})
+
+	// zparent sorts after achild alphabetically, but is emitted first.
+	lines := []string{
+		"USE `db`\n",
+		"-- Table structure for table `zparent`\n",
+		"CREATE TABLE `zparent` (id int);\n",
+		"-- Table structure for table `achild`\n",
+		"CREATE TABLE `achild` (id int);\n",
+	}
+	for _, l := range lines {
+		bus.CurrentLine <- l
+	}
+	close(bus.CurrentLine)
+
+	select {
+	case <-bus.Finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	m, err := ReadManifest(outputDir)
+	if err != nil {
+		t.Fatalf("expected manifest: %v", err)
+	}
+	if len(m.Schema) < 2 {
+		t.Fatalf("expected at least 2 schema entries, got %d: %v", len(m.Schema), m.Schema)
+	}
+	if !strings.Contains(m.Schema[0], "zparent") {
+		t.Fatalf("expected zparent first in manifest schema (emission order), got: %v", m.Schema)
+	}
+	if !strings.Contains(m.Schema[1], "achild") {
+		t.Fatalf("expected achild second in manifest schema, got: %v", m.Schema)
+	}
+}
+
+// TestSplitDumpManifestSeparatesSchemaDataPost verifies that table schema, data, trigger, and
+// event artifacts land in the correct manifest phase.
+func TestSplitDumpManifestSeparatesSchemaDataPost(t *testing.T) {
+	bus := NewSplitDumpChannelBus()
+	outputDir := filepath.Join(t.TempDir(), "splitdump")
+
+	go SplitDumpLineParser(bus, outputDir, SplitDumpOptions{})
+
+	lines := []string{
+		"USE `db`\n",
+		"-- Table structure for table `tbl`\n",
+		"CREATE TABLE `tbl` (id int);\n",
+		"-- Dumping data for table `tbl`\n",
+		"LOCK TABLES `tbl` WRITE;\n",
+		"INSERT INTO `tbl` VALUES (1);\n",
+		"UNLOCK TABLES;\n",
+		"-- Dumping triggers for table `tbl`\n",
+		"CREATE TRIGGER `trg` BEFORE INSERT ON `tbl` FOR EACH ROW SET NEW.id = NEW.id;\n",
+		"-- Dumping events for database 'db'\n",
+		"CREATE EVENT `ev` ON SCHEDULE EVERY 1 DAY DO SELECT 1;\n",
+	}
+	for _, l := range lines {
+		bus.CurrentLine <- l
+	}
+	close(bus.CurrentLine)
+
+	select {
+	case <-bus.Finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	m, err := ReadManifest(outputDir)
+	if err != nil {
+		t.Fatalf("expected manifest: %v", err)
+	}
+
+	// Schema phase must contain the table definition.
+	foundSchema := false
+	for _, e := range m.Schema {
+		if strings.HasSuffix(e, "-schema.sql.gz") {
+			foundSchema = true
+			break
+		}
+	}
+	if !foundSchema {
+		t.Fatalf("expected table schema in manifest schema phase, got schema=%v", m.Schema)
+	}
+
+	// Data phase must contain the data file.
+	if len(m.Data) == 0 {
+		t.Fatalf("expected data entries in manifest, got none")
+	}
+
+	// Post phase must contain trigger and event files.
+	hasTrigger, hasEvent := false, false
+	for _, e := range m.Post {
+		if strings.Contains(e, "-schema-trigger") {
+			hasTrigger = true
+		}
+		if strings.Contains(e, "-schema-event") {
+			hasEvent = true
+		}
+	}
+	if !hasTrigger {
+		t.Fatalf("expected trigger in manifest post phase, got post=%v", m.Post)
+	}
+	if !hasEvent {
+		t.Fatalf("expected event in manifest post phase, got post=%v", m.Post)
+	}
+}
+
+// TestSplitDumpManifestIncludesMysqlSystemAndRoutineArtifacts verifies that mysql.system-all
+// and routine artifacts are recorded in the manifest schema phase.
+func TestSplitDumpManifestIncludesMysqlSystemAndRoutineArtifacts(t *testing.T) {
+	bus := NewSplitDumpChannelBus()
+	outputDir := filepath.Join(t.TempDir(), "splitdump")
+
+	go SplitDumpLineParser(bus, outputDir, SplitDumpOptions{})
+
+	lines := []string{
+		"USE `db`\n",
+		"-- Dumping routines for database 'db'\n",
+		"CREATE PROCEDURE `sp`() BEGIN SELECT 1; END;\n",
+		"CREATE USER 'app'@'%' IDENTIFIED BY 'x';\n",
+	}
+	for _, l := range lines {
+		bus.CurrentLine <- l
+	}
+	close(bus.CurrentLine)
+
+	select {
+	case <-bus.Finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	m, err := ReadManifest(outputDir)
+	if err != nil {
+		t.Fatalf("expected manifest: %v", err)
+	}
+
+	hasRoutine, hasSystemAll := false, false
+	for _, e := range m.Schema {
+		if strings.Contains(e, "-schema-routine") {
+			hasRoutine = true
+		}
+		if strings.Contains(e, "mysql.system-all") {
+			hasSystemAll = true
+		}
+	}
+	if !hasRoutine {
+		t.Fatalf("expected routine artifact in manifest schema phase, got schema=%v", m.Schema)
+	}
+	if !hasSystemAll {
+		t.Fatalf("expected mysql.system-all in manifest schema phase, got schema=%v", m.Schema)
+	}
+}


### PR DESCRIPTION
Splitdump restore could fail when child table schemas were restored before parent tables (alphabetical ordering reintroduced an old FK ordering bug).

This change:
- Adds a manifest file to splitdump backups that records emission order
- Uses manifest order directly during restore when present and valid
- Falls back to FK dependency analysis for old backups without manifest (parent tables are restored before child tables)
- Adds transparent retry on bufio.ErrTooLong via semicolon-delimited statement parsing for oversized DDL files
- Keeps existing mysql.proc overlap pruning intact

Includes regression tests for manifest emission, manifest restore ordering, FK-based ordering, and oversized plain/gzip DDL retry.