### PR TITLE
feat(monitoring): implement monitoring-schema-change-script hook

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -144,6 +144,8 @@ type Cluster struct {
 	LogTask                       s18log.HttpLog             `json:"-" groups:"web"`
 	LogSecurity                   s18log.HttpLog             `json:"-" groups:"web"`
 	LogWorkload                   s18log.HttpLog             `json:"-" groups:"web"`
+	LogDDL                        s18log.HttpLog             `json:"-" groups:"web"`
+	LogVariableChange             s18log.HttpLog             `json:"-" groups:"web"`
 	LogSlack                      *slackman.SlackManager     `json:"-"`
 	JobResults                    *config.TasksMap           `json:"jobResults" groups:"web"`
 	FalsePositiveChecks           map[string]bool            `json:"falsePositiveChecks" groups:"web"`
@@ -494,6 +496,8 @@ func (cluster *Cluster) InitFromConf() {
 	cluster.LogTask = s18log.NewHttpLog(200)
 	cluster.LogSecurity = s18log.NewHttpLog(200)
 	cluster.LogWorkload = s18log.NewHttpLog(200)
+	cluster.LogDDL = s18log.NewHttpLog(200)
+	cluster.LogVariableChange = s18log.NewHttpLog(200)
 
 	cluster.MonitorType = config.GetMonitorType()
 	cluster.TopologyType = config.GetTopologyType()
@@ -2195,6 +2199,13 @@ func (cluster *Cluster) MonitorMasterTableSchema() error {
 			if err == nil {
 				oldCols = oldtable.TableColumns
 			}
+			diff := columnDiff(t.TableSchema, t.TableName, oldCols, t.TableColumns)
+			cluster.LogDDL.Add(s18log.HttpMessage{
+				Group:     cluster.Name,
+				Level:     "INFO",
+				Timestamp: time.Now().Format("2006-01-02 15:04:05"),
+				Text:      fmt.Sprintf("Server %s: %s %s.%s\n%s", cmaster.URL, changeType, t.TableSchema, t.TableName, diff),
+			})
 			cluster.BashScriptSchemaChange(cmaster.URL, t.TableSchema, t.TableName, changeType, oldCols, t.TableColumns)
 		}
 
@@ -2238,6 +2249,13 @@ func (cluster *Cluster) MonitorMasterTableSchema() error {
 	for fqn, oldT := range oldTables {
 		if _, exists := tables[fqn]; !exists {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Dropped table %s", fqn)
+			diff := columnDiff(oldT.TableSchema, oldT.TableName, oldT.TableColumns, nil)
+			cluster.LogDDL.Add(s18log.HttpMessage{
+				Group:     cluster.Name,
+				Level:     "INFO",
+				Timestamp: time.Now().Format("2006-01-02 15:04:05"),
+				Text:      fmt.Sprintf("Server %s: dropped %s\n%s", cmaster.URL, fqn, diff),
+			})
 			cluster.BashScriptSchemaChange(cmaster.URL, oldT.TableSchema, oldT.TableName, "dropped", oldT.TableColumns, nil)
 		}
 	}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -2229,6 +2229,15 @@ func (cluster *Cluster) MonitorMasterTableSchema() error {
 		}
 	}
 
+	// Detect dropped tables: in old cache but not in current scan
+	oldTables := cmaster.DictTables.ToNewMap()
+	for fqn, oldT := range oldTables {
+		if _, exists := tables[fqn]; !exists {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Dropped table %s", fqn)
+			cluster.BashScriptSchemaChange(cmaster.URL, oldT.TableSchema, oldT.TableName, "dropped", oldT.TableColumns, nil)
+		}
+	}
+
 	cluster.WorkLoad.DBIndexSize = totindexsize
 	cluster.WorkLoad.DBTableSize = tottablesize
 	cmaster.DictTables = dbhelper.FromNormalTablesMap(cmaster.DictTables, tables)

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -2170,20 +2170,28 @@ func (cluster *Cluster) MonitorMasterTableSchema() error {
 		tableCluster = append(tableCluster, cluster.GetName())
 		oldtable, err := cmaster.GetTableFromDict(t.TableSchema + "." + t.TableName)
 		haschanged := false
+		changeType := ""
 		if err != nil {
 			if err.Error() == "Empty" {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Init table %s", t.TableSchema+"."+t.TableName)
 				haschanged = true
+				changeType = "init"
 			} else {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "New table %s", t.TableSchema+"."+t.TableName)
 				haschanged = true
+				changeType = "new"
 			}
 		} else {
 			if oldtable.TableCrc != t.TableCrc {
 				haschanged = true
+				changeType = "altered"
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Change table %s", t.TableSchema+"."+t.TableName)
 			}
 			t.TableSync = oldtable.TableSync
+		}
+
+		if haschanged && changeType != "init" {
+			cluster.BashScriptSchemaChange(cmaster.URL, t.TableSchema, t.TableName, changeType)
 		}
 
 		// If shardproxy is enabled, check for duplicates in child clusters

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -2191,7 +2191,7 @@ func (cluster *Cluster) MonitorMasterTableSchema() error {
 		}
 
 		if haschanged && changeType != "init" {
-			cluster.BashScriptSchemaChange(cmaster.URL, t.TableSchema, t.TableName, changeType)
+			cluster.BashScriptSchemaChange(cmaster.URL, t.TableSchema, t.TableName, changeType, oldtable.TableColumns, t.TableColumns)
 		}
 
 		// If shardproxy is enabled, check for duplicates in child clusters

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -2191,7 +2191,11 @@ func (cluster *Cluster) MonitorMasterTableSchema() error {
 		}
 
 		if haschanged && changeType != "init" {
-			cluster.BashScriptSchemaChange(cmaster.URL, t.TableSchema, t.TableName, changeType, oldtable.TableColumns, t.TableColumns)
+			var oldCols []dbhelper.Column
+			if err == nil {
+				oldCols = oldtable.TableColumns
+			}
+			cluster.BashScriptSchemaChange(cmaster.URL, t.TableSchema, t.TableName, changeType, oldCols, t.TableColumns)
 		}
 
 		// If shardproxy is enabled, check for duplicates in child clusters

--- a/cluster/cluster_bash.go
+++ b/cluster/cluster_bash.go
@@ -51,6 +51,22 @@ func (cluster *Cluster) BashScriptProvDNS(cname string) error {
 	return nil
 }
 
+func (cluster *Cluster) BashScriptSchemaChange(serverURL, schema, table, changeType string) error {
+	if cluster.Conf.MonitorSchemaChangeScript == "" {
+		return nil
+	}
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO",
+		"Calling schema change script for %s.%s (%s) on %s", schema, table, changeType, serverURL)
+	out, err := exec.Command(cluster.Conf.MonitorSchemaChangeScript, cluster.Name, serverURL, schema, table, changeType).CombinedOutput()
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR",
+			"Schema change script error: %s", err)
+	}
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO",
+		"Schema change script complete: %s", string(out))
+	return nil
+}
+
 func (cluster *Cluster) BashScriptOpenSate(state state.State) error {
 	if cluster.Conf.MonitoringOpenStateScript != "" {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Calling open state script")

--- a/cluster/cluster_bash.go
+++ b/cluster/cluster_bash.go
@@ -7,6 +7,7 @@
 package cluster
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -56,6 +57,7 @@ func (cluster *Cluster) BashScriptProvDNS(cname string) error {
 // BashScriptSchemaChange calls the monitoring-schema-change-script when a table
 // change is detected. The diff of column definitions is piped to stdin.
 // Args: $1=cluster $2=server_url $3=schema $4=table $5=change_type(new/altered/dropped)
+// The script runs with a 30-second timeout to avoid stalling the monitoring loop.
 func (cluster *Cluster) BashScriptSchemaChange(serverURL, schema, table, changeType string, oldCols, newCols []dbhelper.Column) error {
 	if cluster.Conf.MonitorSchemaChangeScript == "" {
 		return nil
@@ -63,18 +65,26 @@ func (cluster *Cluster) BashScriptSchemaChange(serverURL, schema, table, changeT
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO",
 		"Calling schema change script for %s.%s (%s) on %s", schema, table, changeType, serverURL)
 
-	// Build column diff
 	diff := columnDiff(schema, table, oldCols, newCols)
 
-	cmd := exec.Command(cluster.Conf.MonitorSchemaChangeScript, cluster.Name, serverURL, schema, table, changeType)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, cluster.Conf.MonitorSchemaChangeScript, cluster.Name, serverURL, schema, table, changeType)
 	cmd.Stdin = strings.NewReader(diff)
 	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR",
+			"Schema change script timed out after 30s for %s.%s", schema, table)
+		return ctx.Err()
+	}
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR",
 			"Schema change script error: %s", err)
 	}
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO",
-		"Schema change script complete: %s", string(out))
+	if len(out) > 0 {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO",
+			"Schema change script output: %s", string(out))
+	}
 	return nil
 }
 

