### PR TITLE
fix: change RelayLogSpace from sql.NullInt64 to sql.Null[uint64]

### DIFF
--- a/utils/dbhelper/replication_test.go
+++ b/utils/dbhelper/replication_test.go
@@ -8,6 +8,7 @@
 package dbhelper
 
 import (
+	"math"
 	"strings"
 	"testing"
 )
@@ -578,6 +579,99 @@ func TestSkipBinlogEvent_CommandGeneration(t *testing.T) {
 
 			if !strings.Contains(cmd, tt.wantCmd) {
 				t.Errorf("Generated command %q doesn't contain expected %q", cmd, tt.wantCmd)
+			}
+		})
+	}
+}
+
+func TestRelayLogSpaceNullUint64Scan(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     any
+		wantVal   uint64
+		wantValid bool
+		wantErr   bool
+	}{
+		{
+			name:      "NULL",
+			input:     nil,
+			wantVal:   0,
+			wantValid: false,
+		},
+		{
+			name:      "normal uint64",
+			input:     uint64(42),
+			wantVal:   42,
+			wantValid: true,
+		},
+		{
+			name:      "huge uint64 exceeding MaxInt64",
+			input:     uint64(math.MaxUint64),
+			wantVal:   math.MaxUint64,
+			wantValid: true,
+		},
+		{
+			name:      "positive int64",
+			input:     int64(100),
+			wantVal:   100,
+			wantValid: true,
+		},
+		{
+			name:    "negative int64 rejected",
+			input:   int64(-1),
+			wantErr: true,
+		},
+		// []byte and string are the shapes many DB drivers send for TEXT/BIGINT columns.
+		{
+			name:      "byte slice numeric",
+			input:     []byte("9999999999999999999"),
+			wantVal:   9999999999999999999,
+			wantValid: true,
+		},
+		{
+			name:      "string max uint64",
+			input:     "18446744073709551615",
+			wantVal:   math.MaxUint64,
+			wantValid: true,
+		},
+		{
+			name:      "zero value explicit (Valid=true)",
+			input:     uint64(0),
+			wantVal:   0,
+			wantValid: true,
+		},
+		// Values that exceed uint64 max must be rejected at parse time.
+		{
+			name:    "byte slice overflow",
+			input:   []byte("18446744073709551616"),
+			wantErr: true,
+		},
+		{
+			name:    "string non-numeric",
+			input:   "abc",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rs ReplicaStatus
+			err := rs.RelayLogSpace.Scan(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Scan(%v) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Scan(%v) unexpected error: %v", tt.input, err)
+				return
+			}
+			if rs.RelayLogSpace.Valid != tt.wantValid {
+				t.Errorf("Scan(%v) Valid = %v, want %v", tt.input, rs.RelayLogSpace.Valid, tt.wantValid)
+			}
+			if rs.RelayLogSpace.V != tt.wantVal {
+				t.Errorf("Scan(%v) V = %v, want %v", tt.input, rs.RelayLogSpace.V, tt.wantVal)
 			}
 		})
 	}

--- a/utils/dbhelper/types.go
+++ b/utils/dbhelper/types.go
@@ -621,7 +621,10 @@ type ReplicaStatus struct {
 	LastError                      sql.NullString `db:"Last_Error" json:"lastError"`
 	SkipCounter                    sql.NullInt64  `db:"Skip_Counter" json:"skipCounter"`
 	ExecSourceLogPos               sql.NullString `db:"Exec_Source_Log_Pos" json:"execSourceLogPos"`
-	RelayLogSpace                  sql.NullInt64  `db:"Relay_Log_Space" json:"relayLogSpace"`
+	// RelayLogSpace uses sql.Null[uint64] (not sql.NullInt64) because Percona/MySQL 8.4 can
+	// return values exceeding int64 max, causing a scan overflow. JSON encoding changes from
+	// {"Int64":…,"Valid":…} (sql.NullInt64) to {"V":…,"Valid":…} (sql.Null[uint64]).
+	RelayLogSpace sql.Null[uint64] `db:"Relay_Log_Space" json:"relayLogSpace"`
 	UntilCondition                 sql.NullString `db:"Until_Condition" json:"untilCondition"`
 	UntilLogFile                   sql.NullString `db:"Until_Log_File" json:"untilLogFile"`
 	UntilLogPos                    sql.NullString `db:"Until_Log_Pos" json:"untilLogPos"`


### PR DESCRIPTION
Percona/MySQL 8.4 can return Relay_Log_Space as a large uint64 that exceeds int64 range, causing SHOW REPLICA STATUS parsing to fail with:
  sql: Scan error on column index 22, name \"Relay_Log_Space\":
  converting driver.Value type uint64 to a int64: value out of range

This scan failure causes the replica to disappear from topology detection, leading to cascading failures:
- slave seen as StandAlone
- no failover candidates available
- automatic failover can create split-brain

The fix changes the field type to sql.Null[uint64] which safely handles large unsigned values and preserves NULL semantics.

Also adds comprehensive tests covering:
- NULL, uint64, int64, MaxUint64, negative rejection
- []byte and string numeric inputs
- overflow and non-numeric rejection