### PR TITLE
feat(monitoring): add monitoring-variable-change temporal detection + script hook

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -896,6 +896,7 @@ func (cluster *Cluster) Run() {
 							go cluster.initOrchetratorNodes()
 							cluster.MonitorQueryRules()
 							cluster.MonitorVariablesDiff()
+							cluster.MonitorVariablesChange()
 							cluster.IsValidBackup = cluster.HasValidBackup()
 							go cluster.CheckCredentialRotation()
 							cluster.CheckCanSaveDynamicConfig()
@@ -2125,6 +2126,48 @@ func (cluster *Cluster) MonitorVariablesDiff() {
 			return
 		}
 		cluster.SetState("WARN0084", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0084"], string(jtext)), ErrFrom: "MON", ServerUrl: cluster.GetMaster().URL})
+	}
+}
+
+// MonitorVariablesChange detects when a variable value changes over time on any
+// server (temporal change, not cross-server diff). Compares current Variables
+// with PrevVariables snapshot and calls the monitoring-variable-change-script.
+func (cluster *Cluster) MonitorVariablesChange() {
+	if !cluster.Conf.MonitorVariableChange {
+		return
+	}
+	for _, srv := range cluster.Servers {
+		if srv == nil || srv.State == stateFailed || srv.Variables == nil {
+			continue
+		}
+		if srv.PrevVariables == nil {
+			// First run: snapshot current variables, no diff yet
+			srv.PrevVariables = config.FromStringSyncMap(nil, srv.Variables)
+			continue
+		}
+		currentVars := srv.Variables.ToNewMap()
+		prevVars := srv.PrevVariables.ToNewMap()
+
+		var changes []string
+		for k, v := range currentVars {
+			if old, exists := prevVars[k]; exists && old != v {
+				changes = append(changes, "- "+k+" = "+old)
+				changes = append(changes, "+ "+k+" = "+v)
+			}
+		}
+
+		if len(changes) > 0 {
+			diff := "--- " + srv.URL + " (before)\n+++ " + srv.URL + " (after)\n"
+			for _, line := range changes {
+				diff += line + "\n"
+			}
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+				"Variable change detected on %s: %d variable(s) changed", srv.URL, len(changes)/2)
+			cluster.BashScriptVariableChange(srv.URL, diff)
+		}
+
+		// Update snapshot
+		srv.PrevVariables = config.FromStringSyncMap(nil, srv.Variables)
 	}
 }
 

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -144,6 +144,8 @@ type Cluster struct {
 	LogTask                       s18log.HttpLog             `json:"-" groups:"web"`
 	LogSecurity                   s18log.HttpLog             `json:"-" groups:"web"`
 	LogWorkload                   s18log.HttpLog             `json:"-" groups:"web"`
+	LogDDL                        s18log.HttpLog             `json:"-" groups:"web"`
+	LogVariableChange             s18log.HttpLog             `json:"-" groups:"web"`
 	LogSlack                      *slackman.SlackManager     `json:"-"`
 	JobResults                    *config.TasksMap           `json:"jobResults" groups:"web"`
 	FalsePositiveChecks           map[string]bool            `json:"falsePositiveChecks" groups:"web"`
@@ -494,6 +496,8 @@ func (cluster *Cluster) InitFromConf() {
 	cluster.LogTask = s18log.NewHttpLog(200)
 	cluster.LogSecurity = s18log.NewHttpLog(200)
 	cluster.LogWorkload = s18log.NewHttpLog(200)
+	cluster.LogDDL = s18log.NewHttpLog(200)
+	cluster.LogVariableChange = s18log.NewHttpLog(200)
 
 	cluster.MonitorType = config.GetMonitorType()
 	cluster.TopologyType = config.GetTopologyType()
@@ -2177,9 +2181,16 @@ func (cluster *Cluster) MonitorVariablesChange() {
 		}
 
 		if changeCount > 0 {
+			diffStr := sb.String()
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
 				"Variable change detected on %s: %d variable(s) changed", srv.URL, changeCount)
-			cluster.BashScriptVariableChange(srv.URL, sb.String())
+			cluster.LogVariableChange.Add(s18log.HttpMessage{
+				Group:     cluster.Name,
+				Level:     "INFO",
+				Timestamp: time.Now().Format("2006-01-02 15:04:05"),
+				Text:      fmt.Sprintf("Server %s: %d variable(s) changed\n%s", srv.URL, changeCount, diffStr),
+			})
+			cluster.BashScriptVariableChange(srv.URL, diffStr)
 		}
 
 		// Update snapshot

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -2137,33 +2137,49 @@ func (cluster *Cluster) MonitorVariablesChange() {
 		return
 	}
 	for _, srv := range cluster.Servers {
-		if srv == nil || srv.State == stateFailed || srv.Variables == nil {
+		if srv == nil || srv.State == stateFailed || srv.State == stateUnconn || srv.Variables == nil {
+			// Reset snapshot on failure/disconnect so recovery diff is clean
+			if srv != nil && srv.PrevVariables != nil && (srv.State == stateFailed || srv.State == stateUnconn) {
+				srv.PrevVariables = nil
+			}
 			continue
 		}
 		if srv.PrevVariables == nil {
-			// First run: snapshot current variables, no diff yet
+			// First run or post-recovery: snapshot current variables, no diff yet
 			srv.PrevVariables = config.FromStringSyncMap(nil, srv.Variables)
 			continue
 		}
 		currentVars := srv.Variables.ToNewMap()
 		prevVars := srv.PrevVariables.ToNewMap()
 
-		var changes []string
+		var sb strings.Builder
+		sb.WriteString("--- " + srv.URL + " (before)\n")
+		sb.WriteString("+++ " + srv.URL + " (after)\n")
+		changeCount := 0
+
+		// Detect changed and removed variables
+		for k, old := range prevVars {
+			if v, exists := currentVars[k]; !exists {
+				sb.WriteString("- " + k + " = " + old + "\n")
+				changeCount++
+			} else if old != v {
+				sb.WriteString("- " + k + " = " + old + "\n")
+				sb.WriteString("+ " + k + " = " + v + "\n")
+				changeCount++
+			}
+		}
+		// Detect new variables (in current but not in prev)
 		for k, v := range currentVars {
-			if old, exists := prevVars[k]; exists && old != v {
-				changes = append(changes, "- "+k+" = "+old)
-				changes = append(changes, "+ "+k+" = "+v)
+			if _, exists := prevVars[k]; !exists {
+				sb.WriteString("+ " + k + " = " + v + "\n")
+				changeCount++
 			}
 		}
 
-		if len(changes) > 0 {
-			diff := "--- " + srv.URL + " (before)\n+++ " + srv.URL + " (after)\n"
-			for _, line := range changes {
-				diff += line + "\n"
-			}
+		if changeCount > 0 {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
-				"Variable change detected on %s: %d variable(s) changed", srv.URL, len(changes)/2)
-			cluster.BashScriptVariableChange(srv.URL, diff)
+				"Variable change detected on %s: %d variable(s) changed", srv.URL, changeCount)
+			cluster.BashScriptVariableChange(srv.URL, sb.String())
 		}
 
 		// Update snapshot

--- a/cluster/cluster_bash.go
+++ b/cluster/cluster_bash.go
@@ -7,6 +7,7 @@
 package cluster
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -55,21 +56,33 @@ func (cluster *Cluster) BashScriptProvDNS(cname string) error {
 // BashScriptVariableChange calls the monitoring-variable-change-script when
 // server variables change over time. The diff is piped to stdin.
 // Args: $1=cluster $2=server_url
+// Runs with a 30-second timeout to avoid stalling the monitoring loop.
 func (cluster *Cluster) BashScriptVariableChange(serverURL, diff string) error {
 	if cluster.Conf.MonitorVariableChangeScript == "" {
 		return nil
 	}
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO",
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
 		"Calling variable change script for %s", serverURL)
-	cmd := exec.Command(cluster.Conf.MonitorVariableChangeScript, cluster.Name, serverURL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, cluster.Conf.MonitorVariableChangeScript, cluster.Name, serverURL)
 	cmd.Stdin = strings.NewReader(diff)
 	out, err := cmd.CombinedOutput()
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR",
-			"Variable change script error: %s", err)
+	if ctx.Err() == context.DeadlineExceeded {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
+			"Variable change script timed out after 30s for %s", serverURL)
+		return ctx.Err()
 	}
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO",
-		"Variable change script complete: %s", string(out))
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
+			"Variable change script error for %s: %s %s", serverURL, err, string(out))
+		return err
+	}
+	if len(out) > 0 {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+			"Variable change script output: %s", string(out))
+	}
 	return nil
 }
 

