### PR TITLE
fix(gui): handle pending signup confirmation

### DIFF
--- a/server/api_signup_security_test.go
+++ b/server/api_signup_security_test.go
@@ -119,6 +119,73 @@ func TestSignupHandlers_ErrorResponseJSONAndSanitized(t *testing.T) {
 	})
 }
 
+func TestHandlerSignup_PassesThroughCRMContractStatuses(t *testing.T) {
+	tests := []struct {
+		name       string
+		crmStatus  int
+		crmBody    string
+		wantStatus int
+	}{
+		{
+			name:       "created and already confirmed",
+			crmStatus:  http.StatusCreated,
+			crmBody:    `{"state":"created","identity":{"email_confirmed":true}}`,
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name:       "accepted pending email confirmation",
+			crmStatus:  http.StatusAccepted,
+			crmBody:    `{"state":"pending","message":"waiting for email confirmation","identity":{"email_confirmed":false}}`,
+			wantStatus: http.StatusAccepted,
+		},
+		{
+			name:       "existing account conflict",
+			crmStatus:  http.StatusConflict,
+			crmBody:    `{"error":"account_exists","message":"GitLab account already exists for this email. Please log in."}`,
+			wantStatus: http.StatusConflict,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signupLimiter.resetForTests()
+			t.Cleanup(signupLimiter.resetForTests)
+
+			crm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Fatalf("expected method POST, got %s", r.Method)
+				}
+				if r.URL.Path != "/api/signup" {
+					t.Fatalf("expected path /api/signup, got %s", r.URL.Path)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.crmStatus)
+				_, _ = w.Write([]byte(tt.crmBody))
+			}))
+			defer crm.Close()
+
+			repman := &ReplicationManager{Conf: &config.Config{Cloud18CrmApiUrl: crm.URL}}
+			payload := `{"first_name":"Ada","last_name":"Lovelace","username":"ada","email":"ADA@example.com","password":"secret-password"}`
+			req := httptest.NewRequest(http.MethodPost, "/api/signup", strings.NewReader(payload))
+			req.RemoteAddr = "203.0.113.20:12345"
+			w := httptest.NewRecorder()
+
+			repman.handlerSignup(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+			if got := strings.TrimSpace(w.Body.String()); got != tt.crmBody {
+				t.Fatalf("expected CRM response body %s, got %s", tt.crmBody, got)
+			}
+			if got := w.Header().Get("Content-Type"); !strings.Contains(got, "application/json") {
+				t.Fatalf("expected JSON content type, got %q", got)
+			}
+		})
+	}
+}
+
 func TestSignupOptionsPreflight(t *testing.T) {
 	repman := &ReplicationManager{Conf: &config.Config{
 		APIPublicURL:         "https://public.example",

--- a/server/api_signup_security_test.go
+++ b/server/api_signup_security_test.go
@@ -163,7 +163,7 @@ func TestHandlerSignup_PassesThroughCRMContractStatuses(t *testing.T) {
 				w.WriteHeader(tt.crmStatus)
 				_, _ = w.Write([]byte(tt.crmBody))
 			}))
-			defer crm.Close()
+			t.Cleanup(crm.Close)
 
 			repman := &ReplicationManager{Conf: &config.Config{Cloud18CrmApiUrl: crm.URL}}
 			payload := `{"first_name":"Ada","last_name":"Lovelace","username":"ada","email":"ADA@example.com","password":"secret-password"}`

--- a/share/dashboard_react/package.json
+++ b/share/dashboard_react/package.json
@@ -11,7 +11,8 @@
     "test:terminal-rid": "node src/Pages/Terminal/__tests__/ridUtils.test.js",
     "test:s3-provider-picker": "node src/Pages/ClusterApp/components/Storage/__tests__/s3DirectoryProviderPicker.test.js",
     "test:s3-provider-bulk-sync": "node src/Pages/Settings/__tests__/s3ProviderBulkSyncUtils.test.js",
-    "test:sync-diff-utils": "node src/components/__tests__/syncDiffUtils.test.js"
+    "test:sync-diff-utils": "node src/components/__tests__/syncDiffUtils.test.js",
+    "test:signup-response": "node src/components/Auth/__tests__/signupResponse.test.js"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.10.5",

--- a/share/dashboard_react/src/Pages/ClustersGlobalSettings/CloudSettings.jsx
+++ b/share/dashboard_react/src/Pages/ClustersGlobalSettings/CloudSettings.jsx
@@ -23,6 +23,7 @@ import modalStyles from '../../components/Modals/styles.module.scss'
 import remarkGfm from 'remark-gfm'
 import SignupForm from '../../components/Auth/SignupForm'
 import { authService } from '../../services/authService'
+import { isConfirmedSignupResponse, isPendingSignupResponse } from '../../components/Auth/signupResponse'
 
 function CloudSettings({ config }) {
   const dispatch = useDispatch()
@@ -35,7 +36,7 @@ function CloudSettings({ config }) {
   const [showPassword, setShowPassword] = useState(false)
   const [registerForm, setRegisterForm] = useState({ email: '', password: '', domain: '', subdomain: '', zone: '' })
   const [registerErrors, setRegisterErrors] = useState({})
-  const [signupSeed, setSignupSeed] = useState(null) // { email } from successful signup
+  const [signupSeed, setSignupSeed] = useState(null) // { email, pendingEmailConfirmation }
   const [isSignupModalOpen, setIsSignupModalOpen] = useState(false)
   const signupCloseTimerRef = useRef(null)
   const [isSendingCode, setIsSendingCode] = useState(false)
@@ -139,14 +140,19 @@ Start create an account in https://gitlab.signal18.io
     setRegisterErrors(e => ({ ...e, email: undefined, password: undefined }))
   }
 
-  const handleSignupSuccess = (_, payload) => {
+  const handleSignupSuccess = (response, payload) => {
+    const pendingEmailConfirmation = isPendingSignupResponse(response)
+    const confirmedSignup = isConfirmedSignupResponse(response)
     const seeded = {
-      email: payload?.email || ''
+      email: payload?.email || '',
+      pendingEmailConfirmation
     }
     setSignupSeed(seeded)
     setRegisterForm(f => ({ ...f, email: seeded.email }))
     clearTimeout(signupCloseTimerRef.current)
-    signupCloseTimerRef.current = setTimeout(() => setIsSignupModalOpen(false), 1500)
+    if (confirmedSignup) {
+      signupCloseTimerRef.current = setTimeout(() => setIsSignupModalOpen(false), 1500)
+    }
   }
 
   // Start polling when step 2 becomes active
@@ -262,8 +268,12 @@ Start create an account in https://gitlab.signal18.io
         <FormErrorMessage>{registerErrors.password}</FormErrorMessage>
       </FormControl>
       {signupSeed && (
-        <HStack justify='space-between' align='center' bg='green.50' borderRadius='md' p={3}>
-          <Text fontSize='xs' color='green.700'>Using newly created GitLab SSO account.</Text>
+        <HStack justify='space-between' align='center' bg={signupSeed.pendingEmailConfirmation ? 'orange.50' : 'green.50'} borderRadius='md' p={3}>
+          <Text fontSize='xs' color={signupSeed.pendingEmailConfirmation ? 'orange.700' : 'green.700'}>
+            {signupSeed.pendingEmailConfirmation
+              ? 'Signup is waiting for GitLab email confirmation. Confirm your email before continuing registration.'
+              : 'Using confirmed GitLab SSO signup account.'}
+          </Text>
           <RMButton size='xs' variant='ghost' onClick={clearSignupSeed}>Use different account</RMButton>
         </HStack>
       )}
@@ -349,14 +359,14 @@ Start create an account in https://gitlab.signal18.io
     )
   })()
 
