### PR TITLE
fix: configurator agreed/delta/preserved flow + per-variable actions

### DIFF
--- a/cluster/configurator/configurator.go
+++ b/cluster/configurator/configurator.go
@@ -1011,13 +1011,16 @@ func (configurator *Configurator) GenerateDatabaseConfig(Datadir string, Cluster
 	}
 
 	if preserve {
-		// Deploy preserved and delta to the DB config.
-		// - preserved.cnf: user-set overrides that must persist across restarts
-		// - delta.cnf: current runtime values that differ from tags, preserving
-		//   the DB's state until the user explicitly accepts a change
-		// agreed.cnf is repman-internal — it tracks acknowledged deviations
-		// and should NOT be deployed to the DB config.
+		// Deploy config override files to the DB:
+		// - preserved.cnf: user-set overrides (keep DB runtime values)
+		// - delta.cnf: runtime diffs not yet decided (protect current state)
 		difflist := []string{"01_preserved.cnf", "02_delta.cnf"}
+
+		// Deploy an empty agreed.cnf to wipe stale entries from previous deployments.
+		// The real agreed.cnf stays in repman's datadir for acceptance tracking.
+		emptyAgreed := filepath.Join(Datadir, "init/etc/mysql/custom.d/", "03_agreed.cnf")
+		os.MkdirAll(filepath.Dir(emptyAgreed), 0755)
+		os.WriteFile(emptyAgreed, []byte("[mysqld]\n"), 0644)
 
 		for _, fname := range difflist {
 			srcpath := filepath.Join(Datadir, fname)

--- a/cluster/configurator/configurator.go
+++ b/cluster/configurator/configurator.go
@@ -1011,7 +1011,13 @@ func (configurator *Configurator) GenerateDatabaseConfig(Datadir string, Cluster
 	}
 
 	if preserve {
-		difflist := []string{"01_preserved.cnf", "02_delta.cnf", "03_agreed.cnf"}
+		// Deploy preserved and delta to the DB config.
+		// - preserved.cnf: user-set overrides that must persist across restarts
+		// - delta.cnf: current runtime values that differ from tags, preserving
+		//   the DB's state until the user explicitly accepts a change
+		// agreed.cnf is repman-internal — it tracks acknowledged deviations
+		// and should NOT be deployed to the DB config.
+		difflist := []string{"01_preserved.cnf", "02_delta.cnf"}
 
 		for _, fname := range difflist {
 			srcpath := filepath.Join(Datadir, fname)

--- a/cluster/srv_cnf.go
+++ b/cluster/srv_cnf.go
@@ -997,10 +997,8 @@ func (server *ServerMonitor) WritePreservedVariables() error {
 		if v.Preserved != nil {
 			// Prefix with loose_ if the variable has no config counterpart
 			varKey := key
-			looseTag := ""
 			if v.Config == nil && !strings.HasPrefix(key, "loose_") && !strings.HasPrefix(key, "loose-") {
 				varKey = "loose_" + key
-				looseTag = " (loose)"
 			}
 			if v.IsPreserved() {
 				// Determine origin comment for preserved variables
@@ -1008,11 +1006,11 @@ func (server *ServerMonitor) WritePreservedVariables() error {
 				if source == "" {
 					source = "unknown"
 				}
-				preservedContent.WriteString(fmt.Sprintf("# preserved:%s%s\n", source, looseTag))
+				preservedContent.WriteString(fmt.Sprintf("# preserved:%s\n", source))
 				preservedContent.WriteString(fmt.Sprintf("%s=%s\n", varKey, v.Preserved.String()))
 			} else {
 				// Agreed variables
-				agreedContent.WriteString(fmt.Sprintf("# agreed:accepted%s\n", looseTag))
+				agreedContent.WriteString("# agreed:accepted\n")
 				agreedContent.WriteString(fmt.Sprintf("%s=%s\n", varKey, v.Preserved.String()))
 			}
 		}

--- a/cluster/srv_cnf.go
+++ b/cluster/srv_cnf.go
@@ -1111,8 +1111,11 @@ func (server *ServerMonitor) SetVariablePreserved(variableName string) error {
 		return fmt.Errorf("variable %s has no deployed value", variableName)
 	}
 
-	// Write preserved variables to files
-	return server.WritePreservedVariables()
+	// Write preserved variables and refresh delta to remove this entry
+	if err := server.WritePreservedVariables(); err != nil {
+		return err
+	}
+	return server.WriteDeltaVariables()
 }
 
 // SetVariableCustomPreserved sets a custom preserved value for a variable
@@ -1181,8 +1184,11 @@ func (server *ServerMonitor) SetVariableAccepted(variableName string) error {
 			"Variable %s marked as dropped (no config value — removed in newer version)", variableName)
 	}
 
-	// Write preserved variables to files
-	return server.WritePreservedVariables()
+	// Write preserved variables and refresh delta
+	if err := server.WritePreservedVariables(); err != nil {
+		return err
+	}
+	return server.WriteDeltaVariables()
 }
 
 // ClearVariablePreservation removes preservation status from a variable
@@ -1198,6 +1204,9 @@ func (server *ServerMonitor) ClearVariablePreservation(variableName string) erro
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
 		"Variable %s preservation cleared", variableName)
 
-	// Write preserved variables to files
-	return server.WritePreservedVariables()
+	// Write preserved variables and refresh delta
+	if err := server.WritePreservedVariables(); err != nil {
+		return err
+	}
+	return server.WriteDeltaVariables()
 }

--- a/cluster/srv_cnf.go
+++ b/cluster/srv_cnf.go
@@ -658,7 +658,8 @@ func (server *ServerMonitor) ReadVariablesFromConfigFile(srcpath string, cnftype
 
 	// Parse unknown variable markers from dbjobs validation (# unknown:varname=value)
 	// These are variables in the compliance config that the DB doesn't recognize.
-	// Add them to the config side so they appear in the delta for user action.
+	// Route them to agreed.cnf (not delta) so the user can Drop them — putting
+	// them in delta would deploy them to DB config and crash on restart.
 	if cnftype == "config" {
 		if data, readErr := os.ReadFile(srcpath); readErr == nil {
 			for _, line := range strings.Split(string(data), "\n") {
@@ -672,9 +673,15 @@ func (server *ServerMonitor) ReadVariablesFromConfigFile(srcpath string, cnftype
 						varValue = strings.TrimSpace(parts[1])
 					}
 					if varName != "" {
+						// Set both Config and Preserved to the same value so:
+						// - Delta skips it (Preserved != nil)
+						// - WritePreservedVariables routes to agreed.cnf (Preserved == Config)
 						server.VariablesMap.SetConfigValue(varName, varValue)
+						if vs, exists := server.VariablesMap.CheckAndGet(varName); exists {
+							vs.Preserved = vs.Config
+						}
 						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
-							"Unknown variable detected by DB validation: %s=%s", varName, varValue)
+							"Unknown variable detected by DB validation: %s=%s (routed to agreed.cnf)", varName, varValue)
 					}
 				}
 			}

--- a/cluster/srv_cnf.go
+++ b/cluster/srv_cnf.go
@@ -548,6 +548,12 @@ func (server *ServerMonitor) LoadFromTempConfigFile(srcpath, dstpath string) err
 	for scanner.Scan() {
 		line := scanner.Text()
 
+		// Pass through unknown variable markers from dbjobs validation
+		if strings.HasPrefix(line, "# unknown:") {
+			vars = append(vars, line)
+			continue
+		}
+
 		// Only process lines that start with --
 		if !strings.HasPrefix(line, "--") {
 			continue
@@ -648,6 +654,31 @@ func (server *ServerMonitor) ReadVariablesFromConfigFile(srcpath string, cnftype
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Error reading file %s: %s", srcpath, err)
 		return err
+	}
+
+	// Parse unknown variable markers from dbjobs validation (# unknown:varname=value)
+	// These are variables in the compliance config that the DB doesn't recognize.
+	// Add them to the config side so they appear in the delta for user action.
+	if cnftype == "config" {
+		if data, readErr := os.ReadFile(srcpath); readErr == nil {
+			for _, line := range strings.Split(string(data), "\n") {
+				line = strings.TrimSpace(line)
+				if strings.HasPrefix(line, "# unknown:") {
+					varExpr := strings.TrimPrefix(line, "# unknown:")
+					parts := strings.SplitN(varExpr, "=", 2)
+					varName := strings.TrimSpace(parts[0])
+					varValue := ""
+					if len(parts) > 1 {
+						varValue = strings.TrimSpace(parts[1])
+					}
+					if varName != "" {
+						server.VariablesMap.SetConfigValue(varName, varValue)
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+							"Unknown variable detected by DB validation: %s=%s", varName, varValue)
+					}
+				}
+			}
+		}
 	}
 
 	return nil

--- a/cluster/srv_cnf.go
+++ b/cluster/srv_cnf.go
@@ -418,6 +418,9 @@ func (server *ServerMonitor) ReadVariablesFromConfigs() {
 	wg.Wait()
 
 	server.ReadPreservedVariables()
+	// Always rewrite delta to ensure consistency with preserved state.
+	// This also cleans up stale delta files from upgrades where
+	// WriteDeltaVariables wasn't called after preserve actions.
 	server.WriteDeltaVariables()
 	server.IsNeedPathCheck = true
 }

--- a/cluster/srv_cnf.go
+++ b/cluster/srv_cnf.go
@@ -839,6 +839,10 @@ func (server *ServerMonitor) ReadPreservedVariables() error {
 		}
 	}
 
+	// Load accepted variables from agreed.cnf so they survive repman restarts
+	// and stay out of delta until the DB is restarted with the compliance value
+	server.VariablesMap.LoadFromConfigFile(filepath.Join(server.Datadir, "03_agreed.cnf"), "preserved")
+
 	// Load dropped variables state from disk
 	droppedpath := filepath.Join(server.Datadir, "dropped_variables.json")
 	if data, err := os.ReadFile(droppedpath); err == nil {

--- a/cluster/srv_cnf.go
+++ b/cluster/srv_cnf.go
@@ -661,8 +661,8 @@ func (server *ServerMonitor) ReadVariablesFromConfigFile(srcpath string, cnftype
 
 	// Parse unknown variable markers from dbjobs validation (# unknown:varname=value)
 	// These are variables in the compliance config that the DB doesn't recognize.
-	// Route them to agreed.cnf (not delta) so the user can Drop them — putting
-	// them in delta would deploy them to DB config and crash on restart.
+	// They must NOT be in delta or preserved (both deployed to DB = crash on restart).
+	// Route them to agreed.cnf with an explicit message so the user can see and fix.
 	if cnftype == "config" {
 		if data, readErr := os.ReadFile(srcpath); readErr == nil {
 			for _, line := range strings.Split(string(data), "\n") {
@@ -676,15 +676,27 @@ func (server *ServerMonitor) ReadVariablesFromConfigFile(srcpath string, cnftype
 						varValue = strings.TrimSpace(parts[1])
 					}
 					if varName != "" {
-						// Set both Config and Preserved to the same value so:
-						// - Delta skips it (Preserved != nil)
-						// - WritePreservedVariables routes to agreed.cnf (Preserved == Config)
-						server.VariablesMap.SetConfigValue(varName, varValue)
-						if vs, exists := server.VariablesMap.CheckAndGet(varName); exists {
+						// Normalize to match map keys
+						normalizedName := strings.ToLower(strings.TrimSpace(
+							strings.TrimPrefix(strings.ReplaceAll(varName, "-", "_"), "loose_")))
+
+						// Remove from preserved if present (would crash DB)
+						if vs, exists := server.VariablesMap.CheckAndGet(normalizedName); exists {
+							if vs.IsPreserved() {
+								vs.Preserved = nil
+								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+									"Removed unknown variable %s from preserved (would crash DB on restart)", varName)
+							}
+						}
+
+						// Set Config and Preserved equal so delta skips it and it routes to agreed
+						server.VariablesMap.SetConfigValue(normalizedName, varValue)
+						if vs, exists := server.VariablesMap.CheckAndGet(normalizedName); exists {
 							vs.Preserved = vs.Config
+							vs.PreservedSource = "unknown-variable"
 						}
 						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
-							"Unknown variable detected by DB validation: %s=%s (routed to agreed.cnf)", varName, varValue)
+							"Unknown variable detected by DB: %s — removed from delta/preserved, added to agreed for review", varName)
 					}
 				}
 			}
@@ -1054,8 +1066,12 @@ func (server *ServerMonitor) WritePreservedVariables() error {
 				preservedContent.WriteString(fmt.Sprintf("# preserved:%s\n", source))
 				preservedContent.WriteString(fmt.Sprintf("%s=%s\n", varKey, v.Preserved.String()))
 			} else {
-				// Agreed variables
-				agreedContent.WriteString("# agreed:accepted\n")
+				// Agreed variables — use specific comment for unknown variables
+				if v.PreservedSource == "unknown-variable" {
+					agreedContent.WriteString("# agreed:unknown-variable\n")
+				} else {
+					agreedContent.WriteString("# agreed:accepted\n")
+				}
 				agreedContent.WriteString(fmt.Sprintf("%s=%s\n", varKey, v.Preserved.String()))
 			}
 		}

--- a/share/dashboard_react/src/components/ConfigFilesPanel/index.jsx
+++ b/share/dashboard_react/src/components/ConfigFilesPanel/index.jsx
@@ -1,4 +1,5 @@
-import { Box, Button, Flex, HStack, Select, Text, VStack, Code, Badge } from '@chakra-ui/react'
+import { Box, Button, Flex, HStack, Select, Text, VStack, Code, Badge, IconButton, Tooltip } from '@chakra-ui/react'
+import { HiCheck, HiLockClosed, HiTrash } from 'react-icons/hi'
 import React, { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { clusterService } from '../../services/clusterService'
@@ -155,6 +156,13 @@ function ConfigFilesPanel({ selectedCluster }) {
       .catch(() => {})
   }
 
+  const handleVariableAction = (variableName, action) => {
+    if (!selectedCluster?.name || !selectedServer || !variableName) return
+    clusterService.preserveVariable(selectedCluster.name, selectedServer, variableName, action, baseURL)
+      .then(() => setRefreshKey((k) => k + 1))
+      .catch(() => {})
+  }
+
   return (
     <VStack className={styles.container} align='stretch' spacing={3}>
       <HStack>
@@ -207,19 +215,53 @@ function ConfigFilesPanel({ selectedCluster }) {
                     )
                   }
                   return (
-                    <Flex key={idx} className={styles.fileLine} bg={colors?.bg || 'transparent'}>
-                      {colors && (
-                        <Badge size='sm' mr={2} bg={colors.bg} color={colors.color} border='1px solid' borderColor={colors.color}>
-                          {colors.label}
-                        </Badge>
-                      )}
-                      {line.isLoose && (
-                        <Badge colorScheme='orange' size='sm' mr={2}>loose</Badge>
-                      )}
-                      <Code className={styles.lineText}>
-                        <Text as='span' fontWeight='bold'>{line.name}</Text>
-                        <Text as='span'> = {line.value}</Text>
-                      </Code>
+                    <Flex key={idx} className={styles.fileLine} bg={colors?.bg || 'transparent'} justify='space-between'>
+                      <Flex align='center' flex={1} minW={0}>
+                        {colors && (
+                          <Badge size='sm' mr={2} bg={colors.bg} color={colors.color} border='1px solid' borderColor={colors.color} flexShrink={0}>
+                            {colors.label}
+                          </Badge>
+                        )}
+                        {line.isLoose && (
+                          <Badge colorScheme='orange' size='sm' mr={2} flexShrink={0}>loose</Badge>
+                        )}
+                        <Code className={styles.lineText}>
+                          <Text as='span' fontWeight='bold'>{line.name}</Text>
+                          <Text as='span'> = {line.value}</Text>
+                        </Code>
+                      </Flex>
+                      <HStack spacing={1} flexShrink={0} ml={2}>
+                        <Tooltip label='Accept compliance value'>
+                          <IconButton
+                            size='xs'
+                            variant='ghost'
+                            colorScheme='green'
+                            icon={<HiCheck />}
+                            aria-label='Accept'
+                            onClick={() => handleVariableAction(line.name, 'accept')}
+                          />
+                        </Tooltip>
+                        <Tooltip label='Preserve current DB value'>
+                          <IconButton
+                            size='xs'
+                            variant='ghost'
+                            colorScheme='blue'
+                            icon={<HiLockClosed />}
+                            aria-label='Preserve'
+                            onClick={() => handleVariableAction(line.name, 'preserve')}
+                          />
+                        </Tooltip>
+                        <Tooltip label='Drop (deprecated variable)'>
+                          <IconButton
+                            size='xs'
+                            variant='ghost'
+                            colorScheme='red'
+                            icon={<HiTrash />}
+                            aria-label='Drop'
+                            onClick={() => handleVariableAction(line.name, 'clear')}
+                          />
+                        </Tooltip>
+                      </HStack>
                     </Flex>
                   )
                 })

