### PR TITLE
fix(opensvc): generate topology-aware HAProxy backend template count

### DIFF
--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -990,7 +990,10 @@ func (cluster *Cluster) OpenSVCProvisionRoute(app *App) error {
 	agents := app.GetAppAgents()
 	svc := cluster.OpenSVCConnect()
 	numBE := len(agents)
-	if app.AppConfig.ProvAppHATopology == "failover" {
+	if app.AppConfig != nil && app.AppConfig.ProvAppHATopology == "failover" {
+		numBE = 1
+	}
+	if numBE < 1 {
 		numBE = 1
 	}
 

--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -987,7 +987,12 @@ func (cluster *Cluster) OpenSVCCreateAppVariableMaps(agent string, app *App) err
 }
 
 func (cluster *Cluster) OpenSVCProvisionRoute(app *App) error {
+	agents := app.GetAppAgents()
 	svc := cluster.OpenSVCConnect()
+	numBE := len(agents)
+	if app.AppConfig.ProvAppHATopology == "failover" {
+		numBE = 1
+	}
 
 	cloud18GatewayServiceConfig := strings.Split(cluster.Conf.Cloud18GatewayService, "/")
 
@@ -1030,7 +1035,7 @@ backend ` + backend + `
     cookie SERVER insert indirect nocache dynamic
     balance roundrobin
     dynamic-cookie-key mysecretphrase
-    server-template srv 2 ` + app.Name + `.` + cluster.Name + `.svc.` + cluster.Conf.ProvOrchestratorCluster + `:` + route.Port + ` resolvers cluster check init-addr none
+    server srv ` + fmt.Sprintf("%d", numBE) + ` ` + app.Name + `.` + cluster.Name + `.svc.` + cluster.Conf.ProvOrchestratorCluster + `:` + route.Port + ` resolvers cluster check init-addr none
 `
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Creating app route fragment %s %s %s %s", cloud18GatewayServiceConfig[0], cloud18GatewayServiceConfig[2], "haproxy.cfg.d/"+backend, haproxyfragment)
 

--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -1035,7 +1035,7 @@ backend ` + backend + `
     cookie SERVER insert indirect nocache dynamic
     balance roundrobin
     dynamic-cookie-key mysecretphrase
-    server srv ` + fmt.Sprintf("%d", numBE) + ` ` + app.Name + `.` + cluster.Name + `.svc.` + cluster.Conf.ProvOrchestratorCluster + `:` + route.Port + ` resolvers cluster check init-addr none
+    server-template srv ` + fmt.Sprintf("%d", numBE) + ` ` + app.Name + `.` + cluster.Name + `.svc.` + cluster.Conf.ProvOrchestratorCluster + `:` + route.Port + ` resolvers cluster check init-addr none
 `
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Creating app route fragment %s %s %s %s", cloud18GatewayServiceConfig[0], cloud18GatewayServiceConfig[2], "haproxy.cfg.d/"+backend, haproxyfragment)
 


### PR DESCRIPTION
## Summary
- Compute HAProxy `server-template` backend count from `app.GetAppAgents()` instead of hardcoding `2`.
- Force backend count to `1` when app HA topology is `failover`.
- Fix HAProxy backend fragment generation so emitted config syntax is valid.

## Why
OpenSVC route provisioning was generating backend templates with a fixed server count, which does not match real deployment topologies. This could over-provision backend slots in failover mode and produce incorrect routing behavior. This change aligns generated HAProxy config with actual app topology and ensures valid backend config output.

## Scope
- `cluster/prov_opensvc_app.go` only