--- a/cluster/cluster_bash.go
+++ b/cluster/cluster_bash.go
@@ -12,11 +12,13 @@ import (
 	"os/exec"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/alert"
 	"github.com/signal18/replication-manager/utils/backupmgr"
+	"github.com/signal18/replication-manager/utils/dbhelper"
 	"github.com/signal18/replication-manager/utils/state"
 )
 
@@ -51,13 +53,22 @@ func (cluster *Cluster) BashScriptProvDNS(cname string) error {
 	return nil
 }
 
-func (cluster *Cluster) BashScriptSchemaChange(serverURL, schema, table, changeType string) error {
+// BashScriptSchemaChange calls the monitoring-schema-change-script when a table
+// change is detected. The diff of column definitions is piped to stdin.
+// Args: $1=cluster $2=server_url $3=schema $4=table $5=change_type(new/altered/dropped)
+func (cluster *Cluster) BashScriptSchemaChange(serverURL, schema, table, changeType string, oldCols, newCols []dbhelper.Column) error {
 	if cluster.Conf.MonitorSchemaChangeScript == "" {
 		return nil
 	}
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO",
 		"Calling schema change script for %s.%s (%s) on %s", schema, table, changeType, serverURL)
-	out, err := exec.Command(cluster.Conf.MonitorSchemaChangeScript, cluster.Name, serverURL, schema, table, changeType).CombinedOutput()
+
+	// Build column diff
+	diff := columnDiff(schema, table, oldCols, newCols)
+
+	cmd := exec.Command(cluster.Conf.MonitorSchemaChangeScript, cluster.Name, serverURL, schema, table, changeType)
+	cmd.Stdin = strings.NewReader(diff)
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR",
 			"Schema change script error: %s", err)
