### PR TITLE
fix: unlock restic repo at startup to clear stale locks

### DIFF
--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -541,13 +541,13 @@ func (cluster *Cluster) StartResticManager() error {
 	resticManager.AllowUnsafeMount = cluster.Conf.BackupResticAllowUnsafeMount
 	resticManager.MountRecoveryEnabled = cluster.Conf.BackupResticMountRecoveryEnabled
 	resticManager.AutoDetectAndDisableMount()
-	resticManager.AddUnlockTask() // Unlock repo on startup to prevent stale locks (e.g. after crash). No need to add wait since it will be checked each monitor loop.
 	cluster.ResticManager = resticManager
 	cluster.ReloadResticEnv()
 	if cluster.ResticManager.RecoverMountStateOnStartup() {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlInfo, "Recovered restic mount state on startup")
 	}
 	go cluster.ResticFetchRepo()
+	resticManager.AddUnlockTask() // Unlock repo on startup to prevent stale locks (e.g. after crash). No need to add wait since it will be checked each monitor loop.
 	return nil
 }
 

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -546,8 +546,8 @@ func (cluster *Cluster) StartResticManager() error {
 	if cluster.ResticManager.RecoverMountStateOnStartup() {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlInfo, "Recovered restic mount state on startup")
 	}
+	resticManager.AddUnlockTask() // Queue unlock first to avoid fetch-before-unlock race on startup.
 	go cluster.ResticFetchRepo()
-	resticManager.AddUnlockTask() // Unlock repo on startup to prevent stale locks (e.g. after crash). No need to add wait since it will be checked each monitor loop.
 	return nil
 }
 

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -541,6 +541,7 @@ func (cluster *Cluster) StartResticManager() error {
 	resticManager.AllowUnsafeMount = cluster.Conf.BackupResticAllowUnsafeMount
 	resticManager.MountRecoveryEnabled = cluster.Conf.BackupResticMountRecoveryEnabled
 	resticManager.AutoDetectAndDisableMount()
+	resticManager.AddUnlockTask() // Unlock repo on startup to prevent stale locks (e.g. after crash). No need to add wait since it will be checked each monitor loop.
 	cluster.ResticManager = resticManager
 	cluster.ReloadResticEnv()
 	if cluster.ResticManager.RecoverMountStateOnStartup() {

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -4155,10 +4155,8 @@ func (repo *ResticManager) CheckResticLocks() error {
 
 // ResticUnlockRepo unlocks the repository
 func (repo *ResticManager) UnlockRepo() error {
-
-	if !repo.GetCanFetch() {
+	for !repo.GetCanFetch() {
 		time.Sleep(time.Second)
-		return repo.UnlockRepo()
 	}
 
 	repo.SetCanFetch(false)
@@ -4174,7 +4172,8 @@ func (repo *ResticManager) UnlockRepo() error {
 		return fmt.Errorf("failed to check repo locks: %v, stderr: %s", err, stderr)
 	}
 
-	if !strings.Contains(string(stdout), "successfully removed locks") {
+	output := string(stdout) + "\n" + string(stderr)
+	if !strings.Contains(output, "successfully removed") && !strings.Contains(output, "no locks were found") {
 		return fmt.Errorf("failed to unlock repo: %s. stderr: %s", stdout, stderr)
 	}
 

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -655,6 +655,21 @@ func (repo *ResticManager) GetCanFetch() bool {
 	return repo.CanFetch
 }
 
+// waitCanFetch waits until fetch lock is available or times out.
+func (repo *ResticManager) waitCanFetch() error {
+	timeout := repo.GetOperationTimeout()
+	deadline := time.Now().Add(timeout)
+
+	for !repo.GetCanFetch() {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for restic fetch lock after %v", timeout)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return nil
+}
+
 // SetPermissions sets the permission modes for restic operations
 // dirMode: Directory permission mode (e.g., 0700 for owner-only)
 // fileMode: File permission mode (e.g., 0600 for owner-only)
@@ -4155,8 +4170,8 @@ func (repo *ResticManager) CheckResticLocks() error {
 
 // ResticUnlockRepo unlocks the repository
 func (repo *ResticManager) UnlockRepo() error {
-	for !repo.GetCanFetch() {
-		time.Sleep(time.Second)
+	if err := repo.waitCanFetch(); err != nil {
+		return err
 	}
 
 	repo.SetCanFetch(false)

--- a/utils/backupmgr/restic_test.go
+++ b/utils/backupmgr/restic_test.go
@@ -809,9 +809,6 @@ func TestCheckResticLocksAndUnlock(t *testing.T) {
 
 	err := repo.UnlockRepo()
 	if err != nil {
-		if strings.Contains(err.Error(), "no locks") {
-			t.Skip("restic unlock reports no locks")
-		}
 		t.Fatalf("unlock repo: %v", err)
 	}
 }

--- a/utils/backupmgr/restic_test.go
+++ b/utils/backupmgr/restic_test.go
@@ -813,6 +813,24 @@ func TestCheckResticLocksAndUnlock(t *testing.T) {
 	}
 }
 
+func TestUnlockRepoTimeoutWhenCanFetchBlocked(t *testing.T) {
+	repo := newPausedRepo(t)
+	repo.SetOperationTimeout(500 * time.Millisecond)
+	repo.SetCanFetch(false)
+
+	start := time.Now()
+	err := repo.UnlockRepo()
+	if err == nil {
+		t.Fatalf("expected timeout error when CanFetch remains false")
+	}
+	if !strings.Contains(err.Error(), "timeout waiting for restic fetch lock") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if time.Since(start) > 2*time.Second {
+		t.Fatalf("unlock timeout took too long: %v", time.Since(start))
+	}
+}
+
 func TestKeyManagementAndPassword(t *testing.T) {
 	repo, _, _, _ := newResticRepo(t, false)
 


### PR DESCRIPTION
The change proactively clears stale Restic locks on startup (e.g., after crashes), which is a reliability bugfix.