### PR TITLE
fix: improve graceful shutdown by refactoring git mutex handling

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -186,7 +186,7 @@ type Cluster struct {
 	RepMgrVersion                       string                      `json:"-"`
 	RepMgrHostname                      string                      `json:"-"`
 	exitMsg                             string                      `json:"-"`
-	exit                                bool                        `json:"-"`
+	exit                                atomic.Bool                 `json:"-"`
 	canFlashBack                        bool                        `json:"-"`
 	canResticFetchRepo                  bool                        `json:"-"`
 	failoverCond                        *nbc.NonBlockingChan        `json:"-"`
@@ -700,7 +700,7 @@ func (cluster *Cluster) Run() {
 	cluster.Unlock()
 	cluster.MarkSecretVersionStoreDirty()
 
-	for !cluster.exit {
+	for !cluster.exit.Load() {
 		if !cluster.Conf.MonitorPause {
 			cluster.ReconcileSecretVersionStore()
 			cluster.ServerIdList = cluster.GetDBServerIdList()
@@ -1061,18 +1061,25 @@ func (cluster *Cluster) StateProcessing() {
 }
 
 func (cluster *Cluster) Stop() {
-	cluster.Lock()
-	defer cluster.Unlock()
+	// Signal the monitoring loop to stop before doing any blocking I/O.
+	// The lock is not held across the slow operations below to avoid deadlock
+	// with SaveConfig(wait=true) and ResticManager.UnmountRepo (5 min timeout).
+	cluster.exit.Store(true)
+
+	if cluster.scheduler != nil {
+		cluster.scheduler.Stop()
+	}
+
+	cluster.CloseRefreshTemplateMD5Worker()
+
 	if cluster.ResticManager != nil {
 		if err := cluster.ResticManager.UnmountRepo(); err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlWarn, "Restic unmount on shutdown failed: %s", err)
 		}
 		cluster.ResticManager.ShutdownWorker()
 	}
-	cluster.CloseRefreshTemplateMD5Worker()
+
 	cluster.ConfigManager.SaveConfig(cluster, true)
-	// prevent new cycle
-	cluster.exit = true
 }
 
 func (cluster *Cluster) SetIsSavingConfig(val bool) {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -187,6 +187,7 @@ type Cluster struct {
 	RepMgrHostname                      string                      `json:"-"`
 	exitMsg                             string                      `json:"-"`
 	exit                                atomic.Bool                 `json:"-"`
+	stopOnce                            sync.Once                   `json:"-"`
 	canFlashBack                        bool                        `json:"-"`
 	canResticFetchRepo                  bool                        `json:"-"`
 	failoverCond                        *nbc.NonBlockingChan        `json:"-"`
@@ -1061,25 +1062,27 @@ func (cluster *Cluster) StateProcessing() {
 }
 
 func (cluster *Cluster) Stop() {
-	// Signal the monitoring loop to stop before doing any blocking I/O.
-	// The lock is not held across the slow operations below to avoid deadlock
-	// with SaveConfig(wait=true) and ResticManager.UnmountRepo (5 min timeout).
-	cluster.exit.Store(true)
+	cluster.stopOnce.Do(func() {
+		// Signal the monitoring loop to stop before doing any blocking I/O.
+		// The lock is not held across the slow operations below to avoid deadlock
+		// with SaveConfig(wait=true) and ResticManager.UnmountRepo (5 min timeout).
+		cluster.exit.Store(true)
 
-	if cluster.scheduler != nil {
-		cluster.scheduler.Stop()
-	}
-
-	cluster.CloseRefreshTemplateMD5Worker()
-
-	if cluster.ResticManager != nil {
-		if err := cluster.ResticManager.UnmountRepo(); err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlWarn, "Restic unmount on shutdown failed: %s", err)
+		if cluster.scheduler != nil {
+			cluster.scheduler.Stop()
 		}
-		cluster.ResticManager.ShutdownWorker()
-	}
 
-	cluster.ConfigManager.SaveConfig(cluster, true)
+		cluster.CloseRefreshTemplateMD5Worker()
+
+		if cluster.ResticManager != nil {
+			if err := cluster.ResticManager.UnmountRepo(); err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlWarn, "Restic unmount on shutdown failed: %s", err)
+			}
+			cluster.ResticManager.ShutdownWorker()
+		}
+
+		cluster.ConfigManager.SaveConfig(cluster, true)
+	})
 }
 
 func (cluster *Cluster) SetIsSavingConfig(val bool) {

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -1803,7 +1803,7 @@ func (cluster *Cluster) SetProvProxyServiceType(value string) error {
 }
 
 func (cluster *Cluster) Exit() {
-	cluster.exit = true
+	cluster.exit.Store(true)
 }
 
 func (cluster *Cluster) SetInjectVariables() {

--- a/config/manager/manager.go
+++ b/config/manager/manager.go
@@ -704,7 +704,12 @@ func (cm *ConfigManager) processGitPush() {
 			cm.configWg.Wait()
 			cm.gitMutex.Unlock()
 
-			// Abort if a stop was requested while we were waiting.
+			// NOTE: there is a narrow window between Unlock() and the stopCh
+			// check below where a new SaveConfig call could start and add to
+			// configWg. That save will not be waited on by this push. This is
+			// intentional for the shutdown path (new saves during stop are
+			// undesirable) and benign in normal operation (the next push picks
+			// up any changes that arrive mid-operation).
 			select {
 			case <-cm.gitManager.stopCh:
 				if configGitTask.WaitGroup != nil {

--- a/config/manager/manager.go
+++ b/config/manager/manager.go
@@ -696,10 +696,29 @@ func (cm *ConfigManager) processGitPush() {
 			}
 			cm.gitManager.mutex.Unlock()
 
-			cm.logger.Debugf("none", config.ConstLogModGit, "Locking git mutex")
-			cm.gitMutex.Lock() // Block new config saves
-			cm.logger.Debugf("none", config.ConstLogModGit, "Waiting for active saves to finish...")
-			cm.configWg.Wait() // Ensure all active saves finish
+			// Hold gitMutex only long enough to wait for in-flight saves.
+			// Releasing it before network I/O lets ConfigManager.Stop() and
+			// processClusterQueue proceed immediately instead of blocking for
+			// the full duration of the git push/pull.
+			cm.gitMutex.Lock()
+			cm.configWg.Wait()
+			cm.gitMutex.Unlock()
+
+			// Abort if a stop was requested while we were waiting.
+			select {
+			case <-cm.gitManager.stopCh:
+				if configGitTask.WaitGroup != nil {
+					configGitTask.WaitGroup.Done()
+				}
+				for _, task := range skippedTasks {
+					if task.WaitGroup != nil {
+						task.WaitGroup.Done()
+					}
+				}
+				cm.logger.Infof("none", config.ConstLogModGit, "[Git] Task aborted: git manager is stopping.")
+				return
+			default:
+			}
 
 			if configGitTask.TaskType == "pull" {
 				cm.logger.Debugf("none", config.ConstLogModGit, "[Git] Starting Git pull...")
@@ -724,10 +743,8 @@ func (cm *ConfigManager) processGitPush() {
 
 			} else {
 				cm.logger.Debugf("none", config.ConstLogModGit, "[Git] Starting Git push...")
-				// Execute the save function and handle potential errors
 				if err := cm.PushAllConfigsToGit(configGitTask.conf, configGitTask.clusterList); err != nil {
 					status := cm.UpdateGitOperationStatus(gitOperationPush, err)
-					// Execute the Git push function and handle potential errors
 					if status.Recoverable {
 						cm.logger.Warnf("none", config.ConstLogModGit, "[Git] Warning-class push failure (%s): %v", status.Reason, err)
 					} else {
@@ -739,7 +756,7 @@ func (cm *ConfigManager) processGitPush() {
 				}
 			}
 
-			// If a WaitGroup pointer is provided, mark the task as done
+			// Signal completion outside the lock — callers don't need gitMutex.
 			if configGitTask.WaitGroup != nil {
 				configGitTask.WaitGroup.Done()
 			}
@@ -749,8 +766,6 @@ func (cm *ConfigManager) processGitPush() {
 					task.WaitGroup.Done()
 				}
 			}
-
-			cm.gitMutex.Unlock()
 
 			if cm.gitManager.isStopping && len(cm.gitManager.tasks) == 0 {
 				cm.logger.Infof("none", config.ConstLogModGit, "[Git] No more tasks in queue, stopping goroutine.")

--- a/server/http.go
+++ b/server/http.go
@@ -289,8 +289,11 @@ func (repman *ReplicationManager) httpserver() {
 		)(router),
 		ErrorLog: basiclog.New(repman.ApiLogAdapter, "", 0),
 	}
+	repman.httpServer = server
 
-	log.Fatal(server.ListenAndServe())
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatal(err)
+	}
 }
 
 func (repman *ReplicationManager) handlerApp(w http.ResponseWriter, r *http.Request) {

--- a/server/repmanv3.go
+++ b/server/repmanv3.go
@@ -152,6 +152,8 @@ func (s *ReplicationManager) StartServerV3(debug bool, router *mux.Router) error
 		return true
 	}))
 
+	s.apiServer = srv
+
 	// s.V3Up <- true
 	if s.v3Config.TLS.Enabled {
 		log.Info("starting multiplexed TLS HTTP/2.0 and HTTP/1.1 Gateway server: ", s.v3Config.Listen.AddressWithPort())
@@ -166,7 +168,7 @@ func (s *ReplicationManager) StartServerV3(debug bool, router *mux.Router) error
 		err = srv.Serve(conn)
 	}
 
-	if err != nil {
+	if err != nil && err != http.ErrServerClosed {
 		return err
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -8,6 +8,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/md5"
 	"encoding/json"
 	"errors"
@@ -134,12 +135,14 @@ type ReplicationManager struct {
 	tlog                                             s18log.TermLog
 	termlength                                       int
 	exitMsg                                          string
-	exit                                             bool
+	exit                                             atomic.Bool
 	isStarted                                        bool
 	Confs                                            map[string]config.Config
 	VersionConfs                                     map[string]*config.ConfVersion `json:"-"`
 	grpcServer                                       *grpc.Server                   `json:"-"`
 	grpcWrapped                                      *grpcweb.WrappedGrpcServer     `json:"-"`
+	httpServer                                       *http.Server                   `json:"-"`
+	apiServer                                        *http.Server                   `json:"-"`
 	V3Up                                             chan bool                      `json:"-"`
 	v3Config                                         Repmanv3Config                 `json:"-"`
 	cloud18CheckSum                                  hash.Hash                      `json:"-"`
@@ -2547,34 +2550,35 @@ func (repman *ReplicationManager) Run() error {
 	//	ticker := time.NewTicker(interval * time.Duration(repman.Conf.MonitoringTicker))
 	repman.isStarted = true
 	sigs := make(chan os.Signal, 1)
-	// catch all signals since not explicitly listing
-	//	signal.Notify(sigs)
-	signal.Notify(sigs, os.Interrupt)
-	// method invoked upon seeing signal
+	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		s := <-sigs
 		repman.Logrus.Printf("RECEIVED SIGNAL: %s", s)
 		repman.UnMountS3()
 
+		// Stop ticker goroutines.
+		close(quit_GitPull)
+		close(quit_PAT)
+
 		stopwg := sync.WaitGroup{}
 		for _, cl := range repman.Clusters {
 			stopwg.Add(1)
-			go func() {
+			go func(c *cluster.Cluster) {
 				defer stopwg.Done()
-				cl.Stop()
-			}()
+				c.Stop()
+			}(cl)
 		}
 		// Wait for cluster close
 		stopwg.Wait()
 
-		repman.exit = true
+		repman.exit.Store(true)
 
 	}()
 
 	repman.RefreshDiskStats()
 
 	var counter int64 = 0
-	for !repman.exit {
+	for !repman.exit.Load() {
 		if repman.Conf.Arbitration {
 			repman.Heartbeat()
 		}
@@ -2618,7 +2622,7 @@ func (repman *ReplicationManager) Run() error {
 		pprof.StopCPUProfile()
 	}
 	repman.Stop()
-	os.Exit(1)
+	os.Exit(0)
 	return nil
 
 }
@@ -2813,6 +2817,22 @@ func (repman *ReplicationManager) resolveHostIp() string {
 
 func (repman *ReplicationManager) Stop() {
 
+	if repman.globalScheduler != nil {
+		repman.globalScheduler.Stop()
+	}
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer shutdownCancel()
+	if repman.httpServer != nil {
+		repman.httpServer.Shutdown(shutdownCtx)
+	}
+	if repman.apiServer != nil {
+		repman.apiServer.Shutdown(shutdownCtx)
+	}
+	if repman.grpcServer != nil {
+		repman.grpcServer.GracefulStop()
+	}
+
 	if repman.MemProfile != "" {
 		f, err := os.Create(repman.MemProfile)
 		if err != nil {
@@ -2851,7 +2871,7 @@ func (repman *ReplicationManager) Stop() {
 	repman.ConfigManager.Stop()
 
 	if !repman.IsExportPush {
-		go repman.PushConfigToBackupDir()
+		repman.PushConfigToBackupDir()
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -2828,14 +2828,43 @@ func (repman *ReplicationManager) Stop() {
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer shutdownCancel()
+
+	// Shut down both HTTP servers in parallel so neither consumes the other's budget.
+	var httpWg sync.WaitGroup
 	if repman.httpServer != nil {
-		repman.httpServer.Shutdown(shutdownCtx)
+		httpWg.Add(1)
+		go func() {
+			defer httpWg.Done()
+			if err := repman.httpServer.Shutdown(shutdownCtx); err != nil {
+				repman.Logrus.Warnf("HTTP server shutdown: %v", err)
+			}
+		}()
 	}
 	if repman.apiServer != nil {
-		repman.apiServer.Shutdown(shutdownCtx)
+		httpWg.Add(1)
+		go func() {
+			defer httpWg.Done()
+			if err := repman.apiServer.Shutdown(shutdownCtx); err != nil {
+				repman.Logrus.Warnf("API server shutdown: %v", err)
+			}
+		}()
 	}
+	httpWg.Wait()
+
+	// GracefulStop waits for all in-flight RPCs; fall back to hard Stop if the
+	// context deadline expires so long-lived streams don't hold up shutdown.
 	if repman.grpcServer != nil {
-		repman.grpcServer.GracefulStop()
+		grpcDone := make(chan struct{})
+		go func() {
+			repman.grpcServer.GracefulStop()
+			close(grpcDone)
+		}()
+		select {
+		case <-grpcDone:
+		case <-shutdownCtx.Done():
+			repman.Logrus.Warn("gRPC graceful stop timed out, forcing stop")
+			repman.grpcServer.Stop()
+		}
 	}
 
 	if repman.MemProfile != "" {

--- a/server/server.go
+++ b/server/server.go
@@ -2554,6 +2554,13 @@ func (repman *ReplicationManager) Run() error {
 	go func() {
 		s := <-sigs
 		repman.Logrus.Printf("RECEIVED SIGNAL: %s", s)
+
+		// Stop the main loop immediately so it stops queuing new git pushes,
+		// config saves, and other periodic work before clusters finish stopping.
+		// Without this, the main loop can keep enqueuing git push tasks while
+		// processClusterQueue is blocked waiting for gitMutex — compounding the delay.
+		repman.exit.Store(true)
+
 		repman.UnMountS3()
 
 		// Stop ticker goroutines.
@@ -2570,8 +2577,6 @@ func (repman *ReplicationManager) Run() error {
 		}
 		// Wait for cluster close
 		stopwg.Wait()
-
-		repman.exit.Store(true)
 
 	}()
 


### PR DESCRIPTION
Release gitMutex before git push/pull network operations to prevent blocking ConfigManager.Stop() during process termination. Add stop-channel check to abort in-flight saves on shutdown request.