### PR TITLE
Add OpenSVC runtime pools endpoint and fail-fast app storage

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -308,6 +308,9 @@ type Cluster struct {
 	OrchestratorVersion   string       `json:"-"`
 	orchestratorVersionMu sync.RWMutex `json:"-"`
 	lastOrchestratorProbe time.Time    `json:"-"`
+	opensvcPoolInfoCache   []opensvc.PoolInfo `json:"-"`
+	opensvcPoolInfoCacheAt time.Time          `json:"-"`
+	opensvcPoolInfoCacheMu sync.RWMutex       `json:"-"`
 	// Per-cluster preserved variables (replaces ProvDBConfigPreserveVars mechanism)
 	preservedVars               map[string]string          `json:"-"`
 	preservedVarsExcludeServers map[string]map[string]bool `json:"-"` // varName -> {serverID -> true}

--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -239,6 +239,7 @@ var clusterACLRules = []ACLRule{
 	{"/services/actions/unprovision", nil, []string{config.GrantProvClusterUnprovision}},
 	{"/api/clusters/actions/add", nil, []string{config.GrantProvCluster, config.GrantClusterCreate}},
 	{"/opensvc-gateway", nil, []string{config.GrantProvCluster}},
+	{"/opensvc-pools", nil, []string{config.GrantAppDeployment, config.GrantProvCluster}},
 
 	// Staging
 	{"/actions/staging-refresh", nil, []string{config.GrantClusterStaging}},

--- a/cluster/cluster_acl_test.go
+++ b/cluster/cluster_acl_test.go
@@ -1148,3 +1148,44 @@ func TestIsURLPassACLComprehensiveCoverage(t *testing.T) {
 		})
 	}
 }
+
+func TestIsURLPassACLOpenSVCPools(t *testing.T) {
+	cluster := setupACLTestCluster()
+	cluster.Name = "test"
+
+	cluster.APIUsers["app_deploy_user"] = APIUser{
+		User: "app_deploy_user",
+		Grants: map[string]bool{
+			config.GrantAppDeployment: true,
+		},
+	}
+
+	tests := []struct {
+		name     string
+		user     string
+		url      string
+		expected bool
+	}{
+		{
+			name:     "allow app deployment grant",
+			user:     "app_deploy_user",
+			url:      "/api/clusters/test/opensvc-pools",
+			expected: true,
+		},
+		{
+			name:     "deny without grants",
+			user:     "user_no_grants",
+			url:      "/api/clusters/test/opensvc-pools",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := cluster.IsURLPassACL(tt.user, tt.url, false)
+			if result != tt.expected {
+				t.Errorf("User %s on URL %s: Expected %v, got %v", tt.user, tt.url, tt.expected, result)
+			}
+		})
+	}
+}

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -1712,36 +1712,17 @@ func (cluster *Cluster) GetAppConfig(apphost, port string) *config.AppConfig {
 	return cnf
 }
 
