### PR TITLE
refactor(gui): pause refresh while dashboard menus are open

### DIFF
--- a/share/dashboard_react/src/Pages/ClusterApp/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/index.jsx
@@ -11,6 +11,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { getClusterData, getClusterApps, setRefreshInterval, getAppService } from '../../redux/clusterSlice'
 import { refreshAppTemplateRepo } from '../../redux/globalClustersSlice'
 import { AppSettings } from '../../AppSettings'
+import { isAutoReloadPaused } from '../../utility/autoReloadPause'
 
 function ClusterApp() {
   const params = useParams()
@@ -30,10 +31,9 @@ function ClusterApp() {
   const clusterData = useSelector((state) => state.cluster.clusterData)
 
   const callServices = () => {
-    const isAutoReloadPaused = localStorage.getItem('pause_auto_reload')
     dispatch(getClusterApps({ clusterName }))
     dispatch(getClusterData({ clusterName }))
-    if (!isAutoReloadPaused) {
+    if (!isAutoReloadPaused()) {
       if (tabs.current[selectedTabRef.current] === 'App Overview') {
         dispatch(getAppService({ clusterName, serviceName: 'deployment', appId }))
         dispatch(getAppService({ clusterName, serviceName: 'substitution', appId }))

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppMenu.jsx
@@ -2,7 +2,7 @@ import { useDispatch } from 'react-redux'
 import MenuOptions from '../../../../components/MenuOptions'
 import ConfirmModal from '../../../../components/Modals/ConfirmModal'
 import RestartAppModal from './RestartAppModal'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import {
   abortApp,
   clearApp,
@@ -22,14 +22,8 @@ function AppMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView',
   const [isRestartModalOpen, setIsRestartModalOpen] = useState(false)
   const [confirmTitle, setConfirmTitle] = useState('')
   const [confirmHandler, setConfirmHandler] = useState(null)
-  const [appName, setAppName] = useState('')
+  const appName = row?.id ? `${row.host}:${row.port} (${row.id})` : ''
   const navigate = useNavigate()
-
-  useEffect(() => {
-    if (row?.id) {
-      setAppName(`${row.host}:${row.port} (${row.id})`)
-    }
-  }, [row])
 
   const openConfirmModal = () => {
     setIsConfirmModalOpen(true)
@@ -175,7 +169,7 @@ function AppMenu({ clusterName, row, isDesktop, colorScheme, from = 'tableView',
           closeModal={closeConfirmModal}
           title={confirmTitle}
           onConfirmClick={() => {
-            confirmHandler()
+            confirmHandler?.()
             closeConfirmModal()
           }}
         />

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppTable/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppTable/index.jsx
@@ -8,10 +8,12 @@ import { Link } from 'react-router-dom'
 import ServerName from '../../../../../components/ServerName'
 import TagPill from '../../../../../components/TagPill'
 import ServerStatus from '../../../../../components/ServerStatus'
+import RMIconButton from '../../../../../components/RMIconButton'
+import { HiViewGrid } from 'react-icons/hi'
 
 const columnHelper = createColumnHelper()
 
-function AppTable({ apps = [], isDesktop, clusterName, user, orchestrator }) {
+function AppTable({ apps = [], isDesktop, clusterName, user, orchestrator, showGridView }) {
   const columns = useMemo(
     () => [
       columnHelper.accessor(
@@ -27,7 +29,7 @@ function AppTable({ apps = [], isDesktop, clusterName, user, orchestrator }) {
             />
           ),
           id: 'options',
-          header: '',
+          header: () => <RMIconButton onClick={showGridView} icon={HiViewGrid} tooltip='Show grid view' />,
           width: '40px'
         }
       ),
@@ -52,7 +54,7 @@ function AppTable({ apps = [], isDesktop, clusterName, user, orchestrator }) {
         header: 'Routes'
       }),
     ],
-    [clusterName, isDesktop, orchestrator, user]
+    [clusterName, isDesktop, orchestrator, user, showGridView]
   )
 
   return (

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppTable/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppTable/index.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect, useState } from 'react'
+import { useMemo } from 'react'
 import { DataTable } from '../../../../../components/DataTable'
 import { createColumnHelper } from '@tanstack/react-table'
 import { Box, VStack } from '@chakra-ui/react'
@@ -7,19 +7,11 @@ import styles from './styles.module.scss'
 import { Link } from 'react-router-dom'
 import ServerName from '../../../../../components/ServerName'
 import TagPill from '../../../../../components/TagPill'
-import AppStatus from '../AppStatus'
 import ServerStatus from '../../../../../components/ServerStatus'
 
-function AppTable({ apps = [], isDesktop, clusterName, showGridView, user, states, orchestrator }) {
-  const [tableData, setTableData] = useState([])
-  useEffect(() => {
-    if (apps?.length > 0) {
-      setTableData(apps)
-    }
-    // console.log(apps)
-  }, [apps])
+const columnHelper = createColumnHelper()
 
-  const columnHelper = createColumnHelper()
+function AppTable({ apps = [], isDesktop, clusterName, user, orchestrator }) {
   const columns = useMemo(
     () => [
       columnHelper.accessor(
@@ -65,7 +57,7 @@ function AppTable({ apps = [], isDesktop, clusterName, showGridView, user, state
 
   return (
     <Box className={styles.tableContainer}>
-      <DataTable data={tableData} columns={columns} />
+      <DataTable data={apps} columns={columns} />
     </Box>
   )
 }

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/index.jsx
@@ -6,8 +6,6 @@ import AppGrid from './AppGrid'
 function Apps({ selectedCluster, user }) {
   const isDesktop = useSelector((state) => state.common.isDesktop)
   const clusterApps = useSelector((state) => state.cluster.clusterApps)
-  const clusterAppStates = useSelector((state) => state.cluster.clusterAppStates)
-
   const [viewType, setViewType] = useState('table')
 
   const showGridView = () => {
@@ -23,11 +21,8 @@ function Apps({ selectedCluster, user }) {
         apps={clusterApps}
         isDesktop={isDesktop}
         clusterName={selectedCluster?.name}
-        showGridView={showGridView}
-        isMenuOptionsVisible={true}
         orchestrator={selectedCluster?.config?.provOrchestrator}
         user={user}
-        states={clusterAppStates}
       />
     ) : (
       <AppGrid
@@ -35,10 +30,8 @@ function Apps({ selectedCluster, user }) {
         isDesktop={isDesktop}
         clusterName={selectedCluster?.name}
         showTableView={showTableView}
-        isMenuOptionsVisible={true}
         orchestrator={selectedCluster?.config?.provOrchestrator}
         user={user}
-        states={clusterAppStates}
       />
     )
   ) : null

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/index.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import AppTable from './AppTable'
 import AppGrid from './AppGrid'
@@ -8,12 +8,8 @@ function Apps({ selectedCluster, user }) {
   const clusterApps = useSelector((state) => state.cluster.clusterApps)
   const [viewType, setViewType] = useState('table')
 
-  const showGridView = () => {
-    setViewType('grid')
-  }
-  const showTableView = () => {
-    setViewType('table')
-  }
+  const showGridView = useCallback(() => setViewType('grid'), [])
+  const showTableView = useCallback(() => setViewType('table'), [])
 
   return clusterApps ? (
     viewType === 'table' ? (
@@ -23,6 +19,7 @@ function Apps({ selectedCluster, user }) {
         clusterName={selectedCluster?.name}
         orchestrator={selectedCluster?.config?.provOrchestrator}
         user={user}
+        showGridView={showGridView}
       />
     ) : (
       <AppGrid

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useSelector } from 'react-redux'
 import AppTable from './AppTable'
 import AppGrid from './AppGrid'

--- a/share/dashboard_react/src/Pages/Dashboard/components/DBServers/DBServerGrid/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/DBServers/DBServerGrid/index.jsx
@@ -217,16 +217,6 @@ function DBServerGrid({
                           ) : (
                             <CustomIcon icon={HiX} color='red' />
                           )
-                      },
-                      {
-                        key: 'Semi Sync',
-                        value:
-                          (rowData.state === 'Slave' && rowData.semiSyncSlaveStatus) ||
-                          (rowData.state === 'Master' && rowData.semiSyncMasterStatus) ? (
-                            <CustomIcon icon={HiCheck} color='green' />
-                          ) : (
-                            <CustomIcon icon={HiX} color='red' />
-                          )
                       }
                     ]
 

--- a/share/dashboard_react/src/Pages/Dashboard/components/DBServers/DBServerGrid/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/DBServers/DBServerGrid/index.jsx
@@ -1,5 +1,4 @@
 import { Flex, HStack, SimpleGrid, Spacer, useDisclosure, VStack, Tooltip } from '@chakra-ui/react'
-import React, { useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import ServerMenu from '../ServerMenu'
 import { HiCheck, HiTable, HiX } from 'react-icons/hi'
@@ -24,7 +23,6 @@ import DBFlavourIcon from '../../../../../components/Icons/DBFlavourIcon'
 import ServerName from '../../../../../components/ServerName'
 import AccordionComponent from '../../../../../components/AccordionComponent'
 import NotFound from '../../../../../components/NotFound'
-import GTID from '../../../../../components/GTID'
 import ServerStatus from '../../../../../components/ServerStatus'
 import RMIconButton from '../../../../../components/RMIconButton'
 import styles from './styles.module.scss'
@@ -48,13 +46,7 @@ function DBServerGrid({
   hasMysqlGtid,
   defaultOpenAll = false
 }) {
-  const {
-    common: { isDesktop },
-    cluster: { clusterStates }
-  } = useSelector((state) => state)
-
-  useEffect(() => {
-  }, [clusterStates])
+  const isDesktop = useSelector((state) => state.common.isDesktop)
 
   const { isOpen: isServiceInfoOpen, onToggle: onServiceInfoToggle } = useDisclosure({ defaultIsOpen: false })
   const { isOpen: isReplicationVarOpen, onToggle: onReplicationVarToggle } = useDisclosure({ defaultIsOpen: defaultOpenAll })

--- a/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
@@ -37,7 +37,7 @@ import {
   toggleSlowQueryCapture,
   unprovisionDatabase
 } from '../../../../redux/clusterSlice'
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import { useHref } from 'react-router-dom'
 import { generateConfig } from '../../../../redux/configSlice'
 import { OpenSVCTerminalRID } from '../../../Terminal/ridUtils'
@@ -109,9 +109,10 @@ function ServerMenu({
   const [isReseedModalOpen, setIsReseedModalOpen] = useState(false)
   const [reseedOperationType, setReseedOperationType] = useState('')
 
-  const [serverName, setServerName] = useState('')
+  const serverName = row?.id ? `server ${row.host}:${row.port} (${row.id})` : ''
 
-  const getHref = useHref('/').replace(/\/+$/, '')
+  const rawHref = useHref('/')
+  const getHref = useMemo(() => rawHref.replace(/\/+$/, ''), [rawHref])
 
   const openTerminalPage = useCallback(
     (clusterName, srvId, commandType = '') => {
@@ -122,12 +123,6 @@ function ServerMenu({
     },
     [getHref]
   )
-
-  useEffect(() => {
-    if (row?.id) {
-      setServerName(`server ${row.host}:${row.port} (${row.id})`)
-    }
-  }, [row])
 
   // Handlers for basic ConfirmModal
   const openConfirmModal = () => {
@@ -591,7 +586,7 @@ function ServerMenu({
           closeModal={closeConfirmModal}
           title={confirmTitle}
           onConfirmClick={() => {
-            confirmHandler()
+            confirmHandler?.()
             closeConfirmModal()
           }}
         />

--- a/share/dashboard_react/src/Pages/Dashboard/components/DBServers/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/DBServers/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react'
+import { useState, useMemo, useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import { HiViewGrid } from 'react-icons/hi'
 import { DataTable } from '../../../../components/DataTable'
@@ -17,59 +17,37 @@ import CopyToClipboard from '../../../../components/CopyToClipboard'
 import { Tooltip } from '@chakra-ui/react'
 import { TbAlertCircle } from 'react-icons/tb'
 
+const columnHelper = createColumnHelper()
+
 function DBServers({ selectedCluster, user }) {
   const isDesktop = useSelector((state) => state.common.isDesktop)
   const clusterServers = useSelector((state) => state.cluster.clusterServers)
-  const clusterStates = useSelector((state) => state.cluster.clusterStates)
-  const clusterMaster = useSelector((state) => state.cluster.clusterMaster)
+  const clusterMasterId = useSelector((state) => state.cluster.clusterMaster?.id)
 
-  const [data, setData] = useState([])
   const [viewType, setViewType] = useState('table')
-  const [hasMariadbGtid, setHasMariadbGtid] = useState(false)
-  const [hasMysqlGtid, setHasMysqlGtid] = useState(false)
   const [isCompareModalOpen, setIsCompareModalOpen] = useState(false)
   const [compareServer, setCompareServer] = useState(null)
 
-  useEffect(() => {
-    if (clusterServers?.length > 0) {
-      setData(clusterServers)
+  const hasMariadbGtid = useMemo(
+    () => clusterServers?.some((s) => s.haveMariadbGtid) ?? false,
+    [clusterServers]
+  )
+  const hasMysqlGtid = useMemo(
+    () => clusterServers?.some((s) => s.haveMysqlGtid) ?? false,
+    [clusterServers]
+  )
 
-      setHasMariadbGtid(
-        clusterServers.some(function (currentServer) {
-          return currentServer.haveMariadbGtid
-        })
-      )
-      setHasMysqlGtid(
-        clusterServers.some(function (currentServer) {
-          return currentServer.haveMysqlGtid
-        })
-      )
-    }
+  const showGridView = useCallback(() => setViewType('grid'), [])
+  const showTableView = useCallback(() => setViewType('table'), [])
 
-    return () => {
-      setData([])
-      setHasMariadbGtid(false)
-      setHasMysqlGtid(false)
-    }
-  }, [clusterServers, clusterStates, clusterMaster?.id])
-
-  const showGridView = () => {
-    setViewType('grid')
-  }
-  const showTableView = () => {
-    setViewType('table')
-  }
-
-  const openCompareModal = (rowData) => {
+  const openCompareModal = useCallback((rowData) => {
     setIsCompareModalOpen(true)
     setCompareServer(rowData)
-  }
-  const closeCompareModal = () => {
+  }, [])
+  const closeCompareModal = useCallback(() => {
     setIsCompareModalOpen(false)
     setCompareServer(null)
-  }
-
-  const columnHelper = createColumnHelper()
+  }, [])
 
   const columns = useMemo(
     () => [
@@ -78,7 +56,7 @@ function DBServers({ selectedCluster, user }) {
           selectedCluster?.name ? (
             <ServerMenu
               clusterName={selectedCluster?.name}
-              clusterMasterId={clusterMaster?.id}
+              clusterMasterId={clusterMasterId}
               backupLogicalType={selectedCluster?.config?.backupLogicalType}
               backupPhysicalType={selectedCluster?.config?.backupPhysicalType}
               backupRestic={selectedCluster?.config?.backupRestic}
@@ -270,18 +248,25 @@ function DBServers({ selectedCluster, user }) {
       selectedCluster?.name,
       selectedCluster?.config?.backupPhysicalType,
       selectedCluster?.config?.backupLogicalType,
-      clusterStates,
+      selectedCluster?.config?.backupRestic,
+      selectedCluster?.config?.provOrchestrator,
+      selectedCluster?.config?.terminalSessionEnabled,
+      clusterMasterId,
+      isDesktop,
+      user,
+      openCompareModal,
+      showGridView,
     ]
   )
 
   return clusterServers?.length > 0 ? (
     <>
       {viewType === 'table' ? (
-        <DataTable key="dbservers" data={data} columns={columns} />
+        <DataTable data={clusterServers} columns={columns} />
       ) : (
         <DBServerGrid
-          allDBServers={data}
-          clusterMasterId={clusterMaster?.id}
+          allDBServers={clusterServers}
+          clusterMasterId={clusterMasterId}
           clusterName={selectedCluster?.name}
           backupLogicalType={selectedCluster?.config?.backupLogicalType}
           backupPhysicalType={selectedCluster?.config?.backupPhysicalType}
@@ -300,10 +285,10 @@ function DBServers({ selectedCluster, user }) {
         <CompareModal
           isOpen={isCompareModalOpen}
           closeModal={closeCompareModal}
-          allDBServers={data}
+          allDBServers={clusterServers}
           compareServer={compareServer}
           hasMariadbGtid={hasMariadbGtid}
-          hasMysqlGtid={hasMariadbGtid}
+          hasMysqlGtid={hasMysqlGtid}
         />
       )}
     </>

--- a/share/dashboard_react/src/Pages/Dashboard/components/HADetail/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/HADetail/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useState, useMemo } from 'react'
 import Card from '../../../../components/Card'
 import { Box, Grid, GridItem, Text } from '@chakra-ui/react'
 import TagPill from '../../../../components/TagPill'
@@ -15,26 +15,19 @@ function HADetail({ selectedCluster, user, readOnly = false }) {
       
   const dispatch = useDispatch()
   const [isModalOpen, setIsModalOpen] = useState(false)
-  const [failOverData, setFailOverData] = useState([])
-  const [SLAData, setSLAData] = useState([])
+  const failOverData = useMemo(() => selectedCluster ? [
+    { key: 'Checks', value: selectedCluster.monitorSpin },
+    { key: 'Failed', value: `${selectedCluster.failoverCounter} / ${selectedCluster?.config?.failoverLimit}` },
+    { key: 'Last Time', value: selectedCluster.failoverLastTime }
+  ] : [], [selectedCluster])
 
-  useEffect(() => {
-    if (selectedCluster) {
-      setFailOverData([
-        { key: 'Checks', value: selectedCluster.monitorSpin },
-        { key: 'Failed', value: `${selectedCluster.failoverCounter} / ${selectedCluster?.config?.failoverLimit}` },
-        { key: 'Last Time', value: selectedCluster.failoverLastTime }
-      ])
+  const SLAData = useMemo(() => selectedCluster ? [
+    { key: 'Master Up', value: `${selectedCluster.uptime}%` },
+    { key: 'Slaves Catch Up', value: `${selectedCluster.uptimeFailable}%` },
+    { key: 'Slaves Sync', value: `${selectedCluster.uptimeSemisync}%` }
+  ] : [], [selectedCluster])
 
-      setSLAData([
-        { key: 'Master Up', value: `${selectedCluster.uptime}%` },
-        { key: 'Slaves Catch Up', value: `${selectedCluster.uptimeFailable}%` },
-        { key: 'Slaves Sync', value: `${selectedCluster.uptimeSemisync}%` }
-      ])
-    }
-  }, [selectedCluster])
-
-  const openConfirmModal = (e) => {
+  const openConfirmModal = () => {
     setIsModalOpen(true)
   }
 

--- a/share/dashboard_react/src/Pages/Dashboard/components/Logs/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Logs/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import { useState, useMemo } from 'react'
 import TagPill from '../../../../components/TagPill'
 import { Box, Code, Flex, HStack, Input, VStack } from '@chakra-ui/react'
 import styles from './styles.module.scss'
@@ -6,44 +6,25 @@ import NotFound from '../../../../components/NotFound'
 import { useSelector } from 'react-redux'
 
 function Logs({ logs, className, searchable = false, isScrollable = true }) {
-  const [logsData, setLogsData] = useState([])
-  const [data, setData] = useState([])
   const [search, setSearch] = useState('')
 
-  const searchData = (serverData) => {
-    const searchedData = serverData.filter((x) => {
-      const searchValue = search.toLowerCase()
-      if (x.text.toLowerCase().includes(searchValue)) {
-        return x
-      }
-    })
-    return searchedData
-  }
+  const logsData = useMemo(
+    () => logs?.length > 0 ? logs.filter((log) => log.timestamp) : [],
+    [logs]
+  )
 
-  useEffect(() => {
-    if (logs?.length > 0) {
-      const nonEmptyLogs = logs.filter((log) => log.timestamp)
-      setLogsData(nonEmptyLogs)
-      setData(searchData(nonEmptyLogs))
-    }
-  }, [logs])
-
-  const handleClick = () => {
-    //setIsScrollable(true)
-  }
+  const data = useMemo(
+    () => logsData.filter((x) => x.text.toLowerCase().includes(search.toLowerCase())),
+    [logsData, search]
+  )
 
   const handleSearch = (e) => {
     setSearch(e.target.value)
   }
 
-  useEffect(() => {
-    setData(searchData(logsData))
-  }, [search])
-
   return (
     <Box
       className={`${styles.logContainer} ${className}`}
-      onClick={handleClick}
       overflow={isScrollable ? 'auto' : 'hidden'}>
       <VStack spacing={4} >
         {searchable && (

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyMenu.jsx
@@ -1,7 +1,7 @@
 import { useDispatch } from 'react-redux'
 import MenuOptions from '../../../../components/MenuOptions'
 import ConfirmModal from '../../../../components/Modals/ConfirmModal'
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import {
   abortProxy,
   clearProxy,
@@ -30,19 +30,14 @@ function ProxyMenu({
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false)
   const [confirmTitle, setConfirmTitle] = useState('')
   const [confirmHandler, setConfirmHandler] = useState(null)
-  const [proxyName, setProxyName] = useState('')
-  const getHref = useHref('/').replace(/\/+$/, '');
-      
+  const proxyName = row?.proxyId ? `${row.server} (${row.proxyId})` : ''
+  const rawHref = useHref('/')
+  const getHref = useMemo(() => rawHref.replace(/\/+$/, ''), [rawHref])
+
   const openTerminalPage = useCallback((clusterName, prxId, commandType = '') => {
     const terminalURL = getHref.concat(`/terminal/clusters/${clusterName}/proxies/${prxId}/${commandType}`).replace(/\/+$/, '')
     window.open(terminalURL, '_blank')
   }, [getHref])
-
-  useEffect(() => {
-    if (row?.proxyId) {
-      setProxyName(`${row.server} (${row.proxyId})`)
-    }
-  }, [row])
 
   const openConfirmModal = () => {
     setIsConfirmModalOpen(true)
@@ -176,7 +171,7 @@ function ProxyMenu({
             isDisabled: !user?.grants['cluster-drop-monitor'],
             onClick: () => {
               openConfirmModal()
-              setConfirmTitle(`Confirm removing monitor for ${row.proxyId} (${row.server})?`)
+              setConfirmTitle(`Confirm removing monitor for ${proxyName}?`)
               setConfirmHandler(() => () => dispatch(dropServerByName({ clusterName, serverName: row.proxyId })))
             }
           }
@@ -188,7 +183,7 @@ function ProxyMenu({
           closeModal={closeConfirmModal}
           title={confirmTitle}
           onConfirmClick={() => {
-            confirmHandler()
+            confirmHandler?.()
             closeConfirmModal()
           }}
         />

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyTable/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyTable/index.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect, useState } from 'react'
+import { useMemo } from 'react'
 import { DataTable } from '../../../../../components/DataTable'
 import { createColumnHelper } from '@tanstack/react-table'
 import { Box } from '@chakra-ui/react'
@@ -12,6 +12,26 @@ import RMIconButton from '../../../../../components/RMIconButton'
 import styles from './styles.module.scss'
 import ServerName from '../../../../../components/ServerName'
 
+const columnHelper = createColumnHelper()
+
+const buildReadWriteRow = (proxy, data, readWriteType, isNewProxy) => ({
+  logo: isNewProxy && <ProxyLogo proxyName={proxy.type} />,
+  proxyId: proxy.id,
+  isStaging: proxy.isStaging,
+  showMenu: isNewProxy,
+  server: `${proxy.host}:${data.port}`,
+  status: <ProxyStatus status={proxy.state} />,
+  group: <TagPill text={readWriteType} colorScheme={readWriteType === 'WRITE' ? 'blue' : 'gray'} />,
+  dbName: `${data.prxName}`,
+  dbStatus: <ServerStatus state={data.status} />,
+  pxStatus: data.prxStatus,
+  connections: data.prxConnections,
+  bytesOut: data.prxByteOut,
+  bytesIn: data.prxByteIn,
+  sessTime: data.prxLatency,
+  idGroup: data.prxHostgroup
+})
+
 function ProxyTable({
   proxies = [],
   isDesktop,
@@ -23,56 +43,32 @@ function ProxyTable({
   topoStaging,
   orchestrator
 }) {
-  const [tableData, setTableData] = useState([])
-  useEffect(() => {
-    if (proxies?.length > 0) {
-      const data = []
-      proxies.forEach((proxy) => {
-        let isNewProxy = false
-        proxy.backendsWrite?.forEach((writeData, index) => {
-          isNewProxy = index === 0
-          data.push(readWriteData(proxy, writeData, 'WRITE', isNewProxy))
-        })
-        proxy.backendsRead?.forEach((readData, index) => {
-          isNewProxy = !isNewProxy && index === 0
-          data.push(readWriteData(proxy, readData, 'READ', isNewProxy))
-        })
-        if (!proxy.backendsRead && !proxy.backendsWrite) {
-          data.push({
-            logo: <ProxyLogo proxyName={proxy.type} />,
-            isStaging: proxy.isStaging,
-            proxyId: proxy.id,
-            showMenu: true, // to show the menu icon
-            server: `${proxy.host}:${proxy.port}`,
-            status: <ProxyStatus status={proxy.state} />
-          })
-        }
+  const tableData = useMemo(() => {
+    const data = []
+    proxies.forEach((proxy) => {
+      let isNewProxy = false
+      proxy.backendsWrite?.forEach((writeData, index) => {
+        isNewProxy = index === 0
+        data.push(buildReadWriteRow(proxy, writeData, 'WRITE', isNewProxy))
       })
-      setTableData(data)
-    }
+      proxy.backendsRead?.forEach((readData, index) => {
+        isNewProxy = !isNewProxy && index === 0
+        data.push(buildReadWriteRow(proxy, readData, 'READ', isNewProxy))
+      })
+      if (!proxy.backendsRead && !proxy.backendsWrite) {
+        data.push({
+          logo: <ProxyLogo proxyName={proxy.type} />,
+          isStaging: proxy.isStaging,
+          proxyId: proxy.id,
+          showMenu: true,
+          server: `${proxy.host}:${proxy.port}`,
+          status: <ProxyStatus status={proxy.state} />
+        })
+      }
+    })
+    return data
   }, [proxies])
 
-  const readWriteData = (proxy, data, readWriteType, isNewProxy) => {
-    return {
-      logo: isNewProxy && <ProxyLogo proxyName={proxy.type} />,
-      proxyId: proxy.id,
-      isStaging: proxy.isStaging,
-      showMenu: isNewProxy,
-      server: `${proxy.host}:${data.port}`,
-      status: <ProxyStatus status={proxy.state} />,
-      group: <TagPill text={readWriteType} colorScheme={readWriteType === 'WRITE' ? 'blue' : 'gray'} />,
-      dbName: `${data.prxName}`,
-      dbStatus: <ServerStatus state={data.status} />,
-      pxStatus: data.prxStatus,
-      connections: data.prxConnections,
-      bytesOut: data.prxByteOut,
-      bytesIn: data.prxByteIn,
-      sessTime: data.prxLatency,
-      idGroup: data.prxHostgroup
-    }
-  }
-
-  const columnHelper = createColumnHelper()
   const columns = useMemo(
     () => [
       columnHelper.accessor(
@@ -162,7 +158,7 @@ function ProxyTable({
 
   return (
     <Box className={styles.tableContainer}>
-      <DataTable key="proxy" data={tableData} columns={columns} />
+      <DataTable data={tableData} columns={columns} />
     </Box>
   )
 }

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyTable/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/ProxyTable/index.jsx
@@ -46,16 +46,22 @@ function ProxyTable({
   const tableData = useMemo(() => {
     const data = []
     proxies.forEach((proxy) => {
-      let isNewProxy = false
-      proxy.backendsWrite?.forEach((writeData, index) => {
-        isNewProxy = index === 0
-        data.push(buildReadWriteRow(proxy, writeData, 'WRITE', isNewProxy))
+      // menuShown tracks whether the menu/logo row has been emitted for this proxy.
+      // The menu appears exactly once — on the very first row regardless of whether
+      // that row is a write or read backend.
+      let menuShown = false
+      const isFirst = () => {
+        if (menuShown) return false
+        menuShown = true
+        return true
+      }
+      proxy.backendsWrite?.forEach((writeData) => {
+        data.push(buildReadWriteRow(proxy, writeData, 'WRITE', isFirst()))
       })
-      proxy.backendsRead?.forEach((readData, index) => {
-        isNewProxy = !isNewProxy && index === 0
-        data.push(buildReadWriteRow(proxy, readData, 'READ', isNewProxy))
+      proxy.backendsRead?.forEach((readData) => {
+        data.push(buildReadWriteRow(proxy, readData, 'READ', isFirst()))
       })
-      if (!proxy.backendsRead && !proxy.backendsWrite) {
+      if (!proxy.backendsRead?.length && !proxy.backendsWrite?.length) {
         data.push({
           logo: <ProxyLogo proxyName={proxy.type} />,
           isStaging: proxy.isStaging,

--- a/share/dashboard_react/src/Pages/Dashboard/components/Proxies/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Proxies/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useSelector } from 'react-redux'
 import ProxyTable from './ProxyTable'
 import ProxyGrid from './ProxyGrid'
@@ -6,7 +6,6 @@ import ProxyGrid from './ProxyGrid'
 function Proxies({ selectedCluster, user }) {
   const isDesktop = useSelector((state) => state.common.isDesktop)
   const clusterProxies = useSelector((state) => state.cluster.clusterProxies)
-  const clusterProxiesStaging = useSelector((state) => state.cluster.clusterProxiesStaging)
 
   const [viewType, setViewType] = useState('table')
 
@@ -16,9 +15,6 @@ function Proxies({ selectedCluster, user }) {
   const showTableView = () => {
     setViewType('table')
   }
-
-  useEffect(() => {
-  }, [clusterProxiesStaging])
 
   return clusterProxies ? (
     viewType === 'table' ? (

--- a/share/dashboard_react/src/Pages/Home/index.jsx
+++ b/share/dashboard_react/src/Pages/Home/index.jsx
@@ -30,6 +30,7 @@ import {
 } from '../../redux/clusterSlice'
 import { getClusters, getMonitoredData, getClusterPeers, getClusterForSale, getGlobalAlerts, getGlobalMetrics, getGlobalLogs } from '../../redux/globalClustersSlice'
 import { AppSettings } from '../../AppSettings'
+import { isAutoReloadPaused } from '../../utility/autoReloadPause'
 import styles from './styles.module.scss'
 import { useHref, useParams } from 'react-router-dom'
 import { HiArrowNarrowLeft } from 'react-icons/hi'
@@ -206,14 +207,14 @@ function Home() {
   }
 
   const callServices = () => {
-    const isAutoReloadPaused = localStorage.getItem('pause_auto_reload')
+    const isPaused = isAutoReloadPaused()
 
     if (!isClusterOpenRef.current) {
       if (
         globalTabsRef.current[selectedTabRef.current] === 'Clusters Local' ||
         globalTabsRef.current[selectedTabRef.current] === 'Settings'
       ) {
-        if (!isAutoReloadPaused) {
+        if (!isPaused) {
           dispatch(getMonitoredData({}))
           dispatch(getClusters({}))
         }
@@ -226,14 +227,14 @@ function Home() {
         dispatch(getClusterForSale({}))
       }
       if (globalTabsRef.current[selectedTabRef.current] === 'Dashboard') {
-        if (!isAutoReloadPaused) {
+        if (!isPaused) {
           dispatch(getGlobalAlerts({}))
           dispatch(getGlobalMetrics({}))
           dispatch(getGlobalLogs({}))
         }
       }
     } else if (selectedClusterNameRef.current) {
-      if (!isAutoReloadPaused) {
+      if (!isPaused) {
         dispatch(getClusterData({ clusterName: selectedClusterNameRef.current }))
         dispatch(getClusterLogs({ clusterName: selectedClusterNameRef.current }))
         dispatch(getClusterAlerts({ clusterName: selectedClusterNameRef.current }))

--- a/share/dashboard_react/src/Pages/Shards/index.jsx
+++ b/share/dashboard_react/src/Pages/Shards/index.jsx
@@ -22,6 +22,7 @@ import ConfirmModal from '../../components/Modals/ConfirmModal'
 import { sizeOf } from '../../utility/common'
 import SchemaGraph from './SchemaGraph'
 import { useTheme } from '../../ThemeProvider'
+import { isAutoReloadPaused } from '../../utility/autoReloadPause'
 
 // ─── Sync badge (DataTable Sync column) ───────────────────────────────────────
 // Colours: [bg-light, fg-light, border-light, bg-dark, fg-dark, border-dark]
@@ -167,7 +168,7 @@ function Shards({ selectedCluster, user, onOpenSchedulerSettings }) {
   // pauseAutoReload (clusterSlice) writes ONLY to localStorage, never to Redux
   // state. There is no state.cluster.refreshing field. The correct check —
   // identical to Home/index.jsx::callServices() — is:
-  const isPaused = () => Boolean(localStorage.getItem('pause_auto_reload'))
+  const isPaused = isAutoReloadPaused
 
   // ── Local state ────────────────────────────────────────────────────────────
   // FIX: store the last-seen data in a ref so shardSchema comparisons don't

--- a/share/dashboard_react/src/components/MenuOptions/index.jsx
+++ b/share/dashboard_react/src/components/MenuOptions/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { Menu, MenuButton, MenuList, MenuItem, IconButton, HStack, Spacer } from '@chakra-ui/react'
 import { HiChevronRight, HiDotsVertical } from 'react-icons/hi'
 import styles from './styles.module.scss'
@@ -13,37 +13,25 @@ function MenuOptions({
   className,
   ...rest
 }) {
-  const [menuOptions, setMenuOptions] = useState([])
   const menuPauseRegisteredRef = useRef(false)
 
-  const pauseAutoReloadForMenu = () => {
-    if (menuPauseRegisteredRef.current) {
-      return
-    }
-
+  const pauseAutoReloadForMenu = useCallback(() => {
+    if (menuPauseRegisteredRef.current) return
     acquireAutoReloadPause()
     menuPauseRegisteredRef.current = true
-  }
+  }, [])
 
-  const resumeAutoReloadFromMenu = () => {
-    if (!menuPauseRegisteredRef.current) {
-      return
-    }
-
+  const resumeAutoReloadFromMenu = useCallback(() => {
+    if (!menuPauseRegisteredRef.current) return
     releaseAutoReloadPause()
-
     menuPauseRegisteredRef.current = false
-  }
-
-  useEffect(() => {
-    setMenuOptions(options || [])
-  }, [options])
+  }, [])
 
   useEffect(() => {
     return () => {
       resumeAutoReloadFromMenu()
     }
-  }, [])
+  }, [resumeAutoReloadFromMenu])
 
   return (
     <Menu
@@ -54,11 +42,7 @@ function MenuOptions({
       {...rest}>
       <MenuButton
         colorScheme={colorScheme}
-        onClick={(event) => {
-          if (event) {
-            event.stopPropagation()
-          }
-        }}
+        onClick={(e) => e?.stopPropagation()}
         aria-label='Options'
         type='button'
         className={`${styles.menuButton} ${colorScheme === 'blue' ? styles.baseColor : ''} ${className}`}
@@ -66,12 +50,8 @@ function MenuOptions({
         icon={<HiDotsVertical />}></MenuButton>
       <MenuList
         className={styles.menuList}
-        onClick={(event) => {
-          if (event) {
-            event.stopPropagation()
-          }
-        }}>
-        {menuOptions?.map((option, index) => {
+        onClick={(e) => e?.stopPropagation()}>
+        {options.map((option, index) => {
           return option.subMenu ? (
             <Menu key={index} placement={subMenuPlacement}>
               <MenuItem key={`item-${index}`} as={MenuButton} type='button'>
@@ -82,22 +62,16 @@ function MenuOptions({
               <MenuList
                 key={`sub-${index}`}
                 className={styles.menuList}
-                onClick={(event) => {
-                  if (event) {
-                    event.stopPropagation()
-                  }
-                }}>
+                onClick={(e) => e?.stopPropagation()}>
                 {option.subMenu.map((subMenuOption, subIndex) => (
                   <MenuItem
-                    onClick={(event) => {
-                      if (event) {
-                        event.stopPropagation()
-                      }
-                      if (!subMenuOption.isDisabled && subMenuOption?.onClick) {
+                    onClick={(e) => {
+                      e?.stopPropagation()
+                      if (!subMenuOption.isDisabled && subMenuOption.onClick) {
                         subMenuOption.onClick()
                       }
                     }}
-                    {...(subMenuOption.isDisabled ? { isDisabled: subMenuOption.isDisabled } : {})}
+                    isDisabled={!!subMenuOption.isDisabled}
                     key={subIndex}>
                     {subMenuOption.name}
                   </MenuItem>
@@ -107,19 +81,13 @@ function MenuOptions({
           ) : (
             <MenuItem
               key={index}
-              {...(option.onClick
-                ? {
-                    onClick: (event) => {
-                      if (event) {
-                        event.stopPropagation()
-                      }
-                      if (!option.isDisabled) {
-                        option.onClick()
-                      }
-                    }
-                  }
-                : {})}
-              {...(option.isDisabled ? { isDisabled: option.isDisabled } : {})}
+              onClick={(e) => {
+                e?.stopPropagation()
+                if (!option.isDisabled && option.onClick) {
+                  option.onClick()
+                }
+              }}
+              isDisabled={!!option.isDisabled}
               >
               {option.name}
             </MenuItem>

--- a/share/dashboard_react/src/components/Modals/ConfirmModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/ConfirmModal/index.jsx
@@ -7,7 +7,7 @@ import {
   ModalHeader,
   ModalOverlay
 } from '@chakra-ui/react'
-import React, { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import RMButton from '../../RMButton'
 import styles from './styles.module.scss'
 import { useTheme } from '../../../ThemeProvider'
@@ -31,24 +31,17 @@ function ConfirmModal({
   const { theme } = useTheme()
   const pauseRegisteredRef = useRef(false)
 
-  const pauseAutoReloadForConfirmModal = () => {
-    if (pauseRegisteredRef.current) {
-      return
-    }
-
+  const pauseAutoReloadForConfirmModal = useCallback(() => {
+    if (pauseRegisteredRef.current) return
     acquireAutoReloadPause()
     pauseRegisteredRef.current = true
-  }
+  }, [])
 
-  const resumeAutoReloadFromConfirmModal = () => {
-    if (!pauseRegisteredRef.current) {
-      return
-    }
-
+  const resumeAutoReloadFromConfirmModal = useCallback(() => {
+    if (!pauseRegisteredRef.current) return
     releaseAutoReloadPause()
-
     pauseRegisteredRef.current = false
-  }
+  }, [])
 
   useEffect(() => {
     if (isOpen) {
@@ -60,7 +53,7 @@ function ConfirmModal({
     return () => {
       resumeAutoReloadFromConfirmModal()
     }
-  }, [isOpen])
+  }, [isOpen, pauseAutoReloadForConfirmModal, resumeAutoReloadFromConfirmModal])
 
   return (
     <Modal isOpen={isOpen} onClose={closeModal} closeOnOverlayClick={closeOnOverlayClick} closeOnEsc={closeOnEsc}>

--- a/share/dashboard_react/src/utility/autoReloadPause.js
+++ b/share/dashboard_react/src/utility/autoReloadPause.js
@@ -1,46 +1,86 @@
+// AUTO_RELOAD_PAUSE_KEY is written directly by clusterSlice (user-controlled pause).
+// The menu/modal lock mechanism uses a separate LOCKS_KEY so the two concerns
+// never interfere with each other.
 export const AUTO_RELOAD_PAUSE_KEY = 'pause_auto_reload'
 
-const AUTO_RELOAD_PAUSE_LOCK_COUNT_KEY = 'pause_auto_reload_lock_count'
-const AUTO_RELOAD_PAUSE_PREV_VALUE_KEY = 'pause_auto_reload_prev_value'
-const NO_PREV_VALUE = '__none__'
+const LOCKS_KEY = 'pause_auto_reload_locks'
+const TAB_ID_KEY = 'pause_auto_reload_tab_id'
 
-const parseCount = (rawValue) => {
-  const parsed = parseInt(rawValue || '0', 10)
-  return Number.isNaN(parsed) ? 0 : parsed
+// Locks older than STALE_MS are treated as belonging to a crashed tab.
+// No heartbeat is implemented, so a legitimately open lock held for longer
+// than this window is also expired. 10 minutes covers realistic menu/modal use.
+const STALE_MS = 10 * 60 * 1000
+
+// Stable per-tab identifier. Survives reloads (sessionStorage) but is wiped
+// automatically on tab close or crash, so a fresh tab never inherits a
+// prior session's lock.
+const TAB_ID = (() => {
+  let id = sessionStorage.getItem(TAB_ID_KEY)
+  if (!id) {
+    id = Math.random().toString(36).slice(2)
+    sessionStorage.setItem(TAB_ID_KEY, id)
+  }
+  return id
+})()
+
+// Lock entry shape: { count: number, ts: number }
+
+const readLocks = () => {
+  try {
+    return JSON.parse(localStorage.getItem(LOCKS_KEY) || '{}')
+  } catch {
+    return {}
+  }
 }
 
-export const acquireAutoReloadPause = () => {
-  const currentCount = parseCount(localStorage.getItem(AUTO_RELOAD_PAUSE_LOCK_COUNT_KEY))
-
-  if (currentCount === 0) {
-    const previousPauseState = localStorage.getItem(AUTO_RELOAD_PAUSE_KEY)
-    localStorage.setItem(AUTO_RELOAD_PAUSE_PREV_VALUE_KEY, previousPauseState ?? NO_PREV_VALUE)
-    localStorage.setItem(AUTO_RELOAD_PAUSE_KEY, 'true')
+const writeLocks = (locks) => {
+  // Prune stale entries on every write so the map doesn't grow unboundedly.
+  const now = Date.now()
+  const pruned = Object.fromEntries(
+    Object.entries(locks).filter(([, { ts }]) => now - ts <= STALE_MS)
+  )
+  if (Object.keys(pruned).length === 0) {
+    localStorage.removeItem(LOCKS_KEY)
+  } else {
+    localStorage.setItem(LOCKS_KEY, JSON.stringify(pruned))
   }
+  return pruned
+}
 
-  localStorage.setItem(AUTO_RELOAD_PAUSE_LOCK_COUNT_KEY, String(currentCount + 1))
+const hasActiveLock = (locks) => {
+  const now = Date.now()
+  return Object.values(locks).some(({ count, ts }) => count > 0 && now - ts <= STALE_MS)
+}
+
+// Call this instead of reading localStorage directly. Returns true when either
+// the user has manually paused auto-reload OR any tab has a menu/modal open.
+export const isAutoReloadPaused = () =>
+  !!localStorage.getItem(AUTO_RELOAD_PAUSE_KEY) || hasActiveLock(readLocks())
+
+export const acquireAutoReloadPause = () => {
+  const locks = readLocks()
+  locks[TAB_ID] = { count: (locks[TAB_ID]?.count ?? 0) + 1, ts: Date.now() }
+  writeLocks(locks)
 }
 
 export const releaseAutoReloadPause = () => {
-  const currentCount = parseCount(localStorage.getItem(AUTO_RELOAD_PAUSE_LOCK_COUNT_KEY))
-  if (currentCount <= 0) {
-    return
-  }
+  const locks = readLocks()
+  const current = locks[TAB_ID]?.count ?? 0
+  if (current <= 0) return
 
-  const nextCount = currentCount - 1
-  if (nextCount > 0) {
-    localStorage.setItem(AUTO_RELOAD_PAUSE_LOCK_COUNT_KEY, String(nextCount))
-    return
-  }
-
-  localStorage.removeItem(AUTO_RELOAD_PAUSE_LOCK_COUNT_KEY)
-
-  const previousPauseState = localStorage.getItem(AUTO_RELOAD_PAUSE_PREV_VALUE_KEY)
-  localStorage.removeItem(AUTO_RELOAD_PAUSE_PREV_VALUE_KEY)
-
-  if (previousPauseState && previousPauseState !== NO_PREV_VALUE) {
-    localStorage.setItem(AUTO_RELOAD_PAUSE_KEY, previousPauseState)
+  const next = current - 1
+  if (next === 0) {
+    delete locks[TAB_ID]
   } else {
-    localStorage.removeItem(AUTO_RELOAD_PAUSE_KEY)
+    locks[TAB_ID] = { count: next, ts: Date.now() }
   }
+  writeLocks(locks)
 }
+
+// Remove this tab's lock on normal close. Hard crashes rely on STALE_MS.
+window.addEventListener('beforeunload', () => {
+  const locks = readLocks()
+  if (!locks[TAB_ID]) return
+  delete locks[TAB_ID]
+  writeLocks(locks)
+})


### PR DESCRIPTION
## Summary
- Pause dashboard auto-refresh while server, proxy, and app menus are open
- Keep refresh paused while confirmation modals are open, with lock-counted pause/resume handling
- Remove redundant derived state/effects from dashboard tables, logs, and menu labels
- Fix DB server compare modal to pass the correct MySQL GTID flag

## Testing
- npm run build
- npx eslint changed dashboard files with react/prop-types disabled

Note: full npm run lint still fails due existing project-wide lint debt unrelated to this change.