-  const signupSeedBadgeColor = registerStep === 1 ? 'blue' : 'orange'
+  const signupSeedBadgeColor = signupSeed?.pendingEmailConfirmation || registerStep !== 1 ? 'orange' : 'blue'
 
   const registerModalTitle = (
     <HStack spacing={2} align='center'>
       <Text>
         {registerStep === 1 ? 'Register with Signal18 Cloud18 (1/2)' : 'Waiting for email confirmation (2/2)'}
       </Text>
-      {signupSeed && <TagPill colorScheme={signupSeedBadgeColor} text='Using newly created account' />}
+      {signupSeed && <TagPill colorScheme={signupSeedBadgeColor} text={signupSeed.pendingEmailConfirmation ? 'Pending email confirmation' : 'Using confirmed signup account'} />}
     </HStack>
   )
 
@@ -648,8 +658,8 @@ Start create an account in https://gitlab.signal18.io
                 setIsSignupModalOpen(false)
               }}
               submitLabel='Create GitLab SSO account'
-              loadingText='Creating account'
-              successMessage='Account created. You can continue registration now.'
+              loadingText='Submitting signup'
+              successMessage='Email already confirmed. You can continue registration now.'
             />
           }
         />

--- a/share/dashboard_react/src/Pages/Signup/index.jsx
+++ b/share/dashboard_react/src/Pages/Signup/index.jsx
@@ -3,11 +3,14 @@ import { Container } from '@chakra-ui/react'
 import PageContainer from '../PageContainer'
 import SignupForm from '../../components/Auth/SignupForm'
 import { authService } from '../../services/authService'