-func (cluster *Cluster) SetAppLocalVolume(app *App, dir string) *config.Volume {
-	pools := cluster.Conf.GetAppVolumePools(config.PoolTypeLocal)
-	if len(pools) == 0 {
-		return nil
-	}
-
-	pool := pools[config.PoolTypeLocal]
-
+func (cluster *Cluster) SetAppLocalVolume(app *App, dir string) (*config.Volume, error) {
 	for _, volume := range app.AppConfig.Deployment.Storages.Volumes {
-		if p, ok := pools[volume.PoolName]; ok {
-			pool = p
-			if strings.HasPrefix(volume.VolumeDir, dir) {
-				//cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "GetAppLocalVolume %s %s", volume.VolumeDir, pools[volume.Pool].Path)
-				return volume
-			}
+		if strings.HasPrefix(volume.VolumeDir, dir) {
+			return volume, nil
 		}
 	}
 
-	newVolume := &config.Volume{
-		Name:      "local-" + dir + "-directory",
-		VolumeDir: dir,
-		PoolName:  pool.Name,
-	}
-
-	app.AppConfig.Deployment.InsertVolume(newVolume)
-
-	return newVolume
+	return nil, fmt.Errorf("no existing app volume found for directory %q: explicit volume/pool selection is required", dir)
 }
 
-func (cluster *Cluster) SetAppLocalMountVolume(app *App) *config.Volume {
+func (cluster *Cluster) SetAppLocalMountVolume(app *App) (*config.Volume, error) {
 	return cluster.SetAppLocalVolume(app, "mnt")
 }
 

--- a/cluster/prov_opensvc.go
+++ b/cluster/prov_opensvc.go
@@ -189,6 +189,11 @@ func (cluster *Cluster) OpenSVCGetNodes() ([]Agent, error) {
 	return agents, nil
 }
 
+func (cluster *Cluster) OpenSVCGetPoolList() ([]string, error) {
+	svc := cluster.OpenSVCConnect()
+	return svc.GetPoolList()
+}
+
 func (cluster *Cluster) OpenSVCCreateMaps(agent string) error {
 	if cluster.Conf.ProvOpensvcUseCollectorAPI {
 		return errors.New("No support of Maps in Collector API")

--- a/cluster/prov_opensvc.go
+++ b/cluster/prov_opensvc.go
@@ -26,6 +26,7 @@ var (
 )
 
 const defaultOpenSVCV3ProvisionDelay = 10
+const defaultOpenSVCPoolInfoCacheTTL = 5 * time.Minute
 
 func isOpenSVCAlreadyExists(err error) bool {
 	if err == nil {
@@ -190,8 +191,64 @@ func (cluster *Cluster) OpenSVCGetNodes() ([]Agent, error) {
 }
 
 func (cluster *Cluster) OpenSVCGetPoolList() ([]string, error) {
+	pools, err := cluster.OpenSVCGetPoolInfoList()
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(pools))
+	for _, pool := range pools {
+		if pool.Name == "" {
+			continue
+		}
+		names = append(names, pool.Name)
+	}
+
+	return names, nil
+}
+
+func (cluster *Cluster) OpenSVCGetPoolInfoList() ([]opensvc.PoolInfo, error) {
+	return cluster.openSVCGetPoolInfoList(defaultOpenSVCPoolInfoCacheTTL, false)
+}
+
+func (cluster *Cluster) OpenSVCGetPoolInfoListFresh() ([]opensvc.PoolInfo, error) {
+	return cluster.openSVCGetPoolInfoList(defaultOpenSVCPoolInfoCacheTTL, true)
+}
+
+func cloneOpenSVCPoolInfoList(pools []opensvc.PoolInfo) []opensvc.PoolInfo {
+	if len(pools) == 0 {
+		return nil
+	}
+
+	cloned := make([]opensvc.PoolInfo, len(pools))
+	copy(cloned, pools)
+	return cloned
+}
+
+func (cluster *Cluster) openSVCGetPoolInfoList(ttl time.Duration, forceRefresh bool) ([]opensvc.PoolInfo, error) {
+	if !forceRefresh && ttl > 0 {
+		cluster.opensvcPoolInfoCacheMu.RLock()
+		cacheFresh := !cluster.opensvcPoolInfoCacheAt.IsZero() && time.Since(cluster.opensvcPoolInfoCacheAt) < ttl
+		if cacheFresh {
+			cached := cloneOpenSVCPoolInfoList(cluster.opensvcPoolInfoCache)
+			cluster.opensvcPoolInfoCacheMu.RUnlock()
+			return cached, nil
+		}
+		cluster.opensvcPoolInfoCacheMu.RUnlock()
+	}
+
 	svc := cluster.OpenSVCConnect()
-	return svc.GetPoolList()
+	pools, err := svc.GetPoolInfoList()
+	if err != nil {
+		return nil, err
+	}
+
+	cluster.opensvcPoolInfoCacheMu.Lock()
+	cluster.opensvcPoolInfoCache = cloneOpenSVCPoolInfoList(pools)
+	cluster.opensvcPoolInfoCacheAt = time.Now()
+	cluster.opensvcPoolInfoCacheMu.Unlock()
+
+	return cloneOpenSVCPoolInfoList(pools), nil
 }
 
 func (cluster *Cluster) OpenSVCCreateMaps(agent string) error {

--- a/cluster/prov_opensvc.go
+++ b/cluster/prov_opensvc.go
@@ -221,7 +221,12 @@ func cloneOpenSVCPoolInfoList(pools []opensvc.PoolInfo) []opensvc.PoolInfo {
 	}
 
 	cloned := make([]opensvc.PoolInfo, len(pools))
-	copy(cloned, pools)
+	for i, p := range pools {
+		caps := make([]string, len(p.Capabilities))
+		copy(caps, p.Capabilities)
+		p.Capabilities = caps
+		cloned[i] = p
+	}
 	return cloned
 }
 
@@ -237,6 +242,8 @@ func (cluster *Cluster) openSVCGetPoolInfoList(ttl time.Duration, forceRefresh b
 		cluster.opensvcPoolInfoCacheMu.RUnlock()
 	}
 
+	// Multiple goroutines may reach here concurrently after the read-lock window.
+	// The last writer wins; results are deterministic, so this is benign for a long TTL.
 	svc := cluster.OpenSVCConnect()
 	pools, err := svc.GetPoolInfoList()
 	if err != nil {

--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -492,7 +492,7 @@ func (cluster *Cluster) OpenSVCGetAppVolumeSections(basemap map[string]map[strin
 	volumemap := deployment.Storages.Volumes.GroupByPool()
 	pathmap := deployment.Paths.GetVolumeDirs()
 
-	poolList, err := cluster.OpenSVCGetPoolList()
+	poolList, err := cluster.OpenSVCGetPoolInfoListFresh()
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch OpenSVC pool list before app volume provisioning: %w", err)
 	}
@@ -500,16 +500,17 @@ func (cluster *Cluster) OpenSVCGetAppVolumeSections(basemap map[string]map[strin
 		return nil, errors.New("OpenSVC pool list is empty; cannot provision app volumes")
 	}
 
-	poolSet := make(map[string]struct{}, len(poolList))
-	for _, poolName := range poolList {
-		if poolName != "" {
-			poolSet[poolName] = struct{}{}
+	poolSet := make(map[string]opensvc.PoolInfo, len(poolList))
+	for _, pool := range poolList {
+		if pool.Name != "" {
+			poolSet[pool.Name] = pool
 		}
 	}
 
 	seq := 1
 	for pool, volumes := range volumemap {
-		if _, ok := poolSet[pool]; !ok {
+		poolInfo, ok := poolSet[pool]
+		if !ok {
 			return nil, fmt.Errorf("OpenSVC pool %q not found in runtime pool list", pool)
 		}
 
@@ -517,6 +518,9 @@ func (cluster *Cluster) OpenSVCGetAppVolumeSections(basemap map[string]map[strin
 		svcvol["name"] = app.GetAppVolumeName(pool, false)
 		svcvol["pool"] = pool
 		svcvol["size"] = "{env.size}"
+		if poolInfo.Shared {
+			svcvol["shared"] = "true"
+		}
 
 		// Use set to avoid duplicate directories
 		directorySet := make(map[string]struct{})

--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -377,7 +377,10 @@ func (cluster *Cluster) OpenSVCGetAppTemplateSectionMap(app *App) (map[string]ma
 	svcsection := make(map[string]map[string]string)
 	svcsection["DEFAULT"] = cluster.OpenSVCGetAppDefaultSection(app)
 	svcsection["ip#01"] = cluster.OpenSVCGetNetSection()
-	svcsection = cluster.OpenSVCGetAppVolumeSections(svcsection, app)
+	svcsection, err := cluster.OpenSVCGetAppVolumeSections(svcsection, app)
+	if err != nil {
+		return nil, err
+	}
 	svcsection[fmt.Sprintf("container#%02d", containernum)] = cluster.OpenSVCGetNamespaceContainerSection()
 
 	for _, gc := range deployment.Storages.GitClones {
@@ -473,35 +476,47 @@ func (cluster *Cluster) OpenSVCGetAppTemplateV3(app *App) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func (cluster *Cluster) OpenSVCGetAppVolumeSections(basemap map[string]map[string]string, app *App) map[string]map[string]string {
+func (cluster *Cluster) OpenSVCGetAppVolumeSections(basemap map[string]map[string]string, app *App) (map[string]map[string]string, error) {
 
 	appcnf := app.AppConfig
 	if appcnf == nil {
-		return basemap
+		return basemap, nil
 	}
 
 	deployment := appcnf.Deployment
 	if len(deployment.Storages.Volumes) == 0 {
-		return basemap
+		return basemap, nil
 	}
 
 	deployment.Paths.Sort()
 	volumemap := deployment.Storages.Volumes.GroupByPool()
 	pathmap := deployment.Paths.GetVolumeDirs()
-	pools := cluster.Conf.GetAppVolumePools("")
+
+	poolList, err := cluster.OpenSVCGetPoolList()
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch OpenSVC pool list before app volume provisioning: %w", err)
+	}
+	if len(poolList) == 0 {
+		return nil, errors.New("OpenSVC pool list is empty; cannot provision app volumes")
+	}
+
+	poolSet := make(map[string]struct{}, len(poolList))
+	for _, poolName := range poolList {
+		if poolName != "" {
+			poolSet[poolName] = struct{}{}
+		}
+	}
 
 	seq := 1
 	for pool, volumes := range volumemap {
+		if _, ok := poolSet[pool]; !ok {
+			return nil, fmt.Errorf("OpenSVC pool %q not found in runtime pool list", pool)
+		}
+
 		svcvol := make(map[string]string)
 		svcvol["name"] = app.GetAppVolumeName(pool, false)
 		svcvol["pool"] = pool
 		svcvol["size"] = "{env.size}"
-
-		if poolConfig, ok := pools[pool]; ok {
-			if poolConfig.Type == "shared" {
-				svcvol["shared"] = "true"
-			}
-		}
 
 		// Use set to avoid duplicate directories
 		directorySet := make(map[string]struct{})
@@ -533,7 +548,7 @@ func (cluster *Cluster) OpenSVCGetAppVolumeSections(basemap map[string]map[strin
 		seq++
 	}
 
-	return basemap
+	return basemap, nil
 }
 
 func (cluster *Cluster) OpenSVCFoundAppAgent(app *App) (opensvc.Host, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -667,7 +667,7 @@ type Config struct {
 	ProvProxyStopScript                       string                       `mapstructure:"prov-proxy-stop-script" toml:"prov-proxy-stop-script" json:"provProxyStopScript"`
 	ProvDBCompliance                          string                       `mapstructure:"prov-db-compliance" toml:"prov-db-compliance" json:"provDBCompliance"`
 	ProvProxyCompliance                       string                       `mapstructure:"prov-proxy-compliance" toml:"prov-proxy-compliance" json:"provProxyCompliance"`
-	ProvAutoUpdateCompliance                bool                         `mapstructure:"prov-auto-update-compliance" toml:"prov-auto-update-compliance" json:"provAutoUpdateCompliance"`
+	ProvAutoUpdateCompliance                  bool                         `mapstructure:"prov-auto-update-compliance" toml:"prov-auto-update-compliance" json:"provAutoUpdateCompliance"`
 	ProvDockerRegistryCredentials             string                       `mapstructure:"prov-docker-registry-credentials" toml:"prov-docker-registry-credentials" json:"provDockerRegistryCredentials"`
 	AppOn                                     bool                         `mapstructure:"app" toml:"app" json:"app"`
 	AppHosts                                  string                       `mapstructure:"app-hosts" toml:"app-hosts" json:"appHosts"`
@@ -676,7 +676,6 @@ type Config struct {
 	AppRefreshConcurrency                     int                          `mapstructure:"app-refresh-concurrency" toml:"app-refresh-concurrency" json:"appRefreshConcurrency"`
 	ProvAppMem                                string                       `measurement:"M,bytes,required" mapstructure:"prov-app-memory" toml:"prov-app-memory" json:"provAppMemory" groups:"apps"`
 	ProvAppDisk                               string                       `measurement:"G,bytes,required" mapstructure:"prov-app-disk-size" toml:"prov-app-disk-size" json:"provAppDiskSize" groups:"apps"`
-	ProvAppVolumePools                        string                       `mapstructure:"prov-app-volume-pools" toml:"prov-app-volume-pools" json:"provAppVolumePools" groups:"apps"`
 	ProvAppCpuCores                           string                       `mapstructure:"prov-app-cpu-cores" toml:"prov-app-cpu-cores" json:"provAppCpuCores" groups:"apps"`
 	ProvAppAgents                             string                       `mapstructure:"prov-app-agents" toml:"prov-app-agents" json:"provAppAgents" groups:"apps"`
 	ProvAppHATopology                         string                       `mapstructure:"prov-app-ha-topology" toml:"prov-app-ha-topology" json:"provAppHaTopology" groups:"apps"`
@@ -927,10 +926,10 @@ type Config struct {
 	Cloud18InfraCertifications             string                 `mapstructure:"cloud18-infra-certifications"  toml:"cloud18-infra-certifications" json:"cloud18InfraCertifications"`
 	Cloud18OpenDbops                       bool                   `mapstructure:"cloud18-open-dbops"  toml:"cloud18-open-dbops" json:"cloud18OpenDbops"`
 	Cloud18SubscribedDbops                 bool                   `mapstructure:"cloud18-subscribed-dbops"  toml:"cloud18-subscribed-dbops" json:"cloud18SubscribedDbops"`
-	Cloud18SubscriptionPlan               string                 `scope:"server" mapstructure:"cloud18-subscription-plan" toml:"cloud18-subscription-plan" json:"cloud18SubscriptionPlan"`
-	Cloud18PeerHealthMode                 string                 `scope:"server" mapstructure:"cloud18-peer-health-mode" toml:"cloud18-peer-health-mode" json:"cloud18PeerHealthMode"`
-	Cloud18DisablePeers                   bool                   `scope:"server" mapstructure:"cloud18-disable-peers" toml:"cloud18-disable-peers" json:"cloud18DisablePeers"`
-	Cloud18DisableForSale                 bool                   `scope:"server" mapstructure:"cloud18-disable-for-sale" toml:"cloud18-disable-for-sale" json:"cloud18DisableForSale"`
+	Cloud18SubscriptionPlan                string                 `scope:"server" mapstructure:"cloud18-subscription-plan" toml:"cloud18-subscription-plan" json:"cloud18SubscriptionPlan"`
+	Cloud18PeerHealthMode                  string                 `scope:"server" mapstructure:"cloud18-peer-health-mode" toml:"cloud18-peer-health-mode" json:"cloud18PeerHealthMode"`
+	Cloud18DisablePeers                    bool                   `scope:"server" mapstructure:"cloud18-disable-peers" toml:"cloud18-disable-peers" json:"cloud18DisablePeers"`
+	Cloud18DisableForSale                  bool                   `scope:"server" mapstructure:"cloud18-disable-for-sale" toml:"cloud18-disable-for-sale" json:"cloud18DisableForSale"`
 	Cloud18OpenSysops                      bool                   `mapstructure:"cloud18-open-sysops"  toml:"cloud18-open-sysops" json:"cloud18OpenSysops"`
 	Cloud18DatabaseReadWriteSplitSrvRecord string                 `mapstructure:"cloud18-database-read-write-split-srv-record"  toml:"cloud18-database-read-write-split-srv-record" json:"cloud18DatabaseReadWriteSplitSrvRecord"`
 	Cloud18DatabaseReadSrvRecord           string                 `mapstructure:"cloud18-database-read-srv-record"  toml:"cloud18-database-read-srv-record" json:"cloud18DatabaseReadSrvRecord"`
@@ -1279,13 +1278,11 @@ type Tag struct {
 }
 */
 
-
 const (
 	ExternalActive  string = "active"
 	ExternalPending string = "pending"
 	ExternalQuote   string = "quote"
 )
-
 
 const (
 	ConstOrchestratorOpenSVC    string = "opensvc"
@@ -1352,7 +1349,7 @@ const (
 	// ConstLogModMaintenance covers planned-operations modules (backup, SST,
 	// task execution, purge, orchestrator provisioning). Routed to maintenance.log
 	// when configured so operational noise does not pollute the HA main log.
-	ConstLogModMaintenance    = 31
+	ConstLogModMaintenance = 31
 )
 
 /*
@@ -2322,7 +2319,6 @@ func (conf *Config) GetMemoryPctThreaded() (map[string]int, error) {
 	}
 	return engines, nil
 }
-
 
 func (conf *Config) GetDockerRepos(file string, is_not_embed bool) ([]DockerRepo, error) {
 	var repos DockerRepos
@@ -3588,52 +3584,6 @@ func ParseUnitMeasurementToInt(tag, vstr string, clampToLimit bool) (int, error)
 	}
 
 	return val, nil
-}
-
-type VolumePool struct {
-	Name        string `json:"name"`
-	Type        string `json:"type"`
-	Mode        string `json:"mode"`
-	Description string `json:"description"`
-}
-
-const PoolTypeLocal = "local"
-const PoolTypeRemote = "shared"
-
-func (conf *Config) GetAppVolumePools(pooltype string) map[string]VolumePool {
-	pools := make(map[string]VolumePool)
-
-	vols := strings.Split(conf.ProvAppVolumePools, ",")
-	for _, vol := range vols {
-		var name, poolType, mode, description string
-		parts := strings.SplitN(vol, ":", 4)
-		name = strings.TrimSpace(parts[0])
-		poolType = PoolTypeLocal
-		if len(parts) > 1 {
-			poolType = strings.TrimSpace(parts[1])
-		}
-
-		if pooltype != "" && poolType != pooltype {
-			continue
-		}
-
-		if len(parts) > 2 {
-			mode = strings.TrimSpace(parts[2])
-		}
-
-		if len(parts) > 3 {
-			description = strings.TrimSpace(parts[3])
-		}
-
-		pools[name] = VolumePool{
-			Name:        name,
-			Type:        poolType,
-			Mode:        mode,
-			Description: description,
-		}
-	}
-
-	return pools
 }
 
 func (conf *Config) LoadAppTemplateList() ([]string, error) {

--- a/opensvc/clusterapi.go
+++ b/opensvc/clusterapi.go
@@ -1157,6 +1157,13 @@ func (collector *Collector) GetPoolInfoListV2() ([]PoolInfo, error) {
 		collector.Logrus.WithField("FROM", "OpenSVC").Println("OpenSVC API Response: ", string(body))
 	}
 
+	if !handleSuccessGroup(resp.StatusCode) {
+		return nil, &StatusError{
+			StatusCode: resp.StatusCode,
+			Body:       string(body),
+		}
+	}
+
 	result := gjson.ParseBytes(body)
 	poolInfos := make([]PoolInfo, 0)
 
@@ -1182,7 +1189,7 @@ func (collector *Collector) GetPoolInfoListV2() ([]PoolInfo, error) {
 
 	if result.IsObject() {
 		result.ForEach(func(key, value gjson.Result) bool {
-			if key.String() != "status" && key.String() != "data" && key.String() != "error" && key.String() != "nodes" {
+			if key.String() != "status" && key.String() != "data" && key.String() != "error" && key.String() != "nodes" && value.IsObject() {
 				poolInfos = append(poolInfos, poolInfoFromResult(value, key.String()))
 			}
 			return true

--- a/opensvc/clusterapi.go
+++ b/opensvc/clusterapi.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/signal18/replication-manager/config"
@@ -971,6 +972,12 @@ func (collector *Collector) GetNodes() ([]Host, error) {
 	}
 }
 
+type PoolInfo struct {
+	Name         string
+	Shared       bool
+	Capabilities []string
+}
+
 func normalizeStringList(values []string) []string {
 	uniq := make(map[string]struct{}, len(values))
 	for _, value := range values {
@@ -989,15 +996,125 @@ func normalizeStringList(values []string) []string {
 	return result
 }
 
-func (collector *Collector) GetPoolList() ([]string, error) {
-	if collector.IsV3() {
-		return collector.GetPoolListV3()
+func normalizePoolInfoList(values []PoolInfo) []PoolInfo {
+	if len(values) == 0 {
+		return values
 	}
 
-	return collector.GetPoolListV2()
+	byName := make(map[string]PoolInfo, len(values))
+	for _, value := range values {
+		name := strings.TrimSpace(value.Name)
+		if name == "" {
+			continue
+		}
+
+		normalizedCaps := normalizeStringList(value.Capabilities)
+		value.Name = name
+		value.Capabilities = normalizedCaps
+		value.Shared = value.Shared || slicesContains(normalizedCaps, "shared")
+
+		if existing, ok := byName[name]; ok {
+			existing.Shared = existing.Shared || value.Shared
+			existing.Capabilities = normalizeStringList(append(existing.Capabilities, value.Capabilities...))
+			existing.Shared = existing.Shared || slicesContains(existing.Capabilities, "shared")
+			byName[name] = existing
+			continue
+		}
+
+		byName[name] = value
+	}
+
+	result := make([]PoolInfo, 0, len(byName))
+	for _, value := range byName {
+		result = append(result, value)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+
+	return result
+}
+
+func slicesContains(values []string, needle string) bool {
+	for _, v := range values {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func parseCapabilities(result gjson.Result) []string {
+	capabilities := make([]string, 0)
+	if !result.Exists() {
+		return capabilities
+	}
+
+	if result.IsArray() {
+		for _, item := range result.Array() {
+			if item.Type == gjson.String {
+				capabilities = append(capabilities, strings.TrimSpace(item.String()))
+			}
+		}
+	}
+
+	return normalizeStringList(capabilities)
+}
+
+func poolInfoFromResult(result gjson.Result, fallbackName string) PoolInfo {
+	name := strings.TrimSpace(result.Get("name").String())
+	if name == "" {
+		name = strings.TrimSpace(fallbackName)
+	}
+
+	capabilities := parseCapabilities(result.Get("capabilities"))
+	shared := result.Get("shared").Bool() || slicesContains(capabilities, "shared")
+
+	return PoolInfo{
+		Name:         name,
+		Shared:       shared,
+		Capabilities: capabilities,
+	}
+}
+
+func (collector *Collector) GetPoolInfoList() ([]PoolInfo, error) {
+	if collector.IsV3() {
+		return collector.GetPoolInfoListV3()
+	}
+
+	return collector.GetPoolInfoListV2()
+}
+
+func (collector *Collector) GetPoolList() ([]string, error) {
+	poolInfos, err := collector.GetPoolInfoList()
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(poolInfos))
+	for _, pool := range poolInfos {
+		names = append(names, pool.Name)
+	}
+
+	return normalizeStringList(names), nil
 }
 
 func (collector *Collector) GetPoolListV2() ([]string, error) {
+	poolInfos, err := collector.GetPoolInfoListV2()
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(poolInfos))
+	for _, pool := range poolInfos {
+		names = append(names, pool.Name)
+	}
+
+	return normalizeStringList(names), nil
+}
+
+func (collector *Collector) GetPoolInfoListV2() ([]PoolInfo, error) {
 	url := fmt.Sprintf("https://%s:%s/get_pools", collector.Host, collector.Port)
 
 	client := collector.GetHttpClient()
@@ -1041,55 +1158,47 @@ func (collector *Collector) GetPoolListV2() ([]string, error) {
 	}
 
 	result := gjson.ParseBytes(body)
-	pools := make([]string, 0)
+	poolInfos := make([]PoolInfo, 0)
 
 	if result.IsArray() {
 		for _, item := range result.Array() {
 			if item.Type == gjson.String {
-				pools = append(pools, item.String())
+				poolInfos = append(poolInfos, PoolInfo{Name: strings.TrimSpace(item.String())})
 				continue
 			}
-			if name := item.Get("name"); name.Exists() {
-				pools = append(pools, name.String())
-			}
+			poolInfos = append(poolInfos, poolInfoFromResult(item, ""))
 		}
-	} else if nodes := result.Get("nodes"); nodes.Exists() && nodes.IsObject() {
+	}
+
+	if nodes := result.Get("nodes"); nodes.Exists() && nodes.IsObject() {
 		nodes.ForEach(func(_, nodeData gjson.Result) bool {
 			nodeData.ForEach(func(poolName, poolData gjson.Result) bool {
-				if poolName.String() != "" {
-					pools = append(pools, poolName.String())
-				}
-				if name := poolData.Get("name"); name.Exists() {
-					pools = append(pools, name.String())
-				}
+				poolInfos = append(poolInfos, poolInfoFromResult(poolData, poolName.String()))
 				return true
 			})
 			return true
 		})
-	} else if result.IsObject() {
+	}
+
+	if result.IsObject() {
 		result.ForEach(func(key, value gjson.Result) bool {
-			if key.String() != "status" && key.String() != "data" && key.String() != "error" {
-				pools = append(pools, key.String())
-			}
-			if name := value.Get("name"); name.Exists() {
-				pools = append(pools, name.String())
+			if key.String() != "status" && key.String() != "data" && key.String() != "error" && key.String() != "nodes" {
+				poolInfos = append(poolInfos, poolInfoFromResult(value, key.String()))
 			}
 			return true
 		})
 		if data := result.Get("data"); data.Exists() && data.IsArray() {
 			for _, item := range data.Array() {
 				if item.Type == gjson.String {
-					pools = append(pools, item.String())
+					poolInfos = append(poolInfos, PoolInfo{Name: strings.TrimSpace(item.String())})
 					continue
 				}
-				if name := item.Get("name"); name.Exists() {
-					pools = append(pools, name.String())
-				}
+				poolInfos = append(poolInfos, poolInfoFromResult(item, ""))
 			}
 		}
 	}
 
-	return normalizeStringList(pools), nil
+	return normalizePoolInfoList(poolInfos), nil
 }
 
 func (collector *Collector) GetServiceNodeFromState(svc string) ([]string, error) {

--- a/opensvc/clusterapi.go
+++ b/opensvc/clusterapi.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"time"
 
@@ -968,6 +969,127 @@ func (collector *Collector) GetNodes() ([]Host, error) {
 	} else {
 		return collector.GetNodesV2()
 	}
+}
+
+func normalizeStringList(values []string) []string {
+	uniq := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		uniq[value] = struct{}{}
+	}
+
+	result := make([]string, 0, len(uniq))
+	for value := range uniq {
+		result = append(result, value)
+	}
+
+	sort.Strings(result)
+	return result
+}
+
+func (collector *Collector) GetPoolList() ([]string, error) {
+	if collector.IsV3() {
+		return collector.GetPoolListV3()
+	}
+
+	return collector.GetPoolListV2()
+}
+
+func (collector *Collector) GetPoolListV2() ([]string, error) {
+	url := fmt.Sprintf("https://%s:%s/get_pools", collector.Host, collector.Port)
+
+	client := collector.GetHttpClient()
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("o-node", "*")
+
+	ctx, cancel := context.WithTimeout(req.Context(), time.Duration(collector.ContextTimeoutSecond)*time.Second)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	startConnect := time.Now()
+	resp, err := client.Do(req)
+	stopConnect := time.Now()
+	if collector.isLoggable(config.ConstLogModOrchestrator, config.LvlDbg) {
+		collector.Logrus.WithField("FROM", "OpenSVC").Printf("OpenSVC Connect took: %s\n", stopConnect.Sub(startConnect))
+	}
+	if err != nil {
+		if collector.isLoggable(config.ConstLogModOrchestrator, config.LvlErr) {
+			collector.Logrus.WithField("FROM", "OpenSVC").Errorln("OpenSVC API Error: ", err)
+		}
+		return nil, err
+	}
+
+	defer client.CloseIdleConnections()
+	defer resp.Body.Close()
+
+	startRead := time.Now()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	endRead := time.Now()
+	if collector.isLoggable(config.ConstLogModOrchestrator, config.LvlDbg) {
+		collector.Logrus.WithField("FROM", "OpenSVC").Printf("OpenSVC Read response took: %s\n", endRead.Sub(startRead))
+		collector.Logrus.WithField("FROM", "OpenSVC").Println("OpenSVC API Response: ", string(body))
+	}
+
+	result := gjson.ParseBytes(body)
+	pools := make([]string, 0)
+
+	if result.IsArray() {
+		for _, item := range result.Array() {
+			if item.Type == gjson.String {
+				pools = append(pools, item.String())
+				continue
+			}
+			if name := item.Get("name"); name.Exists() {
+				pools = append(pools, name.String())
+			}
+		}
+	} else if nodes := result.Get("nodes"); nodes.Exists() && nodes.IsObject() {
+		nodes.ForEach(func(_, nodeData gjson.Result) bool {
+			nodeData.ForEach(func(poolName, poolData gjson.Result) bool {
+				if poolName.String() != "" {
+					pools = append(pools, poolName.String())
+				}
+				if name := poolData.Get("name"); name.Exists() {
+					pools = append(pools, name.String())
+				}
+				return true
+			})
+			return true
+		})
+	} else if result.IsObject() {
+		result.ForEach(func(key, value gjson.Result) bool {
+			if key.String() != "status" && key.String() != "data" && key.String() != "error" {
+				pools = append(pools, key.String())
+			}
+			if name := value.Get("name"); name.Exists() {
+				pools = append(pools, name.String())
+			}
+			return true
+		})
+		if data := result.Get("data"); data.Exists() && data.IsArray() {
+			for _, item := range data.Array() {
+				if item.Type == gjson.String {
+					pools = append(pools, item.String())
+					continue
+				}
+				if name := item.Get("name"); name.Exists() {
+					pools = append(pools, name.String())
+				}
+			}
+		}
+	}
+
+	return normalizeStringList(pools), nil
 }
 
 func (collector *Collector) GetServiceNodeFromState(svc string) ([]string, error) {

--- a/opensvc/clusterapi.go
+++ b/opensvc/clusterapi.go
@@ -1188,8 +1188,13 @@ func (collector *Collector) GetPoolInfoListV2() ([]PoolInfo, error) {
 	}
 
 	if result.IsObject() {
+		// All three blocks can fire for the same response (e.g. object with both "nodes" and
+		// top-level pool keys). The nodes block and this block intentionally coexist.
+		// Known top-level metadata keys must be listed here; if the API adds new metadata
+		// object fields in the future they must be added to avoid being misread as pool names.
+		knownMetaKeys := map[string]bool{"status": true, "data": true, "error": true, "nodes": true}
 		result.ForEach(func(key, value gjson.Result) bool {
-			if key.String() != "status" && key.String() != "data" && key.String() != "error" && key.String() != "nodes" && value.IsObject() {
+			if !knownMetaKeys[key.String()] && value.IsObject() {
 				poolInfos = append(poolInfos, poolInfoFromResult(value, key.String()))
 			}
 			return true

--- a/opensvc/clusterapi_test.go
+++ b/opensvc/clusterapi_test.go
@@ -642,6 +642,65 @@ func TestGetPoolInfoListV2_ParsesSharedCapabilities(t *testing.T) {
 	}
 }
 
+func TestGetPoolInfoListV2_Non2xxReturnsStatusError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/get_pools", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"error":"upstream unavailable"}`))
+	})
+
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.TLS = &tls.Config{NextProtos: []string{"h2"}}
+	server.StartTLS()
+	defer server.Close()
+
+	collector := newTestCollector(t, server)
+	collector.ContextTimeoutSecond = 2
+
+	_, err := collector.GetPoolInfoListV2()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var statusErr *StatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("expected StatusError, got %T (%v)", err, err)
+	}
+	if statusErr.StatusCode != http.StatusBadGateway {
+		t.Fatalf("unexpected status code: got %d want %d", statusErr.StatusCode, http.StatusBadGateway)
+	}
+}
+
+func TestGetPoolInfoListV2_IgnoresTopLevelMetadataKeys(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/get_pools", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"poolA":{},"metadata":"ignore-me","count":2,"status":0}`))
+	})
+
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.TLS = &tls.Config{NextProtos: []string{"h2"}}
+	server.StartTLS()
+	defer server.Close()
+
+	collector := newTestCollector(t, server)
+	collector.ContextTimeoutSecond = 2
+
+	infos, err := collector.GetPoolInfoListV2()
+	if err != nil {
+		t.Fatalf("GetPoolInfoListV2 failed: %v", err)
+	}
+
+	if len(infos) != 1 {
+		t.Fatalf("unexpected pool count: got %d want 1", len(infos))
+	}
+	if infos[0].Name != "poolA" {
+		t.Fatalf("unexpected pool name: got %q want %q", infos[0].Name, "poolA")
+	}
+}
+
 func TestGetPoolInfoListV3_ParsesShared(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/opensvc/clusterapi_test.go
+++ b/opensvc/clusterapi_test.go
@@ -601,3 +601,88 @@ func TestGetPoolListV3_StatusAndParsing(t *testing.T) {
 		}
 	})
 }
+
+func TestGetPoolInfoListV2_ParsesSharedCapabilities(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/get_pools", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"poolA":{"capabilities":["blk"]},"poolB":{"capabilities":["shared","blk"]},"nodes":{"n1":{"poolC":{"name":"poolC","capabilities":["shared"]}}}}`))
+	})
+
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.TLS = &tls.Config{NextProtos: []string{"h2"}}
+	server.StartTLS()
+	defer server.Close()
+
+	collector := newTestCollector(t, server)
+	collector.ContextTimeoutSecond = 2
+
+	infos, err := collector.GetPoolInfoListV2()
+	if err != nil {
+		t.Fatalf("GetPoolInfoListV2 failed: %v", err)
+	}
+
+	byName := make(map[string]PoolInfo)
+	for _, info := range infos {
+		byName[info.Name] = info
+	}
+
+	if len(byName) != 3 {
+		t.Fatalf("unexpected pool count: got %d want 3", len(byName))
+	}
+	if byName["poolA"].Shared {
+		t.Fatalf("poolA should not be shared")
+	}
+	if !byName["poolB"].Shared {
+		t.Fatalf("poolB should be shared")
+	}
+	if !byName["poolC"].Shared {
+		t.Fatalf("poolC should be shared")
+	}
+}
+
+func TestGetPoolInfoListV3_ParsesShared(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"name":"pool-a","shared":true},{"name":"pool-b","capabilities":["shared"]},{"name":"pool-c"}]}`))
+	})
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+
+	collector := &Collector{
+		Host:                 parsed.Hostname(),
+		Port:                 parsed.Port(),
+		RplMgrUser:           "user",
+		RplMgrPassword:       "pass",
+		ClusterApiVersion:    "v3",
+		ContextTimeoutSecond: 2,
+	}
+
+	infos, err := collector.GetPoolInfoListV3()
+	if err != nil {
+		t.Fatalf("GetPoolInfoListV3 failed: %v", err)
+	}
+
+	byName := make(map[string]PoolInfo)
+	for _, info := range infos {
+		byName[info.Name] = info
+	}
+
+	if !byName["pool-a"].Shared {
+		t.Fatalf("pool-a should be shared")
+	}
+	if !byName["pool-b"].Shared {
+		t.Fatalf("pool-b should be shared")
+	}
+	if byName["pool-c"].Shared {
+		t.Fatalf("pool-c should not be shared")
+	}
+}

--- a/opensvc/clusterapi_test.go
+++ b/opensvc/clusterapi_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -452,4 +453,151 @@ func TestRunTaskV2_SendsCorrectRequest(t *testing.T) {
 	if rid != task {
 		t.Fatalf("expected rid %q, got %v", task, rid)
 	}
+}
+
+func TestGetPoolListV2_CallsGetPoolsAndParses(t *testing.T) {
+	t.Run("direct object keys", func(t *testing.T) {
+		var gotPath string
+		var gotNode string
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/get_pools", func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotNode = r.Header.Get("o-node")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"poolB":{},"poolA":{},"status":0}`))
+		})
+
+		server := httptest.NewUnstartedServer(mux)
+		server.EnableHTTP2 = true
+		server.TLS = &tls.Config{NextProtos: []string{"h2"}}
+		server.StartTLS()
+		defer server.Close()
+
+		collector := newTestCollector(t, server)
+		collector.ContextTimeoutSecond = 2
+
+		pools, err := collector.GetPoolListV2()
+		if err != nil {
+			t.Fatalf("GetPoolListV2 failed: %v", err)
+		}
+
+		if gotPath != "/get_pools" {
+			t.Fatalf("unexpected endpoint: %s", gotPath)
+		}
+		if gotNode != "*" {
+			t.Fatalf("unexpected o-node header: %s", gotNode)
+		}
+
+		want := []string{"poolA", "poolB"}
+		if fmt.Sprint(pools) != fmt.Sprint(want) {
+			t.Fatalf("unexpected pools: got %v want %v", pools, want)
+		}
+	})
+
+	t.Run("nodes wrapped and deduped", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/get_pools", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"nodes":{"n1":{"poolZ":{},"poolA":{}},"n2":{"poolA":{},"poolB":{}}}}`))
+		})
+
+		server := httptest.NewUnstartedServer(mux)
+		server.EnableHTTP2 = true
+		server.TLS = &tls.Config{NextProtos: []string{"h2"}}
+		server.StartTLS()
+		defer server.Close()
+
+		collector := newTestCollector(t, server)
+		collector.ContextTimeoutSecond = 2
+
+		pools, err := collector.GetPoolListV2()
+		if err != nil {
+			t.Fatalf("GetPoolListV2 failed: %v", err)
+		}
+
+		want := []string{"poolA", "poolB", "poolZ"}
+		if fmt.Sprint(pools) != fmt.Sprint(want) {
+			t.Fatalf("unexpected pools: got %v want %v", pools, want)
+		}
+	})
+}
+
+func TestGetPoolListV3_StatusAndParsing(t *testing.T) {
+	t.Run("success parses and sorts", func(t *testing.T) {
+		var gotPath string
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"items":[{"name":"pool-c"},{"name":"pool-a"},{"name":"pool-a"}]}`))
+		})
+
+		server := httptest.NewTLSServer(mux)
+		defer server.Close()
+
+		parsed, err := url.Parse(server.URL)
+		if err != nil {
+			t.Fatalf("parse server url: %v", err)
+		}
+
+		collector := &Collector{
+			Host:                 parsed.Hostname(),
+			Port:                 parsed.Port(),
+			RplMgrUser:           "user",
+			RplMgrPassword:       "pass",
+			ClusterApiVersion:    "v3",
+			ContextTimeoutSecond: 2,
+		}
+
+		pools, err := collector.GetPoolListV3()
+		if err != nil {
+			t.Fatalf("GetPoolListV3 failed: %v", err)
+		}
+		if !strings.Contains(gotPath, "pool") {
+			t.Fatalf("unexpected endpoint: %s", gotPath)
+		}
+
+		want := []string{"pool-a", "pool-c"}
+		if fmt.Sprint(pools) != fmt.Sprint(want) {
+			t.Fatalf("unexpected pools: got %v want %v", pools, want)
+		}
+	})
+
+	t.Run("non 2xx returns StatusError", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"bad request"}`))
+		})
+
+		server := httptest.NewTLSServer(mux)
+		defer server.Close()
+
+		parsed, err := url.Parse(server.URL)
+		if err != nil {
+			t.Fatalf("parse server url: %v", err)
+		}
+
+		collector := &Collector{
+			Host:                 parsed.Hostname(),
+			Port:                 parsed.Port(),
+			RplMgrUser:           "user",
+			RplMgrPassword:       "pass",
+			ClusterApiVersion:    "v3",
+			ContextTimeoutSecond: 2,
+		}
+
+		_, err = collector.GetPoolListV3()
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		var statusErr *StatusError
+		if !errors.As(err, &statusErr) {
+			t.Fatalf("expected StatusError, got %T (%v)", err, err)
+		}
+		if statusErr.StatusCode != http.StatusBadRequest {
+			t.Fatalf("unexpected status code: %d", statusErr.StatusCode)
+		}
+	})
 }

--- a/opensvc/v3.go
+++ b/opensvc/v3.go
@@ -164,6 +164,20 @@ func (collector *Collector) GetNodesV3() ([]Host, error) {
 }
 
 func (collector *Collector) GetPoolListV3() ([]string, error) {
+	poolInfos, err := collector.GetPoolInfoListV3()
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(poolInfos))
+	for _, pool := range poolInfos {
+		names = append(names, pool.Name)
+	}
+
+	return normalizeStringList(names), nil
+}
+
+func (collector *Collector) GetPoolInfoListV3() ([]PoolInfo, error) {
 	client, err := collector.GetClientV3()
 	if err != nil {
 		return nil, err
@@ -194,14 +208,15 @@ func (collector *Collector) GetPoolListV3() ([]string, error) {
 		}
 	}
 
-	names := make([]string, 0)
+	poolInfos := make([]PoolInfo, 0)
 	for _, item := range gjson.GetBytes(body, "items").Array() {
-		if name := item.Get("name"); name.Exists() {
-			names = append(names, name.String())
+		if !item.IsObject() {
+			continue
 		}
+		poolInfos = append(poolInfos, poolInfoFromResult(item, ""))
 	}
 
-	return normalizeStringList(names), nil
+	return normalizePoolInfoList(poolInfos), nil
 }
 
 func (collector *Collector) CreateObjectV3(namespace, kind, service string, data []byte) ([]byte, error) {

--- a/opensvc/v3.go
+++ b/opensvc/v3.go
@@ -163,6 +163,47 @@ func (collector *Collector) GetNodesV3() ([]Host, error) {
 	return hosts, nil
 }
 
+func (collector *Collector) GetPoolListV3() ([]string, error) {
+	client, err := collector.GetClientV3()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(collector.ContextTimeoutSecond)*time.Second)
+	defer cancel()
+
+	resp, err := client.GetPools(ctx, nil, collector.RequestCloserV3())
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if collector.isLoggable(config.ConstLogModOrchestrator, config.LvlDbg) {
+		collector.LogModulePrintf(config.ConstLogModOrchestrator, config.LvlDbg, "OpenSVC v3 get pools status=%d body=%q", resp.StatusCode, string(body))
+	}
+
+	if !handleSuccessGroup(resp.StatusCode) {
+		return nil, &StatusError{
+			StatusCode: resp.StatusCode,
+			Body:       string(body),
+		}
+	}
+
+	names := make([]string, 0)
+	for _, item := range gjson.GetBytes(body, "items").Array() {
+		if name := item.Get("name"); name.Exists() {
+			names = append(names, name.String())
+		}
+	}
+
+	return normalizeStringList(names), nil
+}
+
 func (collector *Collector) CreateObjectV3(namespace, kind, service string, data []byte) ([]byte, error) {
 	var resp *http.Response
 	var err error

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -1946,7 +1946,11 @@ func (repman *ReplicationManager) handlerMuxAddStorage(w http.ResponseWriter, r 
 		}
 
 		if row.VolumeName == "" {
-			row.Volume = mycluster.SetAppLocalMountVolume(node)
+			row.Volume, err = mycluster.SetAppLocalMountVolume(node)
+			if err != nil {
+				http.Error(w, "Volume selection required before adding storage: "+err.Error(), http.StatusBadRequest)
+				return
+			}
 			row.VolumeName = row.Volume.Name
 			row.VolumeDir = filepath.Join(row.Volume.VolumeDir, row.Name)
 		}

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -45,6 +45,11 @@ import (
 
 type LogLevelEnum string
 
+type PoolOption struct {
+	Value string `json:"value"`
+	Name  string `json:"name"`
+}
+
 const (
 	LogLevelErr   LogLevelEnum = "ERROR"
 	LogLevelWarn  LogLevelEnum = "WARN"
@@ -9169,7 +9174,7 @@ func (repman *ReplicationManager) handlerMuxClusterOpenSVCDaemonStatus(w http.Re
 // @Produce json
 // @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
 // @Param clusterName path string true "Cluster Name"
-// @Success 200 {array} string "OpenSVC pool list fetched"
+// @Success 200 {array} PoolOption "OpenSVC pool list fetched"
 // @Failure 403 {string} string "No valid ACL"
 // @Failure 500 {string} string "No cluster" or "Error getting OpenSVC pool list"
 // @Router /api/clusters/{clusterName}/opensvc-pools [get]
@@ -9190,16 +9195,17 @@ func (repman *ReplicationManager) handlerMuxClusterOpenSVCPoolList(w http.Respon
 			return
 		}
 
-		poolsJSON, err := json.Marshal(pools)
-		if err != nil {
-			http.Error(w, "Error marshalling pool list: "+err.Error(), http.StatusInternalServerError)
-			return
+		options := make([]PoolOption, 0, len(pools))
+		for _, pool := range pools {
+			if pool == "" {
+				continue
+			}
+			options = append(options, PoolOption{Value: pool, Name: pool})
 		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, err = w.Write(poolsJSON)
-		if err != nil {
+		if err := json.NewEncoder(w).Encode(options); err != nil {
 			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "API Error writing response: %s", err)
 			http.Error(w, "Error writing response: "+err.Error(), http.StatusInternalServerError)
 			return

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -46,8 +46,9 @@ import (
 type LogLevelEnum string
 
 type PoolOption struct {
-	Value string `json:"value"`
-	Name  string `json:"name"`
+	Value  string `json:"value"`
+	Name   string `json:"name"`
+	Shared bool   `json:"shared"`
 }
 
 const (
@@ -5322,8 +5323,8 @@ func (repman *ReplicationManager) handlerMuxGetTagContent(w http.ResponseWriter,
 	}
 
 	type tagContentResponse struct {
-		Tag     string                     `json:"tag"`
-		Content string                     `json:"content"`
+		Tag     string                      `json:"tag"`
+		Content string                      `json:"content"`
 		DocHelp *configurator.DocHelpResult `json:"doc_help,omitempty"`
 	}
 
@@ -9188,7 +9189,7 @@ func (repman *ReplicationManager) handlerMuxClusterOpenSVCPoolList(w http.Respon
 			return
 		}
 
-		pools, err := mycluster.OpenSVCGetPoolList()
+		pools, err := mycluster.OpenSVCGetPoolInfoList()
 		if err != nil {
 			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Error getting OpenSVC pool list: %s", err)
 			http.Error(w, "Error getting OpenSVC pool list: "+err.Error(), http.StatusInternalServerError)
@@ -9197,10 +9198,10 @@ func (repman *ReplicationManager) handlerMuxClusterOpenSVCPoolList(w http.Respon
 
 		options := make([]PoolOption, 0, len(pools))
 		for _, pool := range pools {
-			if pool == "" {
+			if pool.Name == "" {
 				continue
 			}
-			options = append(options, PoolOption{Value: pool, Name: pool})
+			options = append(options, PoolOption{Value: pool.Name, Name: pool.Name, Shared: pool.Shared})
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -9205,11 +9205,8 @@ func (repman *ReplicationManager) handlerMuxClusterOpenSVCPoolList(w http.Respon
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
 		if err := json.NewEncoder(w).Encode(options); err != nil {
 			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "API Error writing response: %s", err)
-			http.Error(w, "Error writing response: "+err.Error(), http.StatusInternalServerError)
-			return
 		}
 	} else {
 		http.Error(w, "No cluster", http.StatusInternalServerError)

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -90,6 +90,11 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterOpenSVCDaemonStatus)),
 	))
 
+	router.Handle("/api/clusters/{clusterName}/opensvc-pools", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterOpenSVCPoolList)),
+	))
+
 	//PROTECTED ENDPOINTS FOR CLUSTERS ACTIONS
 	router.Handle("/api/clusters/{clusterName}/settings", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
@@ -9148,6 +9153,54 @@ func (repman *ReplicationManager) handlerMuxClusterOpenSVCDaemonStatus(w http.Re
 		_, err = w.Write(statsJSON)
 		if err != nil {
 			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "API Error writing response: ", err)
+			http.Error(w, "Error writing response: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+	} else {
+		http.Error(w, "No cluster", http.StatusInternalServerError)
+		return
+	}
+}
+
+// handlerMuxClusterOpenSVCPoolList handles the HTTP request to retrieve the OpenSVC pool list of a cluster.
+// @Summary Get OpenSVC Pool List
+// @Description Retrieves the OpenSVC storage pool names of the specified cluster.
+// @Tags ClusterGateway
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Success 200 {array} string "OpenSVC pool list fetched"
+// @Failure 403 {string} string "No valid ACL"
+// @Failure 500 {string} string "No cluster" or "Error getting OpenSVC pool list"
+// @Router /api/clusters/{clusterName}/opensvc-pools [get]
+func (repman *ReplicationManager) handlerMuxClusterOpenSVCPoolList(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster != nil {
+		if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+			http.Error(w, "No valid ACL", http.StatusForbidden)
+			return
+		}
+
+		pools, err := mycluster.OpenSVCGetPoolList()
+		if err != nil {
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Error getting OpenSVC pool list: %s", err)
+			http.Error(w, "Error getting OpenSVC pool list: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		poolsJSON, err := json.Marshal(pools)
+		if err != nil {
+			http.Error(w, "Error marshalling pool list: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write(poolsJSON)
+		if err != nil {
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "API Error writing response: %s", err)
 			http.Error(w, "Error writing response: "+err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -605,7 +605,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.APIPort, "api-port", "10005", "Rest API listen port")
 	flags.StringVar(&conf.APIUsers, "api-credentials", "admin:repman", "Rest API user list user:password,..")
 	flags.StringVar(&conf.APIUsersExternal, "api-credentials-external", "", "Rest API user list user:password,.. as dba:repman,foo:bar")
-	flags.StringVar(&conf.APIUsersACLAllow, "api-credentials-acl-allow", "admin:cluster db proxy prov global grant show sale extrole terminal,dba:cluster proxy db,foo:", "User acl allow")
+	flags.StringVar(&conf.APIUsersACLAllow, "api-credentials-acl-allow", "admin:cluster db proxy prov global grant show sale extrole terminal app,dba:cluster proxy db,foo:", "User acl allow")
 	flags.StringVar(&conf.APIUsersACLAllowExternal, "api-credentials-acl-allow-external", "", "User dynamic acl allow")
 	flags.StringVar(&conf.APIUsersACLDiscard, "api-credentials-acl-discard", "", "User acl discard")
 	flags.StringVar(&conf.APIUsersACLDiscardExternal, "api-credentials-acl-discard-external", "", "User dynamic acl discard")

--- a/server/server.go
+++ b/server/server.go
@@ -1233,7 +1233,6 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.ProvAppDisk, "prov-app-disk-size", "4", "Disk in g for micro service VM. When cloud18 credit system is used, this is the base for 1 credit")
 	flags.StringVar(&conf.ProvAppCpuCores, "prov-app-cpu-cores", "1", "Cpu cores. When cloud18 credit system is used, this is the base for 1 credit")
 	flags.StringVar(&conf.ProvAppMem, "prov-app-memory", "1024", "Memory usage in M bytes. When cloud18 credit system is used, this is the base for 1 credit")
-	flags.StringVar(&conf.ProvAppVolumePools, "prov-app-volume-pools", "tank:local,drbd:shared:active-passive", "List of volume pools to use for application, comma separated. Format: poolname:type:[additional description]. Type can be local or shared. Example of additional description, for shared can be active-passive.")
 	flags.StringVar(&conf.ProvAppHATopology, "prov-app-ha-topology", "failover", "High availability mode for application. [failover|flex]")
 	flags.StringVar(&conf.ProvAppTemplateRepo, "prov-app-template-repo", "https://github.com/signal18/cloud18-templates", "Git repository for application templates (cluster-scoped)")
 	flags.StringVar(&conf.ProvAppTemplateRepoBranch, "prov-app-template-repo-branch", "main", "Git repository branch for application templates (cluster-scoped)")

--- a/share/dashboard_react/src/Pages/ClusterApp/components/ClusterAppTabContent/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/ClusterAppTabContent/index.jsx
@@ -35,10 +35,11 @@ function ClusterAppTabContent({ appId, tab, clusterName, user, selectedApp, conf
       <StoragePage
         clusterName={clusterName}
         appId={appId}
+        appConfig={appConfig}
         user={user}
       />
     )
-  }, [clusterName, appId, user])
+  }, [clusterName, appId, appConfig, user])
 
   const serviceOpenSvcComponent = useMemo(() => {
     return (

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/Volume.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/Volume.jsx
@@ -22,7 +22,7 @@ const maskString = (str, mask = '*') => {
 
 const VolumeSection = ({
     rows = [],
-    volumePools = "",
+    opensvcPools = [],
     fieldName = "volumes",
     title = "Saved Volumes",
     newTitle = "Add New Volume",
@@ -37,19 +37,17 @@ const VolumeSection = ({
     const [isVisible, setIsVisible] = useState(false);
 
     const poolOptions = useMemo(() => {
-        if (!volumePools) {
+        if (!Array.isArray(opensvcPools) || opensvcPools.length === 0) {
             return [];
         }
-        // The source will be a comma-separated string of pool names with characteristics
-        // Example: "tank:local,drbd:shared:failover"
-        return volumePools.split(',').map((pool) => {
-            const parts = pool.trim().split(':');
-            return {
-                value: parts[0].trim(),
-                name: parts[0].trim() + (parts.length > 1 ? ` (${parts.slice(1).join(':').trim()})` : ''),
-            };
-        });
-    }, [volumePools]);
+
+        return [...new Set(opensvcPools.filter(Boolean))]
+            .sort((a, b) => a.localeCompare(b))
+            .map((poolName) => ({
+                value: poolName,
+                name: poolName,
+            }));
+    }, [opensvcPools]);
 
     const handleAddItem = () => {
         setIsVisible(true);
@@ -103,7 +101,7 @@ const VolumeSection = ({
                 cell: () => null,
             }
         ],
-        [fieldName, onRowArrayChange, onRowDropIndex]
+        [fieldName, onRowArrayChange, onRowDropIndex, poolOptions]
     )
 
     return (

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/Volume.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/Volume.jsx
@@ -41,12 +41,34 @@ const VolumeSection = ({
             return [];
         }
 
-        return [...new Set(opensvcPools.filter(Boolean))]
-            .sort((a, b) => a.localeCompare(b))
-            .map((poolName) => ({
-                value: poolName,
-                name: poolName,
-            }));
+        const normalized = opensvcPools
+            .map((pool) => {
+                if (typeof pool === 'string') {
+                    const value = pool.trim();
+                    return value ? { value, name: value } : null;
+                }
+
+                if (pool && typeof pool === 'object') {
+                    const value = String(pool.value ?? pool.name ?? '').trim();
+                    if (!value) {
+                        return null;
+                    }
+                    const name = String(pool.name ?? value).trim() || value;
+                    return { value, name };
+                }
+
+                return null;
+            })
+            .filter(Boolean);
+
+        const dedup = new Map();
+        for (const option of normalized) {
+            if (!dedup.has(option.value)) {
+                dedup.set(option.value, option);
+            }
+        }
+
+        return [...dedup.values()].sort((a, b) => a.name.localeCompare(b.name));
     }, [opensvcPools]);
 
     const handleAddItem = () => {

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/Volume.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/Volume.jsx
@@ -23,6 +23,7 @@ const maskString = (str, mask = '*') => {
 const VolumeSection = ({
     rows = [],
     opensvcPools = [],
+    appHaTopology = '',
     fieldName = "volumes",
     title = "Saved Volumes",
     newTitle = "Add New Volume",
@@ -45,7 +46,7 @@ const VolumeSection = ({
             .map((pool) => {
                 if (typeof pool === 'string') {
                     const value = pool.trim();
-                    return value ? { value, name: value } : null;
+                    return value ? { value, name: value, shared: false } : null;
                 }
 
                 if (pool && typeof pool === 'object') {
@@ -54,7 +55,7 @@ const VolumeSection = ({
                         return null;
                     }
                     const name = String(pool.name ?? value).trim() || value;
-                    return { value, name };
+                    return { value, name, shared: Boolean(pool.shared) };
                 }
 
                 return null;
@@ -65,11 +66,19 @@ const VolumeSection = ({
         for (const option of normalized) {
             if (!dedup.has(option.value)) {
                 dedup.set(option.value, option);
+            } else if (option.shared) {
+                const current = dedup.get(option.value);
+                dedup.set(option.value, { ...current, shared: true });
             }
         }
 
-        return [...dedup.values()].sort((a, b) => a.name.localeCompare(b.name));
-    }, [opensvcPools]);
+        let options = [...dedup.values()];
+        if (appHaTopology === 'failover') {
+            options = options.filter((option) => option.shared);
+        }
+
+        return options.sort((a, b) => a.name.localeCompare(b.name));
+    }, [opensvcPools, appHaTopology]);
 
     const handleAddItem = () => {
         setIsVisible(true);

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/index.jsx
@@ -3,19 +3,27 @@ import GitCloneSection from "./GitClone";
 import VolumeSection from "./Volume";
 import S3DirectorySection from "./S3Directory";
 import styles from "./styles.module.scss";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import AccordionComponent from "../../../../components/AccordionComponent";
 import ConfirmModal from "../../../../components/Modals/ConfirmModal";
-import { addS3Provider, pauseAutoReload, selectClusterS3Providers, storageFieldChange, storageFieldIndexAdd, storageFieldIndexDrop, previewS3MountSync, applyS3MountSync, getClusterData } from "../../../../redux/clusterSlice";
+import { addS3Provider, pauseAutoReload, selectClusterS3Providers, storageFieldChange, storageFieldIndexAdd, storageFieldIndexDrop, previewS3MountSync, applyS3MountSync, getClusterData, getOpenSVCPools } from "../../../../redux/clusterSlice";
 
 export default function StoragePage({ clusterName, appId, user }) {
   const dispatch = useDispatch();
   const storages = useSelector((state) => state.cluster?.app?.deployment?.storages);
-  const volumePools = useSelector((state) => state.cluster?.clusterData?.config?.provAppVolumePools);
+  const opensvcPools = useSelector((state) => state.cluster?.opensvcPools || []);
+  const isOpenSVCOrchestrator = useSelector((state) => state.cluster?.clusterData?.config?.provOrchestrator === "opensvc");
   const s3Providers = useSelector((state) => state.cluster?.clusterData?.appS3Providers);
   const clusterS3Providers = useSelector(selectClusterS3Providers);
   const clusterApps = useSelector((state) => state.cluster?.clusterApps || []);
+
+  useEffect(() => {
+    if (!clusterName || !isOpenSVCOrchestrator) {
+      return;
+    }
+    dispatch(getOpenSVCPools({ clusterName }));
+  }, [clusterName, dispatch, isOpenSVCOrchestrator]);
 
   const getAppEndpoint = useCallback((app) => {
     if (!app) return "";
@@ -167,7 +175,7 @@ export default function StoragePage({ clusterName, appId, user }) {
 
   const volumeComponent = useMemo(() => (
       <VolumeSection
-        volumePools={volumePools}
+        opensvcPools={opensvcPools}
         fieldName="volumes"
         title="Saved Volumes"
         newTitle="Add New Volume"
@@ -176,7 +184,7 @@ export default function StoragePage({ clusterName, appId, user }) {
         rows={volumes}
         {...actionProps}
       />
-  ), [volumes, actionProps]);
+  ), [volumes, opensvcPools, actionProps]);
 
   const s3Component = useMemo(() => (
       <S3DirectorySection appId={appId} rows={s3Mounts} s3ProvOptions={s3ProvOptions} clusterS3Providers={clusterS3Providers} {...actionProps} />

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/index.jsx
@@ -9,7 +9,7 @@ import AccordionComponent from "../../../../components/AccordionComponent";
 import ConfirmModal from "../../../../components/Modals/ConfirmModal";
 import { addS3Provider, pauseAutoReload, selectClusterS3Providers, storageFieldChange, storageFieldIndexAdd, storageFieldIndexDrop, previewS3MountSync, applyS3MountSync, getClusterData, getOpenSVCPools } from "../../../../redux/clusterSlice";
 
-export default function StoragePage({ clusterName, appId, user }) {
+export default function StoragePage({ clusterName, appId, appConfig, user }) {
   const dispatch = useDispatch();
   const storages = useSelector((state) => state.cluster?.app?.deployment?.storages);
   const opensvcPools = useSelector((state) => state.cluster?.opensvcPools || []);
@@ -176,6 +176,7 @@ export default function StoragePage({ clusterName, appId, user }) {
   const volumeComponent = useMemo(() => (
       <VolumeSection
         opensvcPools={opensvcPools}
+        appHaTopology={appConfig?.provAppHaTopology}
         fieldName="volumes"
         title="Saved Volumes"
         newTitle="Add New Volume"
@@ -184,7 +185,7 @@ export default function StoragePage({ clusterName, appId, user }) {
         rows={volumes}
         {...actionProps}
       />
-  ), [volumes, opensvcPools, actionProps]);
+  ), [volumes, opensvcPools, appConfig?.provAppHaTopology, actionProps]);
 
   const s3Component = useMemo(() => (
       <S3DirectorySection appId={appId} rows={s3Mounts} s3ProvOptions={s3ProvOptions} clusterS3Providers={clusterS3Providers} {...actionProps} />

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -78,6 +78,9 @@ const fulfilledHandlers = {
   'cluster/getOpenSVCStats': (state, action) => {
     state.opensvcStats = action.payload.data
   },
+  'cluster/getOpenSVCPools': (state, action) => {
+    state.opensvcPools = action.payload.data
+  },
   'cluster/getBackups': (state, action) => {
     state.backups.list = action.payload.data
   },
@@ -260,6 +263,16 @@ export const getOpenSVCStats = createGuardedAsyncThunk('cluster/getOpenSVCStats'
   try {
     const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
     const { data, status } = await clusterService.getOpenSVCStats(clusterName, baseURL)
+    return { data, status }
+  } catch (error) {
+    return handleError(error, thunkAPI)
+  }
+})
+
+export const getOpenSVCPools = createGuardedAsyncThunk('cluster/getOpenSVCPools', async ({ clusterName }, thunkAPI) => {
+  try {
+    const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+    const { data, status } = await clusterService.getOpenSVCPools(clusterName, baseURL)
     return { data, status }
   } catch (error) {
     return handleError(error, thunkAPI)
@@ -2532,6 +2545,7 @@ const initialState = {
   },
   topProcess: null,
   opensvcStats: null,
+  opensvcPools: null,
   jobs: null,
   shardSchema: null,
   queryRules: null,

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -2629,6 +2629,7 @@ export const clusterSlice = createSlice({
         getDatabaseService.fulfilled,
         getTopProcess.fulfilled,
         getOpenSVCStats.fulfilled,
+        getOpenSVCPools.fulfilled,
         getShardSchema.fulfilled,
         getQueryRules.fulfilled,
         getBackups.fulfilled,

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -11,6 +11,7 @@ export const clusterService = {
   getClusterCertificates,
   getTopProcess,
   getOpenSVCStats,
+  getOpenSVCPools,
   getBackups,
   getBackupStats,
   deleteBackup,
@@ -225,6 +226,10 @@ function getTopProcess(clusterName, baseURL) {
 
 function getOpenSVCStats(clusterName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/opensvc-stats`)
+}
+
+function getOpenSVCPools(clusterName, baseURL) {
+  return getApi(baseURL).get(`clusters/${clusterName}/opensvc-pools`)
 }
 
 function getBackups(clusterName, baseURL) {


### PR DESCRIPTION
## Summary
- add OpenSVC runtime pool discovery for v2/v3 with shared-capability parsing and comprehensive tests
- add protected `GET /api/clusters/{clusterName}/opensvc-pools` and wire React storage UI to consume dynamic pool options
- remove static app pool config dependency, enforce explicit/fail-fast app volume selection, and set shared volume flag from runtime pool metadata
- add pool-info caching at cluster level (5-minute cached reads) with provisioning path using forced fresh fetch

## Validation
- `go test ./opensvc ./cluster ./server`
- React targeted storage/Redux flow validated in prior runs

## Notes
- branch includes ACL updates for `/opensvc-pools` and UI filtering for shared pools in failover topology