### PR TITLE
feat(billing): add billing profile management

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -397,6 +397,11 @@ func (repman *ReplicationManager) apiserver() {
 		negroni.Wrap(http.HandlerFunc(repman.handlerBillingTransactions)),
 	))
 
+	router.Handle("/api/billing/profile", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerBillingProfile)),
+	))
+
 	router.Handle("/api/clusters", negroni.New(
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusters)),
 	))

--- a/server/api.go
+++ b/server/api.go
@@ -400,7 +400,9 @@ func (repman *ReplicationManager) apiserver() {
 	router.Handle("/api/billing/profile", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerBillingProfile)),
-	))
+	)).Methods(http.MethodGet, http.MethodPut)
+
+	router.HandleFunc("/api/billing/profile", repman.handlerBillingProfilePreflight).Methods(http.MethodOptions)
 
 	router.Handle("/api/clusters", negroni.New(
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusters)),

--- a/server/api_register.go
+++ b/server/api_register.go
@@ -1643,3 +1643,90 @@ func (repman *ReplicationManager) handlerUnregister(w http.ResponseWriter, r *ht
 	w.WriteHeader(http.StatusOK)
 	w.Write(respBody)
 }
+
+func crmGetBillingProfile(crmBase, gitlabToken string) (int, []byte, error) {
+	req, err := http.NewRequest(http.MethodGet, crmBase+"/api/profile", nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+gitlabToken)
+	req.Header.Set("Accept", "application/json")
+	resp, err := crmHTTPClient15s.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	return resp.StatusCode, body, err
+}
+
+func crmUpdateBillingProfile(crmBase, gitlabToken string, profile json.RawMessage) (int, []byte, error) {
+	payload, err := json.Marshal(map[string]json.RawMessage{"billing_profile": profile})
+	if err != nil {
+		return 0, nil, err
+	}
+	req, err := http.NewRequest(http.MethodPut, crmBase+"/api/profile", bytes.NewReader(payload))
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+gitlabToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := crmHTTPClient30s.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	return resp.StatusCode, body, err
+}
+
+// handlerBillingProfile — GET /api/billing/profile and PUT /api/billing/profile (JWT required)
+func (repman *ReplicationManager) handlerBillingProfile(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	gitlabToken, err := repman.GetJWTGitLabToken(r)
+	if err != nil {
+		writeJSONError(w, http.StatusPreconditionFailed, "gitlab sso token required")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		status, body, err := repman.fetchWithSessionBootstrap(gitlabToken, func() (int, []byte, error) {
+			return crmGetBillingProfile(repman.crmBase(), gitlabToken)
+		})
+		if err != nil {
+			writeJSONError(w, http.StatusBadGateway, "CRM API unreachable")
+			return
+		}
+		w.WriteHeader(crmStatusToHTTP(status))
+		_, _ = w.Write(body)
+
+	case http.MethodPut:
+		var reqBody struct {
+			BillingProfile json.RawMessage `json:"billing_profile"`
+		}
+		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&reqBody); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid JSON body")
+			return
+		}
+		if len(reqBody.BillingProfile) == 0 {
+			writeJSONError(w, http.StatusBadRequest, "billing_profile is required")
+			return
+		}
+		status, body, err := repman.fetchWithSessionBootstrap(gitlabToken, func() (int, []byte, error) {
+			return crmUpdateBillingProfile(repman.crmBase(), gitlabToken, reqBody.BillingProfile)
+		})
+		if err != nil {
+			writeJSONError(w, http.StatusBadGateway, "CRM API unreachable")
+			return
+		}
+		w.WriteHeader(crmStatusToHTTP(status))
+		_, _ = w.Write(body)
+
+	default:
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}

