### PR TITLE
slideshow, ACL grants, and viewer access improvements

### DIFF
--- a/cluster/cluster_acl.go
+++ b/cluster/cluster_acl.go
@@ -49,6 +49,26 @@ func (cluster *Cluster) SetUserGrants(u *APIUser, grant string) {
 	}
 }
 
+// SetUserGrantsStrict applies grants and always overwrites any previously set value.
+// Used for the main config ACL which must take precedence over cluster-level overrides.
+func (cluster *Cluster) SetUserGrantsStrict(u *APIUser, grant string) {
+	if u.Grants == nil {
+		u.Grants = map[string]bool{}
+	}
+
+	acls := strings.Split(grant, " ")
+	for key, value := range cluster.Grants {
+		found := false
+		for _, acl := range acls {
+			if strings.HasPrefix(key, acl) && acl != "" {
+				found = true
+				break
+			}
+		}
+		u.Grants[value] = found
+	}
+}
+
 func (cluster *Cluster) SetUserRoles(u *APIUser, roles string) {
 	if u.Roles == nil {
 		u.Roles = map[string]bool{}
@@ -234,26 +254,27 @@ func (cluster *Cluster) LoadAPIUsers() error {
 		newapiuser.Grants = make(map[string]bool)
 		newapiuser.Roles = make(map[string]bool)
 
-		// Assign Roles and ACLs
-		if userACL, ok := listACLs[newapiuser.User]; ok {
-			cluster.SetUserGrants(&newapiuser, userACL.ACLs)
-			cluster.SetUserRoles(&newapiuser, userACL.Roles)
-		}
-
-		if discardACL, ok := listDiscard[newapiuser.User]; ok {
-			acls := strings.Split(discardACL.ACLs, " ")
-			for _, acl := range acls {
-				newapiuser.Grants[acl] = false
-			}
-		}
-
-		// Assign Roles and ACLs
+		// Apply cluster-level external ACLs first (lower priority)
 		if userACL, ok := listACLsExt[newapiuser.User]; ok {
 			cluster.SetUserGrants(&newapiuser, userACL.ACLs)
 			cluster.SetUserRoles(&newapiuser, userACL.Roles)
 		}
 
 		if discardACL, ok := listDiscardExt[newapiuser.User]; ok {
+			acls := strings.Split(discardACL.ACLs, " ")
+			for _, acl := range acls {
+				newapiuser.Grants[acl] = false
+			}
+		}
+
+		// Apply main config ACLs last using strict override — main config is always authoritative
+		// and cannot be escalated by cluster-level configuration.
+		if userACL, ok := listACLs[newapiuser.User]; ok {
+			cluster.SetUserGrantsStrict(&newapiuser, userACL.ACLs)
+			cluster.SetUserRoles(&newapiuser, userACL.Roles)
+		}
+
+		if discardACL, ok := listDiscard[newapiuser.User]; ok {
 			acls := strings.Split(discardACL.ACLs, " ")
 			for _, acl := range acls {
 				newapiuser.Grants[acl] = false

--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -152,8 +152,11 @@ var clusterACLRules = []ACLRule{
 	{"/restic", nil, []string{config.GrantClusterProcess}},
 	{"/plugins", nil, []string{config.GrantClusterSettings}},
 
-	// Backups
-	{"/backups", nil, []string{config.GrantClusterShowBackups}},
+	// Backups — ordered longest-match-first so specific rules win
+	{"/backups/stats", nil, []string{config.GrantClusterShowBackups}},  // read-only stats
+	{"/backups/", nil, []string{config.GrantDBBackup}},                 // write sub-paths: delete, reconcile
+	{"/backups", nil, []string{config.GrantClusterShowBackups}},        // list (bare path, no slash)
+	{"/restic/purge", nil, []string{config.GrantDBBackup}},             // delete a snapshot
 	{"/restic/snapshots", nil, []string{config.GrantClusterShowBackups}},
 	{"/restic/stats", nil, []string{config.GrantClusterShowBackups}},
 

--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -146,7 +146,7 @@ var clusterACLRules = []ACLRule{
 	{"/shardclusters", nil, []string{config.GrantClusterSharding}},
 
 	// Process and Jobs
-	{"/jobs", nil, []string{config.GrantClusterProcess}},
+	{"/jobs", nil, []string{config.GrantClusterProcess, config.GrantClusterShowJobs}},
 	{"/top", nil, []string{config.GrantClusterProcess}},
 	{"/actions/restic-mount-toggle", nil, []string{config.GrantClusterSettings}},
 	{"/restic", nil, []string{config.GrantClusterProcess}},

--- a/config/config.go
+++ b/config/config.go
@@ -692,6 +692,8 @@ type Config struct {
 	APIUsersACLDiscard                        string                       `mapstructure:"api-credentials-acl-discard" toml:"api-credentials-acl-discard" json:"apiCredentialsACLDiscard"`
 	APIUsersACLDiscardExternal                string                       `mapstructure:"api-credentials-acl-discard-external" toml:"api-credentials-acl-discard-external" json:"apiCredentialsACLDiscardExternal"`
 	APISecureConfig                           bool                         `mapstructure:"api-credentials-secure-config" toml:"api-credentials-secure-config" json:"apiCredentialsSecureConfig"`
+	APIAutologin                              bool                         `scope:"server" mapstructure:"api-autologin" toml:"api-autologin" json:"apiAutologin"`
+	APIAutologinUser                          string                       `scope:"server" mapstructure:"api-autologin-user" toml:"api-autologin-user" json:"apiAutologinUser"`
 	APIPort                                   string                       `scope:"server" mapstructure:"api-port" toml:"api-port" json:"apiPort"`
 	APIBind                                   string                       `scope:"server" mapstructure:"api-bind" toml:"api-bind" json:"apiBind"`
 	APIPublicURL                              string                       `scope:"server" mapstructure:"api-public-url" toml:"api-public-url" json:"apiPublicUrl"`

--- a/config/config.go
+++ b/config/config.go
@@ -694,6 +694,7 @@ type Config struct {
 	APISecureConfig                           bool                         `mapstructure:"api-credentials-secure-config" toml:"api-credentials-secure-config" json:"apiCredentialsSecureConfig"`
 	APIAutologin                              bool                         `scope:"server" mapstructure:"api-autologin" toml:"api-autologin" json:"apiAutologin"`
 	APIAutologinUser                          string                       `scope:"server" mapstructure:"api-autologin-user" toml:"api-autologin-user" json:"apiAutologinUser"`
+	APIDashboardUser                          string                       `scope:"server" mapstructure:"api-dashboard-user" toml:"api-dashboard-user" json:"apiDashboardUser"`
 	APIPort                                   string                       `scope:"server" mapstructure:"api-port" toml:"api-port" json:"apiPort"`
 	APIBind                                   string                       `scope:"server" mapstructure:"api-bind" toml:"api-bind" json:"apiBind"`
 	APIPublicURL                              string                       `scope:"server" mapstructure:"api-public-url" toml:"api-public-url" json:"apiPublicUrl"`

--- a/config/config.go
+++ b/config/config.go
@@ -1350,6 +1350,7 @@ const (
 	GrantClusterTest               string = "cluster-test"
 	GrantClusterTraffic            string = "cluster-traffic"
 	GrantClusterShowBackups        string = "cluster-show-backups"
+	GrantClusterShowJobs           string = "cluster-show-jobs"
 	GrantClusterShowRoutes         string = "cluster-show-routes"
 	GrantClusterShowGraphs         string = "cluster-show-graphs"
 	GrantClusterConfigGraphs       string = "cluster-config-graphs"
@@ -2489,6 +2490,7 @@ func GetGrantType() map[string]string {
 		GrantClusterProcess:            GrantClusterProcess,
 		GrantClusterDebug:              GrantClusterDebug,
 		GrantClusterShowBackups:        GrantClusterShowBackups,
+		GrantClusterShowJobs:           GrantClusterShowJobs,
 		GrantClusterShowAgents:         GrantClusterShowAgents,
 		GrantClusterShowGraphs:         GrantClusterShowGraphs,
 		GrantClusterConfigGraphs:       GrantClusterConfigGraphs,

--- a/doc/implementation/ui-components/slideshow/SLIDESHOW.md
+++ b/doc/implementation/ui-components/slideshow/SLIDESHOW.md
@@ -1,0 +1,97 @@
+# Slideshow Feature
+
+## Overview
+
+The slideshow page (`/slideshow`) cycles automatically through all monitored clusters and their dashboard sections, designed for NOC screens or unattended display.
+
+## Route
+
+`/slideshow` — accessible to authenticated users; viewer tokens (auto-login from `/dashboard`) are supported.
+
+## Slide Structure
+
+Each slide is a `{ clusterName, view, label }` tuple. Slides are built from the cluster list in this fixed section order per cluster:
+
+| View key | Label | Grant required |
+|---|---|---|
+| `cluster-ha` | Cluster & HA | *(any authenticated user)* |
+| `servers-proxies` | Servers & Proxies | *(any authenticated user)* |
+| `servers-detail` | Server Details | *(any authenticated user)* |
+| `apps` | Application Servers | *(any, cluster must have app servers)* |
+| `logs-cluster` | Cluster & Security Logs | *(any authenticated user)* |
+| `logs-workload` | Workload Logs | *(any authenticated user)* |
+| `maintenance-backup` | Backup | `cluster-show-backups` |
+| `maintenance-jobs` | Scheduler Jobs | `cluster-show-jobs` or `cluster-process` |
+| `logs-jobs` | Job Logs | `cluster-show-jobs` or `cluster-process` |
+
+### Conditional inclusion
+
+- `maintenance-backup`, `maintenance-jobs`, `logs-jobs` are skipped when the cluster has no backup or scheduler configured (`backupRestic`, `backupPhysicalType`, `backupLogicalType`, `schedulerEnabled`).
+- `apps` is skipped when the cluster has no app servers.
+- `maintenance-backup` is skipped when the user lacks `cluster-show-backups`.
+- `maintenance-jobs` and `logs-jobs` are skipped when the user lacks both `cluster-show-jobs` and `cluster-process`.
+- When the user object is not yet loaded (initial state), all structurally eligible slides are shown optimistically.
+
+## Slide Duration
+
+`SLIDE_DURATION_MS = 15000` (15 seconds per slide). Configurable at build time by editing the constant in `src/Pages/Slideshow/index.jsx`.
+
+## Progress Bar
+
+A thin bar under the header advances from 0 → 100 % over each slide's duration. It turns **gray** when the slideshow is paused.
+
+## Stop / Start
+
+A **Stop/Start button** (HiStop / HiPlay icons) appears in the header right side. When paused:
+- The slide ticker freezes (progress bar stops advancing, no slide transitions).
+- The background data poller continues running so data stays fresh when resumed.
+
+## Auto-refresh Controls
+
+The navbar `RefreshCounter` (manual reload button + interval input) is **hidden** on the `/slideshow` route. The slideshow manages its own data polling independently.
+
+## Data Loading
+
+Two independent intervals:
+
+| Interval | Behavior |
+|---|---|
+| **Slide ticker** (250 ms tick) | Advances progress, transitions to next slide, calls `loadSlideData` on transition. Respects pause state. |
+| **Background poller** (`refresh_interval` seconds) | Calls `getClusters` + `loadSlideData` for current slide on every tick. Always runs, even when paused. |
+
+`loadSlideData` dispatches:
+- `getClusterData`, `getClusterServers`, `getClusterProxies`, `getClusterAlerts`, `getClusterMaster`, `getClusterLogs`, `getClusterApps` — for every slide.
+- `getResticSnapshot`, `getBackups`, `getBackupStats`, `getResticCurrentTask`, `getJobs` — only for `maintenance-*` and `logs-jobs` slides.
+
+A fast retrier (5 s) runs until clusters are loaded, to handle server restarts.
+
+## Required Grants for Viewer Users
+
+A typical read-only viewer configured with `show cluster-show` needs the following additional grants to see all slideshow sections:
+
+```
+cluster-show-backups   # to see Backup slide
+cluster-show-jobs      # to see Scheduler Jobs and Job Logs slides
+```
+
+Example ACL entry in `config.toml`:
+```
+api-credentials-acl-allow = "viewer:show cluster-show cluster-show-backups cluster-show-jobs"
+```
+
+## Grant: `cluster-show-jobs`
+
+**Constant**: `config.GrantClusterShowJobs = "cluster-show-jobs"`
+
+**ACL rule** (`cluster/cluster_acl_rules.go`):
+```go
+{"/jobs", nil, []string{config.GrantClusterProcess, config.GrantClusterShowJobs}},
+```
+
+This gives read-only access to `GET /api/clusters/{name}/jobs`. Write operations on jobs (cancel) still require `cluster-process`.
+
+## Authentication
+
+The slideshow uses the same JWT token mechanism as the dashboard. The `/dashboard` route provides auto-login for viewer tokens (no interactive login required for NOC display).
+
+PageContainer redirects unauthenticated `/slideshow` requests to `/dashboard` (not `/login`) so that viewer auto-login is triggered instead of the regular login form.

--- a/server/api.go
+++ b/server/api.go
@@ -741,6 +741,17 @@ func (repman *ReplicationManager) loginHandler(w http.ResponseWriter, r *http.Re
 	repman.jsonResponse(resp, w)
 }
 
+// resolveUserPassword returns the plaintext password for username by looking it up in
+// the already-decrypted cluster.APIUsers map. Returns "" if the user is not found.
+func (repman *ReplicationManager) resolveUserPassword(username string) string {
+	for _, cl := range repman.Clusters {
+		if user, ok := cl.APIUsers[username]; ok {
+			return user.Password
+		}
+	}
+	return ""
+}
+
 // autologinHandler returns a JWT token for the configured auto-login user without requiring credentials.
 // Only active when api-autologin = true. Should only be exposed on trusted networks.
 func (repman *ReplicationManager) autologinHandler(w http.ResponseWriter, r *http.Request) {
@@ -755,12 +766,15 @@ func (repman *ReplicationManager) autologinHandler(w http.ResponseWriter, r *htt
 		username = "admin"
 	}
 
-	// The username is admin-configured — skip password lookup and mint the token directly.
-	// ACL enforcement still applies on every subsequent API call.
+	// Resolve plaintext password from cluster APIUsers (already decrypted there).
+	// The JWT must carry the encrypted password so IsValidClusterACL can authenticate it.
+	password := repman.resolveUserPassword(username)
+
 	userInfo := struct {
-		Name string
-		Role string
-	}{username, "Member"}
+		Name     string
+		Role     string
+		Password string
+	}{username, "Member", repman.Conf.GetEncryptedString(password)}
 
 	signer := jwt.New(jwt.SigningMethodRS256)
 	claims := signer.Claims.(jwt.MapClaims)
@@ -796,12 +810,15 @@ func (repman *ReplicationManager) dashboardTokenHandler(w http.ResponseWriter, r
 		return
 	}
 
-	// The username is admin-configured — skip password lookup and mint the token directly.
-	// ACL enforcement still applies on every subsequent API call.
+	// Resolve plaintext password from cluster APIUsers (already decrypted there).
+	// The JWT must carry the encrypted password so IsValidClusterACL can authenticate it.
+	password := repman.resolveUserPassword(username)
+
 	userInfo := struct {
-		Name string
-		Role string
-	}{username, "Member"}
+		Name     string
+		Role     string
+		Password string
+	}{username, "Member", repman.Conf.GetEncryptedString(password)}
 
 	signer := jwt.New(jwt.SigningMethodRS256)
 	claims := signer.Claims.(jwt.MapClaims)

--- a/server/api.go
+++ b/server/api.go
@@ -755,38 +755,12 @@ func (repman *ReplicationManager) autologinHandler(w http.ResponseWriter, r *htt
 		username = "admin"
 	}
 
-	// Find the password for the configured user
-	password := ""
-	credList := repman.Conf.Secrets["api-credentials"].Value
-	if credList == "" {
-		credList = repman.Conf.APIUsers
-	}
-	for _, entry := range strings.Split(credList, ",") {
-		parts := strings.SplitN(strings.TrimSpace(entry), ":", 2)
-		if len(parts) == 2 && parts[0] == username {
-			password = parts[1]
-			break
-		}
-	}
-
-	// Validate the user exists in at least one cluster
-	found := false
-	for _, cl := range repman.Clusters {
-		if cl.IsValidACL(username, password, r.URL.Path, "password") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		http.Error(w, "Auto-login user not found", http.StatusUnauthorized)
-		return
-	}
-
+	// The username is admin-configured — skip password lookup and mint the token directly.
+	// ACL enforcement still applies on every subsequent API call.
 	userInfo := struct {
-		Name     string
-		Role     string
-		Password string
-	}{username, "Member", repman.Conf.GetEncryptedString(password)}
+		Name string
+		Role string
+	}{username, "Member"}
 
 	signer := jwt.New(jwt.SigningMethodRS256)
 	claims := signer.Claims.(jwt.MapClaims)
@@ -822,37 +796,12 @@ func (repman *ReplicationManager) dashboardTokenHandler(w http.ResponseWriter, r
 		return
 	}
 
-	// Resolve the password from api-credentials
-	password := ""
-	credList := repman.Conf.Secrets["api-credentials"].Value
-	if credList == "" {
-		credList = repman.Conf.APIUsers
-	}
-	for _, entry := range strings.Split(credList, ",") {
-		parts := strings.SplitN(strings.TrimSpace(entry), ":", 2)
-		if len(parts) == 2 && parts[0] == username {
-			password = parts[1]
-			break
-		}
-	}
-
-	found := false
-	for _, cl := range repman.Clusters {
-		if cl.IsValidACL(username, password, r.URL.Path, "password") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		http.Error(w, "Dashboard user not found or invalid credentials", http.StatusUnauthorized)
-		return
-	}
-
+	// The username is admin-configured — skip password lookup and mint the token directly.
+	// ACL enforcement still applies on every subsequent API call.
 	userInfo := struct {
-		Name     string
-		Role     string
-		Password string
-	}{username, "Member", repman.Conf.GetEncryptedString(password)}
+		Name string
+		Role string
+	}{username, "Member"}
 
 	signer := jwt.New(jwt.SigningMethodRS256)
 	claims := signer.Claims.(jwt.MapClaims)

--- a/server/api.go
+++ b/server/api.go
@@ -223,6 +223,9 @@ func (repman *ReplicationManager) apiserver() {
 	if repman.Conf.Test {
 		router.HandleFunc("/", repman.handlerApp)
 		router.PathPrefix("/terminal/").HandlerFunc(repman.handlerApp)
+		router.HandleFunc("/login", repman.handlerApp)
+		router.HandleFunc("/dashboard", repman.handlerApp)
+		router.HandleFunc("/slideshow", repman.handlerApp)
 		router.PathPrefix("/images/").Handler(http.FileServer(http.Dir(repman.Conf.HttpRoot)))
 		router.PathPrefix("/assets/").Handler(http.FileServer(http.Dir(repman.Conf.HttpRoot)))
 
@@ -232,6 +235,9 @@ func (repman *ReplicationManager) apiserver() {
 	} else {
 		router.HandleFunc("/", repman.rootHandler)
 		router.PathPrefix("/terminal/").HandlerFunc(repman.rootHandler)
+		router.HandleFunc("/login", repman.rootHandler)
+		router.HandleFunc("/dashboard", repman.rootHandler)
+		router.HandleFunc("/slideshow", repman.rootHandler)
 		router.PathPrefix("/static/").Handler(repman.handlerStatic(repman.DashboardFSHandler()))
 		router.PathPrefix("/app/").Handler(repman.handlerStatic(repman.DashboardFSHandler()))
 		router.PathPrefix("/images/").Handler(repman.handlerStatic(repman.DashboardFSHandler()))

--- a/server/api.go
+++ b/server/api.go
@@ -263,6 +263,7 @@ func (repman *ReplicationManager) apiserver() {
 
 	router.HandleFunc("/api/login", repman.loginHandler)
 	router.HandleFunc("/api/autologin", repman.autologinHandler)
+	router.HandleFunc("/api/dashboard-token", repman.dashboardTokenHandler)
 	router.HandleFunc("/api/version", repman.handlerVersion)
 
 	router.Handle("/api/terms", negroni.New(
@@ -772,6 +773,72 @@ func (repman *ReplicationManager) autologinHandler(w http.ResponseWriter, r *htt
 	}
 	if !found {
 		http.Error(w, "Auto-login user not found", http.StatusUnauthorized)
+		return
+	}
+
+	userInfo := struct {
+		Name     string
+		Role     string
+		Password string
+	}{username, "Member", repman.Conf.GetEncryptedString(password)}
+
+	signer := jwt.New(jwt.SigningMethodRS256)
+	claims := signer.Claims.(jwt.MapClaims)
+	claims["iss"] = "https://api.replication-manager.signal18.io"
+	claims["iat"] = time.Now().Unix()
+	claims["exp"] = time.Now().Add(time.Hour * time.Duration(repman.Conf.TokenTimeout)).Unix()
+	claims["jti"] = "1"
+	claims["token"] = ""
+	claims["CustomUserInfo"] = userInfo
+	signer.Claims = claims
+	sk, _ := jwt.ParseRSAPrivateKeyFromPEM(signingKey)
+
+	tokenString, err := signer.SignedString(sk)
+	if err != nil {
+		http.Error(w, "Error signing token: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	repman.jsonResponse(struct {
+		Token    string `json:"token"`
+		Username string `json:"username"`
+	}{Token: tokenString, Username: username}, w)
+}
+
+// dashboardTokenHandler issues a read-only JWT for the /dashboard public endpoint.
+// Active whenever api-dashboard-user is set — no separate enable flag needed.
+func (repman *ReplicationManager) dashboardTokenHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	username := repman.Conf.APIDashboardUser
+	if username == "" {
+		http.Error(w, "Dashboard endpoint not configured", http.StatusNotFound)
+		return
+	}
+
+	// Resolve the password from api-credentials
+	password := ""
+	credList := repman.Conf.Secrets["api-credentials"].Value
+	if credList == "" {
+		credList = repman.Conf.APIUsers
+	}
+	for _, entry := range strings.Split(credList, ",") {
+		parts := strings.SplitN(strings.TrimSpace(entry), ":", 2)
+		if len(parts) == 2 && parts[0] == username {
+			password = parts[1]
+			break
+		}
+	}
+
+	found := false
+	for _, cl := range repman.Clusters {
+		if cl.IsValidACL(username, password, r.URL.Path, "password") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		http.Error(w, "Dashboard user not found or invalid credentials", http.StatusUnauthorized)
 		return
 	}
 

--- a/server/api.go
+++ b/server/api.go
@@ -262,6 +262,7 @@ func (repman *ReplicationManager) apiserver() {
 	router.Handle("/api/terminal/connect", http.HandlerFunc(repman.handlerTerminal))
 
 	router.HandleFunc("/api/login", repman.loginHandler)
+	router.HandleFunc("/api/autologin", repman.autologinHandler)
 	router.HandleFunc("/api/version", repman.handlerVersion)
 
 	router.Handle("/api/terms", negroni.New(
@@ -731,6 +732,76 @@ func (repman *ReplicationManager) loginHandler(w http.ResponseWriter, r *http.Re
 	}
 
 	repman.jsonResponse(resp, w)
+}
+
+// autologinHandler returns a JWT token for the configured auto-login user without requiring credentials.
+// Only active when api-autologin = true. Should only be exposed on trusted networks.
+func (repman *ReplicationManager) autologinHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	if !repman.Conf.APIAutologin {
+		http.Error(w, "Auto-login not enabled", http.StatusNotFound)
+		return
+	}
+
+	username := repman.Conf.APIAutologinUser
+	if username == "" {
+		username = "admin"
+	}
+
+	// Find the password for the configured user
+	password := ""
+	credList := repman.Conf.Secrets["api-credentials"].Value
+	if credList == "" {
+		credList = repman.Conf.APIUsers
+	}
+	for _, entry := range strings.Split(credList, ",") {
+		parts := strings.SplitN(strings.TrimSpace(entry), ":", 2)
+		if len(parts) == 2 && parts[0] == username {
+			password = parts[1]
+			break
+		}
+	}
+
+	// Validate the user exists in at least one cluster
+	found := false
+	for _, cl := range repman.Clusters {
+		if cl.IsValidACL(username, password, r.URL.Path, "password") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		http.Error(w, "Auto-login user not found", http.StatusUnauthorized)
+		return
+	}
+
+	userInfo := struct {
+		Name     string
+		Role     string
+		Password string
+	}{username, "Member", repman.Conf.GetEncryptedString(password)}
+
+	signer := jwt.New(jwt.SigningMethodRS256)
+	claims := signer.Claims.(jwt.MapClaims)
+	claims["iss"] = "https://api.replication-manager.signal18.io"
+	claims["iat"] = time.Now().Unix()
+	claims["exp"] = time.Now().Add(time.Hour * time.Duration(repman.Conf.TokenTimeout)).Unix()
+	claims["jti"] = "1"
+	claims["token"] = ""
+	claims["CustomUserInfo"] = userInfo
+	signer.Claims = claims
+	sk, _ := jwt.ParseRSAPrivateKeyFromPEM(signingKey)
+
+	tokenString, err := signer.SignedString(sk)
+	if err != nil {
+		http.Error(w, "Error signing token: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	repman.jsonResponse(struct {
+		Token    string `json:"token"`
+		Username string `json:"username"`
+	}{Token: tokenString, Username: username}, w)
 }
 
 func (repman *ReplicationManager) handlerMuxAuthCallback(w http.ResponseWriter, r *http.Request) {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2006,6 +2006,7 @@ func (repman *ReplicationManager) handlerMuxClusterTags(w http.ResponseWriter, r
 // handlerMuxClusterBackups handles the retrieval of backups for a given cluster.
 // @Summary Retrieve backups for a specific cluster
 // @Description This endpoint retrieves the backups for the specified cluster.
+// @Description Required grant: cluster-show-backups
 // @Tags ClusterBackups
 // @Produce json
 // @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
@@ -2053,6 +2054,7 @@ type resticSnapshotsResponse struct {
 // handlerMuxClusterBackupStat handles the retrieval of backup stats for a given cluster.
 // @Summary Retrieve backup stats for a specific cluster
 // @Description This endpoint retrieves the backup stats for the specified cluster.
+// @Description Required grant: cluster-show-backups
 // @Tags ClusterBackups
 // @Produce json
 // @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
@@ -2086,6 +2088,7 @@ func (repman *ReplicationManager) handlerMuxClusterBackupStat(w http.ResponseWri
 // handlerMuxClusterBackupReconcile handles the manual reconciliation of backup metadata with restic snapshots.
 // @Summary Reconcile backup metadata with restic snapshots
 // @Description This endpoint triggers a manual reconciliation check to detect drift between backup metadata files and restic snapshots.
+// @Description Required grant: db-backup
 // @Tags ClusterBackup
 // @Produce json
 // @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
@@ -2126,6 +2129,7 @@ func (repman *ReplicationManager) handlerMuxClusterBackupReconcile(w http.Respon
 // handlerMuxClusterBackupDelete handles deletion of a non-restic backup by ID.
 // @Summary Delete a backup by ID
 // @Description Deletes a non-restic backup for the specified cluster.
+// @Description Required grant: db-backup
 // @Tags ClusterBackups
 // @Produce json
 // @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
@@ -8135,6 +8139,7 @@ func (repman *ReplicationManager) handlerMuxResticFetch(w http.ResponseWriter, r
 // handlerMuxResticPurge handles the HTTP request to purge the restic repo for a given cluster.
 // @Summary Purge Restic Backup
 // @Description Purges the restic backup for the specified cluster.
+// @Description Required grant: db-backup
 // @Tags ClusterRestic
 // @Produce json
 // @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)

--- a/server/http.go
+++ b/server/http.go
@@ -106,6 +106,9 @@ func (repman *ReplicationManager) httpserver() {
 		}
 		router.HandleFunc("/", repman.handlerApp)
 		router.PathPrefix("/terminal/").HandlerFunc(repman.handlerApp)
+		router.HandleFunc("/login", repman.handlerApp)
+		router.HandleFunc("/dashboard", repman.handlerApp)
+		router.HandleFunc("/slideshow", repman.handlerApp)
 		router.PathPrefix("/images/").Handler(http.FileServer(http.Dir(repman.Conf.HttpRoot)))
 		router.PathPrefix("/assets/").Handler(http.FileServer(http.Dir(repman.Conf.HttpRoot)))
 		router.PathPrefix("/static/").Handler(http.FileServer(http.Dir(repman.Conf.HttpRoot)))
@@ -114,6 +117,9 @@ func (repman *ReplicationManager) httpserver() {
 	} else {
 		router.HandleFunc("/", repman.rootHandler)
 		router.PathPrefix("/terminal/").HandlerFunc(repman.rootHandler)
+		router.HandleFunc("/login", repman.rootHandler)
+		router.HandleFunc("/dashboard", repman.rootHandler)
+		router.HandleFunc("/slideshow", repman.rootHandler)
 		router.PathPrefix("/images/").Handler(repman.handlerStatic(repman.DashboardFSHandler()))
 		router.PathPrefix("/assets/").Handler(repman.handlerStatic(repman.DashboardFSHandler()))
 		router.PathPrefix("/static/").Handler(repman.handlerStatic(repman.DashboardFSHandler()))
@@ -133,6 +139,8 @@ func (repman *ReplicationManager) httpserver() {
 	})
 
 	router.HandleFunc("/api/login", repman.loginHandler)
+	router.HandleFunc("/api/autologin", repman.autologinHandler)
+	router.HandleFunc("/api/dashboard-token", repman.dashboardTokenHandler)
 
 	router.Handle("/api/register", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),

--- a/server/server.go
+++ b/server/server.go
@@ -610,6 +610,8 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.APIBind, "api-bind", "0.0.0.0", "Rest API bind ip")
 	flags.BoolVar(&conf.APIHttpsBind, "api-https-bind", false, "Bind API call to https Web UI will error with http")
 	flags.BoolVar(&conf.APISecureConfig, "api-credentials-secure-config", false, "Need JWT token to download config tar.gz")
+	flags.BoolVar(&conf.APIAutologin, "api-autologin", false, "Enable unauthenticated auto-login token endpoint (trusted networks only)")
+	flags.StringVar(&conf.APIAutologinUser, "api-autologin-user", "admin", "Username to generate a token for when api-autologin is enabled")
 	flags.StringVar(&conf.APIPublicURL, "api-public-url", "https://127.0.0.1:10005", "Public address of monitoring API Used for cloud18 OAuth callback")
 	flags.StringVar(&conf.OAuthProvider, "api-oauth-provider-url", "https://gitlab.signal18.io", "API OAuth Provider URL")
 	flags.StringVar(&conf.OAuthClientID, "api-oauth-client-id", "", "API OAuth Client ID")

--- a/server/server.go
+++ b/server/server.go
@@ -612,6 +612,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.BoolVar(&conf.APISecureConfig, "api-credentials-secure-config", false, "Need JWT token to download config tar.gz")
 	flags.BoolVar(&conf.APIAutologin, "api-autologin", false, "Enable unauthenticated auto-login token endpoint (trusted networks only)")
 	flags.StringVar(&conf.APIAutologinUser, "api-autologin-user", "admin", "Username to generate a token for when api-autologin is enabled")
+	flags.StringVar(&conf.APIDashboardUser, "api-dashboard-user", "", "Read-only user for the /dashboard public endpoint (empty = disabled)")
 	flags.StringVar(&conf.APIPublicURL, "api-public-url", "https://127.0.0.1:10005", "Public address of monitoring API Used for cloud18 OAuth callback")
 	flags.StringVar(&conf.OAuthProvider, "api-oauth-provider-url", "https://gitlab.signal18.io", "API OAuth Provider URL")
 	flags.StringVar(&conf.OAuthClientID, "api-oauth-client-id", "", "API OAuth Client ID")

--- a/share/dashboard_react/src/App.jsx
+++ b/share/dashboard_react/src/App.jsx
@@ -79,9 +79,9 @@ function App() {
         <Route
           path='/slideshow'
           element={
-            <PrivateRoute>
+            <SlideshowRoute>
               <Slideshow />
-            </PrivateRoute>
+            </SlideshowRoute>
           }
         />
       </Routes>
@@ -90,12 +90,22 @@ function App() {
 }
 
 const PrivateRoute = ({ children }) => {
-  // Add your own authentication on the below line.
   const isLoggedIn = localStorage.getItem('user_token') !== null
   return isLoggedIn ? <Suspense fallback={<div>Loading...</div>}>{children}</Suspense> : <Navigate to='/login' />
 }
 
+// Slideshow uses the dashboard token — on auth failure redirect back to /dashboard
+// (not /login) so the viewer token is re-fetched automatically.
+const SlideshowRoute = ({ children }) => {
+  const isLoggedIn = localStorage.getItem('user_token') !== null
+  return isLoggedIn ? <Suspense fallback={<div>Loading...</div>}>{children}</Suspense> : <Navigate to='/dashboard' />
+}
+
 PrivateRoute.propTypes = {
+  children: PropTypes.node.isRequired
+}
+
+SlideshowRoute.propTypes = {
   children: PropTypes.node.isRequired
 }
 

--- a/share/dashboard_react/src/App.jsx
+++ b/share/dashboard_react/src/App.jsx
@@ -74,6 +74,7 @@ function App() {
           </PrivateRoute>
         } />
         <Route path='/login' element={<Login />} />
+        <Route path='/dashboard' element={<Login dashboard />} />
       </Routes>
     </BrowserRouter>
   )

--- a/share/dashboard_react/src/App.jsx
+++ b/share/dashboard_react/src/App.jsx
@@ -7,6 +7,7 @@ import Login from './Pages/Login'
 // const Login = lazy(() => import('./Pages/Login'))
 // const Home = lazy(() => import('./Pages/Home'))
 import Home from './Pages/Home'
+import Slideshow from './Pages/Slideshow'
 import ClusterDB from './Pages/ClusterDB'
 import TerminalComponent from './Pages/Terminal'
 import ClusterApp from './Pages/ClusterApp'
@@ -75,6 +76,14 @@ function App() {
         } />
         <Route path='/login' element={<Login />} />
         <Route path='/dashboard' element={<Login dashboard />} />
+        <Route
+          path='/slideshow'
+          element={
+            <PrivateRoute>
+              <Slideshow />
+            </PrivateRoute>
+          }
+        />
       </Routes>
     </BrowserRouter>
   )

--- a/share/dashboard_react/src/Pages/ClusterDB/components/ClusterDBTabContent/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterDB/components/ClusterDBTabContent/index.jsx
@@ -84,6 +84,7 @@ function ClusterDBTabContent({ tab, dbId, clusterName, digestMode, toggleDigestM
             selectedDBServer={selectedDBServer}
             tableSize={clusterData?.workLoad?.dbTableSize}
             usePersistent={clusterData?.config?.analyzeUsePersistent}
+            user={user}
           />
         ) : null
       ) : currentTab === 'status' ? (

--- a/share/dashboard_react/src/Pages/ClusterDB/components/Tables/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterDB/components/Tables/index.jsx
@@ -18,7 +18,7 @@ const selectTables = (state) => ({ tables: state.cluster.database.tables, isDesk
 
 const columnHelper = createColumnHelper()
 
-function Tables({ clusterName, dbId, selectedDBServer, usePersistent, tableSize }) {
+function Tables({ clusterName, dbId, selectedDBServer, usePersistent, tableSize, user }) {
   const dispatch = useDispatch()
   const { tables, isDesktop } = useSelector(selectTables, shallowEqual)
   const [search, setSearch] = useState('')
@@ -124,6 +124,7 @@ function Tables({ clusterName, dbId, selectedDBServer, usePersistent, tableSize 
         options={[
           {
             name: 'Checksum',
+            isDisabled: !user?.grants['cluster-checksum'],
             onClick: () => {
               openConfirmModal()
               setConfirmTitle(`Confirm run checksum for ${row.table_schema}.${row.table_name}?`)
@@ -132,6 +133,7 @@ function Tables({ clusterName, dbId, selectedDBServer, usePersistent, tableSize 
           },
           {
             name: 'ChecksumRepair',
+            isDisabled: !user?.grants['cluster-checksum-repair'],
             onClick: () => {
               openConfirmModal()
               setConfirmTitle(`Confirm run repair for ${row.table_schema}.${row.table_name}?`)
@@ -143,6 +145,7 @@ function Tables({ clusterName, dbId, selectedDBServer, usePersistent, tableSize 
             subMenu: [
               {
                 name: 'Persistent',
+                isDisabled: !user?.grants['cluster-analyze'],
                 onClick: () => {
                   setConfirmTitle(`Confirm run analyze for ${row.table_schema}.${row.table_name}?`)
                   setConfirmHandler(() => () => handleAnalyze(row.table_schema, row.table_name, true))
@@ -151,6 +154,7 @@ function Tables({ clusterName, dbId, selectedDBServer, usePersistent, tableSize 
               },
               {
                 name: 'Non-Persistent',
+                isDisabled: !user?.grants['cluster-analyze'],
                 onClick: () => {
                   setConfirmTitle(`Confirm run analyze for ${row.table_schema}.${row.table_name}?`)
                   setConfirmHandler(() => () => handleAnalyze(row.table_schema, row.table_name, false))
@@ -258,6 +262,7 @@ function Tables({ clusterName, dbId, selectedDBServer, usePersistent, tableSize 
             options={[
               {
                 name: 'Checksum',
+                isDisabled: !user?.grants['cluster-checksum'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm run checksum for ${row.original.table_schema}?`)
@@ -269,6 +274,7 @@ function Tables({ clusterName, dbId, selectedDBServer, usePersistent, tableSize 
                 subMenu: [
                   {
                     name: 'Persistent',
+                    isDisabled: !user?.grants['cluster-analyze'],
                     onClick: () => {
                       setConfirmTitle(`Confirm run analyze for ${row.table_schema}?`)
                       setConfirmHandler(() => () => handleAnalyzeSchema(row.table_schema, true))
@@ -277,6 +283,7 @@ function Tables({ clusterName, dbId, selectedDBServer, usePersistent, tableSize 
                   },
                   {
                     name: 'Non-Persistent',
+                    isDisabled: !user?.grants['cluster-analyze'],
                     onClick: () => {
                       setConfirmTitle(`Confirm run analyze for ${row.table_schema}?`)
                       setConfirmHandler(() => () => handleAnalyzeSchema(row.table_schema, false))
@@ -303,14 +310,14 @@ function Tables({ clusterName, dbId, selectedDBServer, usePersistent, tableSize 
             <Input id='search' type='search' onChange={handleSearch} />
             <Box className={styles.divider} />
             <label htmlFor='search'>Checksum</label>
-            <RMIconButton icon={HiShieldCheck} tooltip={"Checksum All Tables"} onClick={() => {
+            <RMIconButton icon={HiShieldCheck} tooltip={"Checksum All Tables"} isDisabled={!user?.grants['cluster-checksum']} onClick={() => {
               setConfirmTitle(`Confirm run checksum for all schemas and tables?`)
               setConfirmHandler(() => () => handleChecksumAll())
               openConfirmModal()
             }} />
             <Box className={styles.divider} />
             <label htmlFor='search'>Analyze</label>
-            <RMIconButton icon={HiChartBar} tooltip={"Analyze All Tables"} onClick={() => {
+            <RMIconButton icon={HiChartBar} tooltip={"Analyze All Tables"} isDisabled={!user?.grants['cluster-analyze']} onClick={() => {
               let title = persistent ? 'with PERSISTENT FOR ALL' : ''
               setConfirmTitle(`Confirm run checksum for all schemas and tables ${title}?`)
               setConfirmHandler(() => () => handleAnalyzeAll(persistent))

--- a/share/dashboard_react/src/Pages/ClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterList/index.jsx
@@ -28,6 +28,7 @@ function ClusterList({ onClick }) {
   const monitor = useSelector((state) => state.globalClusters.monitor)
   const isDownList = useSelector((state) => state.globalClusters.isDownList)
   const isFailableList = useSelector((state) => state.globalClusters.isFailableList)
+  const isAdmin = localStorage.getItem('username') === 'admin'
 
   useEffect(() => {
     dispatch(getClusters({}))
@@ -151,7 +152,7 @@ function ClusterList({ onClick }) {
                     }}>
                     <CustomIcon icon={isSponsor || isPending ? (HiCreditCard) : (AiOutlineCluster)} fill={isSponsor ? "green" : isPending ? "orange" : "gray"} />
                     <span className={styles.cardHeaderText}>{headerText}</span>
-                    {monitor?.config?.monitoringSaveConfig && monitor?.config?.cloud18GitUser?.length > 0 && (
+                    {monitor?.config?.monitoringSaveConfig && monitor?.config?.cloud18GitUser?.length > 0 && isAdmin && (
                       <RMIconButton
                         icon={FaUserPlus}
                         tooltip={'Add User'}

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppMenu.jsx
@@ -131,14 +131,18 @@ function AppMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView',
                   },
                 ]
                 : []),
-              {
-                name: 'Remove Monitor',
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle(`Confirm removing monitor for ${appName}?`)
-                  setConfirmHandler(() => () => dispatch(dropApp({ clusterName, host: row.host, port: row.port })))
-                }
-              },
+              ...(user?.grants['prov-app-unprovision']
+                ? [
+                    {
+                      name: 'Remove Monitor',
+                      onClick: () => {
+                        openConfirmModal()
+                        setConfirmTitle(`Confirm removing monitor for ${appName}?`)
+                        setConfirmHandler(() => () => dispatch(dropApp({ clusterName, host: row.host, port: row.port })))
+                      }
+                    }
+                  ]
+                : []),
             ]
           },
           ...(user?.grants['app-terminal'] ? [

--- a/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
@@ -69,12 +69,15 @@ function ClusterDetail({ selectedCluster, user }) {
     setClipboardText('')
   }
 
+  const g = user?.grants ?? {}
+
   const menuOptions = [
     {
       name: 'HA',
       subMenu: [
         {
           name: 'Reset Failover Counter',
+          isDisabled: !g['cluster-settings'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle('Reset failover counter?')
@@ -83,6 +86,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Rotate SLA',
+          isDisabled: !g['cluster-reset-sla'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle('Reset SLA?')
@@ -91,6 +95,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Toggle Traffic',
+          isDisabled: !g['cluster-traffic'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle('Toggle traffic?')
@@ -99,9 +104,10 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         ...(selectedCluster.config?.topologyStaging ? [{
           name: 'Toggle Traffic Staging',
+          isDisabled: !g['cluster-traffic'],
           onClick: () => {
             openConfirmModal()
-            setConfirmTitle('Toggle traffic?')
+            setConfirmTitle('Toggle traffic staging?')
             setConfirmHandler(() => () => dispatch(toggleTrafficStaging({ clusterName: selectedCluster?.name })))
           }
         }] : []),
@@ -109,6 +115,7 @@ function ClusterDetail({ selectedCluster, user }) {
           ? [
             {
               name: 'Failover',
+              isDisabled: !g['cluster-failover'],
               onClick: () => {
                 openConfirmModal()
                 setConfirmTitle('Confirm failover?')
@@ -119,6 +126,7 @@ function ClusterDetail({ selectedCluster, user }) {
           : [
             {
               name: 'Switchover',
+              isDisabled: !g['cluster-switchover'],
               onClick: () => {
                 openConfirmModal()
                 setConfirmTitle('Confirm switchover?')
@@ -135,18 +143,21 @@ function ClusterDetail({ selectedCluster, user }) {
       subMenu: [
         {
           name: 'New Cluster Shard',
+          isDisabled: !g['cluster-create'],
           onClick: () => {
             setIsNewClusterModalOpen(true)
           }
         },
         {
           name: 'New Monitor',
+          isDisabled: !g['cluster-create-monitor'],
           onClick: () => {
             setIsNewServerModalOpen(true)
           }
         },
         {
           name: 'Provision Cluster',
+          isDisabled: !g['prov-cluster'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle('Provision cluster?')
@@ -155,6 +166,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Unprovision Cluster',
+          isDisabled: !g['prov-cluster-unprovision'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle('Unprovision cluster?')
@@ -168,6 +180,7 @@ function ClusterDetail({ selectedCluster, user }) {
       subMenu: [
         {
           name: 'Set Database Credentials',
+          isDisabled: !g['cluster-settings'],
           onClick: () => {
             setIsCredentialModalOpen(true)
             setCredentialType('db-servers-credential')
@@ -175,6 +188,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Set Replication Credentials',
+          isDisabled: !g['cluster-settings'],
           onClick: () => {
             setIsCredentialModalOpen(true)
             setCredentialType('replication-credential')
@@ -182,6 +196,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Set DBA Credentials',
+          isDisabled: !g['cluster-settings'],
           onClick: () => {
             setIsCredentialModalOpen(true)
             setCredentialType('cloud18-dba-user-credentials')
@@ -189,6 +204,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Set Sponsor DB Credentials',
+          isDisabled: !g['cluster-settings'],
           onClick: () => {
             setIsCredentialModalOpen(true)
             setCredentialType('cloud18-sponsor-user-credentials')
@@ -196,6 +212,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Set ProxySQL Credentials',
+          isDisabled: !g['cluster-settings'],
           onClick: () => {
             setIsCredentialModalOpen(true)
             setCredentialType('proxysql-servers-credential')
@@ -203,6 +220,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Set Maxscale Credentials',
+          isDisabled: !g['cluster-settings'],
           onClick: () => {
             setIsCredentialModalOpen(true)
             setCredentialType('maxscale-servers-credential')
@@ -210,6 +228,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Set Sharding Proxy Credentials',
+          isDisabled: !g['cluster-settings'],
           onClick: () => {
             setIsCredentialModalOpen(true)
             setCredentialType('shardproxy-servers-credential')
@@ -217,6 +236,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Rotate Database Credentials',
+          isDisabled: !g['cluster-rotate-passwords'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle('Rotate database credentials?')
@@ -230,7 +250,7 @@ function ClusterDetail({ selectedCluster, user }) {
       subMenu: [
         {
           name: 'Run Monitor Schema',
-          isDisabled: !selectedCluster?.config?.monitoringSchemaChange,
+          isDisabled: !selectedCluster?.config?.monitoringSchemaChange || !g['cluster-sharding'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle('Run monitor schema for all databases?')
@@ -239,6 +259,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Rolling Optimize',
+          isDisabled: !g['cluster-rolling'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle('Rolling optimize?')
@@ -247,6 +268,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Rolling Jobs Upgrade',
+          isDisabled: !g['cluster-rolling'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle('Rolling jobs upgrade?')
@@ -255,6 +277,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Rolling Restart',
+          isDisabled: !g['cluster-rolling'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle('Rolling restart?')
@@ -263,6 +286,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Rotate Certificates',
+          isDisabled: !g['cluster-certificates-rotate'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle('Rotate certificates?')
@@ -271,6 +295,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Reload Certificates',
+          isDisabled: !g['cluster-certificates-reload'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle('Reload certificates?')
@@ -279,6 +304,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Cancel Rolling Restart',
+          isDisabled: !g['cluster-rolling'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle('Cancel Rolling Restart?')
@@ -287,6 +313,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Cancel Rolling Reprove',
+          isDisabled: !g['cluster-rolling'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle('Cancel Rolling Reprove?')
@@ -300,6 +327,7 @@ function ClusterDetail({ selectedCluster, user }) {
       subMenu: [
         {
           name: 'Master Slave',
+          isDisabled: !g['cluster-replication'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle(confirmBootrapMessage)
@@ -308,6 +336,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Master Slave Positional',
+          isDisabled: !g['cluster-replication'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle(confirmBootrapMessage)
@@ -316,6 +345,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Multi Master',
+          isDisabled: !g['cluster-replication'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle(confirmBootrapMessage)
@@ -324,6 +354,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Multi Master Ring',
+          isDisabled: !g['cluster-replication'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle(confirmBootrapMessage)
@@ -332,6 +363,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Multi Tier Slave',
+          isDisabled: !g['cluster-replication'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle(confirmBootrapMessage)
@@ -345,6 +377,7 @@ function ClusterDetail({ selectedCluster, user }) {
       subMenu: [
         {
           name: 'Reload',
+          isDisabled: !g['cluster-settings'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle('Confirm reload config?')
@@ -353,6 +386,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Database discover config',
+          isDisabled: !g['cluster-settings'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle('Confirm database discover config?')
@@ -361,6 +395,7 @@ function ClusterDetail({ selectedCluster, user }) {
         },
         {
           name: 'Database apply dynamic config',
+          isDisabled: !g['db-config-flag'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle('Confirm database apply config?')
@@ -454,9 +489,9 @@ function ClusterDetail({ selectedCluster, user }) {
             valueClassName={`${parentStyles.rowValue} ${parentStyles.ClusterDetailRow}`}
           />
         }
-        {...(user?.grants?.['cluster-settings'] || user?.grants?.['cluster-switchover'] || user?.grants?.['cluster-failover'] || user?.grants?.['prov-cluster-provision']
-          ? { headerAction: 'menu', isLoading: menuActionsLoading, menuOptions }
-          : {})}
+        headerAction='menu'
+        isLoading={menuActionsLoading}
+        menuOptions={menuOptions}
       />
       {isConfirmModalOpen && (
         <ConfirmModal

--- a/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
@@ -72,236 +72,263 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
   const g = user?.grants ?? {}
   const isVisitor = !!user?.roles?.['visitor']
 
-  const haItems = [
-    ...(g['cluster-settings'] ? [{
-      name: 'Reset Failover Counter',
-      onClick: () => {
-        openConfirmModal()
-        setConfirmTitle('Reset failover counter?')
-        setConfirmHandler(() => () => dispatch(resetFailOverCounter({ clusterName: selectedCluster?.name })))
-      }
-    }] : []),
-    ...(g['cluster-reset-sla'] ? [{
-      name: 'Rotate SLA',
-      onClick: () => {
-        openConfirmModal()
-        setConfirmTitle('Reset SLA?')
-        setConfirmHandler(() => () => dispatch(resetSLA({ clusterName: selectedCluster?.name })))
-      }
-    }] : []),
-    ...(g['cluster-traffic'] ? [{
-      name: 'Toggle Traffic',
-      onClick: () => {
-        openConfirmModal()
-        setConfirmTitle('Toggle traffic?')
-        setConfirmHandler(() => () => dispatch(toggleTraffic({ clusterName: selectedCluster?.name })))
-      }
-    }] : []),
-    ...(g['cluster-traffic'] && selectedCluster.config?.topologyStaging ? [{
-      name: 'Toggle Traffic Staging',
-      onClick: () => {
-        openConfirmModal()
-        setConfirmTitle('Toggle traffic staging?')
-        setConfirmHandler(() => () => dispatch(toggleTrafficStaging({ clusterName: selectedCluster?.name })))
-      }
-    }] : []),
-    ...(!isVisitor && !readOnly && clusterMaster?.state === 'Failed' && g['cluster-failover']
-      ? [{
-          name: 'Failover',
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Confirm failover?')
-            setConfirmHandler(() => () => dispatch(failOverCluster({ clusterName: selectedCluster?.name })))
-          }
-        }]
-      : !isVisitor && !readOnly && clusterMaster?.state !== 'Failed' && g['cluster-switchover']
-      ? [{
-          name: 'Switchover',
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Confirm switchover?')
-            setConfirmHandler(() => () => dispatch(switchOverCluster({ clusterName: selectedCluster?.name })))
-          }
-        }]
-      : [])
-  ]
-
-  const provisionItems = [
-    ...(g['cluster-create'] ? [{
-      name: 'New Cluster Shard',
-      onClick: () => { setIsNewClusterModalOpen(true) }
-    }] : []),
-    ...(g['cluster-create-monitor'] ? [{
-      name: 'New Monitor',
-      onClick: () => { setIsNewServerModalOpen(true) }
-    }] : []),
-    ...(g['prov-cluster'] ? [{
-      name: 'Provision Cluster',
-      onClick: () => {
-        openConfirmModal()
-        setConfirmTitle('Provision cluster?')
-        setConfirmHandler(() => () => dispatch(provisionCluster({ clusterName: selectedCluster?.name })))
-      }
-    }] : []),
-    ...(g['prov-cluster-unprovision'] ? [{
-      name: 'Unprovision Cluster',
-      onClick: () => {
-        openConfirmModal()
-        setConfirmTitle('Unprovision cluster?')
-        setConfirmHandler(() => () => dispatch(unProvisionCluster({ clusterName: selectedCluster?.name })))
-      }
-    }] : [])
-  ]
-
-  const credentialItems = [
-    ...(g['cluster-settings'] ? [
-      {
-        name: 'Set Database Credentials',
-        onClick: () => { setIsCredentialModalOpen(true); setCredentialType('db-servers-credential') }
-      },
-      {
-        name: 'Set Replication Credentials',
-        onClick: () => { setIsCredentialModalOpen(true); setCredentialType('replication-credential') }
-      },
-      {
-        name: 'Set DBA Credentials',
-        onClick: () => { setIsCredentialModalOpen(true); setCredentialType('cloud18-dba-user-credentials') }
-      },
-      {
-        name: 'Set Sponsor DB Credentials',
-        onClick: () => { setIsCredentialModalOpen(true); setCredentialType('cloud18-sponsor-user-credentials') }
-      },
-      {
-        name: 'Set ProxySQL Credentials',
-        onClick: () => { setIsCredentialModalOpen(true); setCredentialType('proxysql-servers-credential') }
-      },
-      {
-        name: 'Set Maxscale Credentials',
-        onClick: () => { setIsCredentialModalOpen(true); setCredentialType('maxscale-servers-credential') }
-      },
-      {
-        name: 'Set Sharding Proxy Credentials',
-        onClick: () => { setIsCredentialModalOpen(true); setCredentialType('shardproxy-servers-credential') }
-      }
-    ] : []),
-    ...(g['cluster-rotate-passwords'] ? [{
-      name: 'Rotate Database Credentials',
-      onClick: () => {
-        openConfirmModal()
-        setConfirmTitle('Rotate database credentials?')
-        setConfirmHandler(() => () => dispatch(rotateDBCredential({ clusterName: selectedCluster?.name })))
-      }
-    }] : [])
-  ]
-
-  const maintenanceItems = [
-    ...(g['cluster-sharding'] && selectedCluster?.config?.monitoringSchemaChange ? [{
-      name: 'Run Monitor Schema',
-      onClick: () => {
-        openConfirmModal()
-        setConfirmTitle('Run monitor schema for all databases?')
-        setConfirmHandler(() => () => dispatch(monitorAllSchemas({ clusterName: selectedCluster?.name })))
-      }
-    }] : []),
-    ...(g['cluster-rolling'] ? [
-      {
-        name: 'Rolling Optimize',
-        onClick: () => {
-          openConfirmModal()
-          setConfirmTitle('Rolling optimize?')
-          setConfirmHandler(() => () => dispatch(rollingOptimize({ clusterName: selectedCluster?.name })))
-        }
-      },
-      {
-        name: 'Rolling Jobs Upgrade',
-        onClick: () => {
-          openConfirmModal()
-          setConfirmTitle('Rolling jobs upgrade?')
-          setConfirmHandler(() => () => dispatch(rollingJobsUpgrade({ clusterName: selectedCluster?.name })))
-        }
-      },
-      {
-        name: 'Rolling Restart',
-        onClick: () => {
-          openConfirmModal()
-          setConfirmTitle('Rolling restart?')
-          setConfirmHandler(() => () => dispatch(rollingRestart({ clusterName: selectedCluster?.name })))
-        }
-      },
-      {
-        name: 'Cancel Rolling Restart',
-        onClick: () => {
-          openConfirmModal()
-          setConfirmTitle('Cancel Rolling Restart?')
-          setConfirmHandler(() => () => dispatch(cancelRollingRestart({ clusterName: selectedCluster?.name })))
-        }
-      },
-      {
-        name: 'Cancel Rolling Reprove',
-        onClick: () => {
-          openConfirmModal()
-          setConfirmTitle('Cancel Rolling Reprove?')
-          setConfirmHandler(() => () => dispatch(cancelRollingReprov({ clusterName: selectedCluster?.name })))
-        }
-      }
-    ] : []),
-    ...(g['cluster-certificates-rotate'] ? [{
-      name: 'Rotate Certificates',
-      onClick: () => {
-        openConfirmModal()
-        setConfirmTitle('Rotate certificates?')
-        setConfirmHandler(() => () => dispatch(rotateCertificates({ clusterName: selectedCluster?.name })))
-      }
-    }] : []),
-    ...(g['cluster-certificates-reload'] ? [{
-      name: 'Reload Certificates',
-      onClick: () => {
-        openConfirmModal()
-        setConfirmTitle('Reload certificates?')
-        setConfirmHandler(() => () => dispatch(reloadCertificates({ clusterName: selectedCluster?.name })))
-      }
-    }] : [])
-  ]
-
-  const configItems = [
-    ...(g['cluster-settings'] ? [
-      {
-        name: 'Reload',
-        onClick: () => {
-          openConfirmModal()
-          setConfirmTitle('Confirm reload config?')
-          setConfirmHandler(() => () => dispatch(configReload({ clusterName: selectedCluster?.name })))
-        }
-      },
-      {
-        name: 'Database discover config',
-        onClick: () => {
-          openConfirmModal()
-          setConfirmTitle('Confirm database discover config?')
-          setConfirmHandler(() => () => dispatch(configDiscoverDB({ clusterName: selectedCluster?.name })))
-        }
-      }
-    ] : []),
-    ...(g['db-config-flag'] ? [{
-      name: 'Database apply dynamic config',
-      onClick: () => {
-        openConfirmModal()
-        setConfirmTitle('Confirm database apply config?')
-        setConfirmHandler(() => () => dispatch(configDynamic({ clusterName: selectedCluster?.name })))
-      }
-    }] : [])
-  ]
-
   const menuOptions = [
-    ...(haItems.length > 0 ? [{ name: 'HA', subMenu: haItems }] : []),
-    ...(provisionItems.length > 0 ? [{ name: 'Provision', subMenu: provisionItems }] : []),
-    ...(credentialItems.length > 0 ? [{ name: 'Credentials', subMenu: credentialItems }] : []),
-    ...(maintenanceItems.length > 0 ? [{ name: 'Maintenance', subMenu: maintenanceItems }] : []),
-    ...(g['cluster-replication'] ? [{
+    {
+      name: 'HA',
+      subMenu: [
+        {
+          name: 'Reset Failover Counter',
+          isDisabled: !g['cluster-settings'],
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Reset failover counter?')
+            setConfirmHandler(() => () => dispatch(resetFailOverCounter({ clusterName: selectedCluster?.name })))
+          }
+        },
+        {
+          name: 'Rotate SLA',
+          isDisabled: !g['cluster-reset-sla'],
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Reset SLA?')
+            setConfirmHandler(() => () => dispatch(resetSLA({ clusterName: selectedCluster?.name })))
+          }
+        },
+        {
+          name: 'Toggle Traffic',
+          isDisabled: !g['cluster-traffic'],
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Toggle traffic?')
+            setConfirmHandler(() => () => dispatch(toggleTraffic({ clusterName: selectedCluster?.name })))
+          }
+        },
+        ...(selectedCluster.config?.topologyStaging ? [{
+          name: 'Toggle Traffic Staging',
+          isDisabled: !g['cluster-traffic'],
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Toggle traffic staging?')
+            setConfirmHandler(() => () => dispatch(toggleTrafficStaging({ clusterName: selectedCluster?.name })))
+          }
+        }] : []),
+        ...(!isVisitor && !readOnly && clusterMaster?.state === 'Failed' && g['cluster-failover']
+          ? [
+            {
+              name: 'Failover',
+              onClick: () => {
+                openConfirmModal()
+                setConfirmTitle('Confirm failover?')
+                setConfirmHandler(() => () => dispatch(failOverCluster({ clusterName: selectedCluster?.name })))
+              }
+            }
+          ]
+          : !isVisitor && !readOnly && clusterMaster?.state !== 'Failed' && g['cluster-switchover']
+          ? [
+            {
+              name: 'Switchover',
+              onClick: () => {
+                openConfirmModal()
+                setConfirmTitle('Confirm switchover?')
+                setConfirmHandler(
+                  () => () => dispatch(switchOverCluster({ clusterName: selectedCluster?.name }))
+                )
+              }
+            }
+          ]
+          : [])
+      ]
+    },
+    {
+      name: 'Provision',
+      subMenu: [
+        {
+          name: 'New Cluster Shard',
+          isDisabled: !g['cluster-create'],
+          onClick: () => {
+            setIsNewClusterModalOpen(true)
+          }
+        },
+        {
+          name: 'New Monitor',
+          isDisabled: !g['cluster-create-monitor'],
+          onClick: () => {
+            setIsNewServerModalOpen(true)
+          }
+        },
+        {
+          name: 'Provision Cluster',
+          isDisabled: !g['prov-cluster'],
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Provision cluster?')
+            setConfirmHandler(() => () => dispatch(provisionCluster({ clusterName: selectedCluster?.name })))
+          }
+        },
+        {
+          name: 'Unprovision Cluster',
+          isDisabled: !g['prov-cluster-unprovision'],
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Unprovision cluster?')
+            setConfirmHandler(() => () => dispatch(unProvisionCluster({ clusterName: selectedCluster?.name })))
+          }
+        }
+      ]
+    },
+    {
+      name: 'Credentials',
+      subMenu: [
+        {
+          name: 'Set Database Credentials',
+          isDisabled: !g['cluster-settings'],
+          onClick: () => {
+            setIsCredentialModalOpen(true)
+            setCredentialType('db-servers-credential')
+          }
+        },
+        {
+          name: 'Set Replication Credentials',
+          isDisabled: !g['cluster-settings'],
+          onClick: () => {
+            setIsCredentialModalOpen(true)
+            setCredentialType('replication-credential')
+          }
+        },
+        {
+          name: 'Set DBA Credentials',
+          isDisabled: !g['cluster-settings'],
+          onClick: () => {
+            setIsCredentialModalOpen(true)
+            setCredentialType('cloud18-dba-user-credentials')
+          }
+        },
+        {
+          name: 'Set Sponsor DB Credentials',
+          isDisabled: !g['cluster-settings'],
+          onClick: () => {
+            setIsCredentialModalOpen(true)
+            setCredentialType('cloud18-sponsor-user-credentials')
+          }
+        },
+        {
+          name: 'Set ProxySQL Credentials',
+          isDisabled: !g['cluster-settings'],
+          onClick: () => {
+            setIsCredentialModalOpen(true)
+            setCredentialType('proxysql-servers-credential')
+          }
+        },
+        {
+          name: 'Set Maxscale Credentials',
+          isDisabled: !g['cluster-settings'],
+          onClick: () => {
+            setIsCredentialModalOpen(true)
+            setCredentialType('maxscale-servers-credential')
+          }
+        },
+        {
+          name: 'Set Sharding Proxy Credentials',
+          isDisabled: !g['cluster-settings'],
+          onClick: () => {
+            setIsCredentialModalOpen(true)
+            setCredentialType('shardproxy-servers-credential')
+          }
+        },
+        {
+          name: 'Rotate Database Credentials',
+          isDisabled: !g['cluster-rotate-passwords'],
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Rotate database credentials?')
+            setConfirmHandler(() => () => dispatch(rotateDBCredential({ clusterName: selectedCluster?.name })))
+          }
+        }
+      ]
+    },
+    {
+      name: 'Maintenance',
+      subMenu: [
+        {
+          name: 'Run Monitor Schema',
+          isDisabled: !selectedCluster?.config?.monitoringSchemaChange || !g['cluster-sharding'],
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Run monitor schema for all databases?')
+            setConfirmHandler(() => () => dispatch(monitorAllSchemas({ clusterName: selectedCluster?.name })))
+          }
+        },
+        {
+          name: 'Rolling Optimize',
+          isDisabled: !g['cluster-rolling'],
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Rolling optimize?')
+            setConfirmHandler(() => () => dispatch(rollingOptimize({ clusterName: selectedCluster?.name })))
+          }
+        },
+        {
+          name: 'Rolling Jobs Upgrade',
+          isDisabled: !g['cluster-rolling'],
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Rolling jobs upgrade?')
+            setConfirmHandler(() => () => dispatch(rollingJobsUpgrade({ clusterName: selectedCluster?.name })))
+          }
+        },
+        {
+          name: 'Rolling Restart',
+          isDisabled: !g['cluster-rolling'],
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Rolling restart?')
+            setConfirmHandler(() => () => dispatch(rollingRestart({ clusterName: selectedCluster?.name })))
+          }
+        },
+        {
+          name: 'Rotate Certificates',
+          isDisabled: !g['cluster-certificates-rotate'],
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Rotate certificates?')
+            setConfirmHandler(() => () => dispatch(rotateCertificates({ clusterName: selectedCluster?.name })))
+          }
+        },
+        {
+          name: 'Reload Certificates',
+          isDisabled: !g['cluster-certificates-reload'],
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Reload certificates?')
+            setConfirmHandler(() => () => dispatch(reloadCertificates({ clusterName: selectedCluster?.name })))
+          }
+        },
+        {
+          name: 'Cancel Rolling Restart',
+          isDisabled: !g['cluster-rolling'],
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Cancel Rolling Restart?')
+            setConfirmHandler(() => () => dispatch(cancelRollingRestart({ clusterName: selectedCluster?.name })))
+          }
+        },
+        {
+          name: 'Cancel Rolling Reprove',
+          isDisabled: !g['cluster-rolling'],
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Cancel Rolling Reprove?')
+            setConfirmHandler(() => () => dispatch(cancelRollingReprov({ clusterName: selectedCluster?.name })))
+          }
+        }
+      ]
+    },
+    {
       name: 'Replication Bootstrap',
       subMenu: [
         {
           name: 'Master Slave',
+          isDisabled: !g['cluster-replication'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle(confirmBootrapMessage)
@@ -310,6 +337,7 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
         },
         {
           name: 'Master Slave Positional',
+          isDisabled: !g['cluster-replication'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle(confirmBootrapMessage)
@@ -318,6 +346,7 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
         },
         {
           name: 'Multi Master',
+          isDisabled: !g['cluster-replication'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle(confirmBootrapMessage)
@@ -326,6 +355,7 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
         },
         {
           name: 'Multi Master Ring',
+          isDisabled: !g['cluster-replication'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle(confirmBootrapMessage)
@@ -334,6 +364,7 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
         },
         {
           name: 'Multi Tier Slave',
+          isDisabled: !g['cluster-replication'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle(confirmBootrapMessage)
@@ -341,13 +372,45 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
           }
         }
       ]
-    }] : []),
-    ...(configItems.length > 0 ? [{ name: 'Config', subMenu: configItems }] : []),
-    ...(g['cluster-debug'] ? [{
+    },
+    {
+      name: 'Config',
+      subMenu: [
+        {
+          name: 'Reload',
+          isDisabled: !g['cluster-settings'],
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Confirm reload config?')
+            setConfirmHandler(() => () => dispatch(configReload({ clusterName: selectedCluster?.name })))
+          }
+        },
+        {
+          name: 'Database discover config',
+          isDisabled: !g['cluster-settings'],
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Confirm database discover config?')
+            setConfirmHandler(() => () => dispatch(configDiscoverDB({ clusterName: selectedCluster?.name })))
+          }
+        },
+        {
+          name: 'Database apply dynamic config',
+          isDisabled: !g['db-config-flag'],
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Confirm database apply config?')
+            setConfirmHandler(() => () => dispatch(configDynamic({ clusterName: selectedCluster?.name })))
+          }
+        }
+      ]
+    },
+    {
       name: 'Debug',
       subMenu: [
         {
           name: 'Clusters',
+          isDisabled: !g['cluster-debug'],
           onClick: () => {
             setIsClipboardModalOpen(true)
             setClipboardText(JSON.stringify(selectedCluster))
@@ -356,6 +419,7 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
         },
         {
           name: 'Servers',
+          isDisabled: !g['cluster-debug'],
           onClick: () => {
             setIsClipboardModalOpen(true)
             setClipboardText(JSON.stringify(clusterServers))
@@ -364,6 +428,7 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
         },
         {
           name: 'Proxies',
+          isDisabled: !g['cluster-debug'],
           onClick: () => {
             setIsClipboardModalOpen(true)
             setClipboardText(JSON.stringify(clusterProxies))
@@ -371,7 +436,7 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
           }
         }
       ]
-    }] : [])
+    }
   ]
 
   const dataObject = [

--- a/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
@@ -111,11 +111,10 @@ function ClusterDetail({ selectedCluster, user }) {
             setConfirmHandler(() => () => dispatch(toggleTrafficStaging({ clusterName: selectedCluster?.name })))
           }
         }] : []),
-        ...(clusterMaster?.state === 'Failed'
+        ...(clusterMaster?.state === 'Failed' && g['cluster-failover']
           ? [
             {
               name: 'Failover',
-              isDisabled: !g['cluster-failover'],
               onClick: () => {
                 openConfirmModal()
                 setConfirmTitle('Confirm failover?')
@@ -123,10 +122,10 @@ function ClusterDetail({ selectedCluster, user }) {
               }
             }
           ]
-          : [
+          : clusterMaster?.state !== 'Failed' && g['cluster-switchover']
+          ? [
             {
               name: 'Switchover',
-              isDisabled: !g['cluster-switchover'],
               onClick: () => {
                 openConfirmModal()
                 setConfirmTitle('Confirm switchover?')
@@ -135,7 +134,8 @@ function ClusterDetail({ selectedCluster, user }) {
                 )
               }
             }
-          ])
+          ]
+          : [])
       ]
     },
     {

--- a/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
@@ -410,6 +410,7 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
       subMenu: [
         {
           name: 'Clusters',
+          isDisabled: !g['cluster-debug'],
           onClick: () => {
             setIsClipboardModalOpen(true)
             setClipboardText(JSON.stringify(selectedCluster))
@@ -418,6 +419,7 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
         },
         {
           name: 'Servers',
+          isDisabled: !g['cluster-debug'],
           onClick: () => {
             setIsClipboardModalOpen(true)
             setClipboardText(JSON.stringify(clusterServers))
@@ -426,6 +428,7 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
         },
         {
           name: 'Proxies',
+          isDisabled: !g['cluster-debug'],
           onClick: () => {
             setIsClipboardModalOpen(true)
             setClipboardText(JSON.stringify(clusterProxies))

--- a/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
@@ -38,7 +38,7 @@ import CopyTextModal from '../../../components/Modals/CopyTextModal'
 import SetCredentialsModal from '../../../components/Modals/SetCredentialsModal'
 import NewClusterModal from '../../../components/Modals/NewClusterModal'
 
-function ClusterDetail({ selectedCluster }) {
+function ClusterDetail({ selectedCluster, user }) {
   const dispatch = useDispatch()
   const isDesktop = useSelector((state) => state.common.isDesktop)
   const monitor = useSelector((state) => state.globalClusters.monitor)
@@ -454,9 +454,9 @@ function ClusterDetail({ selectedCluster }) {
             valueClassName={`${parentStyles.rowValue} ${parentStyles.ClusterDetailRow}`}
           />
         }
-        headerAction='menu'
-        isLoading={menuActionsLoading}
-        menuOptions={menuOptions}
+        {...(user?.grants?.['cluster-settings'] || user?.grants?.['cluster-switchover'] || user?.grants?.['cluster-failover'] || user?.grants?.['prov-cluster-provision']
+          ? { headerAction: 'menu', isLoading: menuActionsLoading, menuOptions }
+          : {})}
       />
       {isConfirmModalOpen && (
         <ConfirmModal

--- a/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
@@ -38,7 +38,7 @@ import CopyTextModal from '../../../components/Modals/CopyTextModal'
 import SetCredentialsModal from '../../../components/Modals/SetCredentialsModal'
 import NewClusterModal from '../../../components/Modals/NewClusterModal'
 
-function ClusterDetail({ selectedCluster, user }) {
+function ClusterDetail({ selectedCluster, user, readOnly = false }) {
   const dispatch = useDispatch()
   const isDesktop = useSelector((state) => state.common.isDesktop)
   const monitor = useSelector((state) => state.globalClusters.monitor)
@@ -70,6 +70,7 @@ function ClusterDetail({ selectedCluster, user }) {
   }
 
   const g = user?.grants ?? {}
+  const isVisitor = !!user?.roles?.['visitor']
 
   const menuOptions = [
     {
@@ -111,7 +112,7 @@ function ClusterDetail({ selectedCluster, user }) {
             setConfirmHandler(() => () => dispatch(toggleTrafficStaging({ clusterName: selectedCluster?.name })))
           }
         }] : []),
-        ...(clusterMaster?.state === 'Failed' && g['cluster-failover']
+        ...(!isVisitor && !readOnly && clusterMaster?.state === 'Failed' && g['cluster-failover']
           ? [
             {
               name: 'Failover',
@@ -122,7 +123,7 @@ function ClusterDetail({ selectedCluster, user }) {
               }
             }
           ]
-          : clusterMaster?.state !== 'Failed' && g['cluster-switchover']
+          : !isVisitor && !readOnly && clusterMaster?.state !== 'Failed' && g['cluster-switchover']
           ? [
             {
               name: 'Switchover',

--- a/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
@@ -72,263 +72,236 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
   const g = user?.grants ?? {}
   const isVisitor = !!user?.roles?.['visitor']
 
+  const haItems = [
+    ...(g['cluster-settings'] ? [{
+      name: 'Reset Failover Counter',
+      onClick: () => {
+        openConfirmModal()
+        setConfirmTitle('Reset failover counter?')
+        setConfirmHandler(() => () => dispatch(resetFailOverCounter({ clusterName: selectedCluster?.name })))
+      }
+    }] : []),
+    ...(g['cluster-reset-sla'] ? [{
+      name: 'Rotate SLA',
+      onClick: () => {
+        openConfirmModal()
+        setConfirmTitle('Reset SLA?')
+        setConfirmHandler(() => () => dispatch(resetSLA({ clusterName: selectedCluster?.name })))
+      }
+    }] : []),
+    ...(g['cluster-traffic'] ? [{
+      name: 'Toggle Traffic',
+      onClick: () => {
+        openConfirmModal()
+        setConfirmTitle('Toggle traffic?')
+        setConfirmHandler(() => () => dispatch(toggleTraffic({ clusterName: selectedCluster?.name })))
+      }
+    }] : []),
+    ...(g['cluster-traffic'] && selectedCluster.config?.topologyStaging ? [{
+      name: 'Toggle Traffic Staging',
+      onClick: () => {
+        openConfirmModal()
+        setConfirmTitle('Toggle traffic staging?')
+        setConfirmHandler(() => () => dispatch(toggleTrafficStaging({ clusterName: selectedCluster?.name })))
+      }
+    }] : []),
+    ...(!isVisitor && !readOnly && clusterMaster?.state === 'Failed' && g['cluster-failover']
+      ? [{
+          name: 'Failover',
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Confirm failover?')
+            setConfirmHandler(() => () => dispatch(failOverCluster({ clusterName: selectedCluster?.name })))
+          }
+        }]
+      : !isVisitor && !readOnly && clusterMaster?.state !== 'Failed' && g['cluster-switchover']
+      ? [{
+          name: 'Switchover',
+          onClick: () => {
+            openConfirmModal()
+            setConfirmTitle('Confirm switchover?')
+            setConfirmHandler(() => () => dispatch(switchOverCluster({ clusterName: selectedCluster?.name })))
+          }
+        }]
+      : [])
+  ]
+
+  const provisionItems = [
+    ...(g['cluster-create'] ? [{
+      name: 'New Cluster Shard',
+      onClick: () => { setIsNewClusterModalOpen(true) }
+    }] : []),
+    ...(g['cluster-create-monitor'] ? [{
+      name: 'New Monitor',
+      onClick: () => { setIsNewServerModalOpen(true) }
+    }] : []),
+    ...(g['prov-cluster'] ? [{
+      name: 'Provision Cluster',
+      onClick: () => {
+        openConfirmModal()
+        setConfirmTitle('Provision cluster?')
+        setConfirmHandler(() => () => dispatch(provisionCluster({ clusterName: selectedCluster?.name })))
+      }
+    }] : []),
+    ...(g['prov-cluster-unprovision'] ? [{
+      name: 'Unprovision Cluster',
+      onClick: () => {
+        openConfirmModal()
+        setConfirmTitle('Unprovision cluster?')
+        setConfirmHandler(() => () => dispatch(unProvisionCluster({ clusterName: selectedCluster?.name })))
+      }
+    }] : [])
+  ]
+
+  const credentialItems = [
+    ...(g['cluster-settings'] ? [
+      {
+        name: 'Set Database Credentials',
+        onClick: () => { setIsCredentialModalOpen(true); setCredentialType('db-servers-credential') }
+      },
+      {
+        name: 'Set Replication Credentials',
+        onClick: () => { setIsCredentialModalOpen(true); setCredentialType('replication-credential') }
+      },
+      {
+        name: 'Set DBA Credentials',
+        onClick: () => { setIsCredentialModalOpen(true); setCredentialType('cloud18-dba-user-credentials') }
+      },
+      {
+        name: 'Set Sponsor DB Credentials',
+        onClick: () => { setIsCredentialModalOpen(true); setCredentialType('cloud18-sponsor-user-credentials') }
+      },
+      {
+        name: 'Set ProxySQL Credentials',
+        onClick: () => { setIsCredentialModalOpen(true); setCredentialType('proxysql-servers-credential') }
+      },
+      {
+        name: 'Set Maxscale Credentials',
+        onClick: () => { setIsCredentialModalOpen(true); setCredentialType('maxscale-servers-credential') }
+      },
+      {
+        name: 'Set Sharding Proxy Credentials',
+        onClick: () => { setIsCredentialModalOpen(true); setCredentialType('shardproxy-servers-credential') }
+      }
+    ] : []),
+    ...(g['cluster-rotate-passwords'] ? [{
+      name: 'Rotate Database Credentials',
+      onClick: () => {
+        openConfirmModal()
+        setConfirmTitle('Rotate database credentials?')
+        setConfirmHandler(() => () => dispatch(rotateDBCredential({ clusterName: selectedCluster?.name })))
+      }
+    }] : [])
+  ]
+
+  const maintenanceItems = [
+    ...(g['cluster-sharding'] && selectedCluster?.config?.monitoringSchemaChange ? [{
+      name: 'Run Monitor Schema',
+      onClick: () => {
+        openConfirmModal()
+        setConfirmTitle('Run monitor schema for all databases?')
+        setConfirmHandler(() => () => dispatch(monitorAllSchemas({ clusterName: selectedCluster?.name })))
+      }
+    }] : []),
+    ...(g['cluster-rolling'] ? [
+      {
+        name: 'Rolling Optimize',
+        onClick: () => {
+          openConfirmModal()
+          setConfirmTitle('Rolling optimize?')
+          setConfirmHandler(() => () => dispatch(rollingOptimize({ clusterName: selectedCluster?.name })))
+        }
+      },
+      {
+        name: 'Rolling Jobs Upgrade',
+        onClick: () => {
+          openConfirmModal()
+          setConfirmTitle('Rolling jobs upgrade?')
+          setConfirmHandler(() => () => dispatch(rollingJobsUpgrade({ clusterName: selectedCluster?.name })))
+        }
+      },
+      {
+        name: 'Rolling Restart',
+        onClick: () => {
+          openConfirmModal()
+          setConfirmTitle('Rolling restart?')
+          setConfirmHandler(() => () => dispatch(rollingRestart({ clusterName: selectedCluster?.name })))
+        }
+      },
+      {
+        name: 'Cancel Rolling Restart',
+        onClick: () => {
+          openConfirmModal()
+          setConfirmTitle('Cancel Rolling Restart?')
+          setConfirmHandler(() => () => dispatch(cancelRollingRestart({ clusterName: selectedCluster?.name })))
+        }
+      },
+      {
+        name: 'Cancel Rolling Reprove',
+        onClick: () => {
+          openConfirmModal()
+          setConfirmTitle('Cancel Rolling Reprove?')
+          setConfirmHandler(() => () => dispatch(cancelRollingReprov({ clusterName: selectedCluster?.name })))
+        }
+      }
+    ] : []),
+    ...(g['cluster-certificates-rotate'] ? [{
+      name: 'Rotate Certificates',
+      onClick: () => {
+        openConfirmModal()
+        setConfirmTitle('Rotate certificates?')
+        setConfirmHandler(() => () => dispatch(rotateCertificates({ clusterName: selectedCluster?.name })))
+      }
+    }] : []),
+    ...(g['cluster-certificates-reload'] ? [{
+      name: 'Reload Certificates',
+      onClick: () => {
+        openConfirmModal()
+        setConfirmTitle('Reload certificates?')
+        setConfirmHandler(() => () => dispatch(reloadCertificates({ clusterName: selectedCluster?.name })))
+      }
+    }] : [])
+  ]
+
+  const configItems = [
+    ...(g['cluster-settings'] ? [
+      {
+        name: 'Reload',
+        onClick: () => {
+          openConfirmModal()
+          setConfirmTitle('Confirm reload config?')
+          setConfirmHandler(() => () => dispatch(configReload({ clusterName: selectedCluster?.name })))
+        }
+      },
+      {
+        name: 'Database discover config',
+        onClick: () => {
+          openConfirmModal()
+          setConfirmTitle('Confirm database discover config?')
+          setConfirmHandler(() => () => dispatch(configDiscoverDB({ clusterName: selectedCluster?.name })))
+        }
+      }
+    ] : []),
+    ...(g['db-config-flag'] ? [{
+      name: 'Database apply dynamic config',
+      onClick: () => {
+        openConfirmModal()
+        setConfirmTitle('Confirm database apply config?')
+        setConfirmHandler(() => () => dispatch(configDynamic({ clusterName: selectedCluster?.name })))
+      }
+    }] : [])
+  ]
+
   const menuOptions = [
-    {
-      name: 'HA',
-      subMenu: [
-        {
-          name: 'Reset Failover Counter',
-          isDisabled: !g['cluster-settings'],
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Reset failover counter?')
-            setConfirmHandler(() => () => dispatch(resetFailOverCounter({ clusterName: selectedCluster?.name })))
-          }
-        },
-        {
-          name: 'Rotate SLA',
-          isDisabled: !g['cluster-reset-sla'],
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Reset SLA?')
-            setConfirmHandler(() => () => dispatch(resetSLA({ clusterName: selectedCluster?.name })))
-          }
-        },
-        {
-          name: 'Toggle Traffic',
-          isDisabled: !g['cluster-traffic'],
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Toggle traffic?')
-            setConfirmHandler(() => () => dispatch(toggleTraffic({ clusterName: selectedCluster?.name })))
-          }
-        },
-        ...(selectedCluster.config?.topologyStaging ? [{
-          name: 'Toggle Traffic Staging',
-          isDisabled: !g['cluster-traffic'],
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Toggle traffic staging?')
-            setConfirmHandler(() => () => dispatch(toggleTrafficStaging({ clusterName: selectedCluster?.name })))
-          }
-        }] : []),
-        ...(!isVisitor && !readOnly && clusterMaster?.state === 'Failed' && g['cluster-failover']
-          ? [
-            {
-              name: 'Failover',
-              onClick: () => {
-                openConfirmModal()
-                setConfirmTitle('Confirm failover?')
-                setConfirmHandler(() => () => dispatch(failOverCluster({ clusterName: selectedCluster?.name })))
-              }
-            }
-          ]
-          : !isVisitor && !readOnly && clusterMaster?.state !== 'Failed' && g['cluster-switchover']
-          ? [
-            {
-              name: 'Switchover',
-              onClick: () => {
-                openConfirmModal()
-                setConfirmTitle('Confirm switchover?')
-                setConfirmHandler(
-                  () => () => dispatch(switchOverCluster({ clusterName: selectedCluster?.name }))
-                )
-              }
-            }
-          ]
-          : [])
-      ]
-    },
-    {
-      name: 'Provision',
-      subMenu: [
-        {
-          name: 'New Cluster Shard',
-          isDisabled: !g['cluster-create'],
-          onClick: () => {
-            setIsNewClusterModalOpen(true)
-          }
-        },
-        {
-          name: 'New Monitor',
-          isDisabled: !g['cluster-create-monitor'],
-          onClick: () => {
-            setIsNewServerModalOpen(true)
-          }
-        },
-        {
-          name: 'Provision Cluster',
-          isDisabled: !g['prov-cluster'],
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Provision cluster?')
-            setConfirmHandler(() => () => dispatch(provisionCluster({ clusterName: selectedCluster?.name })))
-          }
-        },
-        {
-          name: 'Unprovision Cluster',
-          isDisabled: !g['prov-cluster-unprovision'],
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Unprovision cluster?')
-            setConfirmHandler(() => () => dispatch(unProvisionCluster({ clusterName: selectedCluster?.name })))
-          }
-        }
-      ]
-    },
-    {
-      name: 'Credentials',
-      subMenu: [
-        {
-          name: 'Set Database Credentials',
-          isDisabled: !g['cluster-settings'],
-          onClick: () => {
-            setIsCredentialModalOpen(true)
-            setCredentialType('db-servers-credential')
-          }
-        },
-        {
-          name: 'Set Replication Credentials',
-          isDisabled: !g['cluster-settings'],
-          onClick: () => {
-            setIsCredentialModalOpen(true)
-            setCredentialType('replication-credential')
-          }
-        },
-        {
-          name: 'Set DBA Credentials',
-          isDisabled: !g['cluster-settings'],
-          onClick: () => {
-            setIsCredentialModalOpen(true)
-            setCredentialType('cloud18-dba-user-credentials')
-          }
-        },
-        {
-          name: 'Set Sponsor DB Credentials',
-          isDisabled: !g['cluster-settings'],
-          onClick: () => {
-            setIsCredentialModalOpen(true)
-            setCredentialType('cloud18-sponsor-user-credentials')
-          }
-        },
-        {
-          name: 'Set ProxySQL Credentials',
-          isDisabled: !g['cluster-settings'],
-          onClick: () => {
-            setIsCredentialModalOpen(true)
-            setCredentialType('proxysql-servers-credential')
-          }
-        },
-        {
-          name: 'Set Maxscale Credentials',
-          isDisabled: !g['cluster-settings'],
-          onClick: () => {
-            setIsCredentialModalOpen(true)
-            setCredentialType('maxscale-servers-credential')
-          }
-        },
-        {
-          name: 'Set Sharding Proxy Credentials',
-          isDisabled: !g['cluster-settings'],
-          onClick: () => {
-            setIsCredentialModalOpen(true)
-            setCredentialType('shardproxy-servers-credential')
-          }
-        },
-        {
-          name: 'Rotate Database Credentials',
-          isDisabled: !g['cluster-rotate-passwords'],
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Rotate database credentials?')
-            setConfirmHandler(() => () => dispatch(rotateDBCredential({ clusterName: selectedCluster?.name })))
-          }
-        }
-      ]
-    },
-    {
-      name: 'Maintenance',
-      subMenu: [
-        {
-          name: 'Run Monitor Schema',
-          isDisabled: !selectedCluster?.config?.monitoringSchemaChange || !g['cluster-sharding'],
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Run monitor schema for all databases?')
-            setConfirmHandler(() => () => dispatch(monitorAllSchemas({ clusterName: selectedCluster?.name })))
-          }
-        },
-        {
-          name: 'Rolling Optimize',
-          isDisabled: !g['cluster-rolling'],
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Rolling optimize?')
-            setConfirmHandler(() => () => dispatch(rollingOptimize({ clusterName: selectedCluster?.name })))
-          }
-        },
-        {
-          name: 'Rolling Jobs Upgrade',
-          isDisabled: !g['cluster-rolling'],
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Rolling jobs upgrade?')
-            setConfirmHandler(() => () => dispatch(rollingJobsUpgrade({ clusterName: selectedCluster?.name })))
-          }
-        },
-        {
-          name: 'Rolling Restart',
-          isDisabled: !g['cluster-rolling'],
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Rolling restart?')
-            setConfirmHandler(() => () => dispatch(rollingRestart({ clusterName: selectedCluster?.name })))
-          }
-        },
-        {
-          name: 'Rotate Certificates',
-          isDisabled: !g['cluster-certificates-rotate'],
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Rotate certificates?')
-            setConfirmHandler(() => () => dispatch(rotateCertificates({ clusterName: selectedCluster?.name })))
-          }
-        },
-        {
-          name: 'Reload Certificates',
-          isDisabled: !g['cluster-certificates-reload'],
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Reload certificates?')
-            setConfirmHandler(() => () => dispatch(reloadCertificates({ clusterName: selectedCluster?.name })))
-          }
-        },
-        {
-          name: 'Cancel Rolling Restart',
-          isDisabled: !g['cluster-rolling'],
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Cancel Rolling Restart?')
-            setConfirmHandler(() => () => dispatch(cancelRollingRestart({ clusterName: selectedCluster?.name })))
-          }
-        },
-        {
-          name: 'Cancel Rolling Reprove',
-          isDisabled: !g['cluster-rolling'],
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Cancel Rolling Reprove?')
-            setConfirmHandler(() => () => dispatch(cancelRollingReprov({ clusterName: selectedCluster?.name })))
-          }
-        }
-      ]
-    },
-    {
+    ...(haItems.length > 0 ? [{ name: 'HA', subMenu: haItems }] : []),
+    ...(provisionItems.length > 0 ? [{ name: 'Provision', subMenu: provisionItems }] : []),
+    ...(credentialItems.length > 0 ? [{ name: 'Credentials', subMenu: credentialItems }] : []),
+    ...(maintenanceItems.length > 0 ? [{ name: 'Maintenance', subMenu: maintenanceItems }] : []),
+    ...(g['cluster-replication'] ? [{
       name: 'Replication Bootstrap',
       subMenu: [
         {
           name: 'Master Slave',
-          isDisabled: !g['cluster-replication'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle(confirmBootrapMessage)
@@ -337,7 +310,6 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
         },
         {
           name: 'Master Slave Positional',
-          isDisabled: !g['cluster-replication'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle(confirmBootrapMessage)
@@ -346,7 +318,6 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
         },
         {
           name: 'Multi Master',
-          isDisabled: !g['cluster-replication'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle(confirmBootrapMessage)
@@ -355,7 +326,6 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
         },
         {
           name: 'Multi Master Ring',
-          isDisabled: !g['cluster-replication'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle(confirmBootrapMessage)
@@ -364,7 +334,6 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
         },
         {
           name: 'Multi Tier Slave',
-          isDisabled: !g['cluster-replication'],
           onClick: () => {
             openConfirmModal()
             setConfirmTitle(confirmBootrapMessage)
@@ -372,45 +341,13 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
           }
         }
       ]
-    },
-    {
-      name: 'Config',
-      subMenu: [
-        {
-          name: 'Reload',
-          isDisabled: !g['cluster-settings'],
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Confirm reload config?')
-            setConfirmHandler(() => () => dispatch(configReload({ clusterName: selectedCluster?.name })))
-          }
-        },
-        {
-          name: 'Database discover config',
-          isDisabled: !g['cluster-settings'],
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Confirm database discover config?')
-            setConfirmHandler(() => () => dispatch(configDiscoverDB({ clusterName: selectedCluster?.name })))
-          }
-        },
-        {
-          name: 'Database apply dynamic config',
-          isDisabled: !g['db-config-flag'],
-          onClick: () => {
-            openConfirmModal()
-            setConfirmTitle('Confirm database apply config?')
-            setConfirmHandler(() => () => dispatch(configDynamic({ clusterName: selectedCluster?.name })))
-          }
-        }
-      ]
-    },
-    {
+    }] : []),
+    ...(configItems.length > 0 ? [{ name: 'Config', subMenu: configItems }] : []),
+    ...(g['cluster-debug'] ? [{
       name: 'Debug',
       subMenu: [
         {
           name: 'Clusters',
-          isDisabled: !g['cluster-debug'],
           onClick: () => {
             setIsClipboardModalOpen(true)
             setClipboardText(JSON.stringify(selectedCluster))
@@ -419,7 +356,6 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
         },
         {
           name: 'Servers',
-          isDisabled: !g['cluster-debug'],
           onClick: () => {
             setIsClipboardModalOpen(true)
             setClipboardText(JSON.stringify(clusterServers))
@@ -428,7 +364,6 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
         },
         {
           name: 'Proxies',
-          isDisabled: !g['cluster-debug'],
           onClick: () => {
             setIsClipboardModalOpen(true)
             setClipboardText(JSON.stringify(clusterProxies))
@@ -436,7 +371,7 @@ function ClusterDetail({ selectedCluster, user, readOnly = false }) {
           }
         }
       ]
-    }
+    }] : [])
   ]
 
   const dataObject = [

--- a/share/dashboard_react/src/Pages/Dashboard/components/DBServers/DBServerGrid/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/DBServers/DBServerGrid/index.jsx
@@ -45,7 +45,8 @@ function DBServerGrid({
   showTerminal,
   openCompareModal,
   hasMariadbGtid,
-  hasMysqlGtid
+  hasMysqlGtid,
+  defaultOpenAll = false
 }) {
   const {
     common: { isDesktop },
@@ -56,8 +57,8 @@ function DBServerGrid({
   }, [clusterStates])
 
   const { isOpen: isServiceInfoOpen, onToggle: onServiceInfoToggle } = useDisclosure({ defaultIsOpen: false })
-  const { isOpen: isReplicationVarOpen, onToggle: onReplicationVarToggle } = useDisclosure({ defaultIsOpen: false })
-  const { isOpen: isLeaderStatusOpen, onToggle: onLeaderStatusToggle } = useDisclosure({ defaultIsOpen: false })
+  const { isOpen: isReplicationVarOpen, onToggle: onReplicationVarToggle } = useDisclosure({ defaultIsOpen: defaultOpenAll })
+  const { isOpen: isLeaderStatusOpen, onToggle: onLeaderStatusToggle } = useDisclosure({ defaultIsOpen: defaultOpenAll })
   const { isOpen: isReplicationStatusOpen, onToggle: onReplicationStatusToggle } = useDisclosure({
     defaultIsOpen: true
   })

--- a/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
@@ -188,21 +188,66 @@ function ServerMenu({
         colorScheme={colorScheme}
         placement={from === 'tableView' ? 'right-end' : 'left-end'}
         subMenuPlacement={isDesktop ? (from === 'tableView' ? 'right-end' : 'left-end') : 'bottom'}
-        options={(() => {
-          const terminalItems = showTerminal ? [
-            ...(user?.grants['terminal-db'] ? [
-              { name: 'MySQL Terminal', onClick: () => openTerminalPage(clusterName, row.id, 'mysql') },
-              { name: 'MyTop Terminal', onClick: () => openTerminalPage(clusterName, row.id, 'mytop') }
-            ] : []),
-            ...(user?.grants['terminal-global'] ? [
-              { name: 'Shell Terminal', onClick: () => openTerminalPage(clusterName, row.id) }
-            ] : [])
-          ] : []
-
-          const failoverCandidateItems = user?.grants['cluster-failover'] ? [
-            ...(!row.prefered && !row.ignored ? [
+        options={[
+          ...(showCompareWithOption
+            ? [
+                {
+                  name: 'Compare With',
+                  onClick: () => openCompareModal(row)
+                }
+              ]
+            : []),
+          {
+            name: 'Maintenance Mode',
+            isDisabled: !user?.grants['db-maintenance'],
+            onClick: () => {
+              openConfirmModal()
+              setConfirmTitle(`Confirm maintenance for ${serverName}?`)
+              setConfirmHandler(() => () => dispatch(setMaintenanceMode({ clusterName, serverId: row.id })))
+            }
+          },
+          ...(showTerminal
+            ? [
+                {
+                  name: 'Web Terminal',
+                  subMenu: [
+                    {
+                      name: 'MySQL Terminal',
+                      isDisabled: !user?.grants['terminal-db'],
+                      onClick: () => openTerminalPage(clusterName, row.id, 'mysql')
+                    },
+                    {
+                      name: 'MyTop Terminal',
+                      isDisabled: !user?.grants['terminal-db'],
+                      onClick: () => openTerminalPage(clusterName, row.id, 'mytop')
+                    },
+                    {
+                      name: 'Shell Terminal',
+                      isDisabled: !user?.grants['terminal-global'],
+                      onClick: () => openTerminalPage(clusterName, row.id)
+                    }
+                  ]
+                }
+              ]
+            : []),
+          ...(row.isSlave && user?.grants['cluster-switchover']
+            ? [
+                {
+                  name: 'Promote To Leader',
+                  onClick: () => {
+                    openConfirmModal()
+                    setConfirmTitle(`Confirm promotion for ${serverName}?`)
+                    setConfirmHandler(() => () => dispatch(promoteToLeader({ clusterName, serverId: row.id })))
+                  }
+                }
+              ]
+            : []),
+          {
+            name: 'Failover Candidate',
+            subMenu: [
               {
                 name: 'Set as Preferred',
+                isDisabled: !user?.grants['cluster-failover'] || row.prefered || row.ignored,
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm set as preferred for ${serverName}?`)
@@ -211,29 +256,30 @@ function ServerMenu({
               },
               {
                 name: 'Set as Ignored',
+                isDisabled: !user?.grants['cluster-failover'] || row.prefered || row.ignored,
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm set as ignored for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(setAsIgnored({ clusterName, serverId: row.id })))
                 }
-              }
-            ] : []),
-            ...(row.prefered || row.ignored ? [
+              },
               {
                 name: 'Set as unrated',
+                isDisabled: !user?.grants['cluster-failover'] || (!row.prefered && !row.ignored),
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm set as unrated for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(setAsUnrated({ clusterName, serverId: row.id })))
                 }
               }
-            ] : [])
-          ] : []
-
-          const backupItems = [
-            ...(user?.grants['db-backup'] && clusterMasterId === row.id ? [
+            ]
+          },
+          {
+            name: 'Backup',
+            subMenu: [
               {
                 name: 'Physical Backup',
+                isDisabled: !user?.grants['db-backup'] || clusterMasterId !== row.id,
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm master physical (${backupPhysicalType}) backup?`)
@@ -242,186 +288,197 @@ function ServerMenu({
               },
               {
                 name: 'Logical Backup',
+                isDisabled: !user?.grants['db-backup'] || clusterMasterId !== row.id,
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm sending logical backup (${backupLogicalType}) for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(logicalBackup({ clusterName, serverId: row.id })))
                 }
-              }
-            ] : []),
-            ...(user?.grants['db-restore'] && clusterMasterId !== row.id ? [
+              },
               {
                 name: 'Reseed Logical From Backup',
+                isDisabled: !user?.grants['db-restore'] || clusterMasterId === row.id,
                 onClick: () => {
                   if (backupRestic) {
                     openReseedModal('logical-backup')
                   } else {
                     openConfirmModal()
                     setConfirmTitle(`Confirm reseed with logical backup (${backupLogicalType}) for ${serverName}?`)
-                    setConfirmHandler(() => () => dispatch(reseedLogicalFromBackup({ clusterName, serverId: row.id })))
+                    setConfirmHandler(
+                      () => () => dispatch(reseedLogicalFromBackup({ clusterName, serverId: row.id }))
+                    )
                   }
                 }
               },
               {
                 name: 'Reseed Logical From Master',
+                isDisabled: !user?.grants['db-restore'] || clusterMasterId === row.id,
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm reseed with ${backupLogicalType} for ${serverName}?`)
-                  setConfirmHandler(() => () => dispatch(reseedLogicalFromMaster({ clusterName, serverId: row.id })))
+                  setConfirmHandler(
+                    () => () => dispatch(reseedLogicalFromMaster({ clusterName, serverId: row.id }))
+                  )
                 }
               },
               {
                 name: 'Reseed Physical From Backup',
+                isDisabled: !user?.grants['db-restore'] || clusterMasterId === row.id,
                 onClick: () => {
                   if (backupRestic) {
                     openReseedModal('physical-backup')
                   } else {
                     openConfirmModal()
                     setConfirmTitle(`Confirm reseed with physical backup (${backupPhysicalType}) for ${serverName}?`)
-                    setConfirmHandler(() => () => dispatch(reseedPhysicalFromBackup({ clusterName, serverId: row.id })))
+                    setConfirmHandler(
+                      () => () => dispatch(reseedPhysicalFromBackup({ clusterName, serverId: row.id }))
+                    )
                   }
                 }
-              }
-            ] : []),
-            ...(user?.grants['db-backup'] ? [
+              },
               {
                 name: 'Flush logs',
+                isDisabled: !user?.grants['db-backup'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm flush logs for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(flushLogs({ clusterName, serverId: row.id })))
                 }
-              }
-            ] : []),
-            ...(user?.grants['cluster-process'] ? [
+              },
               {
                 name: 'Run Remote Jobs',
+                isDisabled: !user?.grants['cluster-process'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm running remote jobs for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(runRemoteJobs({ clusterName, serverId: row.id })))
                 }
               }
-            ] : [])
-          ]
-
-          const serverProvisionItems = [
-            ...(user?.grants['db-maintenance'] ? [
+            ]
+          },
+          {
+            name: 'Provision',
+            subMenu: [
               {
                 name: 'Jobs Upgrade',
+                isDisabled: !user?.grants['db-maintenance'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm jobs upgrade for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(jobsUpgrade({ clusterName, serverId: row.id })))
                 }
-              }
-            ] : []),
-            ...(user?.grants['db-stop'] ? [
+              },
               {
                 name: 'Stop Database',
+                isDisabled: !user?.grants['db-stop'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm stop for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(stopDatabase({ clusterName, serverId: row.id })))
                 }
-              }
-            ] : []),
-            ...(orchestrator === 'opensvc' && user?.grants['db-stop'] ? [
-              {
-                name: 'Abort Orchestration',
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle(`Confirm orchestration abort for ${serverName}?`)
-                  setConfirmHandler(() => () => dispatch(abortDatabase({ clusterName, serverId: row.id })))
-                }
-              }
-            ] : []),
-            ...(user?.grants['db-start'] ? [
+              },
+              ...(orchestrator === 'opensvc'
+                ? [
+                    {
+                      name: 'Abort Orchestration',
+                      isDisabled: !user?.grants['db-stop'],
+                      onClick: () => {
+                        openConfirmModal()
+                        setConfirmTitle(`Confirm orchestration abort for ${serverName}?`)
+                        setConfirmHandler(() => () => dispatch(abortDatabase({ clusterName, serverId: row.id })))
+                      }
+                    }
+                  ]
+                : []),
               {
                 name: 'Start Database',
+                isDisabled: !user?.grants['db-start'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm start for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(startDatabase({ clusterName, serverId: row.id })))
                 }
-              }
-            ] : []),
-            ...(orchestrator === 'opensvc' && user?.grants['db-start'] ? [
-              {
-                name: 'Clear Instance State',
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle(`Confirm clear instance state for ${serverName}?`)
-                  setConfirmHandler(() => () => dispatch(clearDatabase({ clusterName, serverId: row.id })))
-                }
               },
-              {
-                name: 'Restart Jobs Container',
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle(`Confirm restart jobs container for ${serverName}?`)
-                  setConfirmHandler(
-                    () => () => dispatch(restartDatabase({ clusterName, serverId: row.id, rid: OpenSVCTerminalRID.Jobs }))
-                  )
-                }
-              }
-            ] : []),
-            ...(user?.grants['prov-db-provision'] ? [
+              ...(orchestrator === 'opensvc'
+                ? [
+                    {
+                      name: 'Clear Instance State',
+                      isDisabled: !user?.grants['db-start'],
+                      onClick: () => {
+                        openConfirmModal()
+                        setConfirmTitle(`Confirm clear instance state for ${serverName}?`)
+                        setConfirmHandler(() => () => dispatch(clearDatabase({ clusterName, serverId: row.id })))
+                      }
+                    },
+                    {
+                      name: 'Restart Jobs Container',
+                      isDisabled: !user?.grants['db-start'],
+                      onClick: () => {
+                        openConfirmModal()
+                        setConfirmTitle(`Confirm restart jobs container for ${serverName}?`)
+                        setConfirmHandler(
+                          () => () =>
+                            dispatch(restartDatabase({ clusterName, serverId: row.id, rid: OpenSVCTerminalRID.Jobs }))
+                        )
+                      }
+                    }
+                  ]
+                : []),
               {
                 name: 'Provision Database',
+                isDisabled: !user?.grants['prov-db-provision'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm provision ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(provisionDatabase({ clusterName, serverId: row.id })))
                 }
-              }
-            ] : []),
-            ...(user?.grants['prov-db-unprovision'] ? [
+              },
               {
                 name: 'Unprovision Database',
+                isDisabled: !user?.grants['prov-db-unprovision'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm unprovision for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(unprovisionDatabase({ clusterName, serverId: row.id })))
                 }
-              }
-            ] : []),
-            ...(user?.grants['db-config-flag'] ? [
+              },
               {
                 name: 'Refresh Variables and Generate Config',
+                isDisabled: !user?.grants['db-config-flag'],
                 onClick: () => {
                   setConfirmTitle(`Confirm generate db config for ${serverName}?`)
-                  setConfirmHandler(() => () => dispatch(generateConfig({ clusterName, host: row.host, port: row.port })))
+                  setConfirmHandler(
+                    () => () => dispatch(generateConfig({ clusterName, host: row.host, port: row.port }))
+                  )
                   openConfirmModal()
                 }
-              }
-            ] : []),
-            ...(user?.grants['cluster-drop-monitor'] ? [
+              },
               {
                 name: 'Remove Monitor',
+                isDisabled: !user?.grants['cluster-drop-monitor'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm removing monitor for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(dropServer({ clusterName, host: row.host, port: row.port })))
                 }
               }
-            ] : [])
-          ]
-
-          const dbUtilsItems = [
-            ...(user?.grants['db-optimize'] ? [
+            ]
+          },
+          {
+            name: 'DB Utils',
+            subMenu: [
               {
                 name: 'Optimize',
+                isDisabled: !user?.grants['db-optimize'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm optimize for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(optimizeServer({ clusterName, serverId: row.id })))
                 }
-              }
-            ] : []),
-            ...(user?.grants['db-replication'] ? [
+              },
               {
                 name: 'Skip 1 Replication Event',
+                isDisabled: !user?.grants['db-replication'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm skip replication event for ${serverName}?`)
@@ -429,7 +486,26 @@ function ServerMenu({
                 }
               },
               {
+                name: 'Toggle InnoDB Monitor',
+                isDisabled: !user?.grants['db-logs'],
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm toggle innodb monitor ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(toggleInnodbMonitor({ clusterName, serverId: row.id })))
+                }
+              },
+              {
+                name: 'Toggle Slow Query Capture',
+                isDisabled: !user?.grants['db-capture'],
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm toggle slow query capture ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(toggleSlowQueryCapture({ clusterName, serverId: row.id })))
+                }
+              },
+              {
                 name: 'Start Slave',
+                isDisabled: !user?.grants['db-replication'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm start slave on ${serverName}?`)
@@ -438,6 +514,7 @@ function ServerMenu({
               },
               {
                 name: 'Stop Slave',
+                isDisabled: !user?.grants['db-replication'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm stop slave on ${serverName}?`)
@@ -446,6 +523,7 @@ function ServerMenu({
               },
               {
                 name: 'Reset Master',
+                isDisabled: !user?.grants['db-replication'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm reset master this may break replication when done on master, ${serverName}?`)
@@ -454,74 +532,25 @@ function ServerMenu({
               },
               {
                 name: 'Reset Slave',
+                isDisabled: !user?.grants['db-replication'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm reset slave this will break replication on, ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(resetSlaveAll({ clusterName, serverId: row.id })))
                 }
-              }
-            ] : []),
-            ...(user?.grants['db-logs'] ? [
-              {
-                name: 'Toggle InnoDB Monitor',
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle(`Confirm toggle innodb monitor ${serverName}?`)
-                  setConfirmHandler(() => () => dispatch(toggleInnodbMonitor({ clusterName, serverId: row.id })))
-                }
-              }
-            ] : []),
-            ...(user?.grants['db-capture'] ? [
-              {
-                name: 'Toggle Slow Query Capture',
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle(`Confirm toggle slow query capture ${serverName}?`)
-                  setConfirmHandler(() => () => dispatch(toggleSlowQueryCapture({ clusterName, serverId: row.id })))
-                }
-              }
-            ] : []),
-            ...(user?.grants['db-readonly'] ? [
+              },
               {
                 name: 'Toggle Readonly',
+                isDisabled: !user?.grants['db-readonly'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm toggle read only on ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(toggleReadOnly({ clusterName, serverId: row.id })))
                 }
               }
-            ] : [])
-          ]
-
-          return [
-            ...(showCompareWithOption ? [{ name: 'Compare With', onClick: () => openCompareModal(row) }] : []),
-            ...(user?.grants['db-maintenance'] ? [
-              {
-                name: 'Maintenance Mode',
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle(`Confirm maintenance for ${serverName}?`)
-                  setConfirmHandler(() => () => dispatch(setMaintenanceMode({ clusterName, serverId: row.id })))
-                }
-              }
-            ] : []),
-            ...(terminalItems.length > 0 ? [{ name: 'Web Terminal', subMenu: terminalItems }] : []),
-            ...(row.isSlave && user?.grants['cluster-switchover'] ? [
-              {
-                name: 'Promote To Leader',
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle(`Confirm promotion for ${serverName}?`)
-                  setConfirmHandler(() => () => dispatch(promoteToLeader({ clusterName, serverId: row.id })))
-                }
-              }
-            ] : []),
-            ...(failoverCandidateItems.length > 0 ? [{ name: 'Failover Candidate', subMenu: failoverCandidateItems }] : []),
-            ...(backupItems.length > 0 ? [{ name: 'Backup', subMenu: backupItems }] : []),
-            ...(serverProvisionItems.length > 0 ? [{ name: 'Provision', subMenu: serverProvisionItems }] : []),
-            ...(dbUtilsItems.length > 0 ? [{ name: 'DB Utils', subMenu: dbUtilsItems }] : [])
-          ]
-        })()}
+            ]
+          }
+        ]}
       />
 
       {/* Basic ConfirmModal for all non-reseed operations */}

--- a/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
@@ -205,35 +205,35 @@ function ServerMenu({
               setConfirmHandler(() => () => dispatch(setMaintenanceMode({ clusterName, serverId: row.id })))
             }
           },
-          ...(user?.grants['terminal-db'] && showTerminal
+          ...(showTerminal
             ? [
                 {
                   name: 'Web Terminal',
                   subMenu: [
                     {
                       name: 'MySQL Terminal',
+                      isDisabled: !user?.grants['terminal-db'],
                       onClick: () => openTerminalPage(clusterName, row.id, 'mysql')
                     },
                     {
                       name: 'MyTop Terminal',
+                      isDisabled: !user?.grants['terminal-db'],
                       onClick: () => openTerminalPage(clusterName, row.id, 'mytop')
                     },
-                    ...(user?.grants['terminal-global']
-                      ? [
-                          {
-                            name: 'Shell Terminal',
-                            onClick: () => openTerminalPage(clusterName, row.id)
-                          }
-                        ]
-                      : [])
+                    {
+                      name: 'Shell Terminal',
+                      isDisabled: !user?.grants['terminal-global'],
+                      onClick: () => openTerminalPage(clusterName, row.id)
+                    }
                   ]
                 }
               ]
             : []),
-          ...(user?.grants['cluster-switchover'] && row.isSlave
+          ...(row.isSlave
             ? [
                 {
                   name: 'Promote To Leader',
+                  isDisabled: !user?.grants['cluster-switchover'],
                   onClick: () => {
                     openConfirmModal()
                     setConfirmTitle(`Confirm promotion for ${serverName}?`)
@@ -245,120 +245,106 @@ function ServerMenu({
           {
             name: 'Failover Candidate',
             subMenu: [
-              ...(user?.grants['cluster-failover'] && !row.prefered && !row.ignored
-                ? [
-                    {
-                      name: 'Set as Preferred',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm set as preferred for ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(setAsPreferred({ clusterName, serverId: row.id })))
-                      }
-                    },
-                    {
-                      name: 'Set as Ignored',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm set as ignored for ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(setAsIgnored({ clusterName, serverId: row.id })))
-                      }
-                    }
-                  ]
-                : []),
-              ...(user?.grants['cluster-failover'] && (row.prefered || row.ignored)
-                ? [
-                    {
-                      name: 'Set as unrated',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm set as unrated for ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(setAsUnrated({ clusterName, serverId: row.id })))
-                      }
-                    }
-                  ]
-                : [])
+              {
+                name: 'Set as Preferred',
+                isDisabled: !user?.grants['cluster-failover'] || row.prefered || row.ignored,
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm set as preferred for ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(setAsPreferred({ clusterName, serverId: row.id })))
+                }
+              },
+              {
+                name: 'Set as Ignored',
+                isDisabled: !user?.grants['cluster-failover'] || row.prefered || row.ignored,
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm set as ignored for ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(setAsIgnored({ clusterName, serverId: row.id })))
+                }
+              },
+              {
+                name: 'Set as unrated',
+                isDisabled: !user?.grants['cluster-failover'] || (!row.prefered && !row.ignored),
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm set as unrated for ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(setAsUnrated({ clusterName, serverId: row.id })))
+                }
+              }
             ]
           },
           {
             name: 'Backup',
             subMenu: [
-              ...(clusterMasterId === row.id && user?.grants['db-backup']
-                ? [
-                    {
-                      name: 'Physical Backup',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm master physical (${backupPhysicalType}) backup?`)
-                        setConfirmHandler(() => () => dispatch(physicalBackupMaster({ clusterName, serverId: row.id })))
-                      }
-                    },
-                    {
-                      name: 'Logical Backup',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm sending logical backup (${backupLogicalType}) for ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(logicalBackup({ clusterName, serverId: row.id })))
-                      }
-                    }
-                  ]
-                : user?.grants['db-restore']
-                  ? [
-                      {
-                        name: 'Reseed Logical From Backup',
-                        onClick: () => {
-                          if (backupRestic) {
-                            openReseedModal('logical-backup')
-                          } else {
-                            openConfirmModal()
-                            setConfirmTitle(
-                              `Confirm reseed with logical backup (${backupLogicalType}) for ${serverName}?`
-                            )
-                            setConfirmHandler(
-                              () => () => dispatch(reseedLogicalFromBackup({ clusterName, serverId: row.id }))
-                            )
-                          }
-                        }
-                      },
-                      {
-                        name: 'Reseed Logical From Master',
-                        onClick: () => {
-                          openConfirmModal()
-                          setConfirmTitle(`Confirm reseed with ${backupLogicalType} for ${serverName}?`)
-                          setConfirmHandler(
-                            () => () => dispatch(reseedLogicalFromMaster({ clusterName, serverId: row.id }))
-                          )
-                        }
-                      },
-                      {
-                        name: 'Reseed Physical From Backup',
-                        onClick: () => {
-                          if (backupRestic) {
-                            openReseedModal('physical-backup')
-                          } else {
-                            openConfirmModal()
-                            setConfirmTitle(
-                              `Confirm reseed with physical backup (${backupPhysicalType}) for ${serverName}?`
-                            )
-                            setConfirmHandler(
-                              () => () => dispatch(reseedPhysicalFromBackup({ clusterName, serverId: row.id }))
-                            )
-                          }
-                        }
-                      }
-                    ]
-                  : []),
-              ...(user?.grants['db-backup']
-                ? [
-                    {
-                      name: 'Flush logs',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm flush logs for ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(flushLogs({ clusterName, serverId: row.id })))
-                      }
-                    }
-                  ]
-                : []),
+              {
+                name: 'Physical Backup',
+                isDisabled: !user?.grants['db-backup'] || clusterMasterId !== row.id,
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm master physical (${backupPhysicalType}) backup?`)
+                  setConfirmHandler(() => () => dispatch(physicalBackupMaster({ clusterName, serverId: row.id })))
+                }
+              },
+              {
+                name: 'Logical Backup',
+                isDisabled: !user?.grants['db-backup'] || clusterMasterId !== row.id,
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm sending logical backup (${backupLogicalType}) for ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(logicalBackup({ clusterName, serverId: row.id })))
+                }
+              },
+              {
+                name: 'Reseed Logical From Backup',
+                isDisabled: !user?.grants['db-restore'] || clusterMasterId === row.id,
+                onClick: () => {
+                  if (backupRestic) {
+                    openReseedModal('logical-backup')
+                  } else {
+                    openConfirmModal()
+                    setConfirmTitle(`Confirm reseed with logical backup (${backupLogicalType}) for ${serverName}?`)
+                    setConfirmHandler(
+                      () => () => dispatch(reseedLogicalFromBackup({ clusterName, serverId: row.id }))
+                    )
+                  }
+                }
+              },
+              {
+                name: 'Reseed Logical From Master',
+                isDisabled: !user?.grants['db-restore'] || clusterMasterId === row.id,
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm reseed with ${backupLogicalType} for ${serverName}?`)
+                  setConfirmHandler(
+                    () => () => dispatch(reseedLogicalFromMaster({ clusterName, serverId: row.id }))
+                  )
+                }
+              },
+              {
+                name: 'Reseed Physical From Backup',
+                isDisabled: !user?.grants['db-restore'] || clusterMasterId === row.id,
+                onClick: () => {
+                  if (backupRestic) {
+                    openReseedModal('physical-backup')
+                  } else {
+                    openConfirmModal()
+                    setConfirmTitle(`Confirm reseed with physical backup (${backupPhysicalType}) for ${serverName}?`)
+                    setConfirmHandler(
+                      () => () => dispatch(reseedPhysicalFromBackup({ clusterName, serverId: row.id }))
+                    )
+                  }
+                }
+              },
+              {
+                name: 'Flush logs',
+                isDisabled: !user?.grants['db-backup'],
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm flush logs for ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(flushLogs({ clusterName, serverId: row.id })))
+                }
+              },
               {
                 name: 'Run Remote Jobs',
                 onClick: () => {
@@ -372,119 +358,100 @@ function ServerMenu({
           {
             name: 'Provision',
             subMenu: [
-              ...(user?.grants['db-maintenance']
+              {
+                name: 'Jobs Upgrade',
+                isDisabled: !user?.grants['db-maintenance'],
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm jobs upgrade for ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(jobsUpgrade({ clusterName, serverId: row.id })))
+                }
+              },
+              {
+                name: 'Stop Database',
+                isDisabled: !user?.grants['db-stop'],
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm stop for ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(stopDatabase({ clusterName, serverId: row.id })))
+                }
+              },
+              ...(orchestrator === 'opensvc'
                 ? [
                     {
-                      name: 'Jobs Upgrade',
+                      name: 'Abort Orchestration',
+                      isDisabled: !user?.grants['db-stop'],
                       onClick: () => {
                         openConfirmModal()
-                        setConfirmTitle(`Confirm jobs upgrade for ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(jobsUpgrade({ clusterName, serverId: row.id })))
+                        setConfirmTitle(`Confirm orchestration abort for ${serverName}?`)
+                        setConfirmHandler(() => () => dispatch(abortDatabase({ clusterName, serverId: row.id })))
                       }
                     }
                   ]
                 : []),