--- a/share/dashboard_react/src/components/ConfigFilesPanel/index.jsx
+++ b/share/dashboard_react/src/components/ConfigFilesPanel/index.jsx
@@ -15,6 +15,7 @@ const COMMENT_COLORS_LIGHT = {
   'delta:value-differs': { bg: '#fffde7', color: '#f57f17', label: 'Value Differs' },
   'agreed:accepted': { bg: '#e8f5e9', color: '#2e7d32', label: 'Accepted' },
   'agreed:dropped': { bg: '#ffebee', color: '#c62828', label: 'Dropped' },
+  'agreed:unknown-variable': { bg: '#fce4ec', color: '#b71c1c', label: 'UNKNOWN — not recognized by DB' },
 }
 
 const COMMENT_COLORS_DARK = {
@@ -26,6 +27,7 @@ const COMMENT_COLORS_DARK = {
   'delta:value-differs': { bg: '#3a3a1a', color: '#fff176', label: 'Value Differs' },
   'agreed:accepted': { bg: '#1a2e1a', color: '#81c784', label: 'Accepted' },
   'agreed:dropped': { bg: '#3a1a1a', color: '#ef9a9a', label: 'Dropped' },
+  'agreed:unknown-variable': { bg: '#3a1a1a', color: '#ef5350', label: 'UNKNOWN — not recognized by DB' },
 }
 
 function parseConfigLines(content) {
@@ -77,7 +79,7 @@ function parseConfigLines(content) {
   return result
 }
 
-function FilePanel({ title, content, emptyText, commentColors }) {
+function FilePanel({ title, content, emptyText, commentColors, onRemove }) {
   const lines = parseConfigLines(content)
 
   return (
@@ -100,19 +102,35 @@ function FilePanel({ title, content, emptyText, commentColors }) {
               )
             }
             return (
-              <Flex key={idx} className={styles.fileLine} bg={colors?.bg || 'transparent'}>
-                {colors && (
-                  <Badge size='sm' mr={2} bg={colors.bg} color={colors.color} border='1px solid' borderColor={colors.color}>
-                    {colors.label}
-                  </Badge>
+              <Flex key={idx} className={styles.fileLine} bg={colors?.bg || 'transparent'} justify='space-between'>
+                <Flex align='center' flex={1} minW={0}>
+                  {colors && (
+                    <Badge size='sm' mr={2} bg={colors.bg} color={colors.color} border='1px solid' borderColor={colors.color} flexShrink={0}>
+                      {colors.label}
+                    </Badge>
+                  )}
+                  {line.isLoose && (
+                    <Badge colorScheme='orange' size='sm' mr={2} flexShrink={0}>loose</Badge>
+                  )}
+                  <Code className={styles.lineText}>
+                    <Text as='span' fontWeight='bold'>{line.name}</Text>
+                    <Text as='span'> = {line.value}</Text>
+                  </Code>
+                </Flex>
+                {onRemove && line.name && (
+                  <Tooltip label='Remove from preserved'>
+                    <IconButton
+                      size='xs'
+                      variant='ghost'
+                      colorScheme='red'
+                      icon={<HiTrash />}
+                      aria-label='Remove'
+                      onClick={() => onRemove(line.name)}
+                      ml={2}
+                      flexShrink={0}
+                    />
+                  </Tooltip>
                 )}
-                {line.isLoose && (
-                  <Badge colorScheme='orange' size='sm' mr={2}>loose</Badge>
-                )}
-                <Code className={styles.lineText}>
-                  <Text as='span' fontWeight='bold'>{line.name}</Text>
-                  <Text as='span'> = {line.value}</Text>
-                </Code>
               </Flex>
             )
           })
@@ -188,6 +206,7 @@ function ConfigFilesPanel({ selectedCluster }) {
             content={configFiles.preserved}
             emptyText='No preserved variables'
             commentColors={commentColors}
+            onRemove={(varName) => handleVariableAction(varName, 'clear')}
           />
           <Box className={styles.filePanel}>
             <Flex className={styles.fileTitle} justify='space-between' align='center'>
@@ -249,16 +268,6 @@ function ConfigFilesPanel({ selectedCluster }) {
                             icon={<HiLockClosed />}
                             aria-label='Preserve'
                             onClick={() => handleVariableAction(line.name, 'preserve')}
-                          />
-                        </Tooltip>
-                        <Tooltip label='Drop (deprecated variable)'>
-                          <IconButton
-                            size='xs'
-                            variant='ghost'
-                            colorScheme='red'
-                            icon={<HiTrash />}
-                            aria-label='Drop'
-                            onClick={() => handleVariableAction(line.name, 'clear')}
                           />
                         </Tooltip>
                       </HStack>

--- a/share/opensvc/moduleset_mariadb.svc.mrm.db.json
+++ b/share/opensvc/moduleset_mariadb.svc.mrm.db.json
@@ -2467,6 +2467,25 @@
                 }
             ],
             "fset_name": "mariadb.security.pwdcheckreuse"
+        },
+        {
+            "fset_stats": false,
+            "id": 426,
+            "filters": [
+                {
+                    "filter": {
+                        "f_op": "=",
+                        "f_field": "tag_name",
+                        "f_value": "badconfig",
+                        "f_table": "v_tags",
+                        "id": 382
+                    },
+                    "f_order": 0,
+                    "f_log_op": "AND",
+                    "filterset": null
+                }
+            ],
+            "fset_name": "mariadb.test.badconfig"
         }
     ],
     "rulesets": [
@@ -4287,6 +4306,14 @@
                     "var_updated": "2026-04-12 16:03:28",
                     "var_name": "db_cnf_sec_with_checkpwdreuse",
                     "id": 6359
+                },
+                {
+                    "var_author": "admin Manager",
+                    "var_class": "file",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/with_test_badconfig.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"[mysqld]\\nthis_does_not_exist = 1\\nloose_this_also_does_not_exist = 1\"}",
+                    "var_updated": "2026-05-29 11:42:12",
+                    "var_name": "db_cnf_test_badconfig",
+                    "id": 6362
                 }
             ],
             "ruleset_public": false,
@@ -4417,7 +4444,8 @@
                 "mariadb.svc.mrm.db.cnf.generic.withlogmutex",
                 "mariadb.svc.mrm.db.cnf.generic.opt_withrepeatableread",
                 "mariadb.svc.mrm.db.cnf.generic.sec_withstrictssl",
-                "mariadb.svc.mrm.db.cnf.generic.sec_withcheckpwdreuse"
+                "mariadb.svc.mrm.db.cnf.generic.sec_withcheckpwdreuse",
+                "mariadb.svc.mrm.db.cnf.generic.test_badconfig"
             ],
             "publications": [
                 "replication-manager"
@@ -7773,6 +7801,30 @@
                 "replication-manager"
             ],
             "id": 1175,