--- a/server/api_register.go
+++ b/server/api_register.go
@@ -1466,6 +1466,17 @@ func (repman *ReplicationManager) handlerGetSubscriptionPlans(w http.ResponseWri
 
 // handlerGetSubscription — GET /api/register/subscription  (admin JWT required)
 //
+// handlerBillingProfilePreflight responds to CORS preflight requests for
+// /api/billing/profile, advertising that GET and PUT are accepted.
+// It is registered as a dedicated OPTIONS route so handlerBillingProfile
+// never receives OPTIONS (which it would otherwise reject with 405).
+func (repman *ReplicationManager) handlerBillingProfilePreflight(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, PUT, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // handlerSubscriptionPreflight responds to CORS preflight requests for
 // /api/register/subscription, advertising that GET and POST are accepted.
 // It is registered as a dedicated OPTIONS route so the business handlers

--- a/server/http.go
+++ b/server/http.go
@@ -246,6 +246,11 @@ func (repman *ReplicationManager) httpserver() {
 		negroni.Wrap(http.HandlerFunc(repman.handlerBillingTransactions)),
 	))
 
+	router.Handle("/api/billing/profile", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerBillingProfile)),
+	))
+
 	router.Handle("/api/prometheus", negroni.New(
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxPrometheus)),
 	))

--- a/server/http.go
+++ b/server/http.go
@@ -249,7 +249,9 @@ func (repman *ReplicationManager) httpserver() {
 	router.Handle("/api/billing/profile", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerBillingProfile)),
-	))
+	)).Methods(http.MethodGet, http.MethodPut)
+
+	router.HandleFunc("/api/billing/profile", repman.handlerBillingProfilePreflight).Methods(http.MethodOptions)
 
 	router.Handle("/api/prometheus", negroni.New(
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxPrometheus)),

