### PR TITLE
feat: intervention mode (mute) — silence notifications during maintenance

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -124,6 +124,10 @@ type Cluster struct {
 	IsNeedGitPush                 bool                       `json:"-"`
 	IsExportPush                  bool                       `json:"isExportPush" groups:"web"`
 	IsAlertDisable                bool                       `json:"isAlertDisable" groups:"web"`
+	IsIntervention                bool                       `json:"isIntervention" groups:"web"`
+	InterventionCurrent           *InterventionEntry         `json:"interventionCurrent,omitempty" groups:"web"`
+	InterventionHistory           []InterventionEntry        `json:"interventionHistory" groups:"web"`
+	InterventionSuppressedAlerts  int                        `json:"interventionSuppressedAlerts" groups:"web"`
 	IsRefreshStaging              bool                       `json:"isRefreshStaging" groups:"web"`
 	IsNeedStagingChange           bool                       `json:"isNeedStagingChange" groups:"web"`
 	IsConfigPathChange            bool                       `json:"isConfigPathChange" groups:"web"`
@@ -485,6 +489,8 @@ func (cluster *Cluster) InitFromConf() {
 	cluster.VersionsMap = config.NewVersionsMap()
 
 	cluster.WorkingDir = cluster.Conf.WorkingDir + "/" + cluster.Name
+	cluster.InterventionHistory = make([]InterventionEntry, 0)
+	cluster.LoadInterventionHistory()
 	cluster.pluginSpikeCache = make(map[string]*logplugin.SpikeCache)
 	cluster.pluginRegistry = logplugin.NewRegistry()
 	if cluster.Conf.Arbitration {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -128,6 +128,7 @@ type Cluster struct {
 	InterventionCurrent           *InterventionEntry         `json:"interventionCurrent,omitempty" groups:"web"`
 	InterventionHistory           []InterventionEntry        `json:"interventionHistory" groups:"web"`
 	InterventionSuppressedAlerts  int                        `json:"interventionSuppressedAlerts" groups:"web"`
+	InterventionPending           *InterventionEntry         `json:"interventionPending,omitempty" groups:"web"`
 	IsRefreshStaging              bool                       `json:"isRefreshStaging" groups:"web"`
 	IsNeedStagingChange           bool                       `json:"isNeedStagingChange" groups:"web"`
 	IsConfigPathChange            bool                       `json:"isConfigPathChange" groups:"web"`
@@ -838,6 +839,9 @@ func (cluster *Cluster) Run() {
 				wg.Add(1)
 				go cluster.Heartbeat(wg)
 				wg.Wait()
+				// Check scheduled/auto-end interventions on every tick
+				cluster.CheckInterventionSchedule()
+
 				// Heartbeat switchover or failover controller runs only on active repman
 
 				if cluster.runOnceAfterTopology {

--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -202,6 +202,10 @@ var clusterACLRules = []ACLRule{
 
 	// Rolling Operations
 	{"/actions/optimize", nil, []string{config.GrantClusterRolling}},
+	// Intervention
+	{"/actions/intervention-start", nil, []string{config.GrantDBMaintenance}},
+	{"/actions/intervention-end", nil, []string{config.GrantDBMaintenance}},
+
 	{"/actions/rolling", nil, []string{config.GrantClusterRolling}},
 	{"/actions/cancel-rolling-restart", nil, []string{config.GrantClusterRolling}},
 	{"/actions/cancel-rolling-reprov", nil, []string{config.GrantClusterRolling}},

--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -584,6 +584,11 @@ func (cluster *Cluster) SendAlert(alert alert.Alert) error {
 		return nil
 	}
 
+	if cluster.IsIntervention {
+		cluster.IncrementSuppressedAlerts()
+		return nil
+	}
+
 	if cluster.Conf.MailTo != "" {
 		if cluster.Mailer == nil {
 			if err := cluster.InitMailer(); err != nil {

--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -584,7 +584,7 @@ func (cluster *Cluster) SendAlert(alert alert.Alert) error {
 		return nil
 	}
 
-	if cluster.IsIntervention {
+	if cluster.IsIntervention || cluster.IsAlertDisable {
 		cluster.IncrementSuppressedAlerts()
 		return nil
 	}

--- a/cluster/cluster_intervention.go
+++ b/cluster/cluster_intervention.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/state"
 )
 
 type InterventionEntry struct {
@@ -49,6 +50,7 @@ func (cluster *Cluster) StartInterventionAt(user string, reason string, scope st
 		cluster.InterventionPending = entry
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
 			"Intervention scheduled by %s at %s: %s", user, startAt.Format(time.RFC3339), reason)
+		cluster.SetState("WARN0172", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(config.ClusterError["WARN0172"], startAt.Format(time.RFC3339), user, reason), ErrFrom: "INTERVENTION"})
 		cluster.SaveInterventionHistory()
 		return nil
 	}
@@ -67,6 +69,7 @@ func (cluster *Cluster) StartInterventionAt(user string, reason string, scope st
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
 		"Intervention started by %s: %s (scope: %s)", user, reason, scope)
+	cluster.SetState("WARN0173", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(config.ClusterError["WARN0173"], entry.StartedAt.Format(time.RFC3339), user, reason), ErrFrom: "INTERVENTION"})
 
 	cluster.SaveInterventionHistory()
 	return nil
@@ -101,6 +104,16 @@ func (cluster *Cluster) EndIntervention(user string) error {
 // CheckInterventionSchedule checks if a pending intervention should start
 // or if an active intervention should auto-end. Called from the monitoring loop.
 func (cluster *Cluster) CheckInterventionSchedule() {
+	// Re-set warning states each tick (state machine is cleared per tick)
+	if cluster.InterventionPending != nil && !cluster.IsIntervention {
+		pending := cluster.InterventionPending
+		cluster.SetState("WARN0172", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(config.ClusterError["WARN0172"], pending.ScheduledAt.Format(time.RFC3339), pending.User, pending.Reason), ErrFrom: "INTERVENTION"})
+	}
+	if cluster.IsIntervention && cluster.InterventionCurrent != nil {
+		cur := cluster.InterventionCurrent
+		cluster.SetState("WARN0173", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(config.ClusterError["WARN0173"], cur.StartedAt.Format(time.RFC3339), cur.User, cur.Reason), ErrFrom: "INTERVENTION"})
+	}
+
 	// Check pending → start
 	if cluster.InterventionPending != nil && !cluster.IsIntervention {
 		if time.Now().After(cluster.InterventionPending.ScheduledAt) {

--- a/cluster/cluster_intervention.go
+++ b/cluster/cluster_intervention.go
@@ -1,0 +1,122 @@
+package cluster
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/signal18/replication-manager/config"
+)
+
+type InterventionEntry struct {
+	User             string    `json:"user"`
+	Reason           string    `json:"reason"`
+	Scope            string    `json:"scope"` // "cluster" or "global"
+	StartedAt        time.Time `json:"startedAt"`
+	EndedAt          time.Time `json:"endedAt,omitempty"`
+	SuppressedAlerts int       `json:"suppressedAlerts"`
+}
+
+var interventionMu sync.Mutex
+
+func (cluster *Cluster) StartIntervention(user string, reason string, scope string) error {
+	interventionMu.Lock()
+	defer interventionMu.Unlock()
+
+	if cluster.IsIntervention {
+		return fmt.Errorf("intervention already active since %s by %s",
+			cluster.InterventionCurrent.StartedAt.Format(time.RFC3339), cluster.InterventionCurrent.User)
+	}
+
+	entry := &InterventionEntry{
+		User:      user,
+		Reason:    reason,
+		Scope:     scope,
+		StartedAt: time.Now(),
+	}
+
+	cluster.IsIntervention = true
+	cluster.InterventionCurrent = entry
+	cluster.InterventionSuppressedAlerts = 0
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+		"Intervention started by %s: %s (scope: %s)", user, reason, scope)
+
+	cluster.SaveInterventionHistory()
+	return nil
+}
+
+func (cluster *Cluster) EndIntervention(user string) error {
+	interventionMu.Lock()
+	defer interventionMu.Unlock()
+
+	if !cluster.IsIntervention {
+		return fmt.Errorf("no active intervention")
+	}
+
+	cluster.InterventionCurrent.EndedAt = time.Now()
+	cluster.InterventionCurrent.SuppressedAlerts = cluster.InterventionSuppressedAlerts
+
+	duration := cluster.InterventionCurrent.EndedAt.Sub(cluster.InterventionCurrent.StartedAt)
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+		"Intervention ended by %s. Duration: %s. Suppressed alerts: %d",
+		user, duration.Round(time.Second), cluster.InterventionSuppressedAlerts)
+
+	cluster.InterventionHistory = append(cluster.InterventionHistory, *cluster.InterventionCurrent)
+	cluster.IsIntervention = false
+	cluster.InterventionCurrent = nil
+	cluster.InterventionSuppressedAlerts = 0
+
+	cluster.SaveInterventionHistory()
+	return nil
+}
+
+func (cluster *Cluster) IncrementSuppressedAlerts() {
+	if cluster.IsIntervention {
+		cluster.InterventionSuppressedAlerts++
+	}
+}
+
+func (cluster *Cluster) SaveInterventionHistory() {
+	path := filepath.Join(cluster.WorkingDir, cluster.Name, "interventions.json")
+	os.MkdirAll(filepath.Dir(path), 0755)
+
+	data := struct {
+		Current *InterventionEntry  `json:"current,omitempty"`
+		History []InterventionEntry `json:"history"`
+	}{
+		Current: cluster.InterventionCurrent,
+		History: cluster.InterventionHistory,
+	}
+
+	if bytes, err := json.MarshalIndent(data, "", "  "); err == nil {
+		os.WriteFile(path, bytes, 0644)
+	}
+}
+
+func (cluster *Cluster) LoadInterventionHistory() {
+	path := filepath.Join(cluster.WorkingDir, cluster.Name, "interventions.json")
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+
+	var data struct {
+		Current *InterventionEntry  `json:"current,omitempty"`
+		History []InterventionEntry `json:"history"`
+	}
+
+	if err := json.Unmarshal(bytes, &data); err != nil {
+		return
+	}
+
+	cluster.InterventionHistory = data.History
+	if data.Current != nil {
+		cluster.IsIntervention = true
+		cluster.InterventionCurrent = data.Current
+	}
+}

--- a/cluster/cluster_intervention.go
+++ b/cluster/cluster_intervention.go
@@ -85,7 +85,7 @@ func (cluster *Cluster) IncrementSuppressedAlerts() {
 }
 
 func (cluster *Cluster) SaveInterventionHistory() {
-	path := filepath.Join(cluster.WorkingDir, cluster.Name, "interventions.json")
+	path := filepath.Join(cluster.WorkingDir, "interventions.json")
 	os.MkdirAll(filepath.Dir(path), 0755)
 
 	data := struct {
@@ -102,7 +102,7 @@ func (cluster *Cluster) SaveInterventionHistory() {
 }
 
 func (cluster *Cluster) LoadInterventionHistory() {
-	path := filepath.Join(cluster.WorkingDir, cluster.Name, "interventions.json")
+	path := filepath.Join(cluster.WorkingDir, "interventions.json")
 	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return

--- a/cluster/cluster_intervention.go
+++ b/cluster/cluster_intervention.go
@@ -14,18 +14,21 @@ import (
 type InterventionEntry struct {
 	User             string    `json:"user"`
 	Reason           string    `json:"reason"`
-	Scope            string    `json:"scope"` // "cluster" or "global"
+	Scope            string    `json:"scope"`    // "cluster" or "global"
 	StartedAt        time.Time `json:"startedAt"`
 	EndedAt          time.Time `json:"endedAt,omitempty"`
+	ScheduledAt      time.Time `json:"scheduledAt,omitempty"` // future start time (zero = immediate)
+	AutoEndAt        time.Time `json:"autoEndAt,omitempty"`   // auto-unmute time (zero = manual)
 	SuppressedAlerts int       `json:"suppressedAlerts"`
 }
-
-// The reason field contains both description and estimated time
-// formatted as: "description (est. 30 minutes)"
 
 var interventionMu sync.Mutex
 
 func (cluster *Cluster) StartIntervention(user string, reason string, scope string) error {
+	return cluster.StartInterventionAt(user, reason, scope, time.Now(), time.Time{})
+}
+
+func (cluster *Cluster) StartInterventionAt(user string, reason string, scope string, startAt time.Time, autoEndAt time.Time) error {
 	interventionMu.Lock()
 	defer interventionMu.Unlock()
 
@@ -34,11 +37,28 @@ func (cluster *Cluster) StartIntervention(user string, reason string, scope stri
 			cluster.InterventionCurrent.StartedAt.Format(time.RFC3339), cluster.InterventionCurrent.User)
 	}
 
+	// If scheduled in the future, store as pending
+	if startAt.After(time.Now().Add(30 * time.Second)) {
+		entry := &InterventionEntry{
+			User:        user,
+			Reason:      reason,
+			Scope:       scope,
+			ScheduledAt: startAt,
+			AutoEndAt:   autoEndAt,
+		}
+		cluster.InterventionPending = entry
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+			"Intervention scheduled by %s at %s: %s", user, startAt.Format(time.RFC3339), reason)
+		cluster.SaveInterventionHistory()
+		return nil
+	}
+
 	entry := &InterventionEntry{
 		User:      user,
 		Reason:    reason,
 		Scope:     scope,
 		StartedAt: time.Now(),
+		AutoEndAt: autoEndAt,
 	}
 
 	cluster.IsIntervention = true
@@ -78,6 +98,28 @@ func (cluster *Cluster) EndIntervention(user string) error {
 	return nil
 }
 
+// CheckInterventionSchedule checks if a pending intervention should start
+// or if an active intervention should auto-end. Called from the monitoring loop.
+func (cluster *Cluster) CheckInterventionSchedule() {
+	// Check pending → start
+	if cluster.InterventionPending != nil && !cluster.IsIntervention {
+		if time.Now().After(cluster.InterventionPending.ScheduledAt) {
+			pending := cluster.InterventionPending
+			cluster.InterventionPending = nil
+			cluster.StartInterventionAt(pending.User, pending.Reason, pending.Scope, time.Now(), pending.AutoEndAt)
+		}
+	}
+
+	// Check active → auto-end
+	if cluster.IsIntervention && cluster.InterventionCurrent != nil {
+		if !cluster.InterventionCurrent.AutoEndAt.IsZero() && time.Now().After(cluster.InterventionCurrent.AutoEndAt) {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+				"Intervention auto-unmute triggered (scheduled end: %s)", cluster.InterventionCurrent.AutoEndAt.Format(time.RFC3339))
+			cluster.EndIntervention("auto-unmute")
+		}
+	}
+}
+
 func (cluster *Cluster) IncrementSuppressedAlerts() {
 	if cluster.IsIntervention {
 		cluster.InterventionSuppressedAlerts++
@@ -90,9 +132,11 @@ func (cluster *Cluster) SaveInterventionHistory() {
 
 	data := struct {
 		Current *InterventionEntry  `json:"current,omitempty"`
+		Pending *InterventionEntry  `json:"pending,omitempty"`
 		History []InterventionEntry `json:"history"`
 	}{
 		Current: cluster.InterventionCurrent,
+		Pending: cluster.InterventionPending,
 		History: cluster.InterventionHistory,
 	}
 
@@ -110,6 +154,7 @@ func (cluster *Cluster) LoadInterventionHistory() {
 
 	var data struct {
 		Current *InterventionEntry  `json:"current,omitempty"`
+		Pending *InterventionEntry  `json:"pending,omitempty"`
 		History []InterventionEntry `json:"history"`
 	}
 
@@ -121,5 +166,8 @@ func (cluster *Cluster) LoadInterventionHistory() {
 	if data.Current != nil {
 		cluster.IsIntervention = true
 		cluster.InterventionCurrent = data.Current
+	}
+	if data.Pending != nil {
+		cluster.InterventionPending = data.Pending
 	}
 }

--- a/cluster/cluster_intervention.go
+++ b/cluster/cluster_intervention.go
@@ -20,6 +20,9 @@ type InterventionEntry struct {
 	SuppressedAlerts int       `json:"suppressedAlerts"`
 }
 
+// The reason field contains both description and estimated time
+// formatted as: "description (est. 30 minutes)"
+
 var interventionMu sync.Mutex
 
 func (cluster *Cluster) StartIntervention(user string, reason string, scope string) error {

--- a/cluster/cluster_intervention.go
+++ b/cluster/cluster_intervention.go
@@ -48,8 +48,8 @@ func (cluster *Cluster) StartInterventionAt(user string, reason string, scope st
 			AutoEndAt:   autoEndAt,
 		}
 		cluster.InterventionPending = entry
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
-			"Intervention scheduled by %s at %s: %s", user, startAt.Format(time.RFC3339), reason)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ALERT",
+			"Intervention scheduled by %s at %s: %s — notifications will be muted", user, startAt.Format(time.RFC3339), reason)
 		cluster.SetState("WARN0172", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(config.ClusterError["WARN0172"], startAt.Format(time.RFC3339), user, reason), ErrFrom: "INTERVENTION"})
 		cluster.SaveInterventionHistory()
 		return nil
@@ -63,12 +63,14 @@ func (cluster *Cluster) StartInterventionAt(user string, reason string, scope st
 		AutoEndAt: autoEndAt,
 	}
 
+	// Notify all channels BEFORE muting so the notification goes through
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ALERT",
+		"Intervention started by %s: %s (scope: %s) — notifications are now muted", user, reason, scope)
+
 	cluster.IsIntervention = true
 	cluster.InterventionCurrent = entry
 	cluster.InterventionSuppressedAlerts = 0
 
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
-		"Intervention started by %s: %s (scope: %s)", user, reason, scope)
 	cluster.SetState("WARN0173", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(config.ClusterError["WARN0173"], entry.StartedAt.Format(time.RFC3339), user, reason), ErrFrom: "INTERVENTION"})
 
 	cluster.SaveInterventionHistory()
@@ -87,15 +89,18 @@ func (cluster *Cluster) EndIntervention(user string) error {
 	cluster.InterventionCurrent.SuppressedAlerts = cluster.InterventionSuppressedAlerts
 
 	duration := cluster.InterventionCurrent.EndedAt.Sub(cluster.InterventionCurrent.StartedAt)
-
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
-		"Intervention ended by %s. Duration: %s. Suppressed alerts: %d",
-		user, duration.Round(time.Second), cluster.InterventionSuppressedAlerts)
+	suppressedCount := cluster.InterventionSuppressedAlerts
+	reason := cluster.InterventionCurrent.Reason
 
 	cluster.InterventionHistory = append(cluster.InterventionHistory, *cluster.InterventionCurrent)
 	cluster.IsIntervention = false
 	cluster.InterventionCurrent = nil
 	cluster.InterventionSuppressedAlerts = 0
+
+	// Notify all channels AFTER unmuting so the notification goes through
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "ALERTOK",
+		"Intervention ended by %s: %s. Duration: %s. Suppressed alerts: %d — notifications resumed",
+		user, reason, duration.Round(time.Second), suppressedCount)
 
 	cluster.SaveInterventionHistory()
 	return nil

--- a/cluster/cluster_log.go
+++ b/cluster/cluster_log.go
@@ -523,7 +523,7 @@ func (cluster *Cluster) logPrintStateTo(st state.State, resolved bool, buf *s18l
 		// wrap logrus levels
 		if resolved {
 			cluster.Logrus.WithFields(log.Fields{"cluster": cluster.Name, "type": "state", "status": "RESOLV", "code": st.ErrKey, "channel": "StdOut"}).Warn(st.ErrDesc)
-			if strings.Contains(cluster.Conf.MonitoringAlertTrigger, st.ErrKey) {
+			if !cluster.IsIntervention && strings.Contains(cluster.Conf.MonitoringAlertTrigger, st.ErrKey) {
 				if cluster.LogSlack.HasActiveHook() {
 					slackFields["status"] = "RESOLV"
 					cluster.LogSlack.WithFields(slackFields).Info(st.ErrDesc)
@@ -531,7 +531,7 @@ func (cluster *Cluster) logPrintStateTo(st state.State, resolved bool, buf *s18l
 			}
 		} else {
 			cluster.Logrus.WithFields(log.Fields{"cluster": cluster.Name, "type": "state", "status": "OPENED", "code": st.ErrKey, "channel": "StdOut"}).Warn(st.ErrDesc)
-			if strings.Contains(cluster.Conf.MonitoringAlertTrigger, st.ErrKey) {
+			if !cluster.IsIntervention && strings.Contains(cluster.Conf.MonitoringAlertTrigger, st.ErrKey) {
 				if cluster.LogSlack.HasActiveHook() {
 					slackFields["status"] = "OPENED"
 					cluster.LogSlack.WithFields(slackFields).Error(st.ErrDesc)
@@ -539,7 +539,7 @@ func (cluster *Cluster) logPrintStateTo(st state.State, resolved bool, buf *s18l
 			}
 		}
 
-		if cluster.Conf.TeamsUrl != "" && cluster.Conf.TeamsAlertState != "" {
+		if !cluster.IsIntervention && cluster.Conf.TeamsUrl != "" && cluster.Conf.TeamsAlertState != "" {
 			stateList := strings.Split(cluster.Conf.TeamsAlertState, ",")
 			for _, alertcode := range stateList {
 				if strings.Contains(st.ErrKey, alertcode) {
@@ -547,6 +547,10 @@ func (cluster *Cluster) logPrintStateTo(st state.State, resolved bool, buf *s18l
 					break
 				}
 			}
+		}
+
+		if cluster.IsIntervention && (strings.Contains(cluster.Conf.MonitoringAlertTrigger, st.ErrKey) || (cluster.Conf.TeamsUrl != "" && cluster.Conf.TeamsAlertState != "")) {
+			cluster.IncrementSuppressedAlerts()
 		}
 	}
 

--- a/cluster/cluster_log.go
+++ b/cluster/cluster_log.go
@@ -259,13 +259,15 @@ func (cluster *Cluster) LogModuleWithFieldsPrintf(forcingLog bool, module int, l
 			switch level {
 			case "ERROR":
 				targetLogger.WithFields(printfields).Errorf(cliformat, args...)
-				if !isMaintenance {
+				if !isMaintenance && !cluster.IsIntervention {
 					if cluster.Conf.SlackURL != "" {
 						cluster.LogSlack.WithFields(slackFields).Errorf(cliformat, args...)
 					}
 					if cluster.Conf.TeamsUrl != "" {
 						go cluster.sendMsTeams(level, format, args...)
 					}
+				} else if cluster.IsIntervention {
+					cluster.IncrementSuppressedAlerts()
 				}
 			case "INFO":
 				targetLogger.WithFields(printfields).Infof(cliformat, args...)
@@ -273,13 +275,15 @@ func (cluster *Cluster) LogModuleWithFieldsPrintf(forcingLog bool, module int, l
 				targetLogger.WithFields(printfields).Debugf(cliformat, args...)
 			case "WARN":
 				targetLogger.WithFields(printfields).Warnf(cliformat, args...)
-				if !isMaintenance {
+				if !isMaintenance && !cluster.IsIntervention {
 					if cluster.Conf.SlackURL != "" {
 						cluster.LogSlack.WithFields(slackFields).Warnf(cliformat, args...)
 					}
 					if cluster.Conf.TeamsUrl != "" {
 						go cluster.sendMsTeams(level, format, args...)
 					}
+				} else if cluster.IsIntervention {
+					cluster.IncrementSuppressedAlerts()
 				}
 			case "TEST":
 				printfields["type"] = "test"
@@ -293,44 +297,56 @@ func (cluster *Cluster) LogModuleWithFieldsPrintf(forcingLog bool, module int, l
 				printfields["type"] = "alert"
 				printfields["channel"] = "StdOut"
 				cluster.Logrus.WithFields(printfields).Errorf(cliformat, args...)
-				if cluster.Conf.Cloud18Alert && cluster.Conf.Cloud18SubscriptionPlan != "free" {
-					cluster.LogSlack.WithFields(slackFields).Errorf(cliformat, args...)
-				}
-				if cluster.Conf.PushoverAppToken != "" && cluster.Conf.PushoverUserToken != "" {
-					printfields["channel"] = "Pushover"
-					cluster.LogPushover.WithFields(printfields).Errorf(cliformat, args...)
-				}
-				if cluster.Conf.TeamsUrl != "" {
-					go cluster.sendMsTeams(level, format, args...)
+				if !cluster.IsIntervention {
+					if cluster.Conf.Cloud18Alert && cluster.Conf.Cloud18SubscriptionPlan != "free" {
+						cluster.LogSlack.WithFields(slackFields).Errorf(cliformat, args...)
+					}
+					if cluster.Conf.PushoverAppToken != "" && cluster.Conf.PushoverUserToken != "" {
+						printfields["channel"] = "Pushover"
+						cluster.LogPushover.WithFields(printfields).Errorf(cliformat, args...)
+					}
+					if cluster.Conf.TeamsUrl != "" {
+						go cluster.sendMsTeams(level, format, args...)
+					}
+				} else {
+					cluster.IncrementSuppressedAlerts()
 				}
 			case "START":
 				printfields["type"] = "alert"
 				printfields["channel"] = "StdOut"
 				cluster.Logrus.WithFields(printfields).Warnf(cliformat, args...)
-				if cluster.LogSlack.HasActiveHook() {
-					slackFields["type"] = "start"
-					cluster.LogSlack.WithFields(slackFields).Warnf(cliformat, args...)
-				}
-				if cluster.Conf.PushoverAppToken != "" && cluster.Conf.PushoverUserToken != "" {
-					printfields["type"] = "start"
-					printfields["channel"] = "Pushover"
-					cluster.LogPushover.WithFields(printfields).Warnf(cliformat, args...)
-				}
-				if cluster.Conf.TeamsUrl != "" {
-					go cluster.sendMsTeams(level, format, args...)
+				if !cluster.IsIntervention {
+					if cluster.LogSlack.HasActiveHook() {
+						slackFields["type"] = "start"
+						cluster.LogSlack.WithFields(slackFields).Warnf(cliformat, args...)
+					}
+					if cluster.Conf.PushoverAppToken != "" && cluster.Conf.PushoverUserToken != "" {
+						printfields["type"] = "start"
+						printfields["channel"] = "Pushover"
+						cluster.LogPushover.WithFields(printfields).Warnf(cliformat, args...)
+					}
+					if cluster.Conf.TeamsUrl != "" {
+						go cluster.sendMsTeams(level, format, args...)
+					}
+				} else {
+					cluster.IncrementSuppressedAlerts()
 				}
 			case "ALERTOK":
 				printfields["type"] = "alert"
 				printfields["channel"] = "StdOut"
 				cluster.Logrus.WithFields(printfields).Infof(cliformat, args...)
-				if cluster.Conf.Cloud18Alert && cluster.Conf.Cloud18SubscriptionPlan != "free" {
-					cluster.LogSlack.WithFields(slackFields).Infof(cliformat, args...)
-				}
-				if cluster.Conf.PushoverAppToken != "" && cluster.Conf.PushoverUserToken != "" {
-					cluster.LogPushover.WithFields(printfields).Infof(cliformat, args...)
-				}
-				if cluster.Conf.TeamsUrl != "" {
-					go cluster.sendMsTeams(level, format, args...)
+				if !cluster.IsIntervention {
+					if cluster.Conf.Cloud18Alert && cluster.Conf.Cloud18SubscriptionPlan != "free" {
+						cluster.LogSlack.WithFields(slackFields).Infof(cliformat, args...)
+					}
+					if cluster.Conf.PushoverAppToken != "" && cluster.Conf.PushoverUserToken != "" {
+						cluster.LogPushover.WithFields(printfields).Infof(cliformat, args...)
+					}
+					if cluster.Conf.TeamsUrl != "" {
+						go cluster.sendMsTeams(level, format, args...)
+					}
+				} else {
+					cluster.IncrementSuppressedAlerts()
 				}
 			default:
 				targetLogger.WithFields(printfields).Printf(cliformat, args...)

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -539,8 +539,7 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 		if server.State != stateFailed {
 			cluster.StateMachine.CopyOldStateFromUnknowServer(server.URL)
 		}
-		// cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral,LvlDbg, "Failure detection handling for server %s %s", server.URL, err)
-		// cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral,config.LvlErr, "Failure detection handling for server %s %s", server.URL, err)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Failure detection handling for server %s %s", server.URL, err)
 
 		if driverErr, ok := err.(*mysql.MySQLError); ok {
 			//	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral,LvlDbg, "Driver Error %s %d ", server.URL, driverErr.Number)

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -539,7 +539,7 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 		if server.State != stateFailed {
 			cluster.StateMachine.CopyOldStateFromUnknowServer(server.URL)
 		}
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Failure detection handling for server %s %s", server.URL, err)
+		cluster.SetState("WARN0171", state.State{ErrType: config.LvlWarn, ErrDesc: fmt.Sprintf(clusterError["WARN0171"], server.URL, err), ErrFrom: "MON", ServerUrl: server.URL})
 
 		if driverErr, ok := err.(*mysql.MySQLError); ok {
 			//	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral,LvlDbg, "Driver Error %s %d ", server.URL, driverErr.Number)
@@ -681,7 +681,11 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 			isStagingServer = true
 		}
 
-		if server.PrevState == stateFailed || server.PrevState == stateErrorAuth /*|| server.PrevState == stateSuspect*/ {
+		// stateSuspect intentionally excluded — enabling it would cause false standalone
+		// detection during network glitches (ab0e92ba0, Aug 2021). 2-node clusters
+		// without arbitrator cannot auto-recover after restart. Use an arbitrator.
+		// See: https://docs.signal18.io/faq/topology-deployment#15-4-2
+		if server.PrevState == stateFailed || server.PrevState == stateErrorAuth {
 			// If we reached this stage with a previously failed server, reintroduce it as unconnected server.master
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "State changed, init failed server %s as unconnected", server.URL)
 

--- a/config/error.go
+++ b/config/error.go
@@ -245,6 +245,7 @@ var ClusterError = map[string]string{
 	"WARN0168":  "New compliance moduleset available from back office (DB CRC: %08x → %08x, Proxy CRC: %08x → %08x). Accept the update via Settings to apply.",
 	"WARN0169":  "On-premise SSH enabled but private key not found: %s. Generate a key for the repman user or set onpremise-ssh-private-key",
 	"WARN0170":  "Configurator enabled (prov-db-config=true) but %s. Config tracking will not work until this is resolved.",
+	"WARN0171":  "Server %s connection failed: %s",
 	// Log-tailer plugin state codes (WARN0200-WARN0299 reserved for logplugin)
 	"WARN0200":  "Server %s has recent ERROR entries in database error log (last 24h)",
 	"WARN0201":  "Server %s has recent SQL errors in SQL error log (last 24h)",

--- a/config/error.go
+++ b/config/error.go
@@ -246,6 +246,8 @@ var ClusterError = map[string]string{
 	"WARN0169":  "On-premise SSH enabled but private key not found: %s. Generate a key for the repman user or set onpremise-ssh-private-key",
 	"WARN0170":  "Configurator enabled (prov-db-config=true) but %s. Config tracking will not work until this is resolved.",
 	"WARN0171":  "Server %s connection failed: %s",
+	"WARN0172":  "Intervention scheduled at %s by %s: %s",
+	"WARN0173":  "Intervention active since %s by %s: %s — notifications muted",
 	// Log-tailer plugin state codes (WARN0200-WARN0299 reserved for logplugin)
 	"WARN0200":  "Server %s has recent ERROR entries in database error log (last 24h)",
 	"WARN0201":  "Server %s has recent SQL errors in SQL error log (last 24h)",

--- a/server/api.go
+++ b/server/api.go
@@ -1171,6 +1171,7 @@ func (repman *ReplicationManager) handlerMuxAuthCallback(w http.ResponseWriter, 
 // @Router /api/monitor [get]
 func (repman *ReplicationManager) handlerMuxReplicationManager(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
+	repman.RefreshGlobalInterventionState()
 
 	var cl []string
 	for _, cluster := range repman.Clusters {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -10221,7 +10221,6 @@ func (repman *ReplicationManager) handlerMuxInterventionStart(w http.ResponseWri
 
 		var body struct {
 			Reason string `json:"reason"`
-			User   string `json:"user"`
 		}
 		if r.Body != nil {
 			json.NewDecoder(r.Body).Decode(&body)
@@ -10230,10 +10229,7 @@ func (repman *ReplicationManager) handlerMuxInterventionStart(w http.ResponseWri
 			body.Reason = "No reason provided"
 		}
 
-		user := body.User
-		if user == "" {
-			user = repman.GetUserFromRequest(r)
-		}
+		user := repman.GetUserFromRequest(r)
 		if err := mycluster.StartIntervention(user, body.Reason, "cluster"); err != nil {
 			http.Error(w, err.Error(), http.StatusConflict)
 			return

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -393,6 +393,14 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxResetSla)),
 	))
+	router.Handle("/api/clusters/{clusterName}/actions/intervention-start", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxInterventionStart)),
+	))
+	router.Handle("/api/clusters/{clusterName}/actions/intervention-end", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxInterventionEnd)),
+	))
 	router.Handle("/api/clusters/{clusterName}/actions/replication/bootstrap/{topology}", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxBootstrapReplication)),
@@ -10198,5 +10206,57 @@ func (repman *ReplicationManager) handlerMuxClusterS3ProviderSyncApply(w http.Re
 	e.SetIndent("", "\t")
 	if err := e.Encode(resp); err != nil {
 		http.Error(w, "Encoding error", http.StatusInternalServerError)
+	}
+}
+
+func (repman *ReplicationManager) handlerMuxInterventionStart(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster != nil {
+		if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+			http.Error(w, "No valid ACL", http.StatusForbidden)
+			return
+		}
+
+		var body struct {
+			Reason string `json:"reason"`
+		}
+		if r.Body != nil {
+			json.NewDecoder(r.Body).Decode(&body)
+		}
+		if body.Reason == "" {
+			body.Reason = "No reason provided"
+		}
+
+		user := repman.GetUserFromRequest(r)
+		if err := mycluster.StartIntervention(user, body.Reason, "cluster"); err != nil {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
+		w.Write([]byte("Intervention started"))
+	} else {
+		http.Error(w, "Cluster Not Found", http.StatusInternalServerError)
+	}
+}
+
+func (repman *ReplicationManager) handlerMuxInterventionEnd(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster != nil {
+		if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+			http.Error(w, "No valid ACL", http.StatusForbidden)
+			return
+		}
+
+		user := repman.GetUserFromRequest(r)
+		if err := mycluster.EndIntervention(user); err != nil {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
+		w.Write([]byte("Intervention ended"))
+	} else {
+		http.Error(w, "Cluster Not Found", http.StatusInternalServerError)
 	}
 }

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -10220,7 +10220,9 @@ func (repman *ReplicationManager) handlerMuxInterventionStart(w http.ResponseWri
 		}
 
 		var body struct {
-			Reason string `json:"reason"`
+			Reason    string `json:"reason"`
+			StartAt   string `json:"startAt"`
+			EndAt     string `json:"endAt"`
 		}
 		if r.Body != nil {
 			json.NewDecoder(r.Body).Decode(&body)
@@ -10229,8 +10231,21 @@ func (repman *ReplicationManager) handlerMuxInterventionStart(w http.ResponseWri
 			body.Reason = "No reason provided"
 		}
 
+		startAt := time.Now()
+		if body.StartAt != "" {
+			if t, err := time.Parse(time.RFC3339, body.StartAt); err == nil {
+				startAt = t
+			}
+		}
+		var autoEndAt time.Time
+		if body.EndAt != "" {
+			if t, err := time.Parse(time.RFC3339, body.EndAt); err == nil {
+				autoEndAt = t
+			}
+		}
+
 		user := repman.GetUserFromRequest(r)
-		if err := mycluster.StartIntervention(user, body.Reason, "cluster"); err != nil {
+		if err := mycluster.StartInterventionAt(user, body.Reason, "cluster", startAt, autoEndAt); err != nil {
 			http.Error(w, err.Error(), http.StatusConflict)
 			return
 		}

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -10221,6 +10221,7 @@ func (repman *ReplicationManager) handlerMuxInterventionStart(w http.ResponseWri
 
 		var body struct {
 			Reason string `json:"reason"`
+			User   string `json:"user"`
 		}
 		if r.Body != nil {
 			json.NewDecoder(r.Body).Decode(&body)
@@ -10229,7 +10230,10 @@ func (repman *ReplicationManager) handlerMuxInterventionStart(w http.ResponseWri
 			body.Reason = "No reason provided"
 		}
 
-		user := repman.GetUserFromRequest(r)
+		user := body.User
+		if user == "" {
+			user = repman.GetUserFromRequest(r)
+		}
 		if err := mycluster.StartIntervention(user, body.Reason, "cluster"); err != nil {
 			http.Error(w, err.Error(), http.StatusConflict)
 			return

--- a/server/api_database.go
+++ b/server/api_database.go
@@ -3836,7 +3836,7 @@ func (repman *ReplicationManager) handlerMuxServerErrorLog(w http.ResponseWriter
 			return
 		}
 		node := mycluster.GetServerFromName(vars["serverName"])
-		if node != nil && !node.IsDown() {
+		if node != nil {
 			e := json.NewEncoder(w)
 			e.SetIndent("", "\t")
 			l := node.GetErrorLog()
@@ -3847,8 +3847,7 @@ func (repman *ReplicationManager) handlerMuxServerErrorLog(w http.ResponseWriter
 			}
 			return
 		} else {
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("503 -Not a Valid Server!"))
+			http.Error(w, "Server not found", 500)
 		}
 	} else {
 		http.Error(w, "No cluster", 500)
@@ -3878,7 +3877,7 @@ func (repman *ReplicationManager) handlerMuxServerSqlErrorLog(w http.ResponseWri
 			return
 		}
 		node := mycluster.GetServerFromName(vars["serverName"])
-		if node != nil && !node.IsDown() {
+		if node != nil {
 			e := json.NewEncoder(w)
 			e.SetIndent("", "\t")
 			l := node.GetSqlErrorLog()
@@ -3889,8 +3888,7 @@ func (repman *ReplicationManager) handlerMuxServerSqlErrorLog(w http.ResponseWri
 			}
 			return
 		} else {
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("503 -Not a Valid Server!"))
+			http.Error(w, "Server not found", 500)
 		}
 	} else {
 		http.Error(w, "No cluster", 500)
@@ -3920,7 +3918,7 @@ func (repman *ReplicationManager) handlerMuxServerAuditLog(w http.ResponseWriter
 			return
 		}
 		node := mycluster.GetServerFromName(vars["serverName"])
-		if node != nil && !node.IsDown() {
+		if node != nil {
 			e := json.NewEncoder(w)
 			e.SetIndent("", "\t")
 			l := node.GetAuditLog()
@@ -3931,8 +3929,7 @@ func (repman *ReplicationManager) handlerMuxServerAuditLog(w http.ResponseWriter
 			}
 			return
 		} else {
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("503 -Not a Valid Server!"))
+			http.Error(w, "Server not found", 500)
 		}
 	} else {
 		http.Error(w, "No cluster", 500)
@@ -3962,7 +3959,7 @@ func (repman *ReplicationManager) handlerMuxServerSlowLog(w http.ResponseWriter,
 			return
 		}
 		node := mycluster.GetServerFromName(vars["serverName"])
-		if node != nil && !node.IsDown() {
+		if node != nil {
 			e := json.NewEncoder(w)
 			e.SetIndent("", "\t")
 			l := node.GetSlowLog()
@@ -3973,8 +3970,7 @@ func (repman *ReplicationManager) handlerMuxServerSlowLog(w http.ResponseWriter,
 			}
 			return
 		} else {
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("503 -Not a Valid Server!"))
+			http.Error(w, "Server not found", 500)
 		}
 
 	} else {

--- a/server/api_intervention.go
+++ b/server/api_intervention.go
@@ -9,31 +9,63 @@ import (
 	"github.com/signal18/replication-manager/cluster"
 )
 
-// RefreshGlobalInterventionState counts active interventions across all clusters
-// and restores the global intervention flag if all clusters have a global-scope intervention.
+// RefreshGlobalInterventionState counts active and pending interventions across all clusters
+// and restores the global intervention flag on restart.
 func (repman *ReplicationManager) RefreshGlobalInterventionState() {
-	count := 0
-	globalCount := 0
+	activeCount := 0
+	globalActiveCount := 0
+	globalPendingCount := 0
 	for _, cl := range repman.Clusters {
 		if cl.IsIntervention {
-			count++
+			activeCount++
 			if cl.InterventionCurrent != nil && cl.InterventionCurrent.Scope == "global" {
-				globalCount++
+				globalActiveCount++
 			}
 		}
+		if cl.InterventionPending != nil && cl.InterventionPending.Scope == "global" {
+			globalPendingCount++
+		}
 	}
-	repman.ActiveInterventionCount = count
+	repman.ActiveInterventionCount = activeCount
 
-	// Restore global flag if all clusters have a global-scope intervention (restart recovery)
-	if !repman.IsGlobalIntervention && globalCount > 0 && globalCount == len(repman.Clusters) {
+	// Restore global flag from active interventions (restart recovery)
+	if !repman.IsGlobalIntervention && globalActiveCount > 0 && globalActiveCount == len(repman.Clusters) {
 		repman.IsGlobalIntervention = true
-		// Use the first cluster's entry as the global entry
 		for _, cl := range repman.Clusters {
 			if cl.InterventionCurrent != nil && cl.InterventionCurrent.Scope == "global" {
 				repman.GlobalInterventionEntry = cl.InterventionCurrent
 				break
 			}
 		}
+	}
+
+	// Restore global pending flag (restart recovery)
+	if !repman.IsGlobalIntervention && !repman.IsGlobalInterventionPending && globalPendingCount > 0 && globalPendingCount == len(repman.Clusters) {
+		repman.IsGlobalInterventionPending = true
+		for _, cl := range repman.Clusters {
+			if cl.InterventionPending != nil && cl.InterventionPending.Scope == "global" {
+				repman.GlobalInterventionEntry = cl.InterventionPending
+				break
+			}
+		}
+	}
+
+	// Transition: pending became active on all clusters
+	if repman.IsGlobalInterventionPending && globalActiveCount > 0 && globalPendingCount == 0 {
+		repman.IsGlobalInterventionPending = false
+		repman.IsGlobalIntervention = true
+		for _, cl := range repman.Clusters {
+			if cl.InterventionCurrent != nil && cl.InterventionCurrent.Scope == "global" {
+				repman.GlobalInterventionEntry = cl.InterventionCurrent
+				break
+			}
+		}
+	}
+
+	// Transition: active intervention ended on all clusters
+	if repman.IsGlobalIntervention && globalActiveCount == 0 {
+		repman.IsGlobalIntervention = false
+		repman.GlobalInterventionEntry = nil
 	}
 }
 
@@ -63,6 +95,12 @@ func (repman *ReplicationManager) handlerMuxGlobalInterventionStart(w http.Respo
 			repman.GlobalInterventionEntry.User), http.StatusConflict)
 		return
 	}
+	if repman.IsGlobalInterventionPending {
+		http.Error(w, fmt.Sprintf("Global intervention already scheduled at %s by %s",
+			repman.GlobalInterventionEntry.ScheduledAt.Format(time.RFC3339),
+			repman.GlobalInterventionEntry.User), http.StatusConflict)
+		return
+	}
 
 	startAt := time.Now()
 	if body.StartAt != "" {
@@ -78,22 +116,38 @@ func (repman *ReplicationManager) handlerMuxGlobalInterventionStart(w http.Respo
 	}
 
 	user := repman.GetUserFromRequest(r)
+	isScheduled := startAt.After(time.Now().Add(30 * time.Second))
 
-	repman.IsGlobalIntervention = true
-	repman.GlobalInterventionEntry = &cluster.InterventionEntry{
-		User:      user,
-		Reason:    body.Reason,
-		Scope:     "global",
-		StartedAt: startAt,
-		AutoEndAt: autoEndAt,
+	if isScheduled {
+		repman.IsGlobalInterventionPending = true
+		repman.GlobalInterventionEntry = &cluster.InterventionEntry{
+			User:        user,
+			Reason:      body.Reason,
+			Scope:       "global",
+			ScheduledAt: startAt,
+			AutoEndAt:   autoEndAt,
+		}
+	} else {
+		repman.IsGlobalIntervention = true
+		repman.GlobalInterventionEntry = &cluster.InterventionEntry{
+			User:      user,
+			Reason:    body.Reason,
+			Scope:     "global",
+			StartedAt: startAt,
+			AutoEndAt: autoEndAt,
+		}
 	}
 
-	// Start intervention on all clusters
+	// Start or schedule intervention on all clusters
 	for _, cl := range repman.Clusters {
 		cl.StartInterventionAt(user, body.Reason, "global", startAt, autoEndAt)
 	}
 
-	w.Write([]byte("Global intervention started on all clusters"))
+	if isScheduled {
+		w.Write([]byte(fmt.Sprintf("Global intervention scheduled at %s", startAt.Format(time.RFC3339))))
+	} else {
+		w.Write([]byte("Global intervention started on all clusters"))
+	}
 }
 
 func (repman *ReplicationManager) handlerMuxGlobalInterventionEnd(w http.ResponseWriter, r *http.Request) {
@@ -107,22 +161,29 @@ func (repman *ReplicationManager) handlerMuxGlobalInterventionEnd(w http.Respons
 	user := repman.GetUserFromRequest(r)
 
 	closed := 0
-	// End intervention on all clusters (both global and per-cluster)
+	cancelled := 0
+	// End active interventions on all clusters
 	for _, cl := range repman.Clusters {
 		if cl.IsIntervention {
 			cl.EndIntervention(user)
 			closed++
 		}
+		if cl.InterventionPending != nil {
+			cl.InterventionPending = nil
+			cl.SaveInterventionHistory()
+			cancelled++
+		}
 	}
 
 	repman.IsGlobalIntervention = false
+	repman.IsGlobalInterventionPending = false
 	repman.GlobalInterventionEntry = nil
 	repman.ActiveInterventionCount = 0
 
-	if closed == 0 {
-		http.Error(w, "No active interventions", http.StatusConflict)
+	if closed == 0 && cancelled == 0 {
+		http.Error(w, "No active or pending interventions", http.StatusConflict)
 		return
 	}
 
-	w.Write([]byte(fmt.Sprintf("Closed %d interventions across all clusters", closed)))
+	w.Write([]byte(fmt.Sprintf("Closed %d active, cancelled %d pending interventions", closed, cancelled)))
 }

--- a/server/api_intervention.go
+++ b/server/api_intervention.go
@@ -46,7 +46,9 @@ func (repman *ReplicationManager) handlerMuxGlobalInterventionStart(w http.Respo
 	}
 
 	var body struct {
-		Reason string `json:"reason"`
+		Reason  string `json:"reason"`
+		StartAt string `json:"startAt"`
+		EndAt   string `json:"endAt"`
 	}
 	if r.Body != nil {
 		json.NewDecoder(r.Body).Decode(&body)
@@ -62,6 +64,19 @@ func (repman *ReplicationManager) handlerMuxGlobalInterventionStart(w http.Respo
 		return
 	}
 
+	startAt := time.Now()
+	if body.StartAt != "" {
+		if t, err := time.Parse(time.RFC3339, body.StartAt); err == nil {
+			startAt = t
+		}
+	}
+	var autoEndAt time.Time
+	if body.EndAt != "" {
+		if t, err := time.Parse(time.RFC3339, body.EndAt); err == nil {
+			autoEndAt = t
+		}
+	}
+
 	user := repman.GetUserFromRequest(r)
 
 	repman.IsGlobalIntervention = true
@@ -69,12 +84,13 @@ func (repman *ReplicationManager) handlerMuxGlobalInterventionStart(w http.Respo
 		User:      user,
 		Reason:    body.Reason,
 		Scope:     "global",
-		StartedAt: time.Now(),
+		StartedAt: startAt,
+		AutoEndAt: autoEndAt,
 	}
 
 	// Start intervention on all clusters
 	for _, cl := range repman.Clusters {
-		cl.StartIntervention(user, body.Reason, "global")
+		cl.StartInterventionAt(user, body.Reason, "global", startAt, autoEndAt)
 	}
 
 	w.Write([]byte("Global intervention started on all clusters"))

--- a/server/api_intervention.go
+++ b/server/api_intervention.go
@@ -1,0 +1,81 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/signal18/replication-manager/cluster"
+)
+
+func (repman *ReplicationManager) handlerMuxGlobalInterventionStart(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	if valid, _ := repman.IsValidClusterACL(r, repman.currentCluster); !valid {
+		http.Error(w, "No valid ACL", http.StatusForbidden)
+		return
+	}
+
+	var body struct {
+		Reason string `json:"reason"`
+	}
+	if r.Body != nil {
+		json.NewDecoder(r.Body).Decode(&body)
+	}
+	if body.Reason == "" {
+		body.Reason = "Global intervention"
+	}
+
+	if repman.IsGlobalIntervention {
+		http.Error(w, fmt.Sprintf("Global intervention already active since %s by %s",
+			repman.GlobalInterventionEntry.StartedAt.Format(time.RFC3339),
+			repman.GlobalInterventionEntry.User), http.StatusConflict)
+		return
+	}
+
+	user := repman.GetUserFromRequest(r)
+
+	repman.IsGlobalIntervention = true
+	repman.GlobalInterventionEntry = &cluster.InterventionEntry{
+		User:      user,
+		Reason:    body.Reason,
+		Scope:     "global",
+		StartedAt: time.Now(),
+	}
+
+	// Start intervention on all clusters
+	for _, cl := range repman.Clusters {
+		cl.StartIntervention(user, body.Reason, "global")
+	}
+
+	w.Write([]byte("Global intervention started on all clusters"))
+}
+
+func (repman *ReplicationManager) handlerMuxGlobalInterventionEnd(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	if valid, _ := repman.IsValidClusterACL(r, repman.currentCluster); !valid {
+		http.Error(w, "No valid ACL", http.StatusForbidden)
+		return
+	}
+
+	if !repman.IsGlobalIntervention {
+		http.Error(w, "No active global intervention", http.StatusConflict)
+		return
+	}
+
+	user := repman.GetUserFromRequest(r)
+
+	// End intervention on all clusters
+	for _, cl := range repman.Clusters {
+		if cl.IsIntervention {
+			cl.EndIntervention(user)
+		}
+	}
+
+	repman.IsGlobalIntervention = false
+	repman.GlobalInterventionEntry = nil
+
+	w.Write([]byte("Global intervention ended on all clusters"))
+}

--- a/server/api_intervention.go
+++ b/server/api_intervention.go
@@ -9,6 +9,34 @@ import (
 	"github.com/signal18/replication-manager/cluster"
 )
 
+// RefreshGlobalInterventionState counts active interventions across all clusters
+// and restores the global intervention flag if all clusters have a global-scope intervention.
+func (repman *ReplicationManager) RefreshGlobalInterventionState() {
+	count := 0
+	globalCount := 0
+	for _, cl := range repman.Clusters {
+		if cl.IsIntervention {
+			count++
+			if cl.InterventionCurrent != nil && cl.InterventionCurrent.Scope == "global" {
+				globalCount++
+			}
+		}
+	}
+	repman.ActiveInterventionCount = count
+
+	// Restore global flag if all clusters have a global-scope intervention (restart recovery)
+	if !repman.IsGlobalIntervention && globalCount > 0 && globalCount == len(repman.Clusters) {
+		repman.IsGlobalIntervention = true
+		// Use the first cluster's entry as the global entry
+		for _, cl := range repman.Clusters {
+			if cl.InterventionCurrent != nil && cl.InterventionCurrent.Scope == "global" {
+				repman.GlobalInterventionEntry = cl.InterventionCurrent
+				break
+			}
+		}
+	}
+}
+
 func (repman *ReplicationManager) handlerMuxGlobalInterventionStart(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 
@@ -60,22 +88,25 @@ func (repman *ReplicationManager) handlerMuxGlobalInterventionEnd(w http.Respons
 		return
 	}
 
-	if !repman.IsGlobalIntervention {
-		http.Error(w, "No active global intervention", http.StatusConflict)
-		return
-	}
-
 	user := repman.GetUserFromRequest(r)
 
-	// End intervention on all clusters
+	closed := 0
+	// End intervention on all clusters (both global and per-cluster)
 	for _, cl := range repman.Clusters {
 		if cl.IsIntervention {
 			cl.EndIntervention(user)
+			closed++
 		}
 	}
 
 	repman.IsGlobalIntervention = false
 	repman.GlobalInterventionEntry = nil
+	repman.ActiveInterventionCount = 0
 
-	w.Write([]byte("Global intervention ended on all clusters"))
+	if closed == 0 {
+		http.Error(w, "No active interventions", http.StatusConflict)
+		return
+	}
+
+	w.Write([]byte(fmt.Sprintf("Closed %d interventions across all clusters", closed)))
 }

--- a/server/http.go
+++ b/server/http.go
@@ -330,6 +330,14 @@ func (repman *ReplicationManager) httpserver() {
 			negroni.HandlerFunc(repman.validateSwaggerMiddleware),
 			negroni.Wrap(http.HandlerFunc(httpSwagger.Handler(httpSwagger.URL("/api-docs/doc.json")))),
 		))
+		router.Handle("/api/actions/intervention-start", negroni.New(
+			negroni.HandlerFunc(repman.validateTokenMiddleware),
+			negroni.Wrap(http.HandlerFunc(repman.handlerMuxGlobalInterventionStart)),
+		))
+		router.Handle("/api/actions/intervention-end", negroni.New(
+			negroni.HandlerFunc(repman.validateTokenMiddleware),
+			negroni.Wrap(http.HandlerFunc(repman.handlerMuxGlobalInterventionEnd)),
+		))
 		router.Handle("/api/email/send", negroni.New(
 			negroni.HandlerFunc(repman.validateTokenMiddleware),
 			negroni.Wrap(http.HandlerFunc(repman.handlerMuxSendEmail)),

--- a/server/server.go
+++ b/server/server.go
@@ -129,6 +129,8 @@ type ReplicationManager struct {
 	GraphiteTemplateList map[string]bool             `json:"graphiteTemplateList"`
 	ServerScopeList      map[string]bool             `json:"-"`
 	currentCluster       *cluster.Cluster            `json:"-"`
+	IsGlobalIntervention bool                        `json:"isGlobalIntervention"`
+	GlobalInterventionEntry *cluster.InterventionEntry `json:"globalInterventionEntry,omitempty"`
 	UserAuthTry          sync.Map                    `json:"-"`
 	OAuthAccessToken     *oauth2.Token               `json:"-"`
 	ViperConfig          *viper.Viper                `json:"-"`

--- a/server/server.go
+++ b/server/server.go
@@ -129,8 +129,9 @@ type ReplicationManager struct {
 	GraphiteTemplateList map[string]bool             `json:"graphiteTemplateList"`
 	ServerScopeList      map[string]bool             `json:"-"`
 	currentCluster       *cluster.Cluster            `json:"-"`
-	IsGlobalIntervention bool                        `json:"isGlobalIntervention"`
+	IsGlobalIntervention    bool                        `json:"isGlobalIntervention"`
 	GlobalInterventionEntry *cluster.InterventionEntry `json:"globalInterventionEntry,omitempty"`
+	ActiveInterventionCount int                        `json:"activeInterventionCount"`
 	UserAuthTry          sync.Map                    `json:"-"`
 	OAuthAccessToken     *oauth2.Token               `json:"-"`
 	ViperConfig          *viper.Viper                `json:"-"`

--- a/server/server.go
+++ b/server/server.go
@@ -419,7 +419,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.BoolVar(&conf.MonitorCapture, "monitoring-capture", true, "Enable capture on error for 5 monitor loops")
 	flags.StringVar(&conf.MonitorCaptureTrigger, "monitoring-capture-trigger", "ERR00076,ERR00041", "List of errno triggering capture mode")
 	flags.IntVar(&conf.MonitorCaptureFileKeep, "monitoring-capture-file-keep", 5, "Purge capture file keep that number of them")
-	flags.StringVar(&conf.MonitoringAlertTrigger, "monitoring-alert-trigger", "ERR00027,ERR00042,ERR00087,ERR00002,WARN0023,WARN0100,WARN0115,WARN0116,WARN0139,WARN0140,WARN0141", "List of errno triggering an alert to be send")
+	flags.StringVar(&conf.MonitoringAlertTrigger, "monitoring-alert-trigger", "ERR00027,ERR00042,ERR00087,ERR00002,WARN0023,WARN0100,WARN0115,WARN0116,WARN0139,WARN0140,WARN0141,WARN0172,WARN0173", "List of errno triggering an alert to be send")
 
 	flags.BoolVar(&conf.LogSQLInMonitoring, "log-sql-in-monitoring", false, "Log SQL queries send to servers in monitoring")
 	flags.IntVar(&conf.LogSQLLevel, "log-level-sql", 2, "Log SQL Level")

--- a/server/server.go
+++ b/server/server.go
@@ -129,9 +129,10 @@ type ReplicationManager struct {
 	GraphiteTemplateList map[string]bool             `json:"graphiteTemplateList"`
 	ServerScopeList      map[string]bool             `json:"-"`
 	currentCluster       *cluster.Cluster            `json:"-"`
-	IsGlobalIntervention    bool                        `json:"isGlobalIntervention"`
-	GlobalInterventionEntry *cluster.InterventionEntry `json:"globalInterventionEntry,omitempty"`
-	ActiveInterventionCount int                        `json:"activeInterventionCount"`
+	IsGlobalIntervention        bool                        `json:"isGlobalIntervention"`
+	IsGlobalInterventionPending bool                        `json:"isGlobalInterventionPending"`
+	GlobalInterventionEntry     *cluster.InterventionEntry  `json:"globalInterventionEntry,omitempty"`
+	ActiveInterventionCount     int                         `json:"activeInterventionCount"`
 	UserAuthTry          sync.Map                    `json:"-"`
 	OAuthAccessToken     *oauth2.Token               `json:"-"`
 	ViperConfig          *viper.Viper                `json:"-"`

--- a/share/dashboard_react/src/Pages/ClustersGlobalSettings/GlobalSettings.jsx
+++ b/share/dashboard_react/src/Pages/ClustersGlobalSettings/GlobalSettings.jsx
@@ -1,7 +1,7 @@
 import { Flex, HStack, Link } from '@chakra-ui/react'
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import styles from './styles.module.scss'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import TableType2 from '../../components/TableType2'
 import { setGlobalSetting, switchGlobalSetting } from '../../redux/globalClustersSlice'
 import LogSlider from '../../components/Sliders/LogSlider'
@@ -10,15 +10,52 @@ import TextForm from '../../components/TextForm'
 import { TbApi } from 'react-icons/tb'
 import RMIconButton from '../../components/RMIconButton'
 import NumberInput from '../../components/NumberInput'
+import InterventionModal from '../../components/Modals/InterventionModal'
+import ConfirmModal from '../../components/Modals/ConfirmModal'
+import { getApi } from '../../services/apiHelper'
 
 function GlobalSettings({ config }) {
   const dispatch = useDispatch()
-  
+  const monitor = useSelector((state) => state?.globalClusters?.monitor)
+  const baseURL = useSelector((state) => state?.auth?.baseURL)
+  const [isInterventionModalOpen, setIsInterventionModalOpen] = useState(false)
+  const [isEndInterventionModalOpen, setIsEndInterventionModalOpen] = useState(false)
+
   useEffect(() => {
     // Re-render when the config prop changes
   }, [config]);
 
+  const handleStartGlobalIntervention = ({ reason }) => {
+    getApi(baseURL).post('actions/intervention-start', { reason })
+      .then(() => setIsInterventionModalOpen(false))
+      .catch((err) => console.error('Failed to start global intervention:', err))
+  }
+
+  const handleEndGlobalIntervention = () => {
+    getApi(baseURL).post('actions/intervention-end')
+      .then(() => setIsEndInterventionModalOpen(false))
+      .catch((err) => console.error('Failed to end global intervention:', err))
+  }
+
   const dataObject = [
+    {
+      key: 'Global Intervention',
+      value: (
+        <RMSwitch
+          isChecked={monitor?.isGlobalIntervention}
+          confirmTitle={monitor?.isGlobalIntervention
+            ? `End global intervention? (${monitor?.globalInterventionEntry?.reason || 'active'})`
+            : undefined}
+          onChange={() => {
+            if (monitor?.isGlobalIntervention) {
+              setIsEndInterventionModalOpen(true)
+            } else {
+              setIsInterventionModalOpen(true)
+            }
+          }}
+        />
+      )
+    },
     {
       key: 'API Token Timeout in Hours',
       value: (
@@ -256,9 +293,26 @@ function GlobalSettings({ config }) {
   ]
 
   return (
-    <Flex justify='space-between' gap='0'>
-      <TableType2 dataArray={dataObject} className={styles.table} />
-    </Flex>
+    <>
+      <Flex justify='space-between' gap='0'>
+        <TableType2 dataArray={dataObject} className={styles.table} />
+      </Flex>
+      {isInterventionModalOpen && (
+        <InterventionModal
+          isOpen={isInterventionModalOpen}
+          closeModal={() => setIsInterventionModalOpen(false)}
+          onStart={handleStartGlobalIntervention}
+        />
+      )}
+      {isEndInterventionModalOpen && (
+        <ConfirmModal
+          isOpen={isEndInterventionModalOpen}
+          closeModal={() => setIsEndInterventionModalOpen(false)}
+          title={`End global intervention? All clusters will resume notifications.`}
+          onConfirmClick={handleEndGlobalIntervention}
+        />
+      )}
+    </>
   )
 }
 

--- a/share/dashboard_react/src/components/AlertBadge/index.jsx
+++ b/share/dashboard_react/src/components/AlertBadge/index.jsx
@@ -13,6 +13,7 @@ function AlertBadge({
   showText,
   isSupport = false,
   isConnect = true,
+  blink = false,
   // Optional overrides — when provided, bypass the isBlocking/isSupport logic
   colorScheme: colorSchemeProp,
   icon: iconProp,
@@ -34,14 +35,14 @@ function AlertBadge({
 
   const bubbleClassName = `alertCount ${styles.alertCount} ${
     isBlocking ? styles.blocker : isSupport ? styles.support : styles.warning
-  } ${isBlocking && count > 0 ? styles.blinking : ''}`
+  } ${(isBlocking && count > 0) || blink ? styles.blinking : ''}`
 
   return (
     <Badge
       as={'button'}
       {...(onClick ? { onClick: onClick } : {})}
       colorScheme={resolvedColorScheme}
-      className={styles.badge}>
+      className={`${styles.badge} ${blink ? styles.blinking : ''}`}>
       {showBubble && (
         <Box
           as='span'

--- a/share/dashboard_react/src/components/AlertBadge/index.jsx
+++ b/share/dashboard_react/src/components/AlertBadge/index.jsx
@@ -31,7 +31,7 @@ function AlertBadge({
       : isBlocking ? HiBan : isSupport ? BiSupport : HiExclamation
 
   const showBubble =
-    (isBlocking || (!isBlocking && !isSupport) || (isSupport && isConnect)) && !(blink && (count === '' || count === 0))
+    (isBlocking || (!isBlocking && !isSupport) || (isSupport && isConnect)) && count !== '' && count !== undefined && count !== null
 
   const bubbleClassName = `alertCount ${styles.alertCount} ${
     isBlocking ? styles.blocker : isSupport ? styles.support : styles.warning

--- a/share/dashboard_react/src/components/AlertBadge/index.jsx
+++ b/share/dashboard_react/src/components/AlertBadge/index.jsx
@@ -31,7 +31,7 @@ function AlertBadge({
       : isBlocking ? HiBan : isSupport ? BiSupport : HiExclamation
 
   const showBubble =
-    isBlocking || (!isBlocking && !isSupport) || (isSupport && isConnect)
+    (isBlocking || (!isBlocking && !isSupport) || (isSupport && isConnect)) && !(blink && (count === '' || count === 0))
 
   const bubbleClassName = `alertCount ${styles.alertCount} ${
     isBlocking ? styles.blocker : isSupport ? styles.support : styles.warning

--- a/share/dashboard_react/src/components/Modals/InterventionModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/InterventionModal/index.jsx
@@ -1,0 +1,85 @@
+import {
+  Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalCloseButton, ModalFooter,
+  FormControl, FormLabel, Input, Textarea, Select, HStack
+} from '@chakra-ui/react'
+import React, { useState } from 'react'
+import RMButton from '../../RMButton'
+import { useTheme } from '../../../ThemeProvider'
+import parentStyles from '../styles.module.scss'
+
+function InterventionModal({ isOpen, closeModal, onStart }) {
+  const { theme } = useTheme()
+  const [user, setUser] = useState('')
+  const [description, setDescription] = useState('')
+  const [estimatedTime, setEstimatedTime] = useState('30')
+  const [unit, setUnit] = useState('minutes')
+
+  const handleStart = () => {
+    const est = `${estimatedTime} ${unit}`
+    const reason = description ? `${description} (est. ${est})` : `Intervention (est. ${est})`
+    onStart({ user, reason, estimatedTime: est })
+    setUser('')
+    setDescription('')
+    setEstimatedTime('30')
+    setUnit('minutes')
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={closeModal} size='lg'>
+      <ModalOverlay />
+      <ModalContent className={theme === 'light' ? parentStyles.modalLightContent : parentStyles.modalDarkContent}>
+        <ModalHeader fontSize='md'>Start Intervention — all notifications will be silenced</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody pb={4}>
+          <FormControl mb={3}>
+            <FormLabel fontSize='sm'>Operator name</FormLabel>
+            <Input
+              size='sm'
+              placeholder='Who is performing the intervention'
+              value={user}
+              onChange={(e) => setUser(e.target.value)}
+            />
+          </FormControl>
+          <FormControl mb={3} isRequired>
+            <FormLabel fontSize='sm'>Description</FormLabel>
+            <Textarea
+              size='sm'
+              placeholder='What are you doing? (e.g. rolling restart for v3.1.25, config change, DB upgrade)'
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+            />
+          </FormControl>
+          <FormControl>
+            <FormLabel fontSize='sm'>Estimated duration</FormLabel>
+            <HStack>
+              <Input
+                size='sm'
+                type='number'
+                width='100px'
+                value={estimatedTime}
+                onChange={(e) => setEstimatedTime(e.target.value)}
+              />
+              <Select size='sm' width='130px' value={unit} onChange={(e) => setUnit(e.target.value)}>
+                <option value='minutes'>minutes</option>
+                <option value='hours'>hours</option>
+              </Select>
+            </HStack>
+          </FormControl>
+        </ModalBody>
+        <ModalFooter>
+          <RMButton onClick={closeModal} mr={3}>Cancel</RMButton>
+          <RMButton
+            colorScheme='orange'
+            onClick={handleStart}
+            isDisabled={!description}
+          >
+            Start Intervention
+          </RMButton>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export default InterventionModal

--- a/share/dashboard_react/src/components/Modals/InterventionModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/InterventionModal/index.jsx
@@ -1,6 +1,6 @@
 import {
   Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalCloseButton, ModalFooter,
-  FormControl, FormLabel, Input, Textarea, Select, HStack
+  FormControl, FormLabel, Textarea, Select, HStack, Input
 } from '@chakra-ui/react'
 import React, { useState } from 'react'
 import RMButton from '../../RMButton'

--- a/share/dashboard_react/src/components/Modals/InterventionModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/InterventionModal/index.jsx
@@ -9,7 +9,6 @@ import parentStyles from '../styles.module.scss'
 
 function InterventionModal({ isOpen, closeModal, onStart }) {
   const { theme } = useTheme()
-  const [user, setUser] = useState('')
   const [description, setDescription] = useState('')
   const [estimatedTime, setEstimatedTime] = useState('30')
   const [unit, setUnit] = useState('minutes')
@@ -17,8 +16,7 @@ function InterventionModal({ isOpen, closeModal, onStart }) {
   const handleStart = () => {
     const est = `${estimatedTime} ${unit}`
     const reason = description ? `${description} (est. ${est})` : `Intervention (est. ${est})`
-    onStart({ user, reason, estimatedTime: est })
-    setUser('')
+    onStart({ reason, estimatedTime: est })
     setDescription('')
     setEstimatedTime('30')
     setUnit('minutes')
@@ -31,15 +29,6 @@ function InterventionModal({ isOpen, closeModal, onStart }) {
         <ModalHeader fontSize='md'>Start Intervention — all notifications will be silenced</ModalHeader>
         <ModalCloseButton />
         <ModalBody pb={4}>
-          <FormControl mb={3}>
-            <FormLabel fontSize='sm'>Operator name</FormLabel>
-            <Input
-              size='sm'
-              placeholder='Who is performing the intervention'
-              value={user}
-              onChange={(e) => setUser(e.target.value)}
-            />
-          </FormControl>
           <FormControl mb={3} isRequired>
             <FormLabel fontSize='sm'>Description</FormLabel>
             <Textarea

--- a/share/dashboard_react/src/components/Modals/InterventionModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/InterventionModal/index.jsx
@@ -1,6 +1,6 @@
 import {
   Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalCloseButton, ModalFooter,
-  FormControl, FormLabel, Textarea, Select, HStack, Input
+  FormControl, FormLabel, Textarea, Select, HStack, Input, Checkbox
 } from '@chakra-ui/react'
 import React, { useState } from 'react'
 import RMButton from '../../RMButton'
@@ -12,14 +12,34 @@ function InterventionModal({ isOpen, closeModal, onStart }) {
   const [description, setDescription] = useState('')
   const [estimatedTime, setEstimatedTime] = useState('30')
   const [unit, setUnit] = useState('minutes')
+  const [autoUnmute, setAutoUnmute] = useState(true)
+
+  // Default start time: now, formatted for datetime-local input
+  const nowLocal = () => {
+    const d = new Date()
+    d.setMinutes(d.getMinutes() - d.getTimezoneOffset())
+    return d.toISOString().slice(0, 16)
+  }
+  const [startTime, setStartTime] = useState(nowLocal())
 
   const handleStart = () => {
     const est = `${estimatedTime} ${unit}`
     const reason = description ? `${description} (est. ${est})` : `Intervention (est. ${est})`
-    onStart({ reason, estimatedTime: est })
+    const startAt = new Date(startTime).toISOString()
+    let endAt = ''
+    if (autoUnmute) {
+      const start = new Date(startTime)
+      const durationMs = unit === 'hours'
+        ? parseInt(estimatedTime) * 60 * 60 * 1000
+        : parseInt(estimatedTime) * 60 * 1000
+      endAt = new Date(start.getTime() + durationMs).toISOString()
+    }
+    onStart({ reason, startAt, endAt, autoUnmute })
     setDescription('')
     setEstimatedTime('30')
     setUnit('minutes')
+    setAutoUnmute(true)
+    setStartTime(nowLocal())
   }
 
   return (
@@ -39,7 +59,17 @@ function InterventionModal({ isOpen, closeModal, onStart }) {
               rows={3}
             />
           </FormControl>
-          <FormControl>
+          <FormControl mb={3}>
+            <FormLabel fontSize='sm'>Start time</FormLabel>
+            <Input
+              size='sm'
+              type='datetime-local'
+              width='250px'
+              value={startTime}
+              onChange={(e) => setStartTime(e.target.value)}
+            />
+          </FormControl>
+          <FormControl mb={3}>
             <FormLabel fontSize='sm'>Estimated duration</FormLabel>
             <HStack>
               <Input
@@ -55,6 +85,15 @@ function InterventionModal({ isOpen, closeModal, onStart }) {
               </Select>
             </HStack>
           </FormControl>
+          <FormControl>
+            <Checkbox
+              isChecked={autoUnmute}
+              onChange={(e) => setAutoUnmute(e.target.checked)}
+              size='sm'
+            >
+              Auto-unmute after estimated duration
+            </Checkbox>
+          </FormControl>
         </ModalBody>
         <ModalFooter>
           <RMButton onClick={closeModal} mr={3}>Cancel</RMButton>
@@ -63,7 +102,7 @@ function InterventionModal({ isOpen, closeModal, onStart }) {
             onClick={handleStart}
             isDisabled={!description}
           >
-            Start Intervention
+            {new Date(startTime) > new Date() ? 'Schedule Intervention' : 'Start Intervention'}
           </RMButton>
         </ModalFooter>
       </ModalContent>

--- a/share/dashboard_react/src/components/Modals/InterventionPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/InterventionPanel/index.jsx
@@ -8,7 +8,7 @@ import InterventionModal from '../InterventionModal'
 import { useTheme } from '../../../ThemeProvider'
 import parentStyles from '../styles.module.scss'
 
-function InterventionPanel({ isOpen, closeModal, isGlobal = false, isActive, current, history = [], suppressedAlerts = 0, activeCount = 0, onStart, onEnd }) {
+function InterventionPanel({ isOpen, closeModal, isGlobal = false, isActive, isPending = false, current, history = [], suppressedAlerts = 0, activeCount = 0, onStart, onEnd }) {
   const { theme } = useTheme()
   const [isNewModalOpen, setIsNewModalOpen] = useState(false)
 
@@ -51,7 +51,28 @@ function InterventionPanel({ isOpen, closeModal, isGlobal = false, isActive, cur
                 </Box>
               )}
 
-              {isActive && current && (
+              {isPending && current && (
+                <Box p={3} borderRadius='md' border='1px solid' borderColor='blue.400' bg={theme === 'light' ? 'blue.50' : 'rgba(66,153,225,0.1)'}>
+                  <Flex justify='space-between' align='center' mb={2}>
+                    <HStack>
+                      <Badge colorScheme='blue'>Scheduled</Badge>
+                      <Text fontSize='sm' fontWeight={600}>{current.reason}</Text>
+                    </HStack>
+                    <RMButton size='xs' colorScheme='red' onClick={onEnd}>
+                      Cancel
+                    </RMButton>
+                  </Flex>
+                  <HStack spacing={4} fontSize='xs' color={theme === 'light' ? 'gray.600' : 'gray.400'}>
+                    <Text>By: {current.user}</Text>
+                    <Text>Starts at: {formatTime(current.scheduledAt)}</Text>
+                    {current.autoEndAt && current.autoEndAt !== '0001-01-01T00:00:00Z' && (
+                      <Text>Auto-unmute: {formatTime(current.autoEndAt)}</Text>
+                    )}
+                  </HStack>
+                </Box>
+              )}
+
+              {isActive && !isPending && current && (
                 <Box p={3} borderRadius='md' border='1px solid' borderColor='orange.400' bg={theme === 'light' ? 'orange.50' : 'rgba(237,137,54,0.1)'}>
                   <Flex justify='space-between' align='center' mb={2}>
                     <HStack>
@@ -71,7 +92,7 @@ function InterventionPanel({ isOpen, closeModal, isGlobal = false, isActive, cur
                 </Box>
               )}
 
-              {!isActive && (
+              {!isActive && !isPending && (
                 <RMButton colorScheme='orange' onClick={() => setIsNewModalOpen(true)}>
                   Start Intervention
                 </RMButton>

--- a/share/dashboard_react/src/components/Modals/InterventionPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/InterventionPanel/index.jsx
@@ -1,0 +1,114 @@
+import {
+  Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalCloseButton,
+  Box, VStack, HStack, Text, Badge, Divider, Flex
+} from '@chakra-ui/react'
+import React, { useState } from 'react'
+import RMButton from '../../RMButton'
+import InterventionModal from '../InterventionModal'
+import { useTheme } from '../../../ThemeProvider'
+import parentStyles from '../styles.module.scss'
+
+function InterventionPanel({ isOpen, closeModal, isActive, current, history = [], suppressedAlerts = 0, onStart, onEnd }) {
+  const { theme } = useTheme()
+  const [isNewModalOpen, setIsNewModalOpen] = useState(false)
+
+  const formatDuration = (start, end) => {
+    const s = new Date(start)
+    const e = end ? new Date(end) : new Date()
+    const diffMs = e - s
+    const mins = Math.floor(diffMs / 60000)
+    const hrs = Math.floor(mins / 60)
+    if (hrs > 0) return `${hrs}h ${mins % 60}m`
+    return `${mins}m`
+  }
+
+  const formatTime = (t) => {
+    if (!t) return '-'
+    return new Date(t).toLocaleString()
+  }
+
+  return (
+    <>
+      <Modal isOpen={isOpen} onClose={closeModal} size='lg'>
+        <ModalOverlay />
+        <ModalContent className={theme === 'light' ? parentStyles.modalLightContent : parentStyles.modalDarkContent}>
+          <ModalHeader fontSize='md'>Interventions</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody pb={6}>
+            <VStack align='stretch' spacing={4}>
+
+              {isActive && current && (
+                <Box p={3} borderRadius='md' border='1px solid' borderColor='orange.400' bg={theme === 'light' ? 'orange.50' : 'rgba(237,137,54,0.1)'}>
+                  <Flex justify='space-between' align='center' mb={2}>
+                    <HStack>
+                      <Badge colorScheme='orange'>Active</Badge>
+                      <Text fontSize='sm' fontWeight={600}>{current.reason}</Text>
+                    </HStack>
+                    <RMButton size='xs' colorScheme='red' onClick={onEnd}>
+                      Close
+                    </RMButton>
+                  </Flex>
+                  <HStack spacing={4} fontSize='xs' color={theme === 'light' ? 'gray.600' : 'gray.400'}>
+                    <Text>By: {current.user}</Text>
+                    <Text>Started: {formatTime(current.startedAt)}</Text>
+                    <Text>Duration: {formatDuration(current.startedAt)}</Text>
+                    <Text>Suppressed: {suppressedAlerts}</Text>
+                  </HStack>
+                </Box>
+              )}
+
+              {!isActive && (
+                <RMButton colorScheme='orange' onClick={() => setIsNewModalOpen(true)}>
+                  Start Intervention
+                </RMButton>
+              )}
+
+              {history.length > 0 && (
+                <>
+                  <Divider />
+                  <Text fontSize='sm' fontWeight={600} color={theme === 'light' ? 'gray.600' : 'gray.400'}>
+                    History ({history.length})
+                  </Text>
+                  <VStack align='stretch' spacing={2} maxH='300px' overflowY='auto'>
+                    {[...history].reverse().map((entry, i) => (
+                      <Box key={i} p={2} borderRadius='md' bg={theme === 'light' ? 'gray.50' : 'rgba(255,255,255,0.05)'} fontSize='xs'>
+                        <Text fontWeight={600} mb={1}>{entry.reason}</Text>
+                        <HStack spacing={3} color={theme === 'light' ? 'gray.500' : 'gray.500'}>
+                          <Text>By: {entry.user}</Text>
+                          <Text>{formatTime(entry.startedAt)}</Text>
+                          <Text>{formatDuration(entry.startedAt, entry.endedAt)}</Text>
+                          <Text>Suppressed: {entry.suppressedAlerts || 0}</Text>
+                          {entry.scope === 'global' && <Badge size='sm' colorScheme='purple'>Global</Badge>}
+                        </HStack>
+                      </Box>
+                    ))}
+                  </VStack>
+                </>
+              )}
+
+              {!isActive && history.length === 0 && (
+                <Text fontSize='sm' color={theme === 'light' ? 'gray.500' : 'gray.500'} textAlign='center' py={4}>
+                  No interventions recorded
+                </Text>
+              )}
+
+            </VStack>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+
+      {isNewModalOpen && (
+        <InterventionModal
+          isOpen={isNewModalOpen}
+          closeModal={() => setIsNewModalOpen(false)}
+          onStart={({ reason }) => {
+            onStart(reason)
+            setIsNewModalOpen(false)
+          }}
+        />
+      )}
+    </>
+  )
+}
+
+export default InterventionPanel

--- a/share/dashboard_react/src/components/Modals/InterventionPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/InterventionPanel/index.jsx
@@ -8,7 +8,7 @@ import InterventionModal from '../InterventionModal'
 import { useTheme } from '../../../ThemeProvider'
 import parentStyles from '../styles.module.scss'
 
-function InterventionPanel({ isOpen, closeModal, isActive, current, history = [], suppressedAlerts = 0, onStart, onEnd }) {
+function InterventionPanel({ isOpen, closeModal, isGlobal = false, isActive, current, history = [], suppressedAlerts = 0, activeCount = 0, onStart, onEnd }) {
   const { theme } = useTheme()
   const [isNewModalOpen, setIsNewModalOpen] = useState(false)
 
@@ -37,15 +37,29 @@ function InterventionPanel({ isOpen, closeModal, isActive, current, history = []
           <ModalBody pb={6}>
             <VStack align='stretch' spacing={4}>
 
+              {isGlobal && activeCount > 0 && !current && (
+                <Box p={3} borderRadius='md' border='1px solid' borderColor='orange.400' bg={theme === 'light' ? 'orange.50' : 'rgba(237,137,54,0.1)'}>
+                  <Flex justify='space-between' align='center'>
+                    <HStack>
+                      <Badge colorScheme='orange'>{activeCount} Active</Badge>
+                      <Text fontSize='sm'>{activeCount} cluster{activeCount > 1 ? 's' : ''} in intervention</Text>
+                    </HStack>
+                    <RMButton size='xs' colorScheme='red' onClick={onEnd}>
+                      Close All
+                    </RMButton>
+                  </Flex>
+                </Box>
+              )}
+
               {isActive && current && (
                 <Box p={3} borderRadius='md' border='1px solid' borderColor='orange.400' bg={theme === 'light' ? 'orange.50' : 'rgba(237,137,54,0.1)'}>
                   <Flex justify='space-between' align='center' mb={2}>
                     <HStack>
-                      <Badge colorScheme='orange'>Active</Badge>
+                      <Badge colorScheme='orange'>{isGlobal && activeCount > 1 ? `${activeCount} Active` : 'Active'}</Badge>
                       <Text fontSize='sm' fontWeight={600}>{current.reason}</Text>
                     </HStack>
                     <RMButton size='xs' colorScheme='red' onClick={onEnd}>
-                      Close
+                      {isGlobal ? 'Close All' : 'Close'}
                     </RMButton>
                   </Flex>
                   <HStack spacing={4} fontSize='xs' color={theme === 'light' ? 'gray.600' : 'gray.400'}>

--- a/share/dashboard_react/src/components/Modals/InterventionPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/InterventionPanel/index.jsx
@@ -81,10 +81,10 @@ function InterventionPanel({ isOpen, closeModal, isGlobal = false, isActive, cur
                 <>
                   <Divider />
                   <Text fontSize='sm' fontWeight={600} color={theme === 'light' ? 'gray.600' : 'gray.400'}>
-                    History ({history.length})
+                    Last interventions
                   </Text>
                   <VStack align='stretch' spacing={2} maxH='300px' overflowY='auto'>
-                    {[...history].reverse().map((entry, i) => (
+                    {[...history].reverse().slice(0, 5).map((entry, i) => (
                       <Box key={i} p={2} borderRadius='md' bg={theme === 'light' ? 'gray.50' : 'rgba(255,255,255,0.05)'} fontSize='xs'>
                         <Text fontWeight={600} mb={1}>{entry.reason}</Text>
                         <HStack spacing={3} color={theme === 'light' ? 'gray.500' : 'gray.500'}>

--- a/share/dashboard_react/src/components/Modals/InterventionPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/InterventionPanel/index.jsx
@@ -66,7 +66,7 @@ function InterventionPanel({ isOpen, closeModal, isGlobal = false, isActive, cur
                     <Text>By: {current.user}</Text>
                     <Text>Started: {formatTime(current.startedAt)}</Text>
                     <Text>Duration: {formatDuration(current.startedAt)}</Text>
-                    <Text>Suppressed: {suppressedAlerts}</Text>
+                    <Text>{suppressedAlerts} blocked notification{suppressedAlerts !== 1 ? 's' : ''}</Text>
                   </HStack>
                 </Box>
               )}
@@ -91,7 +91,7 @@ function InterventionPanel({ isOpen, closeModal, isGlobal = false, isActive, cur
                           <Text>By: {entry.user}</Text>
                           <Text>{formatTime(entry.startedAt)}</Text>
                           <Text>{formatDuration(entry.startedAt, entry.endedAt)}</Text>
-                          <Text>Suppressed: {entry.suppressedAlerts || 0}</Text>
+                          <Text>{entry.suppressedAlerts || 0} blocked</Text>
                           {entry.scope === 'global' && <Badge size='sm' colorScheme='purple'>Global</Badge>}
                         </HStack>
                       </Box>

--- a/share/dashboard_react/src/components/Modals/InterventionPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/InterventionPanel/index.jsx
@@ -115,8 +115,8 @@ function InterventionPanel({ isOpen, closeModal, isGlobal = false, isActive, cur
         <InterventionModal
           isOpen={isNewModalOpen}
           closeModal={() => setIsNewModalOpen(false)}
-          onStart={({ reason }) => {
-            onStart(reason)
+          onStart={({ reason, startAt, endAt }) => {
+            onStart(reason, startAt, endAt)
             setIsNewModalOpen(false)
           }}
         />

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -12,7 +12,7 @@ import AlertModal from '../Modals/AlertModal'
 import SecurityScoreModal from '../Modals/SecurityScoreModal'
 import WorkloadModal from '../Modals/WorkloadModal'
 import { FaPowerOff, FaUserPlus } from 'react-icons/fa'
-import { MdSecurity, MdConstruction } from 'react-icons/md'
+import { MdSecurity, MdWarningAmber } from 'react-icons/md'
 import { RiSpeedFill } from 'react-icons/ri'
 import ConfirmModal from '../Modals/ConfirmModal'
 import InterventionPanel from '../Modals/InterventionPanel'
@@ -166,7 +166,7 @@ function Navbar({ username }) {
               />
               <AlertBadge
                 colorScheme={monitor?.activeInterventionCount > 0 ? 'red' : 'teal'}
-                icon={MdConstruction}
+                icon={MdWarningAmber}
                 text={monitor?.activeInterventionCount > 0 ? 'Muted' : 'Mute'}
                 count={monitor?.activeInterventionCount || ''}
                 onClick={() => setIsInterventionPanelOpen(true)}
@@ -215,7 +215,7 @@ function Navbar({ username }) {
               />
               <AlertBadge
                 colorScheme={clusterData?.isIntervention ? 'red' : 'teal'}
-                icon={MdConstruction}
+                icon={MdWarningAmber}
                 text={clusterData?.isIntervention ? 'Muted' : 'Mute'}
                 count={clusterData?.interventionSuppressedAlerts || ''}
                 onClick={() => setIsInterventionPanelOpen(true)}

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -12,7 +12,7 @@ import AlertModal from '../Modals/AlertModal'
 import SecurityScoreModal from '../Modals/SecurityScoreModal'
 import WorkloadModal from '../Modals/WorkloadModal'
 import { FaPowerOff, FaUserPlus } from 'react-icons/fa'
-import { MdSecurity, MdWarningAmber } from 'react-icons/md'
+import { MdSecurity, MdNotificationsOff } from 'react-icons/md'
 import { RiSpeedFill } from 'react-icons/ri'
 import ConfirmModal from '../Modals/ConfirmModal'
 import InterventionPanel from '../Modals/InterventionPanel'
@@ -166,7 +166,7 @@ function Navbar({ username }) {
               />
               <AlertBadge
                 colorScheme={monitor?.activeInterventionCount > 0 ? 'red' : 'teal'}
-                icon={MdWarningAmber}
+                icon={MdNotificationsOff}
                 text={monitor?.activeInterventionCount > 0 ? 'Muted' : 'Mute'}
                 count={monitor?.activeInterventionCount || ''}
                 onClick={() => setIsInterventionPanelOpen(true)}
@@ -215,7 +215,7 @@ function Navbar({ username }) {
               />
               <AlertBadge
                 colorScheme={clusterData?.isIntervention ? 'red' : 'teal'}
-                icon={MdWarningAmber}
+                icon={MdNotificationsOff}
                 text={clusterData?.isIntervention ? 'Muted' : 'Mute'}
                 count={clusterData?.interventionSuppressedAlerts || ''}
                 onClick={() => setIsInterventionPanelOpen(true)}

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -17,6 +17,7 @@ import { RiSpeedFill } from 'react-icons/ri'
 import ConfirmModal from '../Modals/ConfirmModal'
 import InterventionModal from '../Modals/InterventionModal'
 import { clusterService } from '../../services/clusterService'
+import { getApi } from '../../services/apiHelper'
 import styles from './styles.module.scss'
 import RMButton from '../RMButton'
 import RMIconButton from '../RMIconButton'
@@ -164,6 +165,21 @@ function Navbar({ username }) {
                 onClick={() => setGlobalAlertModalType('warning')}
                 showText={!isMobile}
               />
+              <AlertBadge
+                colorScheme={monitor?.isGlobalIntervention ? 'orange' : 'gray'}
+                icon={FaTools}
+                text={monitor?.isGlobalIntervention ? 'INTERVENTION' : 'Intervene'}
+                count={monitor?.isGlobalIntervention ? '' : ''}
+                onClick={() => {
+                  if (monitor?.isGlobalIntervention) {
+                    setIsEndInterventionModalOpen(true)
+                  } else {
+                    setIsInterventionModalOpen(true)
+                  }
+                }}
+                showText={!isMobile}
+                blink={monitor?.isGlobalIntervention}
+              />
             </Flex>
           )}
 
@@ -208,7 +224,7 @@ function Navbar({ username }) {
                 colorScheme={clusterData?.isIntervention ? 'orange' : 'gray'}
                 icon={FaTools}
                 text={clusterData?.isIntervention ? 'INTERVENTION' : 'Intervene'}
-                count={clusterData?.interventionSuppressedAlerts || 0}
+                count={clusterData?.interventionSuppressedAlerts || ''}
                 onClick={() => {
                   if (clusterData?.isIntervention) {
                     setIsEndInterventionModalOpen(true)
@@ -298,7 +314,10 @@ function Navbar({ username }) {
           isOpen={isInterventionModalOpen}
           closeModal={() => setIsInterventionModalOpen(false)}
           onStart={({ reason }) => {
-            clusterService.startIntervention(clusterData?.name, reason, baseURL)
+            const api = clusterData
+              ? clusterService.startIntervention(clusterData.name, reason, baseURL)
+              : getApi(baseURL).post('actions/intervention-start', { reason })
+            api
               .then(() => setIsInterventionModalOpen(false))
               .catch((err) => console.error('Failed to start intervention:', err))
           }}
@@ -308,9 +327,14 @@ function Navbar({ username }) {
         <ConfirmModal
           isOpen={isEndInterventionModalOpen}
           closeModal={() => setIsEndInterventionModalOpen(false)}
-          title={`End intervention? (${clusterData?.interventionCurrent?.reason || 'active'}) — ${clusterData?.interventionSuppressedAlerts || 0} alerts suppressed`}
+          title={clusterData
+            ? `End intervention? (${clusterData?.interventionCurrent?.reason || 'active'}) — ${clusterData?.interventionSuppressedAlerts || 0} alerts suppressed`
+            : `End global intervention? (${monitor?.globalInterventionEntry?.reason || 'active'}) — all clusters will resume notifications`}
           onConfirmClick={() => {
-            clusterService.endIntervention(clusterData?.name, baseURL)
+            const api = clusterData
+              ? clusterService.endIntervention(clusterData.name, baseURL)
+              : getApi(baseURL).post('actions/intervention-end')
+            api
               .then(() => setIsEndInterventionModalOpen(false))
               .catch((err) => console.error('Failed to end intervention:', err))
           }}

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -15,7 +15,7 @@ import { FaPowerOff, FaUserPlus, FaTools } from 'react-icons/fa'
 import { MdSecurity } from 'react-icons/md'
 import { RiSpeedFill } from 'react-icons/ri'
 import ConfirmModal from '../Modals/ConfirmModal'
-import InterventionModal from '../Modals/InterventionModal'
+import InterventionPanel from '../Modals/InterventionPanel'
 import { clusterService } from '../../services/clusterService'
 import { getApi } from '../../services/apiHelper'
 import styles from './styles.module.scss'
@@ -37,8 +37,7 @@ function Navbar({ username }) {
   const [isSecurityModalOpen, setIsSecurityModalOpen] = useState(false)
   const [isWorkloadModalOpen, setIsWorkloadModalOpen] = useState(false)
   const [isAddUserModalOpen, setIsAddUserModalOpen] = useState(false)
-  const [isInterventionModalOpen, setIsInterventionModalOpen] = useState(false)
-  const [isEndInterventionModalOpen, setIsEndInterventionModalOpen] = useState(false)
+  const [isInterventionPanelOpen, setIsInterventionPanelOpen] = useState(false)
   const [unreadMessagesCount, setUnreadMessagesCount] = useState(0)
   const [isChatOpen, setIsChatOpen] = useState(() => { return localStorage.getItem('chatOpen') === 'true'; });
   const [showImageLogo, setShowImageLogo] = useState(true)
@@ -168,15 +167,9 @@ function Navbar({ username }) {
               <AlertBadge
                 colorScheme={monitor?.isGlobalIntervention ? 'orange' : 'gray'}
                 icon={FaTools}
-                text={monitor?.isGlobalIntervention ? 'MUTED' : 'Mute'}
+                text={monitor?.isGlobalIntervention ? 'Muted' : 'Mute'}
                 count={monitor?.isGlobalIntervention ? '' : ''}
-                onClick={() => {
-                  if (monitor?.isGlobalIntervention) {
-                    setIsEndInterventionModalOpen(true)
-                  } else {
-                    setIsInterventionModalOpen(true)
-                  }
-                }}
+                onClick={() => setIsInterventionPanelOpen(true)}
                 showText={!isMobile}
                 blink={monitor?.isGlobalIntervention}
               />
@@ -223,15 +216,9 @@ function Navbar({ username }) {
               <AlertBadge
                 colorScheme={clusterData?.isIntervention ? 'orange' : 'gray'}
                 icon={FaTools}
-                text={clusterData?.isIntervention ? 'MUTED' : 'Mute'}
+                text={clusterData?.isIntervention ? 'Muted' : 'Mute'}
                 count={clusterData?.interventionSuppressedAlerts || ''}
-                onClick={() => {
-                  if (clusterData?.isIntervention) {
-                    setIsEndInterventionModalOpen(true)
-                  } else {
-                    setIsInterventionModalOpen(true)
-                  }
-                }}
+                onClick={() => setIsInterventionPanelOpen(true)}
                 showText={!isMobile}
                 blink={clusterData?.isIntervention}
               />
@@ -309,34 +296,25 @@ function Navbar({ username }) {
       {isWorkloadModalOpen && (
         <WorkloadModal isOpen={isWorkloadModalOpen} closeModal={() => setIsWorkloadModalOpen(false)} />
       )}
-      {isInterventionModalOpen && (
-        <InterventionModal
-          isOpen={isInterventionModalOpen}
-          closeModal={() => setIsInterventionModalOpen(false)}
-          onStart={({ reason }) => {
+      {isInterventionPanelOpen && (
+        <InterventionPanel
+          isOpen={isInterventionPanelOpen}
+          closeModal={() => setIsInterventionPanelOpen(false)}
+          isActive={clusterData ? clusterData?.isIntervention : monitor?.isGlobalIntervention}
+          current={clusterData ? clusterData?.interventionCurrent : monitor?.globalInterventionEntry}
+          history={clusterData ? (clusterData?.interventionHistory || []) : []}
+          suppressedAlerts={clusterData ? (clusterData?.interventionSuppressedAlerts || 0) : 0}
+          onStart={(reason) => {
             const api = clusterData
               ? clusterService.startIntervention(clusterData.name, reason, baseURL)
               : getApi(baseURL).post('actions/intervention-start', { reason })
-            api
-              .then(() => setIsInterventionModalOpen(false))
-              .catch((err) => console.error('Failed to start intervention:', err))
+            api.catch((err) => console.error('Failed to start intervention:', err))
           }}
-        />
-      )}
-      {isEndInterventionModalOpen && (
-        <ConfirmModal
-          isOpen={isEndInterventionModalOpen}
-          closeModal={() => setIsEndInterventionModalOpen(false)}
-          title={clusterData
-            ? `End intervention? (${clusterData?.interventionCurrent?.reason || 'active'}) — ${clusterData?.interventionSuppressedAlerts || 0} alerts suppressed`
-            : `End global intervention? (${monitor?.globalInterventionEntry?.reason || 'active'}) — all clusters will resume notifications`}
-          onConfirmClick={() => {
+          onEnd={() => {
             const api = clusterData
               ? clusterService.endIntervention(clusterData.name, baseURL)
               : getApi(baseURL).post('actions/intervention-end')
-            api
-              .then(() => setIsEndInterventionModalOpen(false))
-              .catch((err) => console.error('Failed to end intervention:', err))
+            api.catch((err) => console.error('Failed to end intervention:', err))
           }}
         />
       )}

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -297,8 +297,8 @@ function Navbar({ username }) {
         <InterventionModal
           isOpen={isInterventionModalOpen}
           closeModal={() => setIsInterventionModalOpen(false)}
-          onStart={({ user, reason }) => {
-            clusterService.startIntervention(clusterData?.name, reason, baseURL, user)
+          onStart={({ reason }) => {
+            clusterService.startIntervention(clusterData?.name, reason, baseURL)
               .then(() => setIsInterventionModalOpen(false))
               .catch((err) => console.error('Failed to start intervention:', err))
           }}

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -11,8 +11,8 @@ import AlertBadge from '../AlertBadge'
 import AlertModal from '../Modals/AlertModal'
 import SecurityScoreModal from '../Modals/SecurityScoreModal'
 import WorkloadModal from '../Modals/WorkloadModal'
-import { FaPowerOff, FaUserPlus, FaTools } from 'react-icons/fa'
-import { MdSecurity } from 'react-icons/md'
+import { FaPowerOff, FaUserPlus } from 'react-icons/fa'
+import { MdSecurity, MdConstruction } from 'react-icons/md'
 import { RiSpeedFill } from 'react-icons/ri'
 import ConfirmModal from '../Modals/ConfirmModal'
 import InterventionPanel from '../Modals/InterventionPanel'
@@ -165,8 +165,8 @@ function Navbar({ username }) {
                 showText={!isMobile}
               />
               <AlertBadge
-                colorScheme={monitor?.activeInterventionCount > 0 ? 'orange' : 'gray'}
-                icon={FaTools}
+                colorScheme={monitor?.activeInterventionCount > 0 ? 'red' : 'teal'}
+                icon={MdConstruction}
                 text={monitor?.activeInterventionCount > 0 ? 'Muted' : 'Mute'}
                 count={monitor?.activeInterventionCount || ''}
                 onClick={() => setIsInterventionPanelOpen(true)}
@@ -214,8 +214,8 @@ function Navbar({ username }) {
                 showText={!isMobile}
               />
               <AlertBadge
-                colorScheme={clusterData?.isIntervention ? 'orange' : 'gray'}
-                icon={FaTools}
+                colorScheme={clusterData?.isIntervention ? 'red' : 'teal'}
+                icon={MdConstruction}
                 text={clusterData?.isIntervention ? 'Muted' : 'Mute'}
                 count={clusterData?.interventionSuppressedAlerts || ''}
                 onClick={() => setIsInterventionPanelOpen(true)}

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -15,7 +15,7 @@ import { FaPowerOff, FaUserPlus, FaTools } from 'react-icons/fa'
 import { MdSecurity } from 'react-icons/md'
 import { RiSpeedFill } from 'react-icons/ri'
 import ConfirmModal from '../Modals/ConfirmModal'
-import TextInputModal from '../Modals/TextInputModal'
+import InterventionModal from '../Modals/InterventionModal'
 import styles from './styles.module.scss'
 import RMButton from '../RMButton'
 import RMIconButton from '../RMIconButton'
@@ -294,13 +294,11 @@ function Navbar({ username }) {
         <WorkloadModal isOpen={isWorkloadModalOpen} closeModal={() => setIsWorkloadModalOpen(false)} />
       )}
       {isInterventionModalOpen && (
-        <TextInputModal
+        <InterventionModal
           isOpen={isInterventionModalOpen}
           closeModal={() => setIsInterventionModalOpen(false)}
-          title='Start Intervention — all notifications will be silenced'
-          fieldname='Reason (e.g. rolling restart, upgrade, config change)'
-          onSave={(reason) => {
-            clusterService.startIntervention(clusterData?.name, reason, baseURL)
+          onStart={({ user, reason }) => {
+            clusterService.startIntervention(clusterData?.name, reason, baseURL, user)
               .then(() => setIsInterventionModalOpen(false))
               .catch((err) => console.error('Failed to start intervention:', err))
           }}

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -306,10 +306,10 @@ function Navbar({ username }) {
           history={clusterData ? (clusterData?.interventionHistory || []) : []}
           suppressedAlerts={clusterData ? (clusterData?.interventionSuppressedAlerts || 0) : 0}
           activeCount={!clusterData ? (monitor?.activeInterventionCount || 0) : 0}
-          onStart={(reason) => {
+          onStart={(reason, startAt, endAt) => {
             const api = clusterData
-              ? clusterService.startIntervention(clusterData.name, reason, baseURL)
-              : getApi(baseURL).post('actions/intervention-start', { reason })
+              ? clusterService.startIntervention(clusterData.name, reason, baseURL, startAt, endAt)
+              : getApi(baseURL).post('actions/intervention-start', { reason, startAt, endAt })
             api.catch((err) => console.error('Failed to start intervention:', err))
           }}
           onEnd={() => {

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -165,9 +165,9 @@ function Navbar({ username }) {
                 showText={!isMobile}
               />
               <AlertBadge
-                colorScheme={monitor?.activeInterventionCount > 0 ? 'red' : 'teal'}
+                colorScheme={monitor?.activeInterventionCount > 0 ? 'red' : monitor?.isGlobalInterventionPending ? 'orange' : 'teal'}
                 icon={MdNotificationsOff}
-                text={monitor?.activeInterventionCount > 0 ? 'Muted' : 'Mute'}
+                text={monitor?.activeInterventionCount > 0 ? 'Muted' : monitor?.isGlobalInterventionPending ? 'Scheduled' : 'Mute'}
                 count={monitor?.activeInterventionCount || ''}
                 onClick={() => setIsInterventionPanelOpen(true)}
                 showText={!isMobile}
@@ -301,8 +301,9 @@ function Navbar({ username }) {
           isOpen={isInterventionPanelOpen}
           closeModal={() => setIsInterventionPanelOpen(false)}
           isGlobal={!clusterData}
-          isActive={clusterData ? clusterData?.isIntervention : (monitor?.activeInterventionCount > 0)}
+          isActive={clusterData ? clusterData?.isIntervention : (monitor?.activeInterventionCount > 0 || monitor?.isGlobalInterventionPending)}
           current={clusterData ? clusterData?.interventionCurrent : monitor?.globalInterventionEntry}
+          isPending={!clusterData && monitor?.isGlobalInterventionPending && !monitor?.isGlobalIntervention}
           history={clusterData ? (clusterData?.interventionHistory || []) : []}
           suppressedAlerts={clusterData ? (clusterData?.interventionSuppressedAlerts || 0) : 0}
           activeCount={!clusterData ? (monitor?.activeInterventionCount || 0) : 0}

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -16,12 +16,12 @@ import { MdSecurity } from 'react-icons/md'
 import { RiSpeedFill } from 'react-icons/ri'
 import ConfirmModal from '../Modals/ConfirmModal'
 import InterventionModal from '../Modals/InterventionModal'
+import { clusterService } from '../../services/clusterService'
 import styles from './styles.module.scss'
 import RMButton from '../RMButton'
 import RMIconButton from '../RMIconButton'
 import { useTheme } from '../../ThemeProvider'
 import AddUserModal from '../Modals/AddUserModal'
-import { clusterService } from '../../services/clusterService'
 import MattermostIntegration from '../../Pages/Mattermost';
 import { getMeetInfo, logoutFromMeet } from '../../redux/meetSlice';
 import { selectMeetUIState } from '../../redux/memoize'

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -26,7 +26,7 @@ import AddUserModal from '../Modals/AddUserModal'
 import MattermostIntegration from '../../Pages/Mattermost';
 import { getMeetInfo, logoutFromMeet } from '../../redux/meetSlice';
 import { selectMeetUIState } from '../../redux/memoize'
-import { clearClusters } from '../../redux/globalClustersSlice'
+import { clearClusters, getMonitoredData } from '../../redux/globalClustersSlice'
 
 function Navbar({ username }) {
   const dispatch = useDispatch()
@@ -311,13 +311,13 @@ function Navbar({ username }) {
             const api = clusterData
               ? clusterService.startIntervention(clusterData.name, reason, baseURL, startAt, endAt)
               : getApi(baseURL).post('actions/intervention-start', { reason, startAt, endAt })
-            api.catch((err) => console.error('Failed to start intervention:', err))
+            api.then(() => dispatch(getMonitoredData({}))).catch((err) => console.error('Failed to start intervention:', err))
           }}
           onEnd={() => {
             const api = clusterData
               ? clusterService.endIntervention(clusterData.name, baseURL)
               : getApi(baseURL).post('actions/intervention-end')
-            api.catch((err) => console.error('Failed to end intervention:', err))
+            api.then(() => dispatch(getMonitoredData({}))).catch((err) => console.error('Failed to end intervention:', err))
           }}
         />
       )}

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -168,7 +168,7 @@ function Navbar({ username }) {
               <AlertBadge
                 colorScheme={monitor?.isGlobalIntervention ? 'orange' : 'gray'}
                 icon={FaTools}
-                text={monitor?.isGlobalIntervention ? 'INTERVENTION' : 'Intervene'}
+                text={monitor?.isGlobalIntervention ? 'MUTED' : 'Mute'}
                 count={monitor?.isGlobalIntervention ? '' : ''}
                 onClick={() => {
                   if (monitor?.isGlobalIntervention) {
@@ -223,7 +223,7 @@ function Navbar({ username }) {
               <AlertBadge
                 colorScheme={clusterData?.isIntervention ? 'orange' : 'gray'}
                 icon={FaTools}
-                text={clusterData?.isIntervention ? 'INTERVENTION' : 'Intervene'}
+                text={clusterData?.isIntervention ? 'MUTED' : 'Mute'}
                 count={clusterData?.interventionSuppressedAlerts || ''}
                 onClick={() => {
                   if (clusterData?.isIntervention) {

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -214,9 +214,9 @@ function Navbar({ username }) {
                 showText={!isMobile}
               />
               <AlertBadge
-                colorScheme={clusterData?.isIntervention ? 'red' : 'teal'}
+                colorScheme={clusterData?.isIntervention ? 'red' : clusterData?.interventionPending ? 'orange' : 'teal'}
                 icon={MdNotificationsOff}
-                text={clusterData?.isIntervention ? 'Muted' : 'Mute'}
+                text={clusterData?.isIntervention ? 'Muted' : clusterData?.interventionPending ? 'Scheduled' : 'Mute'}
                 count={clusterData?.interventionSuppressedAlerts || ''}
                 onClick={() => setIsInterventionPanelOpen(true)}
                 showText={!isMobile}
@@ -301,9 +301,9 @@ function Navbar({ username }) {
           isOpen={isInterventionPanelOpen}
           closeModal={() => setIsInterventionPanelOpen(false)}
           isGlobal={!clusterData}
-          isActive={clusterData ? clusterData?.isIntervention : (monitor?.activeInterventionCount > 0 || monitor?.isGlobalInterventionPending)}
-          current={clusterData ? clusterData?.interventionCurrent : monitor?.globalInterventionEntry}
-          isPending={!clusterData && monitor?.isGlobalInterventionPending && !monitor?.isGlobalIntervention}
+          isActive={clusterData ? (clusterData?.isIntervention || !!clusterData?.interventionPending) : (monitor?.activeInterventionCount > 0 || monitor?.isGlobalInterventionPending)}
+          current={clusterData ? (clusterData?.interventionCurrent || clusterData?.interventionPending) : monitor?.globalInterventionEntry}
+          isPending={clusterData ? (!!clusterData?.interventionPending && !clusterData?.isIntervention) : (monitor?.isGlobalInterventionPending && !monitor?.isGlobalIntervention)}
           history={clusterData ? (clusterData?.interventionHistory || []) : []}
           suppressedAlerts={clusterData ? (clusterData?.interventionSuppressedAlerts || 0) : 0}
           activeCount={!clusterData ? (monitor?.activeInterventionCount || 0) : 0}

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -11,15 +11,17 @@ import AlertBadge from '../AlertBadge'
 import AlertModal from '../Modals/AlertModal'
 import SecurityScoreModal from '../Modals/SecurityScoreModal'
 import WorkloadModal from '../Modals/WorkloadModal'
-import { FaPowerOff, FaUserPlus } from 'react-icons/fa'
+import { FaPowerOff, FaUserPlus, FaTools } from 'react-icons/fa'
 import { MdSecurity } from 'react-icons/md'
 import { RiSpeedFill } from 'react-icons/ri'
 import ConfirmModal from '../Modals/ConfirmModal'
+import TextInputModal from '../Modals/TextInputModal'
 import styles from './styles.module.scss'
 import RMButton from '../RMButton'
 import RMIconButton from '../RMIconButton'
 import { useTheme } from '../../ThemeProvider'
 import AddUserModal from '../Modals/AddUserModal'
+import { clusterService } from '../../services/clusterService'
 import MattermostIntegration from '../../Pages/Mattermost';
 import { getMeetInfo, logoutFromMeet } from '../../redux/meetSlice';
 import { selectMeetUIState } from '../../redux/memoize'
@@ -34,6 +36,8 @@ function Navbar({ username }) {
   const [isSecurityModalOpen, setIsSecurityModalOpen] = useState(false)
   const [isWorkloadModalOpen, setIsWorkloadModalOpen] = useState(false)
   const [isAddUserModalOpen, setIsAddUserModalOpen] = useState(false)
+  const [isInterventionModalOpen, setIsInterventionModalOpen] = useState(false)
+  const [isEndInterventionModalOpen, setIsEndInterventionModalOpen] = useState(false)
   const [unreadMessagesCount, setUnreadMessagesCount] = useState(0)
   const [isChatOpen, setIsChatOpen] = useState(() => { return localStorage.getItem('chatOpen') === 'true'; });
   const [showImageLogo, setShowImageLogo] = useState(true)
@@ -45,6 +49,7 @@ function Navbar({ username }) {
   const clusterData = useSelector((state) => state?.cluster?.clusterData)
   const globalAlerts = useSelector((state) => state?.globalClusters?.globalAlerts)
   const isLogged = useSelector((state) => state?.auth?.isLogged)
+  const baseURL = useSelector((state) => state?.auth?.baseURL)
   const monitor = useSelector((state) => state?.globalClusters?.monitor)
 
   useEffect(() => {
@@ -199,6 +204,21 @@ function Navbar({ username }) {
                 onClick={() => setIsWorkloadModalOpen(true)}
                 showText={!isMobile}
               />
+              <AlertBadge
+                colorScheme={clusterData?.isIntervention ? 'orange' : 'gray'}
+                icon={FaTools}
+                text={clusterData?.isIntervention ? 'INTERVENTION' : 'Intervene'}
+                count={clusterData?.interventionSuppressedAlerts || 0}
+                onClick={() => {
+                  if (clusterData?.isIntervention) {
+                    setIsEndInterventionModalOpen(true)
+                  } else {
+                    setIsInterventionModalOpen(true)
+                  }
+                }}
+                showText={!isMobile}
+                blink={clusterData?.isIntervention}
+              />
             </Flex>
           )}
 
@@ -272,6 +292,31 @@ function Navbar({ username }) {
       )}
       {isWorkloadModalOpen && (
         <WorkloadModal isOpen={isWorkloadModalOpen} closeModal={() => setIsWorkloadModalOpen(false)} />
+      )}
+      {isInterventionModalOpen && (
+        <TextInputModal
+          isOpen={isInterventionModalOpen}
+          closeModal={() => setIsInterventionModalOpen(false)}
+          title='Start Intervention — all notifications will be silenced'
+          fieldname='Reason (e.g. rolling restart, upgrade, config change)'
+          onSave={(reason) => {
+            clusterService.startIntervention(clusterData?.name, reason, baseURL)
+              .then(() => setIsInterventionModalOpen(false))
+              .catch((err) => console.error('Failed to start intervention:', err))
+          }}
+        />
+      )}
+      {isEndInterventionModalOpen && (
+        <ConfirmModal
+          isOpen={isEndInterventionModalOpen}
+          closeModal={() => setIsEndInterventionModalOpen(false)}
+          title={`End intervention? (${clusterData?.interventionCurrent?.reason || 'active'}) — ${clusterData?.interventionSuppressedAlerts || 0} alerts suppressed`}
+          onConfirmClick={() => {
+            clusterService.endIntervention(clusterData?.name, baseURL)
+              .then(() => setIsEndInterventionModalOpen(false))
+              .catch((err) => console.error('Failed to end intervention:', err))
+          }}
+        />
       )}
     </>
   )

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -165,13 +165,13 @@ function Navbar({ username }) {
                 showText={!isMobile}
               />
               <AlertBadge
-                colorScheme={monitor?.isGlobalIntervention ? 'orange' : 'gray'}
+                colorScheme={monitor?.activeInterventionCount > 0 ? 'orange' : 'gray'}
                 icon={FaTools}
-                text={monitor?.isGlobalIntervention ? 'Muted' : 'Mute'}
-                count={monitor?.isGlobalIntervention ? '' : ''}
+                text={monitor?.activeInterventionCount > 0 ? 'Muted' : 'Mute'}
+                count={monitor?.activeInterventionCount || ''}
                 onClick={() => setIsInterventionPanelOpen(true)}
                 showText={!isMobile}
-                blink={monitor?.isGlobalIntervention}
+                blink={monitor?.activeInterventionCount > 0}
               />
             </Flex>
           )}
@@ -300,10 +300,12 @@ function Navbar({ username }) {
         <InterventionPanel
           isOpen={isInterventionPanelOpen}
           closeModal={() => setIsInterventionPanelOpen(false)}
-          isActive={clusterData ? clusterData?.isIntervention : monitor?.isGlobalIntervention}
+          isGlobal={!clusterData}
+          isActive={clusterData ? clusterData?.isIntervention : (monitor?.activeInterventionCount > 0)}
           current={clusterData ? clusterData?.interventionCurrent : monitor?.globalInterventionEntry}
           history={clusterData ? (clusterData?.interventionHistory || []) : []}
           suppressedAlerts={clusterData ? (clusterData?.interventionSuppressedAlerts || 0) : 0}
+          activeCount={!clusterData ? (monitor?.activeInterventionCount || 0) : 0}
           onStart={(reason) => {
             const api = clusterData
               ? clusterService.startIntervention(clusterData.name, reason, baseURL)

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -311,13 +311,19 @@ function Navbar({ username }) {
             const api = clusterData
               ? clusterService.startIntervention(clusterData.name, reason, baseURL, startAt, endAt)
               : getApi(baseURL).post('actions/intervention-start', { reason, startAt, endAt })
-            api.then(() => dispatch(getMonitoredData({}))).catch((err) => console.error('Failed to start intervention:', err))
+            api.then(() => {
+              dispatch(getMonitoredData({}))
+              setIsInterventionPanelOpen(false)
+            }).catch((err) => console.error('Failed to start intervention:', err))
           }}
           onEnd={() => {
             const api = clusterData
               ? clusterService.endIntervention(clusterData.name, baseURL)
               : getApi(baseURL).post('actions/intervention-end')
-            api.then(() => dispatch(getMonitoredData({}))).catch((err) => console.error('Failed to end intervention:', err))
+            api.then(() => {
+              dispatch(getMonitoredData({}))
+              setIsInterventionPanelOpen(false)
+            }).catch((err) => console.error('Failed to end intervention:', err))
           }}
         />
       )}

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -382,8 +382,8 @@ function cancelRollingReprov(clusterName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/actions/cancel-rolling-reprov`)
 }
 
-function startIntervention(clusterName, reason, baseURL) {
-  return getApi(baseURL).post(`clusters/${clusterName}/actions/intervention-start`, { reason })
+function startIntervention(clusterName, reason, baseURL, startAt, endAt) {
+  return getApi(baseURL).post(`clusters/${clusterName}/actions/intervention-start`, { reason, startAt, endAt })
 }
 
 function endIntervention(clusterName, baseURL) {

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -382,8 +382,8 @@ function cancelRollingReprov(clusterName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/actions/cancel-rolling-reprov`)
 }
 
-function startIntervention(clusterName, reason, baseURL, user) {
-  return getApi(baseURL).post(`clusters/${clusterName}/actions/intervention-start`, { reason, user })
+function startIntervention(clusterName, reason, baseURL) {
+  return getApi(baseURL).post(`clusters/${clusterName}/actions/intervention-start`, { reason })
 }
 
 function endIntervention(clusterName, baseURL) {

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -62,6 +62,8 @@ export const clusterService = {
   reloadCertificates,
   cancelRollingRestart,
   cancelRollingReprov,
+  startIntervention,
+  endIntervention,
   bootstrapMasterSlave,
   bootstrapMasterSlaveNoGtid,
   bootstrapMultiMaster,
@@ -378,6 +380,14 @@ function cancelRollingRestart(clusterName, baseURL) {
 
 function cancelRollingReprov(clusterName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/actions/cancel-rolling-reprov`)
+}
+
+function startIntervention(clusterName, reason, baseURL) {
+  return getApi(baseURL).post(`clusters/${clusterName}/actions/intervention-start`, { reason })
+}
+
+function endIntervention(clusterName, baseURL) {
+  return getApi(baseURL).post(`clusters/${clusterName}/actions/intervention-end`)
 }
 
 function bootstrapMasterSlave(clusterName, baseURL) {

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -382,8 +382,8 @@ function cancelRollingReprov(clusterName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/actions/cancel-rolling-reprov`)
 }
 
-function startIntervention(clusterName, reason, baseURL) {
-  return getApi(baseURL).post(`clusters/${clusterName}/actions/intervention-start`, { reason })
+function startIntervention(clusterName, reason, baseURL, user) {
+  return getApi(baseURL).post(`clusters/${clusterName}/actions/intervention-start`, { reason, user })
 }
 
 function endIntervention(clusterName, baseURL) {


### PR DESCRIPTION
## Summary

- **Intervention mode** silences all notification channels (Email, Slack, Teams, Pushover, Cloud18/Mattermost) during planned maintenance, with on-demand start/stop from GUI or API
- **Cluster and global scope** — mute a single cluster or all clusters at once
- **Scheduled interventions** with datetime picker and auto-unmute after estimated duration
- **WARN0172/WARN0173** warning states in the cluster state machine for scheduled and active interventions, included in default `monitoring-alert-trigger` so email alerts fire on mute/unmute
- **Start/stop notifications** bypass the mute — ALERT sent before muting, ALERTOK sent after unmuting
- **Intervention history** persisted to `interventions.json` per cluster with user, reason, duration, and suppressed alert count
- **GUI**: bell-slash badge in navbar (teal inactive / red blinking active), intervention panel with last 5 history entries, intervention modal with scheduling
- **Bug fix**: state diff RESOLV/OPENED notifications via Slack/Teams were not suppressed during intervention
- **Bug fix**: error/sql/audit/slow log API endpoints returned 503 when server was failed — now serve the in-memory buffer regardless of server state

## Files changed

| Area | Files | Change |
|---|---|---|
| Backend core | `cluster/cluster_intervention.go` (new) | InterventionEntry struct, start/end/schedule, history persistence, warning states |
| Backend log | `cluster/cluster_log.go` | Gate all notification channels on IsIntervention, suppress state diffs |
| Backend checks | `cluster/cluster_chk.go` | Gate SendAlert on IsIntervention |
| Backend API | `server/api_intervention.go` (new), `server/api_cluster.go`, `server/http.go` | Global and cluster intervention endpoints |
| Backend config | `server/server.go` | Add WARN0172/WARN0173 to default monitoring-alert-trigger |
| Backend API fix | `server/api_database.go` | Remove IsDown() check from log endpoints |
| Config | `config/error.go` | WARN0172, WARN0173 |
| Frontend | `Navbar`, `AlertBadge`, `InterventionPanel` (new), `InterventionModal` (new) | Mute badge, panel, scheduling modal |
| Frontend services | `clusterService.js` | startIntervention, endIntervention |

## Test plan

- [ ] Start cluster-level intervention → badge turns red blinking, Slack/Teams/Email notifications stop
- [ ] End intervention → badge returns to teal, ALERTOK notification sent with suppressed count
- [ ] Schedule future intervention → WARN0172 appears in warnings, ALERT sent immediately including email
- [ ] Scheduled intervention auto-starts at the right time → WARN0173 replaces WARN0172
- [ ] Auto-unmute fires after estimated duration
- [ ] Global intervention → all clusters muted, "Close All" ends all
- [ ] Restart repman with active intervention → intervention restored from interventions.json
- [ ] Failed server → error log tab still shows last known entries (not empty)
- [ ] Intervention start/stop notifications reach Slack/Teams/Email despite mute