### PR TITLE
feat: add CRM-backed GitLab signup flow with promo and split-layout UI

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -270,8 +270,10 @@ func (repman *ReplicationManager) apiserver() {
 	router.Handle("/api/terminal/connect", http.HandlerFunc(repman.handlerTerminal))
 
 	router.HandleFunc("/api/login", repman.loginHandler)
-	router.HandleFunc("/api/signup", repman.handlerSignup)
-	router.HandleFunc("/api/signup/promo", repman.handlerSignupPromo)
+	// Public auth routes are intentionally wired in both api.go and http.go because
+	// replication-manager can run this API server path independently of httpserver().
+	router.HandleFunc("/api/signup", repman.handlerSignup).Methods(http.MethodPost, http.MethodOptions)
+	router.HandleFunc("/api/signup/promo", repman.handlerSignupPromo).Methods(http.MethodGet, http.MethodOptions)
 	router.HandleFunc("/api/autologin", repman.autologinHandler)
 	router.HandleFunc("/api/dashboard-token", repman.dashboardTokenHandler)
 	router.HandleFunc("/api/version", repman.handlerVersion)

--- a/server/api.go
+++ b/server/api.go
@@ -224,6 +224,7 @@ func (repman *ReplicationManager) apiserver() {
 		router.HandleFunc("/", repman.handlerApp)
 		router.PathPrefix("/terminal/").HandlerFunc(repman.handlerApp)
 		router.HandleFunc("/login", repman.handlerApp)
+		router.HandleFunc("/signup", repman.handlerApp)
 		router.HandleFunc("/dashboard", repman.handlerApp)
 		router.HandleFunc("/slideshow", repman.handlerApp)
 		router.PathPrefix("/images/").Handler(http.FileServer(http.Dir(repman.Conf.HttpRoot)))
@@ -236,6 +237,7 @@ func (repman *ReplicationManager) apiserver() {
 		router.HandleFunc("/", repman.rootHandler)
 		router.PathPrefix("/terminal/").HandlerFunc(repman.rootHandler)
 		router.HandleFunc("/login", repman.rootHandler)
+		router.HandleFunc("/signup", repman.rootHandler)
 		router.HandleFunc("/dashboard", repman.rootHandler)
 		router.HandleFunc("/slideshow", repman.rootHandler)
 		router.PathPrefix("/static/").Handler(repman.handlerStatic(repman.DashboardFSHandler()))
@@ -268,6 +270,7 @@ func (repman *ReplicationManager) apiserver() {
 	router.Handle("/api/terminal/connect", http.HandlerFunc(repman.handlerTerminal))
 
 	router.HandleFunc("/api/login", repman.loginHandler)
+	router.HandleFunc("/api/signup", repman.handlerSignup)
 	router.HandleFunc("/api/autologin", repman.autologinHandler)
 	router.HandleFunc("/api/dashboard-token", repman.dashboardTokenHandler)
 	router.HandleFunc("/api/version", repman.handlerVersion)

--- a/server/api.go
+++ b/server/api.go
@@ -271,6 +271,7 @@ func (repman *ReplicationManager) apiserver() {
 
 	router.HandleFunc("/api/login", repman.loginHandler)
 	router.HandleFunc("/api/signup", repman.handlerSignup)
+	router.HandleFunc("/api/signup/promo", repman.handlerSignupPromo)
 	router.HandleFunc("/api/autologin", repman.autologinHandler)
 	router.HandleFunc("/api/dashboard-token", repman.dashboardTokenHandler)
 	router.HandleFunc("/api/version", repman.handlerVersion)

--- a/server/api_register.go
+++ b/server/api_register.go
@@ -10,10 +10,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/signal18/replication-manager/config"
@@ -121,6 +124,197 @@ const confirmPollTimeout = 5 * time.Minute
 const defaultCrmBaseURL = "https://api.crm.ovh-fr-2.signal18.cloud18.io"
 
 var basicEmailRegexp = regexp.MustCompile(`^[^@\s]+@[^@\s]+\.[^@\s]+$`)
+
+const (
+	signupRatePerMinute      = 5
+	signupRateBurst          = 3
+	signupPromoRatePerMinute = 30
+	signupPromoRateBurst     = 10
+)
+
+type ipTokenBucket struct {
+	mu         sync.Mutex
+	tokens     float64
+	lastRefill time.Time
+	lastSeen   time.Time
+}
+
+type ipRateLimiter struct {
+	ratePerSecond float64
+	burst         float64
+	staleAfter    time.Duration
+	cleanupEvery  uint64
+	requestCount  atomic.Uint64
+	ipBuckets     sync.Map // map[string]*ipTokenBucket
+}
+
+func newIPRateLimiter(ratePerMinute int, burst int, staleAfter time.Duration, cleanupEvery uint64) *ipRateLimiter {
+	return &ipRateLimiter{
+		ratePerSecond: float64(ratePerMinute) / 60.0,
+		burst:         float64(burst),
+		staleAfter:    staleAfter,
+		cleanupEvery:  cleanupEvery,
+	}
+}
+
+func (l *ipRateLimiter) allow(ip string, now time.Time) bool {
+	v, _ := l.ipBuckets.LoadOrStore(ip, &ipTokenBucket{tokens: l.burst, lastRefill: now, lastSeen: now})
+	b := v.(*ipTokenBucket)
+
+	b.mu.Lock()
+	elapsed := now.Sub(b.lastRefill).Seconds()
+	if elapsed > 0 {
+		b.tokens += elapsed * l.ratePerSecond
+		if b.tokens > l.burst {
+			b.tokens = l.burst
+		}
+		b.lastRefill = now
+	}
+	b.lastSeen = now
+	allowed := b.tokens >= 1
+	if allowed {
+		b.tokens -= 1
+	}
+	b.mu.Unlock()
+
+	if l.cleanupEvery > 0 && l.requestCount.Add(1)%l.cleanupEvery == 0 {
+		l.cleanupStale(now)
+	}
+
+	return allowed
+}
+
+func (l *ipRateLimiter) cleanupStale(now time.Time) {
+	l.ipBuckets.Range(func(key, value interface{}) bool {
+		b, ok := value.(*ipTokenBucket)
+		if !ok {
+			l.ipBuckets.Delete(key)
+			return true
+		}
+		b.mu.Lock()
+		stale := now.Sub(b.lastSeen) > l.staleAfter
+		b.mu.Unlock()
+		if stale {
+			l.ipBuckets.Delete(key)
+		}
+		return true
+	})
+}
+
+func (l *ipRateLimiter) resetForTests() {
+	l.ipBuckets = sync.Map{}
+	l.requestCount.Store(0)
+}
+
+var signupLimiter = newIPRateLimiter(signupRatePerMinute, signupRateBurst, 15*time.Minute, 128)
+var signupPromoLimiter = newIPRateLimiter(signupPromoRatePerMinute, signupPromoRateBurst, 15*time.Minute, 128)
+
+func writeJSONError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}
+
+func (repman *ReplicationManager) setSignupCORSHeaders(w http.ResponseWriter, r *http.Request) {
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if origin == "" {
+		return
+	}
+	if repman.isAllowedSignupOrigin(origin) {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		appendVaryHeader(w, "Origin")
+	}
+}
+
+func appendVaryHeader(w http.ResponseWriter, value string) {
+	existing := w.Header().Get("Vary")
+	if existing == "" {
+		w.Header().Set("Vary", value)
+		return
+	}
+	for _, item := range strings.Split(existing, ",") {
+		if strings.EqualFold(strings.TrimSpace(item), value) {
+			return
+		}
+	}
+	w.Header().Set("Vary", existing+", "+value)
+}
+
+func (repman *ReplicationManager) isAllowedSignupOrigin(origin string) bool {
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	if host == "" {
+		return false
+	}
+	if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+		return true
+	}
+
+	if apiURL := strings.TrimSpace(repman.Conf.APIPublicURL); apiURL != "" {
+		if pu, err := url.Parse(apiURL); err == nil && strings.EqualFold(host, pu.Hostname()) {
+			return true
+		}
+	}
+
+	if repman.PeerManager != nil && repman.handleOriginValidator(origin) {
+		return true
+	}
+
+	instanceURI := strings.ToLower(strings.TrimSpace(repman.registeredInstanceURI()))
+	return instanceURI != "" && host == instanceURI
+}
+
+func signupClientIP(r *http.Request) string {
+	remoteIP := parseRemoteIP(r.RemoteAddr)
+	if remoteIP != nil && isTrustedProxyIP(remoteIP) {
+		xff := strings.TrimSpace(r.Header.Get("X-Forwarded-For"))
+		if xff != "" {
+			parts := strings.Split(xff, ",")
+			if len(parts) > 0 {
+				candidate := strings.TrimSpace(parts[0])
+				if candidateIP := net.ParseIP(candidate); candidateIP != nil {
+					return candidateIP.String()
+				}
+			}
+		}
+	}
+
+	if remoteIP != nil {
+		return remoteIP.String()
+	}
+	if strings.TrimSpace(r.RemoteAddr) != "" {
+		return strings.TrimSpace(r.RemoteAddr)
+	}
+	return "unknown"
+}
+
+func parseRemoteIP(remoteAddr string) net.IP {
+	remoteAddr = strings.TrimSpace(remoteAddr)
+	if remoteAddr == "" {
+		return nil
+	}
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err == nil {
+		return net.ParseIP(host)
+	}
+	return net.ParseIP(remoteAddr)
+}
+
+func isTrustedProxyIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	if ip.IsLoopback() {
+		return true
+	}
+	if ip.IsPrivate() {
+		return true
+	}
+	return ip.IsLinkLocalUnicast()
+}
 
 // crmBase returns the configured CRM API base URL, falling back to the default.
 func (repman *ReplicationManager) crmBase() string {
@@ -367,13 +561,28 @@ func (repman *ReplicationManager) handlerRegister(w http.ResponseWriter, r *http
 // Proxies signup data to CRM and always derives referrer_uri from
 // the registered local Cloud18 instance URI.
 func (repman *ReplicationManager) handlerSignup(w http.ResponseWriter, r *http.Request) {
+	repman.setSignupCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	if r.Method == http.MethodOptions {
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
 
 	if r.Method != http.MethodPost {
 		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
 			"signup: method not allowed: %s", r.Method)
-		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	clientIP := signupClientIP(r)
+	if !signupLimiter.allow(clientIP, time.Now()) {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"signup: throttled request from ip=%s", clientIP)
+		writeJSONError(w, http.StatusTooManyRequests, "too many requests")
 		return
 	}
 
@@ -381,7 +590,7 @@ func (repman *ReplicationManager) handlerSignup(w http.ResponseWriter, r *http.R
 	if err != nil {
 		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
 			"signup: failed to read request body: %s", err)
-		http.Error(w, `{"error":"failed to read request body"}`, http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "failed to read request body")
 		return
 	}
 	defer r.Body.Close()
@@ -390,7 +599,7 @@ func (repman *ReplicationManager) handlerSignup(w http.ResponseWriter, r *http.R
 	if err := json.Unmarshal(body, &req); err != nil {
 		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
 			"signup: invalid JSON body: %s", err)
-		http.Error(w, `{"error":"invalid JSON body"}`, http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
 
@@ -406,12 +615,12 @@ func (repman *ReplicationManager) handlerSignup(w http.ResponseWriter, r *http.R
 	req.URI = strings.TrimSpace(req.URI)
 
 	if req.FirstName == "" || req.LastName == "" || req.Username == "" || req.Email == "" || req.Password == "" {
-		http.Error(w, `{"error":"first_name, last_name, username, email and password are required"}`, http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "first_name, last_name, username, email and password are required")
 		return
 	}
 
 	if !basicEmailRegexp.MatchString(req.Email) {
-		http.Error(w, `{"error":"invalid email format"}`, http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "invalid email format")
 		return
 	}
 
@@ -447,7 +656,7 @@ func (repman *ReplicationManager) handlerSignup(w http.ResponseWriter, r *http.R
 	if err != nil {
 		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
 			"signup: failed to marshal CRM payload: %s", err)
-		http.Error(w, `{"error":"failed to prepare CRM request"}`, http.StatusInternalServerError)
+		writeJSONError(w, http.StatusInternalServerError, "failed to prepare CRM request")
 		return
 	}
 
@@ -455,7 +664,7 @@ func (repman *ReplicationManager) handlerSignup(w http.ResponseWriter, r *http.R
 	if err != nil {
 		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
 			"signup: failed to build CRM request: %s", err)
-		http.Error(w, `{"error":"failed to build CRM request"}`, http.StatusInternalServerError)
+		writeJSONError(w, http.StatusInternalServerError, "failed to build CRM request")
 		return
 	}
 	crmReq.Header.Set("Content-Type", "application/json")
@@ -466,7 +675,7 @@ func (repman *ReplicationManager) handlerSignup(w http.ResponseWriter, r *http.R
 	if err != nil {
 		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
 			"signup: CRM unreachable: %s", err)
-		http.Error(w, fmt.Sprintf(`{"error":"CRM API unreachable: %s"}`, err), http.StatusBadGateway)
+		writeJSONError(w, http.StatusBadGateway, "CRM API unreachable")
 		return
 	}
 	defer crmResp.Body.Close()
@@ -475,7 +684,7 @@ func (repman *ReplicationManager) handlerSignup(w http.ResponseWriter, r *http.R
 	if err != nil {
 		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
 			"signup: failed to read CRM response: %s", err)
-		http.Error(w, `{"error":"failed to read CRM response"}`, http.StatusBadGateway)
+		writeJSONError(w, http.StatusBadGateway, "failed to read CRM response")
 		return
 	}
 
@@ -488,13 +697,28 @@ func (repman *ReplicationManager) handlerSignup(w http.ResponseWriter, r *http.R
 // Returns the best active promotional offer for signup onboarding
 // and the required/optional field definitions expected by the CRM.
 func (repman *ReplicationManager) handlerSignupPromo(w http.ResponseWriter, r *http.Request) {
+	repman.setSignupCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	if r.Method == http.MethodOptions {
+		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
 
 	if r.Method != http.MethodGet {
 		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
 			"signup/promo: method not allowed: %s", r.Method)
-		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	clientIP := signupClientIP(r)
+	if !signupPromoLimiter.allow(clientIP, time.Now()) {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"signup/promo: throttled request from ip=%s", clientIP)
+		writeJSONError(w, http.StatusTooManyRequests, "too many requests")
 		return
 	}
 
@@ -502,7 +726,7 @@ func (repman *ReplicationManager) handlerSignupPromo(w http.ResponseWriter, r *h
 	if err != nil {
 		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
 			"signup/promo: CRM unreachable: %s", err)
-		http.Error(w, fmt.Sprintf(`{"error":"CRM API unreachable: %s"}`, err), http.StatusBadGateway)
+		writeJSONError(w, http.StatusBadGateway, "CRM API unreachable")
 		return
 	}
 

--- a/server/api_register.go
+++ b/server/api_register.go
@@ -76,7 +76,12 @@ type signupRequest struct {
 	Username    string `json:"username"`
 	Email       string `json:"email"`
 	Password    string `json:"password"`
+	Telephone   string `json:"telephone,omitempty"`
+	Phone       string `json:"phone,omitempty"`
+	Tel         string `json:"tel,omitempty"`
+	Company     string `json:"company,omitempty"`
 	ReferrerURI string `json:"referrer_uri,omitempty"`
+	URI         string `json:"uri,omitempty"`
 }
 
 type crmRegisterPayload struct {
@@ -101,6 +106,8 @@ type crmSignupPayload struct {
 	Username    string `json:"username"`
 	Email       string `json:"email"`
 	Password    string `json:"password"`
+	Telephone   string `json:"telephone,omitempty"`
+	Company     string `json:"company,omitempty"`
 	ReferrerURI string `json:"referrer_uri"`
 }
 
@@ -391,6 +398,12 @@ func (repman *ReplicationManager) handlerSignup(w http.ResponseWriter, r *http.R
 	req.LastName = strings.TrimSpace(req.LastName)
 	req.Username = strings.TrimSpace(req.Username)
 	req.Email = strings.TrimSpace(strings.ToLower(req.Email))
+	req.Telephone = strings.TrimSpace(req.Telephone)
+	req.Phone = strings.TrimSpace(req.Phone)
+	req.Tel = strings.TrimSpace(req.Tel)
+	req.Company = strings.TrimSpace(req.Company)
+	req.ReferrerURI = strings.TrimSpace(req.ReferrerURI)
+	req.URI = strings.TrimSpace(req.URI)
 
 	if req.FirstName == "" || req.LastName == "" || req.Username == "" || req.Email == "" || req.Password == "" {
 		http.Error(w, `{"error":"first_name, last_name, username, email and password are required"}`, http.StatusBadRequest)
@@ -402,13 +415,32 @@ func (repman *ReplicationManager) handlerSignup(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	// Normalize aliases
+	telephone := req.Telephone
+	if telephone == "" {
+		telephone = req.Phone
+	}
+	if telephone == "" {
+		telephone = req.Tel
+	}
+
+	referrerURI := req.ReferrerURI
+	if referrerURI == "" {
+		referrerURI = req.URI
+	}
+	if referrerURI == "" {
+		referrerURI = repman.registeredInstanceURI()
+	}
+
 	crmPayload := crmSignupPayload{
 		FirstName:   req.FirstName,
 		LastName:    req.LastName,
 		Username:    req.Username,
 		Email:       req.Email,
 		Password:    req.Password,
-		ReferrerURI: repman.registeredInstanceURI(),
+		Telephone:   telephone,
+		Company:     req.Company,
+		ReferrerURI: referrerURI,
 	}
 
 	crmBody, err := json.Marshal(crmPayload)
@@ -449,6 +481,33 @@ func (repman *ReplicationManager) handlerSignup(w http.ResponseWriter, r *http.R
 
 	w.WriteHeader(crmResp.StatusCode)
 	w.Write(respBody)
+}
+
+// handlerSignupPromo — GET /api/signup/promo (public, no JWT required)
+//
+// Returns the best active promotional offer for signup onboarding
+// and the required/optional field definitions expected by the CRM.
+func (repman *ReplicationManager) handlerSignupPromo(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	if r.Method != http.MethodGet {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"signup/promo: method not allowed: %s", r.Method)
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	status, body, err := crmGetSignupPromo(repman.crmBase())
+	if err != nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
+			"signup/promo: CRM unreachable: %s", err)
+		http.Error(w, fmt.Sprintf(`{"error":"CRM API unreachable: %s"}`, err), http.StatusBadGateway)
+		return
+	}
+
+	w.WriteHeader(status)
+	w.Write(body)
 }
 
 // handlerRegisterStatus — GET /api/register/status  (admin JWT required)
@@ -576,6 +635,24 @@ type changeSubPayload struct {
 // crmGetPlans fetches the available subscription plans from the CRM (no auth required).
 func crmGetPlans(crmBase string) (int, []byte, error) {
 	req, err := http.NewRequest(http.MethodGet, crmBase+"/api/subscription/plans", nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	return resp.StatusCode, body, err
+}
+
+// crmGetSignupPromo fetches the best active promotional offer for signup onboarding
+// from the CRM (no auth required).
+func crmGetSignupPromo(crmBase string) (int, []byte, error) {
+	req, err := http.NewRequest(http.MethodGet, crmBase+"/api/signup/promo", nil)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/server/api_register.go
+++ b/server/api_register.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -25,10 +26,10 @@ import (
 
 const (
 	RegStateIdle    = "idle"
-	RegStatePending = "pending"   // GitLab account created, waiting for email confirmation
-	RegStateOK      = "complete"  // confirmed and Cloud18 connect flow succeeded
-	RegStateTimeout = "timeout"   // user did not click the link in time
-	RegStateError   = "error"     // terminal error (CRM, GitLab, etc.)
+	RegStatePending = "pending"  // GitLab account created, waiting for email confirmation
+	RegStateOK      = "complete" // confirmed and Cloud18 connect flow succeeded
+	RegStateTimeout = "timeout"  // user did not click the link in time
+	RegStateError   = "error"    // terminal error (CRM, GitLab, etc.)
 )
 
 // RegistrationStatus is the current state of an ongoing or completed registration.
@@ -69,6 +70,15 @@ type registerConfirmRequest struct {
 	URI      string `json:"uri"`
 }
 
+type signupRequest struct {
+	FirstName   string `json:"first_name"`
+	LastName    string `json:"last_name"`
+	Username    string `json:"username"`
+	Email       string `json:"email"`
+	Password    string `json:"password"`
+	ReferrerURI string `json:"referrer_uri,omitempty"`
+}
+
 type crmRegisterPayload struct {
 	Email     string `json:"email"`
 	Password  string `json:"password"`
@@ -85,6 +95,15 @@ type crmConfirmPayload struct {
 	Zone      string `json:"zone"`
 }
 
+type crmSignupPayload struct {
+	FirstName   string `json:"first_name"`
+	LastName    string `json:"last_name"`
+	Username    string `json:"username"`
+	Email       string `json:"email"`
+	Password    string `json:"password"`
+	ReferrerURI string `json:"referrer_uri"`
+}
+
 // ---------------------------------------------------------------------------
 // Polling constants
 // ---------------------------------------------------------------------------
@@ -94,12 +113,23 @@ const confirmPollTimeout = 5 * time.Minute
 
 const defaultCrmBaseURL = "https://api.crm.ovh-fr-2.signal18.cloud18.io"
 
+var basicEmailRegexp = regexp.MustCompile(`^[^@\s]+@[^@\s]+\.[^@\s]+$`)
+
 // crmBase returns the configured CRM API base URL, falling back to the default.
 func (repman *ReplicationManager) crmBase() string {
 	if u := strings.TrimRight(repman.Conf.Cloud18CrmApiUrl, "/"); u != "" {
 		return u
 	}
 	return defaultCrmBaseURL
+}
+
+// registeredInstanceURI returns this instance URI when fully configured.
+// Format: domain.subdomain.zone. Returns empty string when incomplete.
+func (repman *ReplicationManager) registeredInstanceURI() string {
+	if repman.Conf.Cloud18Domain == "" || repman.Conf.Cloud18SubDomain == "" || repman.Conf.Cloud18SubDomainZone == "" {
+		return ""
+	}
+	return repman.Conf.Cloud18Domain + "." + repman.Conf.Cloud18SubDomain + "." + repman.Conf.Cloud18SubDomainZone
 }
 
 // ---------------------------------------------------------------------------
@@ -323,6 +353,102 @@ func (repman *ReplicationManager) handlerRegister(w http.ResponseWriter, r *http
 
 	w.WriteHeader(http.StatusAccepted)
 	w.Write(step1Body)
+}
+
+// handlerSignup — POST /api/signup (public, no JWT required)
+//
+// Proxies signup data to CRM and always derives referrer_uri from
+// the registered local Cloud18 instance URI.
+func (repman *ReplicationManager) handlerSignup(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	if r.Method != http.MethodPost {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"signup: method not allowed: %s", r.Method)
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"signup: failed to read request body: %s", err)
+		http.Error(w, `{"error":"failed to read request body"}`, http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	var req signupRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"signup: invalid JSON body: %s", err)
+		http.Error(w, `{"error":"invalid JSON body"}`, http.StatusBadRequest)
+		return
+	}
+
+	req.FirstName = strings.TrimSpace(req.FirstName)
+	req.LastName = strings.TrimSpace(req.LastName)
+	req.Username = strings.TrimSpace(req.Username)
+	req.Email = strings.TrimSpace(strings.ToLower(req.Email))
+
+	if req.FirstName == "" || req.LastName == "" || req.Username == "" || req.Email == "" || req.Password == "" {
+		http.Error(w, `{"error":"first_name, last_name, username, email and password are required"}`, http.StatusBadRequest)
+		return
+	}
+
+	if !basicEmailRegexp.MatchString(req.Email) {
+		http.Error(w, `{"error":"invalid email format"}`, http.StatusBadRequest)
+		return
+	}
+
+	crmPayload := crmSignupPayload{
+		FirstName:   req.FirstName,
+		LastName:    req.LastName,
+		Username:    req.Username,
+		Email:       req.Email,
+		Password:    req.Password,
+		ReferrerURI: repman.registeredInstanceURI(),
+	}
+
+	crmBody, err := json.Marshal(crmPayload)
+	if err != nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
+			"signup: failed to marshal CRM payload: %s", err)
+		http.Error(w, `{"error":"failed to prepare CRM request"}`, http.StatusInternalServerError)
+		return
+	}
+
+	crmReq, err := http.NewRequest(http.MethodPost, repman.crmBase()+"/api/signup", bytes.NewReader(crmBody))
+	if err != nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
+			"signup: failed to build CRM request: %s", err)
+		http.Error(w, `{"error":"failed to build CRM request"}`, http.StatusInternalServerError)
+		return
+	}
+	crmReq.Header.Set("Content-Type", "application/json")
+	crmReq.Header.Set("Accept", "application/json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	crmResp, err := client.Do(crmReq)
+	if err != nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
+			"signup: CRM unreachable: %s", err)
+		http.Error(w, fmt.Sprintf(`{"error":"CRM API unreachable: %s"}`, err), http.StatusBadGateway)
+		return
+	}
+	defer crmResp.Body.Close()
+
+	respBody, err := io.ReadAll(crmResp.Body)
+	if err != nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
+			"signup: failed to read CRM response: %s", err)
+		http.Error(w, `{"error":"failed to read CRM response"}`, http.StatusBadGateway)
+		return
+	}
+
+	w.WriteHeader(crmResp.StatusCode)
+	w.Write(respBody)
 }
 
 // handlerRegisterStatus — GET /api/register/status  (admin JWT required)
@@ -588,7 +714,7 @@ func (repman *ReplicationManager) handlerGetSubscription(w http.ResponseWriter, 
 		return
 	}
 
-	uri := repman.Conf.Cloud18Domain + "." + repman.Conf.Cloud18SubDomain + "." + repman.Conf.Cloud18SubDomainZone
+	uri := repman.registeredInstanceURI()
 
 	status, body, err := crmGetSubscription(repman.crmBase(), tok, uri)
 	if err != nil {
@@ -650,7 +776,7 @@ func (repman *ReplicationManager) handlerChangeSubscription(w http.ResponseWrite
 		return
 	}
 
-	uri := repman.Conf.Cloud18Domain + "." + repman.Conf.Cloud18SubDomain + "." + repman.Conf.Cloud18SubDomainZone
+	uri := repman.registeredInstanceURI()
 
 	status, respBody, err := crmChangeSubscription(repman.crmBase(), tok, uri, req.Plan)
 	if err != nil {
@@ -699,7 +825,7 @@ func (repman *ReplicationManager) handlerUnregister(w http.ResponseWriter, r *ht
 		return
 	}
 
-	uri := repman.Conf.Cloud18Domain + "." + repman.Conf.Cloud18SubDomain + "." + repman.Conf.Cloud18SubDomainZone
+	uri := repman.registeredInstanceURI()
 
 	status, respBody, err := crmUnregister(repman.crmBase(), tok, uri)
 	if err != nil {

--- a/server/api_register.go
+++ b/server/api_register.go
@@ -125,6 +125,9 @@ const defaultCrmBaseURL = "https://api.crm.ovh-fr-2.signal18.cloud18.io"
 
 var basicEmailRegexp = regexp.MustCompile(`^[^@\s]+@[^@\s]+\.[^@\s]+$`)
 
+var crmHTTPClient15s = &http.Client{Timeout: 15 * time.Second}
+var crmHTTPClient30s = &http.Client{Timeout: 30 * time.Second}
+
 const (
 	signupRatePerMinute      = 5
 	signupRateBurst          = 3
@@ -350,8 +353,7 @@ func crmCallConfirm(crmBase string, payload crmConfirmPayload) (int, []byte, err
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := crmHTTPClient30s.Do(req)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -525,8 +527,7 @@ func (repman *ReplicationManager) handlerRegister(w http.ResponseWriter, r *http
 	step1Req.Header.Set("Content-Type", "application/json")
 	step1Req.Header.Set("Accept", "application/json")
 
-	step1Client := &http.Client{Timeout: 30 * time.Second}
-	step1Resp, err := step1Client.Do(step1Req)
+	step1Resp, err := crmHTTPClient30s.Do(step1Req)
 	if err != nil {
 		http.Error(w, fmt.Sprintf(`{"error":"CRM API unreachable: %s"}`, err), http.StatusBadGateway)
 		return
@@ -670,8 +671,7 @@ func (repman *ReplicationManager) handlerSignup(w http.ResponseWriter, r *http.R
 	crmReq.Header.Set("Content-Type", "application/json")
 	crmReq.Header.Set("Accept", "application/json")
 
-	client := &http.Client{Timeout: 30 * time.Second}
-	crmResp, err := client.Do(crmReq)
+	crmResp, err := crmHTTPClient30s.Do(crmReq)
 	if err != nil {
 		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
 			"signup: CRM unreachable: %s", err)
@@ -863,8 +863,7 @@ func crmGetPlans(crmBase string) (int, []byte, error) {
 		return 0, nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	client := &http.Client{Timeout: 15 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := crmHTTPClient15s.Do(req)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -881,8 +880,7 @@ func crmGetSignupPromo(crmBase string) (int, []byte, error) {
 		return 0, nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	client := &http.Client{Timeout: 15 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := crmHTTPClient15s.Do(req)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -900,8 +898,7 @@ func crmGetSubscription(crmBase, gitlabToken, uri string) (int, []byte, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+gitlabToken)
 	req.Header.Set("Accept", "application/json")
-	client := &http.Client{Timeout: 15 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := crmHTTPClient15s.Do(req)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -920,8 +917,7 @@ func crmChangeSubscription(crmBase, gitlabToken, uri, plan string) (int, []byte,
 	req.Header.Set("Authorization", "Bearer "+gitlabToken)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	client := &http.Client{Timeout: 15 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := crmHTTPClient15s.Do(req)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -943,8 +939,7 @@ func crmUnregister(crmBase, gitlabToken, uri string) (int, []byte, error) {
 	req.Header.Set("Authorization", "Bearer "+gitlabToken)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := crmHTTPClient30s.Do(req)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/server/api_signup_security_test.go
+++ b/server/api_signup_security_test.go
@@ -1,0 +1,205 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+)
+
+func newSignupTestRepman() *ReplicationManager {
+	return &ReplicationManager{Conf: &config.Config{}}
+}
+
+func TestHandlerSignup_ThrottlesPerIP(t *testing.T) {
+	signupLimiter.resetForTests()
+	t.Cleanup(signupLimiter.resetForTests)
+
+	repman := newSignupTestRepman()
+
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/api/signup", strings.NewReader(`{}`))
+		req.RemoteAddr = "203.0.113.10:12345"
+		w := httptest.NewRecorder()
+		repman.handlerSignup(w, req)
+		if w.Code == http.StatusTooManyRequests {
+			t.Fatalf("unexpected 429 before burst exhausted at request %d", i+1)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/signup", strings.NewReader(`{}`))
+	req.RemoteAddr = "203.0.113.10:12345"
+	w := httptest.NewRecorder()
+	repman.handlerSignup(w, req)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 on 4th request, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlerSignupPromo_ThrottlesPerIP(t *testing.T) {
+	signupPromoLimiter.resetForTests()
+	t.Cleanup(signupPromoLimiter.resetForTests)
+
+	repman := &ReplicationManager{Conf: &config.Config{Cloud18CrmApiUrl: "http://[::1"}}
+
+	for i := 0; i < 10; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/api/signup/promo", nil)
+		req.RemoteAddr = "203.0.113.11:12345"
+		w := httptest.NewRecorder()
+		repman.handlerSignupPromo(w, req)
+		if w.Code == http.StatusTooManyRequests {
+			t.Fatalf("unexpected 429 before burst exhausted at request %d", i+1)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/signup/promo", nil)
+	req.RemoteAddr = "203.0.113.11:12345"
+	w := httptest.NewRecorder()
+	repman.handlerSignupPromo(w, req)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 on 11th request, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSignupHandlers_ErrorResponseJSONAndSanitized(t *testing.T) {
+	repman := &ReplicationManager{Conf: &config.Config{Cloud18CrmApiUrl: "http://[::1"}}
+
+	t.Run("signup", func(t *testing.T) {
+		signupLimiter.resetForTests()
+		t.Cleanup(signupLimiter.resetForTests)
+
+		payload := `{"first_name":"a","last_name":"b","username":"c","email":"a@b.co","password":"p"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/signup", strings.NewReader(payload))
+		req.RemoteAddr = "203.0.113.12:12345"
+		w := httptest.NewRecorder()
+		repman.handlerSignup(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var body map[string]string
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("response is not valid JSON: %v, body=%q", err, w.Body.String())
+		}
+		if body["error"] == "" {
+			t.Fatalf("expected JSON error field, got: %v", body)
+		}
+		if strings.Contains(w.Body.String(), "missing ']' in host") {
+			t.Fatalf("raw internal error leaked in response: %s", w.Body.String())
+		}
+	})
+
+	t.Run("signup promo", func(t *testing.T) {
+		signupPromoLimiter.resetForTests()
+		t.Cleanup(signupPromoLimiter.resetForTests)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/signup/promo", nil)
+		req.RemoteAddr = "203.0.113.13:12345"
+		w := httptest.NewRecorder()
+		repman.handlerSignupPromo(w, req)
+
+		if w.Code != http.StatusBadGateway {
+			t.Fatalf("expected 502, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var body map[string]string
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("response is not valid JSON: %v, body=%q", err, w.Body.String())
+		}
+		if body["error"] == "" {
+			t.Fatalf("expected JSON error field, got: %v", body)
+		}
+		if strings.Contains(w.Body.String(), "missing ']' in host") {
+			t.Fatalf("raw internal error leaked in response: %s", w.Body.String())
+		}
+	})
+}
+
+func TestSignupOptionsPreflight(t *testing.T) {
+	repman := &ReplicationManager{Conf: &config.Config{
+		APIPublicURL:          "https://public.example",
+		Cloud18Domain:        "acme",
+		Cloud18SubDomain:     "app",
+		Cloud18SubDomainZone: "test",
+	}}
+
+	t.Run("signup options", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodOptions, "/api/signup", nil)
+		req.Header.Set("Origin", "https://acme.app.test")
+		w := httptest.NewRecorder()
+		repman.handlerSignup(w, req)
+
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("expected 204, got %d", w.Code)
+		}
+		if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://acme.app.test" {
+			t.Fatalf("unexpected allow-origin header: %q", got)
+		}
+		if got := w.Header().Get("Access-Control-Allow-Methods"); !strings.Contains(got, "POST") {
+			t.Fatalf("expected POST in allow-methods, got %q", got)
+		}
+	})
+
+	t.Run("signup promo options", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodOptions, "/api/signup/promo", nil)
+		req.Header.Set("Origin", "https://acme.app.test")
+		w := httptest.NewRecorder()
+		repman.handlerSignupPromo(w, req)
+
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("expected 204, got %d", w.Code)
+		}
+		if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://acme.app.test" {
+			t.Fatalf("unexpected allow-origin header: %q", got)
+		}
+		if got := w.Header().Get("Access-Control-Allow-Methods"); !strings.Contains(got, "GET") {
+			t.Fatalf("expected GET in allow-methods, got %q", got)
+		}
+	})
+
+	t.Run("signup options disallowed origin", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodOptions, "/api/signup", nil)
+		req.Header.Set("Origin", "https://evil.example")
+		w := httptest.NewRecorder()
+		repman.handlerSignup(w, req)
+
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("expected 204, got %d", w.Code)
+		}
+		if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+			t.Fatalf("expected no allow-origin for disallowed origin, got %q", got)
+		}
+	})
+}
+
+func TestHandlerSignup_IgnoreSpoofedXFFFromUntrustedRemote(t *testing.T) {
+	signupLimiter.resetForTests()
+	t.Cleanup(signupLimiter.resetForTests)
+
+	repman := newSignupTestRepman()
+	xffs := []string{"203.0.113.1", "203.0.113.2", "203.0.113.3"}
+
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/api/signup", strings.NewReader(`{}`))
+		req.RemoteAddr = "198.51.100.77:34567"
+		req.Header.Set("X-Forwarded-For", xffs[i])
+		w := httptest.NewRecorder()
+		repman.handlerSignup(w, req)
+		if w.Code == http.StatusTooManyRequests {
+			t.Fatalf("unexpected 429 before burst exhausted at request %d", i+1)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/signup", strings.NewReader(`{}`))
+	req.RemoteAddr = "198.51.100.77:34567"
+	req.Header.Set("X-Forwarded-For", "203.0.113.200")
+	w := httptest.NewRecorder()
+	repman.handlerSignup(w, req)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 on 4th request despite spoofed XFF, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/server/api_signup_security_test.go
+++ b/server/api_signup_security_test.go
@@ -121,7 +121,7 @@ func TestSignupHandlers_ErrorResponseJSONAndSanitized(t *testing.T) {
 
 func TestSignupOptionsPreflight(t *testing.T) {
 	repman := &ReplicationManager{Conf: &config.Config{
-		APIPublicURL:          "https://public.example",
+		APIPublicURL:         "https://public.example",
 		Cloud18Domain:        "acme",
 		Cloud18SubDomain:     "app",
 		Cloud18SubDomainZone: "test",

--- a/server/http.go
+++ b/server/http.go
@@ -107,6 +107,7 @@ func (repman *ReplicationManager) httpserver() {
 		router.HandleFunc("/", repman.handlerApp)
 		router.PathPrefix("/terminal/").HandlerFunc(repman.handlerApp)
 		router.HandleFunc("/login", repman.handlerApp)
+		router.HandleFunc("/signup", repman.handlerApp)
 		router.HandleFunc("/dashboard", repman.handlerApp)
 		router.HandleFunc("/slideshow", repman.handlerApp)
 		router.PathPrefix("/images/").Handler(http.FileServer(http.Dir(repman.Conf.HttpRoot)))
@@ -118,6 +119,7 @@ func (repman *ReplicationManager) httpserver() {
 		router.HandleFunc("/", repman.rootHandler)
 		router.PathPrefix("/terminal/").HandlerFunc(repman.rootHandler)
 		router.HandleFunc("/login", repman.rootHandler)
+		router.HandleFunc("/signup", repman.rootHandler)
 		router.HandleFunc("/dashboard", repman.rootHandler)
 		router.HandleFunc("/slideshow", repman.rootHandler)
 		router.PathPrefix("/images/").Handler(repman.handlerStatic(repman.DashboardFSHandler()))
@@ -139,6 +141,7 @@ func (repman *ReplicationManager) httpserver() {
 	})
 
 	router.HandleFunc("/api/login", repman.loginHandler)
+	router.HandleFunc("/api/signup", repman.handlerSignup)
 	router.HandleFunc("/api/autologin", repman.autologinHandler)
 	router.HandleFunc("/api/dashboard-token", repman.dashboardTokenHandler)
 

--- a/server/http.go
+++ b/server/http.go
@@ -141,8 +141,10 @@ func (repman *ReplicationManager) httpserver() {
 	})
 
 	router.HandleFunc("/api/login", repman.loginHandler)
-	router.HandleFunc("/api/signup", repman.handlerSignup)
-	router.HandleFunc("/api/signup/promo", repman.handlerSignupPromo)
+	// Public auth routes are intentionally wired in both http.go and api.go because
+	// replication-manager can run either HTTP API path depending on runtime flags.
+	router.HandleFunc("/api/signup", repman.handlerSignup).Methods(http.MethodPost, http.MethodOptions)
+	router.HandleFunc("/api/signup/promo", repman.handlerSignupPromo).Methods(http.MethodGet, http.MethodOptions)
 	router.HandleFunc("/api/autologin", repman.autologinHandler)
 	router.HandleFunc("/api/dashboard-token", repman.dashboardTokenHandler)
 

--- a/server/http.go
+++ b/server/http.go
@@ -142,6 +142,7 @@ func (repman *ReplicationManager) httpserver() {
 
 	router.HandleFunc("/api/login", repman.loginHandler)
 	router.HandleFunc("/api/signup", repman.handlerSignup)
+	router.HandleFunc("/api/signup/promo", repman.handlerSignupPromo)
 	router.HandleFunc("/api/autologin", repman.autologinHandler)
 	router.HandleFunc("/api/dashboard-token", repman.dashboardTokenHandler)
 

--- a/share/dashboard_react/src/App.jsx
+++ b/share/dashboard_react/src/App.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import './App.css'
 import ToastManager from './components/ToastManager'
 import Login from './Pages/Login'
+import Signup from './Pages/Signup'
 // const Login = lazy(() => import('./Pages/Login'))
 // const Home = lazy(() => import('./Pages/Home'))
 import Home from './Pages/Home'
@@ -85,6 +86,7 @@ function App() {
           </PrivateRoute>
         } />
         <Route path='/login' element={<Login />} />
+        <Route path='/signup' element={<Signup />} />
         <Route path='/dashboard' element={<Login dashboard />} />
         <Route
           path='/slideshow'

--- a/share/dashboard_react/src/Pages/ClustersGlobalSettings/CloudSettings.jsx
+++ b/share/dashboard_react/src/Pages/ClustersGlobalSettings/CloudSettings.jsx
@@ -33,7 +33,7 @@ function CloudSettings({ config }) {
   const [showPassword, setShowPassword] = useState(false)
   const [registerForm, setRegisterForm] = useState({ email: '', password: '', domain: '', subdomain: '', zone: '' })
   const [registerErrors, setRegisterErrors] = useState({})
-  const [signupSeed, setSignupSeed] = useState(null) // { email, password } from successful signup
+  const [signupSeed, setSignupSeed] = useState(null) // { email } from successful signup
   const [isSignupModalOpen, setIsSignupModalOpen] = useState(false)
   const signupCloseTimerRef = useRef(null)
   const [isSendingCode, setIsSendingCode] = useState(false)
@@ -115,7 +115,7 @@ Start create an account in https://gitlab.signal18.io
     setRegisterStep(1)
     setRegisterForm({
       email: signupSeed?.email || config?.cloud18GitUser || '',
-      password: signupSeed?.password || '',
+      password: '',
       domain: config?.cloud18Domain || '',
       subdomain: config?.cloud18SubDomain || '',
       zone: config?.cloud18SubDomainZone || ''
@@ -139,11 +139,10 @@ Start create an account in https://gitlab.signal18.io
 
   const handleSignupSuccess = (_, payload) => {
     const seeded = {
-      email: payload?.email || '',
-      password: payload?.password || ''
+      email: payload?.email || ''
     }
     setSignupSeed(seeded)
-    setRegisterForm(f => ({ ...f, email: seeded.email, password: seeded.password }))
+    setRegisterForm(f => ({ ...f, email: seeded.email }))
     clearTimeout(signupCloseTimerRef.current)
     signupCloseTimerRef.current = setTimeout(() => setIsSignupModalOpen(false), 1500)
   }
@@ -182,7 +181,7 @@ Start create an account in https://gitlab.signal18.io
   const validateRegisterForm = (form) => {
     const errors = {}
     const email = (signupSeed?.email || form.email || '').trim()
-    const password = signupSeed?.password || form.password || ''
+    const password = form.password || ''
 
     if (!email) errors.email = 'Email is required'
     else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) errors.email = 'Enter a valid email address'
@@ -204,7 +203,7 @@ Start create an account in https://gitlab.signal18.io
     setIsSendingCode(true)
     const uri = `${registerForm.domain.trim()}.${registerForm.subdomain.trim()}.${registerForm.zone.trim()}`
     const email = (signupSeed?.email || registerForm.email || '').trim()
-    const password = signupSeed?.password || registerForm.password || ''
+    const password = registerForm.password || ''
     const result = await dispatch(registerInstance({ email, password, uri }))
     setIsSendingCode(false)
     if (result?.payload?.status === 202) {
@@ -218,7 +217,7 @@ Start create an account in https://gitlab.signal18.io
     setIsConfirming(true)
     const uri = `${registerForm.domain.trim()}.${registerForm.subdomain.trim()}.${registerForm.zone.trim()}`
     const email = (signupSeed?.email || registerForm.email || '').trim()
-    const password = signupSeed?.password || registerForm.password || ''
+    const password = registerForm.password || ''
     const result = await dispatch(confirmRegisterInstance({ email, password, uri }))
     setIsConfirming(false)
     if (result?.payload?.status === 201) {
@@ -249,19 +248,15 @@ Start create an account in https://gitlab.signal18.io
       </FormControl>
       <FormControl isInvalid={!!registerErrors.password} isRequired>
         <FormLabel fontSize='sm'>GitLab Password</FormLabel>
-        {signupSeed ? (
-          <Input size='sm' type='password' value='••••••••' isReadOnly />
-        ) : (
-          <InputGroup size='sm'>
-            <Input type={showPassword ? 'text' : 'password'} placeholder='min 8 characters'
-              value={registerForm.password}
-              onChange={(e) => setRegisterForm(f => ({ ...f, password: e.target.value }))}
-            />
-            <InputRightElement>
-              <Box as={showPassword ? HiEyeOff : HiEye} cursor='pointer' onClick={() => setShowPassword(v => !v)} />
-            </InputRightElement>
-          </InputGroup>
-        )}
+        <InputGroup size='sm'>
+          <Input type={showPassword ? 'text' : 'password'} placeholder='min 8 characters'
+            value={registerForm.password}
+            onChange={(e) => setRegisterForm(f => ({ ...f, password: e.target.value }))}
+          />
+          <InputRightElement>
+            <Box as={showPassword ? HiEyeOff : HiEye} cursor='pointer' onClick={() => setShowPassword(v => !v)} />
+          </InputRightElement>
+        </InputGroup>
         <FormErrorMessage>{registerErrors.password}</FormErrorMessage>
       </FormControl>
       {signupSeed && (

--- a/share/dashboard_react/src/Pages/ClustersGlobalSettings/CloudSettings.jsx
+++ b/share/dashboard_react/src/Pages/ClustersGlobalSettings/CloudSettings.jsx
@@ -19,6 +19,8 @@ import Markdown from 'react-markdown'
 import CommonModal from '../../components/Modals/CommonModal'
 import modalStyles from '../../components/Modals/styles.module.scss'
 import remarkGfm from 'remark-gfm'
+import SignupForm from '../../components/Auth/SignupForm'
+import { authService } from '../../services/authService'
 
 function CloudSettings({ config }) {
   const dispatch = useDispatch()
@@ -31,6 +33,9 @@ function CloudSettings({ config }) {
   const [showPassword, setShowPassword] = useState(false)
   const [registerForm, setRegisterForm] = useState({ email: '', password: '', domain: '', subdomain: '', zone: '' })
   const [registerErrors, setRegisterErrors] = useState({})
+  const [signupSeed, setSignupSeed] = useState(null) // { email, password } from successful signup
+  const [isSignupModalOpen, setIsSignupModalOpen] = useState(false)
+  const signupCloseTimerRef = useRef(null)
   const [isSendingCode, setIsSendingCode] = useState(false)
   const [isConfirming, setIsConfirming] = useState(false)
   const [regStatus, setRegStatus] = useState(null)   // {state, message} from server
@@ -109,8 +114,8 @@ Start create an account in https://gitlab.signal18.io
   const openRegisterModal = () => {
     setRegisterStep(1)
     setRegisterForm({
-      email: config?.cloud18GitUser || '',
-      password: '',
+      email: signupSeed?.email || config?.cloud18GitUser || '',
+      password: signupSeed?.password || '',
       domain: config?.cloud18Domain || '',
       subdomain: config?.cloud18SubDomain || '',
       zone: config?.cloud18SubDomainZone || ''
@@ -124,6 +129,23 @@ Start create an account in https://gitlab.signal18.io
   const stopPolling = () => {
     if (pollIntervalRef.current) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null }
     if (tickIntervalRef.current) { clearInterval(tickIntervalRef.current); tickIntervalRef.current = null }
+  }
+
+  const clearSignupSeed = () => {
+    setSignupSeed(null)
+    setRegisterForm(f => ({ ...f, email: '', password: '' }))
+    setRegisterErrors(e => ({ ...e, email: undefined, password: undefined }))
+  }
+
+  const handleSignupSuccess = (_, payload) => {
+    const seeded = {
+      email: payload?.email || '',
+      password: payload?.password || ''
+    }
+    setSignupSeed(seeded)
+    setRegisterForm(f => ({ ...f, email: seeded.email, password: seeded.password }))
+    clearTimeout(signupCloseTimerRef.current)
+    signupCloseTimerRef.current = setTimeout(() => setIsSignupModalOpen(false), 1500)
   }
 
   // Start polling when step 2 becomes active
@@ -159,10 +181,13 @@ Start create an account in https://gitlab.signal18.io
 
   const validateRegisterForm = (form) => {
     const errors = {}
-    if (!form.email.trim()) errors.email = 'Email is required'
-    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email.trim())) errors.email = 'Enter a valid email address'
-    if (!form.password) errors.password = 'Password is required'
-    else if (form.password.length < 8) errors.password = 'Password must be at least 8 characters'
+    const email = (signupSeed?.email || form.email || '').trim()
+    const password = signupSeed?.password || form.password || ''
+
+    if (!email) errors.email = 'Email is required'
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) errors.email = 'Enter a valid email address'
+    if (!password) errors.password = 'Password is required'
+    else if (password.length < 8) errors.password = 'Password must be at least 8 characters'
     if (!form.domain.trim()) errors.domain = 'Domain is required'
     else if (!/^[a-z0-9-]+$/.test(form.domain.trim())) errors.domain = 'Only lowercase letters, digits and hyphens'
     if (!form.subdomain.trim()) errors.subdomain = 'Subdomain is required'
@@ -178,9 +203,12 @@ Start create an account in https://gitlab.signal18.io
     if (Object.keys(errors).length > 0) { setRegisterErrors(errors); return }
     setIsSendingCode(true)
     const uri = `${registerForm.domain.trim()}.${registerForm.subdomain.trim()}.${registerForm.zone.trim()}`
-    const result = await dispatch(registerInstance({ email: registerForm.email.trim(), password: registerForm.password, uri }))
+    const email = (signupSeed?.email || registerForm.email || '').trim()
+    const password = signupSeed?.password || registerForm.password || ''
+    const result = await dispatch(registerInstance({ email, password, uri }))
     setIsSendingCode(false)
     if (result?.payload?.status === 202) {
+      setRegisterForm(f => ({ ...f, email, password }))
       setRegisterStep(2)
     }
   }
@@ -189,7 +217,9 @@ Start create an account in https://gitlab.signal18.io
   const handleConfirmRegistration = async () => {
     setIsConfirming(true)
     const uri = `${registerForm.domain.trim()}.${registerForm.subdomain.trim()}.${registerForm.zone.trim()}`
-    const result = await dispatch(confirmRegisterInstance({ email: registerForm.email.trim(), password: registerForm.password, uri }))
+    const email = (signupSeed?.email || registerForm.email || '').trim()
+    const password = signupSeed?.password || registerForm.password || ''
+    const result = await dispatch(confirmRegisterInstance({ email, password, uri }))
     setIsConfirming(false)
     if (result?.payload?.status === 201) {
       setIsRegisterModalOpen(false)
@@ -201,27 +231,45 @@ Start create an account in https://gitlab.signal18.io
       <Text fontSize='sm' color='gray.500'>
         Creates a GitLab account at <Link href='https://gitlab.signal18.io' target='_blank' color='blue.400'>gitlab.signal18.io</Link>. GitLab will send a confirmation email — you will need to click it before completing registration.
       </Text>
+      <HStack justify='space-between' align='center' bg='blue.50' borderRadius='md' p={3}>
+        <Text fontSize='xs' color='blue.700'>No GitLab SSO account yet?</Text>
+        <RMButton size='xs' variant='outline' onClick={() => setIsSignupModalOpen(true)}>Sign up now</RMButton>
+      </HStack>
       <FormControl isInvalid={!!registerErrors.email} isRequired>
         <FormLabel fontSize='sm'>Email</FormLabel>
-        <Input size='sm' type='email' placeholder='admin@mycompany.com'
-          value={registerForm.email}
-          onChange={(e) => setRegisterForm(f => ({ ...f, email: e.target.value }))}
-        />
+        {signupSeed ? (
+          <Input size='sm' type='email' value={signupSeed.email} isReadOnly />
+        ) : (
+          <Input size='sm' type='email' placeholder='admin@mycompany.com'
+            value={registerForm.email}
+            onChange={(e) => setRegisterForm(f => ({ ...f, email: e.target.value }))}
+          />
+        )}
         <FormErrorMessage>{registerErrors.email}</FormErrorMessage>
       </FormControl>
       <FormControl isInvalid={!!registerErrors.password} isRequired>
         <FormLabel fontSize='sm'>GitLab Password</FormLabel>
-        <InputGroup size='sm'>
-          <Input type={showPassword ? 'text' : 'password'} placeholder='min 8 characters'
-            value={registerForm.password}
-            onChange={(e) => setRegisterForm(f => ({ ...f, password: e.target.value }))}
-          />
-          <InputRightElement>
-            <Box as={showPassword ? HiEyeOff : HiEye} cursor='pointer' onClick={() => setShowPassword(v => !v)} />
-          </InputRightElement>
-        </InputGroup>
+        {signupSeed ? (
+          <Input size='sm' type='password' value='••••••••' isReadOnly />
+        ) : (
+          <InputGroup size='sm'>
+            <Input type={showPassword ? 'text' : 'password'} placeholder='min 8 characters'
+              value={registerForm.password}
+              onChange={(e) => setRegisterForm(f => ({ ...f, password: e.target.value }))}
+            />
+            <InputRightElement>
+              <Box as={showPassword ? HiEyeOff : HiEye} cursor='pointer' onClick={() => setShowPassword(v => !v)} />
+            </InputRightElement>
+          </InputGroup>
+        )}
         <FormErrorMessage>{registerErrors.password}</FormErrorMessage>
       </FormControl>
+      {signupSeed && (
+        <HStack justify='space-between' align='center' bg='green.50' borderRadius='md' p={3}>
+          <Text fontSize='xs' color='green.700'>Using newly created GitLab SSO account.</Text>
+          <RMButton size='xs' variant='ghost' onClick={clearSignupSeed}>Use different account</RMButton>
+        </HStack>
+      )}
       <FormControl isInvalid={!!registerErrors.domain} isRequired>
         <FormLabel fontSize='sm'>Domain <Text as='span' fontWeight='normal' color='gray.400'>(company namespace)</Text></FormLabel>
         <Input size='sm' placeholder='mycompany'
@@ -304,6 +352,17 @@ Start create an account in https://gitlab.signal18.io
     )
   })()
 
+  const signupSeedBadgeColor = registerStep === 1 ? 'blue' : 'orange'
+
+  const registerModalTitle = (
+    <HStack spacing={2} align='center'>
+      <Text>
+        {registerStep === 1 ? 'Register with Signal18 Cloud18 (1/2)' : 'Waiting for email confirmation (2/2)'}
+      </Text>
+      {signupSeed && <TagPill colorScheme={signupSeedBadgeColor} text='Using newly created account' />}
+    </HStack>
+  )
+
   // Plans fetched from CRM; fallback list shown only if CRM is unreachable
   const PLANS_FALLBACK = [
     { value: 'free',             label: 'Free',                                    desc: 'Community access, config backup to GitLab, basic alerting' },
@@ -369,8 +428,13 @@ Start create an account in https://gitlab.signal18.io
 
   // Reset URI unlock when connection is re-established (new registration completed)
   useEffect(() => {
-    if (isConnected) setUriUnlocked(false)
+    if (isConnected) {
+      setUriUnlocked(false)
+      setSignupSeed(null)
+    }
   }, [isConnected])
+
+  useEffect(() => () => clearTimeout(signupCloseTimerRef.current), [])
 
   // True when a full set of credentials + URI is stored, meaning a direct Connect is
   // possible. After Unregister (uriUnlocked=true) we force this false so the UI shows
@@ -498,9 +562,33 @@ Start create an account in https://gitlab.signal18.io
         <CommonModal
           isOpen={isRegisterModalOpen}
           size='md'
-          title={registerStep === 1 ? 'Register with Signal18 Cloud18 (1/2)' : 'Waiting for email confirmation (2/2)'}
+          title={registerModalTitle}
           body={registerFormBody}
           closeModal={() => { stopPolling(); setIsRegisterModalOpen(false) }}
+        />
+      )}
+      {isSignupModalOpen && (
+        <CommonModal
+          isOpen={isSignupModalOpen}
+          size='md'
+          title='Create GitLab SSO account'
+          closeModal={() => {
+            clearTimeout(signupCloseTimerRef.current)
+            setIsSignupModalOpen(false)
+          }}
+          body={
+            <SignupForm
+              onSubmit={authService.signup}
+              onSuccess={handleSignupSuccess}
+              onCancel={() => {
+                clearTimeout(signupCloseTimerRef.current)
+                setIsSignupModalOpen(false)
+              }}
+              submitLabel='Create GitLab SSO account'
+              loadingText='Creating account'
+              successMessage='Account created. You can continue registration now.'
+            />
+          }
         />
       )}
       {isSubModalOpen && (

--- a/share/dashboard_react/src/Pages/Login/index.jsx
+++ b/share/dashboard_react/src/Pages/Login/index.jsx
@@ -166,10 +166,10 @@ function Login({ dashboard = false }) {
                   id='btnGitRegister'
                   type='button'
                   size='medium'
-                  onClick={() => window.open("https://gitlab.signal18.io/users/sign_up", '_blank')}
+                  onClick={() => navigate('/signup')}
                   isLoading={loadingGitLogin}
                   loadingText={'Signing up to Cloud18'}>
-                  Sign Up To cloud18
+                  Sign up with GitLab SSO
                 </RMButton>
               </Stack>
             </Stack>

--- a/share/dashboard_react/src/Pages/PageContainer/index.jsx
+++ b/share/dashboard_react/src/Pages/PageContainer/index.jsx
@@ -66,7 +66,8 @@ function PageContainer({ children }) {
   }, [dispatch, handleResize, user])
 
   useEffect(() => {
-    if (!isLogged && user === null && !isAuthorized() && location.pathname !== '/login') {
+    const isPublicAuthPage = location.pathname === '/login' || location.pathname === '/signup'
+    if (!isLogged && user === null && !isAuthorized() && !isPublicAuthPage) {
       // Slideshow auth goes through /dashboard (viewer token) not /login (regular autologin → /)
       navigate(location.pathname === '/slideshow' ? '/dashboard' : '/login')
     }
@@ -76,8 +77,10 @@ function PageContainer({ children }) {
     <Box className={styles.container}>
       <Navbar username={user?.username} />
       <Box className={styles.pageContent}>{children}</Box>
-      <Box as='footer' className={styles.footer} textAlign={location.pathname === '/login' ? 'right' : 'left'}>
-        {location.pathname === '/login' ? monitor?.config?.apiSwaggerEnabled && (<Link href='/api-docs/index.html' target='_blank' rel='noreferrer'>API Swagger</Link>) : (<Text>{`Replication-Manager ${fullVersion} © 2017-${new Date().getFullYear()} SIGNAL18 CLOUD SAS`}</Text>)}
+      <Box as='footer' className={styles.footer} textAlign={(location.pathname === '/login' || location.pathname === '/signup') ? 'right' : 'left'}>
+        {(location.pathname === '/login' || location.pathname === '/signup')
+          ? monitor?.config?.apiSwaggerEnabled && (<Link href='/api-docs/index.html' target='_blank' rel='noreferrer'>API Swagger</Link>)
+          : (<Text>{`Replication-Manager ${fullVersion} © 2017-${new Date().getFullYear()} SIGNAL18 CLOUD SAS`}</Text>)}
       </Box>
     </Box>
   )

--- a/share/dashboard_react/src/Pages/Signup/index.jsx
+++ b/share/dashboard_react/src/Pages/Signup/index.jsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom'
-import { Container, Heading, Stack } from '@chakra-ui/react'
+import { Container } from '@chakra-ui/react'
 import PageContainer from '../PageContainer'
 import SignupForm from '../../components/Auth/SignupForm'
 import { authService } from '../../services/authService'
@@ -13,19 +13,13 @@ function Signup() {
 
   return (
     <PageContainer>
-      <Container maxWidth='lg' py={{ base: '10', md: '12' }} px={{ base: '0', sm: '8' }}>
-        <Stack spacing='6'>
-          <Stack spacing='4'>
-            <Stack spacing={{ base: '2', md: '3' }} textAlign='center'>
-              <Heading size='md'>Sign up with GitLab SSO</Heading>
-            </Stack>
-          </Stack>
-          <SignupForm
-            onSubmit={authService.signup}
-            onSuccess={handleSignupSuccess}
-            successMessage='Signup successful. Redirecting to login...'
-          />
-        </Stack>
+      <Container maxWidth='6xl' py={{ base: '8', md: '12' }} px={{ base: '0', sm: '8' }}>
+        <SignupForm
+          splitLayout
+          onSubmit={authService.signup}
+          onSuccess={handleSignupSuccess}
+          successMessage='Signup successful. Redirecting to login...'
+        />
       </Container>
     </PageContainer>
   )

--- a/share/dashboard_react/src/Pages/Signup/index.jsx
+++ b/share/dashboard_react/src/Pages/Signup/index.jsx
@@ -13,9 +13,9 @@ function Signup() {
 
   return (
     <PageContainer>
-      <Container maxWidth='lg' py={{ base: '24', md: '24' }} px={{ base: '0', sm: '8' }}>
-        <Stack spacing='8'>
-          <Stack spacing='6'>
+      <Container maxWidth='lg' py={{ base: '10', md: '12' }} px={{ base: '0', sm: '8' }}>
+        <Stack spacing='6'>
+          <Stack spacing='4'>
             <Stack spacing={{ base: '2', md: '3' }} textAlign='center'>
               <Heading size='md'>Sign up with GitLab SSO</Heading>
             </Stack>

--- a/share/dashboard_react/src/Pages/Signup/index.jsx
+++ b/share/dashboard_react/src/Pages/Signup/index.jsx
@@ -1,0 +1,34 @@
+import { useNavigate } from 'react-router-dom'
+import { Container, Heading, Stack } from '@chakra-ui/react'
+import PageContainer from '../PageContainer'
+import SignupForm from '../../components/Auth/SignupForm'
+import { authService } from '../../services/authService'
+
+function Signup() {
+  const navigate = useNavigate()
+
+  const handleSignupSuccess = () => {
+    setTimeout(() => navigate('/login'), 1500)
+  }
+
+  return (
+    <PageContainer>
+      <Container maxWidth='lg' py={{ base: '24', md: '24' }} px={{ base: '0', sm: '8' }}>
+        <Stack spacing='8'>
+          <Stack spacing='6'>
+            <Stack spacing={{ base: '2', md: '3' }} textAlign='center'>
+              <Heading size='md'>Sign up with GitLab SSO</Heading>
+            </Stack>
+          </Stack>
+          <SignupForm
+            onSubmit={authService.signup}
+            onSuccess={handleSignupSuccess}
+            successMessage='Signup successful. Redirecting to login...'
+          />
+        </Stack>
+      </Container>
+    </PageContainer>
+  )
+}
+
+export default Signup

--- a/share/dashboard_react/src/components/Auth/SignupForm.jsx
+++ b/share/dashboard_react/src/components/Auth/SignupForm.jsx
@@ -1,0 +1,131 @@
+import { useState } from 'react'
+import { Box, FormControl, FormErrorMessage, FormLabel, Input, Stack } from '@chakra-ui/react'
+import { useTheme } from '../../ThemeProvider'
+import PasswordControl from '../PasswordControl'
+import RMButton from '../RMButton'
+import Message from '../Message'
+import loginStyles from '../../Pages/Login/styles.module.scss'
+
+const emailRegex = /^[^@\s]+@[^@\s]+\.[^@\s]+$/
+
+function SignupForm({
+  onSubmit,
+  onSuccess,
+  onCancel,
+  submitLabel = 'Create account',
+  loadingText = 'Signing up',
+  successMessage = 'Signup successful',
+  className = ''
+}) {
+  const { theme } = useTheme()
+
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [username, setUsername] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [errors, setErrors] = useState({})
+  const [loading, setLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState('')
+  const [localSuccessMessage, setLocalSuccessMessage] = useState('')
+
+  const validate = () => {
+    const nextErrors = {}
+    if (!firstName.trim()) nextErrors.firstName = 'Please enter your first name'
+    if (!lastName.trim()) nextErrors.lastName = 'Please enter your last name'
+    if (!username.trim()) nextErrors.username = 'Please enter your username'
+    if (!email.trim()) nextErrors.email = 'Please enter your email'
+    else if (!emailRegex.test(email.trim())) nextErrors.email = 'Please enter a valid email'
+    if (!password) nextErrors.password = 'Please enter a password'
+    setErrors(nextErrors)
+    return Object.keys(nextErrors).length === 0
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setErrorMessage('')
+    setLocalSuccessMessage('')
+
+    if (!validate()) return
+
+    setLoading(true)
+    try {
+      const payload = {
+        first_name: firstName.trim(),
+        last_name: lastName.trim(),
+        username: username.trim(),
+        email: email.trim().toLowerCase(),
+        password
+      }
+
+      const response = await onSubmit(payload)
+      if (response.status >= 200 && response.status < 300) {
+        setLocalSuccessMessage(successMessage)
+        if (onSuccess) {
+          await Promise.resolve(onSuccess(response, payload))
+        }
+      } else {
+        const message = typeof response.data === 'object' && response.data?.error
+          ? response.data.error
+          : 'Signup failed'
+        setErrorMessage(message)
+      }
+    } catch (error) {
+      setErrorMessage(error.message || 'Signup failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Box as='form' className={`${loginStyles.loginForm} ${className}`.trim()} onSubmit={handleSubmit}>
+      <Stack spacing='6'>
+        <Stack spacing='5'>
+          <FormControl isInvalid={errors.firstName}>
+            <FormLabel className={theme === 'dark' ? loginStyles.darkLoginText : ''}>First Name</FormLabel>
+            <Input value={firstName} className={theme === 'dark' ? loginStyles.darkLoginText : ''} onChange={(e) => setFirstName(e.target.value)} />
+            <FormErrorMessage sx={loginStyles.errorMessage}>{errors.firstName}</FormErrorMessage>
+          </FormControl>
+          <FormControl isInvalid={errors.lastName}>
+            <FormLabel className={theme === 'dark' ? loginStyles.darkLoginText : ''}>Last Name</FormLabel>
+            <Input value={lastName} className={theme === 'dark' ? loginStyles.darkLoginText : ''} onChange={(e) => setLastName(e.target.value)} />
+            <FormErrorMessage sx={loginStyles.errorMessage}>{errors.lastName}</FormErrorMessage>
+          </FormControl>
+          <FormControl isInvalid={errors.username}>
+            <FormLabel className={theme === 'dark' ? loginStyles.darkLoginText : ''}>Username</FormLabel>
+            <Input value={username} className={theme === 'dark' ? loginStyles.darkLoginText : ''} onChange={(e) => setUsername(e.target.value)} />
+            <FormErrorMessage sx={loginStyles.errorMessage}>{errors.username}</FormErrorMessage>
+          </FormControl>
+          <FormControl isInvalid={errors.email}>
+            <FormLabel className={theme === 'dark' ? loginStyles.darkLoginText : ''}>Email</FormLabel>
+            <Input type='email' value={email} className={theme === 'dark' ? loginStyles.darkLoginText : ''} onChange={(e) => setEmail(e.target.value)} />
+            <FormErrorMessage sx={loginStyles.errorMessage}>{errors.email}</FormErrorMessage>
+          </FormControl>
+          <PasswordControl
+            passwordError={errors.password}
+            inputClassName={theme === 'dark' ? loginStyles.darkLoginText : ''}
+            labelClassName={theme === 'dark' ? loginStyles.darkLoginText : ''}
+            onChange={(e) => setPassword(e.target.value)}
+            className={`${loginStyles.revealButton} ${loginStyles.errorMessage} ${theme === 'dark' ? loginStyles.darkLoginText : ''}`}
+          />
+        </Stack>
+
+        {errorMessage && <Message message={errorMessage} />}
+        {localSuccessMessage && <Message message={localSuccessMessage} type='success' />}
+
+        <Stack spacing='6' direction={{ base: 'column', sm: 'row' }}>
+          <RMButton type='submit' size='medium' isLoading={loading} loadingText={loadingText}>
+            {submitLabel}
+          </RMButton>
+          {onCancel && (
+            <RMButton type='button' size='medium' variant='ghost' onClick={onCancel} isDisabled={loading}>
+              Cancel
+            </RMButton>
+          )}
+        </Stack>
+      </Stack>
+    </Box>
+  )
+}
+
+export default SignupForm

--- a/share/dashboard_react/src/components/Auth/SignupForm.jsx
+++ b/share/dashboard_react/src/components/Auth/SignupForm.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Box, FormControl, FormErrorMessage, FormLabel, Input, Stack } from '@chakra-ui/react'
+import { Box, FormControl, FormErrorMessage, FormLabel, Input, SimpleGrid, Stack, Text } from '@chakra-ui/react'
 import { useTheme } from '../../ThemeProvider'
 import PasswordControl from '../PasswordControl'
 import RMButton from '../RMButton'
@@ -23,6 +23,8 @@ function SignupForm({
   const [lastName, setLastName] = useState('')
   const [username, setUsername] = useState('')
   const [email, setEmail] = useState('')
+  const [telephone, setTelephone] = useState('')
+  const [company, setCompany] = useState('')
   const [password, setPassword] = useState('')
   const [errors, setErrors] = useState({})
   const [loading, setLoading] = useState(false)
@@ -55,6 +57,8 @@ function SignupForm({
         last_name: lastName.trim(),
         username: username.trim(),
         email: email.trim().toLowerCase(),
+        telephone: telephone.trim(),
+        company: company.trim(),
         password
       }
 
@@ -81,16 +85,18 @@ function SignupForm({
     <Box as='form' className={`${loginStyles.loginForm} ${className}`.trim()} onSubmit={handleSubmit}>
       <Stack spacing='6'>
         <Stack spacing='5'>
-          <FormControl isInvalid={errors.firstName}>
-            <FormLabel className={theme === 'dark' ? loginStyles.darkLoginText : ''}>First Name</FormLabel>
-            <Input value={firstName} className={theme === 'dark' ? loginStyles.darkLoginText : ''} onChange={(e) => setFirstName(e.target.value)} />
-            <FormErrorMessage sx={loginStyles.errorMessage}>{errors.firstName}</FormErrorMessage>
-          </FormControl>
-          <FormControl isInvalid={errors.lastName}>
-            <FormLabel className={theme === 'dark' ? loginStyles.darkLoginText : ''}>Last Name</FormLabel>
-            <Input value={lastName} className={theme === 'dark' ? loginStyles.darkLoginText : ''} onChange={(e) => setLastName(e.target.value)} />
-            <FormErrorMessage sx={loginStyles.errorMessage}>{errors.lastName}</FormErrorMessage>
-          </FormControl>
+          <SimpleGrid columns={{ base: 1, md: 2 }} spacing='4'>
+            <FormControl isInvalid={errors.firstName}>
+              <FormLabel className={theme === 'dark' ? loginStyles.darkLoginText : ''}>First Name</FormLabel>
+              <Input value={firstName} className={theme === 'dark' ? loginStyles.darkLoginText : ''} onChange={(e) => setFirstName(e.target.value)} />
+              <FormErrorMessage sx={loginStyles.errorMessage}>{errors.firstName}</FormErrorMessage>
+            </FormControl>
+            <FormControl isInvalid={errors.lastName}>
+              <FormLabel className={theme === 'dark' ? loginStyles.darkLoginText : ''}>Last Name</FormLabel>
+              <Input value={lastName} className={theme === 'dark' ? loginStyles.darkLoginText : ''} onChange={(e) => setLastName(e.target.value)} />
+              <FormErrorMessage sx={loginStyles.errorMessage}>{errors.lastName}</FormErrorMessage>
+            </FormControl>
+          </SimpleGrid>
           <FormControl isInvalid={errors.username}>
             <FormLabel className={theme === 'dark' ? loginStyles.darkLoginText : ''}>Username</FormLabel>
             <Input value={username} className={theme === 'dark' ? loginStyles.darkLoginText : ''} onChange={(e) => setUsername(e.target.value)} />
@@ -100,6 +106,14 @@ function SignupForm({
             <FormLabel className={theme === 'dark' ? loginStyles.darkLoginText : ''}>Email</FormLabel>
             <Input type='email' value={email} className={theme === 'dark' ? loginStyles.darkLoginText : ''} onChange={(e) => setEmail(e.target.value)} />
             <FormErrorMessage sx={loginStyles.errorMessage}>{errors.email}</FormErrorMessage>
+          </FormControl>
+          <FormControl>
+            <FormLabel className={theme === 'dark' ? loginStyles.darkLoginText : ''}>Telephone <Text as='span' fontWeight='normal' color='gray.400'>(optional)</Text></FormLabel>
+            <Input type='tel' value={telephone} className={theme === 'dark' ? loginStyles.darkLoginText : ''} onChange={(e) => setTelephone(e.target.value)} />
+          </FormControl>
+          <FormControl>
+            <FormLabel className={theme === 'dark' ? loginStyles.darkLoginText : ''}>Company <Text as='span' fontWeight='normal' color='gray.400'>(optional)</Text></FormLabel>
+            <Input value={company} className={theme === 'dark' ? loginStyles.darkLoginText : ''} onChange={(e) => setCompany(e.target.value)} />
           </FormControl>
           <PasswordControl
             passwordError={errors.password}

--- a/share/dashboard_react/src/components/Auth/SignupForm.jsx
+++ b/share/dashboard_react/src/components/Auth/SignupForm.jsx
@@ -55,6 +55,7 @@ function SignupForm({
     if (!email.trim()) nextErrors.email = 'Please enter your email'
     else if (!emailRegex.test(email.trim())) nextErrors.email = 'Please enter a valid email'
     if (!password) nextErrors.password = 'Please enter a password'
+    else if (password.length < 8) nextErrors.password = 'Password must be at least 8 characters'
     setErrors(nextErrors)
     return Object.keys(nextErrors).length === 0
   }
@@ -104,23 +105,23 @@ function SignupForm({
   const formFields = (
     <Stack spacing='3'>
       <SimpleGrid columns={{ base: 1, md: 2 }} spacing='3'>
-        <FormControl isInvalid={!!errors.firstName}>
+        <FormControl isInvalid={!!errors.firstName} isRequired>
           <FormLabel className={fieldLabelClass} fontSize='sm' fontWeight='semibold'>First Name</FormLabel>
           <Input value={firstName} size='sm' className={fieldInputClass} onChange={(e) => setFirstName(e.target.value)} />
           <FormErrorMessage>{errors.firstName}</FormErrorMessage>
         </FormControl>
-        <FormControl isInvalid={!!errors.lastName}>
+        <FormControl isInvalid={!!errors.lastName} isRequired>
           <FormLabel className={fieldLabelClass} fontSize='sm' fontWeight='semibold'>Last Name</FormLabel>
           <Input value={lastName} size='sm' className={fieldInputClass} onChange={(e) => setLastName(e.target.value)} />
           <FormErrorMessage>{errors.lastName}</FormErrorMessage>
         </FormControl>
       </SimpleGrid>
-      <FormControl isInvalid={!!errors.username}>
+      <FormControl isInvalid={!!errors.username} isRequired>
         <FormLabel className={fieldLabelClass} fontSize='sm' fontWeight='semibold'>Username</FormLabel>
         <Input value={username} size='sm' className={fieldInputClass} onChange={(e) => setUsername(e.target.value)} />
         <FormErrorMessage>{errors.username}</FormErrorMessage>
       </FormControl>
-      <FormControl isInvalid={!!errors.email}>
+      <FormControl isInvalid={!!errors.email} isRequired>
         <FormLabel className={fieldLabelClass} fontSize='sm' fontWeight='semibold'>Email</FormLabel>
         <Input type='email' value={email} size='sm' className={fieldInputClass} onChange={(e) => setEmail(e.target.value)} />
         <FormErrorMessage>{errors.email}</FormErrorMessage>
@@ -133,14 +134,17 @@ function SignupForm({
         <FormLabel className={fieldLabelClass} fontSize='sm' fontWeight='semibold'>Company <Text as='span' fontWeight='normal' color='gray.400'>(optional)</Text></FormLabel>
         <Input value={company} size='sm' className={fieldInputClass} onChange={(e) => setCompany(e.target.value)} />
       </FormControl>
-      <PasswordControl
-        passwordError={errors.password}
-        inputClassName={fieldInputClass}
-        labelClassName={fieldLabelClass}
-        onChange={(e) => setPassword(e.target.value)}
-        className={revealBtnClass}
-        size='sm'
-      />
+      <FormControl isInvalid={!!errors.password} isRequired>
+        <FormLabel className={fieldLabelClass} fontSize='sm' fontWeight='semibold'>Password</FormLabel>
+        <PasswordControl
+          noControl
+          inputClassName={fieldInputClass}
+          onChange={(e) => setPassword(e.target.value)}
+          className={revealBtnClass}
+          size='sm'
+        />
+        <FormErrorMessage>{errors.password}</FormErrorMessage>
+      </FormControl>
     </Stack>
   )
 
@@ -152,7 +156,7 @@ function SignupForm({
           <VStack spacing={5} align='stretch'>
             {promo?.free_credit_offer > 0 && (
               <Box
-                bg='linear-gradient(135deg, #059669 0%, #10b981 100%)'
+                bgGradient='linear(to-br, green.600, green.500)'
                 borderRadius='lg'
                 p={5}
                 boxShadow='md'
@@ -244,7 +248,7 @@ function SignupForm({
         {/* Promotional hero banner — top of form for maximum visibility */}
         {promo?.free_credit_offer > 0 && (
           <Box
-            bg='linear-gradient(135deg, #059669 0%, #10b981 100%)'
+            bgGradient='linear(to-br, green.600, green.500)'
             borderRadius='lg'
             p={4}
             boxShadow='md'

--- a/share/dashboard_react/src/components/Auth/SignupForm.jsx
+++ b/share/dashboard_react/src/components/Auth/SignupForm.jsx
@@ -1,10 +1,11 @@
-import { useState } from 'react'
-import { Box, FormControl, FormErrorMessage, FormLabel, Input, SimpleGrid, Stack, Text } from '@chakra-ui/react'
+import { useState, useEffect } from 'react'
+import { Box, Flex, FormControl, FormErrorMessage, FormLabel, Heading, HStack, Input, SimpleGrid, Stack, Text, VStack } from '@chakra-ui/react'
 import { useTheme } from '../../ThemeProvider'
 import PasswordControl from '../PasswordControl'
 import RMButton from '../RMButton'
 import Message from '../Message'
 import loginStyles from '../../Pages/Login/styles.module.scss'
+import { authService } from '../../services/authService'
 
 const emailRegex = /^[^@\s]+@[^@\s]+\.[^@\s]+$/
 
@@ -15,7 +16,8 @@ function SignupForm({
   submitLabel = 'Create account',
   loadingText = 'Signing up',
   successMessage = 'Signup successful',
-  className = ''
+  className = '',
+  splitLayout = false
 }) {
   const { theme } = useTheme()
 
@@ -30,6 +32,20 @@ function SignupForm({
   const [loading, setLoading] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
   const [localSuccessMessage, setLocalSuccessMessage] = useState('')
+  const [promo, setPromo] = useState(null) // { enabled, free_credit_offer, ... }
+
+  useEffect(() => {
+    let cancelled = false
+    authService.getSignupPromo()
+      .then((res) => {
+        if (cancelled) return
+        if (res.status === 200 && res.data?.promo?.enabled) {
+          setPromo(res.data.promo)
+        }
+      })
+      .catch(() => { /* promo is optional; fail silently */ })
+    return () => { cancelled = true }
+  }, [])
 
   const validate = () => {
     const nextErrors = {}
@@ -81,48 +97,194 @@ function SignupForm({
     }
   }
 
+  const fieldLabelClass = theme === 'dark' ? loginStyles.darkLoginText : ''
+  const fieldInputClass = theme === 'dark' ? loginStyles.darkLoginText : ''
+  const revealBtnClass = `${loginStyles.revealButton} ${loginStyles.errorMessage} ${theme === 'dark' ? loginStyles.darkLoginText : ''}`
+
+  const formFields = (
+    <Stack spacing='3'>
+      <SimpleGrid columns={{ base: 1, md: 2 }} spacing='3'>
+        <FormControl isInvalid={!!errors.firstName}>
+          <FormLabel className={fieldLabelClass} fontSize='sm' fontWeight='semibold'>First Name</FormLabel>
+          <Input value={firstName} size='sm' className={fieldInputClass} onChange={(e) => setFirstName(e.target.value)} />
+          <FormErrorMessage>{errors.firstName}</FormErrorMessage>
+        </FormControl>
+        <FormControl isInvalid={!!errors.lastName}>
+          <FormLabel className={fieldLabelClass} fontSize='sm' fontWeight='semibold'>Last Name</FormLabel>
+          <Input value={lastName} size='sm' className={fieldInputClass} onChange={(e) => setLastName(e.target.value)} />
+          <FormErrorMessage>{errors.lastName}</FormErrorMessage>
+        </FormControl>
+      </SimpleGrid>
+      <FormControl isInvalid={!!errors.username}>
+        <FormLabel className={fieldLabelClass} fontSize='sm' fontWeight='semibold'>Username</FormLabel>
+        <Input value={username} size='sm' className={fieldInputClass} onChange={(e) => setUsername(e.target.value)} />
+        <FormErrorMessage>{errors.username}</FormErrorMessage>
+      </FormControl>
+      <FormControl isInvalid={!!errors.email}>
+        <FormLabel className={fieldLabelClass} fontSize='sm' fontWeight='semibold'>Email</FormLabel>
+        <Input type='email' value={email} size='sm' className={fieldInputClass} onChange={(e) => setEmail(e.target.value)} />
+        <FormErrorMessage>{errors.email}</FormErrorMessage>
+      </FormControl>
+      <FormControl>
+        <FormLabel className={fieldLabelClass} fontSize='sm' fontWeight='semibold'>Telephone <Text as='span' fontWeight='normal' color='gray.400'>(optional)</Text></FormLabel>
+        <Input type='tel' value={telephone} size='sm' className={fieldInputClass} onChange={(e) => setTelephone(e.target.value)} />
+      </FormControl>
+      <FormControl>
+        <FormLabel className={fieldLabelClass} fontSize='sm' fontWeight='semibold'>Company <Text as='span' fontWeight='normal' color='gray.400'>(optional)</Text></FormLabel>
+        <Input value={company} size='sm' className={fieldInputClass} onChange={(e) => setCompany(e.target.value)} />
+      </FormControl>
+      <PasswordControl
+        passwordError={errors.password}
+        inputClassName={fieldInputClass}
+        labelClassName={fieldLabelClass}
+        onChange={(e) => setPassword(e.target.value)}
+        className={revealBtnClass}
+        size='sm'
+      />
+    </Stack>
+  )
+
+  if (splitLayout) {
+    return (
+      <Box as='form' className={`${loginStyles.loginForm} ${className}`.trim()} onSubmit={handleSubmit}>
+        <SimpleGrid columns={{ base: 1, md: 2 }} spacing={8} alignItems='start'>
+          {/* Left column — promo + branding */}
+          <VStack spacing={5} align='stretch'>
+            {promo?.free_credit_offer > 0 && (
+              <Box
+                bg='linear-gradient(135deg, #059669 0%, #10b981 100%)'
+                borderRadius='lg'
+                p={5}
+                boxShadow='md'
+              >
+                <Flex align='center' gap={3}>
+                  <Box
+                    bg='white'
+                    borderRadius='full'
+                    boxSize='52px'
+                    display='flex'
+                    alignItems='center'
+                    justifyContent='center'
+                    flexShrink={0}
+                  >
+                    <Text fontSize='2xl' role='img' aria-label='gift'>🎁</Text>
+                  </Box>
+                  <Box>
+                    <Text fontSize='xl' fontWeight='bold' color='white'>
+                      Receive {promo.free_credit_offer} free credits
+                    </Text>
+                    <Text fontSize='sm' color='green.100'>
+                      Applied after account verification.
+                    </Text>
+                  </Box>
+                </Flex>
+              </Box>
+            )}
+
+            <Box>
+              <Heading size='lg' mb={2}>Create your GitLab SSO account</Heading>
+              <Text fontSize='sm' color='gray.500'>
+                Get started with Cloud18 — one account, full access.
+              </Text>
+            </Box>
+
+            <Text fontSize='sm' color='gray.600' lineHeight='taller'>
+              With your Cloud18 account you get:
+            </Text>
+            <VStack spacing={3} align='stretch'>
+              {[
+                'Access to community via meet.signal18.io',
+                'Backup encrypted configs to cloud repository',
+                'Extra alerting on MariaDB blocker issues',
+              ].map((item, i) => (
+                <HStack key={i} spacing={3}>
+                  <Box bg='green.100' borderRadius='full' boxSize='24px' display='flex' alignItems='center' justifyContent='center' flexShrink={0}>
+                    <Text fontSize='xs' color='green.700'>✓</Text>
+                  </Box>
+                  <Text fontSize='sm' color='gray.600'>{item}</Text>
+                </HStack>
+              ))}
+            </VStack>
+          </VStack>
+
+          {/* Right column — form card */}
+          <VStack spacing={4} align='stretch'>
+            <Box
+              borderWidth='1px'
+              borderRadius='lg'
+              borderColor={theme === 'dark' ? 'gray.600' : 'gray.200'}
+              bg={theme === 'dark' ? 'gray.700' : 'white'}
+              p={{ base: 3, md: 4 }}
+            >
+              {formFields}
+            </Box>
+
+            {errorMessage && <Message message={errorMessage} />}
+            {localSuccessMessage && <Message message={localSuccessMessage} type='success' />}
+
+            <Stack spacing='4' direction={{ base: 'column', sm: 'row' }}>
+              <RMButton type='submit' size='medium' isLoading={loading} loadingText={loadingText}>
+                {submitLabel}
+              </RMButton>
+              {onCancel && (
+                <RMButton type='button' size='medium' variant='ghost' onClick={onCancel} isDisabled={loading}>
+                  Cancel
+                </RMButton>
+              )}
+            </Stack>
+          </VStack>
+        </SimpleGrid>
+      </Box>
+    )
+  }
+
   return (
     <Box as='form' className={`${loginStyles.loginForm} ${className}`.trim()} onSubmit={handleSubmit}>
-      <Stack spacing='6'>
-        <Stack spacing='5'>
-          <SimpleGrid columns={{ base: 1, md: 2 }} spacing='4'>
-            <FormControl isInvalid={errors.firstName}>
-              <FormLabel className={theme === 'dark' ? loginStyles.darkLoginText : ''}>First Name</FormLabel>
-              <Input value={firstName} className={theme === 'dark' ? loginStyles.darkLoginText : ''} onChange={(e) => setFirstName(e.target.value)} />
-              <FormErrorMessage sx={loginStyles.errorMessage}>{errors.firstName}</FormErrorMessage>
-            </FormControl>
-            <FormControl isInvalid={errors.lastName}>
-              <FormLabel className={theme === 'dark' ? loginStyles.darkLoginText : ''}>Last Name</FormLabel>
-              <Input value={lastName} className={theme === 'dark' ? loginStyles.darkLoginText : ''} onChange={(e) => setLastName(e.target.value)} />
-              <FormErrorMessage sx={loginStyles.errorMessage}>{errors.lastName}</FormErrorMessage>
-            </FormControl>
-          </SimpleGrid>
-          <FormControl isInvalid={errors.username}>
-            <FormLabel className={theme === 'dark' ? loginStyles.darkLoginText : ''}>Username</FormLabel>
-            <Input value={username} className={theme === 'dark' ? loginStyles.darkLoginText : ''} onChange={(e) => setUsername(e.target.value)} />
-            <FormErrorMessage sx={loginStyles.errorMessage}>{errors.username}</FormErrorMessage>
-          </FormControl>
-          <FormControl isInvalid={errors.email}>
-            <FormLabel className={theme === 'dark' ? loginStyles.darkLoginText : ''}>Email</FormLabel>
-            <Input type='email' value={email} className={theme === 'dark' ? loginStyles.darkLoginText : ''} onChange={(e) => setEmail(e.target.value)} />
-            <FormErrorMessage sx={loginStyles.errorMessage}>{errors.email}</FormErrorMessage>
-          </FormControl>
-          <FormControl>
-            <FormLabel className={theme === 'dark' ? loginStyles.darkLoginText : ''}>Telephone <Text as='span' fontWeight='normal' color='gray.400'>(optional)</Text></FormLabel>
-            <Input type='tel' value={telephone} className={theme === 'dark' ? loginStyles.darkLoginText : ''} onChange={(e) => setTelephone(e.target.value)} />
-          </FormControl>
-          <FormControl>
-            <FormLabel className={theme === 'dark' ? loginStyles.darkLoginText : ''}>Company <Text as='span' fontWeight='normal' color='gray.400'>(optional)</Text></FormLabel>
-            <Input value={company} className={theme === 'dark' ? loginStyles.darkLoginText : ''} onChange={(e) => setCompany(e.target.value)} />
-          </FormControl>
-          <PasswordControl
-            passwordError={errors.password}
-            inputClassName={theme === 'dark' ? loginStyles.darkLoginText : ''}
-            labelClassName={theme === 'dark' ? loginStyles.darkLoginText : ''}
-            onChange={(e) => setPassword(e.target.value)}
-            className={`${loginStyles.revealButton} ${loginStyles.errorMessage} ${theme === 'dark' ? loginStyles.darkLoginText : ''}`}
-          />
-        </Stack>
+      <Stack spacing='4'>
+        {/* Promotional hero banner — top of form for maximum visibility */}
+        {promo?.free_credit_offer > 0 && (
+          <Box
+            bg='linear-gradient(135deg, #059669 0%, #10b981 100%)'
+            borderRadius='lg'
+            p={4}
+            boxShadow='md'
+          >
+            <HStack spacing={3}>
+              <Box
+                bg='white'
+                borderRadius='full'
+                boxSize='48px'
+                display='flex'
+                alignItems='center'
+                justifyContent='center'
+                flexShrink={0}
+              >
+                <Text fontSize='2xl' role='img' aria-label='gift'>
+                  🎁
+                </Text>
+              </Box>
+              <Box>
+                <Text fontSize='lg' fontWeight='bold' color='white'>
+                  Receive {promo.free_credit_offer} free credits
+                </Text>
+                <Text fontSize='sm' color='green.100' lineHeight='short'>
+                  Applied after account verification.
+                </Text>
+              </Box>
+            </HStack>
+          </Box>
+        )}
+
+        {/* Account fields card */}
+        <Box
+          borderWidth='1px'
+          borderRadius='lg'
+          borderColor={theme === 'dark' ? 'gray.600' : 'gray.200'}
+          bg={theme === 'dark' ? 'gray.700' : 'white'}
+          p={{ base: 3, md: 4 }}
+        >
+          {formFields}
+        </Box>
 
         {errorMessage && <Message message={errorMessage} />}
         {localSuccessMessage && <Message message={localSuccessMessage} type='success' />}

--- a/share/dashboard_react/src/services/apiHelper.js
+++ b/share/dashboard_react/src/services/apiHelper.js
@@ -5,6 +5,10 @@ const authConfig = {
     resolveUrl: (apiUrl) => `/api/${apiUrl}`,
     getToken: () => localStorage.getItem('user_token')
   },
+  4: { // Local public calls (no auth header)
+    resolveUrl: (apiUrl) => `/api/${apiUrl}`,
+    getToken: () => null
+  },
   2: { // Peer calls
     resolveUrl: (apiUrl, baseUrl) => `/peer/${baseUrl}/api/${apiUrl}`,
     getToken: (baseUrl) => {
@@ -154,6 +158,7 @@ const requestWrapper = (authValue, baseUrl = '') => ({
 });
 
 export const localApi = requestWrapper(1); // Wrapper for local API calls
+export const publicApi = requestWrapper(4); // Wrapper for local public API calls (no auth)
 export const peerApi = (baseUrl) => requestWrapper(2, baseUrl); // Wrapper for peer API calls
 export const meetApi = requestWrapper(3); // Wrapper for Mattermost (meetAPI) calls
 

--- a/share/dashboard_react/src/services/apiHelper.js
+++ b/share/dashboard_react/src/services/apiHelper.js
@@ -1,15 +1,15 @@
 const toBase64 = (str) => btoa(unescape(encodeURIComponent(str)));
 
 const authConfig = {
-  1: { // Local calls
+  local: { // Local calls
     resolveUrl: (apiUrl) => `/api/${apiUrl}`,
     getToken: () => localStorage.getItem('user_token')
   },
-  4: { // Local public calls (no auth header)
+  public: { // Local public calls (no auth header)
     resolveUrl: (apiUrl) => `/api/${apiUrl}`,
     getToken: () => null
   },
-  2: { // Peer calls
+  peer: { // Peer calls
     resolveUrl: (apiUrl, baseUrl) => `/peer/${baseUrl}/api/${apiUrl}`,
     getToken: (baseUrl) => {
       if (baseUrl == "") {
@@ -19,7 +19,7 @@ const authConfig = {
       }
     }
   },
-  3: { // Mattermost API
+  meet: { // Mattermost API
     //resolveUrl: (apiUrl) => `https://meet.signal18.io/api/v4/${apiUrl}`,
     resolveUrl: (apiUrl) => `/meet/${apiUrl}`,
     getToken: () => localStorage.getItem('user_token')
@@ -157,10 +157,10 @@ const requestWrapper = (authValue, baseUrl = '') => ({
   }
 });
 
-export const localApi = requestWrapper(1); // Wrapper for local API calls
-export const publicApi = requestWrapper(4); // Wrapper for local public API calls (no auth)
-export const peerApi = (baseUrl) => requestWrapper(2, baseUrl); // Wrapper for peer API calls
-export const meetApi = requestWrapper(3); // Wrapper for Mattermost (meetAPI) calls
+export const localApi = requestWrapper('local'); // Wrapper for local API calls
+export const publicApi = requestWrapper('public'); // Wrapper for local public API calls (no auth)
+export const peerApi = (baseUrl) => requestWrapper('peer', baseUrl); // Wrapper for peer API calls
+export const meetApi = requestWrapper('meet'); // Wrapper for Mattermost (meetAPI) calls
 
 export const getApi = (baseURL = '') => {
   return baseURL ? peerApi(baseURL) : localApi;

--- a/share/dashboard_react/src/services/authService.js
+++ b/share/dashboard_react/src/services/authService.js
@@ -4,7 +4,8 @@ export const authService = {
   login,
   gitLogin,
   signup,
-  whoami
+  whoami,
+  getSignupPromo
 }
 
 function login(username, password, baseURL) {
@@ -27,4 +28,8 @@ function signup(payload, baseURL) {
     return getApi(baseURL).post('signup', payload)
   }
   return publicApi.post('signup', payload)
+}
+
+function getSignupPromo() {
+  return publicApi.get('signup/promo')
 }

--- a/share/dashboard_react/src/services/authService.js
+++ b/share/dashboard_react/src/services/authService.js
@@ -1,4 +1,4 @@
-import { getApi } from './apiHelper'
+import { getApi, publicApi } from './apiHelper'
 
 export const authService = {
   login,
@@ -8,7 +8,10 @@ export const authService = {
 }
 
 function login(username, password, baseURL) {
-  return getApi(baseURL).post('login', { username, password })
+  if (baseURL) {
+    return getApi(baseURL).post('login', { username, password })
+  }
+  return publicApi.post('login', { username, password })
 }
 
 function gitLogin(username, password, baseURL) {
@@ -20,5 +23,8 @@ function whoami(baseURL) {
 }
 
 function signup(payload, baseURL) {
-  return getApi(baseURL).post('signup', payload)
+  if (baseURL) {
+    return getApi(baseURL).post('signup', payload)
+  }
+  return publicApi.post('signup', payload)
 }

--- a/share/dashboard_react/src/services/authService.js
+++ b/share/dashboard_react/src/services/authService.js
@@ -3,6 +3,7 @@ import { getApi } from './apiHelper'
 export const authService = {
   login,
   gitLogin,
+  signup,
   whoami
 }
 
@@ -16,4 +17,8 @@ function gitLogin(username, password, baseURL) {
 
 function whoami(baseURL) {
   return getApi(baseURL).get('whoami')
+}
+
+function signup(payload, baseURL) {
+  return getApi(baseURL).post('signup', payload)
 }


### PR DESCRIPTION
## Summary

Adds a complete public signup flow for creating GitLab SSO accounts via CRM, including promotional offer display and a redesigned split-layout signup page.

## Commits included

| Commit | Description |
|--------|-------------|
| `7361422` | **feat: add CRM-backed GitLab signup flow** — Public `/api/signup` endpoint, reusable `SignupForm` component, `/signup` page/route, login CTA update, no-auth API wrapper for public endpoints |
| `de50e0d` | **fix signup still wearing bearer** — Local `login` + `signup` use no-auth `publicApi` wrapper; peer login stays on authenticated path |
| `4a165e9` | **feat: add signup promo endpoint, telephone/company fields, and UI polish** — `GET /api/signup/promo` public proxy, telephone/company fields with alias support, first/last name side-by-side, reduced vertical spacing |
| `3f277c3` | **feat: enhance signup page with split layout and promo display** — Split layout (promo/branding left, form right), promo hero banner from CRM, benefits checklist, smaller inputs, tighter spacing, better heading |

## Key features

- **Public `/api/signup`** — validates required fields, forwards to CRM with `referrer_uri` from registered instance or empty
- **Public `GET /api/signup/promo`** — returns best active promotional offer from CRM (e.g. free credits)
- **Telephone + Company** — optional fields with alias support (`phone`, `tel`, `uri`)
- **Reusable `SignupForm`** — shared between standalone `/signup` page and CloudSettings registration modal
- **Split-layout UI** — branding/benefits on the left, form card on the right, no scroll needed
- **No-auth API wrapper** — login/signup never attach bearer token, even if `user_token` exists in localStorage