-              ...(user?.grants['db-stop']
+              {
+                name: 'Start Database',
+                isDisabled: !user?.grants['db-start'],
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm start for ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(startDatabase({ clusterName, serverId: row.id })))
+                }
+              },
+              ...(orchestrator === 'opensvc'
                 ? [
                     {
-                      name: 'Stop Database',
+                      name: 'Clear Instance State',
+                      isDisabled: !user?.grants['db-start'],
                       onClick: () => {
                         openConfirmModal()
-                        setConfirmTitle(`Confirm stop for ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(stopDatabase({ clusterName, serverId: row.id })))
+                        setConfirmTitle(`Confirm clear instance state for ${serverName}?`)
+                        setConfirmHandler(() => () => dispatch(clearDatabase({ clusterName, serverId: row.id })))
                       }
                     },
-                    ...(orchestrator === 'opensvc'
-                      ? [
-                          {
-                            name: 'Abort Orchestration',
-                            onClick: () => {
-                              openConfirmModal()
-                              setConfirmTitle(`Confirm orchestration abort for ${serverName}?`)
-                              setConfirmHandler(() => () => dispatch(abortDatabase({ clusterName, serverId: row.id })))
-                            }
-                          }
-                        ]
-                      : [])
-                  ]
-                : []),
-              ...(user?.grants['db-start']
-                ? [
                     {
-                      name: 'Start Database',
+                      name: 'Restart Jobs Container',
+                      isDisabled: !user?.grants['db-start'],
                       onClick: () => {
                         openConfirmModal()
-                        setConfirmTitle(`Confirm start for ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(startDatabase({ clusterName, serverId: row.id })))
-                      }
-                    },
-                    ...(orchestrator === 'opensvc'
-                      ? [
-                          {
-                            name: 'Clear Instance State',
-                            onClick: () => {
-                              openConfirmModal()
-                              setConfirmTitle(`Confirm clear instance state for ${serverName}?`)
-                              setConfirmHandler(() => () => dispatch(clearDatabase({ clusterName, serverId: row.id })))
-                            }
-                          }
-                        ]
-                      : []),
-                    ...(orchestrator === 'opensvc'
-                      ? [
-                          {
-                            name: 'Restart Jobs Container',
-                            onClick: () => {
-                              openConfirmModal()
-                              setConfirmTitle(`Confirm restart jobs container for ${serverName}?`)
-                              setConfirmHandler(
-                                () => () =>
-                                  dispatch(restartDatabase({ clusterName, serverId: row.id, rid: OpenSVCTerminalRID.Jobs }))
-                              )
-                            }
-                          }
-                        ]
-                      : [])
-                  ]
-                : []),
-              ...(user?.grants['prov-db-provision']
-                ? [
-                    {
-                      name: 'Provision Database',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm provision ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(provisionDatabase({ clusterName, serverId: row.id })))
-                      }
-                    }
-                  ]
-                : []),
-              ...(user?.grants['prov-db-unprovision']
-                ? [
-                    {
-                      name: 'Unprovision Database',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm unprovision for ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(unprovisionDatabase({ clusterName, serverId: row.id })))
-                      }
-                    }
-                  ]
-                : []),
-              ...(user?.grants['db-config-flag']
-                ? [
-                    {
-                      name: 'Refresh Variables and Generate Config',
-                      onClick: () => {
-                        setConfirmTitle(`Confirm generate db config for ${serverName}?`)
+                        setConfirmTitle(`Confirm restart jobs container for ${serverName}?`)
                         setConfirmHandler(
-                          () => () => dispatch(generateConfig({ clusterName, host: row.host, port: row.port }))
+                          () => () =>
+                            dispatch(restartDatabase({ clusterName, serverId: row.id, rid: OpenSVCTerminalRID.Jobs }))
                         )
-                        openConfirmModal()
                       }
                     }
                   ]
                 : []),