--- a/cluster/cluster_bash.go
+++ b/cluster/cluster_bash.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/signal18/replication-manager/config"
@@ -48,6 +49,27 @@ func (cluster *Cluster) BashScriptProvDNS(cname string) error {
 		}
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Calling provision add domain script: %s", string(out))
 	}
+	return nil
+}
+
+// BashScriptVariableChange calls the monitoring-variable-change-script when
+// server variables change over time. The diff is piped to stdin.
+// Args: $1=cluster $2=server_url
+func (cluster *Cluster) BashScriptVariableChange(serverURL, diff string) error {
+	if cluster.Conf.MonitorVariableChangeScript == "" {
+		return nil
+	}
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO",
+		"Calling variable change script for %s", serverURL)
+	cmd := exec.Command(cluster.Conf.MonitorVariableChangeScript, cluster.Name, serverURL)
+	cmd.Stdin = strings.NewReader(diff)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ERROR",
+			"Variable change script error: %s", err)
+	}
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO",
+		"Variable change script complete: %s", string(out))
 	return nil
 }
 

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -1812,6 +1812,10 @@ func (cluster *Cluster) GetWebLogsByType(logtype string) any {
 		return &cluster.LogSecurity
 	case "workload":
 		return &cluster.LogWorkload
+	case "ddl":
+		return &cluster.LogDDL
+	case "variable-change":
+		return &cluster.LogVariableChange
 	default:
 		return nil
 	}
