### PR TITLE
OpenSVC v3 provisioning and fix optimizer_switch boot compatibility

### DIFF
--- a/cluster/cluster_acl.go
+++ b/cluster/cluster_acl.go
@@ -411,6 +411,24 @@ func (cluster *Cluster) IsURLPassACL(strUser string, URL string, errorPrint bool
 }
 
 func (cluster *Cluster) IsURLPassAppsACL(strUser string, URL string) bool {
+	// App settings actions must only be evaluated against app settings rules.
+	// This prevents fallback from /settings/actions/* to generic /actions/* rules.
+	if strings.Contains(URL, "/settings/actions/") {
+		settingsRules := make([]ACLRule, 0)
+		for _, rule := range appACLRules {
+			if strings.Contains(rule.URLPattern, "/settings/actions/") {
+				settingsRules = append(settingsRules, rule)
+			}
+		}
+
+		if cluster.matchACLRules(strUser, URL, settingsRules) {
+			return true
+		}
+
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "ACL app settings check failed for user %s : %s", strUser, URL)
+		return false
+	}
+
 	// Check against rule-based ACL system with improved logging
 	if cluster.matchACLRules(strUser, URL, appACLRules) {
 		return true

--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -29,6 +29,8 @@ var databaseACLRules = []ACLRule{
 	{"/actions/unprovision", nil, []string{config.GrantProvDBUnprovision}},
 	{"/actions/start", nil, []string{config.GrantDBStart}},
 	{"/actions/stop", nil, []string{config.GrantDBStop}},
+	{"/actions/abort", nil, []string{config.GrantDBStop}},
+	{"/actions/clear", nil, []string{config.GrantDBStart}},
 	{"/actions/switchover", nil, []string{config.GrantClusterSwitchover}},
 	{"/actions/set-prefered", nil, []string{config.GrantClusterFailover}},
 	{"/actions/set-unrated", nil, []string{config.GrantClusterFailover}},
@@ -102,6 +104,8 @@ var proxyACLRules = []ACLRule{
 	{"/actions/unprovision", nil, []string{config.GrantProvProxyUnprovision}},
 	{"/actions/start", nil, []string{config.GrantProxyStart}},
 	{"/actions/stop", nil, []string{config.GrantProxyStop}},
+	{"/actions/abort", nil, []string{config.GrantProxyStop}},
+	{"/actions/clear", nil, []string{config.GrantProxyStart}},
 	{"/actions/staging", nil, []string{config.GrantClusterStaging}},
 }
 
@@ -119,6 +123,8 @@ var appACLRules = []ACLRule{
 	{"/settings/actions/save-to-template", nil, []string{config.GrantAppDeployment}},
 	{"/actions/start", nil, []string{config.GrantAppStart}},
 	{"/actions/stop", nil, []string{config.GrantAppStop}},
+	{"/actions/abort", nil, []string{config.GrantAppStop}},
+	{"/actions/clear", nil, []string{config.GrantAppStart}},
 	{"/actions/restart", []string{config.GrantAppStop, config.GrantAppStart}, nil},
 	{"/settings/actions/", nil, []string{config.GrantAppConfig}},
 	{"/git/", nil, []string{config.GrantAppGit}},

--- a/cluster/cluster_acl_test.go
+++ b/cluster/cluster_acl_test.go
@@ -217,6 +217,30 @@ func TestDatabaseStartStopSingleGrant(t *testing.T) {
 			url:      "/api/clusters/testcluster/servers/db1/actions/start",
 			expected: false,
 		},
+		{
+			name:     "User with GrantDBStop can abort",
+			user:     "user_stop_only",
+			url:      "/api/clusters/testcluster/servers/db1/actions/abort",
+			expected: true,
+		},
+		{
+			name:     "User with only GrantDBStart cannot abort",
+			user:     "user_start_only",
+			url:      "/api/clusters/testcluster/servers/db1/actions/abort",
+			expected: false,
+		},
+		{
+			name:     "User with GrantDBStart can clear",
+			user:     "user_start_only",
+			url:      "/api/clusters/testcluster/servers/db1/actions/clear",
+			expected: true,
+		},
+		{
+			name:     "User with only GrantDBStop cannot clear",
+			user:     "user_stop_only",
+			url:      "/api/clusters/testcluster/servers/db1/actions/clear",
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -416,6 +440,30 @@ func TestProxyACL(t *testing.T) {
 			url:      "/api/clusters/testcluster/proxies/proxy1/actions/start",
 			expected: false,
 		},
+		{
+			name:     "User with GrantProxyStop can abort proxy",
+			user:     "user_proxy",
+			url:      "/api/clusters/testcluster/proxies/proxy1/actions/abort",
+			expected: true,
+		},
+		{
+			name:     "User with GrantProxyStart can clear proxy",
+			user:     "user_proxy",
+			url:      "/api/clusters/testcluster/proxies/proxy1/actions/clear",
+			expected: true,
+		},
+		{
+			name:     "User without proxy grants cannot abort proxy",
+			user:     "user_start_only",
+			url:      "/api/clusters/testcluster/proxies/proxy1/actions/abort",
+			expected: false,
+		},
+		{
+			name:     "User without proxy grants cannot clear proxy",
+			user:     "user_start_only",
+			url:      "/api/clusters/testcluster/proxies/proxy1/actions/clear",
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -456,6 +504,30 @@ func TestAppACL(t *testing.T) {
 			url:      "/api/clusters/testcluster/apps/app1/actions/start",
 			expected: false,
 		},
+		{
+			name:     "User with GrantAppStop can abort app",
+			user:     "user_app",
+			url:      "/api/clusters/testcluster/apps/app1/actions/abort",
+			expected: true,
+		},
+		{
+			name:     "User with GrantAppStart can clear app",
+			user:     "user_app",
+			url:      "/api/clusters/testcluster/apps/app1/actions/clear",
+			expected: true,
+		},
+		{
+			name:     "User without app grants cannot abort app",
+			user:     "user_start_only",
+			url:      "/api/clusters/testcluster/apps/app1/actions/abort",
+			expected: false,
+		},
+		{
+			name:     "User without app grants cannot clear app",
+			user:     "user_start_only",
+			url:      "/api/clusters/testcluster/apps/app1/actions/clear",
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -463,6 +535,45 @@ func TestAppACL(t *testing.T) {
 			result := cluster.IsURLPassAppsACL(tt.user, tt.url)
 			if result != tt.expected {
 				t.Errorf("Expected %v for user %s on %s, got %v", tt.expected, tt.user, tt.url, result)
+			}
+		})
+	}
+}
+
+func TestAppSettingsClearDoesNotFallbackToActionClear(t *testing.T) {
+	cluster := setupACLTestCluster()
+
+	cluster.APIUsers["user_app_config"] = APIUser{
+		User: "user_app_config",
+		Grants: map[string]bool{
+			config.GrantAppConfig: true,
+		},
+	}
+
+	url := "/api/clusters/testcluster/apps/app1/settings/actions/clear/setting"
+
+	tests := []struct {
+		name     string
+		user     string
+		expected bool
+	}{
+		{
+			name:     "User with app start/stop cannot clear settings",
+			user:     "user_app",
+			expected: false,
+		},
+		{
+			name:     "User with app config can clear settings",
+			user:     "user_app_config",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := cluster.IsURLPassAppsACL(tt.user, url)
+			if result != tt.expected {
+				t.Errorf("Expected %v for user %s on %s, got %v", tt.expected, tt.user, url, result)
 			}
 		})
 	}
@@ -1003,7 +1114,7 @@ func TestIsURLPassACLComprehensiveCoverage(t *testing.T) {
 		// Maintenance
 		{"Maintenance", "/api/clusters/test/actions/checksum-all-tables", true},
 		{"Maintenance", "/api/clusters/test/actions/analyze-all-tables", true},
-		{"Maintenance", "/api/clusters/test/actions/repair-all-tables", true},
+		{"Maintenance", "/api/clusters/test/actions/checksum-repair-all-tables", true},
 	}
 
 	for _, tt := range tests {

--- a/cluster/prov.go
+++ b/cluster/prov.go
@@ -90,6 +90,7 @@ func (cluster *Cluster) ProvisionServices() error {
 	for _, server := range cluster.Servers {
 		hasConfigPath[server.HostCnf] = server.HasConfigPathCookie()
 		server.DelConfigPathCookie() // remove the config path cookie since we are going to provision it
+		server.WipeDeltaConfig()
 		switch cluster.GetOrchestrator() {
 		case config.ConstOrchestratorOpenSVC:
 			go cluster.OpenSVCProvisionDatabaseService(server)
@@ -170,6 +171,7 @@ func (cluster *Cluster) ProvisionServices() error {
 
 func (cluster *Cluster) InitDatabaseService(server *ServerMonitor) error {
 	cluster.StateMachine.SetFailoverState()
+	server.WipeDeltaConfig()
 	switch cluster.GetOrchestrator() {
 	case config.ConstOrchestratorOpenSVC:
 		go cluster.OpenSVCProvisionDatabaseService(server)

--- a/cluster/prov_opensvc.go
+++ b/cluster/prov_opensvc.go
@@ -224,9 +224,10 @@ func (cluster *Cluster) openSVCCreateMapsV2(svc opensvc.Collector, agent string)
 
 func (cluster *Cluster) openSVCCreateMapsV3(svc opensvc.Collector, agent string) error {
 	var allErr error
+	var se *opensvc.StatusError
 
 	err := svc.CreateSecret(cluster.Name, "env", agent)
-	if err != nil && !errors.Is(err, opensvc.ErrObjectAlreadyExists) && !errors.Is(err, opensvc.ErrObjectConflict) {
+	if err != nil && !errors.Is(err, opensvc.ErrObjectAlreadyExists) && !errors.As(err, &se) && se.StatusCode != 409 {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create secret: %s ", err)
 		return err
 	}
@@ -253,7 +254,7 @@ func (cluster *Cluster) openSVCCreateMapsV3(svc opensvc.Collector, agent string)
 	}
 
 	err = svc.CreateConfig(cluster.Name, "env", agent)
-	if err != nil && !errors.Is(err, opensvc.ErrObjectAlreadyExists) && !errors.Is(err, opensvc.ErrObjectConflict) {
+	if err != nil && !errors.Is(err, opensvc.ErrObjectAlreadyExists) && !errors.As(err, &se) && se.StatusCode != 409 {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create config: %s ", err)
 		allErr = errors.Join(allErr, fmt.Errorf("create config env: %w", err))
 	}

--- a/cluster/prov_opensvc.go
+++ b/cluster/prov_opensvc.go
@@ -224,10 +224,20 @@ func (cluster *Cluster) openSVCCreateMapsV2(svc opensvc.Collector, agent string)
 
 func (cluster *Cluster) openSVCCreateMapsV3(svc opensvc.Collector, agent string) error {
 	var allErr error
-	var se *opensvc.StatusError
+	isAlreadyExists := func(err error) bool {
+		if err == nil {
+			return false
+		}
+		if errors.Is(err, opensvc.ErrObjectAlreadyExists) {
+			return true
+		}
+
+		var se *opensvc.StatusError
+		return errors.As(err, &se) && se != nil && se.StatusCode == 409
+	}
 
 	err := svc.CreateSecret(cluster.Name, "env", agent)
-	if err != nil && !errors.Is(err, opensvc.ErrObjectAlreadyExists) && !errors.As(err, &se) && se.StatusCode != 409 {
+	if err != nil && !isAlreadyExists(err) {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create secret: %s ", err)
 		return err
 	}
@@ -254,7 +264,7 @@ func (cluster *Cluster) openSVCCreateMapsV3(svc opensvc.Collector, agent string)
 	}
 
 	err = svc.CreateConfig(cluster.Name, "env", agent)
-	if err != nil && !errors.Is(err, opensvc.ErrObjectAlreadyExists) && !errors.As(err, &se) && se.StatusCode != 409 {
+	if err != nil && !isAlreadyExists(err) {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create config: %s ", err)
 		allErr = errors.Join(allErr, fmt.Errorf("create config env: %w", err))
 	}

--- a/cluster/prov_opensvc.go
+++ b/cluster/prov_opensvc.go
@@ -20,6 +20,11 @@ import (
 
 var dockerMinusRm bool
 
+var (
+	ErrOpenSVCAbortNotSupported = errors.New("abort not supported for this OpenSVC API version")
+	ErrOpenSVCClearNotSupported = errors.New("clear not supported for this OpenSVC API version")
+)
+
 func (cluster *Cluster) OpenSVCConnect() opensvc.Collector {
 	var svc opensvc.Collector
 	svc.ClusterConf = cluster.Conf

--- a/cluster/prov_opensvc.go
+++ b/cluster/prov_opensvc.go
@@ -226,7 +226,7 @@ func (cluster *Cluster) openSVCCreateMapsV3(svc opensvc.Collector, agent string)
 	var allErr error
 
 	err := svc.CreateSecret(cluster.Name, "env", agent)
-	if err != nil && !errors.Is(err, opensvc.ErrObjectAlreadyExists) {
+	if err != nil && !errors.Is(err, opensvc.ErrObjectAlreadyExists) && !errors.Is(err, opensvc.ErrObjectConflict) {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create secret: %s ", err)
 		return err
 	}
@@ -253,7 +253,7 @@ func (cluster *Cluster) openSVCCreateMapsV3(svc opensvc.Collector, agent string)
 	}
 
 	err = svc.CreateConfig(cluster.Name, "env", agent)
-	if err != nil && !errors.Is(err, opensvc.ErrObjectAlreadyExists) {
+	if err != nil && !errors.Is(err, opensvc.ErrObjectAlreadyExists) && !errors.Is(err, opensvc.ErrObjectConflict) {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create config: %s ", err)
 		allErr = errors.Join(allErr, fmt.Errorf("create config env: %w", err))
 	}

--- a/cluster/prov_opensvc.go
+++ b/cluster/prov_opensvc.go
@@ -226,13 +226,9 @@ func (cluster *Cluster) openSVCCreateMapsV3(svc opensvc.Collector, agent string)
 	var allErr error
 
 	err := svc.CreateSecret(cluster.Name, "env", agent)
-	if err != nil {
-		if errors.Is(err, opensvc.ErrObjectAlreadyExists) && cluster.Conf.ProvObjectAllowOverwrite {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Secret object exists. Reuse secret env on cluster to avoid truncation of keys")
-		} else {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create secret: %s ", err)
-			allErr = errors.Join(allErr, fmt.Errorf("create secret env: %w", err))
-		}
+	if err != nil && !errors.Is(err, opensvc.ErrObjectAlreadyExists) {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create secret: %s ", err)
+		return err
 	}
 
 	errs := make(map[string]error)
@@ -257,13 +253,9 @@ func (cluster *Cluster) openSVCCreateMapsV3(svc opensvc.Collector, agent string)
 	}
 
 	err = svc.CreateConfig(cluster.Name, "env", agent)
-	if err != nil {
-		if errors.Is(err, opensvc.ErrObjectAlreadyExists) && cluster.Conf.ProvObjectAllowOverwrite {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Config object exists. Reuse config env on cluster to avoid truncation of keys")
-		} else {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create config: %s ", err)
-			allErr = errors.Join(allErr, fmt.Errorf("create config env: %w", err))
-		}
+	if err != nil && !errors.Is(err, opensvc.ErrObjectAlreadyExists) {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create config: %s ", err)
+		allErr = errors.Join(allErr, fmt.Errorf("create config env: %w", err))
 	}
 
 	errs = make(map[string]error)

--- a/cluster/prov_opensvc.go
+++ b/cluster/prov_opensvc.go
@@ -25,6 +25,29 @@ var (
 	ErrOpenSVCClearNotSupported = errors.New("clear not supported for this OpenSVC API version")
 )
 
+const defaultOpenSVCV3ProvisionDelay = 10
+
+func isOpenSVCAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, opensvc.ErrObjectAlreadyExists) {
+		return true
+	}
+
+	var se *opensvc.StatusError
+	return errors.As(err, &se) && se != nil && se.StatusCode == 409
+}
+
+func normalizeOpenSVCV3ProvisionDelay(delay int) int {
+	if delay < 0 {
+		return defaultOpenSVCV3ProvisionDelay
+	}
+
+	return delay
+}
+
 func (cluster *Cluster) OpenSVCConnect() opensvc.Collector {
 	var svc opensvc.Collector
 	svc.ClusterConf = cluster.Conf
@@ -229,22 +252,20 @@ func (cluster *Cluster) openSVCCreateMapsV2(svc opensvc.Collector, agent string)
 
 func (cluster *Cluster) openSVCCreateMapsV3(svc opensvc.Collector, agent string) error {
 	var allErr error
-	isAlreadyExists := func(err error) bool {
-		if err == nil {
-			return false
-		}
-		if errors.Is(err, opensvc.ErrObjectAlreadyExists) {
-			return true
-		}
-
-		var se *opensvc.StatusError
-		return errors.As(err, &se) && se != nil && se.StatusCode == 409
-	}
 
 	err := svc.CreateSecret(cluster.Name, "env", agent)
-	if err != nil && !isAlreadyExists(err) {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create secret: %s ", err)
-		return err
+	if err != nil {
+		if isOpenSVCAlreadyExists(err) {
+			if cluster.Conf.ProvObjectAllowOverwrite {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Secret object exists. Reuse secret env on cluster to avoid truncation of keys")
+			} else {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create secret: %s", err)
+				return err
+			}
+		} else {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create secret: %s", err)
+			return err
+		}
 	}
 
 	errs := make(map[string]error)
@@ -269,9 +290,18 @@ func (cluster *Cluster) openSVCCreateMapsV3(svc opensvc.Collector, agent string)
 	}
 
 	err = svc.CreateConfig(cluster.Name, "env", agent)
-	if err != nil && !isAlreadyExists(err) {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create config: %s ", err)
-		allErr = errors.Join(allErr, fmt.Errorf("create config env: %w", err))
+	if err != nil {
+		if isOpenSVCAlreadyExists(err) {
+			if cluster.Conf.ProvObjectAllowOverwrite {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Config object exists. Reuse config env on cluster to avoid truncation of keys")
+			} else {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create config: %s", err)
+				return err
+			}
+		} else {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create config: %s", err)
+			return err
+		}
 	}
 
 	errs = make(map[string]error)

--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -201,6 +201,45 @@ func (cluster *Cluster) OpenSVCRestartAppService(app *App, node string, rid stri
 	return nil
 }
 
+func (cluster *Cluster) OpenSVCAbortAppService(app *App) error {
+	svc := cluster.OpenSVCConnect()
+	if cluster.Conf.ProvOpensvcUseCollectorAPI || !svc.IsV3() {
+		err := ErrOpenSVCAbortNotSupported
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not abort app: %s", err)
+		return err
+	}
+
+	err := svc.AbortServiceV3(cluster.Name, app.GetServiceName())
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not abort app: %s", err)
+		return err
+	}
+
+	return nil
+}
+
+func (cluster *Cluster) OpenSVCClearAppInstanceState(app *App, node string) error {
+	svc := cluster.OpenSVCConnect()
+	if cluster.Conf.ProvOpensvcUseCollectorAPI || !svc.IsV3() {
+		err := ErrOpenSVCClearNotSupported
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not clear app instance state: %s", err)
+		return err
+	}
+
+	agent := app.GetAgent()
+	if node != "" {
+		agent = node
+	}
+
+	err := svc.ClearInstanceV3(agent, app.GetServiceName())
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not clear app instance state: %s", err)
+		return err
+	}
+
+	return nil
+}
+
 func (cluster *Cluster) OpenSVCProvisionAppV3(app *App, svc opensvc.Collector, agent opensvc.Host) error {
 	err := cluster.OpenSVCCreateAppVariableMaps(agent.Node_name, app)
 	if err != nil {

--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -17,11 +17,13 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/opensvc"
 	"github.com/signal18/replication-manager/utils/misc"
 	"github.com/signal18/replication-manager/utils/state"
+	ini "gopkg.in/ini.v1"
 )
 
 // replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
@@ -31,32 +33,42 @@ import (
 // This source code is licensed under the GNU General Public License, version 3.
 
 func (cluster *Cluster) OpenSVCUnprovisionAppService(app *App) {
-	opensvc := cluster.OpenSVCConnect()
-	//agents := opensvc.GetNodes()
-	if !cluster.Conf.ProvOpensvcUseCollectorAPI {
-		err := opensvc.PurgeServiceV2(cluster.GetName(), app.GetServiceName(), app.GetAgent())
+	svc := cluster.OpenSVCConnect()
+	if cluster.Conf.ProvOpensvcUseCollectorAPI {
+		node, _ := cluster.OpenSVCFoundAppAgent(app)
+		for _, service := range node.Svc {
+			if app.GetServiceName() == service.Svc_name {
+				idaction, _ := svc.UnprovisionService(node.Node_id, service.Svc_id)
+				err := cluster.OpenSVCWaitDequeue(svc, idaction)
+				if err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can't unprovision app %s, %s", app.GetId(), err)
+				}
+			}
+		}
+	} else if svc.IsV3() {
+		err := svc.PurgeServiceV3(cluster.Name, app.GetServiceName())
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision app service:  %s ", err)
 			cluster.errorChan <- err
 		}
-
-		// Unprovision volumes
 		for _, volumename := range app.GetVolumes(true) {
-			err = opensvc.PurgeServiceV2(cluster.Name, cluster.Name+"/vol/"+volumename, app.GetAgent())
+			err = svc.PurgeServiceV3(cluster.Name, cluster.Name+"/vol/"+volumename)
 			if err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision app volume:  %s ", err)
 				cluster.errorChan <- err
 			}
 		}
 	} else {
-		node, _ := cluster.OpenSVCFoundAppAgent(app)
-		for _, svc := range node.Svc {
-			if app.GetServiceName() == svc.Svc_name {
-				idaction, _ := opensvc.UnprovisionService(node.Node_id, svc.Svc_id)
-				err := cluster.OpenSVCWaitDequeue(opensvc, idaction)
-				if err != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can't unprovision app %s, %s", app.GetId(), err)
-				}
+		err := svc.PurgeServiceV2(cluster.GetName(), app.GetServiceName(), app.GetAgent())
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision app service:  %s ", err)
+			cluster.errorChan <- err
+		}
+		for _, volumename := range app.GetVolumes(true) {
+			err = svc.PurgeServiceV2(cluster.Name, cluster.Name+"/vol/"+volumename, app.GetAgent())
+			if err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision app volume:  %s ", err)
+				cluster.errorChan <- err
 			}
 		}
 	}
@@ -93,6 +105,12 @@ func (cluster *Cluster) OpenSVCStopAppService(app *App, node string) error {
 			}
 			svc.StopService(agent.Node_id, service.Svc_id)
 		}
+	} else if svc.IsV3() {
+		err := svc.StopServiceV3(cluster.Name, app.GetServiceName())
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not stop app:  %s ", err)
+			return err
+		}
 	} else {
 		if strings.ToUpper(node) == "ALL" {
 			err := svc.StopServiceV2(cluster.Name, app.GetServiceName(), "*")
@@ -117,6 +135,14 @@ func (cluster *Cluster) OpenSVCStopAppService(app *App, node string) error {
 
 func (cluster *Cluster) OpenSVCStartAppService(app *App, node string) error {
 	svc := cluster.OpenSVCConnect()
+	if svc.IsV3() {
+		err := svc.StartServiceV3(cluster.Name, app.GetServiceName())
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not start app:  %s ", err)
+			return err
+		}
+		return nil
+	}
 	agent := app.GetAgent()
 	if strings.ToUpper(node) == "ALL" {
 		nodes := strings.Split(app.GetAppConfig().ProvAppAgents, ",")
@@ -143,8 +169,18 @@ func (cluster *Cluster) OpenSVCStartAppService(app *App, node string) error {
 
 func (cluster *Cluster) OpenSVCRestartAppService(app *App, node string, rid string) error {
 	svc := cluster.OpenSVCConnect()
+	if svc.IsV3() {
+		if rid != "" {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn, "RID restart is not supported in OpenSVC v3, falling back to full service restart")
+		}
+		err := svc.RestartServiceV3(cluster.Name, app.GetServiceName())
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not restart app:  %s ", err)
+			return err
+		}
+		return nil
+	}
 	agent := app.GetAgent()
-
 	if strings.ToUpper(node) == "ALL" || node == "*" {
 		err := svc.RestartServiceV2(cluster.Name, app.GetServiceName(), "*", rid)
 		if err != nil {
@@ -165,6 +201,41 @@ func (cluster *Cluster) OpenSVCRestartAppService(app *App, node string, rid stri
 	return nil
 }
 
+func (cluster *Cluster) OpenSVCProvisionAppV3(app *App, svc opensvc.Collector, agent opensvc.Host) error {
+	err := cluster.OpenSVCCreateAppVariableMaps(agent.Node_name, app)
+	if err != nil {
+		return err
+	}
+
+	res, err := cluster.OpenSVCGetAppTemplateV3(app)
+	if err != nil {
+		return err
+	}
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "%s", res)
+
+	templatefile := filepath.Join(app.Datadir, "opensvc_template.ini")
+	_ = os.WriteFile(templatefile, res, 0644)
+
+	app.TemplateMD5Prov = misc.GetMD5HashFromBytes(res)
+	app.TemplateMD5 = app.TemplateMD5Prov
+
+	body, err := svc.CreateTemplateV3(cluster.Name, app.ServiceName, app.Agent, res)
+	var se *opensvc.StatusError
+	if err != nil {
+		if !errors.As(err, &se) || se.StatusCode != 409 {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not provision app:  %s ", err)
+			return err
+		}
+	} else {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Template created with response: %s", body)
+	}
+
+	time.Sleep(10 * time.Second)
+
+	return svc.ProvisionServiceV3(cluster.Name, app.ServiceName)
+}
+
 func (cluster *Cluster) OpenSVCProvisionAppService(app *App) error {
 	svc := cluster.OpenSVCConnect()
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlDbg, "Provisioning app %s on OpenSVC", app.GetId())
@@ -176,6 +247,23 @@ func (cluster *Cluster) OpenSVCProvisionAppService(app *App) error {
 	}
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlDbg, "Found app agent %s. Creating maps", agent.Node_name)
+
+	if !cluster.Conf.ProvOpensvcUseCollectorAPI && svc.IsV3() {
+		err = cluster.OpenSVCProvisionAppV3(app, svc, agent)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not provision app:  %s ", err)
+			cluster.errorChan <- err
+			return err
+		}
+		err = cluster.OpenSVCProvisionRoute(app)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create app route:  %s ", err)
+			cluster.errorChan <- err
+			return err
+		}
+		cluster.errorChan <- nil
+		return nil
+	}
 
 	err = cluster.OpenSVCCreateAppVariableMaps(agent.Node_name, app)
 	if err != nil {
@@ -217,10 +305,9 @@ func (cluster *Cluster) OpenSVCProvisionAppService(app *App) error {
 	return nil
 }
 
-func (cluster *Cluster) OpenSVCGetAppTemplateV2(app *App) ([]byte, error) {
-	// Check if app image not empty
+func (cluster *Cluster) OpenSVCGetAppTemplateSectionMap(app *App) (map[string]map[string]string, error) {
 	if app.AppConfig.ProvAppDockerImg == "" {
-		return []byte(""), errors.New("App image is not defined in app config")
+		return nil, errors.New("App image is not defined in app config")
 	}
 
 	deployment := app.AppConfig.Deployment
@@ -231,14 +318,13 @@ func (cluster *Cluster) OpenSVCGetAppTemplateV2(app *App) ([]byte, error) {
 	svcsection["ip#01"] = cluster.OpenSVCGetNetSection()
 	svcsection = cluster.OpenSVCGetAppVolumeSections(svcsection, app)
 	svcsection[fmt.Sprintf("container#%02d", containernum)] = cluster.OpenSVCGetNamespaceContainerSection()
-	var err error
+
 	for _, gc := range deployment.Storages.GitClones {
 		if gc.Volume == nil {
-			// If the volume is not set, try to resolve it
 			if vol, err := deployment.GetVolumeByName(gc.VolumeName); err == nil {
 				gc.Volume = vol
 			} else {
-				return []byte(""), fmt.Errorf("Git clone volume %s not found in deployment", gc.VolumeName)
+				return nil, fmt.Errorf("Git clone volume %s not found in deployment", gc.VolumeName)
 			}
 		}
 		containernum++
@@ -248,24 +334,33 @@ func (cluster *Cluster) OpenSVCGetAppTemplateV2(app *App) ([]byte, error) {
 
 	for _, s3m := range deployment.Storages.S3Mounts {
 		if s3m.Volume == nil {
-			// If the volume is not set, try to resolve it
 			if vol, err := deployment.GetVolumeByName(s3m.VolumeName); err == nil {
 				s3m.Volume = vol
 			} else {
-				return []byte(""), fmt.Errorf("S3 mount volume %s not found in deployment", s3m.VolumeName)
+				return nil, fmt.Errorf("S3 mount volume %s not found in deployment", s3m.VolumeName)
 			}
 		}
 
 		if _, err := cluster.resolveS3MountProvisioningEndpoint(app, s3m); err != nil {
-			return []byte(""), err
+			return nil, err
 		}
 
 		containernum++
 		sectionName := fmt.Sprintf("container#%02dinit%s", containernum, s3m.Name)
 		svcsection[sectionName] = cluster.OpenSVCGetAppS3MountContainerSection(app, s3m)
 	}
+
 	svcsection["container#app"] = cluster.OpenSVCGetAppContainerSection(app)
 	svcsection["env"] = cluster.OpenSVCGetAppEnvSection(app)
+
+	return svcsection, nil
+}
+
+func (cluster *Cluster) OpenSVCGetAppTemplateV2(app *App) ([]byte, error) {
+	svcsection, err := cluster.OpenSVCGetAppTemplateSectionMap(app)
+	if err != nil {
+		return []byte(""), err
+	}
 
 	svcsectionJson, err := json.MarshalIndent(svcsection, "", "\t")
 	if err != nil {
@@ -273,7 +368,36 @@ func (cluster *Cluster) OpenSVCGetAppTemplateV2(app *App) ([]byte, error) {
 	}
 
 	return svcsectionJson, nil
+}
 
+func (cluster *Cluster) OpenSVCGetAppTemplateV3(app *App) ([]byte, error) {
+	svcsection, err := cluster.OpenSVCGetAppTemplateSectionMap(app)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := ini.Empty()
+
+	for sectionName, kv := range svcsection {
+		sec, err := cfg.NewSection(sectionName)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range kv {
+			_, err := sec.NewKey(k, v)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	var buf bytes.Buffer
+	_, err = cfg.WriteTo(&buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
 }
 
 func (cluster *Cluster) OpenSVCGetAppVolumeSections(basemap map[string]map[string]string, app *App) map[string]map[string]string {
@@ -651,21 +775,28 @@ func (cluster *Cluster) OpenSVCCreateAppVariableMaps(agent string, app *App) err
 	}
 
 	svc := cluster.OpenSVCConnect()
-	err := svc.CreateSecretV2(cluster.Name, app.Name, agent)
+
+	isAlreadyExists := func(err error) bool {
+		if errors.Is(err, opensvc.ErrObjectAlreadyExists) {
+			return true
+		}
+		var se *opensvc.StatusError
+		return errors.As(err, &se) && se.StatusCode == 409
+	}
+
+	err := svc.CreateSecret(cluster.Name, app.Name, agent)
 	if err != nil {
-		if errors.Is(err, opensvc.ErrObjectAlreadyExists) && cluster.Conf.ProvObjectAllowOverwrite {
+		if isAlreadyExists(err) && cluster.Conf.ProvObjectAllowOverwrite {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Overwriting existing secret for app %s without truncation", app.Name)
-			err = nil
 		} else {
 			return err
 		}
 	}
 
-	err = svc.CreateConfigV2(cluster.Name, app.Name, agent)
+	err = svc.CreateConfig(cluster.Name, app.Name, agent)
 	if err != nil {
-		if errors.Is(err, opensvc.ErrObjectAlreadyExists) && cluster.Conf.ProvObjectAllowOverwrite {
+		if isAlreadyExists(err) && cluster.Conf.ProvObjectAllowOverwrite {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Overwriting existing config for app %s without truncation", app.Name)
-			err = nil
 		} else {
 			return err
 		}
@@ -673,27 +804,27 @@ func (cluster *Cluster) OpenSVCCreateAppVariableMaps(agent string, app *App) err
 
 	for _, v := range app.AppConfig.Deployment.Variables {
 		if v.Type == "secret" {
-			err = svc.CreateSecretKeyValueV2(cluster.Name, app.Name, v.Name, cluster.Conf.GetDecryptedPassword(v.Name, v.Value))
+			err = svc.CreateSecretKeyValue(cluster.Name, app.Name, v.Name, cluster.Conf.GetDecryptedPassword(v.Name, v.Value))
 			if err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not add key to secret: %s %s ", v.Name, err)
 			}
 
 			for _, cd := range v.Conditional {
 				cdname := fmt.Sprintf("%s@%s", v.Name, cd.Agent)
-				err = svc.CreateSecretKeyValueV2(cluster.Name, app.Name, cdname, cluster.Conf.GetDecryptedPassword(cdname, cd.Value))
+				err = svc.CreateSecretKeyValue(cluster.Name, app.Name, cdname, cluster.Conf.GetDecryptedPassword(cdname, cd.Value))
 				if err != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not add conditional key to secret: %s %s ", cdname, err)
 				}
 			}
 		} else {
-			err = svc.CreateConfigKeyValueV2(cluster.Name, app.Name, v.Name, v.Value)
+			err = svc.CreateConfigKeyValue(cluster.Name, app.Name, v.Name, v.Value)
 			if err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not add key to config: %s %s ", v.Name, err)
 			}
 
 			for _, cd := range v.Conditional {
 				cdname := fmt.Sprintf("%s@%s", v.Name, cd.Agent)
-				err = svc.CreateConfigKeyValueV2(cluster.Name, app.Name, cdname, cd.Value)
+				err = svc.CreateConfigKeyValue(cluster.Name, app.Name, cdname, cd.Value)
 				if err != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not add conditional key to config: %s %s ", cdname, err)
 				}
@@ -707,35 +838,30 @@ func (cluster *Cluster) OpenSVCCreateAppVariableMaps(agent string, app *App) err
 		for k, val := range envs {
 			vName := prefix + k
 
-			// Create the git clone config key
 			if k == config.GitVarSuffixRepo {
-				// If the git repo is a URL, we need to remove the protocol part
 				if strings.HasPrefix(val, "http://") || strings.HasPrefix(val, "https://") {
 					val = strings.TrimPrefix(val, "http://")
 					val = strings.TrimPrefix(val, "https://")
 				}
 			}
 			if k == config.GitVarSuffixBranch {
-				// If the git branch is not set, we use the default branch
 				if val == "" {
 					val = "master"
 				}
 			}
 
-			err = svc.CreateConfigKeyValueV2(cluster.Name, app.Name, vName, val)
+			err = svc.CreateConfigKeyValue(cluster.Name, app.Name, vName, val)
 			if err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not add key to config: %s %s ", vName, err)
 			}
 		}
 
-		// Create the git clone secret key
-		err = svc.CreateSecretKeyValueV2(cluster.Name, app.Name, prefix+config.GitVarSuffixPass, cluster.Conf.GetDecryptedPassword(gc.Name, gc.GitPass))
+		err = svc.CreateSecretKeyValue(cluster.Name, app.Name, prefix+config.GitVarSuffixPass, cluster.Conf.GetDecryptedPassword(gc.Name, gc.GitPass))
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not add key to secret: %s %s ", prefix+config.GitVarSuffixPass, err)
 		}
 	}
 
-	// Create the s3 mount config keys
 	for _, s3m := range app.AppConfig.Deployment.Storages.S3Mounts {
 		effectiveEndpoint, err := cluster.resolveS3MountProvisioningEndpoint(app, s3m)
 		if err != nil {
@@ -749,30 +875,26 @@ func (cluster *Cluster) OpenSVCCreateAppVariableMaps(agent string, app *App) err
 			if k == config.S3VarSuffixEndpoint {
 				val = effectiveEndpoint
 			} else if k == config.S3VarSuffixMountDir {
-				// If the mount directory is not set, we use the default mount directory
 				if val == "" {
 					val = "/mnt"
 				}
 			} else if k == config.S3VarSuffixRegion {
-				// If the region is not set, we use the default region
 				if val == "" {
 					val = "fr-east-1"
 				}
 			} else if k == config.S3VarSuffixBucket {
-				// If the bucket is not set, we use the app name as the default bucket
 				if val == "" {
 					val = app.Name
 				}
 			}
 
-			err = svc.CreateConfigKeyValueV2(cluster.Name, app.Name, vName, val)
+			err = svc.CreateConfigKeyValue(cluster.Name, app.Name, vName, val)
 			if err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not add key to config: %s %s ", vName, err)
 			}
 		}
 
-		// Create the s3 mount secret key
-		err = svc.CreateSecretKeyValueV2(cluster.Name, app.Name, prefix+config.S3VarSuffixSecretKey, cluster.Conf.GetDecryptedPassword(s3m.Name, s3m.SecretKey))
+		err = svc.CreateSecretKeyValue(cluster.Name, app.Name, prefix+config.S3VarSuffixSecretKey, cluster.Conf.GetDecryptedPassword(s3m.Name, s3m.SecretKey))
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not add key to secret: %s %s ", prefix+config.S3VarSuffixSecretKey, err)
 		}

--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -215,7 +215,9 @@ func (cluster *Cluster) OpenSVCProvisionAppV3(app *App, svc opensvc.Collector, a
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "%s", res)
 
 	templatefile := filepath.Join(app.Datadir, "opensvc_template.ini")
-	_ = os.WriteFile(templatefile, res, 0644)
+	if err := os.WriteFile(templatefile, res, 0600); err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn, "Failed to write template file %s: %s", templatefile, err)
+	}
 
 	app.TemplateMD5Prov = misc.GetMD5HashFromBytes(res)
 	app.TemplateMD5 = app.TemplateMD5Prov
@@ -231,7 +233,11 @@ func (cluster *Cluster) OpenSVCProvisionAppV3(app *App, svc opensvc.Collector, a
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Template created with response: %s", body)
 	}
 
-	time.Sleep(10 * time.Second)
+	delay := cluster.Conf.ProvOpensvcV3ProvisionDelay
+	if delay <= 0 {
+		delay = 10
+	}
+	time.Sleep(time.Duration(delay) * time.Second)
 
 	return svc.ProvisionServiceV3(cluster.Name, app.ServiceName)
 }
@@ -378,13 +384,25 @@ func (cluster *Cluster) OpenSVCGetAppTemplateV3(app *App) ([]byte, error) {
 
 	cfg := ini.Empty()
 
-	for sectionName, kv := range svcsection {
+	sectionNames := make([]string, 0, len(svcsection))
+	for k := range svcsection {
+		sectionNames = append(sectionNames, k)
+	}
+	sort.Strings(sectionNames)
+
+	for _, sectionName := range sectionNames {
+		kv := svcsection[sectionName]
 		sec, err := cfg.NewSection(sectionName)
 		if err != nil {
 			return nil, err
 		}
-		for k, v := range kv {
-			_, err := sec.NewKey(k, v)
+		keys := make([]string, 0, len(kv))
+		for k := range kv {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			_, err := sec.NewKey(k, kv[k])
 			if err != nil {
 				return nil, err
 			}

--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -262,20 +262,17 @@ func (cluster *Cluster) OpenSVCProvisionAppV3(app *App, svc opensvc.Collector, a
 	app.TemplateMD5 = app.TemplateMD5Prov
 
 	body, err := svc.CreateTemplateV3(cluster.Name, app.ServiceName, app.Agent, res)
-	var se *opensvc.StatusError
 	if err != nil {
-		if !errors.As(err, &se) || se.StatusCode != 409 {
+		if !isOpenSVCAlreadyExists(err) {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not provision app:  %s ", err)
 			return err
 		}
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "App template already exists, reusing existing template: %s", app.ServiceName)
 	} else {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Template created with response: %s", body)
 	}
 
-	delay := cluster.Conf.ProvOpensvcV3ProvisionDelay
-	if delay <= 0 {
-		delay = 10
-	}
+	delay := normalizeOpenSVCV3ProvisionDelay(cluster.Conf.ProvOpensvcV3ProvisionDelay)
 	time.Sleep(time.Duration(delay) * time.Second)
 
 	return svc.ProvisionServiceV3(cluster.Name, app.ServiceName)
@@ -834,11 +831,7 @@ func (cluster *Cluster) OpenSVCCreateAppVariableMaps(agent string, app *App) err
 	svc := cluster.OpenSVCConnect()
 
 	isAlreadyExists := func(err error) bool {
-		if errors.Is(err, opensvc.ErrObjectAlreadyExists) {
-			return true
-		}
-		var se *opensvc.StatusError
-		return errors.As(err, &se) && se.StatusCode == 409
+		return isOpenSVCAlreadyExists(err)
 	}
 
 	err := svc.CreateSecret(cluster.Name, app.Name, agent)

--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -32,16 +32,29 @@ import (
 //          Stephane Varoqui  <svaroqui@gmail.com>
 // This source code is licensed under the GNU General Public License, version 3.
 
-func (cluster *Cluster) OpenSVCUnprovisionAppService(app *App) {
+func (cluster *Cluster) OpenSVCUnprovisionAppService(app *App) error {
 	svc := cluster.OpenSVCConnect()
+	var opErr error
 	if cluster.Conf.ProvOpensvcUseCollectorAPI {
-		node, _ := cluster.OpenSVCFoundAppAgent(app)
-		for _, service := range node.Svc {
-			if app.GetServiceName() == service.Svc_name {
-				idaction, _ := svc.UnprovisionService(node.Node_id, service.Svc_id)
-				err := cluster.OpenSVCWaitDequeue(svc, idaction)
-				if err != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can't unprovision app %s, %s", app.GetId(), err)
+		node, err := cluster.OpenSVCFoundAppAgent(app)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can't find app agent %s, %s", app.GetId(), err)
+			opErr = errors.Join(opErr, err)
+		} else {
+			for _, service := range node.Svc {
+				if app.GetServiceName() == service.Svc_name {
+					idaction, err := svc.UnprovisionService(node.Node_id, service.Svc_id)
+					if err != nil {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can't queue unprovision app %s, %s", app.GetId(), err)
+						opErr = errors.Join(opErr, err)
+						continue
+					}
+
+					err = cluster.OpenSVCWaitDequeue(svc, idaction)
+					if err != nil {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can't unprovision app %s, %s", app.GetId(), err)
+						opErr = errors.Join(opErr, err)
+					}
 				}
 			}
 		}
@@ -49,30 +62,31 @@ func (cluster *Cluster) OpenSVCUnprovisionAppService(app *App) {
 		err := svc.PurgeServiceV3(cluster.Name, app.GetServiceName())
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision app service:  %s ", err)
-			cluster.errorChan <- err
+			opErr = errors.Join(opErr, err)
 		}
 		for _, volumename := range app.GetVolumes(true) {
 			err = svc.PurgeServiceV3(cluster.Name, cluster.Name+"/vol/"+volumename)
 			if err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision app volume:  %s ", err)
-				cluster.errorChan <- err
+				opErr = errors.Join(opErr, err)
 			}
 		}
 	} else {
 		err := svc.PurgeServiceV2(cluster.GetName(), app.GetServiceName(), app.GetAgent())
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision app service:  %s ", err)
-			cluster.errorChan <- err
+			opErr = errors.Join(opErr, err)
 		}
 		for _, volumename := range app.GetVolumes(true) {
 			err = svc.PurgeServiceV2(cluster.Name, cluster.Name+"/vol/"+volumename, app.GetAgent())
 			if err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision app volume:  %s ", err)
-				cluster.errorChan <- err
+				opErr = errors.Join(opErr, err)
 			}
 		}
 	}
-	cluster.errorChan <- nil
+
+	return opErr
 }
 
 func (cluster *Cluster) OpenSVCStopAppService(app *App, node string) error {
@@ -830,13 +844,9 @@ func (cluster *Cluster) OpenSVCCreateAppVariableMaps(agent string, app *App) err
 
 	svc := cluster.OpenSVCConnect()
 
-	isAlreadyExists := func(err error) bool {
-		return isOpenSVCAlreadyExists(err)
-	}
-
 	err := svc.CreateSecret(cluster.Name, app.Name, agent)
 	if err != nil {
-		if isAlreadyExists(err) && cluster.Conf.ProvObjectAllowOverwrite {
+		if isOpenSVCAlreadyExists(err) && cluster.Conf.ProvObjectAllowOverwrite {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Overwriting existing secret for app %s without truncation", app.Name)
 		} else {
 			return err
@@ -845,7 +855,7 @@ func (cluster *Cluster) OpenSVCCreateAppVariableMaps(agent string, app *App) err
 
 	err = svc.CreateConfig(cluster.Name, app.Name, agent)
 	if err != nil {
-		if isAlreadyExists(err) && cluster.Conf.ProvObjectAllowOverwrite {
+		if isOpenSVCAlreadyExists(err) && cluster.Conf.ProvObjectAllowOverwrite {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Overwriting existing config for app %s without truncation", app.Name)
 		} else {
 			return err

--- a/cluster/prov_opensvc_db.go
+++ b/cluster/prov_opensvc_db.go
@@ -269,6 +269,45 @@ func (cluster *Cluster) OpenSVCRestartDatabaseService(server *ServerMonitor, nod
 	return nil
 }
 
+func (cluster *Cluster) OpenSVCAbortDatabaseService(server *ServerMonitor) error {
+	svc := cluster.OpenSVCConnect()
+	if cluster.Conf.ProvOpensvcUseCollectorAPI || !svc.IsV3() {
+		err := ErrOpenSVCAbortNotSupported
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not abort database: %s", err)
+		return err
+	}
+
+	err := svc.AbortServiceV3(cluster.Name, server.ServiceName)
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not abort database: %s", err)
+		return err
+	}
+
+	return nil
+}
+
+func (cluster *Cluster) OpenSVCClearDatabaseInstanceState(server *ServerMonitor, node string) error {
+	svc := cluster.OpenSVCConnect()
+	if cluster.Conf.ProvOpensvcUseCollectorAPI || !svc.IsV3() {
+		err := ErrOpenSVCClearNotSupported
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not clear database instance state: %s", err)
+		return err
+	}
+
+	agent := server.Agent
+	if node != "" {
+		agent = node
+	}
+
+	err := svc.ClearInstanceV3(agent, server.ServiceName)
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not clear database instance state: %s", err)
+		return err
+	}
+
+	return nil
+}
+
 func (cluster *Cluster) OpenSVCUnprovisionDatabaseService(server *ServerMonitor) {
 	svc := cluster.OpenSVCConnect()
 	if cluster.Conf.ProvOpensvcUseCollectorAPI {

--- a/cluster/prov_opensvc_db.go
+++ b/cluster/prov_opensvc_db.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/opensvc"
@@ -128,12 +129,19 @@ func (cluster *Cluster) OpenSVCProvisionDatabaseV3(s *ServerMonitor, svc opensvc
 	}
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "%s", res)
-	err = svc.CreateTemplateV3(cluster.Name, s.ServiceName, s.Agent, res)
+	body, err := svc.CreateTemplateV3(cluster.Name, s.ServiceName, s.Agent, res)
+	var se *opensvc.StatusError
 	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not provision database:  %s ", err)
+		if !errors.As(err, &se) || se.StatusCode != 409 {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not provision database:  %s ", err)
+		}
+	} else {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Template created with response: %s", body)
 	}
 
-	return nil
+	time.Sleep(10 * time.Second)
+
+	return svc.ProvisionServiceV3(cluster.Name, s.ServiceName)
 }
 
 func (cluster *Cluster) OpenSVCProvisionDatabaseService(s *ServerMonitor) {

--- a/cluster/prov_opensvc_db.go
+++ b/cluster/prov_opensvc_db.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -139,7 +140,11 @@ func (cluster *Cluster) OpenSVCProvisionDatabaseV3(s *ServerMonitor, svc opensvc
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Template created with response: %s", body)
 	}
 
-	time.Sleep(10 * time.Second)
+	delay := cluster.Conf.ProvOpensvcV3ProvisionDelay
+	if delay <= 0 {
+		delay = 10
+	}
+	time.Sleep(time.Duration(delay) * time.Second)
 
 	return svc.ProvisionServiceV3(cluster.Name, s.ServiceName)
 }
@@ -767,13 +772,25 @@ func (server *ServerMonitor) GenerateDBTemplateV3() ([]byte, error) {
 
 	cfg := ini.Empty()
 
-	for sectionName, kv := range svcsection {
+	sectionNames := make([]string, 0, len(svcsection))
+	for k := range svcsection {
+		sectionNames = append(sectionNames, k)
+	}
+	sort.Strings(sectionNames)
+
+	for _, sectionName := range sectionNames {
+		kv := svcsection[sectionName]
 		sec, err := cfg.NewSection(sectionName)
 		if err != nil {
 			return nil, err
 		}
-		for k, v := range kv {
-			_, err := sec.NewKey(k, v)
+		keys := make([]string, 0, len(kv))
+		for k := range kv {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			_, err := sec.NewKey(k, kv[k])
 			if err != nil {
 				return nil, err
 			}

--- a/cluster/prov_opensvc_db.go
+++ b/cluster/prov_opensvc_db.go
@@ -308,15 +308,27 @@ func (cluster *Cluster) OpenSVCClearDatabaseInstanceState(server *ServerMonitor,
 
 func (cluster *Cluster) OpenSVCUnprovisionDatabaseService(server *ServerMonitor) {
 	svc := cluster.OpenSVCConnect()
+	var opErr error
 	if cluster.Conf.ProvOpensvcUseCollectorAPI {
-		node, _ := cluster.OpenSVCFoundDatabaseAgent(server)
-		for _, service := range node.Svc {
-			if cluster.Name+"/svc/"+server.Name == service.Svc_name {
-				idaction, _ := svc.UnprovisionService(node.Node_id, service.Svc_id)
-				err := cluster.OpenSVCWaitDequeue(svc, idaction)
-				if err != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can't unprovision database %s, %s", cluster.Name+"/svc/"+server.Name, err)
-					cluster.errorChan <- err
+		node, err := cluster.OpenSVCFoundDatabaseAgent(server)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can't find database agent %s, %s", cluster.Name+"/svc/"+server.Name, err)
+			opErr = errors.Join(opErr, err)
+		} else {
+			for _, service := range node.Svc {
+				if cluster.Name+"/svc/"+server.Name == service.Svc_name {
+					idaction, err := svc.UnprovisionService(node.Node_id, service.Svc_id)
+					if err != nil {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can't queue unprovision database %s, %s", cluster.Name+"/svc/"+server.Name, err)
+						opErr = errors.Join(opErr, err)
+						continue
+					}
+
+					err = cluster.OpenSVCWaitDequeue(svc, idaction)
+					if err != nil {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can't unprovision database %s, %s", cluster.Name+"/svc/"+server.Name, err)
+						opErr = errors.Join(opErr, err)
+					}
 				}
 			}
 		}
@@ -324,26 +336,26 @@ func (cluster *Cluster) OpenSVCUnprovisionDatabaseService(server *ServerMonitor)
 		err := svc.PurgeServiceV3(cluster.Name, server.ServiceName)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision database service:  %s ", err)
-			cluster.errorChan <- err
+			opErr = errors.Join(opErr, err)
 		}
 		err = svc.PurgeServiceV3(cluster.Name, cluster.Name+"/vol/"+server.Name)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision database volume:  %s ", err)
-			cluster.errorChan <- err
+			opErr = errors.Join(opErr, err)
 		}
 	} else {
 		err := svc.PurgeServiceV2(cluster.Name, server.ServiceName, server.Agent)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision database service:  %s ", err)
-			cluster.errorChan <- err
+			opErr = errors.Join(opErr, err)
 		}
 		err = svc.PurgeServiceV2(cluster.Name, cluster.Name+"/vol/"+server.Name, server.Agent)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision database volume:  %s ", err)
-			cluster.errorChan <- err
+			opErr = errors.Join(opErr, err)
 		}
 	}
-	cluster.errorChan <- nil
+	cluster.errorChan <- opErr
 }
 
 func (cluster *Cluster) OpenSVCFoundDatabaseAgent(server *ServerMonitor) (opensvc.Host, error) {

--- a/cluster/prov_opensvc_db.go
+++ b/cluster/prov_opensvc_db.go
@@ -131,19 +131,17 @@ func (cluster *Cluster) OpenSVCProvisionDatabaseV3(s *ServerMonitor, svc opensvc
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "%s", res)
 	body, err := svc.CreateTemplateV3(cluster.Name, s.ServiceName, s.Agent, res)
-	var se *opensvc.StatusError
 	if err != nil {
-		if !errors.As(err, &se) || se.StatusCode != 409 {
+		if !isOpenSVCAlreadyExists(err) {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not provision database:  %s ", err)
+			return err
 		}
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Database template already exists, reusing existing template: %s", s.ServiceName)
 	} else {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Template created with response: %s", body)
 	}
 
-	delay := cluster.Conf.ProvOpensvcV3ProvisionDelay
-	if delay <= 0 {
-		delay = 10
-	}
+	delay := normalizeOpenSVCV3ProvisionDelay(cluster.Conf.ProvOpensvcV3ProvisionDelay)
 	time.Sleep(time.Duration(delay) * time.Second)
 
 	return svc.ProvisionServiceV3(cluster.Name, s.ServiceName)

--- a/cluster/prov_opensvc_prx.go
+++ b/cluster/prov_opensvc_prx.go
@@ -27,15 +27,27 @@ import (
 
 func (cluster *Cluster) OpenSVCUnprovisionProxyService(prx DatabaseProxy) {
 	svc := cluster.OpenSVCConnect()
+	var opErr error
 	if cluster.Conf.ProvOpensvcUseCollectorAPI {
-		node, _ := cluster.FoundProxyAgent(prx)
-		for _, service := range node.Svc {
-			if prx.GetServiceName() == service.Svc_name {
-				idaction, _ := svc.UnprovisionService(node.Node_id, service.Svc_id)
-				err := cluster.OpenSVCWaitDequeue(svc, idaction)
-				if err != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can't unprovision proxy %s, %s", prx.GetId(), err)
-					cluster.errorChan <- err
+		node, err := cluster.FoundProxyAgent(prx)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can't find proxy agent %s, %s", prx.GetId(), err)
+			opErr = errors.Join(opErr, err)
+		} else {
+			for _, service := range node.Svc {
+				if prx.GetServiceName() == service.Svc_name {
+					idaction, err := svc.UnprovisionService(node.Node_id, service.Svc_id)
+					if err != nil {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can't queue unprovision proxy %s, %s", prx.GetId(), err)
+						opErr = errors.Join(opErr, err)
+						continue
+					}
+
+					err = cluster.OpenSVCWaitDequeue(svc, idaction)
+					if err != nil {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can't unprovision proxy %s, %s", prx.GetId(), err)
+						opErr = errors.Join(opErr, err)
+					}
 				}
 			}
 		}
@@ -43,26 +55,26 @@ func (cluster *Cluster) OpenSVCUnprovisionProxyService(prx DatabaseProxy) {
 		err := svc.PurgeServiceV3(cluster.Name, prx.GetServiceName())
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision proxy service:  %s ", err)
-			cluster.errorChan <- err
+			opErr = errors.Join(opErr, err)
 		}
 		err = svc.PurgeServiceV3(cluster.Name, cluster.Name+"/vol/"+prx.GetName())
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision proxy volume:  %s ", err)
-			cluster.errorChan <- err
+			opErr = errors.Join(opErr, err)
 		}
 	} else {
 		err := svc.PurgeServiceV2(cluster.GetName(), prx.GetServiceName(), prx.GetAgent())
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision proxy service:  %s ", err)
-			cluster.errorChan <- err
+			opErr = errors.Join(opErr, err)
 		}
 		err = svc.PurgeServiceV2(cluster.Name, cluster.Name+"/vol/"+prx.GetName(), prx.GetAgent())
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision proxy volume:  %s ", err)
-			cluster.errorChan <- err
+			opErr = errors.Join(opErr, err)
 		}
 	}
-	cluster.errorChan <- nil
+	cluster.errorChan <- opErr
 }
 
 func (cluster *Cluster) OpenSVCStopProxyService(server DatabaseProxy) error {

--- a/cluster/prov_opensvc_prx.go
+++ b/cluster/prov_opensvc_prx.go
@@ -121,6 +121,45 @@ func (cluster *Cluster) OpenSVCStartProxyService(server DatabaseProxy) error {
 	return nil
 }
 
+func (cluster *Cluster) OpenSVCAbortProxyService(server DatabaseProxy) error {
+	svc := cluster.OpenSVCConnect()
+	if cluster.Conf.ProvOpensvcUseCollectorAPI || !svc.IsV3() {
+		err := ErrOpenSVCAbortNotSupported
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not abort proxy: %s", err)
+		return err
+	}
+
+	err := svc.AbortServiceV3(cluster.Name, server.GetServiceName())
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not abort proxy: %s", err)
+		return err
+	}
+
+	return nil
+}
+
+func (cluster *Cluster) OpenSVCClearProxyInstanceState(server DatabaseProxy, node string) error {
+	svc := cluster.OpenSVCConnect()
+	if cluster.Conf.ProvOpensvcUseCollectorAPI || !svc.IsV3() {
+		err := ErrOpenSVCClearNotSupported
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not clear proxy instance state: %s", err)
+		return err
+	}
+
+	agent := server.GetAgent()
+	if node != "" {
+		agent = node
+	}
+
+	err := svc.ClearInstanceV3(agent, server.GetServiceName())
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not clear proxy instance state: %s", err)
+		return err
+	}
+
+	return nil
+}
+
 func (cluster *Cluster) OpenSVCProvisionProxyV3(pri DatabaseProxy, svc opensvc.Collector, agent opensvc.Host) error {
 	err := cluster.OpenSVCCreateMaps(agent.Node_name)
 	if err != nil {

--- a/cluster/prov_opensvc_prx.go
+++ b/cluster/prov_opensvc_prx.go
@@ -11,6 +11,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -136,6 +139,16 @@ func (cluster *Cluster) OpenSVCProvisionProxyV3(pri DatabaseProxy, svc opensvc.C
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "%s", res)
 
+	templatefile := filepath.Join(pri.GetDatadir(), "opensvc_template.ini")
+	if werr := os.WriteFile(templatefile, res, 0600); werr != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn, "Failed to write template file %s: %s", templatefile, werr)
+	}
+
+	if p, ok := pri.(*Proxy); ok {
+		p.TemplateMD5Prov = misc.GetMD5HashFromBytes(res)
+		p.TemplateMD5 = p.TemplateMD5Prov
+	}
+
 	body, err := svc.CreateTemplateV3(cluster.Name, pri.GetServiceName(), pri.GetAgent(), res)
 	var se *opensvc.StatusError
 	if err != nil {
@@ -147,7 +160,11 @@ func (cluster *Cluster) OpenSVCProvisionProxyV3(pri DatabaseProxy, svc opensvc.C
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Template created with response: %s", body)
 	}
 
-	time.Sleep(10 * time.Second)
+	delay := cluster.Conf.ProvOpensvcV3ProvisionDelay
+	if delay <= 0 {
+		delay = 10
+	}
+	time.Sleep(time.Duration(delay) * time.Second)
 
 	return svc.ProvisionServiceV3(cluster.Name, pri.GetServiceName())
 }
@@ -467,13 +484,25 @@ func (cluster *Cluster) OpenSVCGetProxyTemplateV3(servers string, pri DatabasePr
 
 	cfg := ini.Empty()
 
-	for sectionName, kv := range svcsection {
+	sectionNames := make([]string, 0, len(svcsection))
+	for k := range svcsection {
+		sectionNames = append(sectionNames, k)
+	}
+	sort.Strings(sectionNames)
+
+	for _, sectionName := range sectionNames {
+		kv := svcsection[sectionName]
 		sec, err := cfg.NewSection(sectionName)
 		if err != nil {
 			return nil, err
 		}
-		for k, v := range kv {
-			_, err := sec.NewKey(k, v)
+		keys := make([]string, 0, len(kv))
+		for k := range kv {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			_, err := sec.NewKey(k, kv[k])
 			if err != nil {
 				return nil, err
 			}

--- a/cluster/prov_opensvc_prx.go
+++ b/cluster/prov_opensvc_prx.go
@@ -7,42 +7,56 @@
 package cluster
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/opensvc"
 	"github.com/signal18/replication-manager/utils/misc"
 	"github.com/signal18/replication-manager/utils/state"
+	ini "gopkg.in/ini.v1"
 )
 
 func (cluster *Cluster) OpenSVCUnprovisionProxyService(prx DatabaseProxy) {
-	opensvc := cluster.OpenSVCConnect()
-	//agents := opensvc.GetNodes()
-	if !cluster.Conf.ProvOpensvcUseCollectorAPI {
-		err := opensvc.PurgeServiceV2(cluster.GetName(), prx.GetServiceName(), prx.GetAgent())
+	svc := cluster.OpenSVCConnect()
+	if cluster.Conf.ProvOpensvcUseCollectorAPI {
+		node, _ := cluster.FoundProxyAgent(prx)
+		for _, service := range node.Svc {
+			if prx.GetServiceName() == service.Svc_name {
+				idaction, _ := svc.UnprovisionService(node.Node_id, service.Svc_id)
+				err := cluster.OpenSVCWaitDequeue(svc, idaction)
+				if err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can't unprovision proxy %s, %s", prx.GetId(), err)
+					cluster.errorChan <- err
+				}
+			}
+		}
+	} else if svc.IsV3() {
+		err := svc.PurgeServiceV3(cluster.Name, prx.GetServiceName())
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision proxy service:  %s ", err)
 			cluster.errorChan <- err
 		}
-		err = opensvc.PurgeServiceV2(cluster.Name, cluster.Name+"/vol/"+prx.GetName(), prx.GetAgent())
+		err = svc.PurgeServiceV3(cluster.Name, cluster.Name+"/vol/"+prx.GetName())
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision proxy volume:  %s ", err)
 			cluster.errorChan <- err
 		}
 	} else {
-		node, _ := cluster.FoundProxyAgent(prx)
-		for _, svc := range node.Svc {
-			if prx.GetServiceName() == svc.Svc_name {
-				idaction, _ := opensvc.UnprovisionService(node.Node_id, svc.Svc_id)
-				err := cluster.OpenSVCWaitDequeue(opensvc, idaction)
-				if err != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can't unprovision proxy %s, %s", prx.GetId(), err)
-				}
-			}
+		err := svc.PurgeServiceV2(cluster.GetName(), prx.GetServiceName(), prx.GetAgent())
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision proxy service:  %s ", err)
+			cluster.errorChan <- err
+		}
+		err = svc.PurgeServiceV2(cluster.Name, cluster.Name+"/vol/"+prx.GetName(), prx.GetAgent())
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision proxy volume:  %s ", err)
+			cluster.errorChan <- err
 		}
 	}
 	cluster.errorChan <- nil
@@ -60,6 +74,12 @@ func (cluster *Cluster) OpenSVCStopProxyService(server DatabaseProxy) error {
 			return err
 		}
 		svc.StopService(agent.Node_id, service.Svc_id)
+	} else if svc.IsV3() {
+		err := svc.StopServiceV3(cluster.Name, server.GetServiceName())
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not stop proxy:  %s ", err)
+			return err
+		}
 	} else {
 		err := svc.StopServiceV2(cluster.Name, server.GetServiceName(), server.GetAgent())
 		if err != nil {
@@ -82,14 +102,54 @@ func (cluster *Cluster) OpenSVCStartProxyService(server DatabaseProxy) error {
 			return err
 		}
 		svc.StartService(agent.Node_id, service.Svc_id)
+	} else if svc.IsV3() {
+		err := svc.StartServiceV3(cluster.Name, server.GetServiceName())
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not start proxy:  %s ", err)
+			return err
+		}
 	} else {
 		err := svc.StartServiceV2(cluster.Name, server.GetServiceName(), server.GetAgent())
 		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not stop proxy:  %s ", err)
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not start proxy:  %s ", err)
 			return err
 		}
 	}
 	return nil
+}
+
+func (cluster *Cluster) OpenSVCProvisionProxyV3(pri DatabaseProxy, svc opensvc.Collector, agent opensvc.Host) error {
+	err := cluster.OpenSVCCreateMaps(agent.Node_name)
+	if err != nil {
+		return err
+	}
+
+	srvlist := make([]string, len(cluster.Servers))
+	for i, s := range cluster.Servers {
+		srvlist[i] = s.Host
+	}
+
+	res, err := cluster.OpenSVCGetProxyTemplateV3(strings.Join(srvlist, " "), pri)
+	if err != nil {
+		return err
+	}
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "%s", res)
+
+	body, err := svc.CreateTemplateV3(cluster.Name, pri.GetServiceName(), pri.GetAgent(), res)
+	var se *opensvc.StatusError
+	if err != nil {
+		if !errors.As(err, &se) || se.StatusCode != 409 {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not provision proxy:  %s ", err)
+			return err
+		}
+	} else {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Template created with response: %s", body)
+	}
+
+	time.Sleep(10 * time.Second)
+
+	return svc.ProvisionServiceV3(cluster.Name, pri.GetServiceName())
 }
 
 func (cluster *Cluster) OpenSVCProvisionProxyService(pri DatabaseProxy) error {
@@ -99,6 +159,17 @@ func (cluster *Cluster) OpenSVCProvisionProxyService(pri DatabaseProxy) error {
 		cluster.errorChan <- err
 		return err
 	}
+
+	if !cluster.Conf.ProvOpensvcUseCollectorAPI && svc.IsV3() {
+		err = cluster.OpenSVCProvisionProxyV3(pri, svc, agent)
+		if err != nil {
+			cluster.errorChan <- err
+			return err
+		}
+		cluster.errorChan <- nil
+		return nil
+	}
+
 	// Unprovision if already in OpenSVC
 	if cluster.Conf.ProvOpensvcUseCollectorAPI {
 		var idsrv string
@@ -332,7 +403,7 @@ func (cluster *Cluster) OpenSVCProvisionProxyService(pri DatabaseProxy) error {
 	return nil
 }
 
-func (cluster *Cluster) OpenSVCGetProxyTemplateV2(servers string, pri DatabaseProxy) ([]byte, error) {
+func (cluster *Cluster) OpenSVCGetProxyTemplateSectionMap(servers string, pri DatabaseProxy) map[string]map[string]string {
 	svcsection := make(map[string]map[string]string)
 	svcsection["DEFAULT"] = pri.OpenSVCGetProxyDefaultSection()
 	svcsection["ip#01"] = cluster.OpenSVCGetNetSection()
@@ -343,9 +414,6 @@ func (cluster *Cluster) OpenSVCGetProxyTemplateV2(servers string, pri DatabasePr
 		svcsection["disk#0001"] = cluster.OpenSVCGetDiskLoopbackSnapshotPodSection()
 		svcsection["fs#00"] = cluster.OpenSVCGetFSDockerPrivateSection()
 		svcsection["fs#01"] = cluster.OpenSVCGetFSPodSection()
-		//	svcsection["sync#01"] = server.OpenSVCGetZFSSnapshotSection()
-		//	svcsection["task#02"] = server.OpenSVCGetTaskZFSSnapshotSection()
-
 	} else {
 		if cluster.Conf.ProvDockerDaemonPrivate {
 			svcsection["volume#00"] = cluster.OpenSVCGetVolumeDockerSection()
@@ -381,12 +449,44 @@ func (cluster *Cluster) OpenSVCGetProxyTemplateV2(servers string, pri DatabasePr
 
 	svcsection["env"] = cluster.OpenSVCGetProxyEnvSection(servers, pri)
 
+	return svcsection
+}
+
+func (cluster *Cluster) OpenSVCGetProxyTemplateV2(servers string, pri DatabaseProxy) ([]byte, error) {
+	svcsection := cluster.OpenSVCGetProxyTemplateSectionMap(servers, pri)
+
 	svcsectionJson, err := json.MarshalIndent(svcsection, "", "\t")
 	if err != nil {
 		return []byte(""), err
 	}
 	return svcsectionJson, nil
+}
 
+func (cluster *Cluster) OpenSVCGetProxyTemplateV3(servers string, pri DatabaseProxy) ([]byte, error) {
+	svcsection := cluster.OpenSVCGetProxyTemplateSectionMap(servers, pri)
+
+	cfg := ini.Empty()
+
+	for sectionName, kv := range svcsection {
+		sec, err := cfg.NewSection(sectionName)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range kv {
+			_, err := sec.NewKey(k, v)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	var buf bytes.Buffer
+	_, err := cfg.WriteTo(&buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
 }
 
 func (cluster *Cluster) OpenSVCGetProxyVolumeDataSection() map[string]string {

--- a/cluster/prov_opensvc_prx.go
+++ b/cluster/prov_opensvc_prx.go
@@ -183,26 +183,20 @@ func (cluster *Cluster) OpenSVCProvisionProxyV3(pri DatabaseProxy, svc opensvc.C
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn, "Failed to write template file %s: %s", templatefile, werr)
 	}
 
-	if p, ok := pri.(*Proxy); ok {
-		p.TemplateMD5Prov = misc.GetMD5HashFromBytes(res)
-		p.TemplateMD5 = p.TemplateMD5Prov
-	}
+	pri.SetTemplateMD5(misc.GetMD5HashFromBytes(res))
 
 	body, err := svc.CreateTemplateV3(cluster.Name, pri.GetServiceName(), pri.GetAgent(), res)
-	var se *opensvc.StatusError
 	if err != nil {
-		if !errors.As(err, &se) || se.StatusCode != 409 {
+		if !isOpenSVCAlreadyExists(err) {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not provision proxy:  %s ", err)
 			return err
 		}
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Proxy template already exists, reusing existing template: %s", pri.GetServiceName())
 	} else {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Template created with response: %s", body)
 	}
 
-	delay := cluster.Conf.ProvOpensvcV3ProvisionDelay
-	if delay <= 0 {
-		delay = 10
-	}
+	delay := normalizeOpenSVCV3ProvisionDelay(cluster.Conf.ProvOpensvcV3ProvisionDelay)
 	time.Sleep(time.Duration(delay) * time.Second)
 
 	return svc.ProvisionServiceV3(cluster.Name, pri.GetServiceName())

--- a/cluster/prov_opensvc_v3_test.go
+++ b/cluster/prov_opensvc_v3_test.go
@@ -1,0 +1,67 @@
+package cluster
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/signal18/replication-manager/opensvc"
+)
+
+func TestIsOpenSVCAlreadyExists(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "sentinel", err: opensvc.ErrObjectAlreadyExists, want: true},
+		{name: "wrapped sentinel", err: fmt.Errorf("wrapped: %w", opensvc.ErrObjectAlreadyExists), want: true},
+		{name: "status 409", err: &opensvc.StatusError{StatusCode: 409, Body: "conflict"}, want: true},
+		{name: "status 500", err: &opensvc.StatusError{StatusCode: 500, Body: "server error"}, want: false},
+		{name: "generic error", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isOpenSVCAlreadyExists(tt.err)
+			if got != tt.want {
+				t.Fatalf("isOpenSVCAlreadyExists(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeOpenSVCV3ProvisionDelay(t *testing.T) {
+	tests := []struct {
+		name  string
+		delay int
+		want  int
+	}{
+		{name: "negative uses default", delay: -1, want: defaultOpenSVCV3ProvisionDelay},
+		{name: "zero allowed", delay: 0, want: 0},
+		{name: "positive unchanged", delay: 3, want: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeOpenSVCV3ProvisionDelay(tt.delay)
+			if got != tt.want {
+				t.Fatalf("normalizeOpenSVCV3ProvisionDelay(%d) = %d, want %d", tt.delay, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProxySetTemplateMD5SetsBothFields(t *testing.T) {
+	p := &Proxy{}
+	p.SetTemplateMD5("abc123")
+
+	if p.TemplateMD5Prov != "abc123" {
+		t.Fatalf("TemplateMD5Prov = %q, want %q", p.TemplateMD5Prov, "abc123")
+	}
+
+	if p.TemplateMD5 != "abc123" {
+		t.Fatalf("TemplateMD5 = %q, want %q", p.TemplateMD5, "abc123")
+	}
+}

--- a/cluster/prx.go
+++ b/cluster/prx.go
@@ -69,6 +69,8 @@ type Proxy struct {
 	workingAgentMu  sync.RWMutex         `json:"-"`
 	Weight          string               `json:"weight"`
 	IsStaging       bool                 `json:"isStaging"`
+	TemplateMD5Prov string               `json:"templateMD5Prov"`
+	TemplateMD5     string               `json:"templateMD5"`
 	Lock            sync.Mutex
 }
 

--- a/cluster/prx.go
+++ b/cluster/prx.go
@@ -142,6 +142,7 @@ type DatabaseProxy interface {
 	SetID()
 	SetDataDir()
 	SetServiceName(namespace string)
+	SetTemplateMD5(md5 string)
 	SetStaging(staging bool)
 	IsInStaging() bool
 

--- a/cluster/prx_set.go
+++ b/cluster/prx_set.go
@@ -40,6 +40,11 @@ func (proxy *Proxy) SetStaging(staging bool) {
 	proxy.IsStaging = staging
 }
 
+func (proxy *Proxy) SetTemplateMD5(md5 string) {
+	proxy.TemplateMD5Prov = md5
+	proxy.TemplateMD5 = md5
+}
+
 func (proxy *Proxy) SetPlacement(k int, ProvAgents string, SlapOSDBPartitions string, ProxysqlHostsIPV6 string, Weights string) {
 	slapospartitions := strings.Split(SlapOSDBPartitions, ",")
 	agents := strings.Split(ProvAgents, ",")

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -44,179 +44,179 @@ import (
 
 // ServerMonitor defines a server to monitor.
 type ServerMonitor struct {
-	Id                          string                     `json:"id" groups:"apps"` //Unique name given by cluster & crc64(URL) used by test to provision
-	Name                        string                     `json:"name" groups:"apps"`
-	Domain                      string                     `json:"domain" groups:"apps""` // Use to store orchestrator CNI domain .<cluster_name>.svc.<cluster_name>
-	ServiceName                 string                     `json:"serviceName"`
-	SourceClusterName           string                     `json:"sourceClusterName" groups:"apps"` //Used to idenfied server added from other clusters linked with multi source
-	Conn                        *sqlx.DB                   `json:"-"`
-	User                        string                     `json:"user"`
-	Pass                        string                     `json:"-"`
-	URL                         string                     `json:"url" groups:"apps"`
-	DSN                         string                     `json:"-"`
-	Host                        string                     `json:"host" groups:"apps"`
-	HostCnf                     string                     `json:"-"` // used to store host from config file
-	Port                        string                     `json:"port" groups:"apps"`
-	TunnelPort                  string                     `json:"tunnelPort"`
-	IP                          string                     `json:"ip"`
-	Strict                      string                     `json:"strict"`
-	ServerID                    uint64                     `json:"serverId"`
-	HashUUID                    uint64                     `json:"hashUUID"`
-	DomainID                    uint64                     `json:"domainId"`
-	GTIDBinlogPos               *gtid.List                 `json:"gtidBinlogPos"`
-	CurrentGtid                 *gtid.List                 `json:"currentGtid"`
-	SlaveGtid                   *gtid.List                 `json:"slaveGtid"`
-	IOGtid                      *gtid.List                 `json:"ioGtid"`
-	FailoverIOGtid              *gtid.List                 `json:"failoverIoGtid"`
-	GTIDExecuted                string                     `json:"gtidExecuted"`
-	ReadOnly                    string                     `json:"readOnly"`
-	State                       string                     `json:"state"`
-	PrevState                   string                     `json:"prevState"`
-	FailCount                   int                        `json:"failCount"`
-	FailSuspectHeartbeat        int64                      `json:"failSuspectHeartbeat"`
-	ClusterGroup                *Cluster                   `json:"-"` //avoid recusive json
-	BinaryLogFile               string                     `json:"binaryLogFile"`
-	BinaryLogFilePrevious       string                     `json:"binaryLogFilePrevious"`
-	BinaryLogPos                string                     `json:"binaryLogPos"`
-	FailoverMasterLogFile       string                     `json:"failoverMasterLogFile"`
-	FailoverMasterLogPos        string                     `json:"failoverMasterLogPos"`
-	FailoverSemiSyncSlaveStatus bool                       `json:"failoverSemiSyncSlaveStatus"`
-	Process                     *os.Process                `json:"process"`
-	SemiSyncMasterStatus        bool                       `json:"semiSyncMasterStatus"`
-	SemiSyncSlaveStatus         bool                       `json:"semiSyncSlaveStatus"`
-	HaveSSHError                bool                       `json:"HaveSshError"`
-	HaveHealthyReplica          bool                       `json:"HaveHealthyReplica"`
-	HaveEventScheduler          bool                       `json:"eventScheduler"`
-	HaveSemiSync                bool                       `json:"haveSemiSync"`
-	HaveInnodbTrxCommit         bool                       `json:"haveInnodbTrxCommit"`
-	HaveChecksum                bool                       `json:"haveInnodbChecksum"`
-	HaveLogGeneral              bool                       `json:"haveLogGeneral"`
-	HaveBinlog                  bool                       `json:"haveBinlog"`
-	HaveBinlogSync              bool                       `json:"haveBinLogSync"`
-	HaveBinlogRow               bool                       `json:"haveBinlogRow"`
-	HaveBinlogMixed             bool                       `json:"haveBinlogMixed"`
-	HaveBinlogStatement         bool                       `json:"haveBinlogStatement"`
-	HaveBinlogAnnotate          bool                       `json:"haveBinlogAnnotate"`
-	HaveBinlogSlowqueries       bool                       `json:"haveBinlogSlowqueries"`
-	HaveBinlogCompress          bool                       `json:"haveBinlogCompress"`
-	HaveBinlogSlaveUpdates      bool                       `json:"HaveBinlogSlaveUpdates"`
-	HaveGtidStrictMode          bool                       `json:"haveGtidStrictMode"`
-	HaveMySQLGTID               bool                       `json:"haveMysqlGtid"`
-	HaveMariaDBGTID             bool                       `json:"haveMariadbGtid"`
-	HaveSlowQueryLog            bool                       `json:"haveSlowQueryLog"`
-	HavePFSSlowQueryLog         bool                       `json:"havePFSSlowQueryLog"`
-	HaveMetaDataLocksLog        bool                       `json:"haveMetaDataLocksLog"`
-	HaveQueryResponseTimeLog    bool                       `json:"haveQueryResponseTimeLog"`
-	HaveDiskMonitor             bool                       `json:"haveDiskMonitor"`
-	HaveSQLErrorLog             bool                       `json:"haveSQLErrorLog"`
-	HavePFS                     bool                       `json:"havePFS"`
-	HaveWsrep                   bool                       `json:"haveWsrep"`
-	HaveReadOnly                bool                       `json:"haveReadOnly"`
-	HaveNoMasterOnStart         bool                       `json:"haveNoMasterOnStart"`
-	HaveSlaveIdempotent         bool                       `json:"haveSlaveIdempotent"`
-	HaveSlaveOptimistic         bool                       `json:"haveSlaveOptimistic"`
-	HaveSlaveSerialized         bool                       `json:"haveSlaveSerialized"`
-	HaveSlaveAggressive         bool                       `json:"haveSlaveAggressive"`
-	HaveSlaveMinimal            bool                       `json:"haveSlaveMinimal"`
-	HaveSlaveConservative       bool                       `json:"haveSlaveConservative"`
-	IsWsrepSync                 bool                       `json:"isWsrepSync"`
-	IsWsrepDonor                bool                       `json:"isWsrepDonor"`
-	IsWsrepPrimary              bool                       `json:"isWsrepPrimary"`
-	IsMaxscale                  bool                       `json:"isMaxscale"`
-	IsRelay                     bool                       `json:"isRelay"`
-	IsSlave                     bool                       `json:"isSlave"`
-	IsGroupReplicationSlave     bool                       `json:"isGroupReplicationSlave"`
-	IsGroupReplicationMaster    bool                       `json:"isGroupReplicationMaster"`
-	IsVirtualMaster             bool                       `json:"isVirtualMaster"`
-	IsMaintenance               bool                       `json:"isMaintenance"`
-	IsCompute                   bool                       `json:"isCompute"` //Used to idenfied spider compute nide
-	IsDelayed                   bool                       `json:"isDelayed"`
-	IsFull                      bool                       `json:"isFull"`
-	IsConfigGen                 bool                       `json:"isConfigGen"`
-	IsRunningJobs               bool                       `json:"isRunningJobs"`
-	IsDataDiverge               bool                       `json:"isDataDiverge"`
-	Ignored                     bool                       `json:"ignored"`
-	IgnoredRO                   bool                       `json:"ignoredRO"`
-	Prefered                    bool                       `json:"prefered"`
-	PreferedBackup              bool                       `json:"preferedBackup"`
-	InCaptureMode               bool                       `json:"inCaptureMode"`
-	LongQueryTimeSaved          string                     `json:"longQueryTimeSaved"`
-	LongQueryTime               string                     `json:"longQueryTime"`
-	LogOutput                   string                     `json:"logOutput"`
-	SlowQueryLog                string                     `json:"slowQueryLog"`
-	SlowQueryCapture            bool                       `json:"slowQueryCapture"`
-	BinlogDumpThreads           int                        `json:"binlogDumpThreads"`
-	MxsVersion                  int                        `json:"maxscaleVersion"`
-	MxsHaveGtid                 bool                       `json:"maxscaleHaveGtid"`
-	MxsServerName               string                     `json:"maxscaleServerName"` //Unique server Name in maxscale conf
-	MxsServerStatus             string                     `json:"maxscaleServerStatus"`
-	ProxysqlHostgroup           string                     `json:"proxysqlHostgroup"`
-	RelayLogSize                uint64                     `json:"relayLogSize"`
-	Replications                []dbhelper.SlaveStatus     `json:"replications"`
-	LastSeenReplications        []dbhelper.SlaveStatus     `json:"lastSeenReplications"`
-	MasterStatus                dbhelper.MasterStatus      `json:"masterStatus"`
-	SlaveStatus                 *dbhelper.SlaveStatus      `json:"-"`
-	ReplicationSourceName       string                     `json:"replicationSourceName"`
-	DBVersion                   *version.Version           `json:"dbVersion"`
-	Version                     int                        `json:"-"`
-	QPS                         int64                      `json:"qps"`
-	ReplicationHealth           string                     `json:"replicationHealth"`
-	EventStatus                 []dbhelper.Event           `json:"eventStatus"`
-	FullProcessList             []dbhelper.Processlist     `json:"-"`
-	Variables                   *config.StringsMap         `json:"-"`
-	SensitiveVariables          *config.StringsMap         `json:"-"`
-	VariablesMap                *config.VariablesMap       `json:"-"`
-	EngineInnoDB                *config.StringsMap         `json:"engineInnodb"`
-	ErrorLog                    s18log.HttpLog             `json:"-"`
-	SqlErrorLog                 s18log.HttpLog             `json:"-"`
-	AuditLog                    s18log.HttpLog             `json:"-"`
-	SlowLog                     s18log.SlowLog             `json:"-"`
-	Status                      *config.StringsMap         `json:"-"`
-	PrevStatus                  *config.StringsMap         `json:"-"`
-	PFSQueries                  *dbhelper.PFSQueriesMap    `json:"-"` //PFS queries
-	PFSInstruments              *config.StringsMap         `json:"pfsInstruments"`
-	SlowPFSQueries              *dbhelper.PFSQueriesMap    `json:"-"` //PFS queries from slow
-	DictTables                  *dbhelper.TablesMap        `json:"-"`
-	Tables                      []dbhelper.Table           `json:"-"`
-	Disks                       []dbhelper.Disk            `json:"-"`
-	Plugins                     *dbhelper.PluginsMap       `json:"-"`
-	Users                       *dbhelper.GrantsMap        `json:"-"`
-	MetaDataLocks               []dbhelper.MetaDataLock    `json:"-"`
-	ErrorLogTailer              *tail.Tail                 `json:"-"`
-	SlowLogTailer               *tail.Tail                 `json:"-"`
-	SqlErrorLogTailer           *tail.Tail                 `json:"-"`
-	AuditLogTailer              *tail.Tail                 `json:"-"`
-	BinlogEventLog              s18log.BinlogEventLog      `json:"-"` // recent binlog QUERY events for security plugins
-	binlogEventSyncer           *replication.BinlogSyncer  // persistent syncer for security event scanning
+	Id                          string                      `json:"id" groups:"apps"` //Unique name given by cluster & crc64(URL) used by test to provision
+	Name                        string                      `json:"name" groups:"apps"`
+	Domain                      string                      `json:"domain" groups:"apps""` // Use to store orchestrator CNI domain .<cluster_name>.svc.<cluster_name>
+	ServiceName                 string                      `json:"serviceName"`
+	SourceClusterName           string                      `json:"sourceClusterName" groups:"apps"` //Used to idenfied server added from other clusters linked with multi source
+	Conn                        *sqlx.DB                    `json:"-"`
+	User                        string                      `json:"user"`
+	Pass                        string                      `json:"-"`
+	URL                         string                      `json:"url" groups:"apps"`
+	DSN                         string                      `json:"-"`
+	Host                        string                      `json:"host" groups:"apps"`
+	HostCnf                     string                      `json:"-"` // used to store host from config file
+	Port                        string                      `json:"port" groups:"apps"`
+	TunnelPort                  string                      `json:"tunnelPort"`
+	IP                          string                      `json:"ip"`
+	Strict                      string                      `json:"strict"`
+	ServerID                    uint64                      `json:"serverId"`
+	HashUUID                    uint64                      `json:"hashUUID"`
+	DomainID                    uint64                      `json:"domainId"`
+	GTIDBinlogPos               *gtid.List                  `json:"gtidBinlogPos"`
+	CurrentGtid                 *gtid.List                  `json:"currentGtid"`
+	SlaveGtid                   *gtid.List                  `json:"slaveGtid"`
+	IOGtid                      *gtid.List                  `json:"ioGtid"`
+	FailoverIOGtid              *gtid.List                  `json:"failoverIoGtid"`
+	GTIDExecuted                string                      `json:"gtidExecuted"`
+	ReadOnly                    string                      `json:"readOnly"`
+	State                       string                      `json:"state"`
+	PrevState                   string                      `json:"prevState"`
+	FailCount                   int                         `json:"failCount"`
+	FailSuspectHeartbeat        int64                       `json:"failSuspectHeartbeat"`
+	ClusterGroup                *Cluster                    `json:"-"` //avoid recusive json
+	BinaryLogFile               string                      `json:"binaryLogFile"`
+	BinaryLogFilePrevious       string                      `json:"binaryLogFilePrevious"`
+	BinaryLogPos                string                      `json:"binaryLogPos"`
+	FailoverMasterLogFile       string                      `json:"failoverMasterLogFile"`
+	FailoverMasterLogPos        string                      `json:"failoverMasterLogPos"`
+	FailoverSemiSyncSlaveStatus bool                        `json:"failoverSemiSyncSlaveStatus"`
+	Process                     *os.Process                 `json:"process"`
+	SemiSyncMasterStatus        bool                        `json:"semiSyncMasterStatus"`
+	SemiSyncSlaveStatus         bool                        `json:"semiSyncSlaveStatus"`
+	HaveSSHError                bool                        `json:"HaveSshError"`
+	HaveHealthyReplica          bool                        `json:"HaveHealthyReplica"`
+	HaveEventScheduler          bool                        `json:"eventScheduler"`
+	HaveSemiSync                bool                        `json:"haveSemiSync"`
+	HaveInnodbTrxCommit         bool                        `json:"haveInnodbTrxCommit"`
+	HaveChecksum                bool                        `json:"haveInnodbChecksum"`
+	HaveLogGeneral              bool                        `json:"haveLogGeneral"`
+	HaveBinlog                  bool                        `json:"haveBinlog"`
+	HaveBinlogSync              bool                        `json:"haveBinLogSync"`
+	HaveBinlogRow               bool                        `json:"haveBinlogRow"`
+	HaveBinlogMixed             bool                        `json:"haveBinlogMixed"`
+	HaveBinlogStatement         bool                        `json:"haveBinlogStatement"`
+	HaveBinlogAnnotate          bool                        `json:"haveBinlogAnnotate"`
+	HaveBinlogSlowqueries       bool                        `json:"haveBinlogSlowqueries"`
+	HaveBinlogCompress          bool                        `json:"haveBinlogCompress"`
+	HaveBinlogSlaveUpdates      bool                        `json:"HaveBinlogSlaveUpdates"`
+	HaveGtidStrictMode          bool                        `json:"haveGtidStrictMode"`
+	HaveMySQLGTID               bool                        `json:"haveMysqlGtid"`
+	HaveMariaDBGTID             bool                        `json:"haveMariadbGtid"`
+	HaveSlowQueryLog            bool                        `json:"haveSlowQueryLog"`
+	HavePFSSlowQueryLog         bool                        `json:"havePFSSlowQueryLog"`
+	HaveMetaDataLocksLog        bool                        `json:"haveMetaDataLocksLog"`
+	HaveQueryResponseTimeLog    bool                        `json:"haveQueryResponseTimeLog"`
+	HaveDiskMonitor             bool                        `json:"haveDiskMonitor"`
+	HaveSQLErrorLog             bool                        `json:"haveSQLErrorLog"`
+	HavePFS                     bool                        `json:"havePFS"`
+	HaveWsrep                   bool                        `json:"haveWsrep"`
+	HaveReadOnly                bool                        `json:"haveReadOnly"`
+	HaveNoMasterOnStart         bool                        `json:"haveNoMasterOnStart"`
+	HaveSlaveIdempotent         bool                        `json:"haveSlaveIdempotent"`
+	HaveSlaveOptimistic         bool                        `json:"haveSlaveOptimistic"`
+	HaveSlaveSerialized         bool                        `json:"haveSlaveSerialized"`
+	HaveSlaveAggressive         bool                        `json:"haveSlaveAggressive"`
+	HaveSlaveMinimal            bool                        `json:"haveSlaveMinimal"`
+	HaveSlaveConservative       bool                        `json:"haveSlaveConservative"`
+	IsWsrepSync                 bool                        `json:"isWsrepSync"`
+	IsWsrepDonor                bool                        `json:"isWsrepDonor"`
+	IsWsrepPrimary              bool                        `json:"isWsrepPrimary"`
+	IsMaxscale                  bool                        `json:"isMaxscale"`
+	IsRelay                     bool                        `json:"isRelay"`
+	IsSlave                     bool                        `json:"isSlave"`
+	IsGroupReplicationSlave     bool                        `json:"isGroupReplicationSlave"`
+	IsGroupReplicationMaster    bool                        `json:"isGroupReplicationMaster"`
+	IsVirtualMaster             bool                        `json:"isVirtualMaster"`
+	IsMaintenance               bool                        `json:"isMaintenance"`
+	IsCompute                   bool                        `json:"isCompute"` //Used to idenfied spider compute nide
+	IsDelayed                   bool                        `json:"isDelayed"`
+	IsFull                      bool                        `json:"isFull"`
+	IsConfigGen                 bool                        `json:"isConfigGen"`
+	IsRunningJobs               bool                        `json:"isRunningJobs"`
+	IsDataDiverge               bool                        `json:"isDataDiverge"`
+	Ignored                     bool                        `json:"ignored"`
+	IgnoredRO                   bool                        `json:"ignoredRO"`
+	Prefered                    bool                        `json:"prefered"`
+	PreferedBackup              bool                        `json:"preferedBackup"`
+	InCaptureMode               bool                        `json:"inCaptureMode"`
+	LongQueryTimeSaved          string                      `json:"longQueryTimeSaved"`
+	LongQueryTime               string                      `json:"longQueryTime"`
+	LogOutput                   string                      `json:"logOutput"`
+	SlowQueryLog                string                      `json:"slowQueryLog"`
+	SlowQueryCapture            bool                        `json:"slowQueryCapture"`
+	BinlogDumpThreads           int                         `json:"binlogDumpThreads"`
+	MxsVersion                  int                         `json:"maxscaleVersion"`
+	MxsHaveGtid                 bool                        `json:"maxscaleHaveGtid"`
+	MxsServerName               string                      `json:"maxscaleServerName"` //Unique server Name in maxscale conf
+	MxsServerStatus             string                      `json:"maxscaleServerStatus"`
+	ProxysqlHostgroup           string                      `json:"proxysqlHostgroup"`
+	RelayLogSize                uint64                      `json:"relayLogSize"`
+	Replications                []dbhelper.SlaveStatus      `json:"replications"`
+	LastSeenReplications        []dbhelper.SlaveStatus      `json:"lastSeenReplications"`
+	MasterStatus                dbhelper.MasterStatus       `json:"masterStatus"`
+	SlaveStatus                 *dbhelper.SlaveStatus       `json:"-"`
+	ReplicationSourceName       string                      `json:"replicationSourceName"`
+	DBVersion                   *version.Version            `json:"dbVersion"`
+	Version                     int                         `json:"-"`
+	QPS                         int64                       `json:"qps"`
+	ReplicationHealth           string                      `json:"replicationHealth"`
+	EventStatus                 []dbhelper.Event            `json:"eventStatus"`
+	FullProcessList             []dbhelper.Processlist      `json:"-"`
+	Variables                   *config.StringsMap          `json:"-"`
+	SensitiveVariables          *config.StringsMap          `json:"-"`
+	VariablesMap                *config.VariablesMap        `json:"-"`
+	EngineInnoDB                *config.StringsMap          `json:"engineInnodb"`
+	ErrorLog                    s18log.HttpLog              `json:"-"`
+	SqlErrorLog                 s18log.HttpLog              `json:"-"`
+	AuditLog                    s18log.HttpLog              `json:"-"`
+	SlowLog                     s18log.SlowLog              `json:"-"`
+	Status                      *config.StringsMap          `json:"-"`
+	PrevStatus                  *config.StringsMap          `json:"-"`
+	PFSQueries                  *dbhelper.PFSQueriesMap     `json:"-"` //PFS queries
+	PFSInstruments              *config.StringsMap          `json:"pfsInstruments"`
+	SlowPFSQueries              *dbhelper.PFSQueriesMap     `json:"-"` //PFS queries from slow
+	DictTables                  *dbhelper.TablesMap         `json:"-"`
+	Tables                      []dbhelper.Table            `json:"-"`
+	Disks                       []dbhelper.Disk             `json:"-"`
+	Plugins                     *dbhelper.PluginsMap        `json:"-"`
+	Users                       *dbhelper.GrantsMap         `json:"-"`
+	MetaDataLocks               []dbhelper.MetaDataLock     `json:"-"`
+	ErrorLogTailer              *tail.Tail                  `json:"-"`
+	SlowLogTailer               *tail.Tail                  `json:"-"`
+	SqlErrorLogTailer           *tail.Tail                  `json:"-"`
+	AuditLogTailer              *tail.Tail                  `json:"-"`
+	BinlogEventLog              s18log.BinlogEventLog       `json:"-"` // recent binlog QUERY events for security plugins
+	binlogEventSyncer           *replication.BinlogSyncer   // persistent syncer for security event scanning
 	binlogEventStreamer         *replication.BinlogStreamer // stream open on the current binlog file
-	binlogEventFile             string                     // binlog filename the streamer is attached to
-	MonitorTime                 int64                      `json:"-"`
-	PrevMonitorTime             int64                      `json:"-"`
-	maxConn                     string                     `json:"maxConn"` // used to back max connection for failover
-	Datadir                     string                     `json:"datadir"`
-	SlapOSDatadir               string                     `json:"slaposDatadir"`
-	PostgressDB                 string                     `json:"postgressDB"`
-	TLSConfigUsed               string                     `json:"tlsConfigUsed"` //used to track TLS config during key rotation
-	LastTLSConfig               string                     `json:"lastTLSConfig"` //used to track last working TLS config
-	ForceTLSSkipVerify          bool                       `json:"forceTLSSkipVerify"` // auto-detected when server returns error 3159 (require_secure_transport=ON)
-	SSTPort                     string                     `json:"sstPort"`       //used to send data to dbjobs
-	Agent                       string                     `json:"agent"`         //used to provision service in orchestrator
-	WorkingAgent                string                     `json:"workingAgent"`  //used to track on which agent the server is running
-	workingAgentMu              sync.RWMutex               `json:"-"`
-	BinaryLogFiles              *dbhelper.BinaryLogMetaMap `json:"binaryLogFiles"`
-	BinaryLogMetaToWrite        []string                   `json:"-"`
-	BinaryLogMetaToRemove       []string                   `json:"-"`
-	BinaryLogFilesCount         int                        `json:"binaryLogFilesCount"`
-	BinaryLogFileOldest         string                     `json:"binaryLogFileOldest"`
-	BinaryLogOldestTimestamp    int64                      `json:"binaryLogOldestTimestamp"`
-	BinaryLogPurgeBefore        int64                      `json:"binaryLogPurgeBefore"`
-	MaxSlowQueryTimestamp       int64                      `json:"maxSlowQueryTimestamp"`
-	WorkLoad                    *config.WorkLoadsMap       `json:"workLoad"`
-	DelayStat                   *ServerDelayStat           `json:"delayStat"`
-	SlaveVariables              SlaveVariables             `json:"slaveVariables"`
-	IsReseeding                 string                     `json:"isReseeding"`
-	ReplicationTags             string                     `json:"replicationTags"`
-	JobResults                  *config.TasksMap           `json:"jobResults"`
+	binlogEventFile             string                      // binlog filename the streamer is attached to
+	MonitorTime                 int64                       `json:"-"`
+	PrevMonitorTime             int64                       `json:"-"`
+	maxConn                     string                      `json:"maxConn"` // used to back max connection for failover
+	Datadir                     string                      `json:"datadir"`
+	SlapOSDatadir               string                      `json:"slaposDatadir"`
+	PostgressDB                 string                      `json:"postgressDB"`
+	TLSConfigUsed               string                      `json:"tlsConfigUsed"`      //used to track TLS config during key rotation
+	LastTLSConfig               string                      `json:"lastTLSConfig"`      //used to track last working TLS config
+	ForceTLSSkipVerify          bool                        `json:"forceTLSSkipVerify"` // auto-detected when server returns error 3159 (require_secure_transport=ON)
+	SSTPort                     string                      `json:"sstPort"`            //used to send data to dbjobs
+	Agent                       string                      `json:"agent"`              //used to provision service in orchestrator
+	WorkingAgent                string                      `json:"workingAgent"`       //used to track on which agent the server is running
+	workingAgentMu              sync.RWMutex                `json:"-"`
+	BinaryLogFiles              *dbhelper.BinaryLogMetaMap  `json:"binaryLogFiles"`
+	BinaryLogMetaToWrite        []string                    `json:"-"`
+	BinaryLogMetaToRemove       []string                    `json:"-"`
+	BinaryLogFilesCount         int                         `json:"binaryLogFilesCount"`
+	BinaryLogFileOldest         string                      `json:"binaryLogFileOldest"`
+	BinaryLogOldestTimestamp    int64                       `json:"binaryLogOldestTimestamp"`
+	BinaryLogPurgeBefore        int64                       `json:"binaryLogPurgeBefore"`
+	MaxSlowQueryTimestamp       int64                       `json:"maxSlowQueryTimestamp"`
+	WorkLoad                    *config.WorkLoadsMap        `json:"workLoad"`
+	DelayStat                   *ServerDelayStat            `json:"delayStat"`
+	SlaveVariables              SlaveVariables              `json:"slaveVariables"`
+	IsReseeding                 string                      `json:"isReseeding"`
+	ReplicationTags             string                      `json:"replicationTags"`
+	JobResults                  *config.TasksMap            `json:"jobResults"`
 	IsInSlowQueryCapture        bool
 	IsInPFSQueryCapture         bool
 	PFSLastSnapshot             time.Time                   // timestamp of last periodic PFS digest snapshot flush
@@ -1533,7 +1533,10 @@ func (server *ServerMonitor) FlushTables() (string, error) {
 
 func (server *ServerMonitor) Uprovision() {
 	cluster := server.ClusterGroup
-	cluster.OpenSVCUnprovisionDatabaseService(server)
+	go cluster.OpenSVCUnprovisionDatabaseService(server)
+	if err := <-cluster.errorChan; err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision database service %s: %s", server.ServiceName, err)
+	}
 }
 
 func (server *ServerMonitor) Provision() {

--- a/cluster/srv_cnf.go
+++ b/cluster/srv_cnf.go
@@ -945,53 +945,6 @@ func (server *ServerMonitor) WriteDeltaVariables() error {
 			continue
 		}
 
-		// 4-LAYER SAFETY FRAMEWORK FOR RUNTIME FALLBACK
-		// Only use runtime value if deployed is nil and all safety checks pass
-		if v.Deployed == nil && v.Runtime != nil {
-			runtimeStr := v.Runtime.String()
-
-			// Layer 1: Empty value check - never write empty values
-			// Layer 2: Read-only check - never write read-only variables
-			// Layer 3: Whitelist check - only write whitelisted variables
-			// Layer 4: Server status check - only if server is running (not failed)
-			if runtimeStr != "" &&
-				!isReadOnlyVariable(v.VariableName) &&
-				isSafeForRuntimeFallback(v.VariableName) &&
-				!server.IsFailed() {
-				// Safe to use runtime value as fallback
-				v.Deployed = v.Runtime
-				content.WriteString(v.PrintDeployedDelta() + "\n")
-				v.Deployed = nil // Reset to avoid persisting the change
-			}
-			// If any check fails, skip this variable (don't write it)
-			continue
-		}
-
-		// LAYER 5: MYSQL DEFAULT FALLBACK - REMOVED
-		// This layer has been removed because Configurator generates a base CNF from tags.
-		// Configuration priority is now:
-		//   1. Server-specific preserved variables (01_preserved.cnf, 02_delta.cnf, 03_agreed.cnf)
-		//   2. Cluster-wide preserved variables
-		//   3. Configurator settings (tags, templates, dynamic configs)
-		//   4. Runtime/deployed values
-		// No need for mysql_defaults.cnf as configurator provides the base configuration.
-		/*
-			if v.Deployed == nil && v.Runtime == nil && server.IsFailed() {
-				defaultValue := cluster.getMySQLDefaultForVar(v.VariableName)
-				if defaultValue != "" {
-					sv := config.SingleValue(defaultValue)
-					v.Deployed = &sv
-					content.WriteString(v.PrintDeployedDelta() + "\n")
-					v.Deployed = nil // Reset to avoid persisting the change
-
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
-						"Using MySQL default for variable %s=%s (server failed, no deployed/runtime values)",
-						v.VariableName, defaultValue)
-				}
-				continue
-			}
-		*/
-
 		// Normal case: deployed value exists
 		content.WriteString(v.PrintDeployedDelta() + "\n")
 	}

--- a/cluster/srv_cnf.go
+++ b/cluster/srv_cnf.go
@@ -840,92 +840,6 @@ func (server *ServerMonitor) ReadPreservedVariables() error {
 	return nil
 }
 
-// Read-only variables that should never be written to config files
-var readOnlyVariables = []string{
-	"VERSION",
-	"VERSION_COMMENT",
-	"VERSION_COMPILE_MACHINE",
-	"VERSION_COMPILE_OS",
-	"HOSTNAME",
-	"SERVER_UUID",
-	"BASEDIR",
-	"LOG_BIN_BASENAME",
-	"LOG_BIN_INDEX",
-	"RELAY_LOG_BASENAME",
-	"RELAY_LOG_INDEX",
-	"DATADIR", // Paths should not be changed via runtime fallback
-}
-
-// Variables safe for runtime fallback (whitelist)
-var safeRuntimeFallbackVariables = []string{
-	"INNODB_BUFFER_POOL_SIZE",
-	"MAX_CONNECTIONS",
-	"INNODB_LOG_FILE_SIZE",
-	"INNODB_FLUSH_LOG_AT_TRX_COMMIT",
-	"SYNC_BINLOG",
-	"BINLOG_FORMAT",
-	"SLOW_QUERY_LOG",
-	"SLOW_QUERY_LOG_FILE",
-	"LONG_QUERY_TIME",
-	"LOG_QUERIES_NOT_USING_INDEXES",
-	"GENERAL_LOG",
-	"GENERAL_LOG_FILE",
-	"LOG_ERROR",
-	"LOG_WARNINGS",
-	"EXPIRE_LOGS_DAYS",
-	"BINLOG_EXPIRE_LOGS_SECONDS",
-	"MAX_ALLOWED_PACKET",
-	"MAX_BINLOG_SIZE",
-	"MAX_RELAY_LOG_SIZE",
-	"RELAY_LOG_SPACE_LIMIT",
-	"INNODB_IO_CAPACITY",
-	"INNODB_IO_CAPACITY_MAX",
-	"INNODB_FLUSH_METHOD",
-	"INNODB_FILE_PER_TABLE",
-	"INNODB_BUFFER_POOL_INSTANCES",
-	"INNODB_LOG_BUFFER_SIZE",
-	"INNODB_WRITE_IO_THREADS",
-	"INNODB_READ_IO_THREADS",
-	"INNODB_PURGE_THREADS",
-	"INNODB_PAGE_CLEANERS",
-	"TABLE_OPEN_CACHE",
-	"TABLE_DEFINITION_CACHE",
-	"OPEN_FILES_LIMIT",
-	"THREAD_CACHE_SIZE",
-	"QUERY_CACHE_SIZE",
-	"QUERY_CACHE_TYPE",
-	"TMP_TABLE_SIZE",
-	"MAX_HEAP_TABLE_SIZE",
-	"JOIN_BUFFER_SIZE",
-	"SORT_BUFFER_SIZE",
-	"READ_BUFFER_SIZE",
-	"READ_RND_BUFFER_SIZE",
-	"BINLOG_CACHE_SIZE",
-	"BINLOG_STMT_CACHE_SIZE",
-}
-
-// isReadOnlyVariable checks if a variable is read-only and should never be changed
-func isReadOnlyVariable(varName string) bool {
-	upperName := strings.ToUpper(varName)
-	for _, readOnly := range readOnlyVariables {
-		if upperName == readOnly {
-			return true
-		}
-	}
-	return false
-}
-
-// isSafeForRuntimeFallback checks if a variable is whitelisted for runtime fallback
-func isSafeForRuntimeFallback(varName string) bool {
-	upperName := strings.ToUpper(varName)
-	for _, safe := range safeRuntimeFallbackVariables {
-		if upperName == safe {
-			return true
-		}
-	}
-	return false
-}
-
 func (server *ServerMonitor) WriteDeltaVariables() error {
 	cluster := server.ClusterGroup
 	deltapath := filepath.Join(server.Datadir, "02_delta.cnf")
@@ -946,8 +860,14 @@ func (server *ServerMonitor) WriteDeltaVariables() error {
 			continue
 		}
 
-		// Normal case: deployed value exists
-		content.WriteString(v.PrintDeployedDelta() + "\n")
+		// Runtime fallback is intentionally disabled here. Delta files only persist
+		// deployed values that differ from config and are not preserved.
+		deltaLine := strings.TrimSpace(v.PrintDeployedDelta())
+		if deltaLine == "" {
+			continue
+		}
+
+		content.WriteString(deltaLine + "\n")
 	}
 
 	// Write atomically

--- a/cluster/srv_cnf.go
+++ b/cluster/srv_cnf.go
@@ -8,6 +8,7 @@ package cluster
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -960,7 +961,10 @@ func (server *ServerMonitor) WriteDeltaVariables() error {
 
 func (server *ServerMonitor) WipeDeltaConfig() {
 	deltapath := filepath.Join(server.Datadir, "02_delta.cnf")
-	os.Remove(deltapath)
+	if err := os.Remove(deltapath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		server.ClusterGroup.LogModulePrintf(server.ClusterGroup.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"Failed to remove delta config %s: %s", deltapath, err)
+	}
 }
 
 // atomicWriteFile writes data to a file atomically by writing to a temp file first,

--- a/cluster/srv_cnf.go
+++ b/cluster/srv_cnf.go
@@ -958,6 +958,11 @@ func (server *ServerMonitor) WriteDeltaVariables() error {
 	return nil
 }
 
+func (server *ServerMonitor) WipeDeltaConfig() {
+	deltapath := filepath.Join(server.Datadir, "02_delta.cnf")
+	os.Remove(deltapath)
+}
+
 // atomicWriteFile writes data to a file atomically by writing to a temp file first,
 // then renaming it to the target path. This prevents partial writes and corruption.
 func atomicWriteFile(path string, data []byte, perm os.FileMode) error {

--- a/cluster/srv_cnf_test.go
+++ b/cluster/srv_cnf_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/signal18/replication-manager/config"
 )
 
 // TestProcessDummyConfigSendCookie_NoCookie tests processing when no cookie exists
@@ -85,6 +87,35 @@ func TestProcessDummyConfigSendCookie_CookieDeletion(t *testing.T) {
 	// Note: In the real implementation, cookie is deleted before processing
 	// So even if processing fails, cookie should be gone
 	t.Log("Cookie deletion test completed")
+}
+
+func TestWipeDeltaConfig_RemoveErrorIsNonFatal(t *testing.T) {
+	tempDir := t.TempDir()
+	deltaPath := filepath.Join(tempDir, "02_delta.cnf")
+
+	if err := os.MkdirAll(deltaPath, 0o755); err != nil {
+		t.Fatalf("failed to create directory-backed delta path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(deltaPath, "guard.txt"), []byte("non-empty"), 0o644); err != nil {
+		t.Fatalf("failed to create guard file in delta directory: %v", err)
+	}
+
+	server := &ServerMonitor{
+		Datadir: tempDir,
+		ClusterGroup: &Cluster{
+			Conf: &config.Config{},
+		},
+	}
+
+	// os.Remove on a directory returns an error. WipeDeltaConfig should keep running
+	// and only log a warning.
+	server.WipeDeltaConfig()
+
+	if info, err := os.Stat(deltaPath); err != nil {
+		t.Fatalf("expected delta path to still exist after non-fatal remove error: %v", err)
+	} else if !info.IsDir() {
+		t.Fatalf("expected directory to remain at %s", deltaPath)
+	}
 }
 
 // TestTimingSafetyCalculation tests the timing safety logic

--- a/config/config.go
+++ b/config/config.go
@@ -548,6 +548,7 @@ type Config struct {
 	ProvOpensvcP12Secret                      string                       `mapstructure:"opensvc-p12-secret" toml:"opensvc-p12-secret" json:"opensvcP12Secret"`
 	ProvOpensvcUseCollectorAPI                bool                         `mapstructure:"opensvc-use-collector-api" toml:"opensvc-use-collector-api" json:"opensvcUseCollectorApi"`
 	ProvOpensvcCollectorAccount               string                       `mapstructure:"opensvc-collector-account" toml:"opensvc-collector-account" json:"opensvcCollectorAccount"`
+	ProvOpensvcV3ProvisionDelay               int                          `mapstructure:"opensvc-v3-provision-delay" toml:"opensvc-v3-provision-delay" json:"opensvcV3ProvisionDelay"`
 	ProvUser                                  string                       `mapstructure:"opensvc-user" toml:"opensvc-user" json:"opensvcUser"`
 	ProvCodeApp                               string                       `mapstructure:"opensvc-codeapp" toml:"opensvc-codeapp" json:"opensvcCodeapp"`
 	ProvEventTimeout                          int                          `mapstructure:"prov-timeout" toml:"prov-timeout" json:"provEventTimeout"`

--- a/config/maps.go
+++ b/config/maps.go
@@ -662,6 +662,10 @@ func (mv MapValue) Print(varname string) string {
 func (mv MapValue) PrintWithExclude(varname string, exclude VariableValue) []string {
 	pairs := make([]string, 0)
 
+	if strings.ToLower(varname) == "optimizer_switch" {
+		varname = "loose_optimizer_switch"
+	}
+
 	o, ok := exclude.(MapValue)
 	if !ok {
 		o = make(MapValue)

--- a/config/variable_value_test.go
+++ b/config/variable_value_test.go
@@ -9,6 +9,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -328,6 +329,23 @@ func TestVariablesMapSetValue(t *testing.T) {
 	// Should be a map value
 	if _, ok := state.Config.(MapValue); !ok {
 		t.Error("optimizer_switch should be MapValue")
+	}
+}
+
+func TestMapValuePrintWithExcludeUsesLooseOptimizerSwitch(t *testing.T) {
+	mv := make(MapValue)
+	mv.Set("index_merge=on")
+	mv.Set("mrr=off")
+
+	lines := mv.PrintWithExclude("optimizer_switch", nil)
+	if len(lines) == 0 {
+		t.Fatalf("expected printed lines for optimizer_switch")
+	}
+
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "loose_optimizer_switch=") {
+			t.Fatalf("expected loose_optimizer_switch prefix, got %q", line)
+		}
 	}
 }
 

--- a/opensvc/v3.go
+++ b/opensvc/v3.go
@@ -21,7 +21,14 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-var ErrObjectConflict = errors.New("unexpected status code: 409")
+type StatusError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("unexpected status code: %d, body: %s", e.StatusCode, e.Body)
+}
 
 func (collector *Collector) IsV3() bool {
 	return collector.ClusterApiVersion == "v3"
@@ -92,7 +99,10 @@ func (collector *Collector) GetAuthInfoV3() error {
 	}
 
 	if !handleSuccessGroup(resp.StatusCode) {
-		return fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, body)
+		return &StatusError{
+			StatusCode: resp.StatusCode,
+			Body:       string(body),
+		}
 	}
 
 	// Set the API version in the collector if successful
@@ -133,7 +143,10 @@ func (collector *Collector) GetNodesV3() ([]Host, error) {
 	}
 
 	if !handleSuccessGroup(resp.StatusCode) {
-		return nil, fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, body)
+		return nil, &StatusError{
+			StatusCode: resp.StatusCode,
+			Body:       string(body),
+		}
 	}
 
 	var hosts []Host
@@ -175,7 +188,10 @@ func (collector *Collector) CreateObjectV3(namespace, kind, service string, data
 	}
 
 	if !handleSuccessGroup(resp.StatusCode) {
-		return nil, fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, body)
+		return nil, &StatusError{
+			StatusCode: resp.StatusCode,
+			Body:       string(body),
+		}
 	}
 
 	return body, nil
@@ -213,7 +229,10 @@ func (collector *Collector) GetObjectV3(namespace, kind, service string, getFunc
 	}
 
 	if !handleSuccessGroup(resp.StatusCode) {
-		return nil, fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, body)
+		return nil, &StatusError{
+			StatusCode: resp.StatusCode,
+			Body:       string(body),
+		}
 	}
 
 	if getFunc == nil {
@@ -310,7 +329,10 @@ func (collector *Collector) handleObjectKeyValueV3(operation, namespace, kind, s
 	}
 
 	if !handleSuccessGroup(resp.StatusCode) {
-		return nil, fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, body)
+		return nil, &StatusError{
+			StatusCode: resp.StatusCode,
+			Body:       string(body),
+		}
 	}
 
 	return body, nil
@@ -322,7 +344,8 @@ func (collector *Collector) GetSecretKeyValueV3(namespace, service, key string) 
 
 func (collector *Collector) CreateSecretKeyValueV3(namespace, service, key, value string) error {
 	_, err := collector.handleObjectKeyValueV3("create", namespace, "sec", service, key, value)
-	if err != nil && errors.Is(err, ErrObjectConflict) {
+	var se *StatusError
+	if err != nil && errors.As(err, &se) && se.StatusCode == 409 {
 		return collector.UpdateSecretKeyValueV3(namespace, service, key, value)
 	}
 	return err
@@ -344,7 +367,8 @@ func (collector *Collector) GetConfigKeyValueV3(namespace, service, key string) 
 
 func (collector *Collector) CreateConfigKeyValueV3(namespace, service, key, value string) error {
 	_, err := collector.handleObjectKeyValueV3("create", namespace, "cfg", service, key, value)
-	if err != nil && errors.Is(err, ErrObjectConflict) {
+	var se *StatusError
+	if err != nil && errors.As(err, &se) && se.StatusCode == 409 {
 		return collector.UpdateConfigKeyValueV3(namespace, service, key, value)
 	}
 	return err
@@ -400,7 +424,10 @@ func (collector *Collector) handleObjectActionV3(namespace, kind, service, actio
 	}
 
 	if !handleSuccessGroup(resp.StatusCode) {
-		return nil, fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, body)
+		return nil, &StatusError{
+			StatusCode: resp.StatusCode,
+			Body:       string(body),
+		}
 	}
 
 	return body, nil
@@ -555,7 +582,10 @@ func (collector *Collector) handleInstanceActionV3(node, namespace, kind, servic
 	}
 
 	if !handleSuccessGroup(resp.StatusCode) {
-		return nil, fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, body)
+		return nil, &StatusError{
+			StatusCode: resp.StatusCode,
+			Body:       string(body),
+		}
 	}
 
 	return body, nil
@@ -589,7 +619,10 @@ func (collector *Collector) handleInstanceConsoleV3(node, namespace, kind, servi
 	}
 
 	if !handleSuccessGroup(resp.StatusCode) {
-		return nil, fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, body)
+		return nil, &StatusError{
+			StatusCode: resp.StatusCode,
+			Body:       string(body),
+		}
 	}
 
 	return []byte(resp.Header.Get("Location")), nil

--- a/opensvc/v3.go
+++ b/opensvc/v3.go
@@ -402,6 +402,8 @@ func (collector *Collector) handleObjectActionV3(namespace, kind, service, actio
 		resp, err = client.PostObjectActionProvision(ctx, namespace, oKind, service, collector.RequestCloserV3())
 	case "unprovision":
 		resp, err = client.PostObjectActionUnprovision(ctx, namespace, oKind, service, collector.RequestCloserV3())
+	case "abort":
+		resp, err = client.PostObjectActionAbort(ctx, namespace, oKind, service, collector.RequestCloserV3())
 	case "start":
 		resp, err = client.PostObjectActionStart(ctx, namespace, oKind, service, collector.RequestCloserV3())
 	case "stop":
@@ -524,6 +526,20 @@ func (collector *Collector) RestartServiceV3(cluster, svc string) error {
 	return err
 }
 
+func (collector *Collector) AbortServiceV3(cluster, svc string) error {
+	svcparts := strings.SplitN(svc, "/", 3)
+	if len(svcparts) != 3 {
+		return fmt.Errorf("invalid service format: %s, expected namespace/kind/name", svc)
+	}
+
+	ns := svcparts[0]
+	kind := svcparts[1]
+	svcname := svcparts[2]
+
+	_, err := collector.handleObjectActionV3(ns, kind, svcname, "abort", nil)
+	return err
+}
+
 func (collector *Collector) handleInstanceActionV3(node, namespace, kind, service, action string, params *InstanceActionParams) ([]byte, error) {
 	var resp *http.Response
 	var err error
@@ -568,6 +584,8 @@ func (collector *Collector) handleInstanceActionV3(node, namespace, kind, servic
 			rtparams = params.ToRestartParams()
 		}
 		resp, err = client.PostInstanceActionRestart(ctx, node, namespace, oKind, service, rtparams, collector.RequestCloserV3())
+	case "clear":
+		resp, err = client.PostInstanceClear(ctx, node, namespace, oKind, service, collector.RequestCloserV3())
 	default:
 		return nil, fmt.Errorf("unsupported action: %s", action)
 	}
@@ -589,6 +607,20 @@ func (collector *Collector) handleInstanceActionV3(node, namespace, kind, servic
 	}
 
 	return body, nil
+}
+
+func (collector *Collector) ClearInstanceV3(node, svc string) error {
+	svcparts := strings.SplitN(svc, "/", 3)
+	if len(svcparts) != 3 {
+		return fmt.Errorf("invalid service format: %s, expected namespace/kind/name", svc)
+	}
+
+	ns := svcparts[0]
+	kind := svcparts[1]
+	svcname := svcparts[2]
+
+	_, err := collector.handleInstanceActionV3(node, ns, kind, svcname, "clear", nil)
+	return err
 }
 
 func (collector *Collector) handleInstanceConsoleV3(node, namespace, kind, service, rid string) ([]byte, error) {

--- a/opensvc/v3.go
+++ b/opensvc/v3.go
@@ -21,6 +21,8 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+var ErrObjectConflict = errors.New("unexpected status code: 409")
+
 func (collector *Collector) IsV3() bool {
 	return collector.ClusterApiVersion == "v3"
 }
@@ -320,7 +322,7 @@ func (collector *Collector) GetSecretKeyValueV3(namespace, service, key string) 
 
 func (collector *Collector) CreateSecretKeyValueV3(namespace, service, key, value string) error {
 	_, err := collector.handleObjectKeyValueV3("create", namespace, "sec", service, key, value)
-	if err != nil && errors.Is(err, ErrObjectAlreadyExists) {
+	if err != nil && errors.Is(err, ErrObjectConflict) {
 		return collector.UpdateSecretKeyValueV3(namespace, service, key, value)
 	}
 	return err
@@ -342,7 +344,7 @@ func (collector *Collector) GetConfigKeyValueV3(namespace, service, key string) 
 
 func (collector *Collector) CreateConfigKeyValueV3(namespace, service, key, value string) error {
 	_, err := collector.handleObjectKeyValueV3("create", namespace, "cfg", service, key, value)
-	if err != nil && errors.Is(err, ErrObjectAlreadyExists) {
+	if err != nil && errors.Is(err, ErrObjectConflict) {
 		return collector.UpdateConfigKeyValueV3(namespace, service, key, value)
 	}
 	return err

--- a/opensvc/v3.go
+++ b/opensvc/v3.go
@@ -433,23 +433,23 @@ func (collector *Collector) handleObjectActionV3(namespace, kind, service, actio
 	return body, nil
 }
 
-func (collector *Collector) CreateTemplateV3(cluster string, svc string, node string, template []byte) error {
+func (collector *Collector) CreateTemplateV3(cluster string, svc string, node string, template []byte) ([]byte, error) {
 
 	svcparts := strings.SplitN(svc, "/", 3)
 	if len(svcparts) != 3 {
-		return fmt.Errorf("invalid service format: %s, expected namespace/kind/name", svc)
+		return nil, fmt.Errorf("invalid service format: %s, expected namespace/kind/name", svc)
 	}
 
 	ns := svcparts[0]
 	kind := svcparts[1]
 	svcname := svcparts[2]
 
-	if _, err := collector.CreateObjectV3(ns, kind, svcname, template); err != nil {
-		return fmt.Errorf("failed to create object %s/%s/%s: %w", ns, kind, svcname, err)
+	resp, err := collector.CreateObjectV3(ns, kind, svcname, template)
+	if err != nil {
+		return nil, err
 	}
 
-	_, err := collector.handleObjectActionV3(ns, kind, svcname, "provision", nil)
-	return err
+	return resp, nil
 }
 
 func (collector *Collector) ProvisionServiceV3(cluster, svc string) error {

--- a/opensvc/v3.go
+++ b/opensvc/v3.go
@@ -3,6 +3,7 @@ package opensvc
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -319,6 +320,9 @@ func (collector *Collector) GetSecretKeyValueV3(namespace, service, key string) 
 
 func (collector *Collector) CreateSecretKeyValueV3(namespace, service, key, value string) error {
 	_, err := collector.handleObjectKeyValueV3("create", namespace, "sec", service, key, value)
+	if err != nil && errors.Is(err, ErrObjectAlreadyExists) {
+		return collector.UpdateSecretKeyValueV3(namespace, service, key, value)
+	}
 	return err
 }
 
@@ -338,6 +342,9 @@ func (collector *Collector) GetConfigKeyValueV3(namespace, service, key string) 
 
 func (collector *Collector) CreateConfigKeyValueV3(namespace, service, key, value string) error {
 	_, err := collector.handleObjectKeyValueV3("create", namespace, "cfg", service, key, value)
+	if err != nil && errors.Is(err, ErrObjectAlreadyExists) {
+		return collector.UpdateConfigKeyValueV3(namespace, service, key, value)
+	}
 	return err
 }
 

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -2718,6 +2718,52 @@ func (repman *ReplicationManager) handlerMuxAppSaveAsTemplate(w http.ResponseWri
 	}
 }
 
+type appTemplateActionBody struct {
+	Template     interface{} `json:"template"`
+	ForceRefresh bool        `json:"forceRefresh"`
+}
+
+func decodeAppTemplateActionBody(r *http.Request) (string, bool, error) {
+	var body appTemplateActionBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		return "", false, err
+	}
+
+	templateName, err := normalizeTemplatePayloadName(body.Template)
+	if err != nil {
+		return "", body.ForceRefresh, err
+	}
+	if templateName == "" {
+		return "", body.ForceRefresh, errors.New("template name must be provided")
+	}
+
+	return templateName, body.ForceRefresh, nil
+}
+
+func normalizeTemplatePayloadName(template interface{}) (string, error) {
+	switch value := template.(type) {
+	case string:
+		return strings.TrimSpace(value), nil
+	case map[string]interface{}:
+		for _, key := range []string{"value", "name", "template", "label"} {
+			raw, ok := value[key]
+			if !ok {
+				continue
+			}
+
+			s, ok := raw.(string)
+			if ok && strings.TrimSpace(s) != "" {
+				return strings.TrimSpace(s), nil
+			}
+		}
+		return "", errors.New("template must be a string or an object with value/name/template/label")
+	case nil:
+		return "", nil
+	default:
+		return "", errors.New("template must be a string or an object")
+	}
+}
+
 // @Summary Reset App from Template
 // @Description Reloads the app template configuration for a specific app in a cluster.
 // @Tags Apps
@@ -2742,22 +2788,13 @@ func (repman *ReplicationManager) handlerMuxAppResetFromTemplate(w http.Response
 
 		node := mycluster.GetAppFromName(vars["appName"])
 		if node != nil {
-			//Get the request body {template: value}
-			var body struct {
-				Template     string `json:"template"`
-				ForceRefresh bool   `json:"forceRefresh"`
-			}
-			err := json.NewDecoder(r.Body).Decode(&body)
+			templateName, forceRefresh, err := decodeAppTemplateActionBody(r)
 			if err != nil {
 				http.Error(w, fmt.Sprintf("Error decoding request body: %v", err), http.StatusBadRequest)
 				return
 			}
-			if body.Template == "" {
-				http.Error(w, "Template name must be provided", http.StatusBadRequest)
-				return
-			}
 
-			err = resetAppFromTemplateWithProjection(mycluster, node, body.Template, body.ForceRefresh)
+			err = resetAppFromTemplateWithProjection(mycluster, node, templateName, forceRefresh)
 			if err != nil {
 				http.Error(w, fmt.Sprintf("Error applying template: %v", err), http.StatusInternalServerError)
 				return
@@ -2806,30 +2843,22 @@ func (repman *ReplicationManager) handlerMuxAppResetFromTemplatePreview(w http.R
 		return
 	}
 
-	var body struct {
-		Template     string `json:"template"`
-		ForceRefresh bool   `json:"forceRefresh"`
-	}
-	err := json.NewDecoder(r.Body).Decode(&body)
+	templateName, forceRefresh, err := decodeAppTemplateActionBody(r)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Error decoding request body: %v", err), http.StatusBadRequest)
 		return
 	}
-	if body.Template == "" {
-		http.Error(w, "Template name must be provided", http.StatusBadRequest)
-		return
-	}
 
-	tempConfig, err := buildValidatedTempAppConfigFromTemplate(mycluster, node, body.Template, body.ForceRefresh)
+	tempConfig, err := buildValidatedTempAppConfigFromTemplate(mycluster, node, templateName, forceRefresh)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Error applying template: %v", err), http.StatusInternalServerError)
 		return
 	}
 
-	changes := buildTemplateProjectionImpact(node.AppConfig, tempConfig, body.Template)
+	changes := buildTemplateProjectionImpact(node.AppConfig, tempConfig, templateName)
 	preview := appTemplateResetPreview{
-		TemplateName: body.Template,
-		ForceRefresh: body.ForceRefresh,
+		TemplateName: templateName,
+		ForceRefresh: forceRefresh,
 		ChangeCount:  len(changes),
 		Changes:      changes,
 	}

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -706,7 +706,7 @@ func (repman *ReplicationManager) handlerMuxAppAbort(w http.ResponseWriter, r *h
 	app := mycluster.GetAppFromName(vars["appName"])
 	if app == nil {
 		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Server Not Found"})
+		json.NewEncoder(w).Encode(map[string]string{"error": "App Not Found"})
 		return
 	}
 
@@ -755,7 +755,7 @@ func (repman *ReplicationManager) handlerMuxAppClear(w http.ResponseWriter, r *h
 	app := mycluster.GetAppFromName(vars["appName"])
 	if app == nil {
 		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Server Not Found"})
+		json.NewEncoder(w).Encode(map[string]string{"error": "App Not Found"})
 		return
 	}
 

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -93,6 +93,14 @@ func (repman *ReplicationManager) apiAppProtectedHandler(router *mux.Router) {
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxAppRestart)),
 	))
+	router.Handle("/api/clusters/{clusterName}/apps/{appName}/actions/abort", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxAppAbort)),
+	)).Methods("POST")
+	router.Handle("/api/clusters/{clusterName}/apps/{appName}/actions/clear", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxAppClear)),
+	)).Methods("POST")
 	router.Handle("/api/clusters/{clusterName}/apps/{appName}/actions/need-restart", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxAppNeedRestart)),
@@ -670,6 +678,111 @@ func (repman *ReplicationManager) handlerMuxAppRestart(w http.ResponseWriter, r 
 		http.Error(w, "Cluster Not Found", http.StatusInternalServerError)
 		return
 	}
+}
+
+func (repman *ReplicationManager) handlerMuxAppAbort(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Content-Type", "application/json")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster == nil {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Cluster Not Found"})
+		return
+	}
+
+	if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{"error": "No valid ACL"})
+		return
+	}
+
+	if mycluster.GetOrchestrator() != "opensvc" {
+		w.WriteHeader(http.StatusNotImplemented)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Abort is only supported for OpenSVC orchestrator"})
+		return
+	}
+
+	app := mycluster.GetAppFromName(vars["appName"])
+	if app == nil {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Server Not Found"})
+		return
+	}
+
+	err := mycluster.OpenSVCAbortAppService(app)
+	if err != nil {
+		if errors.Is(err, cluster.ErrOpenSVCAbortNotSupported) {
+			w.WriteHeader(http.StatusNotImplemented)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": fmt.Sprintf("Failed to abort app service: %s", err)})
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"message": "Abort requested successfully",
+		"app":     app.GetName(),
+	})
+}
+
+func (repman *ReplicationManager) handlerMuxAppClear(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Content-Type", "application/json")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster == nil {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Cluster Not Found"})
+		return
+	}
+
+	if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{"error": "No valid ACL"})
+		return
+	}
+
+	if mycluster.GetOrchestrator() != "opensvc" {
+		w.WriteHeader(http.StatusNotImplemented)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Clear is only supported for OpenSVC orchestrator"})
+		return
+	}
+
+	app := mycluster.GetAppFromName(vars["appName"])
+	if app == nil {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Server Not Found"})
+		return
+	}
+
+	nodeParam := r.URL.Query().Get("node")
+	err := mycluster.OpenSVCClearAppInstanceState(app, nodeParam)
+	if err != nil {
+		if errors.Is(err, cluster.ErrOpenSVCClearNotSupported) {
+			w.WriteHeader(http.StatusNotImplemented)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": fmt.Sprintf("Failed to clear app instance state: %s", err)})
+		return
+	}
+
+	effectiveNode := nodeParam
+	if effectiveNode == "" {
+		effectiveNode = app.GetAgent()
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"message": "Instance monitor state cleared successfully",
+		"app":     app.GetName(),
+		"node":    effectiveNode,
+	})
 }
 
 // @Summary Provision App Service

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -858,7 +858,10 @@ func (repman *ReplicationManager) handlerMuxAppUnprovision(w http.ResponseWriter
 
 		node := mycluster.GetAppFromName(vars["appName"])
 		if node != nil {
-			mycluster.OpenSVCUnprovisionAppService(node)
+			if err := mycluster.OpenSVCUnprovisionAppService(node); err != nil {
+				http.Error(w, fmt.Sprintf("Can not unprovision app service: %s", err), http.StatusInternalServerError)
+				return
+			}
 		} else {
 			http.Error(w, "Server Not Found", http.StatusInternalServerError)
 			return

--- a/server/api_database.go
+++ b/server/api_database.go
@@ -10,6 +10,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -293,6 +294,14 @@ func (repman *ReplicationManager) apiDatabaseProtectedHandler(router *mux.Router
 	router.Handle("/api/clusters/{clusterName}/servers/{serverName}/actions/restart", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxServerRestart)),
+	)).Methods("POST")
+	router.Handle("/api/clusters/{clusterName}/servers/{serverName}/actions/abort", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxServerAbort)),
+	)).Methods("POST")
+	router.Handle("/api/clusters/{clusterName}/servers/{serverName}/actions/clear", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxServerClear)),
 	)).Methods("POST")
 	router.Handle("/api/clusters/{clusterName}/servers/{serverName}/actions/maintenance", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
@@ -2514,6 +2523,111 @@ func (repman *ReplicationManager) handlerMuxServerRestart(w http.ResponseWriter,
 		"server":  node.Name,
 		"node":    nodeParam,
 		"rid":     ridParam,
+	})
+}
+
+func (repman *ReplicationManager) handlerMuxServerAbort(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Content-Type", "application/json")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster == nil {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Cluster Not Found"})
+		return
+	}
+
+	if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{"error": "No valid ACL"})
+		return
+	}
+
+	if mycluster.GetOrchestrator() != "opensvc" {
+		w.WriteHeader(http.StatusNotImplemented)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Abort is only supported for OpenSVC orchestrator"})
+		return
+	}
+
+	node := mycluster.GetServerFromName(vars["serverName"])
+	if node == nil {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Server Not Found"})
+		return
+	}
+
+	err := mycluster.OpenSVCAbortDatabaseService(node)
+	if err != nil {
+		if errors.Is(err, cluster.ErrOpenSVCAbortNotSupported) {
+			w.WriteHeader(http.StatusNotImplemented)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": fmt.Sprintf("Failed to abort server service: %s", err)})
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"message": "Abort requested successfully",
+		"server":  node.Name,
+	})
+}
+
+func (repman *ReplicationManager) handlerMuxServerClear(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Content-Type", "application/json")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster == nil {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Cluster Not Found"})
+		return
+	}
+
+	if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{"error": "No valid ACL"})
+		return
+	}
+
+	if mycluster.GetOrchestrator() != "opensvc" {
+		w.WriteHeader(http.StatusNotImplemented)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Clear is only supported for OpenSVC orchestrator"})
+		return
+	}
+
+	node := mycluster.GetServerFromName(vars["serverName"])
+	if node == nil {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Server Not Found"})
+		return
+	}
+
+	nodeParam := r.URL.Query().Get("node")
+	err := mycluster.OpenSVCClearDatabaseInstanceState(node, nodeParam)
+	if err != nil {
+		if errors.Is(err, cluster.ErrOpenSVCClearNotSupported) {
+			w.WriteHeader(http.StatusNotImplemented)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": fmt.Sprintf("Failed to clear server instance state: %s", err)})
+		return
+	}
+
+	effectiveNode := nodeParam
+	if effectiveNode == "" {
+		effectiveNode = node.Agent
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"message": "Instance monitor state cleared successfully",
+		"server":  node.Name,
+		"node":    effectiveNode,
 	})
 }
 

--- a/server/api_proxy.go
+++ b/server/api_proxy.go
@@ -8,6 +8,8 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"os"
 
@@ -39,6 +41,14 @@ func (repman *ReplicationManager) apiProxyProtectedHandler(router *mux.Router) {
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxProxyStart)),
 	))
+	router.Handle("/api/clusters/{clusterName}/proxies/{proxyName}/actions/abort", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxProxyAbort)),
+	)).Methods("POST")
+	router.Handle("/api/clusters/{clusterName}/proxies/{proxyName}/actions/clear", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxProxyClear)),
+	)).Methods("POST")
 	router.Handle("/api/clusters/{clusterName}/proxies/{proxyName}/actions/need-restart", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxProxyNeedRestart)),
@@ -173,6 +183,111 @@ func (repman *ReplicationManager) handlerMuxProxyStop(w http.ResponseWriter, r *
 		http.Error(w, "Cluster Not Found", 500)
 		return
 	}
+}
+
+func (repman *ReplicationManager) handlerMuxProxyAbort(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Content-Type", "application/json")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster == nil {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Cluster Not Found"})
+		return
+	}
+
+	if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{"error": "No valid ACL"})
+		return
+	}
+
+	if mycluster.GetOrchestrator() != "opensvc" {
+		w.WriteHeader(http.StatusNotImplemented)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Abort is only supported for OpenSVC orchestrator"})
+		return
+	}
+
+	node := mycluster.GetProxyFromName(vars["proxyName"])
+	if node == nil {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Server Not Found"})
+		return
+	}
+
+	err := mycluster.OpenSVCAbortProxyService(node)
+	if err != nil {
+		if errors.Is(err, cluster.ErrOpenSVCAbortNotSupported) {
+			w.WriteHeader(http.StatusNotImplemented)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": fmt.Sprintf("Failed to abort proxy service: %s", err)})
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"message": "Abort requested successfully",
+		"proxy":   node.GetName(),
+	})
+}
+
+func (repman *ReplicationManager) handlerMuxProxyClear(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Content-Type", "application/json")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster == nil {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Cluster Not Found"})
+		return
+	}
+
+	if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{"error": "No valid ACL"})
+		return
+	}
+
+	if mycluster.GetOrchestrator() != "opensvc" {
+		w.WriteHeader(http.StatusNotImplemented)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Clear is only supported for OpenSVC orchestrator"})
+		return
+	}
+
+	node := mycluster.GetProxyFromName(vars["proxyName"])
+	if node == nil {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Server Not Found"})
+		return
+	}
+
+	nodeParam := r.URL.Query().Get("node")
+	err := mycluster.OpenSVCClearProxyInstanceState(node, nodeParam)
+	if err != nil {
+		if errors.Is(err, cluster.ErrOpenSVCClearNotSupported) {
+			w.WriteHeader(http.StatusNotImplemented)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": fmt.Sprintf("Failed to clear proxy instance state: %s", err)})
+		return
+	}
+
+	effectiveNode := nodeParam
+	if effectiveNode == "" {
+		effectiveNode = node.GetAgent()
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"message": "Instance monitor state cleared successfully",
+		"proxy":   node.GetName(),
+		"node":    effectiveNode,
+	})
 }
 
 // @Summary Provision Proxy Service