+              {
+                name: 'Provision Database',
+                isDisabled: !user?.grants['prov-db-provision'],
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm provision ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(provisionDatabase({ clusterName, serverId: row.id })))
+                }
+              },
+              {
+                name: 'Unprovision Database',
+                isDisabled: !user?.grants['prov-db-unprovision'],
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm unprovision for ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(unprovisionDatabase({ clusterName, serverId: row.id })))
+                }
+              },
+              {
+                name: 'Refresh Variables and Generate Config',
+                isDisabled: !user?.grants['db-config-flag'],
+                onClick: () => {
+                  setConfirmTitle(`Confirm generate db config for ${serverName}?`)
+                  setConfirmHandler(
+                    () => () => dispatch(generateConfig({ clusterName, host: row.host, port: row.port }))
+                  )
+                  openConfirmModal()
+                }
+              },
               {
                 name: 'Remove Monitor',
                 onClick: () => {
@@ -498,107 +465,87 @@ function ServerMenu({
           {
             name: 'DB Utils',
             subMenu: [
-              ...(user?.grants['db-optimize']
-                ? [
-                    {
-                      name: 'Optimize',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm optimize for ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(optimizeServer({ clusterName, serverId: row.id })))
-                      }
-                    }
-                  ]
-                : []),
-              ...(user?.grants['db-replication']
-                ? [
-                    {
-                      name: 'Skip 1 Replication Event',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm skip replication event for ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(skipReplicationEvent({ clusterName, serverId: row.id })))
-                      }
-                    }
-                  ]
-                : []),
-              ...(user?.grants['db-logs']
-                ? [
-                    {
-                      name: 'Toggle InnoDB Monitor',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm toggle innodb monitor ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(toggleInnodbMonitor({ clusterName, serverId: row.id })))
-                      }
-                    }
-                  ]
-                : []),
-
-              ...(user?.grants['db-capture']
-                ? [
-                    {
-                      name: 'Toggle Slow Query Capture',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm toggle slow query capture ${serverName}?`)
-                        setConfirmHandler(
-                          () => () => dispatch(toggleSlowQueryCapture({ clusterName, serverId: row.id }))
-                        )
-                      }
-                    }
-                  ]
-                : []),
-              ...(user?.grants['db-replication']
-                ? [
-                    {
-                      name: 'Start Slave',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm start slave on ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(startSlave({ clusterName, serverId: row.id })))
-                      }
-                    },
-                    {
-                      name: 'Stop Slave',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm stop slave on ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(stopSlave({ clusterName, serverId: row.id })))
-                      }
-                    },
-                    {
-                      name: 'Reset Master',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(
-                          `Confirm reset master this may break replication when done on master, ${serverName}?`
-                        )
-                        setConfirmHandler(() => () => dispatch(resetMaster({ clusterName, serverId: row.id })))
-                      }
-                    },
-                    {
-                      name: 'Reset Slave',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm reset slave this will break replication on, ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(resetSlaveAll({ clusterName, serverId: row.id })))
-                      }
-                    }
-                  ]
-                : []),
-              ...(user?.grants['db-readonly']
-                ? [
-                    {
-                      name: 'Toggle Readonly',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm toggle read only on ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(toggleReadOnly({ clusterName, serverId: row.id })))
-                      }
-                    }
-                  ]
-                : [])
+              {
+                name: 'Optimize',
+                isDisabled: !user?.grants['db-optimize'],
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm optimize for ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(optimizeServer({ clusterName, serverId: row.id })))
+                }
+              },
+              {
+                name: 'Skip 1 Replication Event',
+                isDisabled: !user?.grants['db-replication'],
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm skip replication event for ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(skipReplicationEvent({ clusterName, serverId: row.id })))
+                }
+              },
+              {
+                name: 'Toggle InnoDB Monitor',
+                isDisabled: !user?.grants['db-logs'],
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm toggle innodb monitor ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(toggleInnodbMonitor({ clusterName, serverId: row.id })))
+                }
+              },
+              {
+                name: 'Toggle Slow Query Capture',
+                isDisabled: !user?.grants['db-capture'],
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm toggle slow query capture ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(toggleSlowQueryCapture({ clusterName, serverId: row.id })))
+                }
+              },
+              {
+                name: 'Start Slave',
+                isDisabled: !user?.grants['db-replication'],
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm start slave on ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(startSlave({ clusterName, serverId: row.id })))
+                }
+              },
+              {
+                name: 'Stop Slave',
+                isDisabled: !user?.grants['db-replication'],
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm stop slave on ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(stopSlave({ clusterName, serverId: row.id })))
+                }
+              },
+              {
+                name: 'Reset Master',
+                isDisabled: !user?.grants['db-replication'],
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm reset master this may break replication when done on master, ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(resetMaster({ clusterName, serverId: row.id })))
+                }
+              },
+              {
+                name: 'Reset Slave',
+                isDisabled: !user?.grants['db-replication'],
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm reset slave this will break replication on, ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(resetSlaveAll({ clusterName, serverId: row.id })))
+                }
+              },
+              {
+                name: 'Toggle Readonly',
+                isDisabled: !user?.grants['db-readonly'],
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm toggle read only on ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(toggleReadOnly({ clusterName, serverId: row.id })))
+                }
+              }
             ]
           }
         ]}

--- a/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
@@ -199,6 +199,7 @@ function ServerMenu({
             : []),
           {
             name: 'Maintenance Mode',
+            isDisabled: !user?.grants['db-maintenance'],
             onClick: () => {
               openConfirmModal()
               setConfirmTitle(`Confirm maintenance for ${serverName}?`)
@@ -346,6 +347,7 @@ function ServerMenu({
               },
               {
                 name: 'Run Remote Jobs',
+                isDisabled: !user?.grants['cluster-process'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm running remote jobs for ${serverName}?`)
@@ -453,6 +455,7 @@ function ServerMenu({
               },
               {
                 name: 'Remove Monitor',
+                isDisabled: !user?.grants['cluster-drop-monitor'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm removing monitor for ${serverName}?`)

--- a/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
@@ -229,11 +229,10 @@ function ServerMenu({
                 }
               ]
             : []),
-          ...(row.isSlave
+          ...(row.isSlave && user?.grants['cluster-switchover']
             ? [
                 {
                   name: 'Promote To Leader',
-                  isDisabled: !user?.grants['cluster-switchover'],
                   onClick: () => {
                     openConfirmModal()
                     setConfirmTitle(`Confirm promotion for ${serverName}?`)

--- a/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
@@ -188,66 +188,21 @@ function ServerMenu({
         colorScheme={colorScheme}
         placement={from === 'tableView' ? 'right-end' : 'left-end'}
         subMenuPlacement={isDesktop ? (from === 'tableView' ? 'right-end' : 'left-end') : 'bottom'}
-        options={[
-          ...(showCompareWithOption
-            ? [
-                {
-                  name: 'Compare With',
-                  onClick: () => openCompareModal(row)
-                }
-              ]
-            : []),
-          {
-            name: 'Maintenance Mode',
-            isDisabled: !user?.grants['db-maintenance'],
-            onClick: () => {
-              openConfirmModal()
-              setConfirmTitle(`Confirm maintenance for ${serverName}?`)
-              setConfirmHandler(() => () => dispatch(setMaintenanceMode({ clusterName, serverId: row.id })))
-            }
-          },
-          ...(showTerminal
-            ? [
-                {
-                  name: 'Web Terminal',
-                  subMenu: [
-                    {
-                      name: 'MySQL Terminal',
-                      isDisabled: !user?.grants['terminal-db'],
-                      onClick: () => openTerminalPage(clusterName, row.id, 'mysql')
-                    },
-                    {
-                      name: 'MyTop Terminal',
-                      isDisabled: !user?.grants['terminal-db'],
-                      onClick: () => openTerminalPage(clusterName, row.id, 'mytop')
-                    },
-                    {
-                      name: 'Shell Terminal',
-                      isDisabled: !user?.grants['terminal-global'],
-                      onClick: () => openTerminalPage(clusterName, row.id)
-                    }
-                  ]
-                }
-              ]
-            : []),
-          ...(row.isSlave && user?.grants['cluster-switchover']
-            ? [
-                {
-                  name: 'Promote To Leader',
-                  onClick: () => {
-                    openConfirmModal()
-                    setConfirmTitle(`Confirm promotion for ${serverName}?`)
-                    setConfirmHandler(() => () => dispatch(promoteToLeader({ clusterName, serverId: row.id })))
-                  }
-                }
-              ]
-            : []),
-          {
-            name: 'Failover Candidate',
-            subMenu: [
+        options={(() => {
+          const terminalItems = showTerminal ? [
+            ...(user?.grants['terminal-db'] ? [
+              { name: 'MySQL Terminal', onClick: () => openTerminalPage(clusterName, row.id, 'mysql') },
+              { name: 'MyTop Terminal', onClick: () => openTerminalPage(clusterName, row.id, 'mytop') }
+            ] : []),
+            ...(user?.grants['terminal-global'] ? [
+              { name: 'Shell Terminal', onClick: () => openTerminalPage(clusterName, row.id) }
+            ] : [])
+          ] : []
+
+          const failoverCandidateItems = user?.grants['cluster-failover'] ? [
+            ...(!row.prefered && !row.ignored ? [
               {
                 name: 'Set as Preferred',
-                isDisabled: !user?.grants['cluster-failover'] || row.prefered || row.ignored,
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm set as preferred for ${serverName}?`)
@@ -256,30 +211,29 @@ function ServerMenu({
               },
               {
                 name: 'Set as Ignored',
-                isDisabled: !user?.grants['cluster-failover'] || row.prefered || row.ignored,
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm set as ignored for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(setAsIgnored({ clusterName, serverId: row.id })))
                 }
-              },
+              }
+            ] : []),
+            ...(row.prefered || row.ignored ? [
               {
                 name: 'Set as unrated',
-                isDisabled: !user?.grants['cluster-failover'] || (!row.prefered && !row.ignored),
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm set as unrated for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(setAsUnrated({ clusterName, serverId: row.id })))
                 }
               }