@@ -1823,6 +1827,8 @@ func (cluster *Cluster) GetAllWebLogs() map[string]any {
 	logs["task"] = &cluster.LogTask
 	logs["security"] = &cluster.LogSecurity
 	logs["workload"] = &cluster.LogWorkload
+	logs["ddl"] = &cluster.LogDDL
+	logs["variable-change"] = &cluster.LogVariableChange
 	return logs
 }
 

--- a/cluster/cluster_variables_test.go
+++ b/cluster/cluster_variables_test.go
@@ -1,0 +1,137 @@
+package cluster
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVariableDiff_Changed(t *testing.T) {
+	prev := map[string]string{
+		"MAX_CONNECTIONS":         "500",
+		"INNODB_BUFFER_POOL_SIZE": "4G",
+	}
+	current := map[string]string{
+		"MAX_CONNECTIONS":         "1000",
+		"INNODB_BUFFER_POOL_SIZE": "4G",
+	}
+	diff := buildVariableDiff("db1:3306", prev, current)
+
+	if !strings.Contains(diff, "- MAX_CONNECTIONS = 500") {
+		t.Error("missing old MAX_CONNECTIONS")
+	}
+	if !strings.Contains(diff, "+ MAX_CONNECTIONS = 1000") {
+		t.Error("missing new MAX_CONNECTIONS")
+	}
+	if strings.Contains(diff, "INNODB_BUFFER_POOL_SIZE") {
+		t.Error("unchanged variable should not appear")
+	}
+}
+
+func TestVariableDiff_Removed(t *testing.T) {
+	prev := map[string]string{
+		"MAX_CONNECTIONS": "500",
+		"OLD_VAR":         "old_value",
+	}
+	current := map[string]string{
+		"MAX_CONNECTIONS": "500",
+	}
+	diff := buildVariableDiff("db1:3306", prev, current)
+
+	if !strings.Contains(diff, "- OLD_VAR = old_value") {
+		t.Error("missing removed OLD_VAR")
+	}
+	if strings.Contains(diff, "MAX_CONNECTIONS") {
+		t.Error("unchanged variable should not appear")
+	}
+}
+
+func TestVariableDiff_New(t *testing.T) {
+	prev := map[string]string{
+		"MAX_CONNECTIONS": "500",
+	}
+	current := map[string]string{
+		"MAX_CONNECTIONS": "500",
+		"NEW_VAR":         "new_value",
+	}
+	diff := buildVariableDiff("db1:3306", prev, current)
+
+	if !strings.Contains(diff, "+ NEW_VAR = new_value") {
+		t.Error("missing new NEW_VAR")
+	}
+	if strings.Contains(diff, "MAX_CONNECTIONS") {
+		t.Error("unchanged variable should not appear")
+	}
+}
+
+func TestVariableDiff_NoChange(t *testing.T) {
+	vars := map[string]string{
+		"MAX_CONNECTIONS": "500",
+		"PORT":            "3306",
+	}
+	diff := buildVariableDiff("db1:3306", vars, vars)
+
+	if strings.Contains(diff, "\n- ") || strings.Contains(diff, "\n+ ") {
+		t.Errorf("identical vars should produce no diff lines, got: %q", diff)
+	}
+}
+
+func TestVariableDiff_EmptyBoth(t *testing.T) {
+	diff := buildVariableDiff("db1:3306", nil, nil)
+	lines := strings.Split(strings.TrimSpace(diff), "\n")
+	if len(lines) != 2 {
+		t.Errorf("expected 2 header lines, got %d", len(lines))
+	}
+}
+
+func TestVariableDiff_AllNew(t *testing.T) {
+	current := map[string]string{
+		"VAR_A": "1",
+		"VAR_B": "2",
+	}
+	diff := buildVariableDiff("db1:3306", nil, current)
+
+	if !strings.Contains(diff, "+ VAR_A = 1") {
+		t.Error("missing VAR_A")
+	}
+	if !strings.Contains(diff, "+ VAR_B = 2") {
+		t.Error("missing VAR_B")
+	}
+}
+
+func TestVariableDiff_AllRemoved(t *testing.T) {
+	prev := map[string]string{
+		"VAR_A": "1",
+		"VAR_B": "2",
+	}
+	diff := buildVariableDiff("db1:3306", prev, nil)
+
+	if !strings.Contains(diff, "- VAR_A = 1") {
+		t.Error("missing VAR_A")
+	}
+	if !strings.Contains(diff, "- VAR_B = 2") {
+		t.Error("missing VAR_B")
+	}
+}
+
+// buildVariableDiff is the same logic as MonitorVariablesChange, extracted for testing.
+func buildVariableDiff(serverURL string, prevVars, currentVars map[string]string) string {
+	var sb strings.Builder
+	sb.WriteString("--- " + serverURL + " (before)\n")
+	sb.WriteString("+++ " + serverURL + " (after)\n")
+
+	for k, old := range prevVars {
+		if v, exists := currentVars[k]; !exists {
+			sb.WriteString("- " + k + " = " + old + "\n")
+		} else if old != v {
+			sb.WriteString("- " + k + " = " + old + "\n")
+			sb.WriteString("+ " + k + " = " + v + "\n")
+		}
+	}
+	for k, v := range currentVars {
+		if _, exists := prevVars[k]; !exists {
+			sb.WriteString("+ " + k + " = " + v + "\n")
+		}
+	}
+
+	return sb.String()
+}

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -164,6 +164,7 @@ type ServerMonitor struct {
 	EventStatus                 []dbhelper.Event            `json:"eventStatus"`
 	FullProcessList             []dbhelper.Processlist      `json:"-"`
 	Variables                   *config.StringsMap          `json:"-"`
+	PrevVariables               *config.StringsMap          `json:"-"`
 	SensitiveVariables          *config.StringsMap          `json:"-"`
 	VariablesMap                *config.VariablesMap        `json:"-"`
 	EngineInnoDB                *config.StringsMap          `json:"engineInnodb"`

--- a/config/config.go
+++ b/config/config.go
@@ -88,6 +88,8 @@ type Config struct {
 	MonitorGlobalHeartbeatStallThreshold      int                          `scope:"server" mapstructure:"monitoring-global-heartbeat-stall-threshold" toml:"monitoring-global-heartbeat-stall-threshold" json:"monitoringGlobalHeartbeatStallThreshold"`
 	MonitorWriteHeartbeatCredential           string                       `mapstructure:"monitoring-write-heartbeat-credential" toml:"monitoring-write-heartbeat-credential" json:"monitoringWriteHeartbeatCredential"`
 	MonitorVariableDiff                       bool                         `mapstructure:"monitoring-variable-diff" toml:"monitoring-variable-diff" json:"monitoringVariableDiff"`
+	MonitorVariableChange                     bool                         `mapstructure:"monitoring-variable-change" toml:"monitoring-variable-change" json:"monitoringVariableChange"`
+	MonitorVariableChangeScript               string                       `mapstructure:"monitoring-variable-change-script" toml:"monitoring-variable-change-script" json:"monitoringVariableChangeScript"`
 	MonitorSchemaChange                       bool                         `mapstructure:"monitoring-schema-change" toml:"monitoring-schema-change" json:"monitoringSchemaChange"`
 	MonitorSchemaColumns                      bool                         `mapstructure:"monitoring-schema-columns" toml:"monitoring-schema-columns" json:"monitoringSchemaColumns"`
 	MonitorSchemaIndexes                      bool                         `mapstructure:"monitoring-schema-indexes" toml:"monitoring-schema-indexes" json:"monitoringSchemaIndexes"`

--- a/server/server.go
+++ b/server/server.go
@@ -351,6 +351,8 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.BoolVar(&conf.MonitorWriteHeartbeat, "monitoring-write-heartbeat", false, "Inject heartbeat into proxy or via external vip")
 	flags.StringVar(&conf.MonitorWriteHeartbeatCredential, "monitoring-write-heartbeat-credential", "", "Database user:password to inject traffic into proxy or via external vip")
 	flags.BoolVar(&conf.MonitorVariableDiff, "monitoring-variable-diff", true, "Monitor variable difference beetween nodes")
+	flags.BoolVar(&conf.MonitorVariableChange, "monitoring-variable-change", false, "Monitor variable changes over time on each server")
+	flags.StringVar(&conf.MonitorVariableChangeScript, "monitoring-variable-change-script", "", "Script called when a variable changes on a server")
 	flags.BoolVar(&conf.MonitorPFS, "monitoring-performance-schema", true, "Monitor performance schema")
 	flags.BoolVar(&conf.MonitorPFSInstruments, "monitoring-performance-schema-instruments", true, "Monitor performance schema instruments")
 	flags.BoolVar(&conf.MonitorPFSMutex, "monitoring-performance-schema-mutex", true, "Monitor mutex metrics")


### PR DESCRIPTION
## Summary

New monitoring pair: `monitoring-variable-change` (bool) + `monitoring-variable-change-script` (string).

Detects when a server variable changes over time on any server (temporal — same server, before vs after). This is distinct from the existing `monitoring-variable-diff` which compares master vs slaves (spatial).

## Script interface

**Args:** `$1` cluster name, `$2` server URL

**Stdin:** unified diff of changed variables:
```
--- db1:3306 (before)
+++ db1:3306 (after)
- max_connections = 500
+ max_connections = 1000
- innodb_buffer_pool_size = 4G
+ innodb_buffer_pool_size = 8G
```

## Implementation

- `PrevVariables` field on `ServerMonitor` stores the last-seen variable snapshot
- `MonitorVariablesChange()` compares current vs previous on each cycle
- Runs on the 30-heartbeat cycle alongside `MonitorVariablesDiff`
- First cycle snapshots without diffing (avoids startup flood)
- `BashScriptVariableChange()` pipes the diff to stdin

## Files changed

| File | Change |
|---|---|
| `config/config.go` | Add `MonitorVariableChange` + `MonitorVariableChangeScript` fields |
| `server/server.go` | Register flags (default: false) |
| `cluster/srv.go` | Add `PrevVariables` field to `ServerMonitor` |
| `cluster/cluster.go` | `MonitorVariablesChange()` + wire into monitoring loop |
| `cluster/cluster_bash.go` | `BashScriptVariableChange()` |

## Test plan

- [ ] Enable `monitoring-variable-change`, set script to a logger
- [ ] `SET GLOBAL max_connections = 1000` → verify script called with diff
- [ ] Restart repman → verify no flood on first cycle
- [ ] Verify `monitoring-variable-diff` still works independently