--- a/share/dashboard_react/src/Pages/Billing/index.jsx
+++ b/share/dashboard_react/src/Pages/Billing/index.jsx
@@ -94,6 +94,7 @@ function Billing() {
   const rows = useMemo(() => (Array.isArray(transactions) ? transactions : []), [transactions])
 
   useEffect(() => {
+    dispatch(clearUpdateBillingProfileStatus())
     dispatch(fetchPersonalBalance())
     dispatch(fetchBillingSubscription())
     dispatch(fetchBillingPlansCatalog())
@@ -102,16 +103,15 @@ function Billing() {
 
   useEffect(() => {
     if (billingProfile && typeof billingProfile === 'object') {
-      const bp = billingProfile.billing_profile || billingProfile
       setProfileForm({
-        name: bp.name || '',
-        email: bp.email || '',
-        phone: bp.phone || '',
-        address: bp.address || '',
-        city: bp.city || '',
-        country: bp.country || '',
-        postal_code: bp.postal_code || '',
-        vat_number: bp.vat_number || ''
+        name: billingProfile.name || '',
+        email: billingProfile.email || '',
+        phone: billingProfile.phone || '',
+        address: billingProfile.address || '',
+        city: billingProfile.city || '',
+        country: billingProfile.country || '',
+        postal_code: billingProfile.postal_code || '',
+        vat_number: billingProfile.vat_number || ''
       })
     }
   }, [billingProfile])
@@ -288,6 +288,7 @@ function Billing() {
                 <Box borderWidth='1px' borderColor={pendingBorderColor} borderRadius='md' p={2} w='full' bg={pendingBoxBg}>
                   <Text fontSize='xs' color='var(--warning-primary-color)' fontWeight='bold' textTransform='uppercase' letterSpacing='wide'>Pending Request</Text>
                   <Text fontSize='sm' color='var(--text-color)'>
+                    {/* requested_subscription is the current DBaaS API field; requested_plan is the legacy field / next_plan shim */}
                     {String(pendingChangeRequest.requested_subscription || pendingChangeRequest.requested_plan || 'change request')} ({String(pendingChangeRequest.status || 'pending')})
                   </Text>
                 </Box>

--- a/share/dashboard_react/src/Pages/Billing/index.jsx
+++ b/share/dashboard_react/src/Pages/Billing/index.jsx
@@ -6,7 +6,10 @@ import {
   Button,
   Divider,
   Flex,
+  FormControl,
+  FormLabel,
   HStack,
+  Input,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -15,6 +18,7 @@ import {
   ModalHeader,
   ModalOverlay,
   Select,
+  SimpleGrid,
   Spinner,
   Table,
   Tbody,
@@ -28,11 +32,14 @@ import {
 } from '@chakra-ui/react'
 import {
   clearChangeSubscriptionError,
+  clearUpdateBillingProfileStatus,
   fetchBillingPlansCatalog,
+  fetchBillingProfile,
   fetchBillingSubscription,
   fetchBillingTransactions,
   fetchPersonalBalance,
-  requestBillingSubscriptionChange
+  requestBillingSubscriptionChange,
+  updateBillingProfile
 } from '../../redux/billingSlice'
 import { useTheme } from '../../ThemeProvider'
 import parentStyles from '../../components/Modals/styles.module.scss'
@@ -63,17 +70,26 @@ function Billing() {
     subscription,
     plansCatalog,
     transactions,
+    billingProfile,
     loadingBalance,
     loadingSubscription,
     loadingPlansCatalog,
     loadingChangeSubscription,
     loadingTransactions,
+    loadingBillingProfile,
+    loadingUpdateBillingProfile,
     errorBalance,
     errorSubscription,
     errorPlansCatalog,
     errorChangeSubscription,
-    errorTransactions
+    errorTransactions,
+    errorBillingProfile,
+    errorUpdateBillingProfile,
+    updateBillingProfileSuccess
   } = useSelector((state) => state.billing)
+
+  const emptyProfile = { name: '', email: '', phone: '', address: '', city: '', country: '', postal_code: '', vat_number: '' }
+  const [profileForm, setProfileForm] = useState(emptyProfile)
 
   const rows = useMemo(() => (Array.isArray(transactions) ? transactions : []), [transactions])
 
@@ -81,7 +97,24 @@ function Billing() {
     dispatch(fetchPersonalBalance())
     dispatch(fetchBillingSubscription())
     dispatch(fetchBillingPlansCatalog())
+    dispatch(fetchBillingProfile())
   }, [dispatch])
+
+  useEffect(() => {
+    if (billingProfile && typeof billingProfile === 'object') {
+      const bp = billingProfile.billing_profile || billingProfile
+      setProfileForm({
+        name: bp.name || '',
+        email: bp.email || '',
+        phone: bp.phone || '',
+        address: bp.address || '',
+        city: bp.city || '',
+        country: bp.country || '',
+        postal_code: bp.postal_code || '',
+        vat_number: bp.vat_number || ''
+      })
+    }
+  }, [billingProfile])
 
   useEffect(() => {
     dispatch(fetchBillingTransactions({ limit: PAGE_SIZE, offset, direction: 'desc' }))
@@ -109,8 +142,21 @@ function Billing() {
     return Array.isArray(source) ? source : []
   }, [plansCatalog])
 
+  const handleProfileChange = (e) => {
+    const { name, value } = e.target
+    setProfileForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleProfileSubmit = async () => {
+    dispatch(clearUpdateBillingProfileStatus())
+    const result = await dispatch(updateBillingProfile(profileForm))
+    if (updateBillingProfile.fulfilled.match(result)) {
+      dispatch(fetchBillingProfile())
+    }
+  }
+
   const crmUnavailableMessage = useMemo(() => {
-    const candidates = [errorBalance, errorSubscription, errorPlansCatalog, errorTransactions, errorChangeSubscription]
+    const candidates = [errorBalance, errorSubscription, errorPlansCatalog, errorTransactions, errorChangeSubscription, errorBillingProfile]
       .filter((msg) => typeof msg === 'string' && msg.trim().length > 0)
 
     const unavailable = candidates.find((msg) => {
@@ -119,7 +165,7 @@ function Billing() {
     })
 
     return unavailable || null
-  }, [errorBalance, errorSubscription, errorPlansCatalog, errorTransactions, errorChangeSubscription])
+  }, [errorBalance, errorSubscription, errorPlansCatalog, errorTransactions, errorChangeSubscription, errorBillingProfile])
 
   const isDBaaSServiceUnavailable = useMemo(() => {
     const dbassCandidates = [errorSubscription, errorPlansCatalog, errorChangeSubscription]
@@ -242,7 +288,7 @@ function Billing() {
                 <Box borderWidth='1px' borderColor={pendingBorderColor} borderRadius='md' p={2} w='full' bg={pendingBoxBg}>
                   <Text fontSize='xs' color='var(--warning-primary-color)' fontWeight='bold' textTransform='uppercase' letterSpacing='wide'>Pending Request</Text>
                   <Text fontSize='sm' color='var(--text-color)'>
-                    {String(pendingChangeRequest.requested_plan || pendingChangeRequest.requested_subscription || 'change request')} ({String(pendingChangeRequest.status || 'pending')})
+                    {String(pendingChangeRequest.requested_subscription || pendingChangeRequest.requested_plan || 'change request')} ({String(pendingChangeRequest.status || 'pending')})
                   </Text>
                 </Box>
               )}
@@ -271,6 +317,70 @@ function Billing() {
           )}
         </Box>
       </HStack>
+
+      <Divider />
+
+      <Box borderWidth='1px' borderColor={cardBorderColor} borderRadius='lg' p={5} boxShadow='sm' bg={sectionCardBg}>
+        <Text fontSize='md' fontWeight='semibold' mb={4}>Billing Profile</Text>
+        {loadingBillingProfile ? (
+          <HStack py={3}><Spinner size='sm' /><Text fontSize='sm'>Loading profile…</Text></HStack>
+        ) : errorBillingProfile && showInlineServiceErrors ? (
+          <Text fontSize='sm' color='red.500' mb={3}>{errorBillingProfile}</Text>
+        ) : null}
+        {updateBillingProfileSuccess && (
+          <Box borderWidth='1px' borderColor='var(--success-secondary-color, #68d391)' borderRadius='md' p={2} mb={3} bg='var(--success-tertiary-color, #f0fff4)'>
+            <Text fontSize='sm' color='var(--success-primary-color, #276749)'>Billing profile updated successfully.</Text>
+          </Box>
+        )}
+        {errorUpdateBillingProfile && (
+          <Text fontSize='sm' color='red.500' mb={3}>{errorUpdateBillingProfile}</Text>
+        )}
+        <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
+          <FormControl>
+            <FormLabel fontSize='sm'>Name</FormLabel>
+            <Input size='sm' name='name' value={profileForm.name} onChange={handleProfileChange} placeholder='Acme Corp' />
+          </FormControl>
+          <FormControl>
+            <FormLabel fontSize='sm'>Billing Email</FormLabel>
+            <Input size='sm' name='email' value={profileForm.email} onChange={handleProfileChange} placeholder='billing@acme.com' />
+          </FormControl>
+          <FormControl>
+            <FormLabel fontSize='sm'>Phone</FormLabel>
+            <Input size='sm' name='phone' value={profileForm.phone} onChange={handleProfileChange} placeholder='+33 1 23 45 67 89' />
+          </FormControl>
+          <FormControl>
+            <FormLabel fontSize='sm'>Address</FormLabel>
+            <Input size='sm' name='address' value={profileForm.address} onChange={handleProfileChange} placeholder='12 rue de la Paix' />
+          </FormControl>
+          <FormControl>
+            <FormLabel fontSize='sm'>City</FormLabel>
+            <Input size='sm' name='city' value={profileForm.city} onChange={handleProfileChange} placeholder='Paris' />
+          </FormControl>
+          <FormControl>
+            <FormLabel fontSize='sm'>Country</FormLabel>
+            <Input size='sm' name='country' value={profileForm.country} onChange={handleProfileChange} placeholder='FR' />
+          </FormControl>
+          <FormControl>
+            <FormLabel fontSize='sm'>Postal Code</FormLabel>
+            <Input size='sm' name='postal_code' value={profileForm.postal_code} onChange={handleProfileChange} placeholder='75001' />
+          </FormControl>
+          <FormControl>
+            <FormLabel fontSize='sm'>VAT Number</FormLabel>
+            <Input size='sm' name='vat_number' value={profileForm.vat_number} onChange={handleProfileChange} placeholder='FR12345678901' />
+          </FormControl>
+        </SimpleGrid>
+        <Box mt={4}>
+          <Button
+            size='sm'
+            colorScheme='blue'
+            onClick={handleProfileSubmit}
+            isLoading={loadingUpdateBillingProfile}
+            isDisabled={loadingBillingProfile}
+          >
+            Save Profile
+          </Button>
+        </Box>
+      </Box>
 
       <Divider />
 

--- a/share/dashboard_react/src/redux/billingSlice.js
+++ b/share/dashboard_react/src/redux/billingSlice.js
@@ -34,6 +34,14 @@ const normalizeMaybeWrapped = (payload) => {
   return payload
 }
 
+const normalizeBillingProfile = (payload) => {
+  const unwrapped = normalizeMaybeWrapped(payload)
+  if (unwrapped && typeof unwrapped === 'object') {
+    return unwrapped.billing_profile || unwrapped
+  }
+  return null
+}
+
 const normalizeTransactions = (payload) => {
   const unwrapped = normalizeMaybeWrapped(payload)
   if (Array.isArray(unwrapped)) {
@@ -295,7 +303,7 @@ const billingSlice = createSlice({
       })
       .addCase(fetchBillingProfile.fulfilled, (state, action) => {
         state.loadingBillingProfile = false
-        state.billingProfile = normalizeMaybeWrapped(action.payload?.data)
+        state.billingProfile = normalizeBillingProfile(action.payload?.data)
       })
       .addCase(fetchBillingProfile.rejected, (state, action) => {
         state.loadingBillingProfile = false

--- a/share/dashboard_react/src/redux/billingSlice.js
+++ b/share/dashboard_react/src/redux/billingSlice.js
@@ -9,16 +9,22 @@ const initialState = {
   changeSubscriptionResult: null,
   transactions: [],
   transactionsMeta: null,
+  billingProfile: null,
   loadingBalance: false,
   loadingSubscription: false,
   loadingPlansCatalog: false,
   loadingChangeSubscription: false,
   loadingTransactions: false,
+  loadingBillingProfile: false,
+  loadingUpdateBillingProfile: false,
   errorBalance: null,
   errorSubscription: null,
   errorPlansCatalog: null,
   errorChangeSubscription: null,
-  errorTransactions: null
+  errorTransactions: null,
+  errorBillingProfile: null,
+  errorUpdateBillingProfile: null,
+  updateBillingProfileSuccess: false
 }
 
 const normalizeMaybeWrapped = (payload) => {
@@ -166,6 +172,43 @@ export const requestBillingSubscriptionChange = createAsyncThunk('billing/reques
   }
 })
 
+export const fetchBillingProfile = createAsyncThunk('billing/fetchBillingProfile', async (_, thunkAPI) => {
+  try {
+    const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+    const response = await billingService.getBillingProfile(baseURL)
+    const status = Number(response?.status || 0)
+    if (status >= 200 && status < 300) {
+      return response
+    }
+    return thunkAPI.rejectWithValue({
+      message: normalizeBillingErrorMessage(
+        response,
+        'Failed to fetch billing profile',
+        'The CRM billing service is temporarily unavailable. Billing profile cannot be loaded right now.'
+      )
+    })
+  } catch (error) {
+    return thunkAPI.rejectWithValue({ message: extractApiErrorMessage(error, 'Failed to fetch billing profile') })
+  }
+})
+
+export const updateBillingProfile = createAsyncThunk('billing/updateBillingProfile', async (profile, thunkAPI) => {
+  try {
+    const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+    const response = await billingService.updateBillingProfile(profile, baseURL)
+    const status = Number(response?.status || 0)
+    if (status >= 200 && status < 300) {
+      return response
+    }
+    const apiMessage = typeof response?.data === 'object'
+      ? (response.data?.error || response.data?.message)
+      : ''
+    return thunkAPI.rejectWithValue({ message: apiMessage || 'Failed to update billing profile' })
+  } catch (error) {
+    return thunkAPI.rejectWithValue({ message: extractApiErrorMessage(error, 'Failed to update billing profile') })
+  }
+})
+
 const billingSlice = createSlice({
   name: 'billing',
   initialState,
@@ -175,6 +218,10 @@ const billingSlice = createSlice({
     },
     clearChangeSubscriptionError: (state) => {
       state.errorChangeSubscription = null
+    },
+    clearUpdateBillingProfileStatus: (state) => {
+      state.errorUpdateBillingProfile = null
+      state.updateBillingProfileSuccess = false
     }
   },
   extraReducers: (builder) => {
@@ -242,8 +289,33 @@ const billingSlice = createSlice({
         state.loadingChangeSubscription = false
         state.errorChangeSubscription = action.payload?.message || action.error?.message || 'Failed to change billing subscription'
       })
+      .addCase(fetchBillingProfile.pending, (state) => {
+        state.loadingBillingProfile = true
+        state.errorBillingProfile = null
+      })
+      .addCase(fetchBillingProfile.fulfilled, (state, action) => {
+        state.loadingBillingProfile = false
+        state.billingProfile = normalizeMaybeWrapped(action.payload?.data)
+      })
+      .addCase(fetchBillingProfile.rejected, (state, action) => {
+        state.loadingBillingProfile = false
+        state.errorBillingProfile = action.payload?.message || action.error?.message || 'Failed to fetch billing profile'
+      })
+      .addCase(updateBillingProfile.pending, (state) => {
+        state.loadingUpdateBillingProfile = true
+        state.errorUpdateBillingProfile = null
+        state.updateBillingProfileSuccess = false
+      })
+      .addCase(updateBillingProfile.fulfilled, (state) => {
+        state.loadingUpdateBillingProfile = false
+        state.updateBillingProfileSuccess = true
+      })
+      .addCase(updateBillingProfile.rejected, (state, action) => {
+        state.loadingUpdateBillingProfile = false
+        state.errorUpdateBillingProfile = action.payload?.message || action.error?.message || 'Failed to update billing profile'
+      })
   }
 })
 
-export const { clearBillingState, clearChangeSubscriptionError } = billingSlice.actions
+export const { clearBillingState, clearChangeSubscriptionError, clearUpdateBillingProfileStatus } = billingSlice.actions
 export default billingSlice.reducer

--- a/share/dashboard_react/src/services/apiHelper.js
+++ b/share/dashboard_react/src/services/apiHelper.js
@@ -133,6 +133,7 @@ const performRequest = async (method, apiUrl, params, authValue, baseUrl = '') =
 const requestWrapper = (authValue, baseUrl = '') => ({
   get: (apiUrl, params) => performRequest('GET', apiUrl, params, authValue, baseUrl),
   post: (apiUrl, params) => performRequest('POST', apiUrl, params, authValue, baseUrl),
+  put: (apiUrl, params) => performRequest('PUT', apiUrl, params, authValue, baseUrl),
   getAll: (urls, params) => {
     const requests = urls.map((url) => {
       const resolvedUrl = resolveUrl(url, authValue, baseUrl);

--- a/share/dashboard_react/src/services/billingService.js
+++ b/share/dashboard_react/src/services/billingService.js
@@ -5,7 +5,9 @@ export const billingService = {
   getSubscription,
   getSubscriptionPlans,
   changeSubscriptionPlan,
-  getTransactions
+  getTransactions,
+  getBillingProfile,
+  updateBillingProfile
 }
 
 function getPersonalBalance(baseURL = '') {
@@ -26,4 +28,12 @@ function changeSubscriptionPlan(subscription, baseURL = '') {
 
 function getTransactions({ limit = 20, offset = 0, direction = 'desc' } = {}, baseURL = '') {
   return getApi(baseURL).get('billing/transactions', { limit, offset, direction })
+}
+
+function getBillingProfile(baseURL = '') {
+  return getApi(baseURL).get('billing/profile')
+}
+
+function updateBillingProfile(profile, baseURL = '') {
+  return getApi(baseURL).put('billing/profile', { billing_profile: profile })
 }


### PR DESCRIPTION
## Summary
- add authenticated billing profile GET/PUT proxy endpoints to both API routers
- add billing profile form, state, and service calls in the React billing page
- preserve billing subscription payment and pending-plan compatibility behavior

## Verification
- reviewed staged diff
- git diff --cached --check