+import { shouldRedirectToLoginAfterSignup } from '../../components/Auth/signupResponse'
 
 function Signup() {
   const navigate = useNavigate()
 
-  const handleSignupSuccess = () => {
+  const handleSignupSuccess = (response) => {
+    if (!shouldRedirectToLoginAfterSignup(response)) return
+
     setTimeout(() => navigate('/login'), 1500)
   }
 
@@ -18,7 +21,7 @@ function Signup() {
           splitLayout
           onSubmit={authService.signup}
           onSuccess={handleSignupSuccess}
-          successMessage='Signup successful. Redirecting to login...'
+          successMessage='Email already confirmed. Redirecting to login...'
         />
       </Container>
     </PageContainer>

--- a/share/dashboard_react/src/Pages/Signup/index.jsx
+++ b/share/dashboard_react/src/Pages/Signup/index.jsx
@@ -3,15 +3,18 @@ import { Container } from '@chakra-ui/react'
 import PageContainer from '../PageContainer'
 import SignupForm from '../../components/Auth/SignupForm'
 import { authService } from '../../services/authService'
-import { shouldRedirectToLoginAfterSignup } from '../../components/Auth/signupResponse'
+import { isConfirmedSignupResponse, isPendingSignupResponse } from '../../components/Auth/signupResponse'
 
 function Signup() {
   const navigate = useNavigate()
 
   const handleSignupSuccess = (response) => {
-    if (!shouldRedirectToLoginAfterSignup(response)) return
-
-    setTimeout(() => navigate('/login'), 1500)
+    if (isConfirmedSignupResponse(response)) {
+      setTimeout(() => navigate('/login'), 1500)
+    } else if (isPendingSignupResponse(response)) {
+      // Give the user time to read the "check your email" message before redirecting.
+      setTimeout(() => navigate('/login'), 3000)
+    }
   }
 
   return (

--- a/share/dashboard_react/src/components/Auth/SignupForm.jsx
+++ b/share/dashboard_react/src/components/Auth/SignupForm.jsx
@@ -6,6 +6,7 @@ import RMButton from '../RMButton'
 import Message from '../Message'
 import loginStyles from '../../Pages/Login/styles.module.scss'
 import { authService } from '../../services/authService'
+import { resolveSignupErrorMessage, resolveSignupSuccessMessage } from './signupResponse'
 
 const emailRegex = /^[^@\s]+@[^@\s]+\.[^@\s]+$/
 
@@ -15,7 +16,7 @@ function SignupForm({
   onCancel,
   submitLabel = 'Create account',
   loadingText = 'Signing up',
-  successMessage = 'Signup successful',
+  successMessage = 'Signup submitted',
   className = '',
   splitLayout = false
 }) {
@@ -81,15 +82,12 @@ function SignupForm({
 
       const response = await onSubmit(payload)
       if (response.status >= 200 && response.status < 300) {
-        setLocalSuccessMessage(successMessage)
+        setLocalSuccessMessage(resolveSignupSuccessMessage(response, successMessage))
         if (onSuccess) {
           await Promise.resolve(onSuccess(response, payload))
         }
       } else {
-        const message = typeof response.data === 'object' && response.data?.error
-          ? response.data.error
-          : 'Signup failed'
-        setErrorMessage(message)
+        setErrorMessage(resolveSignupErrorMessage(response))
       }
     } catch (error) {
       setErrorMessage(error.message || 'Signup failed')

--- a/share/dashboard_react/src/components/Auth/__tests__/signupResponse.test.js
+++ b/share/dashboard_react/src/components/Auth/__tests__/signupResponse.test.js
@@ -1,0 +1,148 @@
+import {
+  isPendingSignupResponse,
+  isConfirmedSignupResponse,
+  resolveSignupErrorMessage,
+  pendingSignupMessage,
+  existingAccountMessage,
+} from '../signupResponse.js'
+
+let passed = 0
+let failed = 0
+
+function assertEqual(actual, expected, description) {
+  if (actual === expected) {
+    passed += 1
+    console.log(`  ✓ ${description}`)
+    return
+  }
+  failed += 1
+  console.log(`  ✗ ${description}`)
+  console.log(`      Expected: ${JSON.stringify(expected)}`)
+  console.log(`      Actual:   ${JSON.stringify(actual)}`)
+}
+
+function assertFalse(value, description) {
+  assertEqual(value, false, description)
+}
+
+function assertTrue(value, description) {
+  assertEqual(value, true, description)
+}
+
+// ─── isPendingSignupResponse ──────────────────────────────────────────────────
+
+console.log('\nTest Suite: isPendingSignupResponse')
+
+{
+  // 201 with email_confirmed: false → pending even though status is 201
+  const response = { status: 201, data: { state: 'created', identity: { email_confirmed: false } } }
+  assertTrue(isPendingSignupResponse(response), '201 + email_confirmed: false → pending')
+}
+
+{
+  // 201 with no identity field → not pending
+  const response = { status: 201, data: { state: 'created' } }
+  assertFalse(isPendingSignupResponse(response), '201 + no identity → not pending')
+}
+
+{
+  // 202 with no body → pending
+  const response = { status: 202, data: {} }
+  assertTrue(isPendingSignupResponse(response), '202 + no body → pending')
+}
+
+{
+  // 200 with no pending indicators → not pending
+  const response = { status: 200, data: { state: 'ok' } }
+  assertFalse(isPendingSignupResponse(response), '200 + no pending indicators → not pending')
+}
+
+// ─── isConfirmedSignupResponse ────────────────────────────────────────────────
+
+console.log('\nTest Suite: isConfirmedSignupResponse')
+
+{
+  // 201 + confirmed
+  const response = { status: 201, data: { state: 'created', identity: { email_confirmed: true } } }
+  assertTrue(isConfirmedSignupResponse(response), '201 + email_confirmed: true → confirmed')
+}
+
+{
+  // 201 + email_confirmed: false → NOT confirmed (pending wins)
+  const response = { status: 201, data: { state: 'created', identity: { email_confirmed: false } } }
+  assertFalse(isConfirmedSignupResponse(response), '201 + email_confirmed: false → not confirmed')
+}
+
+{
+  // 202 → not confirmed
+  const response = { status: 202, data: {} }
+  assertFalse(isConfirmedSignupResponse(response), '202 → not confirmed')
+}
+
+{
+  // 201 + no identity → confirmed (absence of false is not false)
+  const response = { status: 201, data: { state: 'created' } }
+  assertTrue(isConfirmedSignupResponse(response), '201 + no identity field → confirmed')
+}
+
+// ─── resolveSignupErrorMessage ────────────────────────────────────────────────
+
+console.log('\nTest Suite: resolveSignupErrorMessage')
+
+{
+  // 409 with CRM message → use CRM message
+  const response = { status: 409, data: { message: 'GitLab account already exists for this email. Please log in.' } }
+  assertEqual(
+    resolveSignupErrorMessage(response),
+    'GitLab account already exists for this email. Please log in.',
+    '409 + CRM message → uses CRM message'
+  )
+}
+
+{
+  // 409 with CRM error field → use CRM error
+  const response = { status: 409, data: { error: 'account_exists' } }
+  assertEqual(
+    resolveSignupErrorMessage(response),
+    'account_exists',
+    '409 + CRM error field → uses CRM error'
+  )
+}
+
+{
+  // 409 with no body → falls back to existingAccountMessage
+  const response = { status: 409, data: {} }
+  assertEqual(
+    resolveSignupErrorMessage(response),
+    existingAccountMessage,
+    '409 + no body → falls back to existingAccountMessage'
+  )
+}
+
+{
+  // Non-409 with message
+  const response = { status: 422, data: { message: 'Invalid username' } }
+  assertEqual(
+    resolveSignupErrorMessage(response),
+    'Invalid username',
+    'non-409 structured message → uses message field'
+  )
+}
+
+{
+  // No response → generic fallback
+  assertEqual(
+    resolveSignupErrorMessage(null),
+    'Signup failed',
+    'null response → generic fallback'
+  )
+}
+
+// ─── Result ───────────────────────────────────────────────────────────────────
+
+if (failed > 0) {
+  console.log(`\n❌ Failed: ${failed}, Passed: ${passed}`)
+  process.exit(1)
+}
+
+console.log(`\n✅ All tests passed: ${passed}`)

--- a/share/dashboard_react/src/components/Auth/signupResponse.js
+++ b/share/dashboard_react/src/components/Auth/signupResponse.js
@@ -1,0 +1,40 @@
+export const pendingSignupMessage = 'Waiting for email confirmation. Check your email to confirm your account.'
+export const existingAccountMessage = 'Account already exists. Please log in.'
+
+export const isPendingSignupResponse = (response) => {
+  const data = response?.data || {}
+  return response?.status === 202 || data?.state === 'pending' || data?.identity?.email_confirmed === false
+}
+
+export const isConfirmedSignupResponse = (response) => {
+  const data = response?.data || {}
+  return response?.status === 201 && data?.state !== 'pending' && data?.identity?.email_confirmed !== false
+}
+
+export const shouldRedirectToLoginAfterSignup = (response) => isConfirmedSignupResponse(response)
+
+export const resolveSignupSuccessMessage = (response, fallbackMessage) => {
+  if (isPendingSignupResponse(response)) {
+    return pendingSignupMessage
+  }
+  if (typeof fallbackMessage === 'function') {
+    return fallbackMessage(response)
+  }
+  return fallbackMessage
+}
+
+export const resolveSignupErrorMessage = (response) => {
+  if (response?.status === 409) {
+    return existingAccountMessage
+  }
+  if (typeof response?.data === 'object' && response.data?.message) {
+    return response.data.message
+  }
+  if (typeof response?.data === 'object' && response.data?.error) {
+    return response.data.error
+  }
+  if (typeof response?.data === 'string' && response.data) {
+    return response.data
+  }
+  return 'Signup failed'
+}

--- a/share/dashboard_react/src/components/Auth/signupResponse.js
+++ b/share/dashboard_react/src/components/Auth/signupResponse.js
@@ -3,6 +3,8 @@ export const existingAccountMessage = 'Account already exists. Please log in.'
 
 export const isPendingSignupResponse = (response) => {
   const data = response?.data || {}
+  // email_confirmed === false also matches a 201 body where the CRM created the account
+  // but deferred confirmation (e.g. GitLab side-effect) — treat that as pending regardless of status.
   return response?.status === 202 || data?.state === 'pending' || data?.identity?.email_confirmed === false
 }
 
@@ -10,8 +12,6 @@ export const isConfirmedSignupResponse = (response) => {
   const data = response?.data || {}
   return response?.status === 201 && data?.state !== 'pending' && data?.identity?.email_confirmed !== false
 }
-
-export const shouldRedirectToLoginAfterSignup = (response) => isConfirmedSignupResponse(response)
 
 export const resolveSignupSuccessMessage = (response, fallbackMessage) => {
   if (isPendingSignupResponse(response)) {
@@ -25,7 +25,8 @@ export const resolveSignupSuccessMessage = (response, fallbackMessage) => {
 
 export const resolveSignupErrorMessage = (response) => {
   if (response?.status === 409) {
-    return existingAccountMessage
+    const msg = response?.data?.message || response?.data?.error
+    return msg || existingAccountMessage
   }
   if (typeof response?.data === 'object' && response.data?.message) {
     return response.data.message


### PR DESCRIPTION
## Summary
- preserve the CRM signup contract in the replication-manager signup consumer
- show email-confirmation wording for 202/pending signup responses instead of account-created wording
- handle 409 signup conflicts by asking the user to log in
- add backend coverage for pass-through 201/202/409 CRM signup statuses

## Tests
- go test ./server -run TestHandlerSignup_PassesThroughCRMContractStatuses
- npm run build