+            "responsibles": [
+                "replication-manager"
+            ]
+        },
+        {
+            "fset_name": "mariadb.test.badconfig",
+            "ruleset_name": "mariadb.svc.mrm.db.cnf.generic.test_badconfig",
+            "variables": [
+                {
+                    "var_author": "admin Manager",
+                    "var_class": "symlink",
+                    "var_value": "{\"symlink\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/conf.d/55_with_test_badconfig.cnf\",\"target\":\"../replication-manager.d/with_test_badconfig.cnf\"}",
+                    "var_updated": "2026-05-29 11:41:28",
+                    "var_name": "db_link_badconfig",
+                    "id": 6363
+                }
+            ],
+            "ruleset_public": false,
+            "ruleset_type": "contextual",
+            "rulesets": [],
+            "publications": [
+                "replication-manager"
+            ],
+            "id": 1176,
             "responsibles": [
                 "replication-manager"
             ]

--- a/share/opensvc/moduleset_mariadb.svc.mrm.db.json
+++ b/share/opensvc/moduleset_mariadb.svc.mrm.db.json
@@ -1,41 +1,4 @@
 {
-    "modulesets": [
-        {
-            "modules": [],
-            "rulesets": [],
-            "modset_name": "mariadb.svc.mrm.db",
-            "modulesets": [
-                "mariadb.svc.mrm.db.cnf"
-            ],
-            "publications": [
-                "replication-manager"
-            ],
-            "id": 350,
-            "responsibles": [
-                "replication-manager"
-            ]
-        },
-        {
-            "modules": [
-                {
-                    "autofix": false,
-                    "modset_mod_name": "mariadb.svc.mrm.db.cnf"
-                }
-            ],
-            "rulesets": [
-                "mariadb.svc.mrm.db.cnf"
-            ],
-            "modset_name": "mariadb.svc.mrm.db.cnf",
-            "modulesets": [],
-            "publications": [
-                "replication-manager"
-            ],
-            "id": 351,
-            "responsibles": [
-                "replication-manager"
-            ]
-        }
-    ],
     "filtersets": [
         {
             "fset_stats": false,
@@ -3166,8 +3129,8 @@
                 {
                     "var_author": "admin Manager",
                     "var_class": "file",
-                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/with_log_pfs.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"[mysqld]\\nloose_performance_schema\\nloose_performance_schema_instrument=\\\"events_statements_history_long=ON\\\"\\nperformance_schema_consumer_events_statements_history=ON\\nloose_performance_schema_consumer_events_statements_history_long=ON\\nloose_performance_schema_consumer_events_statements_current=ON \\nloose_performance_schema_max_sql_text_length=16384                                                                                                      \\nloose_performance_schema_max_digest_text_length=16384 \"}",
-                    "var_updated": "2026-05-28 16:10:35",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/with_log_pfs.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"[mysqld]\\nloose_performance_schema\\nloose_performance_schema_instrument=\\\"events_statements_history_long=ON\\\"\\nperformance_schema_consumer_events_statements_history=ON\\nloose_performance_schema_consumer_events_statements_history_long=ON\\nloose_performance_schema_consumer_events_statements_current=ON \\nloose_performance_schema_max_sql_text_length=16384\\n# MySQL only                                                                                                      \\nloose_performance_schema_max_digest_text_length=16384 \\n\\n[mariadb]\\n# MariaDB 10.0.21+\\nloose_performance_schema_max_digest_length=16384\"}",
+                    "var_updated": "2026-05-29 23:18:03",
                     "var_name": "db_cnf_log_with_pfs",
                     "id": 5949
                 },

--- a/share/scripts/dbjobs_new.sh
+++ b/share/scripts/dbjobs_new.sh
@@ -816,6 +816,17 @@ send_mariadb_defaults() {
     # Process output: replace ' --' with newline
     local processed_output=$(echo "$output" | sed 's/ --/\n--/g')
 
+    # Detect unknown variables via --help --verbose and append them
+    # so repman can present them in the configurator for user action
+    local unknown_vars=$($command --defaults-file="$defaults_file" --help --verbose 2>&1 | grep "unknown variable" | sed "s/.*unknown variable '\\([^']*\\)'.*/\\1/")
+    if [[ -n "$unknown_vars" ]]; then
+        while IFS= read -r bad_var; do
+            processed_output="${processed_output}
+# unknown:${bad_var}"
+            send_lines_to_api "Unknown variable detected: $bad_var" "print-defaults" "$LVL_WARN"
+        done <<< "$unknown_vars"
+    fi
+
     # Send over TCP using socat
     local recv_host="${receiver_addr%%:*}"
     local recv_port="${receiver_addr##*:}"


### PR DESCRIPTION
## Summary

- **Stop deploying agreed.cnf to DB config** — agreed is repman-internal tracking (accepted state), not for DB consumption. Deploy empty agreed.cnf to wipe stale entries from previous deployments
- **Reload agreed.cnf on startup** — so accepted state survives repman restarts and delta stays clean
- **Per-variable Accept/Preserve/Drop buttons** on each delta line in the configurator UI
- **Refresh delta immediately** after preserve/accept/clear actions — no waiting for next tick, no stale duplicates
- **Detect unknown variables via dbjobs** — `mariadbd --help --verbose` catches variables the DB doesn't recognize, routes them to agreed.cnf (not delta) so user can Drop them
- **Upgrade safety** — delta rewrite on every startup ensures no duplicates between preserved and delta after upgrading from older versions

## Flow

1. Delta shows runtime diffs from compliance
2. **Accept** = agree with compliance value → suppressed from delta → compliance applies on restart
3. **Preserve** = keep DB runtime value → goes to preserved.cnf (deployed) → removed from delta
4. **Drop** = deprecated variable → marked as dropped → removed from delta

## Test plan

- [ ] Preserve a delta variable → verify it moves to preserved.cnf and disappears from delta immediately
- [ ] Accept a delta variable → verify it disappears from delta, reappears after repman restart (agreed reload), clears after DB restart
- [ ] Drop a deprecated variable → verify it disappears from delta
- [ ] Add badconfig tag → verify unknown variables appear in agreed (not delta)
- [ ] Upgrade from old version → verify no duplicates between preserved and delta on first start