-            ]
-          },
-          {
-            name: 'Backup',
-            subMenu: [
+            ] : [])
+          ] : []
+
+          const backupItems = [
+            ...(user?.grants['db-backup'] && clusterMasterId === row.id ? [
               {
                 name: 'Physical Backup',
-                isDisabled: !user?.grants['db-backup'] || clusterMasterId !== row.id,
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm master physical (${backupPhysicalType}) backup?`)
@@ -288,197 +242,186 @@ function ServerMenu({
               },
               {
                 name: 'Logical Backup',
-                isDisabled: !user?.grants['db-backup'] || clusterMasterId !== row.id,
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm sending logical backup (${backupLogicalType}) for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(logicalBackup({ clusterName, serverId: row.id })))
                 }
-              },
+              }
+            ] : []),
+            ...(user?.grants['db-restore'] && clusterMasterId !== row.id ? [
               {
                 name: 'Reseed Logical From Backup',
-                isDisabled: !user?.grants['db-restore'] || clusterMasterId === row.id,
                 onClick: () => {
                   if (backupRestic) {
                     openReseedModal('logical-backup')
                   } else {
                     openConfirmModal()
                     setConfirmTitle(`Confirm reseed with logical backup (${backupLogicalType}) for ${serverName}?`)
-                    setConfirmHandler(
-                      () => () => dispatch(reseedLogicalFromBackup({ clusterName, serverId: row.id }))
-                    )
+                    setConfirmHandler(() => () => dispatch(reseedLogicalFromBackup({ clusterName, serverId: row.id })))
                   }
                 }
               },
               {
                 name: 'Reseed Logical From Master',
-                isDisabled: !user?.grants['db-restore'] || clusterMasterId === row.id,
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm reseed with ${backupLogicalType} for ${serverName}?`)
-                  setConfirmHandler(
-                    () => () => dispatch(reseedLogicalFromMaster({ clusterName, serverId: row.id }))
-                  )
+                  setConfirmHandler(() => () => dispatch(reseedLogicalFromMaster({ clusterName, serverId: row.id })))
                 }
               },
               {
                 name: 'Reseed Physical From Backup',
-                isDisabled: !user?.grants['db-restore'] || clusterMasterId === row.id,
                 onClick: () => {
                   if (backupRestic) {
                     openReseedModal('physical-backup')
                   } else {
                     openConfirmModal()
                     setConfirmTitle(`Confirm reseed with physical backup (${backupPhysicalType}) for ${serverName}?`)
-                    setConfirmHandler(
-                      () => () => dispatch(reseedPhysicalFromBackup({ clusterName, serverId: row.id }))
-                    )
+                    setConfirmHandler(() => () => dispatch(reseedPhysicalFromBackup({ clusterName, serverId: row.id })))
                   }
                 }
-              },
+              }
+            ] : []),
+            ...(user?.grants['db-backup'] ? [
               {
                 name: 'Flush logs',
-                isDisabled: !user?.grants['db-backup'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm flush logs for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(flushLogs({ clusterName, serverId: row.id })))
                 }
-              },
+              }
+            ] : []),
+            ...(user?.grants['cluster-process'] ? [
               {
                 name: 'Run Remote Jobs',
-                isDisabled: !user?.grants['cluster-process'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm running remote jobs for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(runRemoteJobs({ clusterName, serverId: row.id })))
                 }
               }
-            ]
-          },
-          {
-            name: 'Provision',
-            subMenu: [
+            ] : [])
+          ]
+
+          const serverProvisionItems = [
+            ...(user?.grants['db-maintenance'] ? [
               {
                 name: 'Jobs Upgrade',
-                isDisabled: !user?.grants['db-maintenance'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm jobs upgrade for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(jobsUpgrade({ clusterName, serverId: row.id })))
                 }
-              },
+              }
+            ] : []),
+            ...(user?.grants['db-stop'] ? [
               {
                 name: 'Stop Database',
-                isDisabled: !user?.grants['db-stop'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm stop for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(stopDatabase({ clusterName, serverId: row.id })))
                 }
-              },
-              ...(orchestrator === 'opensvc'
-                ? [
-                    {
-                      name: 'Abort Orchestration',
-                      isDisabled: !user?.grants['db-stop'],
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm orchestration abort for ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(abortDatabase({ clusterName, serverId: row.id })))
-                      }
-                    }
-                  ]
-                : []),
+              }
+            ] : []),
+            ...(orchestrator === 'opensvc' && user?.grants['db-stop'] ? [
+              {
+                name: 'Abort Orchestration',
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm orchestration abort for ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(abortDatabase({ clusterName, serverId: row.id })))
+                }
+              }
+            ] : []),
+            ...(user?.grants['db-start'] ? [
               {
                 name: 'Start Database',
-                isDisabled: !user?.grants['db-start'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm start for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(startDatabase({ clusterName, serverId: row.id })))
                 }
+              }
+            ] : []),
+            ...(orchestrator === 'opensvc' && user?.grants['db-start'] ? [
+              {
+                name: 'Clear Instance State',
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm clear instance state for ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(clearDatabase({ clusterName, serverId: row.id })))
+                }
               },
