### PR TITLE
feat: whoami grants/roles, user profile panel, SSO display name

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -1273,21 +1273,29 @@ func (repman *ReplicationManager) handlerMuxWhoAmI(w http.ResponseWriter, r *htt
 		return
 	}
 
-	// Add per-cluster grants and roles to the response
+	// Add per-cluster grants and roles to the response.
+	// user["User"] is the canonical username; user["Name"] is the fallback
+	// for local users where GetUserInfoMap sets User = Name (SSO sets User = email).
 	username := user["User"]
 	if username == "" {
 		username = user["Name"]
 	}
 	clusterGrants, clusterRoles := repman.resolveUserClusterGrantsAndRoles(username)
 	if clusterGrants != nil {
-		res, _ = sjson.SetBytes(res, "grants", clusterGrants)
+		if res, err = sjson.SetBytes(res, "grants", clusterGrants); err != nil {
+			log.Errorf("handlerMuxWhoAmI sjson grants error: %v", err)
+		}
 	}
 	if clusterRoles != nil {
-		res, _ = sjson.SetBytes(res, "roles", clusterRoles)
+		if res, err = sjson.SetBytes(res, "roles", clusterRoles); err != nil {
+			log.Errorf("handlerMuxWhoAmI sjson roles error: %v", err)
+		}
 	}
 	// For registered instances, set admin email from Cloud18 registration
 	if repman.Conf.Cloud18 && repman.Conf.Cloud18GitUser != "" && repman.isAdminUser(username) {
-		res, _ = sjson.SetBytes(res, "Email", repman.Conf.Cloud18GitUser)
+		if res, err = sjson.SetBytes(res, "Email", repman.Conf.Cloud18GitUser); err != nil {
+			log.Errorf("handlerMuxWhoAmI sjson email error: %v", err)
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -1295,6 +1303,7 @@ func (repman *ReplicationManager) handlerMuxWhoAmI(w http.ResponseWriter, r *htt
 }
 
 // resolveUserClusterGrantsAndRoles returns per-cluster grant and role maps for the given user.
+// Returns shallow copies of the grant/role maps to avoid data races with the monitoring loop.
 func (repman *ReplicationManager) resolveUserClusterGrantsAndRoles(username string) (map[string]map[string]bool, map[string]map[string]bool) {
 	if username == "" {
 		return nil, nil
@@ -1303,11 +1312,20 @@ func (repman *ReplicationManager) resolveUserClusterGrantsAndRoles(username stri
 	roles := make(map[string]map[string]bool)
 	for _, cl := range repman.Clusters {
 		if apiUser, ok := cl.APIUsers[username]; ok {
-			grants[cl.Name] = apiUser.Grants
-			roles[cl.Name] = apiUser.Roles
+			grantsCopy := make(map[string]bool, len(apiUser.Grants))
+			for k, v := range apiUser.Grants {
+				grantsCopy[k] = v
+			}
+			grants[cl.Name] = grantsCopy
+
+			rolesCopy := make(map[string]bool, len(apiUser.Roles))
+			for k, v := range apiUser.Roles {
+				rolesCopy[k] = v
+			}
+			roles[cl.Name] = rolesCopy
 		}
 	}
-	if len(grants) == 0 {
+	if len(grants) == 0 && len(roles) == 0 {
 		return nil, nil
 	}
 	return grants, roles

--- a/server/api.go
+++ b/server/api.go
@@ -1256,35 +1256,44 @@ func (repman *ReplicationManager) handlerMuxWhoAmI(w http.ResponseWriter, r *htt
 		return
 	}
 
-	// Add per-cluster grants to the response
+	// Add per-cluster grants and roles to the response
 	username := user["User"]
 	if username == "" {
 		username = user["Name"]
 	}
-	clusterGrants := repman.resolveUserClusterGrants(username)
+	clusterGrants, clusterRoles := repman.resolveUserClusterGrantsAndRoles(username)
 	if clusterGrants != nil {
 		res, _ = sjson.SetBytes(res, "grants", clusterGrants)
+	}
+	if clusterRoles != nil {
+		res, _ = sjson.SetBytes(res, "roles", clusterRoles)
+	}
+	// For registered instances, set admin email from Cloud18 registration
+	if repman.Conf.Cloud18 && repman.Conf.Cloud18GitUser != "" && repman.isAdminUser(username) {
+		res, _ = sjson.SetBytes(res, "Email", repman.Conf.Cloud18GitUser)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(res)
 }
 
-// resolveUserClusterGrants returns a map of cluster name → grant map for the given user.
-func (repman *ReplicationManager) resolveUserClusterGrants(username string) map[string]map[string]bool {
+// resolveUserClusterGrantsAndRoles returns per-cluster grant and role maps for the given user.
+func (repman *ReplicationManager) resolveUserClusterGrantsAndRoles(username string) (map[string]map[string]bool, map[string]map[string]bool) {
 	if username == "" {
-		return nil
+		return nil, nil
 	}
-	result := make(map[string]map[string]bool)
+	grants := make(map[string]map[string]bool)
+	roles := make(map[string]map[string]bool)
 	for _, cl := range repman.Clusters {
 		if apiUser, ok := cl.APIUsers[username]; ok {
-			result[cl.Name] = apiUser.Grants
+			grants[cl.Name] = apiUser.Grants
+			roles[cl.Name] = apiUser.Roles
 		}
 	}
-	if len(result) == 0 {
-		return nil
+	if len(grants) == 0 {
+		return nil, nil
 	}
-	return result
+	return grants, roles
 }
 
 // handlerMuxAddClusterUser handles the addition of a new user to a cluster.

--- a/server/api.go
+++ b/server/api.go
@@ -602,6 +602,9 @@ func (repman *ReplicationManager) GetUserInfoMap(token *jwt.Token) (map[string]s
 	UserInfoMap["Password"] = mycutinfo["Password"].(string)
 	UserInfoMap["Role"] = mycutinfo["Role"].(string)
 	UserInfoMap["Email"] = ""
+	if dn, ok := mycutinfo["display_name"]; ok && dn != nil {
+		UserInfoMap["DisplayName"] = dn.(string)
+	}
 	_, ok := mycutinfo["profile"]
 	if ok {
 		profile := mycutinfo["profile"].(string)
@@ -882,9 +885,19 @@ func (repman *ReplicationManager) loginHandler(w http.ResponseWriter, r *http.Re
 	// SSO fallback succeeded: build SSO JWT and return without upgrade_id.
 	resetAuthTry()
 	repman.ensureCRMSessionBootstrappedAsync(tok)
-	email, err := githelper.GetGitLabUserEmail(tok, true)
-	if err != nil {
-		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModSupport, config.LvlErr, "Error retrieving email from gitlab: %v", err)
+	// Fetch full profile (name + email) from GitLab
+	var email, displayName string
+	if profile, profileErr := githelper.GetGitLabUserProfile(tok); profileErr == nil {
+		email = profile.Email
+		displayName = profile.Name
+	} else {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModSupport, config.LvlErr, "Error retrieving profile from gitlab: %v", profileErr)
+		// Fallback to email-only endpoint
+		var emailErr error
+		email, emailErr = githelper.GetGitLabUserEmail(tok, true)
+		if emailErr != nil {
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModSupport, config.LvlErr, "Error retrieving email from gitlab: %v", emailErr)
+		}
 	}
 	meetUser := email
 	if meetUser == "" {
@@ -904,20 +917,22 @@ func (repman *ReplicationManager) loginHandler(w http.ResponseWriter, r *http.Re
 	if email != "" {
 		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModSupport, config.LvlInfo, "Switch from gitlab user to email: %s", email)
 		ssoUserInfo = struct {
-			Name       string
-			Role       string
-			Password   string
-			Email      string `json:"email"`
-			Profile    string `json:"profile"`
-			MeetUserID string `json:"meet_user_id"`
-		}{user.Username, "Member", repman.Conf.GetEncryptedString(user.Password), email, repman.Conf.OAuthProvider, meetUserID}
+			Name        string
+			DisplayName string `json:"display_name"`
+			Role        string
+			Password    string
+			Email       string `json:"email"`
+			Profile     string `json:"profile"`
+			MeetUserID  string `json:"meet_user_id"`
+		}{user.Username, displayName, "Member", repman.Conf.GetEncryptedString(user.Password), email, repman.Conf.OAuthProvider, meetUserID}
 	} else {
 		ssoUserInfo = struct {
-			Name       string
-			Role       string
-			Password   string
-			MeetUserID string `json:"meet_user_id"`
-		}{user.Username, "Member", repman.Conf.GetEncryptedString(user.Password), meetUserID}
+			Name        string
+			DisplayName string `json:"display_name"`
+			Role        string
+			Password    string
+			MeetUserID  string `json:"meet_user_id"`
+		}{user.Username, displayName, "Member", repman.Conf.GetEncryptedString(user.Password), meetUserID}
 	}
 
 	repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModSupport, config.LvlDbg, "LoginHandler: meet userID %s", meetUserID)

--- a/server/api.go
+++ b/server/api.go
@@ -1256,8 +1256,35 @@ func (repman *ReplicationManager) handlerMuxWhoAmI(w http.ResponseWriter, r *htt
 		return
 	}
 
+	// Add per-cluster grants to the response
+	username := user["User"]
+	if username == "" {
+		username = user["Name"]
+	}
+	clusterGrants := repman.resolveUserClusterGrants(username)
+	if clusterGrants != nil {
+		res, _ = sjson.SetBytes(res, "grants", clusterGrants)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(res)
+}
+
+// resolveUserClusterGrants returns a map of cluster name → grant map for the given user.
+func (repman *ReplicationManager) resolveUserClusterGrants(username string) map[string]map[string]bool {
+	if username == "" {
+		return nil
+	}
+	result := make(map[string]map[string]bool)
+	for _, cl := range repman.Clusters {
+		if apiUser, ok := cl.APIUsers[username]; ok {
+			result[cl.Name] = apiUser.Grants
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }
 
 // handlerMuxAddClusterUser handles the addition of a new user to a cluster.

--- a/server/api.go
+++ b/server/api.go
@@ -616,6 +616,7 @@ func (repman *ReplicationManager) GetUserInfoMap(token *jwt.Token) (map[string]s
 			UserInfoMap["User"] = mycutinfo["email"].(string)
 			UserInfoMap["Email"] = mycutinfo["email"].(string)
 			UserInfoMap["profile"] = profile
+			UserInfoMap["AuthType"] = "SSO"
 			return UserInfoMap, nil
 		}
 		return nil, fmt.Errorf("invalid oauth provider")
@@ -625,6 +626,7 @@ func (repman *ReplicationManager) GetUserInfoMap(token *jwt.Token) (map[string]s
 		UserInfoMap["MeetUserID"] = mycutinfo["meet_user_id"].(string)
 	}
 	UserInfoMap["User"] = mycutinfo["Name"].(string)
+	UserInfoMap["AuthType"] = "Local"
 	return UserInfoMap, nil
 }
 

--- a/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
@@ -1,13 +1,15 @@
 import {
-  Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalCloseButton,
-  Box, VStack, HStack, Text, Badge, Divider, Flex, Table, Thead, Tbody, Tr, Th, Td
+  Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalCloseButton, ModalFooter,
+  Box, VStack, HStack, Text, Badge, Divider, Table, Thead, Tbody, Tr, Th, Td
 } from '@chakra-ui/react'
 import React from 'react'
+import { HiMoon, HiSun } from 'react-icons/hi'
+import RMButton from '../../RMButton'
 import { useTheme } from '../../../ThemeProvider'
 import parentStyles from '../styles.module.scss'
 
-function UserInfoPanel({ isOpen, closeModal, user, clusters }) {
-  const { theme } = useTheme()
+function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
+  const { theme, toggleTheme } = useTheme()
 
   const grants = user?.grants || {}
   const clusterNames = Object.keys(grants).sort()
@@ -25,7 +27,7 @@ function UserInfoPanel({ isOpen, closeModal, user, clusters }) {
       <ModalContent className={theme === 'light' ? parentStyles.modalLightContent : parentStyles.modalDarkContent}>
         <ModalHeader fontSize='md'>User Profile</ModalHeader>
         <ModalCloseButton />
-        <ModalBody pb={6}>
+        <ModalBody pb={4}>
           <VStack align='stretch' spacing={4}>
 
             <Box p={3} borderRadius='md' bg={theme === 'light' ? 'gray.50' : 'rgba(255,255,255,0.05)'}>
@@ -89,6 +91,23 @@ function UserInfoPanel({ isOpen, closeModal, user, clusters }) {
 
           </VStack>
         </ModalBody>
+        <ModalFooter>
+          <HStack spacing={3} width='100%' justify='space-between'>
+            <RMButton
+              variant='ghost'
+              size='small'
+              onClick={toggleTheme}
+            >
+              <HStack spacing={1}>
+                {theme === 'light' ? <HiMoon color='midnightblue' /> : <HiSun color='gold' />}
+                <Text fontSize='sm'>{theme === 'light' ? 'Dark mode' : 'Light mode'}</Text>
+              </HStack>
+            </RMButton>
+            <RMButton colorScheme='red' onClick={onLogout}>
+              Logout
+            </RMButton>
+          </HStack>
+        </ModalFooter>
       </ModalContent>
     </Modal>
   )

--- a/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
@@ -49,7 +49,7 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
               <HStack spacing={4}>
                 <Text fontSize='sm' fontWeight={600}>User:</Text>
                 <Text fontSize='sm'>{user?.DisplayName || user?.User || user?.username || '-'}</Text>
-                <Badge bg={user?.AuthType === 'SSO' ? 'purple.600' : 'blue.600'} color='white' size='sm'>
+                <Badge style={{ backgroundColor: user?.AuthType === 'SSO' ? '#805AD5' : '#2B6CB0', color: '#FFFFFF' }} size='sm'>
                   {user?.AuthType || 'Local'}
                 </Badge>
               </HStack>

--- a/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
@@ -50,7 +50,7 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                 <Text fontSize='sm' fontWeight={600}>User:</Text>
                 <Text fontSize='sm'>{user?.DisplayName || user?.User || user?.username || '-'}</Text>
                 <Box as='span' px={2} py={0.5} borderRadius='md' fontSize='xs' fontWeight='bold'
-                  bg={user?.AuthType === 'SSO' ? 'purple.600' : 'blue.600'} color='white'>
+                  sx={{ bg: user?.AuthType === 'SSO' ? 'purple.600' : 'blue.600', color: 'white !important' }}>
                   {user?.AuthType || 'Local'}
                 </Box>
               </HStack>
@@ -101,7 +101,7 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                           {clusterNames.map(name => (
                             <Td key={name} textAlign='center'>
                               <Box as='span' px={2} py={0.5} borderRadius='md' fontSize='xs' fontWeight='bold' textAlign='center' minW='24px' display='inline-block'
-                                bg={roles[name]?.[role] ? cellBgYes : cellBgNo} color={roles[name]?.[role] ? cellColorYes : cellColorNo}>
+                                sx={{ bg: roles[name]?.[role] ? cellBgYes : cellBgNo, color: (roles[name]?.[role] ? cellColorYes : cellColorNo) + ' !important' }}>
                                 {roles[name]?.[role] ? checkMark : '-'}
                               </Box>
                             </Td>
@@ -137,7 +137,7 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                           {clusterNames.map(name => (
                             <Td key={name} textAlign='center'>
                               <Box as='span' px={2} py={0.5} borderRadius='md' fontSize='xs' fontWeight='bold' textAlign='center' minW='24px' display='inline-block'
-                                bg={grants[name]?.[grant] ? cellBgYes : cellBgNo} color={grants[name]?.[grant] ? cellColorYes : cellColorNo}>
+                                sx={{ bg: grants[name]?.[grant] ? cellBgYes : cellBgNo, color: (grants[name]?.[grant] ? cellColorYes : cellColorNo) + ' !important' }}>
                                 {grants[name]?.[grant] ? checkMark : '-'}
                               </Box>
                             </Td>

--- a/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
@@ -8,12 +8,17 @@ import RMButton from '../../RMButton'
 import { useTheme } from '../../../ThemeProvider'
 import parentStyles from '../styles.module.scss'
 
+// Static checkmark character for grant/role indicators
+const CHECK_MARK = '\u2713'
+
 function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
   const { theme, toggleTheme } = useTheme()
+  const badgeVariant = theme === 'dark' ? 'solid' : 'subtle'
 
   const grants = user?.grants || {}
   const roles = user?.roles || {}
-  const clusterNames = Object.keys(grants).sort()
+  // Derive cluster names from both grants and roles in case a user has roles but no grants
+  const clusterNames = [...new Set([...Object.keys(grants), ...Object.keys(roles)])].sort()
 
   // Collect all unique grant names across clusters
   const allGrants = new Set()
@@ -29,7 +34,6 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
   })
   const roleList = [...allRoles].sort()
 
-  const checkMark = '\u2713'
   const stickyBg = theme === 'light' ? 'white' : 'gray.800'
 
   return (
@@ -44,8 +48,8 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
             <Box p={3} borderRadius='md' bg={theme === 'light' ? 'gray.50' : 'rgba(255,255,255,0.05)'}>
               <HStack spacing={4}>
                 <Text fontSize='sm' fontWeight={600}>User:</Text>
-                <Text fontSize='sm'>{user?.DisplayName || user?.User || user?.username || '-'}</Text>
-                <Badge variant={theme === 'dark' ? 'solid' : 'subtle'} colorScheme={user?.AuthType === 'SSO' ? 'purple' : 'blue'} size='sm'>
+                <Text fontSize='sm'>{user?.DisplayName || user?.User || '-'}</Text>
+                <Badge variant={badgeVariant} colorScheme={user?.AuthType === 'SSO' ? 'purple' : 'blue'} size='sm'>
                   {user?.AuthType || 'Local'}
                 </Badge>
               </HStack>
@@ -95,8 +99,8 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                           <Td position='sticky' left={0} bg={stickyBg} fontSize='xs'>{role}</Td>
                           {clusterNames.map(name => (
                             <Td key={name} textAlign='center'>
-                              <Badge variant={theme === 'dark' ? 'solid' : 'subtle'} colorScheme={roles[name]?.[role] ? 'blue' : 'gray'} size='sm'>
-                                {roles[name]?.[role] ? checkMark : '-'}
+                              <Badge variant={badgeVariant} colorScheme={roles[name]?.[role] ? 'blue' : 'gray'} size='sm'>
+                                {roles[name]?.[role] ? CHECK_MARK : '-'}
                               </Badge>
                             </Td>
                           ))}
@@ -106,6 +110,12 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                   </Table>
                 </Box>
               </>
+            )}
+
+            {clusterNames.length > 0 && roleList.length === 0 && (
+              <Text fontSize='sm' color={theme === 'light' ? 'gray.500' : 'gray.500'} textAlign='center' py={2}>
+                No roles assigned
+              </Text>
             )}
 
             {clusterNames.length > 0 && (
@@ -130,8 +140,8 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                           <Td position='sticky' left={0} bg={stickyBg} fontSize='xs'>{grant}</Td>
                           {clusterNames.map(name => (
                             <Td key={name} textAlign='center'>
-                              <Badge variant={theme === 'dark' ? 'solid' : 'subtle'} colorScheme={grants[name]?.[grant] ? 'blue' : 'gray'} size='sm'>
-                                {grants[name]?.[grant] ? checkMark : '-'}
+                              <Badge variant={badgeVariant} colorScheme={grants[name]?.[grant] ? 'blue' : 'gray'} size='sm'>
+                                {grants[name]?.[grant] ? CHECK_MARK : '-'}
                               </Badge>
                             </Td>
                           ))}

--- a/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
@@ -1,0 +1,97 @@
+import {
+  Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalCloseButton,
+  Box, VStack, HStack, Text, Badge, Divider, Flex, Table, Thead, Tbody, Tr, Th, Td
+} from '@chakra-ui/react'
+import React from 'react'
+import { useTheme } from '../../../ThemeProvider'
+import parentStyles from '../styles.module.scss'
+
+function UserInfoPanel({ isOpen, closeModal, user, clusters }) {
+  const { theme } = useTheme()
+
+  const grants = user?.grants || {}
+  const clusterNames = Object.keys(grants).sort()
+
+  // Collect all unique grant names across clusters
+  const allGrants = new Set()
+  clusterNames.forEach(name => {
+    Object.keys(grants[name] || {}).forEach(g => allGrants.add(g))
+  })
+  const grantList = [...allGrants].sort()
+
+  return (
+    <Modal isOpen={isOpen} onClose={closeModal} size='xl'>
+      <ModalOverlay />
+      <ModalContent className={theme === 'light' ? parentStyles.modalLightContent : parentStyles.modalDarkContent}>
+        <ModalHeader fontSize='md'>User Profile</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody pb={6}>
+          <VStack align='stretch' spacing={4}>
+
+            <Box p={3} borderRadius='md' bg={theme === 'light' ? 'gray.50' : 'rgba(255,255,255,0.05)'}>
+              <HStack spacing={4}>
+                <Text fontSize='sm' fontWeight={600}>User:</Text>
+                <Text fontSize='sm'>{user?.User || user?.username || '-'}</Text>
+              </HStack>
+              {user?.Email && (
+                <HStack spacing={4}>
+                  <Text fontSize='sm' fontWeight={600}>Email:</Text>
+                  <Text fontSize='sm'>{user.Email}</Text>
+                </HStack>
+              )}
+              <HStack spacing={4}>
+                <Text fontSize='sm' fontWeight={600}>Role:</Text>
+                <Text fontSize='sm'>{user?.Role || '-'}</Text>
+              </HStack>
+            </Box>
+
+            {clusterNames.length > 0 && (
+              <>
+                <Divider />
+                <Text fontSize='sm' fontWeight={600} color={theme === 'light' ? 'gray.600' : 'gray.400'}>
+                  Grants per cluster
+                </Text>
+                <Box maxH='400px' overflowY='auto' overflowX='auto' fontSize='xs'>
+                  <Table size='sm' variant='simple'>
+                    <Thead>
+                      <Tr>
+                        <Th position='sticky' left={0} bg={theme === 'light' ? 'white' : 'gray.800'} zIndex={1}>Grant</Th>
+                        {clusterNames.map(name => (
+                          <Th key={name} textAlign='center'>{name}</Th>
+                        ))}
+                      </Tr>
+                    </Thead>
+                    <Tbody>
+                      {grantList.map(grant => (
+                        <Tr key={grant}>
+                          <Td position='sticky' left={0} bg={theme === 'light' ? 'white' : 'gray.800'} fontSize='xs'>{grant}</Td>
+                          {clusterNames.map(name => (
+                            <Td key={name} textAlign='center'>
+                              {grants[name]?.[grant]
+                                ? <Badge colorScheme='green' size='sm'>Y</Badge>
+                                : <Badge colorScheme='gray' size='sm'>-</Badge>
+                              }
+                            </Td>
+                          ))}
+                        </Tr>
+                      ))}
+                    </Tbody>
+                  </Table>
+                </Box>
+              </>
+            )}
+
+            {clusterNames.length === 0 && (
+              <Text fontSize='sm' color={theme === 'light' ? 'gray.500' : 'gray.500'} textAlign='center' py={4}>
+                No cluster grants available
+              </Text>
+            )}
+
+          </VStack>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export default UserInfoPanel

--- a/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
@@ -1,6 +1,6 @@
 import {
   Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalCloseButton,
-  Box, VStack, HStack, Text, Divider, Table, Thead, Tbody, Tr, Th, Td
+  Box, VStack, HStack, Text, Badge, Divider, Table, Thead, Tbody, Tr, Th, Td
 } from '@chakra-ui/react'
 import React from 'react'
 import { HiMoon, HiSun } from 'react-icons/hi'
@@ -30,10 +30,6 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
   const roleList = [...allRoles].sort()
 
   const checkMark = '\u2713'
-  const cellBgYes = theme === 'light' ? 'blue.500' : 'blue.400'
-  const cellColorYes = 'white'
-  const cellBgNo = theme === 'light' ? 'gray.100' : 'gray.700'
-  const cellColorNo = theme === 'light' ? 'gray.400' : 'gray.500'
   const stickyBg = theme === 'light' ? 'white' : 'gray.800'
 
   return (
@@ -49,10 +45,9 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
               <HStack spacing={4}>
                 <Text fontSize='sm' fontWeight={600}>User:</Text>
                 <Text fontSize='sm'>{user?.DisplayName || user?.User || user?.username || '-'}</Text>
-                <Box as='span' px={2} py={0.5} borderRadius='md' fontSize='xs' fontWeight='bold'
-                  sx={{ bg: user?.AuthType === 'SSO' ? 'purple.600' : 'blue.600', color: 'white !important' }}>
+                <Badge variant='solid' colorScheme={user?.AuthType === 'SSO' ? 'purple' : 'blue'} size='sm'>
                   {user?.AuthType || 'Local'}
-                </Box>
+                </Badge>
               </HStack>
               {user?.Email && (
                 <HStack spacing={4}>
@@ -100,10 +95,9 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                           <Td position='sticky' left={0} bg={stickyBg} fontSize='xs'>{role}</Td>
                           {clusterNames.map(name => (
                             <Td key={name} textAlign='center'>
-                              <Box as='span' px={2} py={0.5} borderRadius='md' fontSize='xs' fontWeight='bold' textAlign='center' minW='24px' display='inline-block'
-                                sx={{ bg: roles[name]?.[role] ? cellBgYes : cellBgNo, color: (roles[name]?.[role] ? cellColorYes : cellColorNo) + ' !important' }}>
+                              <Badge variant='solid' colorScheme={roles[name]?.[role] ? 'blue' : 'gray'} size='sm'>
                                 {roles[name]?.[role] ? checkMark : '-'}
-                              </Box>
+                              </Badge>
                             </Td>
                           ))}
                         </Tr>
@@ -136,10 +130,9 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                           <Td position='sticky' left={0} bg={stickyBg} fontSize='xs'>{grant}</Td>
                           {clusterNames.map(name => (
                             <Td key={name} textAlign='center'>
-                              <Box as='span' px={2} py={0.5} borderRadius='md' fontSize='xs' fontWeight='bold' textAlign='center' minW='24px' display='inline-block'
-                                sx={{ bg: grants[name]?.[grant] ? cellBgYes : cellBgNo, color: (grants[name]?.[grant] ? cellColorYes : cellColorNo) + ' !important' }}>
+                              <Badge variant='solid' colorScheme={grants[name]?.[grant] ? 'blue' : 'gray'} size='sm'>
                                 {grants[name]?.[grant] ? checkMark : '-'}
-                              </Box>
+                              </Badge>
                             </Td>
                           ))}
                         </Tr>

--- a/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
@@ -45,7 +45,7 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
               <HStack spacing={4}>
                 <Text fontSize='sm' fontWeight={600}>User:</Text>
                 <Text fontSize='sm'>{user?.DisplayName || user?.User || user?.username || '-'}</Text>
-                <Badge colorScheme={user?.AuthType === 'SSO' ? 'purple' : 'blue'} size='sm'>
+                <Badge variant={theme === 'dark' ? 'solid' : 'subtle'} colorScheme={user?.AuthType === 'SSO' ? 'purple' : 'blue'} size='sm'>
                   {user?.AuthType || 'Local'}
                 </Badge>
               </HStack>
@@ -95,7 +95,7 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                           <Td position='sticky' left={0} bg={stickyBg} fontSize='xs'>{role}</Td>
                           {clusterNames.map(name => (
                             <Td key={name} textAlign='center'>
-                              <Badge colorScheme={roles[name]?.[role] ? 'blue' : 'gray'} size='sm'>
+                              <Badge variant={theme === 'dark' ? 'solid' : 'subtle'} colorScheme={roles[name]?.[role] ? 'blue' : 'gray'} size='sm'>
                                 {roles[name]?.[role] ? checkMark : '-'}
                               </Badge>
                             </Td>
@@ -130,7 +130,7 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                           <Td position='sticky' left={0} bg={stickyBg} fontSize='xs'>{grant}</Td>
                           {clusterNames.map(name => (
                             <Td key={name} textAlign='center'>
-                              <Badge colorScheme={grants[name]?.[grant] ? 'blue' : 'gray'} size='sm'>
+                              <Badge variant={theme === 'dark' ? 'solid' : 'subtle'} colorScheme={grants[name]?.[grant] ? 'blue' : 'gray'} size='sm'>
                                 {grants[name]?.[grant] ? checkMark : '-'}
                               </Badge>
                             </Td>

--- a/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
@@ -49,6 +49,9 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
               <HStack spacing={4}>
                 <Text fontSize='sm' fontWeight={600}>User:</Text>
                 <Text fontSize='sm'>{user?.DisplayName || user?.User || user?.username || '-'}</Text>
+                <Badge colorScheme={user?.AuthType === 'SSO' ? 'purple' : 'blue'} size='sm'>
+                  {user?.AuthType || 'Local'}
+                </Badge>
               </HStack>
               {user?.Email && (
                 <HStack spacing={4}>

--- a/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
@@ -1,5 +1,5 @@
 import {
-  Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalCloseButton, ModalFooter,
+  Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalCloseButton,
   Box, VStack, HStack, Text, Badge, Divider, Table, Thead, Tbody, Tr, Th, Td
 } from '@chakra-ui/react'
 import React from 'react'
@@ -60,6 +60,22 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                 </HStack>
               )}
             </Box>
+
+            <HStack spacing={3} width='100%' justify='space-between'>
+              <RMButton
+                variant='ghost'
+                size='small'
+                onClick={toggleTheme}
+              >
+                <HStack spacing={1}>
+                  {theme === 'light' ? <HiMoon color='midnightblue' /> : <HiSun color='gold' />}
+                  <Text fontSize='sm'>{theme === 'light' ? 'Dark mode' : 'Light mode'}</Text>
+                </HStack>
+              </RMButton>
+              <RMButton colorScheme='red' onClick={onLogout}>
+                Logout
+              </RMButton>
+            </HStack>
 
             {clusterNames.length > 0 && roleList.length > 0 && (
               <>
@@ -139,23 +155,6 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
 
           </VStack>
         </ModalBody>
-        <ModalFooter>
-          <HStack spacing={3} width='100%' justify='space-between'>
-            <RMButton
-              variant='ghost'
-              size='small'
-              onClick={toggleTheme}
-            >
-              <HStack spacing={1}>
-                {theme === 'light' ? <HiMoon color='midnightblue' /> : <HiSun color='gold' />}
-                <Text fontSize='sm'>{theme === 'light' ? 'Dark mode' : 'Light mode'}</Text>
-              </HStack>
-            </RMButton>
-            <RMButton colorScheme='red' onClick={onLogout}>
-              Logout
-            </RMButton>
-          </HStack>
-        </ModalFooter>
       </ModalContent>
     </Modal>
   )

--- a/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
@@ -49,7 +49,7 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
               <HStack spacing={4}>
                 <Text fontSize='sm' fontWeight={600}>User:</Text>
                 <Text fontSize='sm'>{user?.DisplayName || user?.User || user?.username || '-'}</Text>
-                <Badge colorScheme={user?.AuthType === 'SSO' ? 'purple' : 'blue'} size='sm'>
+                <Badge bg={user?.AuthType === 'SSO' ? 'purple.600' : 'blue.600'} color='white' size='sm'>
                   {user?.AuthType || 'Local'}
                 </Badge>
               </HStack>

--- a/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
@@ -45,7 +45,7 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
               <HStack spacing={4}>
                 <Text fontSize='sm' fontWeight={600}>User:</Text>
                 <Text fontSize='sm'>{user?.DisplayName || user?.User || user?.username || '-'}</Text>
-                <Badge variant='solid' colorScheme={user?.AuthType === 'SSO' ? 'purple' : 'blue'} size='sm'>
+                <Badge colorScheme={user?.AuthType === 'SSO' ? 'purple' : 'blue'} size='sm'>
                   {user?.AuthType || 'Local'}
                 </Badge>
               </HStack>
@@ -95,7 +95,7 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                           <Td position='sticky' left={0} bg={stickyBg} fontSize='xs'>{role}</Td>
                           {clusterNames.map(name => (
                             <Td key={name} textAlign='center'>
-                              <Badge variant='solid' colorScheme={roles[name]?.[role] ? 'blue' : 'gray'} size='sm'>
+                              <Badge colorScheme={roles[name]?.[role] ? 'blue' : 'gray'} size='sm'>
                                 {roles[name]?.[role] ? checkMark : '-'}
                               </Badge>
                             </Td>
@@ -130,7 +130,7 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                           <Td position='sticky' left={0} bg={stickyBg} fontSize='xs'>{grant}</Td>
                           {clusterNames.map(name => (
                             <Td key={name} textAlign='center'>
-                              <Badge variant='solid' colorScheme={grants[name]?.[grant] ? 'blue' : 'gray'} size='sm'>
+                              <Badge colorScheme={grants[name]?.[grant] ? 'blue' : 'gray'} size='sm'>
                                 {grants[name]?.[grant] ? checkMark : '-'}
                               </Badge>
                             </Td>

--- a/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
@@ -22,11 +22,19 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
   })
   const grantList = [...allGrants].sort()
 
-  // Collect active roles per cluster
-  const getUserRoles = (clusterName) => {
-    const r = roles[clusterName] || {}
-    return Object.keys(r).filter(k => r[k]).sort()
-  }
+  // Collect all unique role names across clusters
+  const allRoles = new Set()
+  clusterNames.forEach(name => {
+    Object.keys(roles[name] || {}).forEach(r => allRoles.add(r))
+  })
+  const roleList = [...allRoles].sort()
+
+  const checkMark = '\u2713'
+  const cellBgYes = theme === 'light' ? 'blue.500' : 'blue.400'
+  const cellColorYes = 'white'
+  const cellBgNo = theme === 'light' ? 'gray.100' : 'gray.700'
+  const cellColorNo = theme === 'light' ? 'gray.400' : 'gray.500'
+  const stickyBg = theme === 'light' ? 'white' : 'gray.800'
 
   return (
     <Modal isOpen={isOpen} onClose={closeModal} size='xl'>
@@ -48,21 +56,42 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                   <Text fontSize='sm'>{user.Email}</Text>
                 </HStack>
               )}
-              {clusterNames.length > 0 && (
-                <HStack spacing={4} flexWrap='wrap'>
-                  <Text fontSize='sm' fontWeight={600}>Roles:</Text>
-                  {clusterNames.map(name => {
-                    const r = getUserRoles(name)
-                    return r.length > 0 ? (
-                      <HStack key={name} spacing={1}>
-                        <Text fontSize='xs' color={theme === 'light' ? 'gray.500' : 'gray.400'}>{name}:</Text>
-                        {r.map(role => <Badge key={role} colorScheme='purple' size='sm'>{role}</Badge>)}
-                      </HStack>
-                    ) : null
-                  })}
-                </HStack>
-              )}
             </Box>
+
+            {clusterNames.length > 0 && roleList.length > 0 && (
+              <>
+                <Divider />
+                <Text fontSize='sm' fontWeight={600} color={theme === 'light' ? 'gray.600' : 'gray.400'}>
+                  Roles per cluster
+                </Text>
+                <Box overflowX='auto' fontSize='xs'>
+                  <Table size='sm' variant='simple'>
+                    <Thead>
+                      <Tr>
+                        <Th position='sticky' left={0} bg={stickyBg} zIndex={1}>Role</Th>
+                        {clusterNames.map(name => (
+                          <Th key={name} textAlign='center'>{name}</Th>
+                        ))}
+                      </Tr>
+                    </Thead>
+                    <Tbody>
+                      {roleList.map(role => (
+                        <Tr key={role}>
+                          <Td position='sticky' left={0} bg={stickyBg} fontSize='xs'>{role}</Td>
+                          {clusterNames.map(name => (
+                            <Td key={name} textAlign='center'>
+                              <Badge bg={roles[name]?.[role] ? cellBgYes : cellBgNo} color={roles[name]?.[role] ? cellColorYes : cellColorNo} size='sm'>
+                                {roles[name]?.[role] ? checkMark : '-'}
+                              </Badge>
+                            </Td>
+                          ))}
+                        </Tr>
+                      ))}
+                    </Tbody>
+                  </Table>
+                </Box>
+              </>
+            )}
 
             {clusterNames.length > 0 && (
               <>
@@ -74,7 +103,7 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                   <Table size='sm' variant='simple'>
                     <Thead>
                       <Tr>
-                        <Th position='sticky' left={0} bg={theme === 'light' ? 'white' : 'gray.800'} zIndex={1}>Grant</Th>
+                        <Th position='sticky' left={0} bg={stickyBg} zIndex={1}>Grant</Th>
                         {clusterNames.map(name => (
                           <Th key={name} textAlign='center'>{name}</Th>
                         ))}
@@ -83,13 +112,12 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                     <Tbody>
                       {grantList.map(grant => (
                         <Tr key={grant}>
-                          <Td position='sticky' left={0} bg={theme === 'light' ? 'white' : 'gray.800'} fontSize='xs'>{grant}</Td>
+                          <Td position='sticky' left={0} bg={stickyBg} fontSize='xs'>{grant}</Td>
                           {clusterNames.map(name => (
                             <Td key={name} textAlign='center'>
-                              {grants[name]?.[grant]
-                                ? <Badge bg='green.600' color='white' size='sm'>Y</Badge>
-                                : <Badge bg={theme === 'light' ? 'gray.200' : 'gray.600'} color={theme === 'light' ? 'gray.500' : 'gray.400'} size='sm'>-</Badge>
-                              }
+                              <Badge bg={grants[name]?.[grant] ? cellBgYes : cellBgNo} color={grants[name]?.[grant] ? cellColorYes : cellColorNo} size='sm'>
+                                {grants[name]?.[grant] ? checkMark : '-'}
+                              </Badge>
                             </Td>
                           ))}
                         </Tr>

--- a/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
@@ -1,6 +1,6 @@
 import {
   Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalCloseButton,
-  Box, VStack, HStack, Text, Badge, Divider, Table, Thead, Tbody, Tr, Th, Td
+  Box, VStack, HStack, Text, Divider, Table, Thead, Tbody, Tr, Th, Td
 } from '@chakra-ui/react'
 import React from 'react'
 import { HiMoon, HiSun } from 'react-icons/hi'
@@ -100,9 +100,10 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                           <Td position='sticky' left={0} bg={stickyBg} fontSize='xs'>{role}</Td>
                           {clusterNames.map(name => (
                             <Td key={name} textAlign='center'>
-                              <Badge bg={roles[name]?.[role] ? cellBgYes : cellBgNo} color={roles[name]?.[role] ? cellColorYes : cellColorNo} size='sm'>
+                              <Box as='span' px={2} py={0.5} borderRadius='md' fontSize='xs' fontWeight='bold' textAlign='center' minW='24px' display='inline-block'
+                                bg={roles[name]?.[role] ? cellBgYes : cellBgNo} color={roles[name]?.[role] ? cellColorYes : cellColorNo}>
                                 {roles[name]?.[role] ? checkMark : '-'}
-                              </Badge>
+                              </Box>
                             </Td>
                           ))}
                         </Tr>
@@ -135,9 +136,10 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                           <Td position='sticky' left={0} bg={stickyBg} fontSize='xs'>{grant}</Td>
                           {clusterNames.map(name => (
                             <Td key={name} textAlign='center'>
-                              <Badge bg={grants[name]?.[grant] ? cellBgYes : cellBgNo} color={grants[name]?.[grant] ? cellColorYes : cellColorNo} size='sm'>
+                              <Box as='span' px={2} py={0.5} borderRadius='md' fontSize='xs' fontWeight='bold' textAlign='center' minW='24px' display='inline-block'
+                                bg={grants[name]?.[grant] ? cellBgYes : cellBgNo} color={grants[name]?.[grant] ? cellColorYes : cellColorNo}>
                                 {grants[name]?.[grant] ? checkMark : '-'}
-                              </Badge>
+                              </Box>
                             </Td>
                           ))}
                         </Tr>

--- a/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
@@ -70,8 +70,8 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                           {clusterNames.map(name => (
                             <Td key={name} textAlign='center'>
                               {grants[name]?.[grant]
-                                ? <Badge colorScheme='green' size='sm'>Y</Badge>
-                                : <Badge colorScheme='gray' size='sm'>-</Badge>
+                                ? <Badge bg='green.600' color='white' size='sm'>Y</Badge>
+                                : <Badge bg={theme === 'light' ? 'gray.200' : 'gray.600'} color={theme === 'light' ? 'gray.500' : 'gray.400'} size='sm'>-</Badge>
                               }
                             </Td>
                           ))}

--- a/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
@@ -12,6 +12,7 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
   const { theme, toggleTheme } = useTheme()
 
   const grants = user?.grants || {}
+  const roles = user?.roles || {}
   const clusterNames = Object.keys(grants).sort()
 
   // Collect all unique grant names across clusters
@@ -20,6 +21,12 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
     Object.keys(grants[name] || {}).forEach(g => allGrants.add(g))
   })
   const grantList = [...allGrants].sort()
+
+  // Collect active roles per cluster
+  const getUserRoles = (clusterName) => {
+    const r = roles[clusterName] || {}
+    return Object.keys(r).filter(k => r[k]).sort()
+  }
 
   return (
     <Modal isOpen={isOpen} onClose={closeModal} size='xl'>
@@ -41,10 +48,20 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
                   <Text fontSize='sm'>{user.Email}</Text>
                 </HStack>
               )}
-              <HStack spacing={4}>
-                <Text fontSize='sm' fontWeight={600}>Role:</Text>
-                <Text fontSize='sm'>{user?.Role || '-'}</Text>
-              </HStack>
+              {clusterNames.length > 0 && (
+                <HStack spacing={4} flexWrap='wrap'>
+                  <Text fontSize='sm' fontWeight={600}>Roles:</Text>
+                  {clusterNames.map(name => {
+                    const r = getUserRoles(name)
+                    return r.length > 0 ? (
+                      <HStack key={name} spacing={1}>
+                        <Text fontSize='xs' color={theme === 'light' ? 'gray.500' : 'gray.400'}>{name}:</Text>
+                        {r.map(role => <Badge key={role} colorScheme='purple' size='sm'>{role}</Badge>)}
+                      </HStack>
+                    ) : null
+                  })}
+                </HStack>
+              )}
             </Box>
 
             {clusterNames.length > 0 && (

--- a/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
@@ -49,9 +49,10 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
               <HStack spacing={4}>
                 <Text fontSize='sm' fontWeight={600}>User:</Text>
                 <Text fontSize='sm'>{user?.DisplayName || user?.User || user?.username || '-'}</Text>
-                <Badge style={{ backgroundColor: user?.AuthType === 'SSO' ? '#805AD5' : '#2B6CB0', color: '#FFFFFF' }} size='sm'>
+                <Box as='span' px={2} py={0.5} borderRadius='md' fontSize='xs' fontWeight='bold'
+                  bg={user?.AuthType === 'SSO' ? 'purple.600' : 'blue.600'} color='white'>
                   {user?.AuthType || 'Local'}
-                </Badge>
+                </Box>
               </HStack>
               {user?.Email && (
                 <HStack spacing={4}>

--- a/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
+++ b/share/dashboard_react/src/components/Modals/UserInfoPanel/index.jsx
@@ -48,7 +48,7 @@ function UserInfoPanel({ isOpen, closeModal, user, onLogout }) {
             <Box p={3} borderRadius='md' bg={theme === 'light' ? 'gray.50' : 'rgba(255,255,255,0.05)'}>
               <HStack spacing={4}>
                 <Text fontSize='sm' fontWeight={600}>User:</Text>
-                <Text fontSize='sm'>{user?.User || user?.username || '-'}</Text>
+                <Text fontSize='sm'>{user?.DisplayName || user?.User || user?.username || '-'}</Text>
               </HStack>
               {user?.Email && (
                 <HStack spacing={4}>

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -2,7 +2,6 @@ import { Box, Flex, Image, Spacer, Text, HStack, VStack, Button, useDisclosure }
 import React, { useState, useEffect} from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { logout } from '../../redux/authSlice'
-import ThemeIcon from '../Icons/ThemeIcon'
 import RefreshCounter from '../RefreshCounter'
 import { isAuthorized } from '../../utility/common'
 import { Link } from 'react-router-dom'
@@ -11,10 +10,9 @@ import AlertBadge from '../AlertBadge'
 import AlertModal from '../Modals/AlertModal'
 import SecurityScoreModal from '../Modals/SecurityScoreModal'
 import WorkloadModal from '../Modals/WorkloadModal'
-import { FaPowerOff, FaUserPlus, FaUserCircle } from 'react-icons/fa'
+import { FaUserPlus, FaUserCircle } from 'react-icons/fa'
 import { MdSecurity, MdNotificationsOff } from 'react-icons/md'
 import { RiSpeedFill } from 'react-icons/ri'
-import ConfirmModal from '../Modals/ConfirmModal'
 import InterventionPanel from '../Modals/InterventionPanel'
 import UserInfoPanel from '../Modals/UserInfoPanel'
 import { clusterService } from '../../services/clusterService'
@@ -34,7 +32,6 @@ function Navbar({ username, user }) {
   const { theme } = useTheme()
   const [alertModalType, setAlertModalType] = useState('')
   const [globalAlertModalType, setGlobalAlertModalType] = useState('')
-  const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false)
   const [isSecurityModalOpen, setIsSecurityModalOpen] = useState(false)
   const [isWorkloadModalOpen, setIsWorkloadModalOpen] = useState(false)
   const [isAddUserModalOpen, setIsAddUserModalOpen] = useState(false)
@@ -109,12 +106,6 @@ function Navbar({ username, user }) {
     setAlertModalType('')
   }
 
-  const openLogoutModal = () => {
-    setIsLogoutModalOpen(true)
-  }
-  const closeLogoutModal = () => {
-    setIsLogoutModalOpen(false)
-  }
 
   const handleLogout = () => {
     dispatch(logoutFromMeet())
@@ -234,32 +225,17 @@ function Navbar({ username, user }) {
 
           {isAuthorized() && (
             <>
-              {username && isDesktop && (
-                  <>
-                      <RMButton variant='ghost' size='small' onClick={() => setIsUserInfoPanelOpen(true)}>
-                        <HStack spacing={1}>
-                          <FaUserCircle />
-                          <Text>{username.length > 5 ? username.substring(0, 5) + '..' : username}</Text>
-                        </HStack>
-                      </RMButton>
-                      {monitor?.config?.cloud18 && (
-                        <Flex className={styles.chatIcon}>
-                          <AlertBadge
-                            isSupport={true}
-                            isConnect={!meetError}
-                            text={meetError ? 'Support (disconnected)' : 'Support'}
-                            count={unreadMessagesCount || 0}
-                            onClick={toggleChat}
-                            showText={!isMobile}
-                          />
-                        </Flex>
-                      )}
-                  </>
-              )}
-              {isMobile ? (
-                <RMIconButton onClick={openLogoutModal} border='none' icon={FaPowerOff} />
-              ) : (
-                <RMButton onClick={openLogoutModal}>Logout</RMButton>
+              {username && isDesktop && monitor?.config?.cloud18 && (
+                <Flex className={styles.chatIcon}>
+                  <AlertBadge
+                    isSupport={true}
+                    isConnect={!meetError}
+                    text={meetError ? 'Support (disconnected)' : 'Support'}
+                    count={unreadMessagesCount || 0}
+                    onClick={toggleChat}
+                    showText={!isMobile}
+                  />
+                </Flex>
               )}
               {clusterData && monitor?.config?.monitoringSaveConfig && monitor?.config?.cloud18GitUser?.length > 0 && (
                 <RMIconButton
@@ -270,10 +246,16 @@ function Navbar({ username, user }) {
                   onClick={openAddUserModal}
                 />
               )}
+              <AlertBadge
+                colorScheme='blue'
+                icon={FaUserCircle}
+                text={username ? (username.length > 5 ? username.substring(0, 5) + '..' : username) : ''}
+                count=''
+                onClick={() => setIsUserInfoPanelOpen(true)}
+                showText={!isMobile}
+              />
             </>
           )}
-
-          <ThemeIcon />
 
         </HStack>
       </Flex>
@@ -290,14 +272,6 @@ function Navbar({ username, user }) {
       )}
       {globalAlertModalType && (
         <AlertModal type={globalAlertModalType} isOpen={globalAlertModalType.length !== 0} closeModal={() => setGlobalAlertModalType('')} alerts={globalAlerts} />
-      )}
-      {isLogoutModalOpen && (
-        <ConfirmModal
-          onConfirmClick={handleLogout}
-          closeModal={closeLogoutModal}
-          isOpen={isLogoutModalOpen}
-          title={'Are you sure you want to log out?'}
-        />
       )}
       {isAddUserModalOpen && (
         <AddUserModal clusterName={clusterData?.name} isOpen={isAddUserModalOpen} closeModal={closeAddUserModal} />
@@ -345,6 +319,10 @@ function Navbar({ username, user }) {
           isOpen={isUserInfoPanelOpen}
           closeModal={() => setIsUserInfoPanelOpen(false)}
           user={user}
+          onLogout={() => {
+            setIsUserInfoPanelOpen(false)
+            handleLogout()
+          }}
         />
       )}
     </>

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -52,9 +52,9 @@ function Navbar({ username, user }) {
   const baseURL = useSelector((state) => state?.auth?.baseURL)
   const monitor = useSelector((state) => state?.globalClusters?.monitor)
 
-  // Resolve cluster-level API user (has grants) from clusterData.apiUsers
-  const clusterUser = clusterData?.apiUsers && user
-    ? (clusterData.apiUsers[user.User] || clusterData.apiUsers[user.Email] || clusterData.apiUsers[user.username])
+  // Resolve per-cluster grants from auth.user.grants (populated by whoami)
+  const userClusterGrants = clusterData?.name && user?.grants
+    ? user.grants[clusterData.name]
     : null
 
   useEffect(() => {
@@ -306,7 +306,7 @@ function Navbar({ username, user }) {
           isOpen={isInterventionPanelOpen}
           closeModal={() => setIsInterventionPanelOpen(false)}
           isGlobal={!clusterData}
-          canManage={!!clusterUser?.grants?.['db-maintenance'] || !clusterData}
+          canManage={!!userClusterGrants?.['db-maintenance'] || !clusterData}
           isActive={clusterData ? (clusterData?.isIntervention || !!clusterData?.interventionPending) : (monitor?.activeInterventionCount > 0 || monitor?.isGlobalInterventionPending)}
           current={clusterData ? (clusterData?.interventionCurrent || clusterData?.interventionPending) : monitor?.globalInterventionEntry}
           isPending={clusterData ? (!!clusterData?.interventionPending && !clusterData?.isIntervention) : (monitor?.isGlobalInterventionPending && !monitor?.isGlobalIntervention)}

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -11,11 +11,12 @@ import AlertBadge from '../AlertBadge'
 import AlertModal from '../Modals/AlertModal'
 import SecurityScoreModal from '../Modals/SecurityScoreModal'
 import WorkloadModal from '../Modals/WorkloadModal'
-import { FaPowerOff, FaUserPlus } from 'react-icons/fa'
+import { FaPowerOff, FaUserPlus, FaUserCircle } from 'react-icons/fa'
 import { MdSecurity, MdNotificationsOff } from 'react-icons/md'
 import { RiSpeedFill } from 'react-icons/ri'
 import ConfirmModal from '../Modals/ConfirmModal'
 import InterventionPanel from '../Modals/InterventionPanel'
+import UserInfoPanel from '../Modals/UserInfoPanel'
 import { clusterService } from '../../services/clusterService'
 import { getApi } from '../../services/apiHelper'
 import styles from './styles.module.scss'
@@ -38,6 +39,7 @@ function Navbar({ username, user }) {
   const [isWorkloadModalOpen, setIsWorkloadModalOpen] = useState(false)
   const [isAddUserModalOpen, setIsAddUserModalOpen] = useState(false)
   const [isInterventionPanelOpen, setIsInterventionPanelOpen] = useState(false)
+  const [isUserInfoPanelOpen, setIsUserInfoPanelOpen] = useState(false)
   const [unreadMessagesCount, setUnreadMessagesCount] = useState(0)
   const [isChatOpen, setIsChatOpen] = useState(() => { return localStorage.getItem('chatOpen') === 'true'; });
   const [showImageLogo, setShowImageLogo] = useState(true)
@@ -234,7 +236,12 @@ function Navbar({ username, user }) {
             <>
               {username && isDesktop && (
                   <>
-                      <Text>{`Welcome, ${username}`}</Text>
+                      <RMButton variant='ghost' size='small' onClick={() => setIsUserInfoPanelOpen(true)}>
+                        <HStack spacing={1}>
+                          <FaUserCircle />
+                          <Text>{username.length > 5 ? username.substring(0, 5) + '..' : username}</Text>
+                        </HStack>
+                      </RMButton>
                       {monitor?.config?.cloud18 && (
                         <Flex className={styles.chatIcon}>
                           <AlertBadge
@@ -331,6 +338,13 @@ function Navbar({ username, user }) {
               setIsInterventionPanelOpen(false)
             }).catch((err) => console.error('Failed to end intervention:', err))
           }}
+        />
+      )}
+      {isUserInfoPanelOpen && (
+        <UserInfoPanel
+          isOpen={isUserInfoPanelOpen}
+          closeModal={() => setIsUserInfoPanelOpen(false)}
+          user={user}
         />
       )}
     </>

--- a/utils/githelper/githelper.go
+++ b/utils/githelper/githelper.go
@@ -415,6 +415,37 @@ func GetGitLabUserEmail(acces_token string, log_git bool) (string, error) {
 
 }
 
+// GitLabUserProfile holds the display name and email from /api/v4/user.
+type GitLabUserProfile struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+// GetGitLabUserProfile fetches the authenticated user's profile (name + email).
+func GetGitLabUserProfile(accessToken string) (*GitLabUserProfile, error) {
+	req, err := http.NewRequest("GET", "https://gitlab.signal18.io/api/v4/user", nil)
+	if err != nil {
+		return nil, fmt.Errorf("gitlab user profile API error: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("gitlab user profile API error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("gitlab user profile API returned %d", resp.StatusCode)
+	}
+
+	var profile GitLabUserProfile
+	if err := json.NewDecoder(resp.Body).Decode(&profile); err != nil {
+		return nil, fmt.Errorf("gitlab user profile decode error: %w", err)
+	}
+	return &profile, nil
+}
+
 // Get User Access Level
 func InitGroupAccessLevel(acces_token, domain string, user_id int, log_git bool) (int, error) {
 	var body = make([]byte, 0)

--- a/utils/githelper/githelper.go
+++ b/utils/githelper/githelper.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -422,14 +423,16 @@ type GitLabUserProfile struct {
 }
 
 // GetGitLabUserProfile fetches the authenticated user's profile (name + email).
+// Uses a 10-second timeout to avoid blocking the login goroutine if GitLab is slow.
 func GetGitLabUserProfile(accessToken string) (*GitLabUserProfile, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
 	req, err := http.NewRequest("GET", "https://gitlab.signal18.io/api/v4/user", nil)
 	if err != nil {
 		return nil, fmt.Errorf("gitlab user profile API error: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("gitlab user profile API error: %w", err)
 	}


### PR DESCRIPTION
## Summary

Enhance the whoami API to return per-cluster grants, roles, and auth type. Add a user profile panel to the navbar replacing the text welcome message.

### Backend (server/api.go, utils/githelper/githelper.go)
- **whoami** returns per-cluster `grants` and `roles` maps from APIUsers
- **AuthType** field: "Local" or "SSO" based on JWT profile claim
- **DisplayName** for SSO users fetched from GitLab `/api/v4/user` profile
- **Admin email** set from Cloud18 registration on registered instances

### Frontend
- **User icon badge** in navbar (blue AlertBadge, same size as other icons)
- **UserInfoPanel** modal with:
  - User info: display name, email, auth type badge (Local/SSO)
  - Theme toggle (Dark/Light mode) — moved from navbar
  - Logout button — moved from navbar
  - Roles per cluster table
  - Grants per cluster table
- **canManage** for intervention panel resolved from whoami grants
- Removed standalone Logout button, ThemeIcon, ConfirmModal from navbar
- Theme-aware Badge styling: subtle in light mode, solid in dark mode

### whoami response format
```json
{
  "User": "admin",
  "DisplayName": "Stephane Varoqui",
  "Email": "stephane@signal18.io",
  "AuthType": "Local",
  "grants": { "cluster1": { "db-maintenance": true, ... } },
  "roles": { "cluster1": { "sysops": true, "dbops": true } }
}
```

## Test plan
- [ ] Login as local admin — panel shows Local badge, grants, roles
- [ ] Login as SSO user — panel shows SSO badge, display name from GitLab
- [ ] Light mode: badges readable (light bg, dark text)
- [ ] Dark mode: badges readable (solid bg, white text)
- [ ] Theme toggle works from panel
- [ ] Logout works from panel
- [ ] Intervention mute button visible when user has db-maintenance grant