@@ -65,6 +76,57 @@ func (cluster *Cluster) BashScriptSchemaChange(serverURL, schema, table, changeT
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO",
 		"Schema change script complete: %s", string(out))
 	return nil
+}
+
+// columnDiff produces a unified-style diff of column definitions between old and new.
+func columnDiff(schema, table string, oldCols, newCols []dbhelper.Column) string {
+	fqn := schema + "." + table
+	var b strings.Builder
+	b.WriteString("--- " + fqn + " (before)\n")
+	b.WriteString("+++ " + fqn + " (after)\n")
+
+	oldMap := make(map[string]dbhelper.Column)
+	for _, c := range oldCols {
+		oldMap[c.Name] = c
+	}
+	newMap := make(map[string]dbhelper.Column)
+	for _, c := range newCols {
+		newMap[c.Name] = c
+	}
+
+	// Dropped columns (in old but not in new)
+	for _, c := range oldCols {
+		if _, exists := newMap[c.Name]; !exists {
+			b.WriteString("- " + formatColumn(c) + "\n")
+		}
+	}
+
+	// New or altered columns
+	for _, c := range newCols {
+		old, exists := oldMap[c.Name]
+		if !exists {
+			b.WriteString("+ " + formatColumn(c) + "\n")
+		} else if formatColumn(old) != formatColumn(c) {
+			b.WriteString("- " + formatColumn(old) + "\n")
+			b.WriteString("+ " + formatColumn(c) + "\n")
+		}
+	}
+
+	return b.String()
+}
+
+func formatColumn(c dbhelper.Column) string {
+	s := c.Name + " " + c.Type
+	if !c.Nullable {
+		s += " NOT NULL"
+	}
+	if c.Default != nil {
+		s += " DEFAULT " + *c.Default
+	}
+	if c.Extra != "" {
+		s += " " + c.Extra
+	}
+	return s
 }
 
 func (cluster *Cluster) BashScriptOpenSate(state state.State) error {

--- a/cluster/cluster_bash_test.go
+++ b/cluster/cluster_bash_test.go
@@ -1,0 +1,144 @@
+package cluster
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/signal18/replication-manager/utils/dbhelper"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestFormatColumn(t *testing.T) {
+	tests := []struct {
+		name string
+		col  dbhelper.Column
+		want string
+	}{
+		{
+			name: "simple not null",
+			col:  dbhelper.Column{Name: "id", Type: "int(11)", Nullable: false},
+			want: "id int(11) NOT NULL",
+		},
+		{
+			name: "nullable with default",
+			col:  dbhelper.Column{Name: "email", Type: "varchar(255)", Nullable: true, Default: strPtr("NULL")},
+			want: "email varchar(255) DEFAULT NULL",
+		},
+		{
+			name: "auto increment",
+			col:  dbhelper.Column{Name: "id", Type: "int(11)", Nullable: false, Extra: "auto_increment"},
+			want: "id int(11) NOT NULL auto_increment",
+		},
+		{
+			name: "default value",
+			col:  dbhelper.Column{Name: "status", Type: "enum('active','inactive')", Nullable: false, Default: strPtr("'active'")},
+			want: "status enum('active','inactive') NOT NULL DEFAULT 'active'",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatColumn(tt.col)
+			if got != tt.want {
+				t.Errorf("formatColumn() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestColumnDiff_NewTable(t *testing.T) {
+	newCols := []dbhelper.Column{
+		{Name: "id", Type: "int(11)", Nullable: false, Extra: "auto_increment"},
+		{Name: "name", Type: "varchar(100)", Nullable: false},
+	}
+	diff := columnDiff("mydb", "users", nil, newCols)
+
+	if !strings.Contains(diff, "--- mydb.users (before)") {
+		t.Error("missing before header")
+	}
+	if !strings.Contains(diff, "+++ mydb.users (after)") {
+		t.Error("missing after header")
+	}
+	if !strings.Contains(diff, "+ id int(11) NOT NULL auto_increment") {
+		t.Error("missing new column id")
+	}
+	if !strings.Contains(diff, "+ name varchar(100) NOT NULL") {
+		t.Error("missing new column name")
+	}
+	if strings.Contains(diff, "\n- ") {
+		t.Error("new table should have no removals")
+	}
+}
+
+func TestColumnDiff_DroppedTable(t *testing.T) {
+	oldCols := []dbhelper.Column{
+		{Name: "id", Type: "int(11)", Nullable: false},
+		{Name: "email", Type: "varchar(50)", Nullable: true},
+	}
+	diff := columnDiff("mydb", "users", oldCols, nil)
+
+	if !strings.Contains(diff, "- id int(11) NOT NULL") {
+		t.Error("missing dropped column id")
+	}
+	if !strings.Contains(diff, "- email varchar(50)") {
+		t.Error("missing dropped column email")
+	}
+	if strings.Contains(diff, "\n+ ") {
+		t.Error("dropped table should have no additions")
+	}
+}
+
+func TestColumnDiff_AlteredTable(t *testing.T) {
+	oldCols := []dbhelper.Column{
+		{Name: "id", Type: "int(11)", Nullable: false},
+		{Name: "email", Type: "varchar(50)", Nullable: false},
+		{Name: "old_field", Type: "text", Nullable: true},
+	}
+	newCols := []dbhelper.Column{
+		{Name: "id", Type: "int(11)", Nullable: false},
+		{Name: "email", Type: "varchar(255)", Nullable: false},
+		{Name: "phone", Type: "varchar(20)", Nullable: true},
+	}
+	diff := columnDiff("mydb", "users", oldCols, newCols)
+
+	// email changed
+	if !strings.Contains(diff, "- email varchar(50) NOT NULL") {
+		t.Error("missing old email")
+	}
+	if !strings.Contains(diff, "+ email varchar(255) NOT NULL") {
+		t.Error("missing new email")
+	}
+	// old_field dropped
+	if !strings.Contains(diff, "- old_field text") {
+		t.Error("missing dropped old_field")
+	}
+	// phone added
+	if !strings.Contains(diff, "+ phone varchar(20)") {
+		t.Error("missing new phone")
+	}
+	// id unchanged — should NOT appear
+	if strings.Contains(diff, "id int(11)") {
+		t.Error("unchanged column id should not appear in diff")
+	}
+}
+
+func TestColumnDiff_EmptyBoth(t *testing.T) {
+	diff := columnDiff("mydb", "empty", nil, nil)
+	lines := strings.Split(strings.TrimSpace(diff), "\n")
+	// Only header lines
+	if len(lines) != 2 {
+		t.Errorf("expected 2 header lines, got %d: %q", len(lines), diff)
+	}
+}
+
+func TestColumnDiff_NoChange(t *testing.T) {
+	cols := []dbhelper.Column{
+		{Name: "id", Type: "int(11)", Nullable: false},
+		{Name: "name", Type: "varchar(100)", Nullable: true},
+	}
+	diff := columnDiff("mydb", "users", cols, cols)
+	// Should only have header lines, no +/- lines
+	if strings.Contains(diff, "\n+ ") || strings.Contains(diff, "\n- ") {
+		t.Errorf("identical columns should produce no diff lines, got: %q", diff)
+	}
+}

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -1812,6 +1812,10 @@ func (cluster *Cluster) GetWebLogsByType(logtype string) any {
 		return &cluster.LogSecurity
 	case "workload":
 		return &cluster.LogWorkload
+	case "ddl":
+		return &cluster.LogDDL
+	case "variable-change":
+		return &cluster.LogVariableChange
 	default:
 		return nil
 	}
@@ -1823,6 +1827,8 @@ func (cluster *Cluster) GetAllWebLogs() map[string]any {
 	logs["task"] = &cluster.LogTask
 	logs["security"] = &cluster.LogSecurity
 	logs["workload"] = &cluster.LogWorkload
+	logs["ddl"] = &cluster.LogDDL
+	logs["variable-change"] = &cluster.LogVariableChange
 	return logs
 }
 


### PR DESCRIPTION
## Summary

- Wire the `monitoring-schema-change-script` config key that was registered but never called
- Call the script when `MonitorMasterTableSchema()` detects a table change (new, altered, or dropped)
- Pass a unified column diff via stdin so the script knows exactly what changed

## Script interface

**Args:** `$1` cluster name, `$2` server URL, `$3` schema, `$4` table, `$5` change type (`new`, `altered`, `dropped`)

**Stdin:** column diff in unified format:
```
--- mydb.users (before)
+++ mydb.users (after)
- email varchar(50) NOT NULL
+ email varchar(255) NOT NULL
+ phone varchar(20) DEFAULT NULL
- old_field text
```

## Change types

| Type | When | Diff content |
|---|---|---|
| `new` | Table created | All columns as `+` additions |
| `altered` | Table CRC changed | Before/after diff of changed columns |
| `dropped` | Table no longer in scan | All columns as `-` removals |

First-time cache population (`init`) is skipped to avoid flooding the script on startup.

## Files changed

- `cluster/cluster.go` — call `BashScriptSchemaChange` on change detection + dropped table detection
- `cluster/cluster_bash.go` — new `BashScriptSchemaChange`, `columnDiff`, `formatColumn` functions

## Test plan

- [ ] Set `monitoring-schema-change-script` to a logging script
- [ ] CREATE TABLE → verify script called with type=new, all columns in diff
- [ ] ALTER TABLE ADD/MODIFY/DROP COLUMN → verify type=altered with before/after diff
- [ ] DROP TABLE → verify type=dropped with all columns as removals
- [ ] Restart repman with empty cache → verify no flood of "init" calls