-              ...(orchestrator === 'opensvc'
-                ? [
-                    {
-                      name: 'Clear Instance State',
-                      isDisabled: !user?.grants['db-start'],
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm clear instance state for ${serverName}?`)
-                        setConfirmHandler(() => () => dispatch(clearDatabase({ clusterName, serverId: row.id })))
-                      }
-                    },
-                    {
-                      name: 'Restart Jobs Container',
-                      isDisabled: !user?.grants['db-start'],
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm restart jobs container for ${serverName}?`)
-                        setConfirmHandler(
-                          () => () =>
-                            dispatch(restartDatabase({ clusterName, serverId: row.id, rid: OpenSVCTerminalRID.Jobs }))
-                        )
-                      }
-                    }
-                  ]
-                : []),
+              {
+                name: 'Restart Jobs Container',
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm restart jobs container for ${serverName}?`)
+                  setConfirmHandler(
+                    () => () => dispatch(restartDatabase({ clusterName, serverId: row.id, rid: OpenSVCTerminalRID.Jobs }))
+                  )
+                }
+              }
+            ] : []),
+            ...(user?.grants['prov-db-provision'] ? [
               {
                 name: 'Provision Database',
-                isDisabled: !user?.grants['prov-db-provision'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm provision ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(provisionDatabase({ clusterName, serverId: row.id })))
                 }
-              },
+              }
+            ] : []),
+            ...(user?.grants['prov-db-unprovision'] ? [
               {
                 name: 'Unprovision Database',
-                isDisabled: !user?.grants['prov-db-unprovision'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm unprovision for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(unprovisionDatabase({ clusterName, serverId: row.id })))
                 }
-              },
+              }
+            ] : []),
+            ...(user?.grants['db-config-flag'] ? [
               {
                 name: 'Refresh Variables and Generate Config',
-                isDisabled: !user?.grants['db-config-flag'],
                 onClick: () => {
                   setConfirmTitle(`Confirm generate db config for ${serverName}?`)
-                  setConfirmHandler(
-                    () => () => dispatch(generateConfig({ clusterName, host: row.host, port: row.port }))
-                  )
+                  setConfirmHandler(() => () => dispatch(generateConfig({ clusterName, host: row.host, port: row.port })))
                   openConfirmModal()
                 }
-              },
+              }
+            ] : []),
+            ...(user?.grants['cluster-drop-monitor'] ? [
               {
                 name: 'Remove Monitor',
-                isDisabled: !user?.grants['cluster-drop-monitor'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm removing monitor for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(dropServer({ clusterName, host: row.host, port: row.port })))
                 }
               }
-            ]
-          },
-          {
-            name: 'DB Utils',
-            subMenu: [
+            ] : [])
+          ]
+
+          const dbUtilsItems = [
+            ...(user?.grants['db-optimize'] ? [
               {
                 name: 'Optimize',
-                isDisabled: !user?.grants['db-optimize'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm optimize for ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(optimizeServer({ clusterName, serverId: row.id })))
                 }
-              },
+              }
+            ] : []),
+            ...(user?.grants['db-replication'] ? [
               {
                 name: 'Skip 1 Replication Event',
-                isDisabled: !user?.grants['db-replication'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm skip replication event for ${serverName}?`)
@@ -486,26 +429,7 @@ function ServerMenu({
                 }
               },
               {
-                name: 'Toggle InnoDB Monitor',
-                isDisabled: !user?.grants['db-logs'],
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle(`Confirm toggle innodb monitor ${serverName}?`)
-                  setConfirmHandler(() => () => dispatch(toggleInnodbMonitor({ clusterName, serverId: row.id })))
-                }
-              },
-              {
-                name: 'Toggle Slow Query Capture',
-                isDisabled: !user?.grants['db-capture'],
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle(`Confirm toggle slow query capture ${serverName}?`)
-                  setConfirmHandler(() => () => dispatch(toggleSlowQueryCapture({ clusterName, serverId: row.id })))
-                }
-              },
-              {
                 name: 'Start Slave',
-                isDisabled: !user?.grants['db-replication'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm start slave on ${serverName}?`)
@@ -514,7 +438,6 @@ function ServerMenu({
               },
               {
                 name: 'Stop Slave',
-                isDisabled: !user?.grants['db-replication'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm stop slave on ${serverName}?`)
@@ -523,7 +446,6 @@ function ServerMenu({
               },
               {
                 name: 'Reset Master',
-                isDisabled: !user?.grants['db-replication'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm reset master this may break replication when done on master, ${serverName}?`)
@@ -532,25 +454,74 @@ function ServerMenu({
               },
               {
                 name: 'Reset Slave',
-                isDisabled: !user?.grants['db-replication'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm reset slave this will break replication on, ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(resetSlaveAll({ clusterName, serverId: row.id })))
                 }
-              },
+              }
+            ] : []),
+            ...(user?.grants['db-logs'] ? [
+              {
+                name: 'Toggle InnoDB Monitor',
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm toggle innodb monitor ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(toggleInnodbMonitor({ clusterName, serverId: row.id })))
+                }
+              }
+            ] : []),
+            ...(user?.grants['db-capture'] ? [
+              {
+                name: 'Toggle Slow Query Capture',
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm toggle slow query capture ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(toggleSlowQueryCapture({ clusterName, serverId: row.id })))
+                }
+              }
+            ] : []),
+            ...(user?.grants['db-readonly'] ? [
               {
                 name: 'Toggle Readonly',
-                isDisabled: !user?.grants['db-readonly'],
                 onClick: () => {
                   openConfirmModal()
                   setConfirmTitle(`Confirm toggle read only on ${serverName}?`)
                   setConfirmHandler(() => () => dispatch(toggleReadOnly({ clusterName, serverId: row.id })))
                 }
               }
-            ]
-          }
-        ]}
+            ] : [])
+          ]
+
+          return [
+            ...(showCompareWithOption ? [{ name: 'Compare With', onClick: () => openCompareModal(row) }] : []),
+            ...(user?.grants['db-maintenance'] ? [
+              {
+                name: 'Maintenance Mode',
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm maintenance for ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(setMaintenanceMode({ clusterName, serverId: row.id })))
+                }
+              }
+            ] : []),
+            ...(terminalItems.length > 0 ? [{ name: 'Web Terminal', subMenu: terminalItems }] : []),
+            ...(row.isSlave && user?.grants['cluster-switchover'] ? [
+              {
+                name: 'Promote To Leader',
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm promotion for ${serverName}?`)
+                  setConfirmHandler(() => () => dispatch(promoteToLeader({ clusterName, serverId: row.id })))
+                }
+              }
+            ] : []),
+            ...(failoverCandidateItems.length > 0 ? [{ name: 'Failover Candidate', subMenu: failoverCandidateItems }] : []),
+            ...(backupItems.length > 0 ? [{ name: 'Backup', subMenu: backupItems }] : []),
+            ...(serverProvisionItems.length > 0 ? [{ name: 'Provision', subMenu: serverProvisionItems }] : []),
+            ...(dbUtilsItems.length > 0 ? [{ name: 'DB Utils', subMenu: dbUtilsItems }] : [])
+          ]
+        })()}
       />
 
       {/* Basic ConfirmModal for all non-reseed operations */}

--- a/share/dashboard_react/src/Pages/Dashboard/components/HADetail/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/HADetail/index.jsx
@@ -8,7 +8,7 @@ import { failOverCluster, switchOverCluster } from '../../../../redux/clusterSli
 import ConfirmModal from '../../../../components/Modals/ConfirmModal'
 import styles from './styles.module.scss'
 
