### PR TITLE
fix(haproxy): add websocket backend timeouts

### DIFF
--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -1086,8 +1086,10 @@ frontend %s
 backend %s
     mode http
     balance leastconn
-    option http-keep-alive
-    option http-ignore-probes
+    option http-server-close
+    timeout connect 10s
+    timeout server 5m
+    timeout tunnel 1h
     default-server inter 5s fastinter 2s downinter 10s fall 3 rise 2
     server-template srv %d %s:%s resolvers cluster check init-addr none
 `, frontend, route.CName, route.SourcePort, backend, backend, numBE, opensvcDNS, route.DestinationPort)
@@ -1102,6 +1104,10 @@ backend %s
     cookie SERVER insert indirect nocache dynamic
     balance roundrobin
     dynamic-cookie-key mysecretphrase
+    option http-server-close
+    timeout connect 10s
+    timeout server 5m
+    timeout tunnel 1h
     server-template srv %d %s:%s resolvers cluster check init-addr none
 `, backend, route.CName, backend, numBE, opensvcDNS, route.DestinationPort)
 	}

--- a/cluster/prov_opensvc_app_route_test.go
+++ b/cluster/prov_opensvc_app_route_test.go
@@ -30,6 +30,9 @@ func TestBuildRouteFragment_HostRouteUsesOriginDevelopNames(t *testing.T) {
 	if !strings.Contains(fragment, "backend minio.crm.svc.cluster.local_9001") {
 		t.Fatalf("host backend name mismatch: %s", fragment)
 	}
+	if !strings.Contains(fragment, "timeout tunnel 1h") {
+		t.Fatalf("host fragment missing websocket timeout tunnel: %s", fragment)
+	}
 	if strings.Contains(fragment, "be_") || strings.Contains(fragment, "repman_") {
 		t.Fatalf("host fragment still contains tokenized naming: %s", fragment)
 	}
@@ -61,6 +64,9 @@ func TestBuildRouteFragment_PortRouteUsesReadableNames(t *testing.T) {
 	}
 	if !strings.Contains(fragment, "backend "+base+"_backend") {
 		t.Fatalf("port backend name mismatch: %s", fragment)
+	}
+	if !strings.Contains(fragment, "timeout tunnel 1h") {
+		t.Fatalf("port fragment missing websocket timeout tunnel: %s", fragment)
 	}
 	if strings.Contains(fragment, "be_") || strings.Contains(fragment, "fe_") || strings.Contains(fragment, "repman_") {
 		t.Fatalf("port fragment still contains tokenized naming: %s", fragment)


### PR DESCRIPTION
## Summary
- add websocket-friendly HAProxy backend settings for OpenSVC app routes
- replace keep-alive/probe options with `http-server-close` plus explicit connect, server, and tunnel timeouts
- extend route fragment tests for both host and port routes

## Why
We need this because websocket traffic requires the HAProxy tunnel/timeout configuration to stay open reliably.

## Testing
- `go test ./cluster -run 'TestBuildRouteFragment'`\n- `go test ./cluster/...` *(currently fails in existing unrelated `cluster/logplugin` drift tests: `TestAuditDrift_NewTemplateDetected`, `TestAuditDrift_CustomWindowViaConfig`, `TestAuditDrift_MaxNewTemplatesList`)*