### PR TITLE
Increase default binlog_row_event_max_size to 128K (#1392)

### DIFF
--- a/share/mysql_defaults.cnf
+++ b/share/mysql_defaults.cnf
@@ -48,6 +48,9 @@ performance_schema = ON
 max_binlog_size = 1073741824
 binlog_expire_logs_seconds = 2592000
 sync_binlog = 1
+# Larger row-event packing improves ROW-based replication throughput.
+# MariaDB/MySQL server default is 8K (8192); 131072 (128K) modernizes it.
+binlog_row_event_max_size = 131072
 
 # Transaction Settings
 transaction_isolation = REPEATABLE-READ


### PR DESCRIPTION
## Summary

Adds a modernized `binlog_row_event_max_size = 131072` (128K) default to the `# Binary Log` section of `share/mysql_defaults.cnf`, the canonical defaults template that replication-manager embeds and deploys to provisioned database servers.

## Why this matters

Issue #1392 (referencing MDEV-37608) notes that the MariaDB/MySQL server default for `binlog_row_event_max_size` of 8K (8192) is outdated. Since `binlog_format = ROW` is the default in this template, the knob is live for every provisioned cluster. Packing more row changes per binary-log event reduces per-event overhead and improves ROW-based replication throughput.

128K (131072) is a conservative bump that stays well within common `max_allowed_packet` and replication-buffer expectations, so it modernizes the default without introducing risk. An inline comment documents the rationale so operators understand why repman diverges from the server default.

The quantitative sysbench/row-write benchmark mentioned as a stretch goal in the issue is left as a follow-up; the config default is the shippable, low-risk unit here.

## Testing

- Confirmed the file still parses as a valid `key = value` my.cnf fragment.
- Verified no other defaults template sets this variable, so no mirroring is needed (the docker test `.cnf` fixtures do not assert on it).
- `gofmt -l` is clean (no Go changes).

Fixes #1392

AI was used for assistance.