-function HADetail({ selectedCluster, user }) {
+function HADetail({ selectedCluster, user, readOnly = false }) {
   const clusterMaster = useSelector((state) => state.cluster.clusterMaster)
   const { switchOverLoading, failOverLoading } = useSelector((state) => state.cluster.loadingStates)
   const isDesktop = useSelector((state) => state.common.isDesktop)
@@ -80,7 +80,7 @@ function HADetail({ selectedCluster, user }) {
           </Grid>
         }
         onClick={openConfirmModal}
-        {...(clusterMaster?.state && (user?.grants?.['cluster-switchover'] || user?.grants?.['cluster-failover'])
+        {...(clusterMaster?.state && !readOnly && !user?.roles?.['visitor'] && (user?.grants?.['cluster-switchover'] || user?.grants?.['cluster-failover'])
           ? {
               headerAction: 'button',
               isLoading: switchOverLoading || failOverLoading,

--- a/share/dashboard_react/src/Pages/Dashboard/components/HADetail/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/HADetail/index.jsx
@@ -8,7 +8,7 @@ import { failOverCluster, switchOverCluster } from '../../../../redux/clusterSli
 import ConfirmModal from '../../../../components/Modals/ConfirmModal'
 import styles from './styles.module.scss'
 
-function HADetail({ selectedCluster }) {
+function HADetail({ selectedCluster, user }) {
   const clusterMaster = useSelector((state) => state.cluster.clusterMaster)
   const { switchOverLoading, failOverLoading } = useSelector((state) => state.cluster.loadingStates)
   const isDesktop = useSelector((state) => state.common.isDesktop)
@@ -80,7 +80,7 @@ function HADetail({ selectedCluster }) {
           </Grid>
         }
         onClick={openConfirmModal}
-        {...(clusterMaster?.state
+        {...(clusterMaster?.state && (user?.grants?.['cluster-switchover'] || user?.grants?.['cluster-failover'])
           ? {
               headerAction: 'button',
               isLoading: switchOverLoading || failOverLoading,

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyMenu.jsx
@@ -60,41 +60,45 @@ function ProxyMenu({
         placement={from === 'tableView' ? 'right-end' : 'left-end'}
         subMenuPlacement={isDesktop ? (from === 'tableView' ? 'right-end' : 'left-end') : 'bottom'}
         options={[
-          ...(user?.grants['cluster-staging'] && topoStaging ? row.isStaging ? [
-            {
-              name: 'Set As Normal Proxy',
-              onClick: () => {
-                openConfirmModal()
-                setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
-                setConfirmHandler(() => () => dispatch(stagingProxy({ clusterName, proxyId: row.proxyId, staging: false })))
-              }
-            }
-          ] : [
-            {
-              name: 'Set As Staging Proxy',
-              onClick: () => {
-                openConfirmModal()
-                setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
-                setConfirmHandler(() => () => dispatch(stagingProxy({ clusterName, proxyId: row.proxyId, staging: true })))
-              }
-            }
-          ] : []),
-          ...(user?.grants['prov-proxy-provision'] && isMenuOptionsVisible
+          ...(topoStaging
+            ? row.isStaging
+              ? [
+                  {
+                    name: 'Set As Normal Proxy',
+                    isDisabled: !user?.grants['cluster-staging'],
+                    onClick: () => {
+                      openConfirmModal()
+                      setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
+                      setConfirmHandler(() => () => dispatch(stagingProxy({ clusterName, proxyId: row.proxyId, staging: false })))
+                    }
+                  }
+                ]
+              : [
+                  {
+                    name: 'Set As Staging Proxy',
+                    isDisabled: !user?.grants['cluster-staging'],
+                    onClick: () => {
+                      openConfirmModal()
+                      setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
+                      setConfirmHandler(() => () => dispatch(stagingProxy({ clusterName, proxyId: row.proxyId, staging: true })))
+                    }
+                  }
+                ]
+            : []),
+          ...(isMenuOptionsVisible
             ? [
                 {
                   name: 'Provision Proxy',
+                  isDisabled: !user?.grants['prov-proxy-provision'],
                   onClick: () => {
                     openConfirmModal()
                     setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
                     setConfirmHandler(() => () => dispatch(provisionProxy({ clusterName, proxyId: row.proxyId })))
                   }
-                }
-            ]
-            : []),
-          ...(user?.grants['prov-proxy-unprovision'] && isMenuOptionsVisible
-            ? [
+                },
                 {
                   name: 'Unprovision Proxy',
+                  isDisabled: !user?.grants['prov-proxy-unprovision'],
                   onClick: () => {
                     openConfirmModal()
                     setConfirmTitle(`Confirm unprovision proxy ${proxyName}?`)
@@ -103,44 +107,38 @@ function ProxyMenu({
                 }
               ]
             : []),
-          ...(user?.grants['proxy-start'] ? [
-                {
-                  name: 'Start Proxy',
-                  onClick: () => {
-                    openConfirmModal()
-                    setConfirmTitle(`Confirm start proxy ${proxyName}?`)
-                    setConfirmHandler(() => () => dispatch(startProxy({ clusterName, proxyId: row.proxyId })))
-                  }
-                }
-              ]
-            : []),
-          ...(user?.grants['proxy-stop'] ? [
-                {
-                  name: 'Stop Proxy',
-                  onClick: () => {
-                    openConfirmModal()
-                    setConfirmTitle(`Confirm stop proxy ${proxyName}?`)
-                    setConfirmHandler(() => () => dispatch(stopProxy({ clusterName, proxyId: row.proxyId })))
-                  }
-                },
-                ...(orchestrator === 'opensvc'
-                  ? [
-                      {
-                        name: 'Abort Orchestration',
-                        onClick: () => {
-                          openConfirmModal()
-                          setConfirmTitle(`Confirm orchestration abort for ${proxyName}?`)
-                          setConfirmHandler(() => () => dispatch(abortProxy({ clusterName, proxyId: row.proxyId })))
-                        }
-                      }
-                    ]
-                  : [])
-              ]
-            : []),
-          ...(user?.grants['proxy-start'] && orchestrator === 'opensvc'
+          {
+            name: 'Start Proxy',
+            isDisabled: !user?.grants['proxy-start'],
+            onClick: () => {
+              openConfirmModal()
+              setConfirmTitle(`Confirm start proxy ${proxyName}?`)
+              setConfirmHandler(() => () => dispatch(startProxy({ clusterName, proxyId: row.proxyId })))
+            }
+          },
+          {
+            name: 'Stop Proxy',
+            isDisabled: !user?.grants['proxy-stop'],
+            onClick: () => {
+              openConfirmModal()
+              setConfirmTitle(`Confirm stop proxy ${proxyName}?`)
+              setConfirmHandler(() => () => dispatch(stopProxy({ clusterName, proxyId: row.proxyId })))
+            }
+          },
+          ...(orchestrator === 'opensvc'
             ? [
                 {
+                  name: 'Abort Orchestration',
+                  isDisabled: !user?.grants['proxy-stop'],
+                  onClick: () => {
+                    openConfirmModal()
+                    setConfirmTitle(`Confirm orchestration abort for ${proxyName}?`)
+                    setConfirmHandler(() => () => dispatch(abortProxy({ clusterName, proxyId: row.proxyId })))
+                  }
+                },
+                {
                   name: 'Clear Instance State',
+                  isDisabled: !user?.grants['proxy-start'],
                   onClick: () => {
                     openConfirmModal()
                     setConfirmTitle(`Confirm clear instance state for ${proxyName}?`)
@@ -149,28 +147,29 @@ function ProxyMenu({
                 }
               ]
             : []),
-          ...(user?.grants['terminal-proxy'] && showTerminal 
+          ...(showTerminal
             ? [
                 {
                   name: 'Web Terminal',
                   subMenu: [
                     {
                       name: 'MySQL Terminal',
+                      isDisabled: !user?.grants['terminal-proxy'],
                       onClick: () => openTerminalPage(clusterName, row.proxyId, 'mysql')
                     },
                     {
                       name: 'MyTop Terminal',
+                      isDisabled: !user?.grants['terminal-proxy'],
                       onClick: () => openTerminalPage(clusterName, row.proxyId, 'mytop')
                     },
-                    ...(user?.grants['terminal-global'] ? [
-                      {
-                        name: 'Shell Terminal',
-                        onClick: () => openTerminalPage(clusterName, row.proxyId)
-                      }
-                    ] : []),
+                    {
+                      name: 'Shell Terminal',
+                      isDisabled: !user?.grants['terminal-global'],
+                      onClick: () => openTerminalPage(clusterName, row.proxyId)
+                    }
                   ]
                 }
-              ] 
+              ]
             : []),
           {
             name: 'Remove Monitor',
@@ -179,7 +178,7 @@ function ProxyMenu({
               setConfirmTitle(`Confirm removing monitor for ${row.proxyId} (${row.server})?`)
               setConfirmHandler(() => () => dispatch(dropServerByName({ clusterName, serverName: row.proxyId })))
             }
-          },
+          }
         ]}
       />
       {isConfirmModalOpen && (

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyMenu.jsx
@@ -59,111 +59,128 @@ function ProxyMenu({
         colorScheme={colorScheme}
         placement={from === 'tableView' ? 'right-end' : 'left-end'}
         subMenuPlacement={isDesktop ? (from === 'tableView' ? 'right-end' : 'left-end') : 'bottom'}
-        options={(() => {
-          const terminalItems = showTerminal ? [
-            ...(user?.grants['terminal-proxy'] ? [
-              { name: 'MySQL Terminal', onClick: () => openTerminalPage(clusterName, row.proxyId, 'mysql') },
-              { name: 'MyTop Terminal', onClick: () => openTerminalPage(clusterName, row.proxyId, 'mytop') }
-            ] : []),
-            ...(user?.grants['terminal-global'] ? [
-              { name: 'Shell Terminal', onClick: () => openTerminalPage(clusterName, row.proxyId) }
-            ] : [])
-          ] : []
-
-          return [
-            ...(topoStaging && user?.grants['cluster-staging']
-              ? [row.isStaging
-                  ? {
-                      name: 'Set As Normal Proxy',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
-                        setConfirmHandler(() => () => dispatch(stagingProxy({ clusterName, proxyId: row.proxyId, staging: false })))
-                      }
+        options={[
+          ...(topoStaging
+            ? row.isStaging
+              ? [
+                  {
+                    name: 'Set As Normal Proxy',
+                    isDisabled: !user?.grants['cluster-staging'],
+                    onClick: () => {
+                      openConfirmModal()
+                      setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
+                      setConfirmHandler(() => () => dispatch(stagingProxy({ clusterName, proxyId: row.proxyId, staging: false })))
                     }
-                  : {
-                      name: 'Set As Staging Proxy',
-                      onClick: () => {
-                        openConfirmModal()
-                        setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
-                        setConfirmHandler(() => () => dispatch(stagingProxy({ clusterName, proxyId: row.proxyId, staging: true })))
-                      }
-                    }
+                  }
                 ]
-              : []),
-            ...(isMenuOptionsVisible && user?.grants['prov-proxy-provision'] ? [
-              {
-                name: 'Provision Proxy',
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
-                  setConfirmHandler(() => () => dispatch(provisionProxy({ clusterName, proxyId: row.proxyId })))
+              : [
+                  {
+                    name: 'Set As Staging Proxy',
+                    isDisabled: !user?.grants['cluster-staging'],
+                    onClick: () => {
+                      openConfirmModal()
+                      setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
+                      setConfirmHandler(() => () => dispatch(stagingProxy({ clusterName, proxyId: row.proxyId, staging: true })))
+                    }
+                  }
+                ]
+            : []),
+          ...(isMenuOptionsVisible
+            ? [
+                {
+                  name: 'Provision Proxy',
+                  isDisabled: !user?.grants['prov-proxy-provision'],
+                  onClick: () => {
+                    openConfirmModal()
+                    setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
+                    setConfirmHandler(() => () => dispatch(provisionProxy({ clusterName, proxyId: row.proxyId })))
+                  }
+                },
+                {
+                  name: 'Unprovision Proxy',
+                  isDisabled: !user?.grants['prov-proxy-unprovision'],
+                  onClick: () => {
+                    openConfirmModal()
+                    setConfirmTitle(`Confirm unprovision proxy ${proxyName}?`)
+                    setConfirmHandler(() => () => dispatch(unprovisionProxy({ clusterName, proxyId: row.proxyId })))
+                  }
                 }
-              }
-            ] : []),
-            ...(isMenuOptionsVisible && user?.grants['prov-proxy-unprovision'] ? [
-              {
-                name: 'Unprovision Proxy',
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle(`Confirm unprovision proxy ${proxyName}?`)
-                  setConfirmHandler(() => () => dispatch(unprovisionProxy({ clusterName, proxyId: row.proxyId })))
+              ]
+            : []),
+          {
+            name: 'Start Proxy',
+            isDisabled: !user?.grants['proxy-start'],
+            onClick: () => {
+              openConfirmModal()
+              setConfirmTitle(`Confirm start proxy ${proxyName}?`)
+              setConfirmHandler(() => () => dispatch(startProxy({ clusterName, proxyId: row.proxyId })))
+            }
+          },
+          {
+            name: 'Stop Proxy',
+            isDisabled: !user?.grants['proxy-stop'],
+            onClick: () => {
+              openConfirmModal()
+              setConfirmTitle(`Confirm stop proxy ${proxyName}?`)
+              setConfirmHandler(() => () => dispatch(stopProxy({ clusterName, proxyId: row.proxyId })))
+            }
+          },
+          ...(orchestrator === 'opensvc'
+            ? [
+                {
+                  name: 'Abort Orchestration',
+                  isDisabled: !user?.grants['proxy-stop'],
+                  onClick: () => {
+                    openConfirmModal()
+                    setConfirmTitle(`Confirm orchestration abort for ${proxyName}?`)
+                    setConfirmHandler(() => () => dispatch(abortProxy({ clusterName, proxyId: row.proxyId })))
+                  }
+                },
+                {
+                  name: 'Clear Instance State',
+                  isDisabled: !user?.grants['proxy-start'],
+                  onClick: () => {
+                    openConfirmModal()
+                    setConfirmTitle(`Confirm clear instance state for ${proxyName}?`)
+                    setConfirmHandler(() => () => dispatch(clearProxy({ clusterName, proxyId: row.proxyId })))
+                  }
                 }
-              }
-            ] : []),
-            ...(user?.grants['proxy-start'] ? [
-              {
-                name: 'Start Proxy',
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle(`Confirm start proxy ${proxyName}?`)
-                  setConfirmHandler(() => () => dispatch(startProxy({ clusterName, proxyId: row.proxyId })))
+              ]
+            : []),
+          ...(showTerminal
+            ? [
+                {
+                  name: 'Web Terminal',
+                  subMenu: [
+                    {
+                      name: 'MySQL Terminal',
+                      isDisabled: !user?.grants['terminal-proxy'],
+                      onClick: () => openTerminalPage(clusterName, row.proxyId, 'mysql')
+                    },
+                    {
+                      name: 'MyTop Terminal',
+                      isDisabled: !user?.grants['terminal-proxy'],
+                      onClick: () => openTerminalPage(clusterName, row.proxyId, 'mytop')
+                    },
+                    {
+                      name: 'Shell Terminal',
+                      isDisabled: !user?.grants['terminal-global'],
+                      onClick: () => openTerminalPage(clusterName, row.proxyId)
+                    }
+                  ]
                 }
-              }
-            ] : []),
-            ...(user?.grants['proxy-stop'] ? [
-              {
-                name: 'Stop Proxy',
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle(`Confirm stop proxy ${proxyName}?`)
-                  setConfirmHandler(() => () => dispatch(stopProxy({ clusterName, proxyId: row.proxyId })))
-                }
-              }
-            ] : []),
-            ...(orchestrator === 'opensvc' && user?.grants['proxy-stop'] ? [
-              {
-                name: 'Abort Orchestration',
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle(`Confirm orchestration abort for ${proxyName}?`)
-                  setConfirmHandler(() => () => dispatch(abortProxy({ clusterName, proxyId: row.proxyId })))
-                }
-              }
-            ] : []),
-            ...(orchestrator === 'opensvc' && user?.grants['proxy-start'] ? [
-              {
-                name: 'Clear Instance State',
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle(`Confirm clear instance state for ${proxyName}?`)
-                  setConfirmHandler(() => () => dispatch(clearProxy({ clusterName, proxyId: row.proxyId })))
-                }
-              }
-            ] : []),
-            ...(terminalItems.length > 0 ? [{ name: 'Web Terminal', subMenu: terminalItems }] : []),
-            ...(user?.grants['cluster-drop-monitor'] ? [
-              {
-                name: 'Remove Monitor',
-                onClick: () => {
-                  openConfirmModal()
-                  setConfirmTitle(`Confirm removing monitor for ${row.proxyId} (${row.server})?`)
-                  setConfirmHandler(() => () => dispatch(dropServerByName({ clusterName, serverName: row.proxyId })))
-                }
-              }
-            ] : [])
-          ]
-        })()}
+              ]
+            : []),
+          {
+            name: 'Remove Monitor',
+            isDisabled: !user?.grants['cluster-drop-monitor'],
+            onClick: () => {
+              openConfirmModal()
+              setConfirmTitle(`Confirm removing monitor for ${row.proxyId} (${row.server})?`)
+              setConfirmHandler(() => () => dispatch(dropServerByName({ clusterName, serverName: row.proxyId })))
+            }
+          }
+        ]}
       />
       {isConfirmModalOpen && (
         <ConfirmModal

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyMenu.jsx
@@ -173,6 +173,7 @@ function ProxyMenu({
             : []),
           {
             name: 'Remove Monitor',
+            isDisabled: !user?.grants['cluster-drop-monitor'],
             onClick: () => {
               openConfirmModal()
               setConfirmTitle(`Confirm removing monitor for ${row.proxyId} (${row.server})?`)

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyMenu.jsx
@@ -59,128 +59,111 @@ function ProxyMenu({
         colorScheme={colorScheme}
         placement={from === 'tableView' ? 'right-end' : 'left-end'}
         subMenuPlacement={isDesktop ? (from === 'tableView' ? 'right-end' : 'left-end') : 'bottom'}
-        options={[
-          ...(topoStaging
-            ? row.isStaging
-              ? [
-                  {
-                    name: 'Set As Normal Proxy',
-                    isDisabled: !user?.grants['cluster-staging'],
-                    onClick: () => {
-                      openConfirmModal()
-                      setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
-                      setConfirmHandler(() => () => dispatch(stagingProxy({ clusterName, proxyId: row.proxyId, staging: false })))
+        options={(() => {
+          const terminalItems = showTerminal ? [
+            ...(user?.grants['terminal-proxy'] ? [
+              { name: 'MySQL Terminal', onClick: () => openTerminalPage(clusterName, row.proxyId, 'mysql') },
+              { name: 'MyTop Terminal', onClick: () => openTerminalPage(clusterName, row.proxyId, 'mytop') }
+            ] : []),
+            ...(user?.grants['terminal-global'] ? [
+              { name: 'Shell Terminal', onClick: () => openTerminalPage(clusterName, row.proxyId) }
+            ] : [])
+          ] : []
+
+          return [
+            ...(topoStaging && user?.grants['cluster-staging']
+              ? [row.isStaging
+                  ? {
+                      name: 'Set As Normal Proxy',
+                      onClick: () => {
+                        openConfirmModal()
+                        setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
+                        setConfirmHandler(() => () => dispatch(stagingProxy({ clusterName, proxyId: row.proxyId, staging: false })))
+                      }
                     }
-                  }
+                  : {
+                      name: 'Set As Staging Proxy',
+                      onClick: () => {
+                        openConfirmModal()
+                        setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
+                        setConfirmHandler(() => () => dispatch(stagingProxy({ clusterName, proxyId: row.proxyId, staging: true })))
+                      }
+                    }
                 ]
-              : [
-                  {
-                    name: 'Set As Staging Proxy',
-                    isDisabled: !user?.grants['cluster-staging'],
-                    onClick: () => {
-                      openConfirmModal()
-                      setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
-                      setConfirmHandler(() => () => dispatch(stagingProxy({ clusterName, proxyId: row.proxyId, staging: true })))
-                    }
-                  }
-                ]
-            : []),
-          ...(isMenuOptionsVisible
-            ? [
-                {
-                  name: 'Provision Proxy',
-                  isDisabled: !user?.grants['prov-proxy-provision'],
-                  onClick: () => {
-                    openConfirmModal()
-                    setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
-                    setConfirmHandler(() => () => dispatch(provisionProxy({ clusterName, proxyId: row.proxyId })))
-                  }
-                },
-                {
-                  name: 'Unprovision Proxy',
-                  isDisabled: !user?.grants['prov-proxy-unprovision'],
-                  onClick: () => {
-                    openConfirmModal()
-                    setConfirmTitle(`Confirm unprovision proxy ${proxyName}?`)
-                    setConfirmHandler(() => () => dispatch(unprovisionProxy({ clusterName, proxyId: row.proxyId })))
-                  }
+              : []),
+            ...(isMenuOptionsVisible && user?.grants['prov-proxy-provision'] ? [
+              {
+                name: 'Provision Proxy',
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm provision proxy ${proxyName}?`)
+                  setConfirmHandler(() => () => dispatch(provisionProxy({ clusterName, proxyId: row.proxyId })))
                 }
-              ]
-            : []),
-          {
-            name: 'Start Proxy',
-            isDisabled: !user?.grants['proxy-start'],
-            onClick: () => {
-              openConfirmModal()
-              setConfirmTitle(`Confirm start proxy ${proxyName}?`)
-              setConfirmHandler(() => () => dispatch(startProxy({ clusterName, proxyId: row.proxyId })))
-            }
-          },
-          {
-            name: 'Stop Proxy',
-            isDisabled: !user?.grants['proxy-stop'],
-            onClick: () => {
-              openConfirmModal()
-              setConfirmTitle(`Confirm stop proxy ${proxyName}?`)
-              setConfirmHandler(() => () => dispatch(stopProxy({ clusterName, proxyId: row.proxyId })))
-            }
-          },
-          ...(orchestrator === 'opensvc'
-            ? [
-                {
-                  name: 'Abort Orchestration',
-                  isDisabled: !user?.grants['proxy-stop'],
-                  onClick: () => {
-                    openConfirmModal()
-                    setConfirmTitle(`Confirm orchestration abort for ${proxyName}?`)
-                    setConfirmHandler(() => () => dispatch(abortProxy({ clusterName, proxyId: row.proxyId })))
-                  }
-                },
-                {
-                  name: 'Clear Instance State',
-                  isDisabled: !user?.grants['proxy-start'],
-                  onClick: () => {
-                    openConfirmModal()
-                    setConfirmTitle(`Confirm clear instance state for ${proxyName}?`)
-                    setConfirmHandler(() => () => dispatch(clearProxy({ clusterName, proxyId: row.proxyId })))
-                  }
+              }
+            ] : []),
+            ...(isMenuOptionsVisible && user?.grants['prov-proxy-unprovision'] ? [
+              {
+                name: 'Unprovision Proxy',
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm unprovision proxy ${proxyName}?`)
+                  setConfirmHandler(() => () => dispatch(unprovisionProxy({ clusterName, proxyId: row.proxyId })))
                 }
-              ]
-            : []),
-          ...(showTerminal
-            ? [
-                {
-                  name: 'Web Terminal',
-                  subMenu: [
-                    {
-                      name: 'MySQL Terminal',
-                      isDisabled: !user?.grants['terminal-proxy'],
-                      onClick: () => openTerminalPage(clusterName, row.proxyId, 'mysql')
-                    },
-                    {
-                      name: 'MyTop Terminal',
-                      isDisabled: !user?.grants['terminal-proxy'],
-                      onClick: () => openTerminalPage(clusterName, row.proxyId, 'mytop')
-                    },
-                    {
-                      name: 'Shell Terminal',
-                      isDisabled: !user?.grants['terminal-global'],
-                      onClick: () => openTerminalPage(clusterName, row.proxyId)
-                    }
-                  ]
+              }
+            ] : []),
+            ...(user?.grants['proxy-start'] ? [
+              {
+                name: 'Start Proxy',
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm start proxy ${proxyName}?`)
+                  setConfirmHandler(() => () => dispatch(startProxy({ clusterName, proxyId: row.proxyId })))
                 }
-              ]
-            : []),
-          {
-            name: 'Remove Monitor',
-            isDisabled: !user?.grants['cluster-drop-monitor'],
-            onClick: () => {
-              openConfirmModal()
-              setConfirmTitle(`Confirm removing monitor for ${row.proxyId} (${row.server})?`)
-              setConfirmHandler(() => () => dispatch(dropServerByName({ clusterName, serverName: row.proxyId })))
-            }
-          }
-        ]}
+              }
+            ] : []),
+            ...(user?.grants['proxy-stop'] ? [
+              {
+                name: 'Stop Proxy',
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm stop proxy ${proxyName}?`)
+                  setConfirmHandler(() => () => dispatch(stopProxy({ clusterName, proxyId: row.proxyId })))
+                }
+              }
+            ] : []),
+            ...(orchestrator === 'opensvc' && user?.grants['proxy-stop'] ? [
+              {
+                name: 'Abort Orchestration',
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm orchestration abort for ${proxyName}?`)
+                  setConfirmHandler(() => () => dispatch(abortProxy({ clusterName, proxyId: row.proxyId })))
+                }
+              }
+            ] : []),
+            ...(orchestrator === 'opensvc' && user?.grants['proxy-start'] ? [
+              {
+                name: 'Clear Instance State',
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm clear instance state for ${proxyName}?`)
+                  setConfirmHandler(() => () => dispatch(clearProxy({ clusterName, proxyId: row.proxyId })))
+                }
+              }
+            ] : []),
+            ...(terminalItems.length > 0 ? [{ name: 'Web Terminal', subMenu: terminalItems }] : []),
+            ...(user?.grants['cluster-drop-monitor'] ? [
+              {
+                name: 'Remove Monitor',
+                onClick: () => {
+                  openConfirmModal()
+                  setConfirmTitle(`Confirm removing monitor for ${row.proxyId} (${row.server})?`)
+                  setConfirmHandler(() => () => dispatch(dropServerByName({ clusterName, serverName: row.proxyId })))
+                }
+              }
+            ] : [])
+          ]
+        })()}
       />
       {isConfirmModalOpen && (
         <ConfirmModal

--- a/share/dashboard_react/src/Pages/Dashboard/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/index.jsx
@@ -45,8 +45,8 @@ function Dashboard({ selectedCluster, user }) {
       <Flex gap='24px'>
         {selectedCluster && (
           <Flex w='100%' gap='24px' direction={isDesktop ? 'row' : 'column'}>
-            <ClusterDetail selectedCluster={selectedCluster} />
-            <HADetail selectedCluster={selectedCluster} />
+            <ClusterDetail selectedCluster={selectedCluster} user={user} />
+            <HADetail selectedCluster={selectedCluster} user={user} />
           </Flex>
         )}
       </Flex>

--- a/share/dashboard_react/src/Pages/Home/index.jsx
+++ b/share/dashboard_react/src/Pages/Home/index.jsx
@@ -291,7 +291,7 @@ function Home() {
               ? [renderClusterListTabWithArrow(), ...dashboardTabsRef.current]
               : globalTabsRef.current
           }
-          tabPrefix={[...(selectedClusterNameRef.current == '' ? [<div onClick={openNewClusterModal} className={styles.tabSelected}><CustomIcon icon={FaPlus} /></div>] : [])]}
+          tabPrefix={[...(selectedClusterNameRef.current == '' && localStorage.getItem('username') == "admin" ? [<div onClick={openNewClusterModal} className={styles.tabSelected}><CustomIcon icon={FaPlus} /></div>] : [])]}
           tabSuffix={[...(selectedClusterNameRef.current == '' && localStorage.getItem('username') == "admin" ? [<div onClick={openTerminalPage} className={styles.tabNormal}>Terminal</div>] : [])]}
           tabContents={[
             <ClusterList onClick={setDashboardTab} />,

--- a/share/dashboard_react/src/Pages/Home/index.jsx
+++ b/share/dashboard_react/src/Pages/Home/index.jsx
@@ -72,6 +72,11 @@ function Home() {
   const refreshInterval = useSelector((state) => state.cluster.refreshInterval)
   const clusterData = useSelector((state) => state.cluster.clusterData)
   const monitor = useSelector((state) => state.globalClusters.monitor)
+  const clusters = useSelector((state) => state.globalClusters.clusters)
+  const clusterPeers = useSelector((state) => state.globalClusters.clusterPeers)
+  const clustersLoading = useSelector((state) => state.globalClusters.loading)
+
+  const isSSOUser = !!loggedUser?.profile
 
   useEffect(() => {
     if (params?.cluster) {
@@ -90,7 +95,38 @@ function Home() {
       globalTabsRef.current.push('Settings')
     }
     globalTabsRef.current.push('Dashboard')
-  }, [monitor?.config?.cloud18,loggedUser?.User])
+  }, [monitor?.config?.cloud18, loggedUser?.User])
+
+  // For SSO users: if local clusters are empty after loading, advance to Peer,
+  // then to For Sale if Peer is also empty.
+  useEffect(() => {
+    if (
+      isClusterOpenRef.current ||     // a cluster is already open — leave it alone
+      !isSSOUser ||                   // non-SSO users stay on local
+      !monitor?.config?.cloud18 ||    // peer/for-sale tabs only exist when cloud18 is on
+      clustersLoading                 // wait until getClusters has finished
+    ) return
+
+    const currentTab = globalTabsRef.current[selectedTabRef.current]
+
+    if (currentTab === 'Clusters Local' && clusters.length === 0) {
+      // Local empty → try Peer
+      const peerIdx = globalTabsRef.current.indexOf('Clusters Peer')
+      if (peerIdx >= 0) {
+        selectedTabRef.current = peerIdx
+        setSelectedTab(peerIdx)
+        dispatch(getClusterPeers({}))
+      }
+    } else if (currentTab === 'Clusters Peer' && clusterPeers !== null && clusterPeers.length === 0) {
+      // Peer empty → try For Sale
+      const forSaleIdx = globalTabsRef.current.indexOf('Clusters For Sale')
+      if (forSaleIdx >= 0) {
+        selectedTabRef.current = forSaleIdx
+        setSelectedTab(forSaleIdx)
+        dispatch(getClusterForSale({}))
+      }
+    }
+  }, [clusters, clusterPeers, clustersLoading, isSSOUser, monitor?.config?.cloud18])
 
   useEffect(() => {
     if (clusterData) {

--- a/share/dashboard_react/src/Pages/Login/index.jsx
+++ b/share/dashboard_react/src/Pages/Login/index.jsx
@@ -30,12 +30,30 @@ function Login(props) {
   useEffect(() => {
     if (isAuthorized()) {
       navigate('/')
-    } else {
-      // If not authorized, ensure the user is logged out and clear clusters
-      dispatch(logout());
-      dispatch(clearClusters());
-      dispatch(clearCluster());
+      return
     }
+    // Try auto-login endpoint (only active when api-autologin=true on the server)
+    fetch('/api/autologin')
+      .then((res) => {
+        if (res.ok) return res.json()
+        return null
+      })
+      .then((data) => {
+        if (data && data.token) {
+          localStorage.setItem('user_token', data.token)
+          localStorage.setItem('username', data.username || 'admin')
+          navigate('/')
+        } else {
+          dispatch(logout())
+          dispatch(clearClusters())
+          dispatch(clearCluster())
+        }
+      })
+      .catch(() => {
+        dispatch(logout())
+        dispatch(clearClusters())
+        dispatch(clearCluster())
+      })
   }, [])
 
   useEffect(() => {

--- a/share/dashboard_react/src/Pages/Login/index.jsx
+++ b/share/dashboard_react/src/Pages/Login/index.jsx
@@ -28,7 +28,9 @@ function Login({ dashboard = false }) {
   } = useSelector((state) => state)
 
   useEffect(() => {
-    if (isAuthorized()) {
+    // In dashboard mode always fetch a fresh token so the viewer lands on
+    // /slideshow even when a stale token is already in localStorage.
+    if (!dashboard && isAuthorized()) {
       navigate('/')
       return
     }

--- a/share/dashboard_react/src/Pages/Login/index.jsx
+++ b/share/dashboard_react/src/Pages/Login/index.jsx
@@ -44,7 +44,7 @@ function Login({ dashboard = false }) {
         if (data && data.token) {
           localStorage.setItem('user_token', data.token)
           localStorage.setItem('username', data.username || 'admin')
-          navigate('/')
+          navigate(dashboard ? '/slideshow' : '/')
         } else {
           dispatch(logout())
           dispatch(clearClusters())

--- a/share/dashboard_react/src/Pages/Login/index.jsx
+++ b/share/dashboard_react/src/Pages/Login/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, Suspense } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
-import { login, logout } from '../../redux/authSlice'
+import { login, logout, setUserData } from '../../redux/authSlice'
 import styles from './styles.module.scss'
 import { Box, Container, FormControl, FormLabel, FormErrorMessage, Heading, Input, Stack, Text } from '@chakra-ui/react'
 import PageContainer from '../PageContainer'
@@ -44,6 +44,7 @@ function Login({ dashboard = false }) {
         if (data && data.token) {
           localStorage.setItem('user_token', data.token)
           localStorage.setItem('username', data.username || 'admin')
+          dispatch(setUserData())
           navigate(dashboard ? '/slideshow' : '/')
         } else {
           dispatch(logout())

--- a/share/dashboard_react/src/Pages/Login/index.jsx
+++ b/share/dashboard_react/src/Pages/Login/index.jsx
@@ -35,36 +35,66 @@ function Login({ dashboard = false }) {
       return
     }
 
-    const autoLoginUrl = dashboard ? '/api/dashboard-token' : '/api/autologin'
-
-    fetch(autoLoginUrl)
-      .then((res) => {
-        if (res.ok) return res.json()
-        return null
-      })
-      .then((data) => {
-        if (data && data.token) {
-          localStorage.setItem('user_token', data.token)
-          localStorage.setItem('username', data.username || 'admin')
-          dispatch(setUserData())
-          navigate(dashboard ? '/slideshow' : '/')
-        } else {
+    if (!dashboard) {
+      // Normal login page: try autologin once, fall through to manual login form on failure.
+      fetch('/api/autologin')
+        .then((res) => (res.ok ? res.json() : null))
+        .then((data) => {
+          if (data && data.token) {
+            localStorage.setItem('user_token', data.token)
+            localStorage.setItem('username', data.username || 'admin')
+            dispatch(setUserData())
+            navigate('/')
+          } else {
+            dispatch(logout())
+            dispatch(clearClusters())
+            dispatch(clearCluster())
+          }
+        })
+        .catch(() => {
           dispatch(logout())
           dispatch(clearClusters())
           dispatch(clearCluster())
-        }
-      })
-      .catch(() => {
-        dispatch(logout())
-        dispatch(clearClusters())
-        dispatch(clearCluster())
-      })
+        })
+      return
+    }
+
+    // Dashboard (slideshow) mode: retry until the server is ready after restart.
+    let retryTimer = null
+    let cancelled = false
+
+    const tryDashboardToken = () => {
+      fetch('/api/dashboard-token')
+        .then((res) => (res.ok ? res.json() : null))
+        .then((data) => {
+          if (cancelled) return
+          if (data && data.token) {
+            localStorage.setItem('user_token', data.token)
+            localStorage.setItem('username', data.username || 'viewer')
+            dispatch(setUserData())
+            navigate('/slideshow')
+          } else {
+            // Server not ready yet or no dashboard token configured — retry.
+            retryTimer = setTimeout(tryDashboardToken, 3000)
+          }
+        })
+        .catch(() => {
+          if (!cancelled) retryTimer = setTimeout(tryDashboardToken, 3000)
+        })
+    }
+
+    tryDashboardToken()
+    return () => {
+      cancelled = true
+      clearTimeout(retryTimer)
+    }
   }, [])
 
   useEffect(() => {
     if (!loading || !loadingGitLogin) {
-      if (isLogged && user && !dashboard) {
-        navigate('/')
+      if (isLogged && user) {
+        // Navigate to the right destination after manual login regardless of mode.
+        navigate(dashboard ? '/slideshow' : '/')
       }
       if (error) {
         setErrorMessage(error)

--- a/share/dashboard_react/src/Pages/Login/index.jsx
+++ b/share/dashboard_react/src/Pages/Login/index.jsx
@@ -13,7 +13,7 @@ import { useTheme } from '../../ThemeProvider'
 import { clearCluster } from '../../redux/clusterSlice'
 import { clearClusters } from '../../redux/globalClustersSlice'
 
-function Login(props) {
+function Login({ dashboard = false }) {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [usernameError, setUsernameError] = useState('')
@@ -32,8 +32,10 @@ function Login(props) {
       navigate('/')
       return
     }
-    // Try auto-login endpoint (only active when api-autologin=true on the server)
-    fetch('/api/autologin')
+
+    const autoLoginUrl = dashboard ? '/api/dashboard-token' : '/api/autologin'
+
+    fetch(autoLoginUrl)
       .then((res) => {
         if (res.ok) return res.json()
         return null

--- a/share/dashboard_react/src/Pages/Login/index.jsx
+++ b/share/dashboard_react/src/Pages/Login/index.jsx
@@ -61,7 +61,7 @@ function Login({ dashboard = false }) {
 
   useEffect(() => {
     if (!loading || !loadingGitLogin) {
-      if (isLogged && user) {
+      if (isLogged && user && !dashboard) {
         navigate('/')
       }
       if (error) {

--- a/share/dashboard_react/src/Pages/Maintenance/DatabaseJobs/index.jsx
+++ b/share/dashboard_react/src/Pages/Maintenance/DatabaseJobs/index.jsx
@@ -13,7 +13,7 @@ import { FaTrash } from 'react-icons/fa'
 import ConfirmModal from '../../../components/Modals/ConfirmModal'
 import { cancelServerJob } from '../../../redux/clusterSlice'
 
-function DatabaseJobs({ clusterName }) {
+function DatabaseJobs({ clusterName, user }) {
   const {
     cluster: { jobs, clusterServers }
   } = useSelector((state) => state)
@@ -80,7 +80,7 @@ function DatabaseJobs({ clusterName }) {
         id: 'cancelTask',
         header: 'Cancel Task',
         cell: (info) =>
-          canCancelJob(info.row.original) ? (
+          canCancelJob(info.row.original) && user?.grants['cluster-process'] ? (
             <RMIconButton
               className={styles.btnCancelTask}
               tooltip={'Cancel task'}

--- a/share/dashboard_react/src/Pages/Maintenance/index.jsx
+++ b/share/dashboard_react/src/Pages/Maintenance/index.jsx
@@ -376,7 +376,7 @@ function Maintenance({ selectedCluster, user, section }) {
             icon={HiTrash}
             tooltip='Delete backup'
             onClick={() => openConfirmModal('Do you want to delete this backup?', { action: 'backupDelete', data: { backupId: info.row.original.id } })}
-            isDisabled={user?.grants['cluster-settings'] == false}
+            isDisabled={!user?.grants['cluster-show-backups']}
           />
         )
       })
@@ -422,7 +422,9 @@ function Maintenance({ selectedCluster, user, section }) {
       cell: (info) => (
         <RMIconButton
           icon={HiTrash}
+          tooltip='Purge snapshot'
           onClick={() => openConfirmModal('Do you want to purge this snapshot?', { action: 'snapshotPurge', data: { snapshotId: info.row.original.id } })}
+          isDisabled={!user?.grants['cluster-process']}
         />
       )
     })
@@ -541,14 +543,16 @@ function Maintenance({ selectedCluster, user, section }) {
       id: 'details',
       minWidth: 200
     }),
-    // Added Purge action column
+    // Added cancel action column
     columnHelper.display({
       id: 'actions',
       header: 'Actions',
       cell: (info) => (
         <RMIconButton
           icon={HiTrash}
+          tooltip='Cancel queued task'
           onClick={() => openConfirmModal('Cancel Queued Task', { action: 'queueCancel', data: { taskId: info.row.original.task_id } })}
+          isDisabled={!user?.grants['cluster-process']}
         />
       )
     })

--- a/share/dashboard_react/src/Pages/Maintenance/index.jsx
+++ b/share/dashboard_react/src/Pages/Maintenance/index.jsx
@@ -444,8 +444,8 @@ function Maintenance({ selectedCluster, user, section }) {
     {
       key: 'Action',
       value: (selectedCluster?.isResticQueuePaused ?
-        <RMIconButton icon={HiPlay} onClick={() => openConfirmModal('Resume Restic Queue', { action: 'queueResume' })} /> :
-        <RMIconButton icon={HiPause} onClick={() => openConfirmModal('Pause Restic Queue', { action: 'queuePause' })} />
+        <RMIconButton icon={HiPlay} tooltip='Resume queue' isDisabled={!user?.grants['cluster-process']} onClick={() => openConfirmModal('Resume Restic Queue', { action: 'queueResume' })} /> :
+        <RMIconButton icon={HiPause} tooltip='Pause queue' isDisabled={!user?.grants['cluster-process']} onClick={() => openConfirmModal('Pause Restic Queue', { action: 'queuePause' })} />
       )
     }
   ], [selectedCluster?.isResticQueuePaused, queuelength])
@@ -611,7 +611,7 @@ function Maintenance({ selectedCluster, user, section }) {
       className={styles.accordion}
       headerClassName={styles.accordionHeader}
       panelClassName={styles.accordionPanel}
-      body={<DatabaseJobs clusterName={selectedCluster?.name} />}
+      body={<DatabaseJobs clusterName={selectedCluster?.name} user={user} />}
     />
   )
 

--- a/share/dashboard_react/src/Pages/Maintenance/index.jsx
+++ b/share/dashboard_react/src/Pages/Maintenance/index.jsx
@@ -376,7 +376,7 @@ function Maintenance({ selectedCluster, user, section }) {
             icon={HiTrash}
             tooltip='Delete backup'
             onClick={() => openConfirmModal('Do you want to delete this backup?', { action: 'backupDelete', data: { backupId: info.row.original.id } })}
-            isDisabled={!user?.grants['cluster-show-backups']}
+            isDisabled={!user?.grants['db-backup']}
           />
         )
       })

--- a/share/dashboard_react/src/Pages/Maintenance/index.jsx
+++ b/share/dashboard_react/src/Pages/Maintenance/index.jsx
@@ -124,7 +124,8 @@ const resticTaskDetail = (row) => {
 }
 
 
-function Maintenance({ selectedCluster, user }) {
+// section: undefined = full page, 'backup' = backup accordions only, 'jobs' = jobs accordion only
+function Maintenance({ selectedCluster, user, section }) {
   const [data, setData] = useState([])
   const [snapshotData, setSnapshotData] = useState([])
   const [queueData, setQueueData] = useState([])
@@ -553,9 +554,9 @@ function Maintenance({ selectedCluster, user }) {
     })
   ])
 
-  return (
-    <VStack className={styles.backupContainer}>
-<AccordionComponent
+  const backupSection = (
+    <>
+      <AccordionComponent
         heading={'Current Backups'}
         isOpen={isBackupsOpen}
         onToggle={onBackupsToggle}
@@ -595,24 +596,38 @@ function Maintenance({ selectedCluster, user }) {
           </VStack>
         }
       />
-      <AccordionComponent
-        heading={'Database Jobs'}
-        isOpen={isDBJobsOpen}
-        onToggle={onDBJobsToggle}
-        className={styles.accordion}
-        headerClassName={styles.accordionHeader}
-        panelClassName={styles.accordionPanel}
-        body={<DatabaseJobs clusterName={selectedCluster?.name} />}
-      />
-      <AccordionComponent
-        className={styles.accordion}
-        isOpen={isLogsOpen}
-        onToggle={onLogsToggle}
-        headerClassName={styles.accordionHeader}
-        panelClassName={styles.accordionPanel}
-        heading={'Job Logs'}
-        body={<TaskLogs />}
-      />
+    </>
+  )
+
+  const jobsSection = (
+    <AccordionComponent
+      heading={'Database Jobs'}
+      isOpen={isDBJobsOpen}
+      onToggle={onDBJobsToggle}
+      className={styles.accordion}
+      headerClassName={styles.accordionHeader}
+      panelClassName={styles.accordionPanel}
+      body={<DatabaseJobs clusterName={selectedCluster?.name} />}
+    />
+  )
+
+  const logsSection = (
+    <AccordionComponent
+      className={styles.accordion}
+      isOpen={isLogsOpen}
+      onToggle={onLogsToggle}
+      headerClassName={styles.accordionHeader}
+      panelClassName={styles.accordionPanel}
+      heading={'Job Logs'}
+      body={<TaskLogs />}
+    />
+  )
+
+  return (
+    <VStack className={styles.backupContainer}>
+      {(!section || section === 'backup') && backupSection}
+      {(!section || section === 'jobs') && jobsSection}
+      {!section && logsSection}
       {isConfirmModalOpen && <ConfirmModal title={title} isOpen={isConfirmModalOpen} body={<DynamicForm
         payload={payload}
         queueData={queueData}

--- a/share/dashboard_react/src/Pages/PageContainer/index.jsx
+++ b/share/dashboard_react/src/Pages/PageContainer/index.jsx
@@ -67,7 +67,8 @@ function PageContainer({ children }) {
 
   useEffect(() => {
     if (!isLogged && user === null && !isAuthorized() && location.pathname !== '/login') {
-      navigate('/login')
+      // Slideshow auth goes through /dashboard (viewer token) not /login (regular autologin → /)
+      navigate(location.pathname === '/slideshow' ? '/dashboard' : '/login')
     }
   }, [isLogged, location.pathname, navigate, user])
 

--- a/share/dashboard_react/src/Pages/Shards/index.jsx
+++ b/share/dashboard_react/src/Pages/Shards/index.jsx
@@ -551,14 +551,14 @@ function Shards({ selectedCluster, user, onOpenSchedulerSettings }) {
           <Flex className={styles.actionsRow}>
             <RMButton
               onClick={handleChecksumAll}
-              isDisabled={!selectedCluster?.name || isChecksumAllRunning}
+              isDisabled={!selectedCluster?.name || isChecksumAllRunning || !user?.grants['cluster-checksum']}
               isLoading={isChecksumAllRunning}
             >
               {isChecksumAllRunning ? 'Preparing schema cache…' : 'Checksum All Tables'}
             </RMButton>
             <RMButton
               onClick={handleChecksumRepairAll}
-              isDisabled={!selectedCluster?.name || isChecksumRepairAllRunning}
+              isDisabled={!selectedCluster?.name || isChecksumRepairAllRunning || !user?.grants['cluster-checksum-repair']}
               isLoading={isChecksumRepairAllRunning}
             >
               {isChecksumRepairAllRunning ? 'Preparing schema cache…' : 'Repair All Tables'}
@@ -566,7 +566,7 @@ function Shards({ selectedCluster, user, onOpenSchedulerSettings }) {
             <RMButton
               variant="outline"
               onClick={onOpenSchedulerSettings}
-              isDisabled={!onOpenSchedulerSettings || user?.grants['cluster-show-backups'] === false}
+              isDisabled={!onOpenSchedulerSettings || !user?.grants['cluster-show-backups']}
             >
               Open Scheduler Settings
             </RMButton>

--- a/share/dashboard_react/src/Pages/Slideshow/index.jsx
+++ b/share/dashboard_react/src/Pages/Slideshow/index.jsx
@@ -163,19 +163,19 @@ function Slideshow() {
     <PageContainer>
       {/* ── Header bar ─────────────────────────────────────── */}
       <Flex
-        px={4}
-        py={2}
+        px={6}
+        py={3}
         align='center'
         justify='space-between'
         borderBottom='1px solid'
         borderColor='gray.200'>
-        <Text fontWeight='bold' fontSize='lg'>
+        <Text fontWeight='bold' fontSize='3xl'>
           {currentSlide?.clusterName || '…'}
         </Text>
-        <Text fontSize='sm' color='gray.500'>
+        <Text fontSize='2xl' fontWeight='semibold' color='gray.500'>
           {currentSlide?.label || '…'}
         </Text>
-        <Text fontSize='xs' color='gray.400'>
+        <Text fontSize='sm' color='gray.400'>
           {clusterCount > 0
             ? `Cluster ${clusterIndex} of ${clusterCount} — section ${sectionIndex} of ${SECTIONS.length}`
             : 'Loading clusters…'}

--- a/share/dashboard_react/src/Pages/Slideshow/index.jsx
+++ b/share/dashboard_react/src/Pages/Slideshow/index.jsx
@@ -1,0 +1,191 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { Box, Flex, Progress, Text } from '@chakra-ui/react'
+import {
+  getBackupStats,
+  getBackups,
+  getClusterAlerts,
+  getClusterApps,
+  getClusterData,
+  getClusterLogs,
+  getClusterMaster,
+  getClusterProxies,
+  getClusterServers,
+  getJobs,
+  getResticCurrentTask,
+  getResticSnapshot,
+  setRefreshInterval
+} from '../../redux/clusterSlice'
+import { getClusters, getMonitoredData } from '../../redux/globalClustersSlice'
+import Dashboard from '../Dashboard'
+import Maintenance from '../Maintenance'
+import PageContainer from '../PageContainer'
+import { AppSettings } from '../../AppSettings'
+
+// Duration in milliseconds each slide is displayed
+const SLIDE_DURATION_MS = 30000
+
+function Slideshow() {
+  const dispatch = useDispatch()
+
+  const clusters = useSelector((state) => state.globalClusters.clusters)
+  const clusterData = useSelector((state) => state.cluster.clusterData)
+
+  const [slides, setSlides] = useState([]) // [{clusterName, view}]
+  const [slideIndex, setSlideIndex] = useState(0)
+  const [progress, setProgress] = useState(0)
+  const [user, setUser] = useState(null)
+
+  // Refs for use inside intervals without stale closures
+  const slidesRef = useRef([])
+  const slideIndexRef = useRef(0)
+
+  // ─── Build slides whenever cluster list changes ───────────────────────────
+  useEffect(() => {
+    if (!clusters || clusters.length === 0) return
+    const built = []
+    clusters.forEach((cl) => {
+      built.push({ clusterName: cl.name, view: 'dashboard' })
+      built.push({ clusterName: cl.name, view: 'maintenance' })
+    })
+    slidesRef.current = built
+    setSlides(built)
+    // Reset to first slide when cluster list changes
+    setSlideIndex(0)
+    slideIndexRef.current = 0
+  }, [clusters])
+
+  // ─── Initial cluster list fetch ───────────────────────────────────────────
+  useEffect(() => {
+    const interval = localStorage.getItem('refresh_interval')
+      ? parseInt(localStorage.getItem('refresh_interval'))
+      : AppSettings.DEFAULT_INTERVAL
+    dispatch(setRefreshInterval({ interval }))
+    dispatch(getClusters({}))
+    dispatch(getMonitoredData({}))
+  }, [])
+
+  // ─── Load all data for a given slide ─────────────────────────────────────
+  const loadSlideData = useCallback(
+    (slide) => {
+      if (!slide) return
+      const { clusterName, view } = slide
+      dispatch(getClusterData({ clusterName }))
+      dispatch(getClusterServers({ clusterName }))
+      dispatch(getClusterProxies({ clusterName }))
+      dispatch(getClusterAlerts({ clusterName }))
+      dispatch(getClusterMaster({ clusterName }))
+      dispatch(getClusterLogs({ clusterName }))
+      dispatch(getClusterApps({ clusterName }))
+      if (view === 'maintenance') {
+        dispatch(getResticSnapshot({ clusterName, filter: 'latest-per-session' }))
+        dispatch(getBackups({ clusterName }))
+        dispatch(getBackupStats({ clusterName }))
+        dispatch(getResticCurrentTask({ clusterName }))
+        dispatch(getJobs({ clusterName }))
+      }
+    },
+    [dispatch]
+  )
+
+  // ─── Slideshow timer ──────────────────────────────────────────────────────
+  useEffect(() => {
+    if (slides.length === 0) return
+
+    // Load data for the first slide immediately
+    loadSlideData(slides[0])
+
+    let elapsed = 0
+    const TICK_MS = 250
+
+    const ticker = setInterval(() => {
+      elapsed += TICK_MS
+      setProgress(Math.min((elapsed / SLIDE_DURATION_MS) * 100, 100))
+
+      if (elapsed >= SLIDE_DURATION_MS) {
+        elapsed = 0
+        setSlideIndex((prev) => {
+          const next = (prev + 1) % slidesRef.current.length
+          slideIndexRef.current = next
+          loadSlideData(slidesRef.current[next])
+          return next
+        })
+      }
+    }, TICK_MS)
+
+    return () => clearInterval(ticker)
+  }, [slides, loadSlideData])
+
+  // ─── Background data refresh on a separate interval ───────────────────────
+  useEffect(() => {
+    const refreshMs =
+      (localStorage.getItem('refresh_interval')
+        ? parseInt(localStorage.getItem('refresh_interval'))
+        : AppSettings.DEFAULT_INTERVAL) * 1000
+
+    const poller = setInterval(() => {
+      const current = slidesRef.current[slideIndexRef.current]
+      if (current) loadSlideData(current)
+    }, refreshMs)
+
+    return () => clearInterval(poller)
+  }, [loadSlideData])
+
+  // ─── Resolve user from clusterData ────────────────────────────────────────
+  useEffect(() => {
+    if (clusterData?.apiUsers) {
+      const username = localStorage.getItem('username')
+      const apiUser = clusterData.apiUsers[username] || clusterData.apiUsers[username?.toLowerCase()]
+      if (apiUser) setUser(apiUser)
+    }
+  }, [clusterData])
+
+  const currentSlide = slides[slideIndex]
+  const totalSlides = slides.length
+  const clusterCount = clusters?.length || 0
+
+  return (
+    <PageContainer>
+      {/* ── Header bar ─────────────────────────────────────── */}
+      <Flex
+        px={4}
+        py={2}
+        align='center'
+        justify='space-between'
+        borderBottom='1px solid'
+        borderColor='gray.200'>
+        <Text fontWeight='bold' fontSize='lg'>
+          {currentSlide?.clusterName || '…'}
+        </Text>
+        <Text fontSize='sm' textTransform='capitalize' color='gray.500'>
+          {currentSlide?.view === 'dashboard' ? 'Dashboard' : 'Maintenance'}
+        </Text>
+        <Text fontSize='xs' color='gray.400'>
+          {clusterCount > 0
+            ? `Cluster ${Math.floor(slideIndex / 2) + 1} of ${clusterCount}`
+            : 'Loading clusters…'}
+        </Text>
+      </Flex>
+
+      {/* ── Progress bar ───────────────────────────────────── */}
+      <Progress value={progress} size='xs' colorScheme='blue' borderRadius={0} />
+
+      {/* ── Slide content ──────────────────────────────────── */}
+      <Box px={4} py={4}>
+        {slides.length === 0 && (
+          <Text color='gray.400' textAlign='center' mt={8}>
+            Loading clusters…
+          </Text>
+        )}
+        {currentSlide?.view === 'dashboard' && (
+          <Dashboard selectedCluster={clusterData} user={user} />
+        )}
+        {currentSlide?.view === 'maintenance' && (
+          <Maintenance selectedCluster={clusterData} user={user} />
+        )}
+      </Box>
+    </PageContainer>
+  )
+}
+
+export default Slideshow

--- a/share/dashboard_react/src/Pages/Slideshow/index.jsx
+++ b/share/dashboard_react/src/Pages/Slideshow/index.jsx
@@ -82,7 +82,16 @@ function Slideshow() {
     if (!clusters || clusters.length === 0) return
     const built = []
     clusters.forEach((cl) => {
+      const hasBackup =
+        cl.config?.backupRestic ||
+        (cl.config?.backupPhysicalType && cl.config?.backupPhysicalType !== 'none') ||
+        (cl.config?.backupLogicalType && cl.config?.backupLogicalType !== 'none')
+      const hasScheduler = cl.config?.schedulerEnabled
+      const hasApps = cl.appServers?.length > 0
+
       SECTIONS.forEach(({ view, label }) => {
+        if (view === 'maintenance' && !hasBackup && !hasScheduler) return
+        if (view === 'apps' && !hasApps) return
         built.push({ clusterName: cl.name, view, label })
       })
     })
@@ -156,8 +165,14 @@ function Slideshow() {
 
   const currentSlide = slides[slideIndex]
   const clusterCount = clusters?.length || 0
-  const clusterIndex = clusterCount > 0 ? Math.floor(slideIndex / SECTIONS.length) + 1 : 0
-  const sectionIndex = (slideIndex % SECTIONS.length) + 1
+  // Derive per-cluster section position dynamically (clusters may have different section counts)
+  const clusterNames = [...new Set(slides.map((s) => s.clusterName))]
+  const clusterIndex = currentSlide ? clusterNames.indexOf(currentSlide.clusterName) + 1 : 0
+  const slidesForCluster = slides.filter((s) => s.clusterName === currentSlide?.clusterName)
+  const sectionIndex = currentSlide
+    ? slidesForCluster.findIndex((s) => s.view === currentSlide.view) + 1
+    : 0
+  const totalSections = slidesForCluster.length
 
   return (
     <PageContainer>
@@ -177,7 +192,7 @@ function Slideshow() {
         </Text>
         <Text fontSize='sm' color='gray.400'>
           {clusterCount > 0
-            ? `Cluster ${clusterIndex} of ${clusterCount} — section ${sectionIndex} of ${SECTIONS.length}`
+            ? `Cluster ${clusterIndex} of ${clusterCount} — section ${sectionIndex} of ${totalSections}`
             : 'Loading clusters…'}
         </Text>
       </Flex>

--- a/share/dashboard_react/src/Pages/Slideshow/index.jsx
+++ b/share/dashboard_react/src/Pages/Slideshow/index.jsx
@@ -217,8 +217,8 @@ function Slideshow() {
 
         {currentSlide?.view === 'cluster-ha' && clusterData && (
           <Flex gap='24px' direction={{ base: 'column', lg: 'row' }}>
-            <ClusterDetail selectedCluster={clusterData} user={user} />
-            <HADetail selectedCluster={clusterData} user={user} />
+            <ClusterDetail selectedCluster={clusterData} user={user} readOnly />
+            <HADetail selectedCluster={clusterData} user={user} readOnly />
           </Flex>
         )}
 

--- a/share/dashboard_react/src/Pages/Slideshow/index.jsx
+++ b/share/dashboard_react/src/Pages/Slideshow/index.jsx
@@ -33,12 +33,18 @@ const SLIDE_DURATION_MS = 15000
 
 // Sections shown per cluster in order
 const SECTIONS = [
-  { view: 'cluster-ha',        label: 'Cluster & HA' },
-  { view: 'servers-proxies',   label: 'Servers & Proxies' },
-  { view: 'apps',              label: 'Application Servers' },
-  { view: 'logs',              label: 'Logs' },
-  { view: 'maintenance',       label: 'Maintenance' },
+  { view: 'cluster-ha',         label: 'Cluster & HA' },
+  { view: 'servers',            label: 'Servers' },
+  { view: 'proxies',            label: 'Proxies' },
+  { view: 'apps',               label: 'Application Servers' },
+  { view: 'logs-cluster',       label: 'Cluster & Security Logs' },
+  { view: 'logs-workload',      label: 'Workload Logs' },
+  { view: 'maintenance-backup', label: 'Backup' },
+  { view: 'maintenance-jobs',   label: 'Scheduler Jobs' },
+  { view: 'logs-jobs',          label: 'Job Logs' },
 ]
+
+const MAINTENANCE_VIEWS = new Set(['maintenance-backup', 'maintenance-jobs', 'logs-jobs'])
 
 function Slideshow() {
   const dispatch = useDispatch()
@@ -67,7 +73,7 @@ function Slideshow() {
       dispatch(getClusterMaster({ clusterName }))
       dispatch(getClusterLogs({ clusterName }))
       dispatch(getClusterApps({ clusterName }))
-      if (view === 'maintenance') {
+      if (MAINTENANCE_VIEWS.has(view)) {
         dispatch(getResticSnapshot({ clusterName, filter: 'latest-per-session' }))
         dispatch(getBackups({ clusterName }))
         dispatch(getBackupStats({ clusterName }))
@@ -91,7 +97,7 @@ function Slideshow() {
       const hasApps = cl.appServers?.length > 0
 
       SECTIONS.forEach(({ view, label }) => {
-        if (view === 'maintenance' && !hasBackup && !hasScheduler) return
+        if (MAINTENANCE_VIEWS.has(view) && !hasBackup && !hasScheduler) return
         if (view === 'apps' && !hasApps) return
         built.push({ clusterName: cl.name, view, label })
       })
@@ -208,31 +214,47 @@ function Slideshow() {
             Loading clusters…
           </Text>
         )}
+
         {currentSlide?.view === 'cluster-ha' && clusterData && (
           <Flex gap='24px' direction={{ base: 'column', lg: 'row' }}>
             <ClusterDetail selectedCluster={clusterData} user={user} />
             <HADetail selectedCluster={clusterData} user={user} />
           </Flex>
         )}
-        {currentSlide?.view === 'servers-proxies' && clusterData && (
-          <Flex direction='column' gap='24px'>
-            <DBServers selectedCluster={clusterData} user={user} />
-            <Proxies selectedCluster={clusterData} user={user} />
-          </Flex>
+
+        {currentSlide?.view === 'servers' && clusterData && (
+          <DBServers selectedCluster={clusterData} user={user} />
         )}
+
+        {currentSlide?.view === 'proxies' && clusterData && (
+          <Proxies selectedCluster={clusterData} user={user} />
+        )}
+
         {currentSlide?.view === 'apps' && clusterData && (
           <Apps selectedCluster={clusterData} user={user} />
         )}
-        {currentSlide?.view === 'logs' && (
+
+        {currentSlide?.view === 'logs-cluster' && (
           <Flex direction='column' gap='8px'>
             <AccordionComponent heading='Cluster Logs' body={<GeneralLogs />} />
-            <AccordionComponent heading='Job Logs' body={<TaskLogs />} />
             <AccordionComponent heading='Security Logs' body={<SecurityLogs />} />
-            <AccordionComponent heading='Workload Logs' body={<WorkloadLogs />} />
           </Flex>
         )}
-        {currentSlide?.view === 'maintenance' && (
-          <Maintenance selectedCluster={clusterData} user={user} />
+
+        {currentSlide?.view === 'logs-workload' && (
+          <AccordionComponent heading='Workload Logs' body={<WorkloadLogs />} />
+        )}
+
+        {currentSlide?.view === 'maintenance-backup' && (
+          <Maintenance selectedCluster={clusterData} user={user} section='backup' />
+        )}
+
+        {currentSlide?.view === 'maintenance-jobs' && (
+          <Maintenance selectedCluster={clusterData} user={user} section='jobs' />
+        )}
+
+        {currentSlide?.view === 'logs-jobs' && (
+          <AccordionComponent heading='Job Logs' body={<TaskLogs />} />
         )}
       </Box>
     </PageContainer>

--- a/share/dashboard_react/src/Pages/Slideshow/index.jsx
+++ b/share/dashboard_react/src/Pages/Slideshow/index.jsx
@@ -51,6 +51,8 @@ function Slideshow() {
 
   const clusters = useSelector((state) => state.globalClusters.clusters)
   const clusterData = useSelector((state) => state.cluster.clusterData)
+  const clusterServers = useSelector((state) => state.cluster.clusterServers)
+  const clusterProxies = useSelector((state) => state.cluster.clusterProxies)
 
   const [slides, setSlides] = useState([]) // [{clusterName, view, label}]
   const [slideIndex, setSlideIndex] = useState(0)
@@ -222,12 +224,16 @@ function Slideshow() {
           </Flex>
         )}
 
-        {currentSlide?.view === 'servers' && clusterData && (
-          <DBServers selectedCluster={clusterData} user={user} />
+        {currentSlide?.view === 'servers' && (
+          clusterData && clusterServers?.length > 0
+            ? <DBServers selectedCluster={clusterData} user={user} />
+            : <Text color='gray.400' textAlign='center' mt={8}>Loading servers…</Text>
         )}
 
-        {currentSlide?.view === 'proxies' && clusterData && (
-          <Proxies selectedCluster={clusterData} user={user} />
+        {currentSlide?.view === 'proxies' && (
+          clusterData && clusterProxies?.length > 0
+            ? <Proxies selectedCluster={clusterData} user={user} />
+            : <Text color='gray.400' textAlign='center' mt={8}>Loading proxies…</Text>
         )}
 
         {currentSlide?.view === 'apps' && clusterData && (

--- a/share/dashboard_react/src/Pages/Slideshow/index.jsx
+++ b/share/dashboard_react/src/Pages/Slideshow/index.jsx
@@ -95,9 +95,11 @@ function Slideshow() {
     [dispatch]
   )
 
-  // ─── Build slides whenever cluster list changes ───────────────────────────
+  // ─── Build slides whenever cluster list or user grants change ────────────
   useEffect(() => {
     if (!clusters || clusters.length === 0) return
+    const canShowBackups = !user || user?.grants?.['cluster-show-backups']
+    const canShowJobs = !user || user?.grants?.['cluster-show-jobs'] || user?.grants?.['cluster-process']
     const built = []
     clusters.forEach((cl) => {
       const hasBackup =
@@ -110,6 +112,8 @@ function Slideshow() {
       SECTIONS.forEach(({ view, label }) => {
         if (MAINTENANCE_VIEWS.has(view) && !hasBackup && !hasScheduler) return
         if (view === 'apps' && !hasApps) return
+        if ((view === 'maintenance-backup') && !canShowBackups) return
+        if ((view === 'maintenance-jobs' || view === 'logs-jobs') && !canShowJobs) return
         built.push({ clusterName: cl.name, view, label })
       })
     })
@@ -131,7 +135,7 @@ function Slideshow() {
       slideIndexRef.current = 0
       loadSlideData(built[0])
     }
-  }, [clusters, loadSlideData])
+  }, [clusters, loadSlideData, user])
 
   // ─── Initial cluster list fetch ───────────────────────────────────────────
   useEffect(() => {

--- a/share/dashboard_react/src/Pages/Slideshow/index.jsx
+++ b/share/dashboard_react/src/Pages/Slideshow/index.jsx
@@ -156,12 +156,27 @@ function Slideshow() {
         : AppSettings.DEFAULT_INTERVAL) * 1000
 
     const poller = setInterval(() => {
+      // Always refresh cluster list so the slideshow recovers after a server restart
+      dispatch(getClusters({}))
+
       const current = slidesRef.current[slideIndexRef.current]
       if (current) loadSlideData(current)
     }, refreshMs)
 
     return () => clearInterval(poller)
   }, [loadSlideData])
+
+  // ─── Fast retry when no clusters loaded yet (handles server restart) ──────
+  // Polls every 5 s until slides are built, then stops polling.
+  useEffect(() => {
+    const retrier = setInterval(() => {
+      if (slidesRef.current.length === 0) {
+        dispatch(getClusters({}))
+        dispatch(getMonitoredData({}))
+      }
+    }, 5000)
+    return () => clearInterval(retrier)
+  }, [dispatch])
 
   // ─── Resolve user from clusterData ────────────────────────────────────────
   useEffect(() => {

--- a/share/dashboard_react/src/Pages/Slideshow/index.jsx
+++ b/share/dashboard_react/src/Pages/Slideshow/index.jsx
@@ -35,9 +35,8 @@ const SLIDE_DURATION_MS = 15000
 // Sections shown per cluster in order
 const SECTIONS = [
   { view: 'cluster-ha',         label: 'Cluster & HA' },
-  { view: 'servers',            label: 'Servers' },
+  { view: 'servers-proxies',    label: 'Servers & Proxies' },
   { view: 'servers-detail',     label: 'Server Details' },
-  { view: 'proxies',            label: 'Proxies' },
   { view: 'apps',               label: 'Application Servers' },
   { view: 'logs-cluster',       label: 'Cluster & Security Logs' },
   { view: 'logs-workload',      label: 'Workload Logs' },
@@ -258,10 +257,17 @@ function Slideshow() {
           </Flex>
         )}
 
-        {currentSlide?.view === 'servers' && (
-          clusterData && clusterServers?.length > 0
-            ? <DBServers selectedCluster={clusterData} user={user} />
-            : <Text color='gray.400' textAlign='center' mt={8}>Loading servers…</Text>
+        {currentSlide?.view === 'servers-proxies' && clusterData && (
+          <Flex direction='column' gap='16px'>
+            {clusterServers?.length > 0
+              ? <DBServers selectedCluster={clusterData} user={user} />
+              : <Text color='gray.400' textAlign='center'>Loading servers…</Text>
+            }
+            {clusterProxies?.length > 0
+              ? <Proxies selectedCluster={clusterData} user={user} />
+              : <Text color='gray.400' textAlign='center'>Loading proxies…</Text>
+            }
+          </Flex>
         )}
 
         {currentSlide?.view === 'servers-detail' && (
@@ -280,14 +286,9 @@ function Slideshow() {
                 openCompareModal={() => {}}
                 hasMariadbGtid={hasMariadbGtid}
                 hasMysqlGtid={hasMysqlGtid}
+                defaultOpenAll
               />
             : <Text color='gray.400' textAlign='center' mt={8}>Loading servers…</Text>
-        )}
-
-        {currentSlide?.view === 'proxies' && (
-          clusterData && clusterProxies?.length > 0
-            ? <Proxies selectedCluster={clusterData} user={user} />
-            : <Text color='gray.400' textAlign='center' mt={8}>Loading proxies…</Text>
         )}
 
         {currentSlide?.view === 'apps' && clusterData && (

--- a/share/dashboard_react/src/Pages/Slideshow/index.jsx
+++ b/share/dashboard_react/src/Pages/Slideshow/index.jsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Box, Flex, Progress, Text } from '@chakra-ui/react'
+import { HiPlay, HiStop } from 'react-icons/hi'
+import RMIconButton from '../../components/RMIconButton'
 import {
   getBackupStats,
   getBackups,
@@ -63,10 +65,12 @@ function Slideshow() {
   const [slideIndex, setSlideIndex] = useState(0)
   const [progress, setProgress] = useState(0)
   const [user, setUser] = useState(null)
+  const [isPaused, setIsPaused] = useState(false)
 
   // Refs for use inside intervals without stale closures
   const slidesRef = useRef([])
   const slideIndexRef = useRef(0)
+  const isPausedRef = useRef(false)
 
   // ─── Load all data for a given slide ─────────────────────────────────────
   const loadSlideData = useCallback(
@@ -139,6 +143,11 @@ function Slideshow() {
     dispatch(getMonitoredData({}))
   }, [])
 
+  // Keep isPausedRef in sync with state so the ticker can read it without stale closures
+  useEffect(() => {
+    isPausedRef.current = isPaused
+  }, [isPaused])
+
   // ─── Slideshow timer ──────────────────────────────────────────────────────
   // Runs once on mount. Uses slidesRef so the interval never restarts when
   // the slides state updates, keeping the elapsed counter stable.
@@ -148,6 +157,7 @@ function Slideshow() {
 
     const ticker = setInterval(() => {
       if (slidesRef.current.length === 0) return // clusters not loaded yet
+      if (isPausedRef.current) return // slideshow paused
 
       elapsed += TICK_MS
       setProgress(Math.min((elapsed / SLIDE_DURATION_MS) * 100, 100))
@@ -232,15 +242,22 @@ function Slideshow() {
         <Text fontSize='2xl' fontWeight='semibold' color='gray.500'>
           {currentSlide?.label || '…'}
         </Text>
-        <Text fontSize='sm' color='gray.400'>
-          {clusterCount > 0
-            ? `Cluster ${clusterIndex} of ${clusterCount} — section ${sectionIndex} of ${totalSections}`
-            : 'Loading clusters…'}
-        </Text>
+        <Flex align='center' gap={3}>
+          <Text fontSize='sm' color='gray.400'>
+            {clusterCount > 0
+              ? `Cluster ${clusterIndex} of ${clusterCount} — section ${sectionIndex} of ${totalSections}`
+              : 'Loading clusters…'}
+          </Text>
+          {isPaused ? (
+            <RMIconButton icon={HiPlay} tooltip='Resume slideshow' onClick={() => setIsPaused(false)} />
+          ) : (
+            <RMIconButton icon={HiStop} tooltip='Pause slideshow' onClick={() => setIsPaused(true)} />
+          )}
+        </Flex>
       </Flex>
 
       {/* ── Progress bar ───────────────────────────────────── */}
-      <Progress value={progress} size='xs' colorScheme='blue' borderRadius={0} />
+      <Progress value={progress} size='xs' colorScheme={isPaused ? 'gray' : 'blue'} borderRadius={0} />
 
       {/* ── Slide content ──────────────────────────────────── */}
       <Box px={4} py={4}>

--- a/share/dashboard_react/src/Pages/Slideshow/index.jsx
+++ b/share/dashboard_react/src/Pages/Slideshow/index.jsx
@@ -20,6 +20,7 @@ import { getClusters, getMonitoredData } from '../../redux/globalClustersSlice'
 import ClusterDetail from '../Dashboard/components/ClusterDetail'
 import HADetail from '../Dashboard/components/HADetail'
 import DBServers from '../Dashboard/components/DBServers'
+import DBServerGrid from '../Dashboard/components/DBServers/DBServerGrid'
 import Proxies from '../Dashboard/components/Proxies'
 import Apps from '../Dashboard/components/Apps'
 import { GeneralLogs, TaskLogs, SecurityLogs, WorkloadLogs } from '../Dashboard/components/Logs'
@@ -35,6 +36,7 @@ const SLIDE_DURATION_MS = 15000
 const SECTIONS = [
   { view: 'cluster-ha',         label: 'Cluster & HA' },
   { view: 'servers',            label: 'Servers' },
+  { view: 'servers-detail',     label: 'Server Details' },
   { view: 'proxies',            label: 'Proxies' },
   { view: 'apps',               label: 'Application Servers' },
   { view: 'logs-cluster',       label: 'Cluster & Security Logs' },
@@ -53,6 +55,10 @@ function Slideshow() {
   const clusterData = useSelector((state) => state.cluster.clusterData)
   const clusterServers = useSelector((state) => state.cluster.clusterServers)
   const clusterProxies = useSelector((state) => state.cluster.clusterProxies)
+  const clusterMaster = useSelector((state) => state.cluster.clusterMaster)
+
+  const hasMariadbGtid = clusterServers?.some((s) => s.haveMariadbGtid) ?? false
+  const hasMysqlGtid = clusterServers?.some((s) => s.haveMysqlGtid) ?? false
 
   const [slides, setSlides] = useState([]) // [{clusterName, view, label}]
   const [slideIndex, setSlideIndex] = useState(0)
@@ -242,6 +248,26 @@ function Slideshow() {
         {currentSlide?.view === 'servers' && (
           clusterData && clusterServers?.length > 0
             ? <DBServers selectedCluster={clusterData} user={user} />
+            : <Text color='gray.400' textAlign='center' mt={8}>Loading servers…</Text>
+        )}
+
+        {currentSlide?.view === 'servers-detail' && (
+          clusterData && clusterServers?.length > 0
+            ? <DBServerGrid
+                allDBServers={clusterServers}
+                clusterMasterId={clusterMaster?.id}
+                clusterName={clusterData.name}
+                backupLogicalType={clusterData.config?.backupLogicalType}
+                backupPhysicalType={clusterData.config?.backupPhysicalType}
+                backupRestic={clusterData.config?.backupRestic}
+                orchestrator={clusterData.config?.provOrchestrator}
+                user={user}
+                showTerminal={clusterData.config?.terminalSessionEnabled}
+                showTableView={() => {}}
+                openCompareModal={() => {}}
+                hasMariadbGtid={hasMariadbGtid}
+                hasMysqlGtid={hasMysqlGtid}
+              />
             : <Text color='gray.400' textAlign='center' mt={8}>Loading servers…</Text>
         )}
 

--- a/share/dashboard_react/src/Pages/Slideshow/index.jsx
+++ b/share/dashboard_react/src/Pages/Slideshow/index.jsx
@@ -28,17 +28,15 @@ import PageContainer from '../PageContainer'
 import { AppSettings } from '../../AppSettings'
 
 // Duration in milliseconds each slide is displayed
-const SLIDE_DURATION_MS = 5000
+const SLIDE_DURATION_MS = 15000
 
 // Sections shown per cluster in order
 const SECTIONS = [
-  { view: 'cluster-detail', label: 'Cluster' },
-  { view: 'ha-detail',      label: 'High Availability' },
-  { view: 'db-servers',     label: 'Database Servers' },
-  { view: 'proxies',        label: 'Proxies' },
-  { view: 'apps',           label: 'Application Servers' },
-  { view: 'logs',           label: 'Logs' },
-  { view: 'maintenance',    label: 'Maintenance' },
+  { view: 'cluster-ha',        label: 'Cluster & HA' },
+  { view: 'servers-proxies',   label: 'Servers & Proxies' },
+  { view: 'apps',              label: 'Application Servers' },
+  { view: 'logs',              label: 'Logs' },
+  { view: 'maintenance',       label: 'Maintenance' },
 ]
 
 function Slideshow() {
@@ -194,17 +192,17 @@ function Slideshow() {
             Loading clusters…
           </Text>
         )}
-        {currentSlide?.view === 'cluster-detail' && clusterData && (
-          <ClusterDetail selectedCluster={clusterData} user={user} />
+        {currentSlide?.view === 'cluster-ha' && clusterData && (
+          <Flex gap='24px' direction={{ base: 'column', lg: 'row' }}>
+            <ClusterDetail selectedCluster={clusterData} user={user} />
+            <HADetail selectedCluster={clusterData} user={user} />
+          </Flex>
         )}
-        {currentSlide?.view === 'ha-detail' && clusterData && (
-          <HADetail selectedCluster={clusterData} user={user} />
-        )}
-        {currentSlide?.view === 'db-servers' && clusterData && (
-          <DBServers selectedCluster={clusterData} user={user} />
-        )}
-        {currentSlide?.view === 'proxies' && clusterData && (
-          <Proxies selectedCluster={clusterData} user={user} />
+        {currentSlide?.view === 'servers-proxies' && clusterData && (
+          <Flex direction='column' gap='24px'>
+            <DBServers selectedCluster={clusterData} user={user} />
+            <Proxies selectedCluster={clusterData} user={user} />
+          </Flex>
         )}
         {currentSlide?.view === 'apps' && clusterData && (
           <Apps selectedCluster={clusterData} user={user} />

--- a/share/dashboard_react/src/Pages/Slideshow/index.jsx
+++ b/share/dashboard_react/src/Pages/Slideshow/index.jsx
@@ -53,7 +53,9 @@ function Slideshow() {
     // Reset to first slide when cluster list changes
     setSlideIndex(0)
     slideIndexRef.current = 0
-  }, [clusters])
+    // Kick off the first slide data load immediately
+    loadSlideData(built[0])
+  }, [clusters, loadSlideData])
 
   // ─── Initial cluster list fetch ───────────────────────────────────────────
   useEffect(() => {
@@ -89,16 +91,15 @@ function Slideshow() {
   )
 
   // ─── Slideshow timer ──────────────────────────────────────────────────────
+  // Runs once on mount. Uses slidesRef so the interval never restarts when
+  // the slides state updates, keeping the elapsed counter stable.
   useEffect(() => {
-    if (slides.length === 0) return
-
-    // Load data for the first slide immediately
-    loadSlideData(slides[0])
-
     let elapsed = 0
     const TICK_MS = 250
 
     const ticker = setInterval(() => {
+      if (slidesRef.current.length === 0) return // clusters not loaded yet
+
       elapsed += TICK_MS
       setProgress(Math.min((elapsed / SLIDE_DURATION_MS) * 100, 100))
 
@@ -114,7 +115,7 @@ function Slideshow() {
     }, TICK_MS)
 
     return () => clearInterval(ticker)
-  }, [slides, loadSlideData])
+  }, [loadSlideData])
 
   // ─── Background data refresh on a separate interval ───────────────────────
   useEffect(() => {

--- a/share/dashboard_react/src/Pages/Slideshow/index.jsx
+++ b/share/dashboard_react/src/Pages/Slideshow/index.jsx
@@ -110,11 +110,24 @@ function Slideshow() {
         built.push({ clusterName: cl.name, view, label })
       })
     })
+
+    // Only reset to slide 0 when the slide structure actually changes
+    // (cluster added/removed, or config that controls which sections appear).
+    // Routine getClusters polls return new array references even when data is
+    // identical, so comparing by reference would reset the index every few seconds.
+    const prev = slidesRef.current
+    const structurallyChanged =
+      built.length !== prev.length ||
+      built.some((s, i) => s.clusterName !== prev[i]?.clusterName || s.view !== prev[i]?.view)
+
     slidesRef.current = built
     setSlides(built)
-    setSlideIndex(0)
-    slideIndexRef.current = 0
-    loadSlideData(built[0])
+
+    if (structurallyChanged) {
+      setSlideIndex(0)
+      slideIndexRef.current = 0
+      loadSlideData(built[0])
+    }
   }, [clusters, loadSlideData])
 
   // ─── Initial cluster list fetch ───────────────────────────────────────────

--- a/share/dashboard_react/src/Pages/Slideshow/index.jsx
+++ b/share/dashboard_react/src/Pages/Slideshow/index.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { Box, Flex, Grid, Progress, Text } from '@chakra-ui/react'
+import { Box, Flex, Progress, Text } from '@chakra-ui/react'
 import {
   getBackupStats,
   getBackups,
@@ -25,6 +25,7 @@ import Apps from '../Dashboard/components/Apps'
 import { GeneralLogs, TaskLogs, SecurityLogs, WorkloadLogs } from '../Dashboard/components/Logs'
 import Maintenance from '../Maintenance'
 import PageContainer from '../PageContainer'
+import AccordionComponent from '../../components/AccordionComponent'
 import { AppSettings } from '../../AppSettings'
 
 // Duration in milliseconds each slide is displayed
@@ -223,24 +224,12 @@ function Slideshow() {
           <Apps selectedCluster={clusterData} user={user} />
         )}
         {currentSlide?.view === 'logs' && (
-          <Grid templateColumns='repeat(2, 1fr)' gap={4}>
-            <Box>
-              <Text fontWeight='semibold' fontSize='sm' mb={2} color='gray.600'>Cluster Logs</Text>
-              <GeneralLogs />
-            </Box>
-            <Box>
-              <Text fontWeight='semibold' fontSize='sm' mb={2} color='gray.600'>Job Logs</Text>
-              <TaskLogs />
-            </Box>
-            <Box>
-              <Text fontWeight='semibold' fontSize='sm' mb={2} color='gray.600'>Security Logs</Text>
-              <SecurityLogs />
-            </Box>
-            <Box>
-              <Text fontWeight='semibold' fontSize='sm' mb={2} color='gray.600'>Workload Logs</Text>
-              <WorkloadLogs />
-            </Box>
-          </Grid>
+          <Flex direction='column' gap='8px'>
+            <AccordionComponent heading='Cluster Logs' body={<GeneralLogs />} />
+            <AccordionComponent heading='Job Logs' body={<TaskLogs />} />
+            <AccordionComponent heading='Security Logs' body={<SecurityLogs />} />
+            <AccordionComponent heading='Workload Logs' body={<WorkloadLogs />} />
+          </Flex>
         )}
         {currentSlide?.view === 'maintenance' && (
           <Maintenance selectedCluster={clusterData} user={user} />

--- a/share/dashboard_react/src/Pages/Slideshow/index.jsx
+++ b/share/dashboard_react/src/Pages/Slideshow/index.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { Box, Flex, Progress, Text } from '@chakra-ui/react'
+import { Box, Flex, Grid, Progress, Text } from '@chakra-ui/react'
 import {
   getBackupStats,
   getBackups,
@@ -17,13 +17,29 @@ import {
   setRefreshInterval
 } from '../../redux/clusterSlice'
 import { getClusters, getMonitoredData } from '../../redux/globalClustersSlice'
-import Dashboard from '../Dashboard'
+import ClusterDetail from '../Dashboard/components/ClusterDetail'
+import HADetail from '../Dashboard/components/HADetail'
+import DBServers from '../Dashboard/components/DBServers'
+import Proxies from '../Dashboard/components/Proxies'
+import Apps from '../Dashboard/components/Apps'
+import { GeneralLogs, TaskLogs, SecurityLogs, WorkloadLogs } from '../Dashboard/components/Logs'
 import Maintenance from '../Maintenance'
 import PageContainer from '../PageContainer'
 import { AppSettings } from '../../AppSettings'
 
 // Duration in milliseconds each slide is displayed
-const SLIDE_DURATION_MS = 30000
+const SLIDE_DURATION_MS = 5000
+
+// Sections shown per cluster in order
+const SECTIONS = [
+  { view: 'cluster-detail', label: 'Cluster' },
+  { view: 'ha-detail',      label: 'High Availability' },
+  { view: 'db-servers',     label: 'Database Servers' },
+  { view: 'proxies',        label: 'Proxies' },
+  { view: 'apps',           label: 'Application Servers' },
+  { view: 'logs',           label: 'Logs' },
+  { view: 'maintenance',    label: 'Maintenance' },
+]
 
 function Slideshow() {
   const dispatch = useDispatch()
@@ -31,7 +47,7 @@ function Slideshow() {
   const clusters = useSelector((state) => state.globalClusters.clusters)
   const clusterData = useSelector((state) => state.cluster.clusterData)
 
-  const [slides, setSlides] = useState([]) // [{clusterName, view}]
+  const [slides, setSlides] = useState([]) // [{clusterName, view, label}]
   const [slideIndex, setSlideIndex] = useState(0)
   const [progress, setProgress] = useState(0)
   const [user, setUser] = useState(null)
@@ -68,8 +84,9 @@ function Slideshow() {
     if (!clusters || clusters.length === 0) return
     const built = []
     clusters.forEach((cl) => {
-      built.push({ clusterName: cl.name, view: 'dashboard' })
-      built.push({ clusterName: cl.name, view: 'maintenance' })
+      SECTIONS.forEach(({ view, label }) => {
+        built.push({ clusterName: cl.name, view, label })
+      })
     })
     slidesRef.current = built
     setSlides(built)
@@ -140,8 +157,9 @@ function Slideshow() {
   }, [clusterData])
 
   const currentSlide = slides[slideIndex]
-  const totalSlides = slides.length
   const clusterCount = clusters?.length || 0
+  const clusterIndex = clusterCount > 0 ? Math.floor(slideIndex / SECTIONS.length) + 1 : 0
+  const sectionIndex = (slideIndex % SECTIONS.length) + 1
 
   return (
     <PageContainer>
@@ -156,12 +174,12 @@ function Slideshow() {
         <Text fontWeight='bold' fontSize='lg'>
           {currentSlide?.clusterName || '…'}
         </Text>
-        <Text fontSize='sm' textTransform='capitalize' color='gray.500'>
-          {currentSlide?.view === 'dashboard' ? 'Dashboard' : 'Maintenance'}
+        <Text fontSize='sm' color='gray.500'>
+          {currentSlide?.label || '…'}
         </Text>
         <Text fontSize='xs' color='gray.400'>
           {clusterCount > 0
-            ? `Cluster ${Math.floor(slideIndex / 2) + 1} of ${clusterCount}`
+            ? `Cluster ${clusterIndex} of ${clusterCount} — section ${sectionIndex} of ${SECTIONS.length}`
             : 'Loading clusters…'}
         </Text>
       </Flex>
@@ -176,8 +194,40 @@ function Slideshow() {
             Loading clusters…
           </Text>
         )}
-        {currentSlide?.view === 'dashboard' && (
-          <Dashboard selectedCluster={clusterData} user={user} />
+        {currentSlide?.view === 'cluster-detail' && clusterData && (
+          <ClusterDetail selectedCluster={clusterData} user={user} />
+        )}
+        {currentSlide?.view === 'ha-detail' && clusterData && (
+          <HADetail selectedCluster={clusterData} user={user} />
+        )}
+        {currentSlide?.view === 'db-servers' && clusterData && (
+          <DBServers selectedCluster={clusterData} user={user} />
+        )}
+        {currentSlide?.view === 'proxies' && clusterData && (
+          <Proxies selectedCluster={clusterData} user={user} />
+        )}
+        {currentSlide?.view === 'apps' && clusterData && (
+          <Apps selectedCluster={clusterData} user={user} />
+        )}
+        {currentSlide?.view === 'logs' && (
+          <Grid templateColumns='repeat(2, 1fr)' gap={4}>
+            <Box>
+              <Text fontWeight='semibold' fontSize='sm' mb={2} color='gray.600'>Cluster Logs</Text>
+              <GeneralLogs />
+            </Box>
+            <Box>
+              <Text fontWeight='semibold' fontSize='sm' mb={2} color='gray.600'>Job Logs</Text>
+              <TaskLogs />
+            </Box>
+            <Box>
+              <Text fontWeight='semibold' fontSize='sm' mb={2} color='gray.600'>Security Logs</Text>
+              <SecurityLogs />
+            </Box>
+            <Box>
+              <Text fontWeight='semibold' fontSize='sm' mb={2} color='gray.600'>Workload Logs</Text>
+              <WorkloadLogs />
+            </Box>
+          </Grid>
         )}
         {currentSlide?.view === 'maintenance' && (
           <Maintenance selectedCluster={clusterData} user={user} />

--- a/share/dashboard_react/src/Pages/Slideshow/index.jsx
+++ b/share/dashboard_react/src/Pages/Slideshow/index.jsx
@@ -40,33 +40,6 @@ function Slideshow() {
   const slidesRef = useRef([])
   const slideIndexRef = useRef(0)
 
-  // ─── Build slides whenever cluster list changes ───────────────────────────
-  useEffect(() => {
-    if (!clusters || clusters.length === 0) return
-    const built = []
-    clusters.forEach((cl) => {
-      built.push({ clusterName: cl.name, view: 'dashboard' })
-      built.push({ clusterName: cl.name, view: 'maintenance' })
-    })
-    slidesRef.current = built
-    setSlides(built)
-    // Reset to first slide when cluster list changes
-    setSlideIndex(0)
-    slideIndexRef.current = 0
-    // Kick off the first slide data load immediately
-    loadSlideData(built[0])
-  }, [clusters, loadSlideData])
-
-  // ─── Initial cluster list fetch ───────────────────────────────────────────
-  useEffect(() => {
-    const interval = localStorage.getItem('refresh_interval')
-      ? parseInt(localStorage.getItem('refresh_interval'))
-      : AppSettings.DEFAULT_INTERVAL
-    dispatch(setRefreshInterval({ interval }))
-    dispatch(getClusters({}))
-    dispatch(getMonitoredData({}))
-  }, [])
-
   // ─── Load all data for a given slide ─────────────────────────────────────
   const loadSlideData = useCallback(
     (slide) => {
@@ -89,6 +62,31 @@ function Slideshow() {
     },
     [dispatch]
   )
+
+  // ─── Build slides whenever cluster list changes ───────────────────────────
+  useEffect(() => {
+    if (!clusters || clusters.length === 0) return
+    const built = []
+    clusters.forEach((cl) => {
+      built.push({ clusterName: cl.name, view: 'dashboard' })
+      built.push({ clusterName: cl.name, view: 'maintenance' })
+    })
+    slidesRef.current = built
+    setSlides(built)
+    setSlideIndex(0)
+    slideIndexRef.current = 0
+    loadSlideData(built[0])
+  }, [clusters, loadSlideData])
+
+  // ─── Initial cluster list fetch ───────────────────────────────────────────
+  useEffect(() => {
+    const interval = localStorage.getItem('refresh_interval')
+      ? parseInt(localStorage.getItem('refresh_interval'))
+      : AppSettings.DEFAULT_INTERVAL
+    dispatch(setRefreshInterval({ interval }))
+    dispatch(getClusters({}))
+    dispatch(getMonitoredData({}))
+  }, [])
 
   // ─── Slideshow timer ──────────────────────────────────────────────────────
   // Runs once on mount. Uses slidesRef so the interval never restarts when

--- a/share/dashboard_react/src/components/MenuOptions/index.jsx
+++ b/share/dashboard_react/src/components/MenuOptions/index.jsx
@@ -93,7 +93,7 @@ function MenuOptions({
                       if (event) {
                         event.stopPropagation()
                       }
-                      if (subMenuOption?.onClick) {
+                      if (!subMenuOption.isDisabled && subMenuOption?.onClick) {
                         subMenuOption.onClick()
                       }
                     }}
@@ -113,7 +113,9 @@ function MenuOptions({
                       if (event) {
                         event.stopPropagation()
                       }
-                      option.onClick()
+                      if (!option.isDisabled) {
+                        option.onClick()
+                      }
                     }
                   }
                 : {})}

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -136,7 +136,7 @@ function Navbar({ username }) {
         </Link>
         <Spacer />
 
-        {isAuthorized() && isDesktop && <RefreshCounter clusterName={clusterData?.name} />}
+        {isAuthorized() && isDesktop && location.pathname !== '/slideshow' && <RefreshCounter clusterName={clusterData?.name} />}
 
 
         <Spacer />
@@ -251,7 +251,7 @@ function Navbar({ username }) {
 
       <MattermostIntegration isOpen={isChatOpen} setIsChatOpen={setIsChatOpen} onClose={() => setIsChatOpen(false)} cloud18={monitor?.config?.cloud18} />
 
-      {isAuthorized() && !isDesktop && (
+      {isAuthorized() && !isDesktop && location.pathname !== '/slideshow' && (
         <Box mx='auto' p='8px' marginTop='60px'>
           <RefreshCounter clusterName={clusterData?.name} />
         </Box>

--- a/share/dashboard_react/src/redux/authSlice.js
+++ b/share/dashboard_react/src/redux/authSlice.js
@@ -75,6 +75,7 @@ export const authSlice = createSlice({
     logout: (state, action) => {
       clearLocalStorageByPrefix('user_token')
       localStorage.removeItem('username')
+      sessionStorage.removeItem('meet_unavailable')
       state.user = null
       state.isLogged = false
     },

--- a/share/dashboard_react/src/redux/meetSlice.js
+++ b/share/dashboard_react/src/redux/meetSlice.js
@@ -11,11 +11,11 @@ export const getMeetInfo = createAsyncThunk('meet/getMeetInfo', async (_, thunkA
     throw error; // Ensure the error is thrown to trigger the rejected state
   }
 },
-// Add a condition to prevent the action from being dispatched if the user is already fetching the info
+// Add a condition to prevent the action from being dispatched if already fetching or previously failed
 {
   condition: (_, { getState }) => {
     const { meet } = getState();
-    if (meet.isFetchingInfo) {
+    if (meet.isFetchingInfo || meet.meetError) {
       return false;
     }
   }

--- a/share/dashboard_react/src/redux/meetSlice.js
+++ b/share/dashboard_react/src/redux/meetSlice.js
@@ -282,6 +282,7 @@ const meetSlice = createSlice({
         state.isFetchingInfo = true;
       })
       .addCase(getMeetInfo.fulfilled, (state, action) => {
+        sessionStorage.removeItem(MEET_UNAVAILABLE_KEY);
         state.meetInfo = action.payload.data;
         //localStorage.setItem('userID', state.meetInfo?.user_id);
         state.unreadMessagesByChannel = action.payload.data.unread_messages_by_channel || {};
@@ -309,10 +310,11 @@ const meetSlice = createSlice({
         state.messages = {};
         state.unreadMessagesByChannel = {};
         state.channels = [];
+        state.meetError = false;
         localStorage.removeItem('userID');
         localStorage.removeItem('chatOpen');
         localStorage.removeItem('selectedChannel');
-        // Handle successful logout if needed
+        sessionStorage.removeItem(MEET_UNAVAILABLE_KEY);
       })
       .addCase(logoutFromMeet.rejected, (state, action) => {
         state.loading = false;

--- a/share/dashboard_react/src/redux/meetSlice.js
+++ b/share/dashboard_react/src/redux/meetSlice.js
@@ -2,20 +2,28 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import { handleError, showErrorBanner, showSuccessBanner } from '../utility/common';
 import { meetService } from '../services/meetService';
 
+const MEET_UNAVAILABLE_KEY = 'meet_unavailable'
+
 export const getMeetInfo = createAsyncThunk('meet/getMeetInfo', async (_, thunkAPI) => {
   try {
     const { data, status } = await meetService.getMeetInfo();
     return { data, status };
   } catch (error) {
-    handleError(error, thunkAPI);
-    throw error; // Ensure the error is thrown to trigger the rejected state
+    // Use rejectWithValue instead of throw to avoid console noise for expected
+    // failures (e.g. viewer tokens that have no meet user ID).
+    return thunkAPI.rejectWithValue({ errorMessage: error.message, errorStatus: error.errorStatus || 500 })
   }
 },
-// Add a condition to prevent the action from being dispatched if already fetching or previously failed
 {
   condition: (_, { getState }) => {
     const { meet } = getState();
+    // Block if already fetching or Redux state records a previous failure
     if (meet.isFetchingInfo || meet.meetError) {
+      return false;
+    }
+    // Also block if a previous failure was recorded in sessionStorage
+    // (survives Redux resets caused by re-login after server restart)
+    if (sessionStorage.getItem(MEET_UNAVAILABLE_KEY) === 'true') {
       return false;
     }
   }
@@ -292,6 +300,8 @@ const meetSlice = createSlice({
         state.meetError = true;
         state.meetInfo = null;
         state.isFetchingInfo = false;
+        // Persist failure so re-login/Redux-reset cycles don't retry needlessly
+        sessionStorage.setItem(MEET_UNAVAILABLE_KEY, 'true');
       })
       .addCase(logoutFromMeet.fulfilled, (state, action) => {
         state.loading = false;

--- a/share/dashboard_react/src/services/meetService.js
+++ b/share/dashboard_react/src/services/meetService.js
@@ -20,16 +20,13 @@ export const meetService = {
 
 
 async function getMeetInfo() {
-    try {
-        const response = await meetApi.get('info');
-        if (response.status !== 200) {
-            throw new Error(`Error fetching meet info: ${response.status} ${response.data}`);
-        }
-        return response;
-    } catch (error) {
-        console.error('Error fetching meet info:', error);
-        throw error;
+    const response = await meetApi.get('info');
+    if (response.status !== 200) {
+        const err = new Error(`Error fetching meet info: ${response.status} ${response.data}`);
+        err.errorStatus = response.status;
+        throw err;
     }
+    return response;
 }
 
 async function postMeetMessageOnChannel(channelId, message) {

--- a/share/dashboard_react/src/utility/common.js
+++ b/share/dashboard_react/src/utility/common.js
@@ -94,6 +94,7 @@ export const padWithZero = (number) => {
 }
 
 export const formatBytes = (bytes, decimals = 2) => {
+  if (bytes == null || isNaN(bytes)) return '—'
   if (bytes === 0) return '0 Bytes'
 
   const k = 1024
@@ -237,6 +238,7 @@ export const getColorFromServerStatus = (status) => {
 }
 
 export const sizeOf = function (bytes) {
+  if (bytes == null || isNaN(bytes)) { return '—'; }
   if (bytes == 0) { return "0.00 B"; }
   var e = Math.floor(Math.log(bytes) / Math.log(1024));
   return (bytes/Math.pow(1024, e)).toFixed(2)+' '+' KMGTP'.charAt(e)+'B';

--- a/share/dashboard_react/src/utility/common.js
+++ b/share/dashboard_react/src/utility/common.js
@@ -147,9 +147,11 @@ export const getBackupStrategy = (strategyId) => {
 }
 
 export const formatDate = (date, format) => {
+  if (!date) return ''
   if (typeof date === 'string') {
     date = new Date(date)
   }
+  if (!(date instanceof Date) || isNaN(date.getTime())) return ''
   const year = date.getFullYear()
   const month = String(date.getMonth() + 1).padStart(2, '0') // Months are zero-based
   const day = String(date.getDate()).padStart(2, '0')


### PR DESCRIPTION
## Summary

- **Auto-login & slideshow**: adds `/dashboard` auto-login route and `/slideshow` NOC page that cycles through all cluster sections; handles auth loss, server restarts, and viewer tokens cleanly
- **Grant hardening**: fixes grant checks across all menus (cluster, server, proxy); prevents cluster-level config from escalating main-config grants; adds `cluster-show-jobs` read-only grant for job visibility without write access
- **Slideshow UX**: pause/resume button in header; auto-refresh controls hidden on slideshow route; slides filtered by user grants (backup, jobs); 15 s per slide with progress bar

## Key commits

- `f4223dc78` Add api-autologin endpoint
- `92a5ba753` / `7004230ea` Add `/dashboard` and `/slideshow` routes
- `5431c457b` / `Ded557a2c` / `bf7afde13` Grant-based menu disabling across cluster, server, proxy menus
- `f8a1e58d7` Fix grant escalation: main config always authoritative over cluster-level config
- `cb19a21eb` Slideshow pause/resume; hide navbar auto-refresh controls
- `92b02a3c6` Add `cluster-show-jobs` grant; filter slideshow slides by user grants

## Test plan

- [ ] Auto-login via `/dashboard` with `api-dashboard-user` configured — should land on `/slideshow`
- [ ] Viewer user with `show cluster-show` — cluster HA/servers/proxies slides visible, backup/jobs slides hidden
- [ ] Viewer with `cluster-show-backups cluster-show-jobs` added — backup and jobs slides appear
- [ ] Pause button freezes progress bar and slide advance; Resume continues from same position
- [ ] Navbar refresh counter absent on `/slideshow`, present on all other pages
- [ ] Main config `cluster-show` grant cannot be overridden by cluster-level `cluster` broad grant
- [ ] Action menu items (switchover, failover, provision, etc.) disabled for viewer, enabled for admin