### PR TITLE
feat: add terminal-app access for OpenSVC app shells

### DIFF
--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -294,6 +294,7 @@ var terminalACLRules = []ACLRule{
 	{"/api/terminal/list", nil, []string{config.GrantTerminalGlobal}},
 	{"/servers", nil, []string{config.GrantTerminalDatabase}},
 	{"/proxies", nil, []string{config.GrantTerminalProxy}},
+	{"/apps", nil, []string{config.GrantTerminalApp}},
 }
 
 // checkACLRule checks if a user has the required grants for a specific rule

--- a/cluster/cluster_acl_test.go
+++ b/cluster/cluster_acl_test.go
@@ -961,13 +961,14 @@ func TestIsURLPassACLTerminalAccess(t *testing.T) {
 		{"Terminal - proxy denied to db user", "terminal_db", "/api/terminal/proxies/proxy1", false},
 
 		// App terminal access
-		{"Terminal - app", "terminal_app", "/api/terminal/apps/app1", true},
-		{"Terminal - app denied to proxy user", "terminal_proxy", "/api/terminal/apps/app1", false},
+		{"Terminal - app", "terminal_app", "/api/terminal/connect/clusters/test/apps/app1", true},
+		{"Terminal - app denied to proxy user", "terminal_proxy", "/api/terminal/connect/clusters/test/apps/app1", false},
+		{"Terminal - global user on app route", "terminal_global", "/api/terminal/connect/clusters/test/apps/app1", true},
 
 		// No terminal access
 		{"Terminal - denied without grant", "no_terminal", "/api/terminal/connect", false},
 		{"Terminal - denied without grant servers", "no_terminal", "/api/terminal/servers/server1", false},
-		{"Terminal - denied without grant apps", "no_terminal", "/api/terminal/apps/app1", false},
+		{"Terminal - denied without grant apps", "no_terminal", "/api/terminal/connect/clusters/test/apps/app1", false},
 	}
 
 	for _, tt := range tests {

--- a/cluster/cluster_acl_test.go
+++ b/cluster/cluster_acl_test.go
@@ -933,6 +933,10 @@ func TestIsURLPassACLTerminalAccess(t *testing.T) {
 		User:   "terminal_proxy",
 		Grants: map[string]bool{config.GrantTerminalProxy: true},
 	}
+	cluster.APIUsers["terminal_app"] = APIUser{
+		User:   "terminal_app",
+		Grants: map[string]bool{config.GrantTerminalApp: true},
+	}
 	cluster.APIUsers["no_terminal"] = APIUser{
 		User:   "no_terminal",
 		Grants: map[string]bool{config.GrantDBStart: true},
@@ -956,9 +960,14 @@ func TestIsURLPassACLTerminalAccess(t *testing.T) {
 		{"Terminal - proxy", "terminal_proxy", "/api/terminal/proxies/proxy1", true},
 		{"Terminal - proxy denied to db user", "terminal_db", "/api/terminal/proxies/proxy1", false},
 
+		// App terminal access
+		{"Terminal - app", "terminal_app", "/api/terminal/apps/app1", true},
+		{"Terminal - app denied to proxy user", "terminal_proxy", "/api/terminal/apps/app1", false},
+
 		// No terminal access
 		{"Terminal - denied without grant", "no_terminal", "/api/terminal/connect", false},
 		{"Terminal - denied without grant servers", "no_terminal", "/api/terminal/servers/server1", false},
+		{"Terminal - denied without grant apps", "no_terminal", "/api/terminal/apps/app1", false},
 	}
 
 	for _, tt := range tests {

--- a/config/grants.go
+++ b/config/grants.go
@@ -146,6 +146,7 @@ const (
 
 	GrantTerminalDatabase string = "terminal-db"
 	GrantTerminalProxy    string = "terminal-proxy"
+	GrantTerminalApp      string = "terminal-app"
 	GrantTerminalGlobal   string = "terminal-global" // Can use global terminal
 )
 
@@ -244,6 +245,7 @@ func GetGrantType() map[string]string {
 		GrantShow:                      GrantShow,
 		GrantTerminalDatabase:          GrantTerminalDatabase,
 		GrantTerminalProxy:             GrantTerminalProxy,
+		GrantTerminalApp:               GrantTerminalApp,
 		GrantTerminalGlobal:            GrantTerminalGlobal,
 	}
 }
@@ -451,6 +453,7 @@ func GetGrantTerminal() []string {
 	return []string{
 		GrantTerminalDatabase,
 		GrantTerminalProxy,
+		GrantTerminalApp,
 		GrantTerminalGlobal,
 	}
 }

--- a/server/api.go
+++ b/server/api.go
@@ -1944,15 +1944,17 @@ func logResponse(resp *http.Response) {
 // @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
 // @Param clusterName path string false "Cluster Name"
 // @Param serverName path string false "Server Name"
-// @Param rid query string false "OpenSVC server bash terminal container RID (allowed: container#db, container#jobs)"
+// @Param rid query string false "OpenSVC bash terminal container RID (server allowed: container#db, container#jobs; app allowed: container#app)"
 // @Success 200 {string} string "Connected successfully"
 // @Failure 400 {string} string "No user provided"
 // @Failure 500 {string} string "No valid node" or "No valid cluster"
 // @Router /api/terminal/connect [get]
 // @Router /api/terminal/connect/clusters/{clusterName}/servers/{serverName} [get]
 // @Router /api/terminal/connect/clusters/{clusterName}/proxies/{serverName} [get]
+// @Router /api/terminal/connect/clusters/{clusterName}/apps/{serverName} [get]
 // @Router /api/terminal/connect/clusters/{clusterName}/servers/{serverName}/{command} [get]
 // @Router /api/terminal/connect/clusters/{clusterName}/proxies/{serverName}/{command} [get]
+// @Router /api/terminal/connect/clusters/{clusterName}/apps/{serverName}/{command} [get]
 func (repman *ReplicationManager) handlerTerminal(w http.ResponseWriter, r *http.Request) {
 	defer repman.LogPanicToFile()
 
@@ -1960,6 +1962,7 @@ func (repman *ReplicationManager) handlerTerminal(w http.ResponseWriter, r *http
 	var mycluster *cluster.Cluster
 	var node *cluster.ServerMonitor
 	var proxy cluster.DatabaseProxy
+	var appTarget *cluster.App
 
 	vars := mux.Vars(r)
 	path := r.URL.Path
@@ -2063,10 +2066,17 @@ func (repman *ReplicationManager) handlerTerminal(w http.ResponseWriter, r *http
 		} else if proxy != nil {
 			sessionID = mycluster.Name + "-" + proxy.GetName()
 		} else {
+			appTarget = mycluster.GetAppFromName(vars["serverName"])
+			if appTarget != nil {
+				sessionID = mycluster.Name + "-" + appTarget.GetName()
+			}
+		}
+		if node == nil && proxy == nil && appTarget == nil {
 			session.SafeWriteMessage(websocket.TextMessage, []byte("No valid node\n"))
 			return
+		} else {
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Terminal session started for user %s on cluster %s", plainuser, mycluster.Name)
 		}
-		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Terminal session started for user %s on cluster %s", plainuser, mycluster.Name)
 
 	}
 
@@ -2104,14 +2114,23 @@ func (repman *ReplicationManager) handlerTerminal(w http.ResponseWriter, r *http
 			err = repman.SetSessionValuesFromNode(session, node)
 		} else if proxy != nil {
 			err = repman.SetSessionValuesFromProxy(session, proxy)
+		} else if appTarget != nil {
+			err = repman.SetSessionValuesFromApp(session, appTarget)
 		}
 		if err != nil {
-			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Error setting session values from node: %v", err)
-			session.SafeWriteMessage(websocket.TextMessage, []byte("Failed to set session values from node\n"))
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Error setting session values from terminal target: %v", err)
+			session.SafeWriteMessage(websocket.TextMessage, []byte("Failed to set session values from terminal target\n"))
 			return
 		}
 
-		selectedRID, shouldSetRID, err := resolveTerminalContainerRIDForSession(node != nil, session.CmdType, session.Orchestrator, r.URL.Query().Get("rid"))
+		targetKind := terminalTargetProxy
+		if node != nil {
+			targetKind = terminalTargetServer
+		} else if appTarget != nil {
+			targetKind = terminalTargetApp
+		}
+
+		selectedRID, shouldSetRID, err := resolveTerminalContainerRIDForSession(targetKind, session.CmdType, session.Orchestrator, r.URL.Query().Get("rid"))
 		if err != nil {
 			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Terminal session rid validation failed: %v", err)
 			session.SafeWriteMessage(websocket.TextMessage, []byte("Invalid rid parameter: "+err.Error()+"\n"))

--- a/server/api.go
+++ b/server/api.go
@@ -1947,14 +1947,14 @@ func logResponse(resp *http.Response) {
 // @Param rid query string false "OpenSVC bash terminal container RID (server allowed: container#db, container#jobs; app allowed: container#app)"
 // @Success 200 {string} string "Connected successfully"
 // @Failure 400 {string} string "No user provided"
-// @Failure 500 {string} string "No valid node" or "No valid cluster"
+// @Failure 500 {string} string "No valid terminal target" or "No valid cluster"
 // @Router /api/terminal/connect [get]
 // @Router /api/terminal/connect/clusters/{clusterName}/servers/{serverName} [get]
 // @Router /api/terminal/connect/clusters/{clusterName}/proxies/{serverName} [get]
-// @Router /api/terminal/connect/clusters/{clusterName}/apps/{serverName} [get]
+// @Router /api/terminal/connect/clusters/{clusterName}/apps/{appName} [get]
 // @Router /api/terminal/connect/clusters/{clusterName}/servers/{serverName}/{command} [get]
 // @Router /api/terminal/connect/clusters/{clusterName}/proxies/{serverName}/{command} [get]
-// @Router /api/terminal/connect/clusters/{clusterName}/apps/{serverName}/{command} [get]
+// @Router /api/terminal/connect/clusters/{clusterName}/apps/{appName}/{command} [get]
 func (repman *ReplicationManager) handlerTerminal(w http.ResponseWriter, r *http.Request) {
 	defer repman.LogPanicToFile()
 
@@ -2059,24 +2059,28 @@ func (repman *ReplicationManager) handlerTerminal(w http.ResponseWriter, r *http
 			return
 		}
 
-		node = mycluster.GetServerFromName(vars["serverName"])
-		proxy = mycluster.GetProxyFromName(vars["serverName"])
+		targetName := vars["serverName"]
+		if targetName == "" {
+			targetName = vars["appName"]
+		}
+
+		node = mycluster.GetServerFromName(targetName)
+		proxy = mycluster.GetProxyFromName(targetName)
 		if node != nil {
 			sessionID = mycluster.Name + "-" + node.Name
 		} else if proxy != nil {
 			sessionID = mycluster.Name + "-" + proxy.GetName()
 		} else {
-			appTarget = mycluster.GetAppFromName(vars["serverName"])
+			appTarget = mycluster.GetAppFromName(targetName)
 			if appTarget != nil {
 				sessionID = mycluster.Name + "-" + appTarget.GetName()
 			}
 		}
 		if node == nil && proxy == nil && appTarget == nil {
-			session.SafeWriteMessage(websocket.TextMessage, []byte("No valid node\n"))
+			session.SafeWriteMessage(websocket.TextMessage, []byte("No valid terminal target\n"))
 			return
-		} else {
-			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Terminal session started for user %s on cluster %s", plainuser, mycluster.Name)
 		}
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Terminal session started for user %s on cluster %s", plainuser, mycluster.Name)
 
 	}
 

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -189,6 +189,12 @@ func (repman *ReplicationManager) apiAppProtectedHandler(router *mux.Router) {
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxAppTemplateContentCreateLocalCopy)),
 	))
+	router.Handle("/api/terminal/connect/clusters/{clusterName}/apps/{serverName}", negroni.New(
+		negroni.Wrap(http.HandlerFunc(repman.handlerTerminal)),
+	))
+	router.Handle("/api/terminal/connect/clusters/{clusterName}/apps/{serverName}/{command}", negroni.New(
+		negroni.Wrap(http.HandlerFunc(repman.handlerTerminal)),
+	))
 }
 
 type appTemplateSummary struct {

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -189,10 +189,10 @@ func (repman *ReplicationManager) apiAppProtectedHandler(router *mux.Router) {
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxAppTemplateContentCreateLocalCopy)),
 	))