--- a/server/api_proxy.go
+++ b/server/api_proxy.go
@@ -211,7 +211,7 @@ func (repman *ReplicationManager) handlerMuxProxyAbort(w http.ResponseWriter, r 
 	node := mycluster.GetProxyFromName(vars["proxyName"])
 	if node == nil {
 		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Server Not Found"})
+		json.NewEncoder(w).Encode(map[string]string{"error": "Proxy Not Found"})
 		return
 	}
 
@@ -260,7 +260,7 @@ func (repman *ReplicationManager) handlerMuxProxyClear(w http.ResponseWriter, r 
 	node := mycluster.GetProxyFromName(vars["proxyName"])
 	if node == nil {
 		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Server Not Found"})
+		json.NewEncoder(w).Encode(map[string]string{"error": "Proxy Not Found"})
 		return
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -1193,6 +1193,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 			flags.BoolVar(&conf.ProvOpensvcUseCollectorAPI, "opensvc-use-collector-api", false, "Use the collector API instead of cluster VIP")
 			flags.StringVar(&conf.KubeConfig, "kube-config", "", "path to ks8 config file")
 			flags.StringVar(&conf.ProvOpensvcCollectorAccount, "opensvc-collector-account", "/etc/replication-manager/account.yaml", "Openscv collector account")
+			flags.IntVar(&conf.ProvOpensvcV3ProvisionDelay, "opensvc-v3-provision-delay", 10, "Seconds to wait after template creation before provisioning in V3")
 
 			if conf.ProvOpensvcUseCollectorAPI {
 				dbConfig := viper.New()

--- a/share/dashboard/static/configurator/opensvc/bootstrap
+++ b/share/dashboard/static/configurator/opensvc/bootstrap
@@ -22,6 +22,8 @@ function get {
 	$GET --header Accept:application/json --header "Authorization: Bearer $TOKEN" $@
 }
 
+mkdir -p /bootstrap
+
 get $REPLICATION_MANAGER_URL/api/clusters/$REPLICATION_MANAGER_CLUSTER_NAME/servers/$REPLICATION_MANAGER_HOST_NAME/$REPLICATION_MANAGER_HOST_PORT/need-config-fetch > need-config-fetch
 if [ $? -eq 0 ]; then
 	get $REPLICATION_MANAGER_URL/api/clusters/$REPLICATION_MANAGER_CLUSTER_NAME/servers/$REPLICATION_MANAGER_HOST_NAME/$REPLICATION_MANAGER_HOST_PORT/config > config.tar.gz
@@ -42,13 +44,12 @@ if [ $? -eq 0 ]; then
 
 fi
 
-CURRENT_VERSION=$(cat /bootstrap/version)
-if [ -z "$CURRENT_VERSION" ]; then
-	CURRENT_VERSION="0.0.0"
+CURRENT_VERSION="0.0.0"
+if [ -f "/bootstrap/version" ]; then 
+	CURRENT_VERSION=$(cat /bootstrap/version)
 fi
 
 get $REPLICATION_MANAGER_URL/api/version > version
-mkdir -p /bootstrap
 MONITOR_VERSION=$(cat version)
 
 # If the version is not the same or the file not exists, download the new version

--- a/share/dashboard_react/src/Pages/ClusterApp/components/ClusterAppTabContent/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/ClusterAppTabContent/index.jsx
@@ -86,6 +86,7 @@ function ClusterAppTabContent({ appId, tab, clusterName, user, selectedApp, conf
                 clusterName={clusterName}
                 row={selectedApp}
                 user={user}
+                orchestrator={config?.provOrchestrator}
               />
               <ServerStatus state={selectedApp?.state} />
               <ServerName className={styles.appName} name={`${selectedApp?.host}`} />

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Overview/GeneralSection.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Overview/GeneralSection.jsx
@@ -41,11 +41,12 @@ const GeneralSection = ({ clusterName, appId, appName, appHost, config, appConfi
   const onSaveDockerCmd = useCallback((value) => dispatch(setAppSetting({ clusterName: clusterName, appId: appId, setting: 'prov-app-docker-cmd', value: value })), [clusterName, appId, dispatch])
   const onSaveAppAsTemplate = useCallback(() => dispatch(saveAppAsTemplate({ clusterName: clusterName, appId: appId, template: appName })), [clusterName, appId, appName, dispatch])
   const onResetAppFromTemplate = useCallback((value) => {
-    if (!value) return
-    dispatch(previewResetAppTemplateImpact({ clusterName, appId, template: value, forceRefresh: false }))
+    const templateName = typeof value === 'string' ? value : value?.value || value?.name || ''
+    if (!templateName) return
+    dispatch(previewResetAppTemplateImpact({ clusterName, appId, template: templateName, forceRefresh: false }))
       .unwrap()
       .then(({ data }) => {
-        setResetImpactTemplate(value)
+        setResetImpactTemplate(templateName)
         setResetImpactForceRefresh(false)
         setResetImpactChanges(Array.isArray(data?.changes) ? data.changes : [])
         setIsResetImpactModalOpen(true)

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppGrid/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppGrid/index.jsx
@@ -11,7 +11,7 @@ import RMIconButton from '../../../../../components/RMIconButton'
 import styles from './styles.module.scss'
 import ServerName from '../../../../../components/ServerName'
 
-function AppGrid({ apps = [], clusterName, showTableView, user, isDesktop }) {
+function AppGrid({ apps = [], clusterName, showTableView, user, isDesktop, orchestrator }) {
   return (
     <SimpleGrid columns={{ base: 1, sm: 1, md: 2, lg: 3 }} spacing={2} spacingY={6} spacingX={6} marginTop='4px'>
       {apps?.length > 0 &&
@@ -43,6 +43,7 @@ function AppGrid({ apps = [], clusterName, showTableView, user, isDesktop }) {
                     clusterName={clusterName}
                     isDesktop={isDesktop}
                     user={user}
+                    orchestrator={orchestrator}
                   />
               </Flex>
 

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppMenu.jsx
@@ -2,10 +2,18 @@ import { useDispatch } from 'react-redux'
 import MenuOptions from '../../../../components/MenuOptions'
 import ConfirmModal from '../../../../components/Modals/ConfirmModal'
 import { useState, useEffect } from 'react'
-import { dropApp, provisionApp, startApp, stopApp, unprovisionApp } from '../../../../redux/clusterSlice'
+import {
+  abortApp,
+  clearApp,
+  dropApp,
+  provisionApp,
+  startApp,
+  stopApp,
+  unprovisionApp
+} from '../../../../redux/clusterSlice'
 import { useNavigate } from 'react-router-dom'
 
-function AppMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView', user }) {
+function AppMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView', user, orchestrator }) {
   const dispatch = useDispatch()
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false)
   const [confirmTitle, setConfirmTitle] = useState('')
@@ -47,7 +55,19 @@ function AppMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView',
                       setConfirmTitle(`Confirm stop for ${appName}?`)
                       setConfirmHandler(() => () => dispatch(stopApp({ clusterName, appId: row.id })))
                     }
-                  }
+                  },
+                  ...(orchestrator === 'opensvc'
+                    ? [
+                        {
+                          name: 'Abort Orchestration',
+                          onClick: () => {
+                            openConfirmModal()
+                            setConfirmTitle(`Confirm orchestration abort for ${appName}?`)
+                            setConfirmHandler(() => () => dispatch(abortApp({ clusterName, appId: row.id })))
+                          }
+                        }
+                      ]
+                    : [])
                 ]
                 : []),
               ...(user?.grants['app-start']
@@ -59,7 +79,19 @@ function AppMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView',
                       setConfirmTitle(`Confirm start for ${appName}?`)
                       setConfirmHandler(() => () => dispatch(startApp({ clusterName, appId: row.id })))
                     }
-                  }
+                  },
+                  ...(orchestrator === 'opensvc'
+                    ? [
+                        {
+                          name: 'Clear Instance State',
+                          onClick: () => {
+                            openConfirmModal()
+                            setConfirmTitle(`Confirm clear instance state for ${appName}?`)
+                            setConfirmHandler(() => () => dispatch(clearApp({ clusterName, appId: row.id })))
+                          }
+                        }
+                      ]
+                    : [])
                 ]
                 : []),
               ...(user?.grants['prov-app-provision']

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppTable/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppTable/index.jsx
@@ -10,7 +10,7 @@ import TagPill from '../../../../../components/TagPill'
 import AppStatus from '../AppStatus'
 import ServerStatus from '../../../../../components/ServerStatus'
 
-function AppTable({ apps = [], isDesktop, clusterName, showGridView, user, states }) {
+function AppTable({ apps = [], isDesktop, clusterName, showGridView, user, states, orchestrator }) {
   const [tableData, setTableData] = useState([])
   useEffect(() => {
     if (apps?.length > 0) {
@@ -25,7 +25,15 @@ function AppTable({ apps = [], isDesktop, clusterName, showGridView, user, state
       columnHelper.accessor(
         (row) => row.name || row.id,
         {
-          cell: ({row}) => <AppMenu row={row.original} isDesktop={isDesktop} clusterName={clusterName} user={user} />,
+          cell: ({row}) => (
+            <AppMenu
+              row={row.original}
+              isDesktop={isDesktop}
+              clusterName={clusterName}
+              user={user}
+              orchestrator={orchestrator}
+            />
+          ),
           id: 'options',
           header: '',
           width: '40px'
@@ -52,7 +60,7 @@ function AppTable({ apps = [], isDesktop, clusterName, showGridView, user, state
         header: 'Routes'
       }),
     ],
-    []
+    [clusterName, isDesktop, orchestrator, user]
   )
 
   return (

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/index.jsx
@@ -25,6 +25,7 @@ function Apps({ selectedCluster, user }) {
         clusterName={selectedCluster?.name}
         showGridView={showGridView}
         isMenuOptionsVisible={true}
+        orchestrator={selectedCluster?.config?.provOrchestrator}
         user={user}
         states={clusterAppStates}
       />
@@ -35,6 +36,7 @@ function Apps({ selectedCluster, user }) {
         clusterName={selectedCluster?.name}
         showTableView={showTableView}
         isMenuOptionsVisible={true}
+        orchestrator={selectedCluster?.config?.provOrchestrator}
         user={user}
         states={clusterAppStates}
       />

--- a/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
@@ -3,6 +3,8 @@ import MenuOptions from '../../../../components/MenuOptions'
 import ConfirmModal from '../../../../components/Modals/ConfirmModal'
 import AdvancedReseedModal from '../../../../components/Modals/AdvancedReseedModal'
 import {
+  abortDatabase,
+  clearDatabase,
   dropServer,
   flushLogs,
   jobsUpgrade,
@@ -391,7 +393,19 @@ function ServerMenu({
                         setConfirmTitle(`Confirm stop for ${serverName}?`)
                         setConfirmHandler(() => () => dispatch(stopDatabase({ clusterName, serverId: row.id })))
                       }
-                    }
+                    },
+                    ...(orchestrator === 'opensvc'
+                      ? [
+                          {
+                            name: 'Abort Orchestration',
+                            onClick: () => {
+                              openConfirmModal()
+                              setConfirmTitle(`Confirm orchestration abort for ${serverName}?`)
+                              setConfirmHandler(() => () => dispatch(abortDatabase({ clusterName, serverId: row.id })))
+                            }
+                          }
+                        ]
+                      : [])
                   ]
                 : []),
               ...(user?.grants['db-start']
@@ -404,6 +418,18 @@ function ServerMenu({
                         setConfirmHandler(() => () => dispatch(startDatabase({ clusterName, serverId: row.id })))
                       }
                     },
+                    ...(orchestrator === 'opensvc'
+                      ? [
+                          {
+                            name: 'Clear Instance State',
+                            onClick: () => {
+                              openConfirmModal()
+                              setConfirmTitle(`Confirm clear instance state for ${serverName}?`)
+                              setConfirmHandler(() => () => dispatch(clearDatabase({ clusterName, serverId: row.id })))
+                            }
+                          }
+                        ]
+                      : []),
                     ...(orchestrator === 'opensvc'
                       ? [
                           {

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyGrid/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyGrid/index.jsx
@@ -12,7 +12,17 @@ import RMIconButton from '../../../../../components/RMIconButton'
 import styles from './styles.module.scss'
 import ServerName from '../../../../../components/ServerName'
 
-function ProxyGrid({ proxies = [], clusterName, showTableView, user, isDesktop, isMenuOptionsVisible, showTerminal, topoStaging }) {
+function ProxyGrid({
+  proxies = [],
+  clusterName,
+  showTableView,
+  user,
+  isDesktop,
+  isMenuOptionsVisible,
+  showTerminal,
+  topoStaging,
+  orchestrator
+}) {
   return (
     <SimpleGrid columns={{ base: 1, sm: 1, md: 2, lg: 3 }} spacing={2} spacingY={6} spacingX={6} marginTop='4px'>
       {proxies?.length > 0 &&
@@ -56,6 +66,7 @@ function ProxyGrid({ proxies = [], clusterName, showTableView, user, isDesktop, 
                   isMenuOptionsVisible={isMenuOptionsVisible}
                   showTerminal={showTerminal}
                   topoStaging={topoStaging}
+                  orchestrator={orchestrator}
                 />
               </Flex>
 

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyMenu.jsx
@@ -2,10 +2,30 @@ import { useDispatch } from 'react-redux'
 import MenuOptions from '../../../../components/MenuOptions'
 import ConfirmModal from '../../../../components/Modals/ConfirmModal'
 import { useState, useEffect, useCallback } from 'react'
-import { dropServerByName, provisionProxy, stagingProxy, startProxy, stopProxy, unprovisionProxy } from '../../../../redux/clusterSlice'
+import {
+  abortProxy,
+  clearProxy,
+  dropServerByName,
+  provisionProxy,
+  stagingProxy,
+  startProxy,
+  stopProxy,
+  unprovisionProxy
+} from '../../../../redux/clusterSlice'
 import { useHref } from 'react-router-dom'
 
-function ProxyMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView', user, isMenuOptionsVisible = false, showTerminal, topoStaging }) {
+function ProxyMenu({
+  clusterName,
+  row,
+  isDesktop,
+  colorScheme,
+  from = 'tableView',
+  user,
+  isMenuOptionsVisible = false,
+  showTerminal,
+  topoStaging,
+  orchestrator
+}) {
   const dispatch = useDispatch()
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false)
   const [confirmTitle, setConfirmTitle] = useState('')
@@ -101,6 +121,30 @@ function ProxyMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView
                     openConfirmModal()
                     setConfirmTitle(`Confirm stop proxy ${proxyName}?`)
                     setConfirmHandler(() => () => dispatch(stopProxy({ clusterName, proxyId: row.proxyId })))
+                  }
+                },
+                ...(orchestrator === 'opensvc'
+                  ? [
+                      {
+                        name: 'Abort Orchestration',
+                        onClick: () => {
+                          openConfirmModal()
+                          setConfirmTitle(`Confirm orchestration abort for ${proxyName}?`)
+                          setConfirmHandler(() => () => dispatch(abortProxy({ clusterName, proxyId: row.proxyId })))
+                        }
+                      }
+                    ]
+                  : [])
+              ]
+            : []),
+          ...(user?.grants['proxy-start'] && orchestrator === 'opensvc'
+            ? [
+                {
+                  name: 'Clear Instance State',
+                  onClick: () => {
+                    openConfirmModal()
+                    setConfirmTitle(`Confirm clear instance state for ${proxyName}?`)
+                    setConfirmHandler(() => () => dispatch(clearProxy({ clusterName, proxyId: row.proxyId })))
                   }
                 }
               ]

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyTable/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyTable/index.jsx
@@ -12,7 +12,17 @@ import RMIconButton from '../../../../../components/RMIconButton'
 import styles from './styles.module.scss'
 import ServerName from '../../../../../components/ServerName'
 
-function ProxyTable({ proxies = [], isDesktop, clusterName, showGridView, user, isMenuOptionsVisible, showTerminal, topoStaging}) {
+function ProxyTable({
+  proxies = [],
+  isDesktop,
+  clusterName,
+  showGridView,
+  user,
+  isMenuOptionsVisible,
+  showTerminal,
+  topoStaging,
+  orchestrator
+}) {
   const [tableData, setTableData] = useState([])
   useEffect(() => {
     if (proxies?.length > 0) {
@@ -66,7 +76,19 @@ function ProxyTable({ proxies = [], isDesktop, clusterName, showGridView, user, 
   const columns = useMemo(
     () => [
       columnHelper.accessor(
-        (row) => row.showMenu && <ProxyMenu row={row} isDesktop={isDesktop} clusterName={clusterName} user={user} isMenuOptionsVisible={isMenuOptionsVisible} showTerminal={showTerminal} topoStaging={topoStaging}/>,
+        (row) =>
+          row.showMenu && (
+            <ProxyMenu
+              row={row}
+              isDesktop={isDesktop}
+              clusterName={clusterName}
+              user={user}
+              isMenuOptionsVisible={isMenuOptionsVisible}
+              showTerminal={showTerminal}
+              topoStaging={topoStaging}
+              orchestrator={orchestrator}
+            />
+          ),
         {
           cell: (info) => info.getValue(),
           id: 'options',
@@ -135,7 +157,7 @@ function ProxyTable({ proxies = [], isDesktop, clusterName, showGridView, user, 
         header: 'ID Group'
       })
     ],
-    []
+    [clusterName, isDesktop, isMenuOptionsVisible, orchestrator, showGridView, showTerminal, topoStaging, user]
   )
 
   return (

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/index.jsx
@@ -30,6 +30,7 @@ function Proxies({ selectedCluster, user }) {
         isMenuOptionsVisible={selectedCluster?.config?.provOrchestrator !== 'onpremise'}
         showTerminal={selectedCluster?.config?.terminalSessionEnabled}
         topoStaging={selectedCluster?.config?.topologyStaging}
+        orchestrator={selectedCluster?.config?.provOrchestrator}
         user={user}
       />
     ) : (
@@ -41,6 +42,7 @@ function Proxies({ selectedCluster, user }) {
         isMenuOptionsVisible={selectedCluster?.config?.provOrchestrator !== 'onpremise'}
         showTerminal={selectedCluster?.config?.terminalSessionEnabled}
         topoStaging={selectedCluster?.config?.topologyStaging}
+        orchestrator={selectedCluster?.config?.provOrchestrator}
         user={user}
       />
     )

--- a/share/dashboard_react/src/components/MenuOptions/index.jsx
+++ b/share/dashboard_react/src/components/MenuOptions/index.jsx
@@ -3,8 +3,8 @@ import { Menu, MenuButton, MenuList, MenuItem, IconButton, HStack, Spacer } from
 import { HiChevronRight, HiDotsVertical } from 'react-icons/hi'
 import styles from './styles.module.scss'
 import CustomIcon from '../Icons/CustomIcon'
+import { AUTO_RELOAD_PAUSE_KEY } from '../../utility/autoReloadPause'
 
-const AUTO_RELOAD_PAUSE_KEY = 'pause_auto_reload'
 const MENU_PAUSE_TOKEN = 'menu-options'
 const MENU_PAUSE_COUNT_KEY = 'pause_auto_reload_menu_count'
 

--- a/share/dashboard_react/src/components/MenuOptions/index.jsx
+++ b/share/dashboard_react/src/components/MenuOptions/index.jsx
@@ -3,10 +3,7 @@ import { Menu, MenuButton, MenuList, MenuItem, IconButton, HStack, Spacer } from
 import { HiChevronRight, HiDotsVertical } from 'react-icons/hi'
 import styles from './styles.module.scss'
 import CustomIcon from '../Icons/CustomIcon'
-import { AUTO_RELOAD_PAUSE_KEY } from '../../utility/autoReloadPause'
-
-const MENU_PAUSE_TOKEN = 'menu-options'
-const MENU_PAUSE_COUNT_KEY = 'pause_auto_reload_menu_count'
+import { acquireAutoReloadPause, releaseAutoReloadPause } from '../../utility/autoReloadPause'
 
 function MenuOptions({
   options = [],
@@ -19,25 +16,13 @@ function MenuOptions({
   const [menuOptions, setMenuOptions] = useState([])
   const menuPauseRegisteredRef = useRef(false)
 
-  const getMenuPauseCount = () => {
-    const pauseCount = parseInt(localStorage.getItem(MENU_PAUSE_COUNT_KEY) || '0', 10)
-    return Number.isNaN(pauseCount) ? 0 : pauseCount
-  }
-
   const pauseAutoReloadForMenu = () => {
     if (menuPauseRegisteredRef.current) {
       return
     }
 
-    const currentPauseState = localStorage.getItem(AUTO_RELOAD_PAUSE_KEY)
-    const currentPauseCount = getMenuPauseCount()
-
-    localStorage.setItem(MENU_PAUSE_COUNT_KEY, String(currentPauseCount + 1))
+    acquireAutoReloadPause()
     menuPauseRegisteredRef.current = true
-
-    if (!currentPauseState) {
-      localStorage.setItem(AUTO_RELOAD_PAUSE_KEY, MENU_PAUSE_TOKEN)
-    }
   }
 
   const resumeAutoReloadFromMenu = () => {
@@ -45,18 +30,7 @@ function MenuOptions({
       return
     }
 
-    const currentPauseCount = getMenuPauseCount()
-    const nextPauseCount = Math.max(0, currentPauseCount - 1)
-
-    if (nextPauseCount === 0) {
-      localStorage.removeItem(MENU_PAUSE_COUNT_KEY)
-
-      if (localStorage.getItem(AUTO_RELOAD_PAUSE_KEY) === MENU_PAUSE_TOKEN) {
-        localStorage.removeItem(AUTO_RELOAD_PAUSE_KEY)
-      }
-    } else {
-      localStorage.setItem(MENU_PAUSE_COUNT_KEY, String(nextPauseCount))
-    }
+    releaseAutoReloadPause()
 
     menuPauseRegisteredRef.current = false
   }

--- a/share/dashboard_react/src/components/MenuOptions/index.jsx
+++ b/share/dashboard_react/src/components/MenuOptions/index.jsx
@@ -68,8 +68,9 @@ function MenuOptions({
   }
 
   const handleMenuToggle = (event) => {
-    event.preventDefault()
-    event.stopPropagation()
+    if (event) {
+      event.stopPropagation()
+    }
 
     if (isOpen) {
       handleMenuClose()
@@ -81,9 +82,7 @@ function MenuOptions({
   }
 
   useEffect(() => {
-    if (options.length > 0) {
-      setMenuOptions(options)
-    }
+    setMenuOptions(options || [])
   }, [options])
 
   useEffect(() => {
@@ -109,11 +108,7 @@ function MenuOptions({
               <MenuItem
                 key={`item-${index}`}
                 as={MenuButton}
-                type='button'
-                onClick={(event) => {
-                  event.preventDefault()
-                  event.stopPropagation()
-                }}>
+                type='button'>
                 <HStack>
                   <span>{option.name}</span> <Spacer /> <CustomIcon icon={HiChevronRight} />
                 </HStack>
@@ -122,8 +117,9 @@ function MenuOptions({
                 {option.subMenu.map((subMenuOption, subIndex) => (
                   <MenuItem
                     onClick={(event) => {
-                      event.preventDefault()
-                      event.stopPropagation()
+                      if (event) {
+                        event.stopPropagation()
+                      }
                       subMenuOption.onClick()
                       handleMenuClose()
                     }}
@@ -140,8 +136,9 @@ function MenuOptions({
               {...(option.onClick
                 ? {
                     onClick: (event) => {
-                      event.preventDefault()
-                      event.stopPropagation()
+                      if (event) {
+                        event.stopPropagation()
+                      }
                       option.onClick()
                       handleMenuClose()
                     }

--- a/share/dashboard_react/src/components/MenuOptions/index.jsx
+++ b/share/dashboard_react/src/components/MenuOptions/index.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { Menu, MenuButton, MenuList, MenuItem, IconButton, HStack, Spacer, useDisclosure } from '@chakra-ui/react'
+import { Menu, MenuButton, MenuList, MenuItem, IconButton, HStack, Spacer } from '@chakra-ui/react'
 import { HiChevronRight, HiDotsVertical } from 'react-icons/hi'
 import styles from './styles.module.scss'
 import CustomIcon from '../Icons/CustomIcon'
@@ -17,7 +17,6 @@ function MenuOptions({
   ...rest
 }) {
   const [menuOptions, setMenuOptions] = useState([])
-  const { isOpen, onOpen, onClose } = useDisclosure()
   const menuPauseRegisteredRef = useRef(false)
 
   const getMenuPauseCount = () => {
@@ -62,25 +61,6 @@ function MenuOptions({
     menuPauseRegisteredRef.current = false
   }
 
-  const handleMenuClose = () => {
-    onClose()
-    resumeAutoReloadFromMenu()
-  }
-
-  const handleMenuToggle = (event) => {
-    if (event) {
-      event.stopPropagation()
-    }
-
-    if (isOpen) {
-      handleMenuClose()
-      return
-    }
-
-    pauseAutoReloadForMenu()
-    onOpen()
-  }
-
   useEffect(() => {
     setMenuOptions(options || [])
   }, [options])
@@ -92,36 +72,56 @@ function MenuOptions({
   }, [])
 
   return (
-    <Menu colorScheme={colorScheme} isOpen={isOpen} placement={placement} onClose={handleMenuClose} {...rest}>
+    <Menu
+      colorScheme={colorScheme}
+      placement={placement}
+      onOpen={pauseAutoReloadForMenu}
+      onClose={resumeAutoReloadFromMenu}
+      {...rest}>
       <MenuButton
         colorScheme={colorScheme}
-        onClick={handleMenuToggle}
+        onClick={(event) => {
+          if (event) {
+            event.stopPropagation()
+          }
+        }}
         aria-label='Options'
         type='button'
         className={`${styles.menuButton} ${colorScheme === 'blue' ? styles.baseColor : ''} ${className}`}
         as={IconButton}
         icon={<HiDotsVertical />}></MenuButton>
-      <MenuList className={styles.menuList}>
+      <MenuList
+        className={styles.menuList}
+        onClick={(event) => {
+          if (event) {
+            event.stopPropagation()
+          }
+        }}>
         {menuOptions?.map((option, index) => {
           return option.subMenu ? (
             <Menu key={index} placement={subMenuPlacement}>
-              <MenuItem
-                key={`item-${index}`}
-                as={MenuButton}
-                type='button'>
+              <MenuItem key={`item-${index}`} as={MenuButton} type='button'>
                 <HStack>
                   <span>{option.name}</span> <Spacer /> <CustomIcon icon={HiChevronRight} />
                 </HStack>
               </MenuItem>
-              <MenuList key={`sub-${index}`} className={styles.menuList}>
+              <MenuList
+                key={`sub-${index}`}
+                className={styles.menuList}
+                onClick={(event) => {
+                  if (event) {
+                    event.stopPropagation()
+                  }
+                }}>
                 {option.subMenu.map((subMenuOption, subIndex) => (
                   <MenuItem
                     onClick={(event) => {
                       if (event) {
                         event.stopPropagation()
                       }
-                      subMenuOption.onClick()
-                      handleMenuClose()
+                      if (subMenuOption?.onClick) {
+                        subMenuOption.onClick()
+                      }
                     }}
                     {...(subMenuOption.isDisabled ? { isDisabled: subMenuOption.isDisabled } : {})}
                     key={subIndex}>
@@ -140,7 +140,6 @@ function MenuOptions({
                         event.stopPropagation()
                       }
                       option.onClick()
-                      handleMenuClose()
                     }
                   }
                 : {})}

--- a/share/dashboard_react/src/components/MenuOptions/index.jsx
+++ b/share/dashboard_react/src/components/MenuOptions/index.jsx
@@ -1,8 +1,12 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Menu, MenuButton, MenuList, MenuItem, IconButton, HStack, Spacer, useDisclosure } from '@chakra-ui/react'
 import { HiChevronRight, HiDotsVertical } from 'react-icons/hi'
 import styles from './styles.module.scss'
 import CustomIcon from '../Icons/CustomIcon'
+
+const AUTO_RELOAD_PAUSE_KEY = 'pause_auto_reload'
+const MENU_PAUSE_TOKEN = 'menu-options'
+const MENU_PAUSE_COUNT_KEY = 'pause_auto_reload_menu_count'
 
 function MenuOptions({
   options = [],
@@ -14,6 +18,67 @@ function MenuOptions({
 }) {
   const [menuOptions, setMenuOptions] = useState([])
   const { isOpen, onOpen, onClose } = useDisclosure()
+  const menuPauseRegisteredRef = useRef(false)
+
+  const getMenuPauseCount = () => {
+    const pauseCount = parseInt(localStorage.getItem(MENU_PAUSE_COUNT_KEY) || '0', 10)
+    return Number.isNaN(pauseCount) ? 0 : pauseCount
+  }
+
+  const pauseAutoReloadForMenu = () => {
+    if (menuPauseRegisteredRef.current) {
+      return
+    }
+
+    const currentPauseState = localStorage.getItem(AUTO_RELOAD_PAUSE_KEY)
+    const currentPauseCount = getMenuPauseCount()
+
+    localStorage.setItem(MENU_PAUSE_COUNT_KEY, String(currentPauseCount + 1))
+    menuPauseRegisteredRef.current = true
+
+    if (!currentPauseState) {
+      localStorage.setItem(AUTO_RELOAD_PAUSE_KEY, MENU_PAUSE_TOKEN)
+    }
+  }
+
+  const resumeAutoReloadFromMenu = () => {
+    if (!menuPauseRegisteredRef.current) {
+      return
+    }
+
+    const currentPauseCount = getMenuPauseCount()
+    const nextPauseCount = Math.max(0, currentPauseCount - 1)
+
+    if (nextPauseCount === 0) {
+      localStorage.removeItem(MENU_PAUSE_COUNT_KEY)
+
+      if (localStorage.getItem(AUTO_RELOAD_PAUSE_KEY) === MENU_PAUSE_TOKEN) {
+        localStorage.removeItem(AUTO_RELOAD_PAUSE_KEY)
+      }
+    } else {
+      localStorage.setItem(MENU_PAUSE_COUNT_KEY, String(nextPauseCount))
+    }
+
+    menuPauseRegisteredRef.current = false
+  }
+
+  const handleMenuClose = () => {
+    onClose()
+    resumeAutoReloadFromMenu()
+  }
+
+  const handleMenuToggle = (event) => {
+    event.preventDefault()
+    event.stopPropagation()
+
+    if (isOpen) {
+      handleMenuClose()
+      return
+    }
+
+    pauseAutoReloadForMenu()
+    onOpen()
+  }
 
   useEffect(() => {
     if (options.length > 0) {
@@ -21,12 +86,19 @@ function MenuOptions({
     }
   }, [options])
 
+  useEffect(() => {
+    return () => {
+      resumeAutoReloadFromMenu()
+    }
+  }, [])
+
   return (
-    <Menu colorScheme={colorScheme} isOpen={isOpen} placement={placement} onClose={onClose} {...rest}>
+    <Menu colorScheme={colorScheme} isOpen={isOpen} placement={placement} onClose={handleMenuClose} {...rest}>
       <MenuButton
         colorScheme={colorScheme}
-        onClick={isOpen ? onClose : onOpen}
+        onClick={handleMenuToggle}
         aria-label='Options'
+        type='button'
         className={`${styles.menuButton} ${colorScheme === 'blue' ? styles.baseColor : ''} ${className}`}
         as={IconButton}
         icon={<HiDotsVertical />}></MenuButton>
@@ -34,7 +106,14 @@ function MenuOptions({
         {menuOptions?.map((option, index) => {
           return option.subMenu ? (
             <Menu key={index} placement={subMenuPlacement}>
-              <MenuItem key={`item-${index}`} as={MenuButton}>
+              <MenuItem
+                key={`item-${index}`}
+                as={MenuButton}
+                type='button'
+                onClick={(event) => {
+                  event.preventDefault()
+                  event.stopPropagation()
+                }}>
                 <HStack>
                   <span>{option.name}</span> <Spacer /> <CustomIcon icon={HiChevronRight} />
                 </HStack>
@@ -42,9 +121,11 @@ function MenuOptions({
               <MenuList key={`sub-${index}`} className={styles.menuList}>
                 {option.subMenu.map((subMenuOption, subIndex) => (
                   <MenuItem
-                    onClick={() => {
+                    onClick={(event) => {
+                      event.preventDefault()
+                      event.stopPropagation()
                       subMenuOption.onClick()
-                      onClose()
+                      handleMenuClose()
                     }}
                     {...(subMenuOption.isDisabled ? { isDisabled: subMenuOption.isDisabled } : {})}
                     key={subIndex}>
@@ -58,9 +139,11 @@ function MenuOptions({
               key={index}
               {...(option.onClick
                 ? {
-                    onClick: () => {
+                    onClick: (event) => {
+                      event.preventDefault()
+                      event.stopPropagation()
                       option.onClick()
-                      onClose()
+                      handleMenuClose()
                     }
                   }
                 : {})}

--- a/share/dashboard_react/src/components/Modals/ConfirmModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/ConfirmModal/index.jsx
@@ -12,10 +12,7 @@ import RMButton from '../../RMButton'
 import styles from './styles.module.scss'
 import { useTheme } from '../../../ThemeProvider'
 import parentStyles from '../styles.module.scss'
-import { AUTO_RELOAD_PAUSE_KEY } from '../../../utility/autoReloadPause'
-
-const CONFIRM_MODAL_PAUSE_TOKEN = 'confirm-modal'
-const CONFIRM_MODAL_PAUSE_COUNT_KEY = 'pause_auto_reload_confirm_modal_count'
+import { acquireAutoReloadPause, releaseAutoReloadPause } from '../../../utility/autoReloadPause'
 
 function ConfirmModal({
   title,
@@ -34,25 +31,13 @@ function ConfirmModal({
   const { theme } = useTheme()
   const pauseRegisteredRef = useRef(false)
 
-  const getConfirmModalPauseCount = () => {
-    const pauseCount = parseInt(localStorage.getItem(CONFIRM_MODAL_PAUSE_COUNT_KEY) || '0', 10)
-    return Number.isNaN(pauseCount) ? 0 : pauseCount
-  }
-
   const pauseAutoReloadForConfirmModal = () => {
     if (pauseRegisteredRef.current) {
       return
     }
 
-    const currentPauseState = localStorage.getItem(AUTO_RELOAD_PAUSE_KEY)
-    const currentPauseCount = getConfirmModalPauseCount()
-
-    localStorage.setItem(CONFIRM_MODAL_PAUSE_COUNT_KEY, String(currentPauseCount + 1))
+    acquireAutoReloadPause()
     pauseRegisteredRef.current = true
-
-    if (!currentPauseState) {
-      localStorage.setItem(AUTO_RELOAD_PAUSE_KEY, CONFIRM_MODAL_PAUSE_TOKEN)
-    }
   }
 
   const resumeAutoReloadFromConfirmModal = () => {
@@ -60,18 +45,7 @@ function ConfirmModal({
       return
     }
 
-    const currentPauseCount = getConfirmModalPauseCount()
-    const nextPauseCount = Math.max(0, currentPauseCount - 1)
-
-    if (nextPauseCount === 0) {
-      localStorage.removeItem(CONFIRM_MODAL_PAUSE_COUNT_KEY)
-
-      if (localStorage.getItem(AUTO_RELOAD_PAUSE_KEY) === CONFIRM_MODAL_PAUSE_TOKEN) {
-        localStorage.removeItem(AUTO_RELOAD_PAUSE_KEY)
-      }
-    } else {
-      localStorage.setItem(CONFIRM_MODAL_PAUSE_COUNT_KEY, String(nextPauseCount))
-    }
+    releaseAutoReloadPause()
 
     pauseRegisteredRef.current = false
   }

--- a/share/dashboard_react/src/components/Modals/ConfirmModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/ConfirmModal/index.jsx
@@ -7,11 +7,15 @@ import {
   ModalHeader,
   ModalOverlay
 } from '@chakra-ui/react'
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import RMButton from '../../RMButton'
 import styles from './styles.module.scss'
 import { useTheme } from '../../../ThemeProvider'
 import parentStyles from '../styles.module.scss'
+
+const AUTO_RELOAD_PAUSE_KEY = 'pause_auto_reload'
+const CONFIRM_MODAL_PAUSE_TOKEN = 'confirm-modal'
+const CONFIRM_MODAL_PAUSE_COUNT_KEY = 'pause_auto_reload_confirm_modal_count'
 
 function ConfirmModal({
   title,
@@ -28,6 +32,61 @@ function ConfirmModal({
   confirmButtonProps = {}
 }) {
   const { theme } = useTheme()
+  const pauseRegisteredRef = useRef(false)
+
+  const getConfirmModalPauseCount = () => {
+    const pauseCount = parseInt(localStorage.getItem(CONFIRM_MODAL_PAUSE_COUNT_KEY) || '0', 10)
+    return Number.isNaN(pauseCount) ? 0 : pauseCount
+  }
+
+  const pauseAutoReloadForConfirmModal = () => {
+    if (pauseRegisteredRef.current) {
+      return
+    }
+
+    const currentPauseState = localStorage.getItem(AUTO_RELOAD_PAUSE_KEY)
+    const currentPauseCount = getConfirmModalPauseCount()
+
+    localStorage.setItem(CONFIRM_MODAL_PAUSE_COUNT_KEY, String(currentPauseCount + 1))
+    pauseRegisteredRef.current = true
+
+    if (!currentPauseState) {
+      localStorage.setItem(AUTO_RELOAD_PAUSE_KEY, CONFIRM_MODAL_PAUSE_TOKEN)
+    }
+  }
+
+  const resumeAutoReloadFromConfirmModal = () => {
+    if (!pauseRegisteredRef.current) {
+      return
+    }
+
+    const currentPauseCount = getConfirmModalPauseCount()
+    const nextPauseCount = Math.max(0, currentPauseCount - 1)
+
+    if (nextPauseCount === 0) {
+      localStorage.removeItem(CONFIRM_MODAL_PAUSE_COUNT_KEY)
+
+      if (localStorage.getItem(AUTO_RELOAD_PAUSE_KEY) === CONFIRM_MODAL_PAUSE_TOKEN) {
+        localStorage.removeItem(AUTO_RELOAD_PAUSE_KEY)
+      }
+    } else {
+      localStorage.setItem(CONFIRM_MODAL_PAUSE_COUNT_KEY, String(nextPauseCount))
+    }
+
+    pauseRegisteredRef.current = false
+  }
+
+  useEffect(() => {
+    if (isOpen) {
+      pauseAutoReloadForConfirmModal()
+    } else {
+      resumeAutoReloadFromConfirmModal()
+    }
+
+    return () => {
+      resumeAutoReloadFromConfirmModal()
+    }
+  }, [isOpen])
 
   return (
     <Modal isOpen={isOpen} onClose={closeModal} closeOnOverlayClick={closeOnOverlayClick} closeOnEsc={closeOnEsc}>

--- a/share/dashboard_react/src/components/Modals/ConfirmModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/ConfirmModal/index.jsx
@@ -12,8 +12,8 @@ import RMButton from '../../RMButton'
 import styles from './styles.module.scss'
 import { useTheme } from '../../../ThemeProvider'
 import parentStyles from '../styles.module.scss'
+import { AUTO_RELOAD_PAUSE_KEY } from '../../../utility/autoReloadPause'
 
-const AUTO_RELOAD_PAUSE_KEY = 'pause_auto_reload'
 const CONFIRM_MODAL_PAUSE_TOKEN = 'confirm-modal'
 const CONFIRM_MODAL_PAUSE_COUNT_KEY = 'pause_auto_reload_confirm_modal_count'
 

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -1169,6 +1169,36 @@ export const stopDatabase = createGuardedAsyncThunk(
   }
 )
 
+export const abortDatabase = createGuardedAsyncThunk(
+  'cluster/abortDatabase',
+  async ({ clusterName, serverId }, thunkAPI) => {
+    try {
+      const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+      const { data, status } = await clusterService.abortDatabase(clusterName, serverId, baseURL)
+      showSuccessBanner('Database orchestration aborted!', status, thunkAPI)
+      return { data, status }
+    } catch (error) {
+      showErrorBanner('Aborting database orchestration failed!', error, thunkAPI)
+      return handleError(error, thunkAPI)
+    }
+  }
+)
+
+export const clearDatabase = createGuardedAsyncThunk(
+  'cluster/clearDatabase',
+  async ({ clusterName, serverId }, thunkAPI) => {
+    try {
+      const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+      const { data, status } = await clusterService.clearDatabase(clusterName, serverId, baseURL)
+      showSuccessBanner('Database instance state cleared!', status, thunkAPI)
+      return { data, status }
+    } catch (error) {
+      showErrorBanner('Clearing database instance state failed!', error, thunkAPI)
+      return handleError(error, thunkAPI)
+    }
+  }
+)
+
 export const startDatabase = createGuardedAsyncThunk(
   'cluster/startDatabase',
   async ({ clusterName, serverId }, thunkAPI) => {
@@ -1478,6 +1508,30 @@ export const stopProxy = createGuardedAsyncThunk('cluster/stopProxy', async ({ c
     return { data, status }
   } catch (error) {
     showErrorBanner('Stopping proxy failed!', error, thunkAPI)
+    return handleError(error, thunkAPI)
+  }
+})
+
+export const abortProxy = createGuardedAsyncThunk('cluster/abortProxy', async ({ clusterName, proxyId }, thunkAPI) => {
+  try {
+    const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+    const { data, status } = await clusterService.abortProxy(clusterName, proxyId, baseURL)
+    showSuccessBanner('Proxy orchestration aborted!', status, thunkAPI)
+    return { data, status }
+  } catch (error) {
+    showErrorBanner('Aborting proxy orchestration failed!', error, thunkAPI)
+    return handleError(error, thunkAPI)
+  }
+})
+
+export const clearProxy = createGuardedAsyncThunk('cluster/clearProxy', async ({ clusterName, proxyId }, thunkAPI) => {
+  try {
+    const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+    const { data, status } = await clusterService.clearProxy(clusterName, proxyId, baseURL)
+    showSuccessBanner('Proxy instance state cleared!', status, thunkAPI)
+    return { data, status }
+  } catch (error) {
+    showErrorBanner('Clearing proxy instance state failed!', error, thunkAPI)
     return handleError(error, thunkAPI)
   }
 })
@@ -2050,6 +2104,30 @@ export const stopApp = createGuardedAsyncThunk('cluster/stopApp', async ({ clust
   }
 })
 
+export const abortApp = createGuardedAsyncThunk('cluster/abortApp', async ({ clusterName, appId }, thunkAPI) => {
+  try {
+    const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+    const { data, status } = await clusterService.abortApp(clusterName, appId, baseURL)
+    showSuccessBanner('App orchestration aborted!', status, thunkAPI)
+    return { data, status }
+  } catch (error) {
+    showErrorBanner('Aborting app orchestration failed!', error, thunkAPI)
+    return handleError(error, thunkAPI)
+  }
+})
+
+export const clearApp = createGuardedAsyncThunk('cluster/clearApp', async ({ clusterName, appId }, thunkAPI) => {
+  try {
+    const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+    const { data, status } = await clusterService.clearApp(clusterName, appId, baseURL)
+    showSuccessBanner('App instance state cleared!', status, thunkAPI)
+    return { data, status }
+  } catch (error) {
+    showErrorBanner('Clearing app instance state failed!', error, thunkAPI)
+    return handleError(error, thunkAPI)
+  }
+})
+
 export const getAppService = createGuardedAsyncThunk(
   'cluster/getAppService',
   async ({ clusterName, serviceName, appId }, thunkAPI) => {
@@ -2598,6 +2676,8 @@ export const clusterSlice = createSlice({
         physicalBackupMaster.pending,
         logicalBackup.pending,
         stopDatabase.pending,
+        abortDatabase.pending,
+        clearDatabase.pending,
         startDatabase.pending,
         restartDatabase.pending,
         provisionDatabase.pending,
@@ -2616,6 +2696,14 @@ export const clusterSlice = createSlice({
         unprovisionProxy.pending,
         startProxy.pending,
         stopProxy.pending,
+        abortProxy.pending,
+        clearProxy.pending,
+        provisionApp.pending,
+        unprovisionApp.pending,
+        startApp.pending,
+        stopApp.pending,
+        abortApp.pending,
+        clearApp.pending,
         refreshStaging.pending,
         killThread.pending,
         killQuery.pending,
@@ -2673,6 +2761,8 @@ export const clusterSlice = createSlice({
         physicalBackupMaster.fulfilled,
         logicalBackup.fulfilled,
         stopDatabase.fulfilled,
+        abortDatabase.fulfilled,
+        clearDatabase.fulfilled,
         startDatabase.fulfilled,
         restartDatabase.fulfilled,
         provisionDatabase.fulfilled,
@@ -2691,6 +2781,14 @@ export const clusterSlice = createSlice({
         unprovisionProxy.fulfilled,
         startProxy.fulfilled,
         stopProxy.fulfilled,
+        abortProxy.fulfilled,
+        clearProxy.fulfilled,
+        provisionApp.fulfilled,
+        unprovisionApp.fulfilled,
+        startApp.fulfilled,
+        stopApp.fulfilled,
+        abortApp.fulfilled,
+        clearApp.fulfilled,
         refreshStaging.fulfilled,
         killThread.fulfilled,
         killQuery.fulfilled,
@@ -2749,6 +2847,8 @@ export const clusterSlice = createSlice({
         physicalBackupMaster.rejected,
         logicalBackup.rejected,
         stopDatabase.rejected,
+        abortDatabase.rejected,
+        clearDatabase.rejected,
         startDatabase.rejected,
         restartDatabase.rejected,
         provisionDatabase.rejected,
@@ -2767,6 +2867,14 @@ export const clusterSlice = createSlice({
         unprovisionProxy.rejected,
         startProxy.rejected,
         stopProxy.rejected,
+        abortProxy.rejected,
+        clearProxy.rejected,
+        provisionApp.rejected,
+        unprovisionApp.rejected,
+        startApp.rejected,
+        stopApp.rejected,
+        abortApp.rejected,
+        clearApp.rejected,
         refreshStaging.rejected,
         killThread.rejected,
         killQuery.rejected,

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -88,6 +88,8 @@ export const clusterService = {
   physicalBackupMaster,
   logicalBackup,
   stopDatabase,
+  abortDatabase,
+  clearDatabase,
   startDatabase,
   restartDatabase,
   provisionDatabase,
@@ -109,6 +111,8 @@ export const clusterService = {
   unprovisionProxy,
   startProxy,
   stopProxy,
+  abortProxy,
+  clearProxy,
   stagingProxy,
 
   // Database service APIs
@@ -157,6 +161,8 @@ export const clusterService = {
   unprovisionApp,
   startApp,
   stopApp,
+  abortApp,
+  clearApp,
   getAppService,
   resolveTemplateVariables,
   addDeployment,
@@ -471,6 +477,14 @@ function stopDatabase(clusterName, serverId, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/servers/${serverId}/actions/stop`)
 }
 
+function abortDatabase(clusterName, serverId, baseURL) {
+  return getApi(baseURL).post(`clusters/${clusterName}/servers/${serverId}/actions/abort`)
+}
+
+function clearDatabase(clusterName, serverId, baseURL) {
+  return getApi(baseURL).post(`clusters/${clusterName}/servers/${serverId}/actions/clear`)
+}
+
 function startDatabase(clusterName, serverId, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/servers/${serverId}/actions/start`)
 }
@@ -548,6 +562,14 @@ function startProxy(clusterName, proxyId, cfgAction, baseURL) {
 
 function stopProxy(clusterName, proxyId, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/proxies/${proxyId}/actions/stop`)
+}
+
+function abortProxy(clusterName, proxyId, baseURL) {
+  return getApi(baseURL).post(`clusters/${clusterName}/proxies/${proxyId}/actions/abort`)
+}
+
+function clearProxy(clusterName, proxyId, baseURL) {
+  return getApi(baseURL).post(`clusters/${clusterName}/proxies/${proxyId}/actions/clear`)
 }
 
 function stagingProxy(clusterName, proxyId, isStaging, baseURL) {
@@ -725,6 +747,14 @@ function startApp(clusterName, appId, baseURL) {
 
 function stopApp(clusterName, appId, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/apps/${appId}/actions/stop`)
+}
+
+function abortApp(clusterName, appId, baseURL) {
+  return getApi(baseURL).post(`clusters/${clusterName}/apps/${appId}/actions/abort`)
+}
+
+function clearApp(clusterName, appId, baseURL) {
+  return getApi(baseURL).post(`clusters/${clusterName}/apps/${appId}/actions/clear`)
 }
 
 function getAppService(clusterName, serviceName, appId, baseURL) {

--- a/share/dashboard_react/src/services/settingsService.js
+++ b/share/dashboard_react/src/services/settingsService.js
@@ -1,5 +1,18 @@
 import { getApi } from './apiHelper'
 
+function normalizeTemplateName(template) {
+  if (typeof template === 'string') {
+    return template
+  }
+
+  if (template && typeof template === 'object') {
+    const candidate = template.value || template.name || template.label || ''
+    return typeof candidate === 'string' ? candidate : ''
+  }
+
+  return ''
+}
+
 export const settingsService = {
   switchSettings,
   changeTopology,
@@ -67,7 +80,7 @@ function clearAppSetting(clusterName, appId, setting, baseURL) {
 }
 
 function resetAppFromTemplate(clusterName, appId, template, forceRefresh = false, baseURL) {
-  const payload = { template: template }
+  const payload = { template: normalizeTemplateName(template) }
   if (forceRefresh) {
     payload.forceRefresh = true
   }
@@ -75,8 +88,9 @@ function resetAppFromTemplate(clusterName, appId, template, forceRefresh = false
 }
 
 function previewResetAppTemplateImpact(clusterName, appId, template, forceRefresh = false, baseURL) {
+  const normalizedTemplate = normalizeTemplateName(template)
   return getApi(baseURL).post(`clusters/${clusterName}/apps/${appId}/settings/actions/reset-from-template/preview`, {
-    template,
+    template: normalizedTemplate,
     forceRefresh
   })
 }

--- a/share/dashboard_react/src/utility/autoReloadPause.js
+++ b/share/dashboard_react/src/utility/autoReloadPause.js
@@ -1,0 +1,1 @@
+export const AUTO_RELOAD_PAUSE_KEY = 'pause_auto_reload'

--- a/share/dashboard_react/src/utility/autoReloadPause.js
+++ b/share/dashboard_react/src/utility/autoReloadPause.js
@@ -1,1 +1,46 @@
 export const AUTO_RELOAD_PAUSE_KEY = 'pause_auto_reload'
+
+const AUTO_RELOAD_PAUSE_LOCK_COUNT_KEY = 'pause_auto_reload_lock_count'
+const AUTO_RELOAD_PAUSE_PREV_VALUE_KEY = 'pause_auto_reload_prev_value'
+const NO_PREV_VALUE = '__none__'
+
+const parseCount = (rawValue) => {
+  const parsed = parseInt(rawValue || '0', 10)
+  return Number.isNaN(parsed) ? 0 : parsed
+}
+
+export const acquireAutoReloadPause = () => {
+  const currentCount = parseCount(localStorage.getItem(AUTO_RELOAD_PAUSE_LOCK_COUNT_KEY))
+
+  if (currentCount === 0) {
+    const previousPauseState = localStorage.getItem(AUTO_RELOAD_PAUSE_KEY)
+    localStorage.setItem(AUTO_RELOAD_PAUSE_PREV_VALUE_KEY, previousPauseState ?? NO_PREV_VALUE)
+    localStorage.setItem(AUTO_RELOAD_PAUSE_KEY, 'true')
+  }
+
+  localStorage.setItem(AUTO_RELOAD_PAUSE_LOCK_COUNT_KEY, String(currentCount + 1))
+}
+
+export const releaseAutoReloadPause = () => {
+  const currentCount = parseCount(localStorage.getItem(AUTO_RELOAD_PAUSE_LOCK_COUNT_KEY))
+  if (currentCount <= 0) {
+    return
+  }
+
+  const nextCount = currentCount - 1
+  if (nextCount > 0) {
+    localStorage.setItem(AUTO_RELOAD_PAUSE_LOCK_COUNT_KEY, String(nextCount))
+    return
+  }
+
+  localStorage.removeItem(AUTO_RELOAD_PAUSE_LOCK_COUNT_KEY)
+
+  const previousPauseState = localStorage.getItem(AUTO_RELOAD_PAUSE_PREV_VALUE_KEY)
+  localStorage.removeItem(AUTO_RELOAD_PAUSE_PREV_VALUE_KEY)
+
+  if (previousPauseState && previousPauseState !== NO_PREV_VALUE) {
+    localStorage.setItem(AUTO_RELOAD_PAUSE_KEY, previousPauseState)
+  } else {
+    localStorage.removeItem(AUTO_RELOAD_PAUSE_KEY)
+  }
+}

--- a/share/opensvc/moduleset_mariadb.svc.mrm.db.json
+++ b/share/opensvc/moduleset_mariadb.svc.mrm.db.json
@@ -3494,7 +3494,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_icp.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3.0\\n# mariadb_documentation: https://mariadb.com/kb/en/index-condition-pushdown/\\n# mysql_version: 5.6.0\\n# mariadb_command: SET GLOBAL optimizer_switch='index_condition_pushdown=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='index_condition_pushdown=on';\\n\\n[mariadb]\\noptimizer_switch ='index_condition_pushdown=off'\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_icp.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3.0\\n# mariadb_documentation: https://mariadb.com/kb/en/index-condition-pushdown/\\n# mysql_version: 5.6.0\\n# mariadb_command: SET GLOBAL optimizer_switch='index_condition_pushdown=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='index_condition_pushdown=on';\\n\\n[mariadb]\\nloose_optimizer_switch ='index_condition_pushdown=off'\"}",
                     "var_updated": "2024-07-29 19:02:38",
                     "var_name": "db_cnf_opt_no_icp",
                     "id": 6112
@@ -3582,7 +3582,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_intoexists.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3.0\\n# mariadb_documentation: https://mariadb.com/kb/en/non-semi-join-subquery-optimizations/#the-in-to-exists-transformation\\n# mariadb_command: SET GLOBAL optimizer_switch='in_to_exists=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='in_to_exists=on';\\n \\n[mariadb]\\noptimizer_switch ='in_to_exists=off'\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_intoexists.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3.0\\n# mariadb_documentation: https://mariadb.com/kb/en/non-semi-join-subquery-optimizations/#the-in-to-exists-transformation\\n# mariadb_command: SET GLOBAL optimizer_switch='in_to_exists=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='in_to_exists=on';\\n \\n[mariadb]\\nloose_optimizer_switch ='in_to_exists=off'\"}",
                     "var_updated": "2024-07-29 19:02:54",
                     "var_name": "db_cnf_opt_no_intoexists",
                     "id": 6135
@@ -3590,7 +3590,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/with_opt_extendedkeys.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.5.21 \\n# mariadb_documentation: https://mariadb.com/kb/en/extended-keys/\\n# mariadb_command: SET GLOBAL optimizer_switch='extended_keys=on';\\n# mariadb_default: SET GLOBAL optimizer_switch='extended_keys=off';\\n\\n# mysql_command: SET GLOBAL optimizer_switch='use_index_extensions=on';\\n# mysql_default: SET GLOBAL optimizer_switch='use_index_extensions=off';\\n\\n[mariadb]\\noptimizer_switch ='extended_keys=on'\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/with_opt_extendedkeys.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.5.21 \\n# mariadb_documentation: https://mariadb.com/kb/en/extended-keys/\\n# mariadb_command: SET GLOBAL optimizer_switch='extended_keys=on';\\n# mariadb_default: SET GLOBAL optimizer_switch='extended_keys=off';\\n\\n# mysql_command: SET GLOBAL optimizer_switch='use_index_extensions=on';\\n# mysql_default: SET GLOBAL optimizer_switch='use_index_extensions=off';\\n\\n[mariadb]\\nloose_optimizer_switch ='extended_keys=on'\"}",
                     "var_updated": "2024-07-29 19:05:05",
                     "var_name": "db_cnf_opt_with_extendedkeys",
                     "id": 6136
@@ -3598,7 +3598,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_derivedwithkeys.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3.0\\n# mariadb_documentation: https://mariadb.com/kb/en/derived-table-with-key-optimization/\\n# mariadb_command: SET GLOBAL optimizer_switch ='derived_with_keys=off';\\n# mariadb_default: SET GLOBAL optimizer_switch ='derived_with_keys=on';\\n \\n# mysql_version: 5.6.0\\n\\n[mariadb]\\noptimizer_switch ='derived_with_keys=off'\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_derivedwithkeys.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3.0\\n# mariadb_documentation: https://mariadb.com/kb/en/derived-table-with-key-optimization/\\n# mariadb_command: SET GLOBAL optimizer_switch ='derived_with_keys=off';\\n# mariadb_default: SET GLOBAL optimizer_switch ='derived_with_keys=on';\\n \\n# mysql_version: 5.6.0\\n\\n[mariadb]\\nloose_optimizer_switch ='derived_with_keys=off'\"}",
                     "var_updated": "2024-07-29 19:01:52",
                     "var_name": "db_cnf_opt_no_derivedwithkeys",
                     "id": 6137
@@ -3606,7 +3606,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_derivedmerge.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_command: SET GLOBAL optimizer_switch ='derived_merge=off';\\n# mariadb_default: SET GLOBAL optimizer_switch ='derived_merge=on';\\n# mariadb_documentation: https://mariadb.com/kb/en/derived-table-merge-optimization/\\n\\n# mysql_command: SET GLOBAL optimizer_switch ='derived_merge=off';\\n# mysql_default: SET GLOBAL optimizer_switch ='derived_merge=on';\\n\\n[mariadb]\\noptimizer_switch ='derived_merge=off'\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_derivedmerge.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_command: SET GLOBAL optimizer_switch ='derived_merge=off';\\n# mariadb_default: SET GLOBAL optimizer_switch ='derived_merge=on';\\n# mariadb_documentation: https://mariadb.com/kb/en/derived-table-merge-optimization/\\n\\n# mysql_command: SET GLOBAL optimizer_switch ='derived_merge=off';\\n# mysql_default: SET GLOBAL optimizer_switch ='derived_merge=on';\\n\\n[mariadb]\\nloose_optimizer_switch ='derived_merge=off'\"}",
                     "var_updated": "2024-07-29 19:01:39",
                     "var_name": "db_cnf_opt_no_derivedmerge",
                     "id": 6138
@@ -3614,7 +3614,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/with_opt_firstmatch.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3.0 \\n# mysql_version: 5.6.0 \\n# mariadb_documentation: https://mariadb.com/kb/en/firstmatch-strategy/\\n# mariadb_command: SET GLOBAL optimizer_switch='firstmatch=on';\\n# mariadb_default: SET GLOBAL optimizer_switch='firstmatch=off';\\n\\n# mysql_command: SET GLOBAL optimizer_switch='firstmatch=on';\\n# mysql_default: SET GLOBAL optimizer_switch='firstmatch=off';\\n\\n[mariadb]\\noptimizer_switch ='firstmatch=on'\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/with_opt_firstmatch.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3.0 \\n# mysql_version: 5.6.0 \\n# mariadb_documentation: https://mariadb.com/kb/en/firstmatch-strategy/\\n# mariadb_command: SET GLOBAL optimizer_switch='firstmatch=on';\\n# mariadb_default: SET GLOBAL optimizer_switch='firstmatch=off';\\n\\n# mysql_command: SET GLOBAL optimizer_switch='firstmatch=on';\\n# mysql_default: SET GLOBAL optimizer_switch='firstmatch=off';\\n\\n[mariadb]\\nloose_optimizer_switch ='firstmatch=on'\"}",
                     "var_updated": "2024-07-29 19:05:17",
                     "var_name": "db_cnf_opt_with_firstmatch",
                     "id": 6139
@@ -3622,7 +3622,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/with_opt_loosescan.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3\\n# mariadb_documentation: https://mariadb.com/kb/en/loosescan-strategy/\\n# mariadb_command: SET GLOBAL optimizer_switch='loosescan=on';\\n# mariadb_default: SET GLOBAL optimizer_switch='loosescan=off';\\n\\n# mysql_version: 5.6\\n# mysql_command: SET GLOBAL optimizer_switch='loosescan=on';\\n# mysql_default: SET GLOBAL optimizer_switch='loosescan=off';\\n\\n[mariadb]\\noptimizer_switch ='loosescan=on'\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/with_opt_loosescan.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3\\n# mariadb_documentation: https://mariadb.com/kb/en/loosescan-strategy/\\n# mariadb_command: SET GLOBAL optimizer_switch='loosescan=on';\\n# mariadb_default: SET GLOBAL optimizer_switch='loosescan=off';\\n\\n# mysql_version: 5.6\\n# mysql_command: SET GLOBAL optimizer_switch='loosescan=on';\\n# mysql_default: SET GLOBAL optimizer_switch='loosescan=off';\\n\\n[mariadb]\\nloose_optimizer_switch ='loosescan=on'\"}",
                     "var_updated": "2024-07-29 19:06:23",
                     "var_name": "db_cnf_opt_with_loosescan",
                     "id": 6140
@@ -3630,7 +3630,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_semijoin.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3.0 \\n# mariadb_documentation: https://mariadb.com/kb/en/semi-join-materialization-strategy/\\n# mariadb_command: SET GLOBAL optimizer_switch='semijoin=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='semijoin=on';\\n\\n# mysql_version: 5.6.0\\n# mysql_command: SET GLOBAL optimizer_switch='semijoin=off';\\n# mysql_default: SET GLOBAL optimizer_switch='semijoin=on';\\n \\n[mariadb]\\noptimizer_switch ='semijoin=off'\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_semijoin.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3.0 \\n# mariadb_documentation: https://mariadb.com/kb/en/semi-join-materialization-strategy/\\n# mariadb_command: SET GLOBAL optimizer_switch='semijoin=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='semijoin=on';\\n\\n# mysql_version: 5.6.0\\n# mysql_command: SET GLOBAL optimizer_switch='semijoin=off';\\n# mysql_default: SET GLOBAL optimizer_switch='semijoin=on';\\n \\n[mariadb]\\nloose_optimizer_switch ='semijoin=off'\"}",
                     "var_updated": "2024-07-29 19:04:24",
                     "var_name": "db_cnf_opt_no_semijoin",
                     "id": 6141
@@ -3638,7 +3638,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/with_opt_subquerycache.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_command: SET GLOBAL optimizer_switch='subquery_cache=on';\\n# mariadb_default: SET GLOBAL optimizer_switch='subquery_cache=off';\\n\\n[mariadb]\\noptimizer_switch ='subquery_cache=on'\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/with_opt_subquerycache.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_command: SET GLOBAL optimizer_switch='subquery_cache=on';\\n# mariadb_default: SET GLOBAL optimizer_switch='subquery_cache=off';\\n\\n[mariadb]\\nloose_optimizer_switch ='subquery_cache=on'\"}",
                     "var_updated": "2025-11-19 08:40:20",
                     "var_name": "db_cnf_opt_with_subquerycache",
                     "id": 6142
@@ -3646,7 +3646,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_mrr.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3.0\\n# mysql_version: 5.6.0  \\n# mariadb_documentation: https://mariadb.com/kb/en/multi-range-read-optimization/\\n# mariadb_command: SET GLOBAL optimizer_switch='mrr=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='mrr=on';\\n\\n# mysql_command: SET GLOBAL optimizer_switch='mrr=off';\\n# mysql_default: SET GLOBAL optimizer_switch='mrr=on';\\n\\n[mariadb]\\noptimizer_switch ='mrr=off'\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_mrr.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3.0\\n# mysql_version: 5.6.0  \\n# mariadb_documentation: https://mariadb.com/kb/en/multi-range-read-optimization/\\n# mariadb_command: SET GLOBAL optimizer_switch='mrr=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='mrr=on';\\n\\n# mysql_command: SET GLOBAL optimizer_switch='mrr=off';\\n# mysql_default: SET GLOBAL optimizer_switch='mrr=on';\\n\\n[mariadb]\\nloose_optimizer_switch ='mrr=off'\"}",
                     "var_updated": "2024-07-29 19:03:51",
                     "var_name": "db_cnf_opt_no_mrr",
                     "id": 6143
@@ -3654,7 +3654,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_outerjoincache.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3.0 \\n# mariadb_documentation: https://mariadb.com/kb/en/block-based-join-algorithms/\\n# mariadb_command: SET GLOBAL optimizer_switch='outer_join_with_cache=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='outer_join_with_cache=on';\\n\\n[mariadb]\\noptimizer_switch ='outer_join_with_cache=off'\\n\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_outerjoincache.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3.0 \\n# mariadb_documentation: https://mariadb.com/kb/en/block-based-join-algorithms/\\n# mariadb_command: SET GLOBAL optimizer_switch='outer_join_with_cache=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='outer_join_with_cache=on';\\n\\n[mariadb]\\nloose_optimizer_switch ='outer_join_with_cache=off'\\n\"}",
                     "var_updated": "2024-07-29 19:04:01",
                     "var_name": "db_cnf_opt_no_outerjoincache",
                     "id": 6144
@@ -3662,7 +3662,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/with_opt_semijoincache.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_command: SET GLOBAL optimizer_switch='semijoin_with_cache=on';\\n# mariadb_default: SET GLOBAL optimizer_switch='semijoin_with_cache=off';\\n\\n[mariadb]\\noptimizer_switch ='semijoin_with_cache=on'\\n\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/with_opt_semijoincache.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_command: SET GLOBAL optimizer_switch='semijoin_with_cache=on';\\n# mariadb_default: SET GLOBAL optimizer_switch='semijoin_with_cache=off';\\n\\n[mariadb]\\nloose_optimizer_switch ='semijoin_with_cache=on'\\n\"}",
                     "var_updated": "2024-07-29 19:07:31",
                     "var_name": "db_cnf_opt_with_semijoincache",
                     "id": 6145
@@ -3670,7 +3670,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_tableelimination.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.1.0 \\n# mariadb_documentation: https://mariadb.com/kb/en/table-elimination-user-interface/\\n# mariadb_command: SET GLOBAL optimizer_switch='table_elimination=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='table_elimination=on';\\n\\n[mariadb]\\noptimizer_switch ='table_elimination=off'\\n\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_tableelimination.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.1.0 \\n# mariadb_documentation: https://mariadb.com/kb/en/table-elimination-user-interface/\\n# mariadb_command: SET GLOBAL optimizer_switch='table_elimination=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='table_elimination=on';\\n\\n[mariadb]\\nloose_optimizer_switch ='table_elimination=off'\\n\"}",
                     "var_updated": "2024-07-29 19:04:34",
                     "var_name": "db_cnf_opt_no_tableelimination",
                     "id": 6146
@@ -3678,7 +3678,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_materialization.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3.0 \\n# mysql_version: 5.6.0 \\n# mariadb_documentation: https://mariadb.com/kb/en/semi-join-materialization-strategy/\\n# mariadb_command: SET GLOBAL optimizer_switch='materialization=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='materialization=on';\\n\\n# mysql_command: SET GLOBAL optimizer_switch='materialization=off';\\n# mysql_default: SET GLOBAL optimizer_switch='materialization=on';\\n\\n[mariadb]\\noptimizer_switch ='materialization=off'\\n\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_materialization.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3.0 \\n# mysql_version: 5.6.0 \\n# mariadb_documentation: https://mariadb.com/kb/en/semi-join-materialization-strategy/\\n# mariadb_command: SET GLOBAL optimizer_switch='materialization=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='materialization=on';\\n\\n# mysql_command: SET GLOBAL optimizer_switch='materialization=off';\\n# mysql_default: SET GLOBAL optimizer_switch='materialization=on';\\n\\n[mariadb]\\nloose_optimizer_switch ='materialization=off'\\n\"}",
                     "var_updated": "2024-07-29 19:03:38",
                     "var_name": "db_cnf_opt_no_materialization",
                     "id": 6147
@@ -3798,7 +3798,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/with_opt_imsi.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 10.3.0 \\n# mariadb_documentation: https://mariadb.com/kb/en/index_merge-sort_intersection/\\n# mariadb_command: SET GLOBAL optimizer_switch='index_merge_sort_intersection=on';\\n# mariadb_default: SET GLOBAL optimizer_switch='index_merge_sort_intersection=off';\\n\\n[mariadb]\\noptimizer_switch='index_merge_sort_intersection=on'\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/with_opt_imsi.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 10.3.0 \\n# mariadb_documentation: https://mariadb.com/kb/en/index_merge-sort_intersection/\\n# mariadb_command: SET GLOBAL optimizer_switch='index_merge_sort_intersection=on';\\n# mariadb_default: SET GLOBAL optimizer_switch='index_merge_sort_intersection=off';\\n\\n[mariadb]\\nloose_optimizer_switch='index_merge_sort_intersection=on'\"}",
                     "var_updated": "2024-07-29 19:05:50",
                     "var_name": "db_cnf_opt_with_imsi",
                     "id": 6197
@@ -3806,7 +3806,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_lateralderived.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 10.3.0\\n# mariadb_documentation: https://mariadb.com/kb/en/lateral-derived-optimization/\\n# mariadb_command: SET GLOBAL optimizer_switch='split_materialized=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='split_materialized=on';\\n\\n[mariadb]\\noptimizer_switch='split_materialized=off'\\n\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_lateralderived.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 10.3.0\\n# mariadb_documentation: https://mariadb.com/kb/en/lateral-derived-optimization/\\n# mariadb_command: SET GLOBAL optimizer_switch='split_materialized=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='split_materialized=on';\\n\\n[mariadb]\\nloose_optimizer_switch='split_materialized=off'\\n\"}",
                     "var_updated": "2024-07-29 19:03:26",
                     "var_name": "db_cnf_opt_no_lateral_derived",
                     "id": 6198
@@ -3814,7 +3814,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_hcp.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 10.4.3\\n# mariadb_documentation: https://mariadb.com/kb/en/condition-pushdown-from-having/\\n# mariadb_command: SET GLOBAL optimizer_switch='condition_pushdown_from_having=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='condition_pushdown_from_having=on';\\n\\n[mariadb]\\noptimizer_switch='condition_pushdown_from_having=off'\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_hcp.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 10.4.3\\n# mariadb_documentation: https://mariadb.com/kb/en/condition-pushdown-from-having/\\n# mariadb_command: SET GLOBAL optimizer_switch='condition_pushdown_from_having=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='condition_pushdown_from_having=on';\\n\\n[mariadb]\\nloose_optimizer_switch='condition_pushdown_from_having=off'\"}",
                     "var_updated": "2024-07-29 19:02:26",
                     "var_name": "db_cnf_opt_no_hcp",
                     "id": 6199
@@ -3822,7 +3822,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_scp.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 10.4.0 \\n# mariadb_documentation: https://mariadb.com/kb/en/condition-pushdown-into-in-subqueries/\\n# mariadb_command: SET GLOBAL optimizer_switch='condition_pushdown_for_subquery=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='condition_pushdown_for_subquery=on';\\n\\n\\n[mariadb]\\noptimizer_switch='condition_pushdown_for_subquery=off'\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_scp.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 10.4.0 \\n# mariadb_documentation: https://mariadb.com/kb/en/condition-pushdown-into-in-subqueries/\\n# mariadb_command: SET GLOBAL optimizer_switch='condition_pushdown_for_subquery=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='condition_pushdown_for_subquery=on';\\n\\n\\n[mariadb]\\nloose_optimizer_switch='condition_pushdown_for_subquery=off'\"}",
                     "var_updated": "2024-07-29 19:04:14",
                     "var_name": "db_cnf_opt_no_scp",
                     "id": 6200
@@ -3830,7 +3830,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_ecp.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3.0\\n# mariadb_deprecated: 10.1.0\\n# mariadb_documentation: https://mariadb.com/kb/en/index-condition-pushdown/\\n# mysql_version: 5.5.0\\n# mariadb_command: SET GLOBAL optimizer_switch='engine_condition_pushdown=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='engine_condition_pushdown=on';\\n\\n\\n\\n[mariadb]\\noptimizer_switch='engine_condition_pushdown=off'\\n\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_ecp.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 5.3.0\\n# mariadb_deprecated: 10.1.0\\n# mariadb_documentation: https://mariadb.com/kb/en/index-condition-pushdown/\\n# mysql_version: 5.5.0\\n# mariadb_command: SET GLOBAL optimizer_switch='engine_condition_pushdown=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='engine_condition_pushdown=on';\\n\\n\\n\\n[mariadb]\\nloose_optimizer_switch='engine_condition_pushdown=off'\\n\"}",
                     "var_updated": "2024-07-29 19:02:03",
                     "var_name": "db_cnf_opt_no_ecp",
                     "id": 6201
@@ -3838,7 +3838,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_dcp.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariabd_version: 10.2.2\\n# mariadb_command: SET GLOBAL optimizer_switch='condition_pushdown_for_derived=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='condition_pushdown_for_derived=on';\\n# mariadb_documentation: https://mariadb.com/kb/en/condition-pushdown-into-derived-table-optimization/\\n \\n[mariadb]\\noptimizer_switch='condition_pushdown_for_derived=off'\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_dcp.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariabd_version: 10.2.2\\n# mariadb_command: SET GLOBAL optimizer_switch='condition_pushdown_for_derived=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='condition_pushdown_for_derived=on';\\n# mariadb_documentation: https://mariadb.com/kb/en/condition-pushdown-into-derived-table-optimization/\\n \\n[mariadb]\\nloose_optimizer_switch='condition_pushdown_for_derived=off'\"}",
                     "var_updated": "2024-07-29 19:01:14",
                     "var_name": "db_cnf_opt_no_dcp",
                     "id": 6202
@@ -3846,7 +3846,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_bloomfilter.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 10.4.3 \\n# mariadb_documnetation: https://mariadb.com/kb/en/rowid-filtering-optimization/\\n# mariadb_command: SET GLOBAL optimizer_switch='rowid_filter=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='rowid_filter=on';\\n\\n[mariadb]\\noptimizer_switch='rowid_filter=off'\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_bloomfilter.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mariadb_version: 10.4.3 \\n# mariadb_documnetation: https://mariadb.com/kb/en/rowid-filtering-optimization/\\n# mariadb_command: SET GLOBAL optimizer_switch='rowid_filter=off';\\n# mariadb_default: SET GLOBAL optimizer_switch='rowid_filter=on';\\n\\n[mariadb]\\nloose_optimizer_switch='rowid_filter=off'\"}",
                     "var_updated": "2024-07-29 19:00:42",
                     "var_name": "db_cnf_opt_no_bloomfilter",
                     "id": 6203
@@ -3862,7 +3862,7 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_conditionfanoutfilter.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mysql_documentation: http://oysteing.blogspot.com/2017/03/mysql-57-improved-join-order-by-taking.html\\n# mysql_version: 5.7.0\\n# mysql_command: SET GLOBAL optimizer_switch='condition_fanout_filter=off';\\n# mysql_default: SET GLOBAL optimizer_switch='condition_fanout_filter=on';\\n\\n[mysqld]\\noptimizer_switch='condition_fanout_filter=off'\"}",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_opt_conditionfanoutfilter.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"# mysql_documentation: http://oysteing.blogspot.com/2017/03/mysql-57-improved-join-order-by-taking.html\\n# mysql_version: 5.7.0\\n# mysql_command: SET GLOBAL optimizer_switch='condition_fanout_filter=off';\\n# mysql_default: SET GLOBAL optimizer_switch='condition_fanout_filter=on';\\n\\n[mysqld]\\nloose_optimizer_switch='condition_fanout_filter=off'\"}",
                     "var_updated": "2024-07-29 19:00:56",
                     "var_name": "db_cnf_opt_no_condition_fanout_filter",
                     "id": 6213


### PR DESCRIPTION
## Summary
This PR improves OpenSVC v3 compatibility and provisioning reliability across database, app, and proxy services.
### What changed
- Added/expanded OpenSVC v3 handling for app/proxy lifecycle operations (provision, unprovision, start/stop/restart).
- Split template generation into reusable section-map builders and introduced INI template rendering for v3 flows.
- Updated v3 provisioning flow to:
  - create template,
  - handle existing-object conflicts (HTTP 409) safely,
  - then explicitly trigger provision.
- Introduced structured OpenSVC `StatusError` handling and improved create/update behavior for config/secret key-values.
- Wipe `02_delta.cnf` before provisioning/init to avoid stale runtime delta carrying into new provision cycles.
- Fixed optimizer boot issues by outputting `loose_optimizer_switch` where `optimizer_switch` options are emitted.
- Updated OpenSVC bootstrap script to safely handle missing `/bootstrap/version` and ensure `/bootstrap` exists early.
## Why
OpenSVC v3 has different API behavior and stricter object lifecycle semantics than earlier flows.  
These changes make provisioning more idempotent and resilient (especially on retries/re-provision), while also preventing startup failures caused by strict optimizer switch parsing.
## Impact
- Safer reprovision behavior when objects/templates already exist.
- Better alignment between generated templates and OpenSVC v3 expectations.
- Reduced risk of failed DB startup due to optimizer switch option handling.
- Cleaner provisioning state by removing stale delta config before re-init/re-provision.