-	router.Handle("/api/terminal/connect/clusters/{clusterName}/apps/{serverName}", negroni.New(
+	router.Handle("/api/terminal/connect/clusters/{clusterName}/apps/{appName}", negroni.New(
 		negroni.Wrap(http.HandlerFunc(repman.handlerTerminal)),
 	))
-	router.Handle("/api/terminal/connect/clusters/{clusterName}/apps/{serverName}/{command}", negroni.New(
+	router.Handle("/api/terminal/connect/clusters/{clusterName}/apps/{appName}/{command}", negroni.New(
 		negroni.Wrap(http.HandlerFunc(repman.handlerTerminal)),
 	))
 }

--- a/server/server_tty.go
+++ b/server/server_tty.go
@@ -14,6 +14,11 @@ import (
 const (
 	defaultServerServiceContainer = "container#db"
 	defaultProxyServiceContainer  = "container#prx"
+	defaultAppServiceContainer    = "container#app"
+
+	terminalTargetServer = "server"
+	terminalTargetProxy  = "proxy"
+	terminalTargetApp    = "app"
 )
 
 // resolveOpenSVCTerminalContainerRID validates and resolves the target OpenSVC
@@ -30,28 +35,52 @@ func resolveOpenSVCTerminalContainerRID(rid string) (string, error) {
 	}
 }
 
+func resolveOpenSVCAppTerminalContainerRID(rid string) (string, error) {
+	switch rid {
+	case defaultAppServiceContainer:
+		return rid, nil
+	default:
+		return "", fmt.Errorf("invalid terminal rid: only '%s' is allowed", defaultAppServiceContainer)
+	}
+}
+
 // resolveTerminalContainerRIDForSession validates whether rid is applicable for
 // the requested terminal type and returns the effective service container name.
 //
-// rid is only accepted for OpenSVC server bash terminals.
-func resolveTerminalContainerRIDForSession(isNodeTerminal bool, cmdType tty.TerminalCommandType, orchestrator string, rid string) (string, bool, error) {
+// rid is only accepted for OpenSVC server/app bash terminals.
+func resolveTerminalContainerRIDForSession(targetKind string, cmdType tty.TerminalCommandType, orchestrator string, rid string) (string, bool, error) {
 	if rid == "" {
-		if isNodeTerminal && cmdType == tty.TerminalBash && orchestrator == config.ConstOrchestratorOpenSVC {
-			return defaultServerServiceContainer, true, nil
+		if cmdType == tty.TerminalBash && orchestrator == config.ConstOrchestratorOpenSVC {
+			switch targetKind {
+			case terminalTargetServer:
+				return defaultServerServiceContainer, true, nil
+			case terminalTargetApp:
+				return defaultAppServiceContainer, true, nil
+			}
 		}
 		return "", false, nil
 	}
 
-	if !isNodeTerminal || cmdType != tty.TerminalBash || orchestrator != config.ConstOrchestratorOpenSVC {
-		return "", false, fmt.Errorf("rid is only supported for OpenSVC server bash terminals")
+	if cmdType != tty.TerminalBash || orchestrator != config.ConstOrchestratorOpenSVC {
+		return "", false, fmt.Errorf("rid is only supported for OpenSVC server/app bash terminals")
 	}
 
-	selectedRID, err := resolveOpenSVCTerminalContainerRID(rid)
-	if err != nil {
-		return "", false, err
+	switch targetKind {
+	case terminalTargetServer:
+		selectedRID, err := resolveOpenSVCTerminalContainerRID(rid)
+		if err != nil {
+			return "", false, err
+		}
+		return selectedRID, true, nil
+	case terminalTargetApp:
+		selectedRID, err := resolveOpenSVCAppTerminalContainerRID(rid)
+		if err != nil {
+			return "", false, err
+		}
+		return selectedRID, true, nil
+	default:
+		return "", false, fmt.Errorf("rid is only supported for OpenSVC server/app bash terminals")
 	}
-
-	return selectedRID, true, nil
 }
 
 func (repman *ReplicationManager) InitWebTTY() {
@@ -190,5 +219,26 @@ func (repman *ReplicationManager) SetSessionValuesFromProxy(session *tty.Session
 	default:
 		return fmt.Errorf("unsupported command type: %s", session.CmdType)
 	}
+	return nil
+}
+
+func (repman *ReplicationManager) SetSessionValuesFromApp(session *tty.Session, app *cluster.App) error {
+	session.Host = app.GetHost()
+	mycluster := app.GetCluster()
+	session.Orchestrator = mycluster.GetOrchestrator()
+	session.ServiceName = app.GetServiceName()
+	session.ServiceContainerName = defaultAppServiceContainer
+	session.ServiceAgentName = app.GetAgent()
+
+	switch session.CmdType {
+	case tty.TerminalBash:
+		session.Port = strconv.Itoa(mycluster.Conf.OnPremiseSSHPort)
+		session.Username = mycluster.GetOnPremiseSSHUser()
+		session.Password = mycluster.GetOnPremiseSSHPass()
+		session.AppendKey(mycluster.OnPremiseGetSSHKey())
+	default:
+		return fmt.Errorf("unsupported command type: %s", session.CmdType)
+	}
+
 	return nil
 }

--- a/server/server_tty.go
+++ b/server/server_tty.go
@@ -225,6 +225,9 @@ func (repman *ReplicationManager) SetSessionValuesFromProxy(session *tty.Session
 func (repman *ReplicationManager) SetSessionValuesFromApp(session *tty.Session, app *cluster.App) error {
 	session.Host = app.GetHost()
 	mycluster := app.GetCluster()
+	if _, ok := mycluster.APIUsers[session.Owner]; !ok {
+		return fmt.Errorf("user %s not found in cluster %s", session.Owner, mycluster.Name)
+	}
 	session.Orchestrator = mycluster.GetOrchestrator()
 	session.ServiceName = app.GetServiceName()
 	session.ServiceContainerName = defaultAppServiceContainer

--- a/server/server_tty_test.go
+++ b/server/server_tty_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"os/user"
 	"testing"
 
 	"github.com/signal18/replication-manager/cluster"
@@ -214,5 +215,62 @@ func TestResolveTerminalContainerRIDForSession(t *testing.T) {
 				t.Fatalf("resolveTerminalContainerRIDForSession() shouldSet = %v, want %v", gotShouldSet, tt.wantShouldSet)
 			}
 		})
+	}
+}
+
+func TestSetSessionValuesFromApp(t *testing.T) {
+	repman := &ReplicationManager{}
+
+	mycluster := &cluster.Cluster{
+		Name: "clusterA",
+		Conf: &config.Config{
+			ProvOrchestrator:       config.ConstOrchestratorOpenSVC,
+			OnPremiseSSHPort:       2200,
+			OnPremiseSSH:           true,
+			OnPremiseSSHPrivateKey: "",
+			Secrets: map[string]config.Secret{
+				"onpremise-ssh-credential": {Value: "sshuser:sshpass"},
+			},
+		},
+		OsUser: &user.User{HomeDir: "/tmp"},
+	}
+
+	app := &cluster.App{
+		Name:         "my-app",
+		Host:         "10.0.0.20",
+		Agent:        "node-1",
+		ClusterGroup: mycluster,
+	}
+
+	session := &tty.Session{CmdType: tty.TerminalBash}
+
+	err := repman.SetSessionValuesFromApp(session, app)
+	if err != nil {
+		t.Fatalf("SetSessionValuesFromApp() returned error: %v", err)
+	}
+
+	if session.Host != "10.0.0.20" {
+		t.Fatalf("session.Host = %q, want %q", session.Host, "10.0.0.20")
+	}
+	if session.Orchestrator != config.ConstOrchestratorOpenSVC {
+		t.Fatalf("session.Orchestrator = %q, want %q", session.Orchestrator, config.ConstOrchestratorOpenSVC)
+	}
+	if session.ServiceName != "clusterA/svc/my-app" {
+		t.Fatalf("session.ServiceName = %q, want %q", session.ServiceName, "clusterA/svc/my-app")
+	}
+	if session.ServiceContainerName != defaultAppServiceContainer {
+		t.Fatalf("session.ServiceContainerName = %q, want %q", session.ServiceContainerName, defaultAppServiceContainer)
+	}
+	if session.ServiceAgentName != "node-1" {
+		t.Fatalf("session.ServiceAgentName = %q, want %q", session.ServiceAgentName, "node-1")
+	}
+	if session.Port != "2200" {
+		t.Fatalf("session.Port = %q, want %q", session.Port, "2200")
+	}
+	if session.Username != "sshuser" {
+		t.Fatalf("session.Username = %q, want %q", session.Username, "sshuser")
+	}
+	if session.Password != "sshpass" {
+		t.Fatalf("session.Password = %q, want %q", session.Password, "sshpass")
 	}
 }

--- a/server/server_tty_test.go
+++ b/server/server_tty_test.go
@@ -54,92 +54,156 @@ func TestResolveOpenSVCTerminalContainerRID(t *testing.T) {
 	}
 }
 
-func TestResolveTerminalContainerRIDForSession(t *testing.T) {
+func TestResolveOpenSVCAppTerminalContainerRID(t *testing.T) {
 	tests := []struct {
-		name           string
-		isNodeTerminal bool
-		cmdType        tty.TerminalCommandType
-		orchestrator   string
-		rid            string
-		wantRID        string
-		wantShouldSet  bool
-		wantErr        bool
+		name    string
+		rid     string
+		want    string
+		wantErr bool
 	}{
 		{
-			name:           "opensvc server bash defaults to db",
-			isNodeTerminal: true,
-			cmdType:        tty.TerminalBash,
-			orchestrator:   config.ConstOrchestratorOpenSVC,
-			rid:            "",
-			wantRID:        defaultServerServiceContainer,
-			wantShouldSet:  true,
-			wantErr:        false,
+			name:    "explicit app container accepted",
+			rid:     defaultAppServiceContainer,
+			want:    defaultAppServiceContainer,
+			wantErr: false,
 		},
 		{
-			name:           "opensvc server bash jobs override accepted",
-			isNodeTerminal: true,
-			cmdType:        tty.TerminalBash,
-			orchestrator:   config.ConstOrchestratorOpenSVC,
-			rid:            cluster.RestartRidJobsContainer,
-			wantRID:        cluster.RestartRidJobsContainer,
-			wantShouldSet:  true,
-			wantErr:        false,
-		},
-		{
-			name:           "rid rejected for proxy bash terminal",
-			isNodeTerminal: false,
-			cmdType:        tty.TerminalBash,
-			orchestrator:   config.ConstOrchestratorOpenSVC,
-			rid:            cluster.RestartRidJobsContainer,
-			wantRID:        "",
-			wantShouldSet:  false,
-			wantErr:        true,
-		},
-		{
-			name:           "rid rejected for opensvc mysql terminal",
-			isNodeTerminal: true,
-			cmdType:        tty.TerminalMySQL,
-			orchestrator:   config.ConstOrchestratorOpenSVC,
-			rid:            cluster.RestartRidJobsContainer,
-			wantRID:        "",
-			wantShouldSet:  false,
-			wantErr:        true,
-		},
-		{
-			name:           "rid rejected for non-opensvc server bash",
-			isNodeTerminal: true,
-			cmdType:        tty.TerminalBash,
-			orchestrator:   config.ConstOrchestratorOnPremise,
-			rid:            cluster.RestartRidJobsContainer,
-			wantRID:        "",
-			wantShouldSet:  false,
-			wantErr:        true,
-		},
-		{
-			name:           "empty rid ignored for non-opensvc path",
-			isNodeTerminal: true,
-			cmdType:        tty.TerminalBash,
-			orchestrator:   config.ConstOrchestratorOnPremise,
-			rid:            "",
-			wantRID:        "",
-			wantShouldSet:  false,
-			wantErr:        false,
-		},
-		{
-			name:           "invalid opensvc rid rejected",
-			isNodeTerminal: true,
-			cmdType:        tty.TerminalBash,
-			orchestrator:   config.ConstOrchestratorOpenSVC,
-			rid:            "container#prx",
-			wantRID:        "",
-			wantShouldSet:  false,
-			wantErr:        true,
+			name:    "invalid rid rejected",
+			rid:     defaultServerServiceContainer,
+			want:    "",
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotRID, gotShouldSet, err := resolveTerminalContainerRIDForSession(tt.isNodeTerminal, tt.cmdType, tt.orchestrator, tt.rid)
+			got, err := resolveOpenSVCAppTerminalContainerRID(tt.rid)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveOpenSVCAppTerminalContainerRID() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("resolveOpenSVCAppTerminalContainerRID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveTerminalContainerRIDForSession(t *testing.T) {
+	tests := []struct {
+		name          string
+		targetKind    string
+		cmdType       tty.TerminalCommandType
+		orchestrator  string
+		rid           string
+		wantRID       string
+		wantShouldSet bool
+		wantErr       bool
+	}{
+		{
+			name:          "opensvc server bash defaults to db",
+			targetKind:    terminalTargetServer,
+			cmdType:       tty.TerminalBash,
+			orchestrator:  config.ConstOrchestratorOpenSVC,
+			rid:           "",
+			wantRID:       defaultServerServiceContainer,
+			wantShouldSet: true,
+			wantErr:       false,
+		},
+		{
+			name:          "opensvc app bash defaults to app",
+			targetKind:    terminalTargetApp,
+			cmdType:       tty.TerminalBash,
+			orchestrator:  config.ConstOrchestratorOpenSVC,
+			rid:           "",
+			wantRID:       defaultAppServiceContainer,
+			wantShouldSet: true,
+			wantErr:       false,
+		},
+		{
+			name:          "opensvc server bash jobs override accepted",
+			targetKind:    terminalTargetServer,
+			cmdType:       tty.TerminalBash,
+			orchestrator:  config.ConstOrchestratorOpenSVC,
+			rid:           cluster.RestartRidJobsContainer,
+			wantRID:       cluster.RestartRidJobsContainer,
+			wantShouldSet: true,
+			wantErr:       false,
+		},
+		{
+			name:          "opensvc app bash app rid accepted",
+			targetKind:    terminalTargetApp,
+			cmdType:       tty.TerminalBash,
+			orchestrator:  config.ConstOrchestratorOpenSVC,
+			rid:           defaultAppServiceContainer,
+			wantRID:       defaultAppServiceContainer,
+			wantShouldSet: true,
+			wantErr:       false,
+		},
+		{
+			name:          "rid rejected for proxy bash terminal",
+			targetKind:    terminalTargetProxy,
+			cmdType:       tty.TerminalBash,
+			orchestrator:  config.ConstOrchestratorOpenSVC,
+			rid:           cluster.RestartRidJobsContainer,
+			wantRID:       "",
+			wantShouldSet: false,
+			wantErr:       true,
+		},
+		{
+			name:          "rid rejected for opensvc mysql terminal",
+			targetKind:    terminalTargetServer,
+			cmdType:       tty.TerminalMySQL,
+			orchestrator:  config.ConstOrchestratorOpenSVC,
+			rid:           cluster.RestartRidJobsContainer,
+			wantRID:       "",
+			wantShouldSet: false,
+			wantErr:       true,
+		},
+		{
+			name:          "rid rejected for non-opensvc server bash",
+			targetKind:    terminalTargetServer,
+			cmdType:       tty.TerminalBash,
+			orchestrator:  config.ConstOrchestratorOnPremise,
+			rid:           cluster.RestartRidJobsContainer,
+			wantRID:       "",
+			wantShouldSet: false,
+			wantErr:       true,
+		},
+		{
+			name:          "empty rid ignored for non-opensvc path",
+			targetKind:    terminalTargetServer,
+			cmdType:       tty.TerminalBash,
+			orchestrator:  config.ConstOrchestratorOnPremise,
+			rid:           "",
+			wantRID:       "",
+			wantShouldSet: false,
+			wantErr:       false,
+		},
+		{
+			name:          "invalid opensvc rid rejected",
+			targetKind:    terminalTargetServer,
+			cmdType:       tty.TerminalBash,
+			orchestrator:  config.ConstOrchestratorOpenSVC,
+			rid:           "container#prx",
+			wantRID:       "",
+			wantShouldSet: false,
+			wantErr:       true,
+		},
+		{
+			name:          "invalid app rid rejected",
+			targetKind:    terminalTargetApp,
+			cmdType:       tty.TerminalBash,
+			orchestrator:  config.ConstOrchestratorOpenSVC,
+			rid:           defaultServerServiceContainer,
+			wantRID:       "",
+			wantShouldSet: false,
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRID, gotShouldSet, err := resolveTerminalContainerRIDForSession(tt.targetKind, tt.cmdType, tt.orchestrator, tt.rid)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("resolveTerminalContainerRIDForSession() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/server/server_tty_test.go
+++ b/server/server_tty_test.go
@@ -151,6 +151,16 @@ func TestResolveTerminalContainerRIDForSession(t *testing.T) {
 			wantErr:       true,
 		},
 		{
+			name:          "empty rid ignored for opensvc proxy bash terminal",
+			targetKind:    terminalTargetProxy,
+			cmdType:       tty.TerminalBash,
+			orchestrator:  config.ConstOrchestratorOpenSVC,
+			rid:           "",
+			wantRID:       "",
+			wantShouldSet: false,
+			wantErr:       false,
+		},
+		{
 			name:          "rid rejected for opensvc mysql terminal",
 			targetKind:    terminalTargetServer,
 			cmdType:       tty.TerminalMySQL,
@@ -223,6 +233,9 @@ func TestSetSessionValuesFromApp(t *testing.T) {
 
 	mycluster := &cluster.Cluster{
 		Name: "clusterA",
+		APIUsers: map[string]cluster.APIUser{
+			"app_terminal_user": {User: "app_terminal_user"},
+		},
 		Conf: &config.Config{
 			ProvOrchestrator:       config.ConstOrchestratorOpenSVC,
 			OnPremiseSSHPort:       2200,
@@ -242,7 +255,7 @@ func TestSetSessionValuesFromApp(t *testing.T) {
 		ClusterGroup: mycluster,
 	}
 
-	session := &tty.Session{CmdType: tty.TerminalBash}
+	session := &tty.Session{CmdType: tty.TerminalBash, Owner: "app_terminal_user"}
 
 	err := repman.SetSessionValuesFromApp(session, app)
 	if err != nil {

--- a/share/dashboard_react/src/App.jsx
+++ b/share/dashboard_react/src/App.jsx
@@ -74,6 +74,16 @@ function App() {
             <TerminalComponent />
           </PrivateRoute>
         } />
+        <Route path={"/terminal/clusters/:clusterName/apps/:appName"} element={
+          <PrivateRoute>
+            <TerminalComponent />
+          </PrivateRoute>
+        } />
+        <Route path={"/terminal/clusters/:clusterName/apps/:appName/:commandType"} element={
+          <PrivateRoute>
+            <TerminalComponent />
+          </PrivateRoute>
+        } />
         <Route path='/login' element={<Login />} />
         <Route path='/dashboard' element={<Login dashboard />} />
         <Route

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppMenu.jsx
@@ -156,13 +156,13 @@ function AppMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView',
                 : []),
             ]
           },
-          ...(user?.grants['app-terminal'] ? [
+          ...(user?.grants['terminal-app'] ? [
             {
               name: 'Web Terminal',
               subMenu: [
                 {
                   name: 'Shell Terminal',
-                  onClick: () => navigate(`/terminal/clusters/${clusterName}/apps/${row.appId}`)
+                  onClick: () => navigate(`/terminal/clusters/${clusterName}/apps/${row.id}`)
                 }
               ]
             }

--- a/share/dashboard_react/src/Pages/Terminal/index.jsx
+++ b/share/dashboard_react/src/Pages/Terminal/index.jsx
@@ -98,6 +98,7 @@ const TerminalComponent = () => {
     if (clusterData) {
       const servers = clusterData.dbServers || [];
       const proxies = clusterData.proxyServers || [];
+      const apps = clusterData.apps || [];
 
       if (serverName) {
         if (!servers.find(srv => srv === serverName)) {
@@ -107,9 +108,13 @@ const TerminalComponent = () => {
         if (!proxies.find(prx => prx === proxyName)) {
           navigate(`/`);
         }
+      } else if (appName) {
+        if (!apps.find(app => app.id === appName)) {
+          navigate(`/`);
+        }
       }
     }
-  }, [clusterData?.name, serverName, proxyName])
+  }, [clusterData?.name, clusterData?.apps, serverName, proxyName, appName, navigate])
 
   const sendMessage = (message) => {
     if (socketRef.current && socketRef.current.readyState === WebSocket.OPEN) {

--- a/share/dashboard_react/src/Pages/Terminal/index.jsx
+++ b/share/dashboard_react/src/Pages/Terminal/index.jsx
@@ -27,7 +27,7 @@ const TerminalComponent = () => {
   const terminalRef = useRef(null);
   const terminalInstanceRef = useRef(null); // Store the terminal instance
   const socketRef = useRef(null); // Store the WebSocket connection in a ref for stability
-  const { clusterName, serverName, proxyName, commandType } = useParams();
+  const { clusterName, serverName, proxyName, appName, commandType } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
   const [serviceContainer, setServiceContainer] = useState(OpenSVCTerminalRID.Default);
@@ -168,6 +168,8 @@ const TerminalComponent = () => {
       websocketUrl = `/api/terminal/connect/clusters/${clusterName}/servers/${serverName}`;
     } else if (clusterName && proxyName) {
       websocketUrl = `/api/terminal/connect/clusters/${clusterName}/proxies/${proxyName}`;
+    } else if (clusterName && appName) {
+      websocketUrl = `/api/terminal/connect/clusters/${clusterName}/apps/${appName}`;
     } else {
       websocketUrl = '/api/terminal/connect';
     }
@@ -241,7 +243,13 @@ const TerminalComponent = () => {
       <Box className={styles.container}>
         <HStack justify="space-between" align="center" spacing={4}>
           <Text fontSize="xl" fontWeight="bold" className={styles.title}>
-            {clusterName ? (serverName ? "Server Terminal" : "Proxy Terminal") : "Web Terminal"}
+            {clusterName
+              ? (serverName
+                  ? "Server Terminal"
+                  : (proxyName
+                      ? "Proxy Terminal"
+                      : (appName ? "App Terminal" : "Web Terminal")))
+              : "Web Terminal"}
           </Text>
 
           <HStack spacing={2}>
@@ -254,7 +262,7 @@ const TerminalComponent = () => {
               </>
             )}
             <Text fontSize="lg" fontWeight="bold">
-              {serverName || proxyName || ""}
+              {serverName || proxyName || appName || ""}
             </Text>
           </HStack>
         </HStack>

--- a/share/dashboard_react/src/Pages/Terminal/index.jsx
+++ b/share/dashboard_react/src/Pages/Terminal/index.jsx
@@ -21,6 +21,14 @@ import {
 
 const ChakraLink = chakra(Link);
 
+function getTerminalTitle(clusterName, serverName, proxyName, appName) {
+  if (!clusterName) return 'Web Terminal';
+  if (serverName) return 'Server Terminal';
+  if (proxyName) return 'Proxy Terminal';
+  if (appName) return 'App Terminal';
+  return 'Web Terminal';
+}
+
 const TerminalComponent = () => {
   const [status, setStatus] = useState('disconnected');
   const [url, setUrl] = useState('');
@@ -243,13 +251,7 @@ const TerminalComponent = () => {
       <Box className={styles.container}>
         <HStack justify="space-between" align="center" spacing={4}>
           <Text fontSize="xl" fontWeight="bold" className={styles.title}>
-            {clusterName
-              ? (serverName
-                  ? "Server Terminal"
-                  : (proxyName
-                      ? "Proxy Terminal"
-                      : (appName ? "App Terminal" : "Web Terminal")))
-              : "Web Terminal"}
+            {getTerminalTitle(clusterName, serverName, proxyName, appName)}
           </Text>
 
           <HStack spacing={2}>


### PR DESCRIPTION
## Summary
- add a new `terminal-app` grant and wire it into terminal ACL handling for `/api/terminal/.../apps/...` routes
- extend terminal backend routing/session resolution to support app targets and enforce OpenSVC app bash RID as `container#app`
- add frontend app terminal routes and menu wiring so app shell launches through `/terminal/clusters/:clusterName/apps/:appName`

## Testing
- go test ./cluster -run TestIsURLPassACLTerminalAccess -count=1
- go test ./server -run 'TestResolve(OpenSVCAppTerminalContainerRID|TerminalContainerRIDForSession|OpenSVCTerminalContainerRID)' -count=1
- go test ./config -count=1
- node share/dashboard_react/src/Pages/Terminal/__tests__/ridUtils.test.js