### PR TITLE
feat: sysbench benchmark history, comparison & h2 WebSocket support

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -313,6 +313,7 @@ type Cluster struct {
 	VersionsMap           *config.VersionsMap
 	SessionManager        *tty.SessionManager `json:"-"`
 	SysBenchTpcMResults   []SysBenchTpcResultPerMinute
+	SysbenchHistory       SysbenchLog                  `json:"sysbenchHistory"  groups:"web"`
 	OpenSVCStats          atomic.Value `json:"-"`
 	OrchestratorVersion   string       `json:"-"`
 	orchestratorVersionMu sync.RWMutex `json:"-"`

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -493,6 +493,7 @@ func (cluster *Cluster) InitFromConf() {
 	cluster.WorkingDir = cluster.Conf.WorkingDir + "/" + cluster.Name
 	cluster.InterventionHistory = make([]InterventionEntry, 0)
 	cluster.LoadInterventionHistory()
+	cluster.LoadSysbenchLog()
 	cluster.pluginSpikeCache = make(map[string]*logplugin.SpikeCache)
 	cluster.pluginRegistry = logplugin.NewRegistry()
 	if cluster.Conf.Arbitration {

--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -194,6 +194,8 @@ var clusterACLRules = []ACLRule{
 
 	// Testing and Benchmarking
 	{"/actions/sysbench", nil, []string{config.GrantClusterBench, config.GrantClusterTest}},
+	{"/actions/sysbench-history", nil, []string{config.GrantClusterBench, config.GrantClusterTest}},
+	{"/actions/sysbench-compare", nil, []string{config.GrantClusterBench, config.GrantClusterTest}},
 	{"/tests/", nil, []string{config.GrantClusterTest}},
 
 	// Replication

--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -194,8 +194,6 @@ var clusterACLRules = []ACLRule{
 
 	// Testing and Benchmarking
 	{"/actions/sysbench", nil, []string{config.GrantClusterBench, config.GrantClusterTest}},
-	{"/actions/sysbench-history", nil, []string{config.GrantClusterBench, config.GrantClusterTest}},
-	{"/actions/sysbench-compare", nil, []string{config.GrantClusterBench, config.GrantClusterTest}},
 	{"/tests/", nil, []string{config.GrantClusterTest}},
 
 	// Replication

--- a/cluster/cluster_bench_log.go
+++ b/cluster/cluster_bench_log.go
@@ -49,17 +49,9 @@ type SysbenchLogEntry struct {
 	AvgTPS       float64                      `json:"avgTps"`
 	AvgLatency   float64                      `json:"avgLatency"`
 	TotalErrors  int                          `json:"totalErrors"`
-	TPSPerDBU    float64                      `json:"tpsPerDbu"`    // avgTps / clusterDBU — performance efficiency
-	ScaleResults []SysbenchScalePoint         `json:"scaleResults,omitempty"` // populated for scaling runs (1-2xCPU)
-}
-
-// SysbenchScalePoint holds the result of a single thread count within a scaling run.
-type SysbenchScalePoint struct {
-	Threads    int     `json:"threads"`
-	AvgTPS     float64 `json:"avgTps"`
-	AvgLatency float64 `json:"avgLatency"`
-	TotalErrors int    `json:"totalErrors"`
-	TPSPerDBU  float64 `json:"tpsPerDbu"`
+	TPSPerDBU    float64                      `json:"tpsPerDbu"`              // avgTps / clusterDBU — performance efficiency
+	IsScale      bool                         `json:"isScale,omitempty"`      // true if part of a thread-scaling run
+	ScaleGroup   time.Time                    `json:"scaleGroup,omitempty"`   // ties scale entries together (start time of the scale run)
 }
 
 // SysbenchLog holds the full history of sysbench runs for a cluster.
@@ -95,7 +87,7 @@ func (cluster *Cluster) LoadSysbenchLog() {
 
 // LogSysbenchRun captures the context and results of a sysbench run and appends it to history.
 // rawOutput is the full sysbench output for summary parsing when per-second records are empty.
-func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads int, tableSize int, duration int, startedAt time.Time, records []SysbenchRecord, rawOutput string) {
+func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads int, tableSize int, duration int, startedAt time.Time, records []SysbenchRecord, rawOutput string, scaleGroup ...time.Time) {
 	dbNodes := len(cluster.Servers) // all database nodes (master + replicas)
 	entry := SysbenchLogEntry{
 		StartedAt:   startedAt,
@@ -164,6 +156,12 @@ func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads
 		entry.TPSPerDBU = entry.AvgTPS / entry.ClusterDBU
 	}
 
+	// Scale run metadata
+	if len(scaleGroup) > 0 && !scaleGroup[0].IsZero() {
+		entry.IsScale = true
+		entry.ScaleGroup = scaleGroup[0]
+	}
+
 	// Append TPCM results
 	entry.Results = cluster.SysBenchTpcMResults
 
@@ -174,67 +172,6 @@ func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads
 		"Sysbench run logged: %s/%s threads=%d avgTPS=%.1f avgLatency=%.2fms flavor=%s/%s proxy=%s/%s replicas=%d DBU=%.1f clusterDBU=%.1f TPS/DBU=%.2f tags=%s",
 		testType, testMode, threads, entry.AvgTPS, entry.AvgLatency, entry.DBFlavor, entry.DBVersion,
 		entry.ProxyType, entry.ProxyVersion, entry.Replicas, entry.DBU, entry.ClusterDBU, entry.TPSPerDBU, entry.ConfigTags)
-}
-
-// LogSysbenchScaleRun creates a single log entry for a thread-scaling run with per-thread results.
-func (cluster *Cluster) LogSysbenchScaleRun(testType string, startedAt time.Time, scalePoints []SysbenchScalePoint) {
-	dbNodes := len(cluster.Servers)
-	entry := SysbenchLogEntry{
-		StartedAt:    startedAt,
-		EndedAt:      time.Now(),
-		TestType:     testType,
-		Threads:      0, // 0 signals a scaling run
-		Tables:       cluster.Conf.SysbenchTables,
-		Scale:        cluster.Conf.SysbenchScale,
-		ConfigTags:   cluster.Conf.ProvTags,
-		ServicePlan:  cluster.Conf.ProvServicePlan,
-		Replicas:     len(cluster.slaves),
-		Cores:        cluster.Conf.ProvCores,
-		MemoryMB:     cluster.Conf.ProvMem,
-		DiskGB:       cluster.Conf.ProvDisk,
-		ScaleResults: scalePoints,
-	}
-
-	// Compute DBU
-	cores, _ := strconv.ParseFloat(cluster.Conf.ProvCores, 64)
-	memMB, _ := strconv.ParseFloat(cluster.Conf.ProvMem, 64)
-	diskGB, _ := strconv.ParseFloat(cluster.Conf.ProvDisk, 64)
-	entry.DBU = math.Max(cores, math.Max(memMB/4096, diskGB/40))
-	entry.ClusterDBU = entry.DBU * float64(dbNodes)
-
-	// DB flavor + version from master
-	if master := cluster.GetMaster(); master != nil && master.DBVersion != nil {
-		entry.DBFlavor = master.DBVersion.Flavor
-		entry.DBVersion = master.DBVersion.ToString()
-		entry.GraphiteHost = master.graphiteHostname()
-	}
-
-	// Proxy info
-	proxies := cluster.GetProxies()
-	if len(proxies) > 0 {
-		prx := proxies[0]
-		entry.ProxyType = prx.GetType()
-		entry.ProxyVersion = prx.GetVersion()
-	}
-
-	// Use the best TPS across scale points as the entry's avgTps
-	for _, sp := range scalePoints {
-		if sp.AvgTPS > entry.AvgTPS {
-			entry.AvgTPS = sp.AvgTPS
-			entry.AvgLatency = sp.AvgLatency
-			entry.Threads = sp.Threads
-		}
-	}
-	if entry.ClusterDBU > 0 && entry.AvgTPS > 0 {
-		entry.TPSPerDBU = entry.AvgTPS / entry.ClusterDBU
-	}
-
-	cluster.SysbenchHistory.Entries = append(cluster.SysbenchHistory.Entries, entry)
-	cluster.SaveSysbenchLog()
-
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "BENCH",
-		"Sysbench scale run logged: %s points=%d peakTPS=%.1f@%dt flavor=%s/%s clusterDBU=%.1f",
-		testType, len(scalePoints), entry.AvgTPS, entry.Threads, entry.DBFlavor, entry.DBVersion, entry.ClusterDBU)
 }
 
 // SysbenchSummary holds parsed values from the sysbench summary output.

--- a/cluster/cluster_bench_log.go
+++ b/cluster/cluster_bench_log.go
@@ -51,7 +51,7 @@ type SysbenchLogEntry struct {
 	TotalErrors  int                          `json:"totalErrors"`
 	TPSPerDBU    float64                      `json:"tpsPerDbu"`              // avgTps / clusterDBU — performance efficiency
 	IsScale      bool                         `json:"isScale,omitempty"`      // true if part of a thread-scaling run
-	ScaleGroup   time.Time                    `json:"scaleGroup,omitempty"`   // ties scale entries together (start time of the scale run)
+	ScaleGroup   *time.Time                   `json:"scaleGroup,omitempty"`   // ties scale entries together (start time of the scale run)
 }
 
 // SysbenchLog holds the full history of sysbench runs for a cluster.
@@ -159,7 +159,8 @@ func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads
 	// Scale run metadata
 	if len(scaleGroup) > 0 && !scaleGroup[0].IsZero() {
 		entry.IsScale = true
-		entry.ScaleGroup = scaleGroup[0]
+		t := scaleGroup[0]
+		entry.ScaleGroup = &t
 	}
 
 	// Append TPCM results

--- a/cluster/cluster_bench_log.go
+++ b/cluster/cluster_bench_log.go
@@ -33,6 +33,7 @@ type SysbenchLogEntry struct {
 	Scale        int                          `json:"scale"`        // sysbench-scale (tpcc warehouses)
 	DBFlavor     string                       `json:"dbFlavor"`     // MariaDB, MySQL, Percona, PostgreSQL
 	DBVersion    string                       `json:"dbVersion"`
+	GraphiteHost string                       `json:"graphiteHost"` // graphite metric hostname (@@hostname with replacements)
 	ProxyType    string                       `json:"proxyType"`    // proxysql, haproxy, maxscale, myproxy
 	ProxyVersion string                       `json:"proxyVersion"`
 	Replicas     int                          `json:"replicas"`
@@ -116,6 +117,7 @@ func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads
 	if master := cluster.GetMaster(); master != nil && master.DBVersion != nil {
 		entry.DBFlavor = master.DBVersion.Flavor
 		entry.DBVersion = master.DBVersion.ToString()
+		entry.GraphiteHost = master.graphiteHostname()
 	}
 
 	// Proxy info

--- a/cluster/cluster_bench_log.go
+++ b/cluster/cluster_bench_log.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -82,7 +83,8 @@ func (cluster *Cluster) LoadSysbenchLog() {
 }
 
 // LogSysbenchRun captures the context and results of a sysbench run and appends it to history.
-func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads int, tableSize int, duration int, startedAt time.Time, records []SysbenchRecord) {
+// rawOutput is the full sysbench output for summary parsing when per-second records are empty.
+func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads int, tableSize int, duration int, startedAt time.Time, records []SysbenchRecord, rawOutput string) {
 	dbNodes := len(cluster.Servers) // all database nodes (master + replicas)
 	entry := SysbenchLogEntry{
 		StartedAt:   startedAt,
@@ -124,7 +126,7 @@ func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads
 		entry.ProxyVersion = prx.GetVersion()
 	}
 
-	// Compute averages from records
+	// Compute averages from per-second records
 	if len(records) > 0 {
 		var totalTPS, totalLatency float64
 		var totalErrors int
@@ -136,6 +138,13 @@ func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads
 		entry.AvgTPS = totalTPS / float64(len(records))
 		entry.AvgLatency = totalLatency / float64(len(records))
 		entry.TotalErrors = totalErrors
+	} else if rawOutput != "" {
+		// Fallback: parse the summary output when no per-second lines available
+		if summary := ParseSysbenchSummary(rawOutput); summary != nil {
+			entry.AvgTPS = summary.TPS
+			entry.AvgLatency = summary.AvgLatency
+			entry.TotalErrors = int(summary.Errors)
+		}
 	}
 
 	// TPS per DBU — performance efficiency metric
@@ -153,6 +162,63 @@ func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads
 		"Sysbench run logged: %s/%s threads=%d avgTPS=%.1f avgLatency=%.2fms flavor=%s/%s proxy=%s/%s replicas=%d DBU=%.1f clusterDBU=%.1f TPS/DBU=%.2f tags=%s",
 		testType, testMode, threads, entry.AvgTPS, entry.AvgLatency, entry.DBFlavor, entry.DBVersion,
 		entry.ProxyType, entry.ProxyVersion, entry.Replicas, entry.DBU, entry.ClusterDBU, entry.TPSPerDBU, entry.ConfigTags)
+}
+
+// SysbenchSummary holds parsed values from the sysbench summary output.
+type SysbenchSummary struct {
+	TPS        float64
+	QPS        float64
+	AvgLatency float64
+	P95Latency float64
+	Errors     float64
+	TotalTime  float64
+}
+
+// ParseSysbenchSummary extracts TPS, QPS, latency from the sysbench summary output
+// when per-second progress lines are not available.
+func ParseSysbenchSummary(output string) *SysbenchSummary {
+	s := &SysbenchSummary{}
+
+	// transactions: 21152 (211.45 per sec.)
+	reTPS := regexp.MustCompile(`transactions:\s+\d+\s+\((\d+\.?\d*)\s+per sec`)
+	if m := reTPS.FindStringSubmatch(output); len(m) > 1 {
+		s.TPS, _ = strconv.ParseFloat(m[1], 64)
+	}
+
+	// queries: 423040 (4228.96 per sec.)
+	reQPS := regexp.MustCompile(`queries:\s+\d+\s+\((\d+\.?\d*)\s+per sec`)
+	if m := reQPS.FindStringSubmatch(output); len(m) > 1 {
+		s.QPS, _ = strconv.ParseFloat(m[1], 64)
+	}
+
+	// avg: 37.83
+	reAvg := regexp.MustCompile(`avg:\s+(\d+\.?\d*)`)
+	if m := reAvg.FindStringSubmatch(output); len(m) > 1 {
+		s.AvgLatency, _ = strconv.ParseFloat(m[1], 64)
+	}
+
+	// 95th percentile: 38.94
+	reP95 := regexp.MustCompile(`95th percentile:\s+(\d+\.?\d*)`)
+	if m := reP95.FindStringSubmatch(output); len(m) > 1 {
+		s.P95Latency, _ = strconv.ParseFloat(m[1], 64)
+	}
+
+	// ignored errors: 0 (0.00 per sec.)
+	reErr := regexp.MustCompile(`ignored errors:\s+(\d+)`)
+	if m := reErr.FindStringSubmatch(output); len(m) > 1 {
+		s.Errors, _ = strconv.ParseFloat(m[1], 64)
+	}
+
+	// total time: 100.0327s
+	reTime := regexp.MustCompile(`total time:\s+(\d+\.?\d*)s`)
+	if m := reTime.FindStringSubmatch(output); len(m) > 1 {
+		s.TotalTime, _ = strconv.ParseFloat(m[1], 64)
+	}
+
+	if s.TPS == 0 && s.QPS == 0 {
+		return nil
+	}
+	return s
 }
 
 // SysbenchCompareResult holds multiple runs and a graphite render URL for comparison.

--- a/cluster/cluster_bench_log.go
+++ b/cluster/cluster_bench_log.go
@@ -8,7 +8,9 @@ package cluster
 
 import (
 	"encoding/json"
+	"fmt"
 	"math"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -151,4 +153,106 @@ func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads
 		"Sysbench run logged: %s/%s threads=%d avgTPS=%.1f avgLatency=%.2fms flavor=%s/%s proxy=%s/%s replicas=%d DBU=%.1f clusterDBU=%.1f TPS/DBU=%.2f tags=%s",
 		testType, testMode, threads, entry.AvgTPS, entry.AvgLatency, entry.DBFlavor, entry.DBVersion,
 		entry.ProxyType, entry.ProxyVersion, entry.Replicas, entry.DBU, entry.ClusterDBU, entry.TPSPerDBU, entry.ConfigTags)
+}
+
+// SysbenchCompareResult holds multiple runs and a graphite render URL for comparison.
+type SysbenchCompareResult struct {
+	Runs        []SysbenchLogEntry `json:"runs"`
+	Metric      string             `json:"metric"`
+	GraphiteURL string             `json:"graphiteUrl"`
+}
+
+// GetLastSysbenchRuns returns the last N runs from history (most recent first).
+func (cluster *Cluster) GetLastSysbenchRuns(n int) []SysbenchLogEntry {
+	entries := cluster.SysbenchHistory.Entries
+	if n <= 0 || n > 10 {
+		n = 10
+	}
+	if len(entries) < n {
+		n = len(entries)
+	}
+	// Return most recent first
+	result := make([]SysbenchLogEntry, n)
+	for i := 0; i < n; i++ {
+		result[i] = entries[len(entries)-1-i]
+	}
+	return result
+}
+
+// CompareSysbenchRuns builds a graphite render URL that overlays a chosen metric
+// from the selected runs, using timeShift to align all runs to the most recent one.
+// metric is a graphite metric suffix like "mysql_global_status_questions".
+// runIndices are positions in the history (0 = oldest). Pass nil for last 10.
+func (cluster *Cluster) CompareSysbenchRuns(metric string, runIndices []int) (*SysbenchCompareResult, error) {
+	entries := cluster.SysbenchHistory.Entries
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("no sysbench runs recorded")
+	}
+
+	// Default: last 10 runs
+	if len(runIndices) == 0 {
+		start := len(entries) - 10
+		if start < 0 {
+			start = 0
+		}
+		for i := start; i < len(entries); i++ {
+			runIndices = append(runIndices, i)
+		}
+	}
+
+	// Validate indices and collect runs
+	var runs []SysbenchLogEntry
+	for _, idx := range runIndices {
+		if idx < 0 || idx >= len(entries) {
+			return nil, fmt.Errorf("run index %d out of range (0-%d)", idx, len(entries)-1)
+		}
+		runs = append(runs, entries[idx])
+	}
+
+	result := &SysbenchCompareResult{
+		Runs:   runs,
+		Metric: metric,
+	}
+
+	// Build graphite render URL
+	apiURL := cluster.graphiteAPIURL()
+	if apiURL == "" {
+		return result, nil
+	}
+	master := cluster.GetMaster()
+	if master == nil {
+		return result, nil
+	}
+	hostname := master.graphiteHostname()
+	fullMetric := fmt.Sprintf("mysql.%s.%s", hostname, metric)
+
+	// Align all runs to the most recent one's time window
+	newest := runs[0]
+	for _, r := range runs {
+		if r.StartedAt.After(newest.StartedAt) {
+			newest = r
+		}
+	}
+
+	u, _ := url.Parse(apiURL + "/render/")
+	q := u.Query()
+	q.Set("format", "json")
+	q.Set("noCache", "1")
+	q.Set("from", strconv.FormatInt(newest.StartedAt.Unix(), 10))
+	q.Set("until", strconv.FormatInt(newest.EndedAt.Unix(), 10))
+
+	for i, run := range runs {
+		label := fmt.Sprintf("Run%d %s %dt %s/%s", i+1, run.TestType, run.Threads, run.DBFlavor, run.DBVersion)
+		if run.StartedAt.Equal(newest.StartedAt) {
+			q.Add("target", fmt.Sprintf("alias(%s,'%s')", fullMetric, label))
+		} else {
+			shift := newest.StartedAt.Sub(run.StartedAt)
+			q.Add("target", fmt.Sprintf("alias(timeShift(%s,'%ds'),'%s')", fullMetric, int(shift.Seconds()), label))
+		}
+	}
+
+	u.RawQuery = q.Encode()
+	result.GraphiteURL = u.String()
+
+	return result, nil
 }

--- a/cluster/cluster_bench_log.go
+++ b/cluster/cluster_bench_log.go
@@ -1,0 +1,130 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// Authors: Guillaume Lefranc <guillaume@signal18.io>
+//          Stephane Varoqui  <svaroqui@gmail.com>
+// This source code is licensed under the GNU General Public License, version 3.
+
+package cluster
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/signal18/replication-manager/config"
+)
+
+// SysbenchLogEntry records the context and results of a single sysbench run.
+type SysbenchLogEntry struct {
+	StartedAt    time.Time                    `json:"startedAt"`
+	EndedAt      time.Time                    `json:"endedAt"`
+	TestType     string                       `json:"testType"`     // oltp_read_write, oltp_read_only, oltp_update_index, oltp_update_non_index, tpcc
+	TestMode     string                       `json:"testMode"`     // complex, simple, nontrx (legacy oltp)
+	Threads      int                          `json:"threads"`
+	Duration     int                          `json:"duration"`     // seconds
+	TableSize    int                          `json:"tableSize"`
+	Tables       int                          `json:"tables"`       // sysbench-tables
+	Scale        int                          `json:"scale"`        // sysbench-scale (tpcc warehouses)
+	DBFlavor     string                       `json:"dbFlavor"`     // MariaDB, MySQL, Percona, PostgreSQL
+	DBVersion    string                       `json:"dbVersion"`
+	ProxyType    string                       `json:"proxyType"`    // proxysql, haproxy, maxscale, myproxy
+	ProxyVersion string                       `json:"proxyVersion"`
+	Replicas     int                          `json:"replicas"`
+	ConfigTags   string                       `json:"configTags"`   // prov-db-tags at run time
+	ServicePlan  string                       `json:"servicePlan"`
+	Results      []SysBenchTpcResultPerMinute `json:"results"`
+	Records      []SysbenchRecord             `json:"records,omitempty"`
+	AvgTPS       float64                      `json:"avgTps"`
+	AvgLatency   float64                      `json:"avgLatency"`
+	TotalErrors  int                          `json:"totalErrors"`
+}
+
+// SysbenchLog holds the full history of sysbench runs for a cluster.
+type SysbenchLog struct {
+	Entries []SysbenchLogEntry `json:"entries"`
+}
+
+// SaveSysbenchLog writes the sysbench history to disk.
+func (cluster *Cluster) SaveSysbenchLog() error {
+	path := filepath.Join(cluster.WorkingDir, "sysbench.json")
+	os.MkdirAll(filepath.Dir(path), 0755)
+
+	data, err := json.MarshalIndent(cluster.SysbenchHistory, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+// LoadSysbenchLog reads the sysbench history from disk.
+func (cluster *Cluster) LoadSysbenchLog() {
+	path := filepath.Join(cluster.WorkingDir, "sysbench.json")
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	var log SysbenchLog
+	if err := json.Unmarshal(bytes, &log); err != nil {
+		return
+	}
+	cluster.SysbenchHistory = log
+}
+
+// LogSysbenchRun captures the context and results of a sysbench run and appends it to history.
+func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads int, tableSize int, duration int, startedAt time.Time, records []SysbenchRecord) {
+	entry := SysbenchLogEntry{
+		StartedAt:   startedAt,
+		EndedAt:     time.Now(),
+		TestType:    testType,
+		TestMode:    testMode,
+		Threads:     threads,
+		Duration:    duration,
+		TableSize:   tableSize,
+		Tables:      cluster.Conf.SysbenchTables,
+		Scale:       cluster.Conf.SysbenchScale,
+		ConfigTags:  cluster.Conf.ProvTags,
+		ServicePlan: cluster.Conf.ProvServicePlan,
+		Replicas:    len(cluster.slaves),
+		Records:     records,
+	}
+
+	// DB flavor + version from master
+	if master := cluster.GetMaster(); master != nil && master.DBVersion != nil {
+		entry.DBFlavor = master.DBVersion.Flavor
+		entry.DBVersion = master.DBVersion.ToString()
+	}
+
+	// Proxy info
+	proxies := cluster.GetProxies()
+	if len(proxies) > 0 {
+		prx := proxies[0]
+		entry.ProxyType = prx.GetType()
+		entry.ProxyVersion = prx.GetVersion()
+	}
+
+	// Compute averages from records
+	if len(records) > 0 {
+		var totalTPS, totalLatency float64
+		var totalErrors int
+		for _, r := range records {
+			totalTPS += r.TPS
+			totalLatency += r.Latency
+			totalErrors += int(r.ErrorPerSec)
+		}
+		entry.AvgTPS = totalTPS / float64(len(records))
+		entry.AvgLatency = totalLatency / float64(len(records))
+		entry.TotalErrors = totalErrors
+	}
+
+	// Append TPCM results
+	entry.Results = cluster.SysBenchTpcMResults
+
+	cluster.SysbenchHistory.Entries = append(cluster.SysbenchHistory.Entries, entry)
+	cluster.SaveSysbenchLog()
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "BENCH",
+		"Sysbench run logged: %s/%s threads=%d avgTPS=%.1f avgLatency=%.2fms flavor=%s/%s proxy=%s/%s replicas=%d tags=%s",
+		testType, testMode, threads, entry.AvgTPS, entry.AvgLatency, entry.DBFlavor, entry.DBVersion,
+		entry.ProxyType, entry.ProxyVersion, entry.Replicas, entry.ConfigTags)
+}

--- a/cluster/cluster_bench_log.go
+++ b/cluster/cluster_bench_log.go
@@ -50,6 +50,16 @@ type SysbenchLogEntry struct {
 	AvgLatency   float64                      `json:"avgLatency"`
 	TotalErrors  int                          `json:"totalErrors"`
 	TPSPerDBU    float64                      `json:"tpsPerDbu"`    // avgTps / clusterDBU — performance efficiency
+	ScaleResults []SysbenchScalePoint         `json:"scaleResults,omitempty"` // populated for scaling runs (1-2xCPU)
+}
+
+// SysbenchScalePoint holds the result of a single thread count within a scaling run.
+type SysbenchScalePoint struct {
+	Threads    int     `json:"threads"`
+	AvgTPS     float64 `json:"avgTps"`
+	AvgLatency float64 `json:"avgLatency"`
+	TotalErrors int    `json:"totalErrors"`
+	TPSPerDBU  float64 `json:"tpsPerDbu"`
 }
 
 // SysbenchLog holds the full history of sysbench runs for a cluster.
@@ -164,6 +174,67 @@ func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads
 		"Sysbench run logged: %s/%s threads=%d avgTPS=%.1f avgLatency=%.2fms flavor=%s/%s proxy=%s/%s replicas=%d DBU=%.1f clusterDBU=%.1f TPS/DBU=%.2f tags=%s",
 		testType, testMode, threads, entry.AvgTPS, entry.AvgLatency, entry.DBFlavor, entry.DBVersion,
 		entry.ProxyType, entry.ProxyVersion, entry.Replicas, entry.DBU, entry.ClusterDBU, entry.TPSPerDBU, entry.ConfigTags)
+}
+
+// LogSysbenchScaleRun creates a single log entry for a thread-scaling run with per-thread results.
+func (cluster *Cluster) LogSysbenchScaleRun(testType string, startedAt time.Time, scalePoints []SysbenchScalePoint) {
+	dbNodes := len(cluster.Servers)
+	entry := SysbenchLogEntry{
+		StartedAt:    startedAt,
+		EndedAt:      time.Now(),
+		TestType:     testType,
+		Threads:      0, // 0 signals a scaling run
+		Tables:       cluster.Conf.SysbenchTables,
+		Scale:        cluster.Conf.SysbenchScale,
+		ConfigTags:   cluster.Conf.ProvTags,
+		ServicePlan:  cluster.Conf.ProvServicePlan,
+		Replicas:     len(cluster.slaves),
+		Cores:        cluster.Conf.ProvCores,
+		MemoryMB:     cluster.Conf.ProvMem,
+		DiskGB:       cluster.Conf.ProvDisk,
+		ScaleResults: scalePoints,
+	}
+
+	// Compute DBU
+	cores, _ := strconv.ParseFloat(cluster.Conf.ProvCores, 64)
+	memMB, _ := strconv.ParseFloat(cluster.Conf.ProvMem, 64)
+	diskGB, _ := strconv.ParseFloat(cluster.Conf.ProvDisk, 64)
+	entry.DBU = math.Max(cores, math.Max(memMB/4096, diskGB/40))
+	entry.ClusterDBU = entry.DBU * float64(dbNodes)
+
+	// DB flavor + version from master
+	if master := cluster.GetMaster(); master != nil && master.DBVersion != nil {
+		entry.DBFlavor = master.DBVersion.Flavor
+		entry.DBVersion = master.DBVersion.ToString()
+		entry.GraphiteHost = master.graphiteHostname()
+	}
+
+	// Proxy info
+	proxies := cluster.GetProxies()
+	if len(proxies) > 0 {
+		prx := proxies[0]
+		entry.ProxyType = prx.GetType()
+		entry.ProxyVersion = prx.GetVersion()
+	}
+
+	// Use the best TPS across scale points as the entry's avgTps
+	for _, sp := range scalePoints {
+		if sp.AvgTPS > entry.AvgTPS {
+			entry.AvgTPS = sp.AvgTPS
+			entry.AvgLatency = sp.AvgLatency
+			entry.Threads = sp.Threads
+		}
+	}
+	if entry.ClusterDBU > 0 && entry.AvgTPS > 0 {
+		entry.TPSPerDBU = entry.AvgTPS / entry.ClusterDBU
+	}
+
+	cluster.SysbenchHistory.Entries = append(cluster.SysbenchHistory.Entries, entry)
+	cluster.SaveSysbenchLog()
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "BENCH",
+		"Sysbench scale run logged: %s points=%d peakTPS=%.1f@%dt flavor=%s/%s clusterDBU=%.1f",
+		testType, len(scalePoints), entry.AvgTPS, entry.Threads, entry.DBFlavor, entry.DBVersion, entry.ClusterDBU)
 }
 
 // SysbenchSummary holds parsed values from the sysbench summary output.

--- a/cluster/cluster_bench_log.go
+++ b/cluster/cluster_bench_log.go
@@ -8,8 +8,10 @@ package cluster
 
 import (
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/signal18/replication-manager/config"
@@ -31,6 +33,11 @@ type SysbenchLogEntry struct {
 	ProxyType    string                       `json:"proxyType"`    // proxysql, haproxy, maxscale, myproxy
 	ProxyVersion string                       `json:"proxyVersion"`
 	Replicas     int                          `json:"replicas"`
+	Cores        string                       `json:"cores"`        // prov-db-cpu-cores (docker cap)
+	MemoryMB     string                       `json:"memoryMB"`     // prov-db-memory in MB (docker cap)
+	DiskGB       string                       `json:"diskGB"`       // prov-db-disk-size in GB (docker cap)
+	DBU          float64                      `json:"dbu"`          // database units: max(cores/1, mem/4096, disk/40)
+	ClusterDBU   float64                      `json:"clusterDbu"`   // DBU × (replicas + 1)
 	ConfigTags   string                       `json:"configTags"`   // prov-db-tags at run time
 	ServicePlan  string                       `json:"servicePlan"`
 	Results      []SysBenchTpcResultPerMinute `json:"results"`
@@ -38,6 +45,7 @@ type SysbenchLogEntry struct {
 	AvgTPS       float64                      `json:"avgTps"`
 	AvgLatency   float64                      `json:"avgLatency"`
 	TotalErrors  int                          `json:"totalErrors"`
+	TPSPerDBU    float64                      `json:"tpsPerDbu"`    // avgTps / clusterDBU — performance efficiency
 }
 
 // SysbenchLog holds the full history of sysbench runs for a cluster.
@@ -73,6 +81,7 @@ func (cluster *Cluster) LoadSysbenchLog() {
 
 // LogSysbenchRun captures the context and results of a sysbench run and appends it to history.
 func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads int, tableSize int, duration int, startedAt time.Time, records []SysbenchRecord) {
+	dbNodes := len(cluster.Servers) // all database nodes (master + replicas)
 	entry := SysbenchLogEntry{
 		StartedAt:   startedAt,
 		EndedAt:     time.Now(),
@@ -86,8 +95,18 @@ func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads
 		ConfigTags:  cluster.Conf.ProvTags,
 		ServicePlan: cluster.Conf.ProvServicePlan,
 		Replicas:    len(cluster.slaves),
+		Cores:       cluster.Conf.ProvCores,
+		MemoryMB:    cluster.Conf.ProvMem,
+		DiskGB:      cluster.Conf.ProvDisk,
 		Records:     records,
 	}
+
+	// Compute DBU: 1 credit = 1 core / 4GB RAM / 40GB NVMe
+	cores, _ := strconv.ParseFloat(cluster.Conf.ProvCores, 64)
+	memMB, _ := strconv.ParseFloat(cluster.Conf.ProvMem, 64)
+	diskGB, _ := strconv.ParseFloat(cluster.Conf.ProvDisk, 64)
+	entry.DBU = math.Max(cores, math.Max(memMB/4096, diskGB/40))
+	entry.ClusterDBU = entry.DBU * float64(dbNodes)
 
 	// DB flavor + version from master
 	if master := cluster.GetMaster(); master != nil && master.DBVersion != nil {
@@ -117,6 +136,11 @@ func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads
 		entry.TotalErrors = totalErrors
 	}
 
+	// TPS per DBU — performance efficiency metric
+	if entry.ClusterDBU > 0 && entry.AvgTPS > 0 {
+		entry.TPSPerDBU = entry.AvgTPS / entry.ClusterDBU
+	}
+
 	// Append TPCM results
 	entry.Results = cluster.SysBenchTpcMResults
 
@@ -124,7 +148,7 @@ func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads
 	cluster.SaveSysbenchLog()
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "BENCH",
-		"Sysbench run logged: %s/%s threads=%d avgTPS=%.1f avgLatency=%.2fms flavor=%s/%s proxy=%s/%s replicas=%d tags=%s",
+		"Sysbench run logged: %s/%s threads=%d avgTPS=%.1f avgLatency=%.2fms flavor=%s/%s proxy=%s/%s replicas=%d DBU=%.1f clusterDBU=%.1f TPS/DBU=%.2f tags=%s",
 		testType, testMode, threads, entry.AvgTPS, entry.AvgLatency, entry.DBFlavor, entry.DBVersion,
-		entry.ProxyType, entry.ProxyVersion, entry.Replicas, entry.ConfigTags)
+		entry.ProxyType, entry.ProxyVersion, entry.Replicas, entry.DBU, entry.ClusterDBU, entry.TPSPerDBU, entry.ConfigTags)
 }

--- a/cluster/cluster_bench_log.go
+++ b/cluster/cluster_bench_log.go
@@ -52,6 +52,7 @@ type SysbenchLogEntry struct {
 	TPSPerDBU    float64                      `json:"tpsPerDbu"`              // avgTps / clusterDBU — performance efficiency
 	IsScale      bool                         `json:"isScale,omitempty"`      // true if part of a thread-scaling run
 	ScaleGroup   *time.Time                   `json:"scaleGroup,omitempty"`   // ties scale entries together (start time of the scale run)
+	Step         string                       `json:"step,omitempty"`         // prepare, run, cleanup — only set for scale entries
 }
 
 // SysbenchLog holds the full history of sysbench runs for a cluster.
@@ -83,6 +84,20 @@ func (cluster *Cluster) LoadSysbenchLog() {
 		return
 	}
 	cluster.SysbenchHistory = log
+}
+
+// LogSysbenchStep logs a prepare or cleanup step within a scale run.
+func (cluster *Cluster) LogSysbenchStep(step string, startedAt time.Time, scaleGroup time.Time) {
+	t := scaleGroup
+	entry := SysbenchLogEntry{
+		StartedAt:  startedAt,
+		EndedAt:    time.Now(),
+		Step:       step,
+		IsScale:    true,
+		ScaleGroup: &t,
+	}
+	cluster.SysbenchHistory.Entries = append(cluster.SysbenchHistory.Entries, entry)
+	cluster.SaveSysbenchLog()
 }
 
 // LogSysbenchRun captures the context and results of a sysbench run and appends it to history.
@@ -159,6 +174,7 @@ func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads
 	// Scale run metadata
 	if len(scaleGroup) > 0 && !scaleGroup[0].IsZero() {
 		entry.IsScale = true
+		entry.Step = "run"
 		t := scaleGroup[0]
 		entry.ScaleGroup = &t
 	}

--- a/cluster/cluster_bench_log.go
+++ b/cluster/cluster_bench_log.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/signal18/replication-manager/config"
@@ -57,15 +58,22 @@ type SysbenchLogEntry struct {
 
 // SysbenchLog holds the full history of sysbench runs for a cluster.
 type SysbenchLog struct {
-	Entries []SysbenchLogEntry `json:"entries"`
+	sync.Mutex `json:"-"`
+	Entries    []SysbenchLogEntry `json:"entries"`
 }
 
 // SaveSysbenchLog writes the sysbench history to disk.
 func (cluster *Cluster) SaveSysbenchLog() error {
 	path := filepath.Join(cluster.WorkingDir, "sysbench.json")
-	os.MkdirAll(filepath.Dir(path), 0755)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
 
-	data, err := json.MarshalIndent(cluster.SysbenchHistory, "", "  ")
+	cluster.SysbenchHistory.Lock()
+	data, err := json.MarshalIndent(struct {
+		Entries []SysbenchLogEntry `json:"entries"`
+	}{Entries: cluster.SysbenchHistory.Entries}, "", "  ")
+	cluster.SysbenchHistory.Unlock()
 	if err != nil {
 		return err
 	}
@@ -75,15 +83,18 @@ func (cluster *Cluster) SaveSysbenchLog() error {
 // LoadSysbenchLog reads the sysbench history from disk.
 func (cluster *Cluster) LoadSysbenchLog() {
 	path := filepath.Join(cluster.WorkingDir, "sysbench.json")
-	bytes, err := os.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return
 	}
-	var log SysbenchLog
-	if err := json.Unmarshal(bytes, &log); err != nil {
+	var loaded SysbenchLog
+	if err := json.Unmarshal(raw, &loaded); err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Corrupt sysbench.json, resetting history: %s", err)
 		return
 	}
-	cluster.SysbenchHistory = log
+	cluster.SysbenchHistory.Lock()
+	cluster.SysbenchHistory.Entries = loaded.Entries
+	cluster.SysbenchHistory.Unlock()
 }
 
 // LogSysbenchStep logs a prepare or cleanup step within a scale run.
@@ -96,7 +107,9 @@ func (cluster *Cluster) LogSysbenchStep(step string, startedAt time.Time, scaleG
 		IsScale:    true,
 		ScaleGroup: &t,
 	}
+	cluster.SysbenchHistory.Lock()
 	cluster.SysbenchHistory.Entries = append(cluster.SysbenchHistory.Entries, entry)
+	cluster.SysbenchHistory.Unlock()
 	cluster.SaveSysbenchLog()
 }
 
@@ -182,7 +195,9 @@ func (cluster *Cluster) LogSysbenchRun(testType string, testMode string, threads
 	// Append TPCM results
 	entry.Results = cluster.SysBenchTpcMResults
 
+	cluster.SysbenchHistory.Lock()
 	cluster.SysbenchHistory.Entries = append(cluster.SysbenchHistory.Entries, entry)
+	cluster.SysbenchHistory.Unlock()
 	cluster.SaveSysbenchLog()
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "BENCH",

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -1816,6 +1816,8 @@ func (cluster *Cluster) GetWebLogsByType(logtype string) any {
 		return &cluster.LogDDL
 	case "variable-change":
 		return &cluster.LogVariableChange
+	case "sysbench":
+		return &cluster.SysbenchHistory
 	default:
 		return nil
 	}
@@ -1829,6 +1831,7 @@ func (cluster *Cluster) GetAllWebLogs() map[string]any {
 	logs["workload"] = &cluster.LogWorkload
 	logs["ddl"] = &cluster.LogDDL
 	logs["variable-change"] = &cluster.LogVariableChange
+	logs["sysbench"] = &cluster.SysbenchHistory
 	return logs
 }
 

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -1348,6 +1348,15 @@ func (cluster *Cluster) SetClusterHead(ClusterName string) {
 	cluster.Conf.ClusterHead = ClusterName
 }
 
+func (cluster *Cluster) SetSysbenchTest(test string) {
+	if config.GetSysbenchTests()[test] {
+		cluster.Conf.SysbenchTest = test
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Setting Sysbench test to %s", test)
+	} else {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Unknown sysbench test: %s", test)
+	}
+}
+
 func (cluster *Cluster) SetSysbenchThreads(Threads string) {
 	i, err := strconv.Atoi(Threads)
 	if err == nil {

--- a/cluster/cluster_tst.go
+++ b/cluster/cluster_tst.go
@@ -336,7 +336,7 @@ func (cluster *Cluster) RunSysBench(myTest string, myThreads string, mySize stri
 	mode := "--oltp-test-mode=" + myMode
 
 	var cmdrun *exec.Cmd
-	cmdrun = exec.Command(cluster.Conf.SysbenchBinaryPath, test, tablesize, "--db-driver=mysql", "--mysql-db=replication_manager_schema", "--mysql-user="+cluster.GetDbUser(), "--mysql-password="+cluster.GetDbPass(), "--mysql-host="+prx.GetHost(), "--mysql-port="+strconv.Itoa(prx.GetWritePort()), time, mode, requests, threads, "run")
+	cmdrun = exec.Command(cluster.Conf.SysbenchBinaryPath, test, tablesize, "--db-driver=mysql", "--mysql-db=replication_manager_schema", "--mysql-user="+cluster.GetDbUser(), "--mysql-password="+cluster.GetDbPass(), "--mysql-host="+prx.GetHost(), "--mysql-port="+strconv.Itoa(prx.GetWritePort()), time, mode, requests, threads, "--report-interval=1", "run")
 
 	if err := cluster.ensureSysbenchVersionAvailable(); err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Sysbench version check failed: %s", err)
@@ -354,7 +354,7 @@ func (cluster *Cluster) RunSysBench(myTest string, myThreads string, mySize stri
 		tablesize = "--table-size=" + mySize
 		threads = "--threads=" + myThreads
 		time = "--time=" + myTime
-		cmdrun = exec.Command(cluster.Conf.SysbenchBinaryPath, test, tablesize, "--db-driver=mysql", "--mysql-db=replication_manager_schema", "--mysql-user="+cluster.GetDbUser(), "--mysql-password="+cluster.GetDbPass(), "--mysql-host="+prx.GetHost(), "--mysql-port="+strconv.Itoa(prx.GetWritePort()), time, threads, "run")
+		cmdrun = exec.Command(cluster.Conf.SysbenchBinaryPath, test, tablesize, "--db-driver=mysql", "--mysql-db=replication_manager_schema", "--mysql-user="+cluster.GetDbUser(), "--mysql-password="+cluster.GetDbPass(), "--mysql-host="+prx.GetHost(), "--mysql-port="+strconv.Itoa(prx.GetWritePort()), time, threads, "--report-interval=1", "run")
 		if cluster.Conf.SysbenchTest == "tpcc" {
 			override := map[string]string{"time": myTime, "threads": myThreads, "tablesize": mySize}
 			cmdrun = exec.Command(cluster.Conf.SysbenchBinaryPath, cluster.prepareTpccParams(prx, "run", override)...)
@@ -379,7 +379,7 @@ func (cluster *Cluster) RunSysBench(myTest string, myThreads string, mySize stri
 	iThreads, _ := strconv.Atoi(myThreads)
 	iTableSize, _ := strconv.Atoi(mySize)
 	iDuration, _ := strconv.Atoi(myTime)
-	cluster.LogSysbenchRun(myTest, myMode, iThreads, iTableSize, iDuration, startedAt, records)
+	cluster.LogSysbenchRun(myTest, myMode, iThreads, iTableSize, iDuration, startedAt, records, string(out))
 
 	return nil
 }

--- a/cluster/cluster_tst.go
+++ b/cluster/cluster_tst.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math"
 	"os"
 	"os/exec"
 	"strconv"
@@ -326,7 +325,7 @@ func (cluster *Cluster) ChecksumBench() bool {
 	return true
 }
 
-func (cluster *Cluster) RunSysBench(myTest string, myThreads string, mySize string, myTime string, myMode string, skipLog ...bool) (float64, float64, int, error) {
+func (cluster *Cluster) RunSysBench(myTest string, myThreads string, mySize string, myTime string, myMode string, scaleGroup ...time.Time) (float64, float64, int, error) {
 	startedAt := time.Now()
 	prx := cluster.GetProxies()[0]
 	if prx == nil {
@@ -409,18 +408,9 @@ func (cluster *Cluster) RunSysBench(myTest string, myThreads string, mySize stri
 		}
 	}
 
-	if len(skipLog) == 0 || !skipLog[0] {
-		cluster.LogSysbenchRun(loggedTest, myMode, iThreads, iTableSize, iDuration, startedAt, records, string(out))
-	}
+	cluster.LogSysbenchRun(loggedTest, myMode, iThreads, iTableSize, iDuration, startedAt, records, string(out), scaleGroup...)
 
 	return avgTPS, avgLatency, totalErrors, nil
-}
-
-// RunSysBenchResult holds stats returned by RunSysBench for use by callers like scale runs.
-type RunSysBenchResult struct {
-	AvgTPS      float64
-	AvgLatency  float64
-	TotalErrors int
 }
 
 func (cluster *Cluster) ExtractSybenchTPCM(records []SysbenchRecord) error {
@@ -483,8 +473,8 @@ func (cluster *Cluster) RunSysbench() error {
 	return nil
 }
 
-// RunSysbenchScaleThreads runs the configured test doubling threads from 1 up to 2×cores,
-// collecting all results into a single log entry with ScaleResults.
+// RunSysbenchScaleThreads runs the configured test doubling threads from 1 up to 2×cores.
+// Each thread count is logged as a normal entry with IsScale=true and a shared ScaleGroup timestamp.
 func (cluster *Cluster) RunSysbenchScaleThreads() error {
 	cluster.CleanupBench()
 	cluster.PrepareBench()
@@ -498,41 +488,13 @@ func (cluster *Cluster) RunSysbenchScaleThreads() error {
 		maxThreads = 2
 	}
 
-	startedAt := time.Now()
-	testType := cluster.Conf.SysbenchTest
-	if testType == "" {
-		testType = "oltp_read_write"
-	}
+	scaleGroupTime := time.Now()
 
-	var scalePoints []SysbenchScalePoint
 	threads := 1
 	for threads <= maxThreads {
-		avgTPS, avgLatency, totalErrors, err := cluster.RunSysBench("oltp", strconv.Itoa(threads), "1000000", strconv.Itoa(cluster.Conf.SysbenchTime), "complex", true)
-		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Scale run at %d threads failed: %s", threads, err)
-		} else {
-			sp := SysbenchScalePoint{
-				Threads:     threads,
-				AvgTPS:      avgTPS,
-				AvgLatency:  avgLatency,
-				TotalErrors: totalErrors,
-			}
-			// Compute TPS/DBU for this point
-			coresF, _ := strconv.ParseFloat(cluster.Conf.ProvCores, 64)
-			memMB, _ := strconv.ParseFloat(cluster.Conf.ProvMem, 64)
-			diskGB, _ := strconv.ParseFloat(cluster.Conf.ProvDisk, 64)
-			dbu := math.Max(coresF, math.Max(memMB/4096, diskGB/40))
-			clusterDBU := dbu * float64(len(cluster.Servers))
-			if clusterDBU > 0 && avgTPS > 0 {
-				sp.TPSPerDBU = avgTPS / clusterDBU
-			}
-			scalePoints = append(scalePoints, sp)
-		}
+		cluster.Conf.SysbenchThreads = threads
+		cluster.RunSysBench("oltp", strconv.Itoa(threads), "1000000", strconv.Itoa(cluster.Conf.SysbenchTime), "complex", scaleGroupTime)
 		threads = threads * 2
-	}
-
-	if len(scalePoints) > 0 {
-		cluster.LogSysbenchScaleRun(testType, startedAt, scalePoints)
 	}
 	return nil
 }

--- a/cluster/cluster_tst.go
+++ b/cluster/cluster_tst.go
@@ -379,11 +379,15 @@ func (cluster *Cluster) RunSysBench(myTest string, myThreads string, mySize stri
 	cluster.ExtractSybenchTPCM(records)
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "BENCH", "%s", strings.ReplaceAll(string(out), cluster.GetDbPass(), "XXXX"))
 
-	// Log run to history
+	// Log run to history — use actual test name (v1 overrides myTest with SysbenchTest)
+	loggedTest := myTest
+	if useV1Syntax {
+		loggedTest = cluster.Conf.SysbenchTest
+	}
 	iThreads, _ := strconv.Atoi(myThreads)
 	iTableSize, _ := strconv.Atoi(mySize)
 	iDuration, _ := strconv.Atoi(myTime)
-	cluster.LogSysbenchRun(myTest, myMode, iThreads, iTableSize, iDuration, startedAt, records, string(out))
+	cluster.LogSysbenchRun(loggedTest, myMode, iThreads, iTableSize, iDuration, startedAt, records, string(out))
 
 	return nil
 }

--- a/cluster/cluster_tst.go
+++ b/cluster/cluster_tst.go
@@ -79,6 +79,10 @@ const (
 func ParseRecord(str string) (SysbenchRecord, error) {
 	record := SysbenchRecord{}
 
+	// Normalize: sysbench v1 outputs "lat (ms, 95%)" with a space after comma
+	// but the format expects "lat (ms,95%)" without space
+	str = strings.Replace(str, "(ms, ", "(ms,", 1)
+
 	_, err := fmt.Sscanf(
 		str,
 		recordFormat,

--- a/cluster/cluster_tst.go
+++ b/cluster/cluster_tst.go
@@ -492,10 +492,16 @@ func (cluster *Cluster) RunSysbenchScaleThreads() error {
 		maxThreads = 2
 	}
 
+	origThreads := cluster.Conf.SysbenchThreads
+	defer func() { cluster.Conf.SysbenchThreads = origThreads }()
+
 	threads := 1
 	for threads <= maxThreads {
 		cluster.Conf.SysbenchThreads = threads
-		cluster.RunSysBench("oltp", strconv.Itoa(threads), "1000000", strconv.Itoa(cluster.Conf.SysbenchTime), "complex", scaleGroupTime)
+		_, _, _, err := cluster.RunSysBench("oltp", strconv.Itoa(threads), "1000000", strconv.Itoa(cluster.Conf.SysbenchTime), "complex", scaleGroupTime)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Scale run at %d threads failed: %s", threads, err)
+		}
 		threads = threads * 2
 	}
 

--- a/cluster/cluster_tst.go
+++ b/cluster/cluster_tst.go
@@ -476,8 +476,12 @@ func (cluster *Cluster) RunSysbench() error {
 // RunSysbenchScaleThreads runs the configured test doubling threads from 1 up to 2×cores.
 // Each thread count is logged as a normal entry with IsScale=true and a shared ScaleGroup timestamp.
 func (cluster *Cluster) RunSysbenchScaleThreads() error {
+	scaleGroupTime := time.Now()
+
+	prepareStart := time.Now()
 	cluster.CleanupBench()
 	cluster.PrepareBench()
+	cluster.LogSysbenchStep("prepare", prepareStart, scaleGroupTime)
 
 	cores, _ := strconv.ParseFloat(cluster.Conf.ProvCores, 64)
 	if cores < 1 {
@@ -488,14 +492,17 @@ func (cluster *Cluster) RunSysbenchScaleThreads() error {
 		maxThreads = 2
 	}
 
-	scaleGroupTime := time.Now()
-
 	threads := 1
 	for threads <= maxThreads {
 		cluster.Conf.SysbenchThreads = threads
 		cluster.RunSysBench("oltp", strconv.Itoa(threads), "1000000", strconv.Itoa(cluster.Conf.SysbenchTime), "complex", scaleGroupTime)
 		threads = threads * 2
 	}
+
+	cleanupStart := time.Now()
+	cluster.CleanupBench()
+	cluster.LogSysbenchStep("cleanup", cleanupStart, scaleGroupTime)
+
 	return nil
 }
 

--- a/cluster/cluster_tst.go
+++ b/cluster/cluster_tst.go
@@ -322,6 +322,7 @@ func (cluster *Cluster) ChecksumBench() bool {
 }
 
 func (cluster *Cluster) RunSysBench(myTest string, myThreads string, mySize string, myTime string, myMode string) error {
+	startedAt := time.Now()
 	prx := cluster.GetProxies()[0]
 	if prx == nil {
 		return errors.New("No proxy")
@@ -373,6 +374,13 @@ func (cluster *Cluster) RunSysBench(myTest string, myThreads string, mySize stri
 
 	cluster.ExtractSybenchTPCM(records)
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "BENCH", "%s", strings.ReplaceAll(string(out), cluster.GetDbPass(), "XXXX"))
+
+	// Log run to history
+	iThreads, _ := strconv.Atoi(myThreads)
+	iTableSize, _ := strconv.Atoi(mySize)
+	iDuration, _ := strconv.Atoi(myTime)
+	cluster.LogSysbenchRun(myTest, myMode, iThreads, iTableSize, iDuration, startedAt, records)
+
 	return nil
 }
 

--- a/cluster/cluster_tst.go
+++ b/cluster/cluster_tst.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"os"
 	"os/exec"
 	"strconv"
@@ -325,11 +326,11 @@ func (cluster *Cluster) ChecksumBench() bool {
 	return true
 }
 
-func (cluster *Cluster) RunSysBench(myTest string, myThreads string, mySize string, myTime string, myMode string) error {
+func (cluster *Cluster) RunSysBench(myTest string, myThreads string, mySize string, myTime string, myMode string, skipLog ...bool) (float64, float64, int, error) {
 	startedAt := time.Now()
 	prx := cluster.GetProxies()[0]
 	if prx == nil {
-		return errors.New("No proxy")
+		return 0, 0, 0, errors.New("No proxy")
 	}
 
 	test := "--test=" + myTest
@@ -344,13 +345,13 @@ func (cluster *Cluster) RunSysBench(myTest string, myThreads string, mySize stri
 
 	if err := cluster.ensureSysbenchVersionAvailable(); err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Sysbench version check failed: %s", err)
-		return err
+		return 0, 0, 0, err
 	}
 
 	useV1Syntax, err := cluster.shouldUseSysbenchV1Syntax()
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Sysbench syntax selection failed: %s", err)
-		return err
+		return 0, 0, 0, err
 	}
 
 	if useV1Syntax {
@@ -370,7 +371,7 @@ func (cluster *Cluster) RunSysBench(myTest string, myThreads string, mySize stri
 	out, err := cmdrun.CombinedOutput()
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "%s , %s", strings.ReplaceAll(string(out), cluster.GetDbPass(), "XXXX"), err)
-		return err
+		return 0, 0, 0, err
 	}
 	analyzer := cluster.NewSysbenchAnalyzer(false)
 	records, viols := analyzer.ParseToEnd(bytes.NewReader(out))
@@ -387,9 +388,39 @@ func (cluster *Cluster) RunSysBench(myTest string, myThreads string, mySize stri
 	iThreads, _ := strconv.Atoi(myThreads)
 	iTableSize, _ := strconv.Atoi(mySize)
 	iDuration, _ := strconv.Atoi(myTime)
-	cluster.LogSysbenchRun(loggedTest, myMode, iThreads, iTableSize, iDuration, startedAt, records, string(out))
 
-	return nil
+	// Compute averages for return value
+	var avgTPS, avgLatency float64
+	var totalErrors int
+	if len(records) > 0 {
+		var sumTPS, sumLat float64
+		for _, r := range records {
+			sumTPS += r.TPS
+			sumLat += r.Latency
+			totalErrors += int(r.ErrorPerSec)
+		}
+		avgTPS = sumTPS / float64(len(records))
+		avgLatency = sumLat / float64(len(records))
+	} else if string(out) != "" {
+		if summary := ParseSysbenchSummary(string(out)); summary != nil {
+			avgTPS = summary.TPS
+			avgLatency = summary.AvgLatency
+			totalErrors = int(summary.Errors)
+		}
+	}
+
+	if len(skipLog) == 0 || !skipLog[0] {
+		cluster.LogSysbenchRun(loggedTest, myMode, iThreads, iTableSize, iDuration, startedAt, records, string(out))
+	}
+
+	return avgTPS, avgLatency, totalErrors, nil
+}
+
+// RunSysBenchResult holds stats returned by RunSysBench for use by callers like scale runs.
+type RunSysBenchResult struct {
+	AvgTPS      float64
+	AvgLatency  float64
+	TotalErrors int
 }
 
 func (cluster *Cluster) ExtractSybenchTPCM(records []SysbenchRecord) error {
@@ -432,7 +463,8 @@ func (cluster *Cluster) WriteSybenchTPCM() error {
 func (cluster *Cluster) RunBench() error {
 
 	if cluster.benchmarkType == "sysbench" {
-		return cluster.RunSysBench("oltp", strconv.Itoa(cluster.Conf.SysbenchThreads), "1000000", strconv.Itoa(cluster.Conf.SysbenchTime), "complex")
+		_, _, _, err := cluster.RunSysBench("oltp", strconv.Itoa(cluster.Conf.SysbenchThreads), "1000000", strconv.Itoa(cluster.Conf.SysbenchTime), "complex")
+		return err
 	}
 	if cluster.benchmarkType == "table" {
 		result, err := dbhelper.WriteConcurrent2(cluster.GetMaster().DSN, 10)
@@ -451,12 +483,66 @@ func (cluster *Cluster) RunSysbench() error {
 	return nil
 }
 
+// RunSysbenchScaleThreads runs the configured test doubling threads from 1 up to 2×cores,
+// collecting all results into a single log entry with ScaleResults.
+func (cluster *Cluster) RunSysbenchScaleThreads() error {
+	cluster.CleanupBench()
+	cluster.PrepareBench()
+
+	cores, _ := strconv.ParseFloat(cluster.Conf.ProvCores, 64)
+	if cores < 1 {
+		cores = 2
+	}
+	maxThreads := int(cores * 2)
+	if maxThreads < 1 {
+		maxThreads = 2
+	}
+
+	startedAt := time.Now()
+	testType := cluster.Conf.SysbenchTest
+	if testType == "" {
+		testType = "oltp_read_write"
+	}
+
+	var scalePoints []SysbenchScalePoint
+	threads := 1
+	for threads <= maxThreads {
+		avgTPS, avgLatency, totalErrors, err := cluster.RunSysBench("oltp", strconv.Itoa(threads), "1000000", strconv.Itoa(cluster.Conf.SysbenchTime), "complex", true)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Scale run at %d threads failed: %s", threads, err)
+		} else {
+			sp := SysbenchScalePoint{
+				Threads:     threads,
+				AvgTPS:      avgTPS,
+				AvgLatency:  avgLatency,
+				TotalErrors: totalErrors,
+			}
+			// Compute TPS/DBU for this point
+			coresF, _ := strconv.ParseFloat(cluster.Conf.ProvCores, 64)
+			memMB, _ := strconv.ParseFloat(cluster.Conf.ProvMem, 64)
+			diskGB, _ := strconv.ParseFloat(cluster.Conf.ProvDisk, 64)
+			dbu := math.Max(coresF, math.Max(memMB/4096, diskGB/40))
+			clusterDBU := dbu * float64(len(cluster.Servers))
+			if clusterDBU > 0 && avgTPS > 0 {
+				sp.TPSPerDBU = avgTPS / clusterDBU
+			}
+			scalePoints = append(scalePoints, sp)
+		}
+		threads = threads * 2
+	}
+
+	if len(scalePoints) > 0 {
+		cluster.LogSysbenchScaleRun(testType, startedAt, scalePoints)
+	}
+	return nil
+}
+
 func (cluster *Cluster) RunSysbenchTPCPerMinuteIncreaseThreads() error {
 	cluster.CleanupBench()
 	cluster.PrepareBench()
 	threads := 1
 	for threads <= 256 {
-		cluster.RunSysBench("tpcc", strconv.Itoa(threads), "1000000", "60", "complex")
+		_, _, _, _ = cluster.RunSysBench("tpcc", strconv.Itoa(threads), "1000000", "60", "complex")
 		threads = threads * 2
 	}
 	cluster.WriteSybenchTPCM()

--- a/cluster/prx.go
+++ b/cluster/prx.go
@@ -123,6 +123,7 @@ type DatabaseProxy interface {
 	GetProxyConfig() error
 	GetJanitorWeight() string
 	// GetInitContainer(collector opensvc.Collector) string
+	GetVersion() string
 	GetBindAddress() string
 	GetBindAddressExtraIPV6() string
 	GetUseSSL() string

--- a/cluster/prx_get.go
+++ b/cluster/prx_get.go
@@ -397,6 +397,10 @@ func (p *Proxy) GetType() string {
 	return p.Type
 }
 
+func (p *Proxy) GetVersion() string {
+	return p.Version
+}
+
 func (p *Proxy) GetHost() string {
 	return p.Host
 }

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -6178,14 +6178,19 @@ func (repman *ReplicationManager) handlerMuxClusterSysbench(w http.ResponseWrite
 			http.Error(w, "No valid ACL", http.StatusForbidden)
 			return
 		}
-		if r.URL.Query().Get("threads") != "" {
-			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Setting Sysbench threads to %s", r.URL.Query().Get("threads"))
-			mycluster.SetSysbenchThreads(r.URL.Query().Get("threads"))
-		}
 		if r.URL.Query().Get("test") != "" {
 			mycluster.SetSysbenchTest(r.URL.Query().Get("test"))
 		}
-		go mycluster.RunSysbench()
+		if r.URL.Query().Get("threads") == "0" {
+			// threads=0 means scale from 1 to 2×cores
+			go mycluster.RunSysbenchScaleThreads()
+		} else {
+			if r.URL.Query().Get("threads") != "" {
+				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Setting Sysbench threads to %s", r.URL.Query().Get("threads"))
+				mycluster.SetSysbenchThreads(r.URL.Query().Get("threads"))
+			}
+			go mycluster.RunSysbench()
+		}
 	}
 }
 

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -5532,9 +5532,10 @@ func (repman *ReplicationManager) handlerMuxLog(w http.ResponseWriter, r *http.R
 // @Success 200 {object} map[string]interface{} "Log data"
 // @Failure 403 {string} string "No valid ACL"
 // @Failure 500 {string} string "Cluster Not Found"
+// @Router /api/clusters/{clusterName}/topology/logs/{logType} [get]
 // @Router /api/clusters/{clusterName}/topology/http-logs [get]
 // @Router /api/clusters/{clusterName}/topology/http-logs/{logType} [get]
-// @Router /api/clusters/{clusterName}/topology/logs/{logType} [get]
+// @Deprecated Use /topology/logs/{logType} instead of /topology/http-logs/{logType}
 func (repman *ReplicationManager) handlerMuxWebLog(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	vars := mux.Vars(r)

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -6195,52 +6195,6 @@ func (repman *ReplicationManager) handlerMuxClusterSysbench(w http.ResponseWrite
 	}
 }
 
-func (repman *ReplicationManager) handlerMuxClusterSysbenchHistory(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	vars := mux.Vars(r)
-	mycluster := repman.getClusterByName(vars["clusterName"])
-	if mycluster != nil {
-		if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
-			http.Error(w, "No valid ACL", http.StatusForbidden)
-			return
-		}
-		n := 10
-		if q := r.URL.Query().Get("last"); q != "" {
-			fmt.Sscanf(q, "%d", &n)
-		}
-		runs := mycluster.GetLastSysbenchRuns(n)
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(runs)
-	} else {
-		http.Error(w, "No cluster", http.StatusInternalServerError)
-	}
-}
-
-func (repman *ReplicationManager) handlerMuxClusterSysbenchCompare(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	vars := mux.Vars(r)
-	mycluster := repman.getClusterByName(vars["clusterName"])
-	if mycluster != nil {
-		if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
-			http.Error(w, "No valid ACL", http.StatusForbidden)
-			return
-		}
-		metric := r.URL.Query().Get("metric")
-		if metric == "" {
-			metric = "mysql_global_status_questions"
-		}
-		result, err := mycluster.CompareSysbenchRuns(metric, nil)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(result)
-	} else {
-		http.Error(w, "No cluster", http.StatusInternalServerError)
-	}
-}
-
 // handlerMuxClusterApplyDynamicConfig handles the application of dynamic configuration for a given cluster.
 // @Summary Apply dynamic configuration for a specific cluster
 // @Description This endpoint applies dynamic configuration for the specified cluster.

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -677,11 +677,7 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxWebLog)),
 	))
-	// Alias: cleaner route for logs by type
-	router.Handle("/api/clusters/{clusterName}/topology/logs", negroni.New(
-		negroni.HandlerFunc(repman.validateTokenMiddleware),
-		negroni.Wrap(http.HandlerFunc(repman.handlerMuxWebLog)),
-	))
+	// Alias: cleaner route for typed logs (security, workload, sysbench, etc.)
 	router.Handle("/api/clusters/{clusterName}/topology/logs/{logType}", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxWebLog)),
@@ -5525,16 +5521,20 @@ func (repman *ReplicationManager) handlerMuxLog(w http.ResponseWriter, r *http.R
 	}
 }
 
-// handlerMuxWebLog handles the retrieval of web logs.
-// @Summary Retrieve web logs
-// @Description This endpoint retrieves the web logs.
+// handlerMuxWebLog handles the retrieval of cluster logs by type.
+// @Summary Retrieve cluster logs by type
+// @Description Returns cluster logs for the specified type. Available types: general, task, security, workload, ddl, variable-change, sysbench. Without logType returns all logs.
 // @Tags ClusterTopology
 // @Produce json
 // @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
-// @Success 200 {array} string "List of web logs"
-// @Failure 500 {string} string "Internal Server Error"
+// @Param clusterName path string true "Cluster Name"
+// @Param logType path string false "Log type: general, task, security, workload, ddl, variable-change, sysbench"
+// @Success 200 {object} map[string]interface{} "Log data"
+// @Failure 403 {string} string "No valid ACL"
+// @Failure 500 {string} string "Cluster Not Found"
 // @Router /api/clusters/{clusterName}/topology/http-logs [get]
 // @Router /api/clusters/{clusterName}/topology/http-logs/{logType} [get]
+// @Router /api/clusters/{clusterName}/topology/logs/{logType} [get]
 func (repman *ReplicationManager) handlerMuxWebLog(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	vars := mux.Vars(r)

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -463,11 +463,11 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterSysbench)),
 	))
-	router.Handle("/api/clusters/{clusterName}/sysbench/history", negroni.New(
+	router.Handle("/api/clusters/{clusterName}/actions/sysbench-history", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterSysbenchHistory)),
 	))
-	router.Handle("/api/clusters/{clusterName}/sysbench/compare", negroni.New(
+	router.Handle("/api/clusters/{clusterName}/actions/sysbench-compare", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterSysbenchCompare)),
 	))

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -463,14 +463,6 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterSysbench)),
 	))
-	router.Handle("/api/clusters/{clusterName}/actions/sysbench-history", negroni.New(
-		negroni.HandlerFunc(repman.validateTokenMiddleware),
-		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterSysbenchHistory)),
-	))
-	router.Handle("/api/clusters/{clusterName}/actions/sysbench-compare", negroni.New(
-		negroni.HandlerFunc(repman.validateTokenMiddleware),
-		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterSysbenchCompare)),
-	))
 
 	router.Handle("/api/clusters/{clusterName}/actions/waitdatabases", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
@@ -682,6 +674,15 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxWebLog)),
 	))
 	router.Handle("/api/clusters/{clusterName}/topology/http-logs/{logType}", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxWebLog)),
+	))
+	// Alias: cleaner route for logs by type
+	router.Handle("/api/clusters/{clusterName}/topology/logs", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxWebLog)),
+	))
+	router.Handle("/api/clusters/{clusterName}/topology/logs/{logType}", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxWebLog)),
 	))

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -463,6 +463,14 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterSysbench)),
 	))
+	router.Handle("/api/clusters/{clusterName}/sysbench/history", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterSysbenchHistory)),
+	))
+	router.Handle("/api/clusters/{clusterName}/sysbench/compare", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterSysbenchCompare)),
+	))
 
 	router.Handle("/api/clusters/{clusterName}/actions/waitdatabases", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
@@ -6173,6 +6181,52 @@ func (repman *ReplicationManager) handlerMuxClusterSysbench(w http.ResponseWrite
 			mycluster.SetSysbenchThreads(r.URL.Query().Get("threads"))
 		}
 		go mycluster.RunSysbench()
+	}
+}
+
+func (repman *ReplicationManager) handlerMuxClusterSysbenchHistory(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster != nil {
+		if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+			http.Error(w, "No valid ACL", http.StatusForbidden)
+			return
+		}
+		n := 10
+		if q := r.URL.Query().Get("last"); q != "" {
+			fmt.Sscanf(q, "%d", &n)
+		}
+		runs := mycluster.GetLastSysbenchRuns(n)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(runs)
+	} else {
+		http.Error(w, "No cluster", http.StatusInternalServerError)
+	}
+}
+
+func (repman *ReplicationManager) handlerMuxClusterSysbenchCompare(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster != nil {
+		if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+			http.Error(w, "No valid ACL", http.StatusForbidden)
+			return
+		}
+		metric := r.URL.Query().Get("metric")
+		if metric == "" {
+			metric = "mysql_global_status_questions"
+		}
+		result, err := mycluster.CompareSysbenchRuns(metric, nil)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(result)
+	} else {
+		http.Error(w, "No cluster", http.StatusInternalServerError)
 	}
 }
 

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -6182,6 +6182,9 @@ func (repman *ReplicationManager) handlerMuxClusterSysbench(w http.ResponseWrite
 			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Setting Sysbench threads to %s", r.URL.Query().Get("threads"))
 			mycluster.SetSysbenchThreads(r.URL.Query().Get("threads"))
 		}
+		if r.URL.Query().Get("test") != "" {
+			mycluster.SetSysbenchTest(r.URL.Query().Get("test"))
+		}
 		go mycluster.RunSysbench()
 	}
 }

--- a/server/http.go
+++ b/server/http.go
@@ -392,12 +392,15 @@ func (repman *ReplicationManager) httpserver() {
 			if repman.Conf.Verbose && repman.Conf.LogLevel >= 4 {
 				repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "TERMINAL: h2 Extended CONNECT detected, rewriting to GET+Upgrade")
 			}
-			r.Method = "GET"
-			r.Header.Set("Connection", "Upgrade")
-			r.Header.Set("Upgrade", "websocket")
-			if r.Header.Get("Sec-WebSocket-Version") == "" {
-				r.Header.Set("Sec-WebSocket-Version", "13")
+			r2 := r.Clone(r.Context())
+			r2.Method = "GET"
+			r2.Header.Set("Connection", "Upgrade")
+			r2.Header.Set("Upgrade", "websocket")
+			if r2.Header.Get("Sec-WebSocket-Version") == "" {
+				r2.Header.Set("Sec-WebSocket-Version", "13")
 			}
+			corsHandler.ServeHTTP(w, r2)
+			return
 		}
 		corsHandler.ServeHTTP(w, r)
 	})

--- a/server/http.go
+++ b/server/http.go
@@ -38,6 +38,7 @@ import (
 	_ "net/http/pprof"
 	"net/url"
 	"os"
+	"strings"
 
 	basiclog "log"
 
@@ -46,6 +47,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/iu0v1/gelada"
 	"github.com/iu0v1/gelada/authguard"
+	"github.com/signal18/replication-manager/config"
 	_ "github.com/signal18/replication-manager/docs"
 	log "github.com/sirupsen/logrus"
 	httpSwagger "github.com/swaggo/http-swagger"
@@ -381,8 +383,13 @@ func (repman *ReplicationManager) httpserver() {
 
 	// Middleware: translate h2 Extended CONNECT (RFC 8441) into h1-style
 	// WebSocket upgrade headers so gorilla/websocket can handle it.
+	// Also logs terminal requests for debugging h2/WebSocket issues.
 	wsH2Adapter := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/terminal/") {
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "TERMINAL DEBUG: method=%s proto=%s url=%s headers=%v", r.Method, r.Proto, r.URL.String(), r.Header)
+		}
 		if r.Method == "CONNECT" && r.Header.Get(":protocol") == "websocket" {
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "TERMINAL DEBUG: h2 Extended CONNECT detected, rewriting to GET+Upgrade")
 			r.Method = "GET"
 			r.Header.Set("Connection", "Upgrade")
 			r.Header.Set("Upgrade", "websocket")

--- a/server/http.go
+++ b/server/http.go
@@ -383,13 +383,15 @@ func (repman *ReplicationManager) httpserver() {
 
 	// Middleware: translate h2 Extended CONNECT (RFC 8441) into h1-style
 	// WebSocket upgrade headers so gorilla/websocket can handle it.
-	// Also logs terminal requests for debugging h2/WebSocket issues.
+	// Debug logging gated on Verbose level >= 4.
 	wsH2Adapter := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "/terminal/") {
-			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "TERMINAL DEBUG: method=%s proto=%s url=%s headers=%v", r.Method, r.Proto, r.URL.String(), r.Header)
+		if repman.Conf.Verbose && repman.Conf.LogLevel >= 4 && strings.Contains(r.URL.Path, "/terminal/") {
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "TERMINAL: method=%s proto=%s url=%s headers=%v", r.Method, r.Proto, r.URL.String(), r.Header)
 		}
 		if r.Method == "CONNECT" && r.Header.Get(":protocol") == "websocket" {
-			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "TERMINAL DEBUG: h2 Extended CONNECT detected, rewriting to GET+Upgrade")
+			if repman.Conf.Verbose && repman.Conf.LogLevel >= 4 {
+				repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "TERMINAL: h2 Extended CONNECT detected, rewriting to GET+Upgrade")
+			}
 			r.Method = "GET"
 			r.Header.Set("Connection", "Upgrade")
 			r.Header.Set("Upgrade", "websocket")

--- a/server/http.go
+++ b/server/http.go
@@ -49,6 +49,8 @@ import (
 	_ "github.com/signal18/replication-manager/docs"
 	log "github.com/sirupsen/logrus"
 	httpSwagger "github.com/swaggo/http-swagger"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 )
 
 type HandlerManager struct {
@@ -370,14 +372,19 @@ func (repman *ReplicationManager) httpserver() {
 
 	repman.IsHttpListenerReady = true
 
+	corsHandler := handlers.CORS(
+		handlers.AllowCredentials(),
+		handlers.AllowedHeaders([]string{"X-Requested-With", "Content-Type", "Authorization"}),
+		handlers.AllowedMethods([]string{"GET", "POST", "PUT", "HEAD", "OPTIONS"}),
+		handlers.AllowedOriginValidator(repman.handleOriginValidator),
+	)(router)
+
+	// Wrap with h2c for HTTP/2 over plain TCP (reverse proxy use case)
+	h2cHandler := h2c.NewHandler(corsHandler, &http2.Server{})
+
 	server := &http.Server{
-		Addr: repman.Conf.BindAddr + ":" + repman.Conf.HttpPort,
-		Handler: handlers.CORS(
-			handlers.AllowCredentials(),
-			handlers.AllowedHeaders([]string{"X-Requested-With", "Content-Type", "Authorization"}),
-			handlers.AllowedMethods([]string{"GET", "POST", "PUT", "HEAD", "OPTIONS"}),
-			handlers.AllowedOriginValidator(repman.handleOriginValidator),
-		)(router),
+		Addr:     repman.Conf.BindAddr + ":" + repman.Conf.HttpPort,
+		Handler:  h2cHandler,
 		ErrorLog: basiclog.New(repman.ApiLogAdapter, "", 0),
 	}
 	repman.httpServer = server

--- a/server/http.go
+++ b/server/http.go
@@ -379,8 +379,22 @@ func (repman *ReplicationManager) httpserver() {
 		handlers.AllowedOriginValidator(repman.handleOriginValidator),
 	)(router)
 
+	// Middleware: translate h2 Extended CONNECT (RFC 8441) into h1-style
+	// WebSocket upgrade headers so gorilla/websocket can handle it.
+	wsH2Adapter := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "CONNECT" && r.Header.Get(":protocol") == "websocket" {
+			r.Method = "GET"
+			r.Header.Set("Connection", "Upgrade")
+			r.Header.Set("Upgrade", "websocket")
+			if r.Header.Get("Sec-WebSocket-Version") == "" {
+				r.Header.Set("Sec-WebSocket-Version", "13")
+			}
+		}
+		corsHandler.ServeHTTP(w, r)
+	})
+
 	// Wrap with h2c for HTTP/2 over plain TCP (reverse proxy use case)
-	h2cHandler := h2c.NewHandler(corsHandler, &http2.Server{})
+	h2cHandler := h2c.NewHandler(wsH2Adapter, &http2.Server{})
 
 	server := &http.Server{
 		Addr:     repman.Conf.BindAddr + ":" + repman.Conf.HttpPort,

--- a/share/dashboard_react/package-lock.json
+++ b/share/dashboard_react/package-lock.json
@@ -22,6 +22,7 @@
         "@zag-js/tree-view": "^1.15.0",
         "axios": "^1.16.0",
         "cubism": "^1.6.0",
+        "d3": "^7.9.0",
         "framer-motion": "^11.18.2",
         "lodash": "^4.18.1",
         "moment": "^2.30.1",

--- a/share/dashboard_react/package.json
+++ b/share/dashboard_react/package.json
@@ -28,6 +28,7 @@
     "@zag-js/tree-view": "^1.15.0",
     "axios": "^1.16.0",
     "cubism": "^1.6.0",
+    "d3": "^7.9.0",
     "framer-motion": "^11.18.2",
     "lodash": "^4.18.1",
     "moment": "^2.30.1",

--- a/share/dashboard_react/src/Pages/Dashboard/components/RunTests/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/RunTests/index.jsx
@@ -1,11 +1,15 @@
 import { Flex, VStack } from '@chakra-ui/react'
-import React from 'react'
+import React, { useState } from 'react'
 import DropdownRegresssionTests from '../../../../components/DropdownRegresssionTests'
 import DropdownSysbench from '../../../../components/DropdownSysbench'
 import styles from './styles.module.scss'
 import TableType2 from '../../../../components/TableType2'
+import RMButton from '../../../../components/RMButton'
+import BenchCompareModal from '../../../../components/Modals/BenchCompareModal'
 
 function RunTests({ selectedCluster }) {
+  const [isBenchCompareOpen, setIsBenchCompareOpen] = useState(false)
+
   const dataObject = [
     { key: 'Waiting Rejoin', value: selectedCluster?.waitingRejoin },
     { key: 'Waiting Switchover', value: selectedCluster?.waitingSwitchover },
@@ -16,8 +20,19 @@ function RunTests({ selectedCluster }) {
       <VStack className={styles.dropdowns}>
         <DropdownRegresssionTests clusterName={selectedCluster?.name} />
         <DropdownSysbench clusterName={selectedCluster?.name} />
+        <RMButton size='small' colorScheme='purple' onClick={() => setIsBenchCompareOpen(true)}>
+          Compare Benchmarks
+        </RMButton>
       </VStack>
       <TableType2 dataArray={dataObject} className={styles.table} />
+
+      {isBenchCompareOpen && (
+        <BenchCompareModal
+          isOpen={isBenchCompareOpen}
+          closeModal={() => setIsBenchCompareOpen(false)}
+          clusterName={selectedCluster?.name}
+        />
+      )}
     </Flex>
   )
 }

--- a/share/dashboard_react/src/Pages/Terminal/index.jsx
+++ b/share/dashboard_react/src/Pages/Terminal/index.jsx
@@ -220,10 +220,6 @@ const TerminalComponent = () => {
       const socket = new WebSocket(url);
       socketRef.current = socket;
 
-      // Attach the terminal to the WebSocket using AttachAddon
-      const attachAddon = new AttachAddon(socket);
-      terminalInstanceRef.current.loadAddon(attachAddon);
-
       socket.onerror = () => {
         if (socketRef.current !== socket) {
           return;
@@ -236,8 +232,17 @@ const TerminalComponent = () => {
         if (socketRef.current !== socket) {
           return;
         }
-        setStatus('connected');
+        // Send auth first, then attach terminal addon after backend processes
+        // the token. AttachAddon intercepts messages — loading it before auth
+        // causes a race that only works when DevTools slows down JS execution.
         socket.send(JSON.stringify({ type: 'auth', token: getTokenByBaseURL(baseURL) }));
+        setTimeout(() => {
+          if (socketRef.current === socket && socket.readyState === WebSocket.OPEN) {
+            const attachAddon = new AttachAddon(socket);
+            terminalInstanceRef.current.loadAddon(attachAddon);
+            setStatus('connected');
+          }
+        }, 100);
       };
 
       socket.onclose = () => {

--- a/share/dashboard_react/src/Pages/Terminal/index.jsx
+++ b/share/dashboard_react/src/Pages/Terminal/index.jsx
@@ -228,21 +228,16 @@ const TerminalComponent = () => {
         setStatus('error');
       };
 
+      // Attach the terminal to the WebSocket using AttachAddon
+      const attachAddon = new AttachAddon(socket);
+      terminalInstanceRef.current.loadAddon(attachAddon);
+
       socket.onopen = () => {
         if (socketRef.current !== socket) {
           return;
         }
-        // Send auth first, then attach terminal addon after backend processes
-        // the token. AttachAddon intercepts messages — loading it before auth
-        // causes a race that only works when DevTools slows down JS execution.
+        setStatus('connected');
         socket.send(JSON.stringify({ type: 'auth', token: getTokenByBaseURL(baseURL) }));
-        setTimeout(() => {
-          if (socketRef.current === socket && socket.readyState === WebSocket.OPEN) {
-            const attachAddon = new AttachAddon(socket);
-            terminalInstanceRef.current.loadAddon(attachAddon);
-            setStatus('connected');
-          }
-        }, 100);
       };
 
       socket.onclose = () => {

--- a/share/dashboard_react/src/components/DropdownSysbench/index.jsx
+++ b/share/dashboard_react/src/components/DropdownSysbench/index.jsx
@@ -16,6 +16,7 @@ const SYSBENCH_TESTS = [
 ]
 
 const THREAD_OPTIONS = [
+  { name: '1-2xCPU', value: 0 },
   { name: 1, value: 1 },
   { name: 4, value: 4 },
   { name: 8, value: 8 },
@@ -54,7 +55,9 @@ function DropdownSysbench({ clusterName }) {
         <ConfirmModal
           isOpen={isConfirmModalOpen}
           closeModal={closeConfirmModal}
-          title={`Run ${selectedTest.name} with ${selectedThread.name} threads?`}
+          title={selectedThread.value === 0
+            ? `Run ${selectedTest.name} scaling threads from 1 to 2×CPU cores?`
+            : `Run ${selectedTest.name} with ${selectedThread.name} threads?`}
           onConfirmClick={runSysbench}
         />
       )}

--- a/share/dashboard_react/src/components/DropdownSysbench/index.jsx
+++ b/share/dashboard_react/src/components/DropdownSysbench/index.jsx
@@ -7,19 +7,29 @@ import { useDispatch } from 'react-redux'
 import ConfirmModal from '../Modals/ConfirmModal'
 import { runSysBench } from '../../redux/clusterSlice'
 
+const SYSBENCH_TESTS = [
+  { name: 'oltp_read_write', value: 'oltp_read_write' },
+  { name: 'oltp_read_only', value: 'oltp_read_only' },
+  { name: 'oltp_update_index', value: 'oltp_update_index' },
+  { name: 'oltp_update_non_index', value: 'oltp_update_non_index' },
+  { name: 'tpcc', value: 'tpcc' },
+]
+
+const THREAD_OPTIONS = [
+  { name: 1, value: 1 },
+  { name: 4, value: 4 },
+  { name: 8, value: 8 },
+  { name: 16, value: 16 },
+  { name: 32, value: 32 },
+  { name: 64, value: 64 },
+  { name: 128, value: 128 }
+]
+
 function DropdownSysbench({ clusterName }) {
   const dispatch = useDispatch()
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false)
-  const [options, setOptions] = useState([
-    { name: 1, value: 1 },
-    { name: 4, value: 4 },
-    { name: 8, value: 8 },
-    { name: 16, value: 16 },
-    { name: 32, value: 32 },
-    { name: 64, value: 64 },
-    { name: 128, value: 128 }
-  ])
-  const [selectedOption, setSelectedOption] = useState({ name: 1, value: 1 })
+  const [selectedThread, setSelectedThread] = useState(THREAD_OPTIONS[0])
+  const [selectedTest, setSelectedTest] = useState(SYSBENCH_TESTS[0])
 
   const openConfirmModal = () => {
     setIsConfirmModalOpen(true)
@@ -30,12 +40,13 @@ function DropdownSysbench({ clusterName }) {
   }
 
   const runSysbench = () => {
-    dispatch(runSysBench({ clusterName, thread: selectedOption.value }))
+    dispatch(runSysBench({ clusterName, thread: selectedThread.value, test: selectedTest.value }))
     closeConfirmModal()
   }
   return (
     <Flex className={styles.sysbenchContainer}>
-      <Dropdown options={options} onChange={(value) => setSelectedOption(value)} label='Sysbench tests' />
+      <Dropdown options={SYSBENCH_TESTS} onChange={(value) => setSelectedTest(value)} label='Sysbench test' selectedValue={selectedTest.value} />
+      <Dropdown options={THREAD_OPTIONS} onChange={(value) => setSelectedThread(value)} label='Threads' selectedValue={selectedThread.value} />
       <RMButton type='button' onClick={openConfirmModal}>
         Run
       </RMButton>
@@ -43,7 +54,7 @@ function DropdownSysbench({ clusterName }) {
         <ConfirmModal
           isOpen={isConfirmModalOpen}
           closeModal={closeConfirmModal}
-          title={`Confirm sysbench run for thread ${selectedOption.name}`}
+          title={`Run ${selectedTest.name} with ${selectedThread.name} threads?`}
           onConfirmClick={runSysbench}
         />
       )}

--- a/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
@@ -1,6 +1,6 @@
 import {
   Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalCloseButton,
-  Box, VStack, HStack, Text, Badge, Table, Thead, Tbody, Tr, Th, Td, Select, Spinner
+  Box, VStack, HStack, Text, Badge, Table, Thead, Tbody, Tr, Th, Td, Select, Spinner, Checkbox
 } from '@chakra-ui/react'
 import React, { useState, useEffect, useRef } from 'react'
 import { useSelector } from 'react-redux'
@@ -128,6 +128,7 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
   const { theme } = useTheme()
   const baseURL = useSelector((state) => state?.auth?.baseURL)
   const [runs, setRuns] = useState([])
+  const [selected, setSelected] = useState(new Set())
   const [metric, setMetric] = useState('mysql_global_status_queries')
   const [chartSeries, setChartSeries] = useState([])
   const [loading, setLoading] = useState(false)
@@ -139,24 +140,43 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
     if (isOpen && clusterName) {
       setChartSeries([])
       setError('')
+      setSelected(new Set())
       clusterService.getSysbenchHistory(clusterName, baseURL)
         .then(res => {
           const data = res.data
-          setRuns(Array.isArray(data) ? data : data?.Entries || data?.entries || [])
+          const entries = Array.isArray(data) ? data : data?.Entries || data?.entries || []
+          setRuns(entries)
+          // Select only the last run by default
+          if (entries.length > 0) setSelected(new Set([entries.length - 1]))
         })
         .catch(() => setRuns([]))
     }
   }, [isOpen, clusterName, baseURL])
 
+  const toggleSelect = (i) => {
+    setSelected(prev => {
+      const next = new Set(prev)
+      if (next.has(i)) next.delete(i)
+      else next.add(i)
+      return next
+    })
+  }
+
+  const toggleAll = () => {
+    if (selected.size === runs.length) setSelected(new Set())
+    else setSelected(new Set(runs.map((_, i) => i)))
+  }
+
   const fetchGraphiteData = async () => {
-    if (runs.length === 0) return
+    const selectedRuns = runs.filter((_, i) => selected.has(i))
+    if (selectedRuns.length === 0) return
     setLoading(true)
     setError('')
     setChartSeries([])
 
     const metricDef = METRICS.find(m => m.value === metric)
-    // Oldest run is the reference (index 0 after sorting by startedAt)
-    const sorted = [...runs].sort((a, b) => new Date(a.startedAt) - new Date(b.startedAt))
+    // Oldest selected run is the reference (index 0 after sorting by startedAt)
+    const sorted = [...selectedRuns].sort((a, b) => new Date(a.startedAt) - new Date(b.startedAt))
     const refRun = sorted[0]
 
     // Find the newest run to align the graphite time window
@@ -246,6 +266,7 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
                   <Table size='sm' variant='simple'>
                     <Thead>
                       <Tr>
+                        <Th px={1}><Checkbox size='sm' isChecked={selected.size === runs.length} isIndeterminate={selected.size > 0 && selected.size < runs.length} onChange={toggleAll} /></Th>
                         <Th>#</Th>
                         <Th>Date</Th>
                         <Th>Test</Th>
@@ -259,7 +280,8 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
                     </Thead>
                     <Tbody>
                       {runs.map((run, i) => (
-                        <Tr key={i}>
+                        <Tr key={i} opacity={selected.has(i) ? 1 : 0.5} cursor='pointer' onClick={() => toggleSelect(i)}>
+                          <Td px={1}><Checkbox size='sm' isChecked={selected.has(i)} onChange={() => toggleSelect(i)} /></Td>
                           <Td>{i + 1}</Td>
                           <Td>{formatDate(run.startedAt)}</Td>
                           <Td>
@@ -283,8 +305,8 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
                       <option key={m.value} value={m.value}>{m.label}</option>
                     ))}
                   </Select>
-                  <RMButton size='small' colorScheme='blue' onClick={fetchGraphiteData} isDisabled={loading}>
-                    {loading ? <Spinner size='xs' /> : 'Show Graph'}
+                  <RMButton size='small' colorScheme='blue' onClick={fetchGraphiteData} isDisabled={loading || selected.size === 0}>
+                    {loading ? <Spinner size='xs' /> : `Show Graph (${selected.size})`}
                   </RMButton>
                 </HStack>
 

--- a/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
@@ -167,7 +167,9 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
       clusterService.getSysbenchHistory(clusterName, baseURL)
         .then(res => {
           const data = res.data
-          const entries = Array.isArray(data) ? data : data?.Entries || data?.entries || []
+          const allEntries = Array.isArray(data) ? data : data?.Entries || data?.entries || []
+          // Filter out prepare/cleanup steps — only show run entries
+          const entries = allEntries.filter(e => !e.step || e.step === 'run')
           setRuns(entries)
           if (entries.length > 0) setSelected(new Set([entries.length - 1]))
         })

--- a/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
@@ -21,6 +21,29 @@ const METRICS = [
   { value: 'mysql_global_status_innodb_row_lock_waits', label: 'InnoDB Row Lock Waits' },
 ]
 
+// Fetch graphite PNG with credentials (img src doesn't send auth)
+function GraphiteImage({ url }) {
+  const [imgSrc, setImgSrc] = useState(null)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    if (!url) return
+    setError(false)
+    fetch(url)
+      .then(res => {
+        if (!res.ok) throw new Error(res.status)
+        return res.blob()
+      })
+      .then(blob => setImgSrc(URL.createObjectURL(blob)))
+      .catch(() => setError(true))
+    return () => { if (imgSrc) URL.revokeObjectURL(imgSrc) }
+  }, [url])
+
+  if (error) return <Text fontSize='sm' color='red.400'>Failed to load graph</Text>
+  if (!imgSrc) return <Text fontSize='sm'>Loading graph...</Text>
+  return <img src={imgSrc} alt='Benchmark comparison' style={{ width: '100%' }} />
+}
+
 function BenchCompareModal({ isOpen, closeModal, clusterName }) {
   const { theme } = useTheme()
   const baseURL = useSelector((state) => state?.auth?.baseURL)
@@ -171,12 +194,7 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
 
                 {graphiteUrl && (
                   <Box borderRadius='md' overflow='hidden' bg={theme === 'light' ? 'gray.50' : 'rgba(255,255,255,0.05)'} p={2}>
-                    <img
-                      src={graphiteUrl}
-                      alt='Benchmark comparison'
-                      style={{ width: '100%' }}
-                      onError={(e) => { e.target.style.display = 'none' }}
-                    />
+                    <GraphiteImage url={graphiteUrl} />
                   </Box>
                 )}
               </>

--- a/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
@@ -33,7 +33,10 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
   useEffect(() => {
     if (isOpen && clusterName) {
       clusterService.getSysbenchHistory(clusterName, 10, baseURL)
-        .then(res => setRuns(res.data || []))
+        .then(res => {
+          const data = res.data
+          setRuns(Array.isArray(data) ? data : data?.entries || [])
+        })
         .catch(() => setRuns([]))
     }
   }, [isOpen, clusterName, baseURL])

--- a/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
@@ -10,15 +10,18 @@ import RMButton from '../../RMButton'
 import parentStyles from '../styles.module.scss'
 
 const METRICS = [
-  { value: 'mysql_global_status_questions', label: 'Questions (QPS)' },
+  { value: 'mysql_global_status_queries', label: 'Queries (QPS)' },
   { value: 'mysql_global_status_com_select', label: 'SELECT' },
   { value: 'mysql_global_status_com_insert', label: 'INSERT' },
   { value: 'mysql_global_status_com_update', label: 'UPDATE' },
   { value: 'mysql_global_status_com_delete', label: 'DELETE' },
   { value: 'mysql_global_status_threads_running', label: 'Threads Running' },
-  { value: 'mysql_global_status_connections', label: 'Connections' },
+  { value: 'mysql_global_status_threads_connected', label: 'Threads Connected' },
   { value: 'mysql_global_status_created_tmp_disk_tables', label: 'Tmp Disk Tables' },
-  { value: 'mysql_global_status_innodb_row_lock_waits', label: 'InnoDB Row Lock Waits' },
+  { value: 'mysql_global_status_innodb_rows_read', label: 'InnoDB Rows Read' },
+  { value: 'mysql_global_status_innodb_rows_inserted', label: 'InnoDB Rows Inserted' },
+  { value: 'mysql_global_status_bytes_sent', label: 'Bytes Sent' },
+  { value: 'mysql_global_status_bytes_received', label: 'Bytes Received' },
 ]
 
 // Fetch graphite PNG with credentials (img src doesn't send auth)
@@ -50,7 +53,7 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
   const monitor = useSelector((state) => state?.globalClusters?.monitor)
   const clusterData = useSelector((state) => state?.cluster?.clusterData)
   const [runs, setRuns] = useState([])
-  const [metric, setMetric] = useState('mysql_global_status_questions')
+  const [metric, setMetric] = useState('mysql_global_status_queries')
   const [graphiteUrl, setGraphiteUrl] = useState('')
 
   const badgeVariant = theme === 'dark' ? 'solid' : 'subtle'
@@ -78,10 +81,11 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
 
     // Wrap cumulative counters in perSecond() for rate-based display
     const rateMetrics = [
-      'mysql_global_status_questions', 'mysql_global_status_com_select',
+      'mysql_global_status_queries', 'mysql_global_status_com_select',
       'mysql_global_status_com_insert', 'mysql_global_status_com_update',
-      'mysql_global_status_com_delete', 'mysql_global_status_connections',
-      'mysql_global_status_created_tmp_disk_tables', 'mysql_global_status_innodb_row_lock_waits'
+      'mysql_global_status_com_delete', 'mysql_global_status_created_tmp_disk_tables',
+      'mysql_global_status_innodb_rows_read', 'mysql_global_status_innodb_rows_inserted',
+      'mysql_global_status_bytes_sent', 'mysql_global_status_bytes_received'
     ]
     const rawMetric = `mysql.${hostname}.${metric}`
     const fullMetric = rateMetrics.includes(metric) ? `perSecond(${rawMetric})` : rawMetric

--- a/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
@@ -46,14 +46,14 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
   const buildGraphiteUrl = () => {
     if (runs.length === 0) return
 
-    // Get graphite API URL from monitor config
-    const graphiteHost = monitor?.config?.graphiteCarbonHost || '127.0.0.1'
-    const graphitePort = monitor?.config?.graphiteCarbonApiPort || 10002
-    const apiUrl = `http://${graphiteHost}:${graphitePort}`
+    // Use repman's graphite proxy route, not direct graphite port
+    const apiUrl = ''
 
     // Get master hostname for metric path
-    const masterHost = clusterData?.master?.host || clusterName
-    const hostname = masterHost.replace(/\./g, '-').replace(/[`? ()/<'"]/g, '-')
+    const servers = clusterData?.servers || []
+    const master = servers.find(s => s.isMaster || s.state === 'Master') || servers[0]
+    const masterHostname = master?.hostname || clusterName
+    const hostname = masterHostname.replace(/\./g, '-').replace(/[`? ()/<'"]/g, '-')
 
     const fullMetric = `mysql.${hostname}.${metric}`
 
@@ -87,7 +87,7 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
     params.set('width', '800')
     params.set('height', '300')
 
-    setGraphiteUrl(`${apiUrl}/render/?${params.toString()}`)
+    setGraphiteUrl(`/graphite/render?${params.toString()}`)
   }
 
   const formatDate = (t) => t ? new Date(t).toLocaleString() : '-'

--- a/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
@@ -66,10 +66,22 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
     const newestStart = Math.floor(new Date(newest.startedAt).getTime() / 1000)
     const newestEnd = Math.floor(new Date(newest.endedAt).getTime() / 1000)
 
+    // First run is the reference, others show delta from reference TPS
+    const refRun = runs[0]
+    const refTPS = refRun?.avgTps || 0
+
     let targets = []
     runs.forEach((run, i) => {
-      const label = `Run${i + 1} ${run.testType} ${run.threads}t ${run.dbFlavor || ''}/${run.dbVersion || ''}`
       const runStart = Math.floor(new Date(run.startedAt).getTime() / 1000)
+      let label
+      if (i === 0) {
+        label = `REF ${run.testType} ${run.threads}t ${run.dbFlavor || ''}/${run.dbVersion || ''} TPS:${run.avgTps?.toFixed(0)}`
+      } else {
+        const diff = (run.avgTps || 0) - refTPS
+        const pct = refTPS > 0 ? ((diff / refTPS) * 100).toFixed(1) : '0'
+        const sign = diff >= 0 ? '+' : ''
+        label = `${run.testType} ${run.threads}t ${run.dbFlavor || ''}/${run.dbVersion || ''} TPS:${run.avgTps?.toFixed(0)} (${sign}${pct}%)`
+      }
 
       if (runStart === newestStart) {
         targets.push(`alias(${fullMetric},'${label}')`)
@@ -79,7 +91,9 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
       }
     })
 
+    const metricLabel = METRICS.find(m => m.value === metric)?.label || metric
     const params = new URLSearchParams()
+    params.set('title', `${metricLabel} — ref: ${refRun.testType} ${refRun.threads}t ${refRun.dbFlavor}/${refRun.dbVersion}`)
     params.set('from', newestStart.toString())
     params.set('until', newestEnd.toString())
     targets.forEach(t => params.append('target', t))

--- a/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
@@ -10,7 +10,7 @@ import { clusterService } from '../../../services/clusterService'
 import RMButton from '../../RMButton'
 import parentStyles from '../styles.module.scss'
 
-const METRICS = [
+const GRAPHITE_METRICS = [
   { value: 'mysql_global_status_queries', label: 'Queries (QPS)', rate: true },
   { value: 'mysql_global_status_com_select', label: 'SELECT/s', rate: true },
   { value: 'mysql_global_status_com_insert', label: 'INSERT/s', rate: true },
@@ -25,29 +25,38 @@ const METRICS = [
   { value: 'mysql_global_status_bytes_received', label: 'Bytes Received/s', rate: true },
 ]
 
+const SCALE_METRICS = [
+  { value: 'avgTps', label: 'TPS' },
+  { value: 'avgLatency', label: 'Latency (ms)' },
+  { value: 'tpsPerDbu', label: 'TPS/DBU' },
+]
+
 const COLORS = ['#3182ce', '#e53e3e', '#38a169', '#d69e2e', '#805ad5', '#dd6b20', '#319795', '#b83280']
+
+const isScaleRun = (run) => run.scaleResults?.length > 0
 
 // Build a label showing what changed vs the reference run
 function buildSeriesLabel(run, refRun, index) {
   if (index === 0) {
-    return `REF ${run.testType} ${run.threads}t ${run.dbFlavor || ''}/${run.dbVersion || ''}`
+    const threads = isScaleRun(run) ? 'scale' : `${run.threads}t`
+    return `REF ${run.testType} ${threads} ${run.dbFlavor || ''}/${run.dbVersion || ''}`
   }
   const diffs = []
   if (run.testType !== refRun.testType) diffs.push(run.testType)
-  if (run.threads !== refRun.threads) diffs.push(`${run.threads}t`)
+  if (!isScaleRun(run) && !isScaleRun(refRun) && run.threads !== refRun.threads) diffs.push(`${run.threads}t`)
   if (run.dbFlavor !== refRun.dbFlavor || run.dbVersion !== refRun.dbVersion) {
     diffs.push(`${run.dbFlavor || ''}/${run.dbVersion || ''}`)
   }
   if (run.proxyType !== refRun.proxyType) diffs.push(run.proxyType)
   if (run.configTags !== refRun.configTags) diffs.push(`tags:${run.configTags}`)
   if (diffs.length === 0) {
-    // Nothing obviously changed — show date
     return `Run${index + 1} ${new Date(run.startedAt).toLocaleString()}`
   }
   return diffs.join(' ')
 }
 
-function BenchChart({ series, theme, metricLabel }) {
+// Generic d3 line chart — used for both graphite time-series and scale charts
+function LineChart({ series, theme, xLabel, yLabel, xAccessor = 'x', yAccessor = 'y' }) {
   const svgRef = useRef()
 
   useEffect(() => {
@@ -65,8 +74,8 @@ function BenchChart({ series, theme, metricLabel }) {
     const validSeries = series.filter(s => s.data.length > 0)
     if (validSeries.length === 0) return
 
-    const maxX = d3.max(validSeries, s => d3.max(s.data, d => d.second)) || 100
-    const maxY = d3.max(validSeries, s => d3.max(s.data, d => d.value)) || 1
+    const maxX = d3.max(validSeries, s => d3.max(s.data, d => d[xAccessor])) || 100
+    const maxY = d3.max(validSeries, s => d3.max(s.data, d => d[yAccessor])) || 1
 
     const x = d3.scaleLinear().domain([0, maxX]).range([0, width])
     const y = d3.scaleLinear().domain([0, maxY * 1.1]).range([height, 0])
@@ -90,8 +99,8 @@ function BenchChart({ series, theme, metricLabel }) {
       .selectAll('text').attr('fill', textColor)
     g.selectAll('.domain').attr('stroke', textColor)
 
-    // Lines
-    const line = d3.line().x(d => x(d.second)).y(d => y(d.value)).curve(d3.curveMonotoneX).defined(d => d.value != null)
+    // Lines + dots
+    const line = d3.line().x(d => x(d[xAccessor])).y(d => y(d[yAccessor])).curve(d3.curveMonotoneX).defined(d => d[yAccessor] != null)
     validSeries.forEach(s => {
       g.append('path')
         .datum(s.data)
@@ -100,6 +109,15 @@ function BenchChart({ series, theme, metricLabel }) {
         .attr('stroke-width', s.isRef ? 2.5 : 1.5)
         .attr('stroke-dasharray', s.isRef ? null : '6,3')
         .attr('d', line)
+      // Data point dots for scale charts (few points)
+      if (s.data.length <= 20) {
+        g.selectAll(null).data(s.data.filter(d => d[yAccessor] != null)).enter()
+          .append('circle')
+          .attr('cx', d => x(d[xAccessor]))
+          .attr('cy', d => y(d[yAccessor]))
+          .attr('r', 3)
+          .attr('fill', s.color)
+      }
     })
 
     // Legend
@@ -115,11 +133,11 @@ function BenchChart({ series, theme, metricLabel }) {
 
     // Axis labels
     g.append('text').attr('x', width / 2).attr('y', height + 30).attr('text-anchor', 'middle')
-      .attr('fill', textColor).attr('font-size', '11px').text('Seconds (from benchmark start)')
+      .attr('fill', textColor).attr('font-size', '11px').text(xLabel)
     g.append('text').attr('transform', 'rotate(-90)').attr('x', -height / 2).attr('y', -45)
-      .attr('text-anchor', 'middle').attr('fill', textColor).attr('font-size', '11px').text(metricLabel)
+      .attr('text-anchor', 'middle').attr('fill', textColor).attr('font-size', '11px').text(yLabel)
 
-  }, [series, theme, metricLabel])
+  }, [series, theme, xLabel, yLabel, xAccessor, yAccessor])
 
   return <svg ref={svgRef} width={800} height={280} />
 }
@@ -130,7 +148,9 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
   const [runs, setRuns] = useState([])
   const [selected, setSelected] = useState(new Set())
   const [metric, setMetric] = useState('mysql_global_status_queries')
+  const [scaleMetric, setScaleMetric] = useState('avgTps')
   const [chartSeries, setChartSeries] = useState([])
+  const [chartMode, setChartMode] = useState(null) // 'graphite' | 'scale'
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
@@ -139,6 +159,7 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
   useEffect(() => {
     if (isOpen && clusterName) {
       setChartSeries([])
+      setChartMode(null)
       setError('')
       setSelected(new Set())
       clusterService.getSysbenchHistory(clusterName, baseURL)
@@ -146,7 +167,6 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
           const data = res.data
           const entries = Array.isArray(data) ? data : data?.Entries || data?.entries || []
           setRuns(entries)
-          // Select only the last run by default
           if (entries.length > 0) setSelected(new Set([entries.length - 1]))
         })
         .catch(() => setRuns([]))
@@ -167,19 +187,52 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
     else setSelected(new Set(runs.map((_, i) => i)))
   }
 
+  // Check if any selected run is a scale run
+  const selectedRuns = runs.filter((_, i) => selected.has(i))
+  const hasScaleRuns = selectedRuns.some(isScaleRun)
+
+  // Show scale chart from embedded scaleResults data
+  const showScaleChart = () => {
+    const sorted = [...selectedRuns].sort((a, b) => new Date(a.startedAt) - new Date(b.startedAt))
+    const refRun = sorted[0]
+
+    let idx = 0
+    const series = sorted.map((run) => {
+      const i = idx++
+      if (isScaleRun(run)) {
+        return {
+          label: buildSeriesLabel(run, refRun, i),
+          color: COLORS[i % COLORS.length],
+          isRef: i === 0,
+          data: run.scaleResults.map(sp => ({ x: sp.threads, y: sp[scaleMetric] || 0 }))
+        }
+      }
+      // Normal single-thread run: plot as a single point on the threads axis
+      const valMap = { avgTps: run.avgTps, avgLatency: run.avgLatency, tpsPerDbu: run.tpsPerDbu }
+      return {
+        label: buildSeriesLabel(run, refRun, i),
+        color: COLORS[i % COLORS.length],
+        isRef: i === 0,
+        data: [{ x: run.threads, y: valMap[scaleMetric] || 0 }]
+      }
+    })
+
+    setChartSeries(series)
+    setChartMode('scale')
+    setError(series.length === 0 ? 'No data in selected runs' : '')
+  }
+
+  // Fetch graphite time-series for all selected runs (normal + scale)
   const fetchGraphiteData = async () => {
-    const selectedRuns = runs.filter((_, i) => selected.has(i))
     if (selectedRuns.length === 0) return
     setLoading(true)
     setError('')
     setChartSeries([])
 
-    const metricDef = METRICS.find(m => m.value === metric)
-    // Oldest selected run is the reference (index 0 after sorting by startedAt)
+    const metricDef = GRAPHITE_METRICS.find(m => m.value === metric)
     const sorted = [...selectedRuns].sort((a, b) => new Date(a.startedAt) - new Date(b.startedAt))
     const refRun = sorted[0]
 
-    // Find the newest run to align the graphite time window
     const newest = sorted[sorted.length - 1]
     const newestStart = Math.floor(new Date(newest.startedAt).getTime() / 1000)
     const newestEnd = Math.floor(new Date(newest.endedAt).getTime() / 1000)
@@ -213,20 +266,17 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
         const text = await res.text()
         if (!text.trim()) return null
 
-        // Parse raw format: name,startTime,endTime,step|val1,val2,...
         const parts = text.split('|')
         if (parts.length !== 2) return null
         const timeInfo = parts[0].split(',')
-        const startTime = parseInt(timeInfo[1])
         const step = parseInt(timeInfo[3])
         const values = parts[1].split(',')
 
-        // Convert to seconds-from-start
         const runDuration = Math.floor(new Date(run.endedAt).getTime() / 1000) - Math.floor(new Date(run.startedAt).getTime() / 1000)
         const data = values.map((v, j) => ({
-          second: j * step,
-          value: v === 'None' ? null : parseFloat(v)
-        })).filter(d => d.second <= runDuration + step)
+          x: j * step,
+          y: v === 'None' ? null : parseFloat(v)
+        })).filter(d => d.x <= runDuration + step)
 
         return {
           label: buildSeriesLabel(run, refRun, i),
@@ -241,6 +291,7 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
         setError('No data returned from graphite for any run')
       }
       setChartSeries(valid)
+      setChartMode('graphite')
     } catch (e) {
       setError(`Graphite fetch failed: ${e.message}`)
     } finally {
@@ -249,7 +300,16 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
   }
 
   const formatDate = (t) => t ? new Date(t).toLocaleString() : '-'
-  const metricLabel = METRICS.find(m => m.value === metric)?.label || metric
+  const graphiteLabel = GRAPHITE_METRICS.find(m => m.value === metric)?.label || metric
+  const scaleLabel = SCALE_METRICS.find(m => m.value === scaleMetric)?.label || scaleMetric
+
+  const formatThreads = (run) => {
+    if (isScaleRun(run)) {
+      const pts = run.scaleResults
+      return `${pts[0]?.threads}→${pts[pts.length - 1]?.threads}`
+    }
+    return run.threads
+  }
 
   return (
     <Modal isOpen={isOpen} onClose={closeModal} size='xl'>
@@ -271,7 +331,7 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
                         <Th>Date</Th>
                         <Th>Test</Th>
                         <Th>Threads</Th>
-                        <Th>Avg TPS</Th>
+                        <Th>Peak TPS</Th>
                         <Th>Avg Lat</Th>
                         <Th>DBU</Th>
                         <Th>TPS/DBU</Th>
@@ -285,9 +345,12 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
                           <Td>{i + 1}</Td>
                           <Td>{formatDate(run.startedAt)}</Td>
                           <Td>
-                            <Badge variant={badgeVariant} colorScheme='blue' size='sm'>{run.testType}</Badge>
+                            <HStack spacing={1}>
+                              <Badge variant={badgeVariant} colorScheme='blue' size='sm'>{run.testType}</Badge>
+                              {isScaleRun(run) && <Badge variant={badgeVariant} colorScheme='purple' size='sm'>scale</Badge>}
+                            </HStack>
                           </Td>
-                          <Td>{run.threads}</Td>
+                          <Td>{formatThreads(run)}</Td>
                           <Td fontWeight={600}>{run.avgTps?.toFixed(1)}</Td>
                           <Td>{run.avgLatency?.toFixed(2)}ms</Td>
                           <Td>{run.clusterDbu?.toFixed(1)}</Td>
@@ -299,14 +362,27 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
                   </Table>
                 </Box>
 
+                {/* Scale chart: threads vs metric — works for scale runs (curves) + normal runs (points) */}
+                <HStack spacing={3}>
+                  <Select size='sm' value={scaleMetric} onChange={(e) => setScaleMetric(e.target.value)} flex={1}>
+                    {SCALE_METRICS.map(m => (
+                      <option key={m.value} value={m.value}>{m.label}</option>
+                    ))}
+                  </Select>
+                  <RMButton size='small' colorScheme='purple' onClick={showScaleChart} isDisabled={selected.size === 0}>
+                    Scale Graph ({selected.size})
+                  </RMButton>
+                </HStack>
+
+                {/* Normal runs: graphite metric selector + show button */}
                 <HStack spacing={3}>
                   <Select size='sm' value={metric} onChange={(e) => setMetric(e.target.value)} flex={1}>
-                    {METRICS.map(m => (
+                    {GRAPHITE_METRICS.map(m => (
                       <option key={m.value} value={m.value}>{m.label}</option>
                     ))}
                   </Select>
                   <RMButton size='small' colorScheme='blue' onClick={fetchGraphiteData} isDisabled={loading || selected.size === 0}>
-                    {loading ? <Spinner size='xs' /> : `Show Graph (${selected.size})`}
+                    {loading ? <Spinner size='xs' /> : `Graphite Graph (${selectedRuns.length})`}
                   </RMButton>
                 </HStack>
 
@@ -316,7 +392,12 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
 
                 {chartSeries.length > 0 && (
                   <Box borderRadius='md' overflow='hidden' bg={theme === 'light' ? 'gray.50' : 'rgba(255,255,255,0.05)'} p={2}>
-                    <BenchChart series={chartSeries} theme={theme} metricLabel={metricLabel} />
+                    <LineChart
+                      series={chartSeries}
+                      theme={theme}
+                      xLabel={chartMode === 'scale' ? 'Threads' : 'Seconds (from benchmark start)'}
+                      yLabel={chartMode === 'scale' ? scaleLabel : graphiteLabel}
+                    />
                   </Box>
                 )}
               </>

--- a/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
@@ -88,7 +88,7 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
       'mysql_global_status_bytes_sent', 'mysql_global_status_bytes_received'
     ]
     const rawMetric = `mysql.${hostname}.${metric}`
-    const fullMetric = rateMetrics.includes(metric) ? `perSecond(${rawMetric})` : rawMetric
+    const fullMetric = rateMetrics.includes(metric) ? `perSecond(keepLastValue(${rawMetric}))` : rawMetric
 
     // Find the newest run to align all others
     let newest = runs[0]

--- a/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
@@ -35,7 +35,7 @@ const SCALE_METRICS = [
 
 const COLORS = ['#3182ce', '#e53e3e', '#38a169', '#d69e2e', '#805ad5', '#dd6b20', '#319795', '#b83280']
 
-const isScaleRun = (run) => run.scaleResults?.length > 0
+const isScaleRun = (run) => !!run.isScale
 
 // Build a label showing what changed vs the reference run
 function buildSeriesLabel(run, refRun, index) {
@@ -193,30 +193,46 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
   const selectedRuns = runs.filter((_, i) => selected.has(i))
   const hasScaleRuns = selectedRuns.some(isScaleRun)
 
-  // Show scale chart from embedded scaleResults data
+  // Show scale chart — group scale entries by scaleGroup, normal entries as single points
   const showScaleChart = () => {
-    const sorted = [...selectedRuns].sort((a, b) => new Date(a.startedAt) - new Date(b.startedAt))
-    const refRun = sorted[0]
+    const series = []
 
-    let idx = 0
-    const series = sorted.map((run) => {
-      const i = idx++
-      if (isScaleRun(run)) {
-        return {
-          label: buildSeriesLabel(run, refRun, i),
-          color: COLORS[i % COLORS.length],
-          isRef: i === 0,
-          data: run.scaleResults.map(sp => ({ x: sp.threads, y: sp[scaleMetric] || 0 }))
-        }
+    // Group scale entries by scaleGroup
+    const scaleGroups = new Map()
+    const normalRuns = []
+    selectedRuns.forEach(run => {
+      if (isScaleRun(run) && run.scaleGroup) {
+        const key = run.scaleGroup
+        if (!scaleGroups.has(key)) scaleGroups.set(key, [])
+        scaleGroups.get(key).push(run)
+      } else {
+        normalRuns.push(run)
       }
-      // Normal single-thread run: plot as a single point on the threads axis
-      const valMap = { avgTps: run.avgTps, avgLatency: run.avgLatency, tpsPerDbu: run.tpsPerDbu }
-      return {
-        label: buildSeriesLabel(run, refRun, i),
+    })
+
+    // Each scale group becomes one series (curve)
+    let idx = 0
+    scaleGroups.forEach((entries, groupKey) => {
+      const sorted = [...entries].sort((a, b) => a.threads - b.threads)
+      const first = sorted[0]
+      const i = idx++
+      series.push({
+        label: `Scale ${first.testType} ${first.dbFlavor || ''}/${first.dbVersion || ''} ${new Date(groupKey).toLocaleDateString()}`,
         color: COLORS[i % COLORS.length],
         isRef: i === 0,
-        data: [{ x: run.threads, y: valMap[scaleMetric] || 0 }]
-      }
+        data: sorted.map(e => ({ x: e.threads, y: e[scaleMetric] || 0 }))
+      })
+    })
+
+    // Normal runs as single points
+    normalRuns.forEach(run => {
+      const i = idx++
+      series.push({
+        label: `${run.testType} ${run.threads}t ${run.dbFlavor || ''}/${run.dbVersion || ''}`,
+        color: COLORS[i % COLORS.length],
+        isRef: series.length === 0,
+        data: [{ x: run.threads, y: run[scaleMetric] || 0 }]
+      })
     })
 
     setChartSeries(series)
@@ -305,13 +321,6 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
   const graphiteLabel = GRAPHITE_METRICS.find(m => m.value === metric)?.label || metric
   const scaleLabel = SCALE_METRICS.find(m => m.value === scaleMetric)?.label || scaleMetric
 
-  const formatThreads = (run) => {
-    if (isScaleRun(run)) {
-      const pts = run.scaleResults
-      return `${pts[0]?.threads}→${pts[pts.length - 1]?.threads}`
-    }
-    return run.threads
-  }
 
   return (
     <Modal isOpen={isOpen} onClose={closeModal} size='xl'>
@@ -352,7 +361,7 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
                               {isScaleRun(run) && <Badge variant={badgeVariant} colorScheme='purple' size='sm'>scale</Badge>}
                             </HStack>
                           </Td>
-                          <Td>{formatThreads(run)}</Td>
+                          <Td>{run.threads}</Td>
                           <Td fontWeight={600}>{run.avgTps?.toFixed(1)}</Td>
                           <Td>{run.avgLatency?.toFixed(2)}ms</Td>
                           <Td>{run.clusterDbu?.toFixed(1)}</Td>

--- a/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
@@ -12,6 +12,8 @@ import parentStyles from '../styles.module.scss'
 
 const GRAPHITE_METRICS = [
   { value: 'mysql_global_status_queries', label: 'Queries (QPS)', rate: true },
+  { value: 'mysql_global_status_com_commit', label: 'Commit/s', rate: true },
+  { value: 'mysql_global_status_com_rollback', label: 'Rollback/s', rate: true },
   { value: 'mysql_global_status_com_select', label: 'SELECT/s', rate: true },
   { value: 'mysql_global_status_com_insert', label: 'INSERT/s', rate: true },
   { value: 'mysql_global_status_com_update', label: 'UPDATE/s', rate: true },

--- a/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
@@ -2,64 +2,115 @@ import {
   Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalCloseButton,
   Box, VStack, HStack, Text, Badge, Table, Thead, Tbody, Tr, Th, Td, Select
 } from '@chakra-ui/react'
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { useSelector } from 'react-redux'
+import * as d3 from 'd3'
 import { useTheme } from '../../../ThemeProvider'
 import { clusterService } from '../../../services/clusterService'
 import RMButton from '../../RMButton'
 import parentStyles from '../styles.module.scss'
 
-const METRICS = [
-  { value: 'mysql_global_status_queries', label: 'Queries (QPS)' },
-  { value: 'mysql_global_status_com_select', label: 'SELECT' },
-  { value: 'mysql_global_status_com_insert', label: 'INSERT' },
-  { value: 'mysql_global_status_com_update', label: 'UPDATE' },
-  { value: 'mysql_global_status_com_delete', label: 'DELETE' },
-  { value: 'mysql_global_status_threads_running', label: 'Threads Running' },
-  { value: 'mysql_global_status_threads_connected', label: 'Threads Connected' },
-  { value: 'mysql_global_status_created_tmp_disk_tables', label: 'Tmp Disk Tables' },
-  { value: 'mysql_global_status_innodb_rows_read', label: 'InnoDB Rows Read' },
-  { value: 'mysql_global_status_innodb_rows_inserted', label: 'InnoDB Rows Inserted' },
-  { value: 'mysql_global_status_bytes_sent', label: 'Bytes Sent' },
-  { value: 'mysql_global_status_bytes_received', label: 'Bytes Received' },
+const RECORD_METRICS = [
+  { value: 'TPS', label: 'TPS' },
+  { value: 'QPS', label: 'QPS' },
+  { value: 'Latency', label: 'Latency (ms)' },
+  { value: 'ReadQPS', label: 'Read QPS' },
+  { value: 'WriteQPS', label: 'Write QPS' },
+  { value: 'ErrorPerSec', label: 'Errors/s' },
 ]
 
-// Fetch graphite PNG with credentials (img src doesn't send auth)
-function GraphiteImage({ url }) {
-  const [imgSrc, setImgSrc] = useState(null)
-  const [error, setError] = useState(false)
+const COLORS = ['#3182ce', '#e53e3e', '#38a169', '#d69e2e', '#805ad5', '#dd6b20', '#319795', '#b83280']
+
+function BenchChart({ runs, metric, theme }) {
+  const svgRef = useRef()
 
   useEffect(() => {
-    if (!url) return
-    setError(false)
-    fetch(url)
-      .then(res => {
-        if (!res.ok) throw new Error(res.status)
-        return res.blob()
-      })
-      .then(blob => setImgSrc(URL.createObjectURL(blob)))
-      .catch(() => setError(true))
-    return () => { if (imgSrc) URL.revokeObjectURL(imgSrc) }
-  }, [url])
+    if (!svgRef.current || runs.length === 0) return
 
-  if (error) return <Text fontSize='sm' color='red.400'>Failed to load graph</Text>
-  if (!imgSrc) return <Text fontSize='sm'>Loading graph...</Text>
-  return <img src={imgSrc} alt='Benchmark comparison' style={{ width: '100%' }} />
+    const svg = d3.select(svgRef.current)
+    svg.selectAll('*').remove()
+
+    const margin = { top: 20, right: 120, bottom: 30, left: 50 }
+    const width = 750 - margin.left - margin.right
+    const height = 250 - margin.top - margin.bottom
+
+    const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
+
+    // Collect all data series
+    const series = runs.map((run, i) => {
+      const records = run.records || []
+      return {
+        label: i === 0
+          ? `REF ${run.testType} ${run.threads}t`
+          : `${run.testType} ${run.threads}t`,
+        color: COLORS[i % COLORS.length],
+        data: records.map((r, j) => ({ second: r.Second || j, value: r[metric] || 0 }))
+      }
+    }).filter(s => s.data.length > 0)
+
+    if (series.length === 0) return
+
+    const maxX = d3.max(series, s => d3.max(s.data, d => d.second)) || 100
+    const maxY = d3.max(series, s => d3.max(s.data, d => d.value)) || 1
+
+    const x = d3.scaleLinear().domain([0, maxX]).range([0, width])
+    const y = d3.scaleLinear().domain([0, maxY * 1.1]).range([height, 0])
+
+    const textColor = theme === 'dark' ? '#e2e8f0' : '#333'
+    const gridColor = theme === 'dark' ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)'
+
+    // Grid
+    g.append('g')
+      .attr('transform', `translate(0,${height})`)
+      .call(d3.axisBottom(x).ticks(10))
+      .selectAll('text').attr('fill', textColor)
+    g.append('g')
+      .call(d3.axisLeft(y).ticks(5))
+      .selectAll('text').attr('fill', textColor)
+    g.selectAll('.domain').attr('stroke', textColor)
+    g.selectAll('.tick line').attr('stroke', gridColor)
+
+    // Lines
+    const line = d3.line().x(d => x(d.second)).y(d => y(d.value)).curve(d3.curveMonotoneX)
+    series.forEach(s => {
+      g.append('path')
+        .datum(s.data)
+        .attr('fill', 'none')
+        .attr('stroke', s.color)
+        .attr('stroke-width', 1.5)
+        .attr('d', line)
+    })
+
+    // Legend
+    const legend = g.append('g').attr('transform', `translate(${width + 10}, 0)`)
+    series.forEach((s, i) => {
+      const row = legend.append('g').attr('transform', `translate(0,${i * 16})`)
+      row.append('rect').attr('width', 10).attr('height', 10).attr('fill', s.color)
+      row.append('text').attr('x', 14).attr('y', 9).text(s.label)
+        .attr('fill', textColor).attr('font-size', '10px')
+    })
+
+    // Axis labels
+    g.append('text').attr('x', width / 2).attr('y', height + 28).attr('text-anchor', 'middle')
+      .attr('fill', textColor).attr('font-size', '11px').text('Seconds')
+
+  }, [runs, metric, theme])
+
+  return <svg ref={svgRef} width={750} height={250} />
 }
 
 function BenchCompareModal({ isOpen, closeModal, clusterName }) {
   const { theme } = useTheme()
   const baseURL = useSelector((state) => state?.auth?.baseURL)
-  const monitor = useSelector((state) => state?.globalClusters?.monitor)
-  const clusterData = useSelector((state) => state?.cluster?.clusterData)
   const [runs, setRuns] = useState([])
-  const [metric, setMetric] = useState('mysql_global_status_queries')
-  const [graphiteUrl, setGraphiteUrl] = useState('')
+  const [metric, setMetric] = useState('TPS')
+  const [showChart, setShowChart] = useState(false)
 
   const badgeVariant = theme === 'dark' ? 'solid' : 'subtle'
 
   useEffect(() => {
     if (isOpen && clusterName) {
+      setShowChart(false)
       clusterService.getSysbenchHistory(clusterName, baseURL)
         .then(res => {
           const data = res.data
@@ -68,74 +119,6 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
         .catch(() => setRuns([]))
     }
   }, [isOpen, clusterName, baseURL])
-
-  const buildGraphiteUrl = () => {
-    if (runs.length === 0) return
-
-    // Use repman's graphite proxy route, not direct graphite port
-    const apiUrl = ''
-
-    // Use graphiteHost from the run entry (@@hostname with graphite replacements)
-    // Falls back to first run's graphiteHost or cluster name
-    const hostname = runs[0]?.graphiteHost || clusterName
-
-    // Wrap cumulative counters in perSecond() for rate-based display
-    const rateMetrics = [
-      'mysql_global_status_queries', 'mysql_global_status_com_select',
-      'mysql_global_status_com_insert', 'mysql_global_status_com_update',
-      'mysql_global_status_com_delete', 'mysql_global_status_created_tmp_disk_tables',
-      'mysql_global_status_innodb_rows_read', 'mysql_global_status_innodb_rows_inserted',
-      'mysql_global_status_bytes_sent', 'mysql_global_status_bytes_received'
-    ]
-    const rawMetric = `mysql.${hostname}.${metric}`
-    const fullMetric = rateMetrics.includes(metric) ? `perSecond(keepLastValue(${rawMetric}))` : rawMetric
-
-    // Find the newest run to align all others
-    let newest = runs[0]
-    runs.forEach(r => {
-      if (new Date(r.startedAt) > new Date(newest.startedAt)) newest = r
-    })
-
-    const newestStart = Math.floor(new Date(newest.startedAt).getTime() / 1000)
-    const newestEnd = Math.floor(new Date(newest.endedAt).getTime() / 1000)
-
-    // First run is the reference, others show delta from reference TPS
-    const refRun = runs[0]
-    const refTPS = refRun?.avgTps || 0
-
-    let targets = []
-    runs.forEach((run, i) => {
-      const runStart = Math.floor(new Date(run.startedAt).getTime() / 1000)
-      let label
-      if (i === 0) {
-        label = `REF ${run.testType} ${run.threads}t ${run.dbFlavor || ''}/${run.dbVersion || ''} TPS:${run.avgTps?.toFixed(0)}`
-      } else {
-        const diff = (run.avgTps || 0) - refTPS
-        const pct = refTPS > 0 ? ((diff / refTPS) * 100).toFixed(1) : '0'
-        const sign = diff >= 0 ? '+' : ''
-        label = `${run.testType} ${run.threads}t ${run.dbFlavor || ''}/${run.dbVersion || ''} TPS:${run.avgTps?.toFixed(0)} (${sign}${pct}%)`
-      }
-
-      if (runStart === newestStart) {
-        targets.push(`alias(${fullMetric},'${label}')`)
-      } else {
-        const shift = newestStart - runStart
-        targets.push(`alias(timeShift(${fullMetric},'${shift}s'),'${label}')`)
-      }
-    })
-
-    const metricLabel = METRICS.find(m => m.value === metric)?.label || metric
-    const params = new URLSearchParams()
-    params.set('title', `${metricLabel} — ref: ${refRun.testType} ${refRun.threads}t ${refRun.dbFlavor}/${refRun.dbVersion}`)
-    params.set('from', newestStart.toString())
-    params.set('until', newestEnd.toString())
-    targets.forEach(t => params.append('target', t))
-    params.set('format', 'png')
-    params.set('width', '800')
-    params.set('height', '300')
-
-    setGraphiteUrl(`/graphite/render?${params.toString()}`)
-  }
 
   const formatDate = (t) => t ? new Date(t).toLocaleString() : '-'
 
@@ -187,18 +170,18 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
 
                 <HStack spacing={3}>
                   <Select size='sm' value={metric} onChange={(e) => setMetric(e.target.value)} flex={1}>
-                    {METRICS.map(m => (
+                    {RECORD_METRICS.map(m => (
                       <option key={m.value} value={m.value}>{m.label}</option>
                     ))}
                   </Select>
-                  <RMButton size='small' colorScheme='blue' onClick={buildGraphiteUrl}>
+                  <RMButton size='small' colorScheme='blue' onClick={() => setShowChart(true)}>
                     Show Graph
                   </RMButton>
                 </HStack>
 
-                {graphiteUrl && (
+                {showChart && (
                   <Box borderRadius='md' overflow='hidden' bg={theme === 'light' ? 'gray.50' : 'rgba(255,255,255,0.05)'} p={2}>
-                    <GraphiteImage url={graphiteUrl} />
+                    <BenchChart runs={runs} metric={metric} theme={theme} />
                   </Box>
                 )}
               </>

--- a/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
@@ -1,11 +1,12 @@
 import {
   Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalCloseButton,
-  Box, VStack, HStack, Text, Badge, Divider, Table, Thead, Tbody, Tr, Th, Td, Select
+  Box, VStack, HStack, Text, Badge, Table, Thead, Tbody, Tr, Th, Td, Select
 } from '@chakra-ui/react'
 import React, { useState, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { useTheme } from '../../../ThemeProvider'
 import { clusterService } from '../../../services/clusterService'
+import RMButton from '../../RMButton'
 import parentStyles from '../styles.module.scss'
 
 const METRICS = [
@@ -23,10 +24,11 @@ const METRICS = [
 function BenchCompareModal({ isOpen, closeModal, clusterName }) {
   const { theme } = useTheme()
   const baseURL = useSelector((state) => state?.auth?.baseURL)
+  const monitor = useSelector((state) => state?.globalClusters?.monitor)
+  const clusterData = useSelector((state) => state?.cluster?.clusterData)
   const [runs, setRuns] = useState([])
   const [metric, setMetric] = useState('mysql_global_status_questions')
-  const [compareResult, setCompareResult] = useState(null)
-  const [loading, setLoading] = useState(false)
+  const [graphiteUrl, setGraphiteUrl] = useState('')
 
   const badgeVariant = theme === 'dark' ? 'solid' : 'subtle'
 
@@ -35,27 +37,60 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
       clusterService.getSysbenchHistory(clusterName, baseURL)
         .then(res => {
           const data = res.data
-          // http-logs returns the SysbenchLog struct with entries field
           setRuns(Array.isArray(data) ? data : data?.Entries || data?.entries || [])
         })
         .catch(() => setRuns([]))
     }
   }, [isOpen, clusterName, baseURL])
 
-  const handleCompare = () => {
-    setLoading(true)
-    clusterService.getSysbenchCompare(clusterName, metric, baseURL)
-      .then(res => setCompareResult(res.data))
-      .catch(() => setCompareResult(null))
-      .finally(() => setLoading(false))
+  const buildGraphiteUrl = () => {
+    if (runs.length === 0) return
+
+    // Get graphite API URL from monitor config
+    const graphiteHost = monitor?.config?.graphiteCarbonHost || '127.0.0.1'
+    const graphitePort = monitor?.config?.graphiteCarbonApiPort || 10002
+    const apiUrl = `http://${graphiteHost}:${graphitePort}`
+
+    // Get master hostname for metric path
+    const masterHost = clusterData?.master?.host || clusterName
+    const hostname = masterHost.replace(/\./g, '-').replace(/[`? ()/<'"]/g, '-')
+
+    const fullMetric = `mysql.${hostname}.${metric}`
+
+    // Find the newest run to align all others
+    let newest = runs[0]
+    runs.forEach(r => {
+      if (new Date(r.startedAt) > new Date(newest.startedAt)) newest = r
+    })
+
+    const newestStart = Math.floor(new Date(newest.startedAt).getTime() / 1000)
+    const newestEnd = Math.floor(new Date(newest.endedAt).getTime() / 1000)
+
+    let targets = []
+    runs.forEach((run, i) => {
+      const label = `Run${i + 1} ${run.testType} ${run.threads}t ${run.dbFlavor || ''}/${run.dbVersion || ''}`
+      const runStart = Math.floor(new Date(run.startedAt).getTime() / 1000)
+
+      if (runStart === newestStart) {
+        targets.push(`alias(${fullMetric},'${label}')`)
+      } else {
+        const shift = newestStart - runStart
+        targets.push(`alias(timeShift(${fullMetric},'${shift}s'),'${label}')`)
+      }
+    })
+
+    const params = new URLSearchParams()
+    params.set('from', newestStart.toString())
+    params.set('until', newestEnd.toString())
+    targets.forEach(t => params.append('target', t))
+    params.set('format', 'png')
+    params.set('width', '800')
+    params.set('height', '300')
+
+    setGraphiteUrl(`${apiUrl}/render/?${params.toString()}`)
   }
 
   const formatDate = (t) => t ? new Date(t).toLocaleString() : '-'
-  const formatDuration = (start, end) => {
-    if (!start || !end) return '-'
-    const ms = new Date(end) - new Date(start)
-    return `${Math.round(ms / 1000)}s`
-  }
 
   return (
     <Modal isOpen={isOpen} onClose={closeModal} size='xl'>
@@ -66,17 +101,9 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
         <ModalBody pb={6}>
           <VStack align='stretch' spacing={4}>
 
-            <HStack spacing={3}>
-              <Select size='sm' value={metric} onChange={(e) => setMetric(e.target.value)} flex={1}>
-                {METRICS.map(m => (
-                  <option key={m.value} value={m.value}>{m.label}</option>
-                ))}
-              </Select>
-            </HStack>
-
             {runs.length > 0 && (
               <>
-                <Box maxH='400px' overflowY='auto' fontSize='xs'>
+                <Box maxH='300px' overflowY='auto' fontSize='xs'>
                   <Table size='sm' variant='simple'>
                     <Thead>
                       <Tr>
@@ -89,7 +116,6 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
                         <Th>DBU</Th>
                         <Th>TPS/DBU</Th>
                         <Th>Flavor</Th>
-                        <Th>Tags</Th>
                       </Tr>
                     </Thead>
                     <Tbody>
@@ -106,27 +132,32 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
                           <Td>{run.clusterDbu?.toFixed(1)}</Td>
                           <Td>{run.tpsPerDbu?.toFixed(2)}</Td>
                           <Td>{run.dbFlavor} {run.dbVersion}</Td>
-                          <Td maxW='150px' isTruncated>{run.configTags}</Td>
                         </Tr>
                       ))}
                     </Tbody>
                   </Table>
                 </Box>
 
-                {compareResult?.graphiteUrl && (
-                  <>
-                    <Divider />
-                    <Text fontSize='sm' fontWeight={600}>
-                      Graphite overlay: {METRICS.find(m => m.value === metric)?.label}
-                    </Text>
-                    <Box borderRadius='md' overflow='hidden'>
-                      <img
-                        src={compareResult.graphiteUrl + '&width=800&height=300&format=png'}
-                        alt='Benchmark comparison'
-                        style={{ width: '100%' }}
-                      />
-                    </Box>
-                  </>
+                <HStack spacing={3}>
+                  <Select size='sm' value={metric} onChange={(e) => setMetric(e.target.value)} flex={1}>
+                    {METRICS.map(m => (
+                      <option key={m.value} value={m.value}>{m.label}</option>
+                    ))}
+                  </Select>
+                  <RMButton size='small' colorScheme='blue' onClick={buildGraphiteUrl}>
+                    Show Graph
+                  </RMButton>
+                </HStack>
+
+                {graphiteUrl && (
+                  <Box borderRadius='md' overflow='hidden' bg={theme === 'light' ? 'gray.50' : 'rgba(255,255,255,0.05)'} p={2}>
+                    <img
+                      src={graphiteUrl}
+                      alt='Benchmark comparison'
+                      style={{ width: '100%' }}
+                      onError={(e) => { e.target.style.display = 'none' }}
+                    />
+                  </Box>
                 )}
               </>
             )}

--- a/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
@@ -1,6 +1,6 @@
 import {
   Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalCloseButton,
-  Box, VStack, HStack, Text, Badge, Table, Thead, Tbody, Tr, Th, Td, Select
+  Box, VStack, HStack, Text, Badge, Table, Thead, Tbody, Tr, Th, Td, Select, Spinner
 } from '@chakra-ui/react'
 import React, { useState, useEffect, useRef } from 'react'
 import { useSelector } from 'react-redux'
@@ -10,48 +10,63 @@ import { clusterService } from '../../../services/clusterService'
 import RMButton from '../../RMButton'
 import parentStyles from '../styles.module.scss'
 
-const RECORD_METRICS = [
-  { value: 'TPS', label: 'TPS' },
-  { value: 'QPS', label: 'QPS' },
-  { value: 'Latency', label: 'Latency (ms)' },
-  { value: 'ReadQPS', label: 'Read QPS' },
-  { value: 'WriteQPS', label: 'Write QPS' },
-  { value: 'ErrorPerSec', label: 'Errors/s' },
+const METRICS = [
+  { value: 'mysql_global_status_queries', label: 'Queries (QPS)', rate: true },
+  { value: 'mysql_global_status_com_select', label: 'SELECT/s', rate: true },
+  { value: 'mysql_global_status_com_insert', label: 'INSERT/s', rate: true },
+  { value: 'mysql_global_status_com_update', label: 'UPDATE/s', rate: true },
+  { value: 'mysql_global_status_com_delete', label: 'DELETE/s', rate: true },
+  { value: 'mysql_global_status_threads_running', label: 'Threads Running', rate: false },
+  { value: 'mysql_global_status_threads_connected', label: 'Threads Connected', rate: false },
+  { value: 'mysql_global_status_created_tmp_disk_tables', label: 'Tmp Disk Tables/s', rate: true },
+  { value: 'mysql_global_status_innodb_rows_read', label: 'InnoDB Rows Read/s', rate: true },
+  { value: 'mysql_global_status_innodb_rows_inserted', label: 'InnoDB Rows Inserted/s', rate: true },
+  { value: 'mysql_global_status_bytes_sent', label: 'Bytes Sent/s', rate: true },
+  { value: 'mysql_global_status_bytes_received', label: 'Bytes Received/s', rate: true },
 ]
 
 const COLORS = ['#3182ce', '#e53e3e', '#38a169', '#d69e2e', '#805ad5', '#dd6b20', '#319795', '#b83280']
 
-function BenchChart({ runs, metric, theme }) {
+// Build a label showing what changed vs the reference run
+function buildSeriesLabel(run, refRun, index) {
+  if (index === 0) {
+    return `REF ${run.testType} ${run.threads}t ${run.dbFlavor || ''}/${run.dbVersion || ''}`
+  }
+  const diffs = []
+  if (run.testType !== refRun.testType) diffs.push(run.testType)
+  if (run.threads !== refRun.threads) diffs.push(`${run.threads}t`)
+  if (run.dbFlavor !== refRun.dbFlavor || run.dbVersion !== refRun.dbVersion) {
+    diffs.push(`${run.dbFlavor || ''}/${run.dbVersion || ''}`)
+  }
+  if (run.proxyType !== refRun.proxyType) diffs.push(run.proxyType)
+  if (run.configTags !== refRun.configTags) diffs.push(`tags:${run.configTags}`)
+  if (diffs.length === 0) {
+    // Nothing obviously changed — show date
+    return `Run${index + 1} ${new Date(run.startedAt).toLocaleString()}`
+  }
+  return diffs.join(' ')
+}
+
+function BenchChart({ series, theme, metricLabel }) {
   const svgRef = useRef()
 
   useEffect(() => {
-    if (!svgRef.current || runs.length === 0) return
+    if (!svgRef.current || series.length === 0) return
 
     const svg = d3.select(svgRef.current)
     svg.selectAll('*').remove()
 
-    const margin = { top: 20, right: 120, bottom: 30, left: 50 }
-    const width = 750 - margin.left - margin.right
-    const height = 250 - margin.top - margin.bottom
+    const margin = { top: 20, right: 180, bottom: 35, left: 60 }
+    const width = 800 - margin.left - margin.right
+    const height = 280 - margin.top - margin.bottom
 
     const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
 
-    // Collect all data series
-    const series = runs.map((run, i) => {
-      const records = run.records || []
-      return {
-        label: i === 0
-          ? `REF ${run.testType} ${run.threads}t`
-          : `${run.testType} ${run.threads}t`,
-        color: COLORS[i % COLORS.length],
-        data: records.map((r, j) => ({ second: r.Second || j, value: r[metric] || 0 }))
-      }
-    }).filter(s => s.data.length > 0)
+    const validSeries = series.filter(s => s.data.length > 0)
+    if (validSeries.length === 0) return
 
-    if (series.length === 0) return
-
-    const maxX = d3.max(series, s => d3.max(s.data, d => d.second)) || 100
-    const maxY = d3.max(series, s => d3.max(s.data, d => d.value)) || 1
+    const maxX = d3.max(validSeries, s => d3.max(s.data, d => d.second)) || 100
+    const maxY = d3.max(validSeries, s => d3.max(s.data, d => d.value)) || 1
 
     const x = d3.scaleLinear().domain([0, maxX]).range([0, width])
     const y = d3.scaleLinear().domain([0, maxY * 1.1]).range([height, 0])
@@ -59,7 +74,13 @@ function BenchChart({ runs, metric, theme }) {
     const textColor = theme === 'dark' ? '#e2e8f0' : '#333'
     const gridColor = theme === 'dark' ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)'
 
-    // Grid
+    // Grid lines
+    g.append('g')
+      .call(d3.axisLeft(y).ticks(5).tickSize(-width))
+      .selectAll('.tick line').attr('stroke', gridColor)
+    g.selectAll('.domain').attr('stroke', textColor)
+
+    // Axes
     g.append('g')
       .attr('transform', `translate(0,${height})`)
       .call(d3.axisBottom(x).ticks(10))
@@ -68,49 +89,56 @@ function BenchChart({ runs, metric, theme }) {
       .call(d3.axisLeft(y).ticks(5))
       .selectAll('text').attr('fill', textColor)
     g.selectAll('.domain').attr('stroke', textColor)
-    g.selectAll('.tick line').attr('stroke', gridColor)
 
     // Lines
-    const line = d3.line().x(d => x(d.second)).y(d => y(d.value)).curve(d3.curveMonotoneX)
-    series.forEach(s => {
+    const line = d3.line().x(d => x(d.second)).y(d => y(d.value)).curve(d3.curveMonotoneX).defined(d => d.value != null)
+    validSeries.forEach(s => {
       g.append('path')
         .datum(s.data)
         .attr('fill', 'none')
         .attr('stroke', s.color)
-        .attr('stroke-width', 1.5)
+        .attr('stroke-width', s.isRef ? 2.5 : 1.5)
+        .attr('stroke-dasharray', s.isRef ? null : '6,3')
         .attr('d', line)
     })
 
     // Legend
     const legend = g.append('g').attr('transform', `translate(${width + 10}, 0)`)
-    series.forEach((s, i) => {
-      const row = legend.append('g').attr('transform', `translate(0,${i * 16})`)
-      row.append('rect').attr('width', 10).attr('height', 10).attr('fill', s.color)
-      row.append('text').attr('x', 14).attr('y', 9).text(s.label)
+    validSeries.forEach((s, i) => {
+      const row = legend.append('g').attr('transform', `translate(0,${i * 18})`)
+      row.append('line').attr('x1', 0).attr('x2', 14).attr('y1', 5).attr('y2', 5)
+        .attr('stroke', s.color).attr('stroke-width', s.isRef ? 2.5 : 1.5)
+        .attr('stroke-dasharray', s.isRef ? null : '6,3')
+      row.append('text').attr('x', 18).attr('y', 9).text(s.label)
         .attr('fill', textColor).attr('font-size', '10px')
     })
 
     // Axis labels
-    g.append('text').attr('x', width / 2).attr('y', height + 28).attr('text-anchor', 'middle')
-      .attr('fill', textColor).attr('font-size', '11px').text('Seconds')
+    g.append('text').attr('x', width / 2).attr('y', height + 30).attr('text-anchor', 'middle')
+      .attr('fill', textColor).attr('font-size', '11px').text('Seconds (from benchmark start)')
+    g.append('text').attr('transform', 'rotate(-90)').attr('x', -height / 2).attr('y', -45)
+      .attr('text-anchor', 'middle').attr('fill', textColor).attr('font-size', '11px').text(metricLabel)
 
-  }, [runs, metric, theme])
+  }, [series, theme, metricLabel])
 
-  return <svg ref={svgRef} width={750} height={250} />
+  return <svg ref={svgRef} width={800} height={280} />
 }
 
 function BenchCompareModal({ isOpen, closeModal, clusterName }) {
   const { theme } = useTheme()
   const baseURL = useSelector((state) => state?.auth?.baseURL)
   const [runs, setRuns] = useState([])
-  const [metric, setMetric] = useState('TPS')
-  const [showChart, setShowChart] = useState(false)
+  const [metric, setMetric] = useState('mysql_global_status_queries')
+  const [chartSeries, setChartSeries] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
 
   const badgeVariant = theme === 'dark' ? 'solid' : 'subtle'
 
   useEffect(() => {
     if (isOpen && clusterName) {
-      setShowChart(false)
+      setChartSeries([])
+      setError('')
       clusterService.getSysbenchHistory(clusterName, baseURL)
         .then(res => {
           const data = res.data
@@ -120,12 +148,93 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
     }
   }, [isOpen, clusterName, baseURL])
 
+  const fetchGraphiteData = async () => {
+    if (runs.length === 0) return
+    setLoading(true)
+    setError('')
+    setChartSeries([])
+
+    const metricDef = METRICS.find(m => m.value === metric)
+    // Oldest run is the reference (index 0 after sorting by startedAt)
+    const sorted = [...runs].sort((a, b) => new Date(a.startedAt) - new Date(b.startedAt))
+    const refRun = sorted[0]
+
+    // Find the newest run to align the graphite time window
+    const newest = sorted[sorted.length - 1]
+    const newestStart = Math.floor(new Date(newest.startedAt).getTime() / 1000)
+    const newestEnd = Math.floor(new Date(newest.endedAt).getTime() / 1000)
+
+    try {
+      const results = await Promise.all(sorted.map(async (run, i) => {
+        const hostname = run.graphiteHost || clusterName
+        const rawMetric = `mysql.${hostname}.${metric}`
+        const wrapped = metricDef?.rate
+          ? `perSecond(keepLastValue(${rawMetric}))`
+          : rawMetric
+
+        const runStart = Math.floor(new Date(run.startedAt).getTime() / 1000)
+        let target
+        if (runStart === newestStart) {
+          target = wrapped
+        } else {
+          const shift = newestStart - runStart
+          target = `timeShift(${wrapped},'${shift}s')`
+        }
+
+        const params = new URLSearchParams()
+        params.set('format', 'raw')
+        params.set('from', newestStart.toString())
+        params.set('until', newestEnd.toString())
+        params.set('target', `alias(${target},'')`)
+        params.set('noCache', '1')
+
+        const res = await fetch(`/graphite/render?${params.toString()}`)
+        if (!res.ok) throw new Error(`Graphite returned ${res.status}`)
+        const text = await res.text()
+        if (!text.trim()) return null
+
+        // Parse raw format: name,startTime,endTime,step|val1,val2,...
+        const parts = text.split('|')
+        if (parts.length !== 2) return null
+        const timeInfo = parts[0].split(',')
+        const startTime = parseInt(timeInfo[1])
+        const step = parseInt(timeInfo[3])
+        const values = parts[1].split(',')
+
+        // Convert to seconds-from-start
+        const runDuration = Math.floor(new Date(run.endedAt).getTime() / 1000) - Math.floor(new Date(run.startedAt).getTime() / 1000)
+        const data = values.map((v, j) => ({
+          second: j * step,
+          value: v === 'None' ? null : parseFloat(v)
+        })).filter(d => d.second <= runDuration + step)
+
+        return {
+          label: buildSeriesLabel(run, refRun, i),
+          color: COLORS[i % COLORS.length],
+          isRef: i === 0,
+          data
+        }
+      }))
+
+      const valid = results.filter(Boolean)
+      if (valid.length === 0) {
+        setError('No data returned from graphite for any run')
+      }
+      setChartSeries(valid)
+    } catch (e) {
+      setError(`Graphite fetch failed: ${e.message}`)
+    } finally {
+      setLoading(false)
+    }
+  }
+
   const formatDate = (t) => t ? new Date(t).toLocaleString() : '-'
+  const metricLabel = METRICS.find(m => m.value === metric)?.label || metric
 
   return (
     <Modal isOpen={isOpen} onClose={closeModal} size='xl'>
       <ModalOverlay />
-      <ModalContent className={theme === 'light' ? parentStyles.modalLightContent : parentStyles.modalDarkContent}>
+      <ModalContent className={theme === 'light' ? parentStyles.modalLightContent : parentStyles.modalDarkContent} maxW='860px'>
         <ModalHeader fontSize='md'>Compare Benchmarks</ModalHeader>
         <ModalCloseButton />
         <ModalBody pb={6}>
@@ -170,25 +279,29 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
 
                 <HStack spacing={3}>
                   <Select size='sm' value={metric} onChange={(e) => setMetric(e.target.value)} flex={1}>
-                    {RECORD_METRICS.map(m => (
+                    {METRICS.map(m => (
                       <option key={m.value} value={m.value}>{m.label}</option>
                     ))}
                   </Select>
-                  <RMButton size='small' colorScheme='blue' onClick={() => setShowChart(true)}>
-                    Show Graph
+                  <RMButton size='small' colorScheme='blue' onClick={fetchGraphiteData} isDisabled={loading}>
+                    {loading ? <Spinner size='xs' /> : 'Show Graph'}
                   </RMButton>
                 </HStack>
 
-                {showChart && (
+                {error && (
+                  <Text fontSize='sm' color='red.400' textAlign='center'>{error}</Text>
+                )}
+
+                {chartSeries.length > 0 && (
                   <Box borderRadius='md' overflow='hidden' bg={theme === 'light' ? 'gray.50' : 'rgba(255,255,255,0.05)'} p={2}>
-                    <BenchChart runs={runs} metric={metric} theme={theme} />
+                    <BenchChart series={chartSeries} theme={theme} metricLabel={metricLabel} />
                   </Box>
                 )}
               </>
             )}
 
             {runs.length === 0 && (
-              <Text fontSize='sm' color={theme === 'light' ? 'gray.500' : 'gray.500'} textAlign='center' py={4}>
+              <Text fontSize='sm' color='gray.500' textAlign='center' py={4}>
                 No benchmark runs recorded
               </Text>
             )}

--- a/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
@@ -49,13 +49,22 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
     // Use repman's graphite proxy route, not direct graphite port
     const apiUrl = ''
 
-    // Get master hostname for metric path
+    // Get master hostname from server variables (same as graphite metric key)
     const servers = clusterData?.servers || []
     const master = servers.find(s => s.isMaster || s.state === 'Master') || servers[0]
+    // graphiteHostname uses @@hostname from SHOW VARIABLES, with dots replaced by dashes
     const masterHostname = master?.hostname || clusterName
     const hostname = masterHostname.replace(/\./g, '-').replace(/[`? ()/<'"]/g, '-')
 
-    const fullMetric = `mysql.${hostname}.${metric}`
+    // Wrap cumulative counters in perSecond() for rate-based display
+    const rateMetrics = [
+      'mysql_global_status_questions', 'mysql_global_status_com_select',
+      'mysql_global_status_com_insert', 'mysql_global_status_com_update',
+      'mysql_global_status_com_delete', 'mysql_global_status_connections',
+      'mysql_global_status_created_tmp_disk_tables', 'mysql_global_status_innodb_row_lock_waits'
+    ]
+    const rawMetric = `mysql.${hostname}.${metric}`
+    const fullMetric = rateMetrics.includes(metric) ? `perSecond(${rawMetric})` : rawMetric
 
     // Find the newest run to align all others
     let newest = runs[0]

--- a/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
@@ -1,0 +1,143 @@
+import {
+  Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalCloseButton,
+  Box, VStack, HStack, Text, Badge, Divider, Table, Thead, Tbody, Tr, Th, Td, Select
+} from '@chakra-ui/react'
+import React, { useState, useEffect } from 'react'
+import { useSelector } from 'react-redux'
+import { useTheme } from '../../../ThemeProvider'
+import { clusterService } from '../../../services/clusterService'
+import parentStyles from '../styles.module.scss'
+
+const METRICS = [
+  { value: 'mysql_global_status_questions', label: 'Questions (QPS)' },
+  { value: 'mysql_global_status_com_select', label: 'SELECT' },
+  { value: 'mysql_global_status_com_insert', label: 'INSERT' },
+  { value: 'mysql_global_status_com_update', label: 'UPDATE' },
+  { value: 'mysql_global_status_com_delete', label: 'DELETE' },
+  { value: 'mysql_global_status_threads_running', label: 'Threads Running' },
+  { value: 'mysql_global_status_connections', label: 'Connections' },
+  { value: 'mysql_global_status_created_tmp_disk_tables', label: 'Tmp Disk Tables' },
+  { value: 'mysql_global_status_innodb_row_lock_waits', label: 'InnoDB Row Lock Waits' },
+]
+
+function BenchCompareModal({ isOpen, closeModal, clusterName }) {
+  const { theme } = useTheme()
+  const baseURL = useSelector((state) => state?.auth?.baseURL)
+  const [runs, setRuns] = useState([])
+  const [metric, setMetric] = useState('mysql_global_status_questions')
+  const [compareResult, setCompareResult] = useState(null)
+  const [loading, setLoading] = useState(false)
+
+  const badgeVariant = theme === 'dark' ? 'solid' : 'subtle'
+
+  useEffect(() => {
+    if (isOpen && clusterName) {
+      clusterService.getSysbenchHistory(clusterName, 10, baseURL)
+        .then(res => setRuns(res.data || []))
+        .catch(() => setRuns([]))
+    }
+  }, [isOpen, clusterName, baseURL])
+
+  const handleCompare = () => {
+    setLoading(true)
+    clusterService.getSysbenchCompare(clusterName, metric, baseURL)
+      .then(res => setCompareResult(res.data))
+      .catch(() => setCompareResult(null))
+      .finally(() => setLoading(false))
+  }
+
+  const formatDate = (t) => t ? new Date(t).toLocaleString() : '-'
+  const formatDuration = (start, end) => {
+    if (!start || !end) return '-'
+    const ms = new Date(end) - new Date(start)
+    return `${Math.round(ms / 1000)}s`
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={closeModal} size='xl'>
+      <ModalOverlay />
+      <ModalContent className={theme === 'light' ? parentStyles.modalLightContent : parentStyles.modalDarkContent}>
+        <ModalHeader fontSize='md'>Compare Benchmarks</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody pb={6}>
+          <VStack align='stretch' spacing={4}>
+
+            <HStack spacing={3}>
+              <Select size='sm' value={metric} onChange={(e) => setMetric(e.target.value)} flex={1}>
+                {METRICS.map(m => (
+                  <option key={m.value} value={m.value}>{m.label}</option>
+                ))}
+              </Select>
+            </HStack>
+
+            {runs.length > 0 && (
+              <>
+                <Box maxH='400px' overflowY='auto' fontSize='xs'>
+                  <Table size='sm' variant='simple'>
+                    <Thead>
+                      <Tr>
+                        <Th>#</Th>
+                        <Th>Date</Th>
+                        <Th>Test</Th>
+                        <Th>Threads</Th>
+                        <Th>Avg TPS</Th>
+                        <Th>Avg Lat</Th>
+                        <Th>DBU</Th>
+                        <Th>TPS/DBU</Th>
+                        <Th>Flavor</Th>
+                        <Th>Tags</Th>
+                      </Tr>
+                    </Thead>
+                    <Tbody>
+                      {runs.map((run, i) => (
+                        <Tr key={i}>
+                          <Td>{i + 1}</Td>
+                          <Td>{formatDate(run.startedAt)}</Td>
+                          <Td>
+                            <Badge variant={badgeVariant} colorScheme='blue' size='sm'>{run.testType}</Badge>
+                          </Td>
+                          <Td>{run.threads}</Td>
+                          <Td fontWeight={600}>{run.avgTps?.toFixed(1)}</Td>
+                          <Td>{run.avgLatency?.toFixed(2)}ms</Td>
+                          <Td>{run.clusterDbu?.toFixed(1)}</Td>
+                          <Td>{run.tpsPerDbu?.toFixed(2)}</Td>
+                          <Td>{run.dbFlavor} {run.dbVersion}</Td>
+                          <Td maxW='150px' isTruncated>{run.configTags}</Td>
+                        </Tr>
+                      ))}
+                    </Tbody>
+                  </Table>
+                </Box>
+
+                {compareResult?.graphiteUrl && (
+                  <>
+                    <Divider />
+                    <Text fontSize='sm' fontWeight={600}>
+                      Graphite overlay: {METRICS.find(m => m.value === metric)?.label}
+                    </Text>
+                    <Box borderRadius='md' overflow='hidden'>
+                      <img
+                        src={compareResult.graphiteUrl + '&width=800&height=300&format=png'}
+                        alt='Benchmark comparison'
+                        style={{ width: '100%' }}
+                      />
+                    </Box>
+                  </>
+                )}
+              </>
+            )}
+
+            {runs.length === 0 && (
+              <Text fontSize='sm' color={theme === 'light' ? 'gray.500' : 'gray.500'} textAlign='center' py={4}>
+                No benchmark runs recorded
+              </Text>
+            )}
+
+          </VStack>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export default BenchCompareModal

--- a/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
@@ -32,10 +32,11 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
 
   useEffect(() => {
     if (isOpen && clusterName) {
-      clusterService.getSysbenchHistory(clusterName, 10, baseURL)
+      clusterService.getSysbenchHistory(clusterName, baseURL)
         .then(res => {
           const data = res.data
-          setRuns(Array.isArray(data) ? data : data?.entries || [])
+          // http-logs returns the SysbenchLog struct with entries field
+          setRuns(Array.isArray(data) ? data : data?.Entries || data?.entries || [])
         })
         .catch(() => setRuns([]))
     }

--- a/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/BenchCompareModal/index.jsx
@@ -49,12 +49,9 @@ function BenchCompareModal({ isOpen, closeModal, clusterName }) {
     // Use repman's graphite proxy route, not direct graphite port
     const apiUrl = ''
 
-    // Get master hostname from server variables (same as graphite metric key)
-    const servers = clusterData?.servers || []
-    const master = servers.find(s => s.isMaster || s.state === 'Master') || servers[0]
-    // graphiteHostname uses @@hostname from SHOW VARIABLES, with dots replaced by dashes
-    const masterHostname = master?.hostname || clusterName
-    const hostname = masterHostname.replace(/\./g, '-').replace(/[`? ()/<'"]/g, '-')
+    // Use graphiteHost from the run entry (@@hostname with graphite replacements)
+    // Falls back to first run's graphiteHost or cluster name
+    const hostname = runs[0]?.graphiteHost || clusterName
 
     // Wrap cumulative counters in perSecond() for rate-based display
     const rateMetrics = [

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -1590,10 +1590,10 @@ export const stagingProxy = createGuardedAsyncThunk(
   }
 )
 
-export const runSysBench = createGuardedAsyncThunk('cluster/runSysBench', async ({ clusterName, thread }, thunkAPI) => {
+export const runSysBench = createGuardedAsyncThunk('cluster/runSysBench', async ({ clusterName, thread, test }, thunkAPI) => {
   try {
     const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
-    const { data, status } = await clusterService.runSysbench(clusterName, thread, baseURL)
+    const { data, status } = await clusterService.runSysbench(clusterName, thread, baseURL, test)
     showSuccessBanner('Sysbench ran successfuly!', status, thunkAPI)
     return { data, status }
   } catch (error) {

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -693,8 +693,9 @@ function monitorAllSchemas(clusterName, baseURL) {
 //#endregion Database service APIs
 
 //#region Test run APIs
-function runSysbench(clusterName, threads, baseURL) {
-  return getApi(baseURL).get(`clusters/${clusterName}/actions/sysbench?threads=${threads}`)
+function runSysbench(clusterName, threads, baseURL, test) {
+  const params = `threads=${threads}` + (test ? `&test=${test}` : '')
+  return getApi(baseURL).get(`clusters/${clusterName}/actions/sysbench?${params}`)
 }
 
 function runRegressionTests(clusterName, testName, baseURL) {

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -703,11 +703,11 @@ function runRegressionTests(clusterName, testName, baseURL) {
 }
 
 function getSysbenchHistory(clusterName, last = 10, baseURL) {
-  return getApi(baseURL).get(`clusters/${clusterName}/sysbench/history?last=${last}`)
+  return getApi(baseURL).get(`clusters/${clusterName}/actions/sysbench-history?last=${last}`)
 }
 
 function getSysbenchCompare(clusterName, metric, baseURL) {
-  return getApi(baseURL).get(`clusters/${clusterName}/sysbench/compare?metric=${metric}`)
+  return getApi(baseURL).get(`clusters/${clusterName}/actions/sysbench-compare?metric=${metric}`)
 }
 //#endregion Test run APIs
 

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -141,7 +141,6 @@ export const clusterService = {
   // Test run APIs
   runSysbench,
   getSysbenchHistory,
-  getSysbenchCompare,
   runRegressionTests,
 
   // User management APIs
@@ -702,12 +701,8 @@ function runRegressionTests(clusterName, testName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/tests/actions/run/${testName}`)
 }
 
-function getSysbenchHistory(clusterName, last = 10, baseURL) {
-  return getApi(baseURL).get(`clusters/${clusterName}/actions/sysbench-history?last=${last}`)
-}
-
-function getSysbenchCompare(clusterName, metric, baseURL) {
-  return getApi(baseURL).get(`clusters/${clusterName}/actions/sysbench-compare?metric=${metric}`)
+function getSysbenchHistory(clusterName, baseURL) {
+  return getApi(baseURL).get(`clusters/${clusterName}/topology/logs/sysbench`)
 }
 //#endregion Test run APIs
 

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -140,6 +140,8 @@ export const clusterService = {
 
   // Test run APIs
   runSysbench,
+  getSysbenchHistory,
+  getSysbenchCompare,
   runRegressionTests,
 
   // User management APIs
@@ -698,6 +700,14 @@ function runSysbench(clusterName, threads, baseURL) {
 
 function runRegressionTests(clusterName, testName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/tests/actions/run/${testName}`)
+}
+
+function getSysbenchHistory(clusterName, last = 10, baseURL) {
+  return getApi(baseURL).get(`clusters/${clusterName}/sysbench/history?last=${last}`)
+}
+
+function getSysbenchCompare(clusterName, metric, baseURL) {
+  return getApi(baseURL).get(`clusters/${clusterName}/sysbench/compare?metric=${metric}`)
 }
 //#endregion Test run APIs
 

--- a/share/opensvc/moduleset_mariadb.svc.mrm.db.json
+++ b/share/opensvc/moduleset_mariadb.svc.mrm.db.json
@@ -2486,6 +2486,25 @@
                 }
             ],
             "fset_name": "mariadb.test.badconfig"
+        },
+        {
+            "fset_stats": false,
+            "id": 427,
+            "filters": [
+                {
+                    "filter": {
+                        "f_op": "=",
+                        "f_field": "tag_name",
+                        "f_value": "no128rowmaxsize",
+                        "f_table": "v_tags",
+                        "id": 383
+                    },
+                    "f_order": 0,
+                    "f_log_op": "AND",
+                    "filterset": null
+                }
+            ],
+            "fset_name": "mariadb.replication.no128krowmaxsize"
         }
     ],
     "rulesets": [
@@ -4314,6 +4333,14 @@
                     "var_updated": "2026-05-29 11:42:12",
                     "var_name": "db_cnf_test_badconfig",
                     "id": 6362
+                },
+                {
+                    "var_author": "admin Manager",
+                    "var_class": "file",
+                    "var_value": "{\"path\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/replication-manager.d/no_rep_128rowmaxsize.cnf\",\"mode\":\"%%ENV:CNF_PERMS%%\",\"uid\":\"%%ENV:MYSQL_UID%%\",\"gid\":\"%%ENV:MYSQL_GID%%\",\"fmt\":\"#mariadb_command: SET GLOBAL binlog_row_event_max_size = 8*1024;\\n#mariadb_default: SET GLOBAL binlog_row_event_max_size=128*1024;\\n\\n#mysql_command: SET GLOBAL binlog_row_event_max_size = 8*1024;\\n#mysql_default: SET GLOBAL binlog_row_event_max_size = 128*1024;\\n\\n[mysql]\\nloose_binlog_row_event_max_size = 8K  \"}",
+                    "var_updated": "2026-06-09 11:58:46",
+                    "var_name": "db_cnf_rep_no_128krowmaxsize",
+                    "id": 6364
                 }
             ],
             "ruleset_public": false,
@@ -4445,7 +4472,8 @@
                 "mariadb.svc.mrm.db.cnf.generic.opt_withrepeatableread",
                 "mariadb.svc.mrm.db.cnf.generic.sec_withstrictssl",
                 "mariadb.svc.mrm.db.cnf.generic.sec_withcheckpwdreuse",
-                "mariadb.svc.mrm.db.cnf.generic.test_badconfig"
+                "mariadb.svc.mrm.db.cnf.generic.test_badconfig",
+                "mariadb.svc.mrm.db.cnf.generic.rep_no128krowmaxsize"
             ],
             "publications": [
                 "replication-manager"
@@ -7825,6 +7853,30 @@
                 "replication-manager"
             ],
             "id": 1176,
+            "responsibles": [
+                "replication-manager"
+            ]
+        },
+        {
+            "fset_name": "mariadb.replication.no128krowmaxsize",
+            "ruleset_name": "mariadb.svc.mrm.db.cnf.generic.rep_no128krowmaxsize",
+            "variables": [
+                {
+                    "var_author": "admin Manager",
+                    "var_class": "symlink",
+                    "var_value": "{\"symlink\":\"%%ENV:SVC_CONF_ENV_BASE_DIR%%/%%ENV:POD%%/etc/mysql/conf.d/55_no_rep_logslavestatement.cnf\",\"target\":\"../replication-manager.d/no_rep_128krowmaxsize.cnf\"}",
+                    "var_updated": "2026-06-09 12:04:24",
+                    "var_name": "db_link_nologwarnings",
+                    "id": 6365
+                }
+            ],
+            "ruleset_public": false,
+            "ruleset_type": "contextual",
+            "rulesets": [],
+            "publications": [
+                "replication-manager"
+            ],
+            "id": 1177,
             "responsibles": [
                 "replication-manager"
             ]


### PR DESCRIPTION
## Summary

- **Sysbench run history**: Log every benchmark run with full context (DB flavor/version, proxy, threads, DBU, config tags, service plan). Stored in `sysbench.json` per cluster.
- **Compare benchmarks GUI**: Modal in Tests tab with checkboxes to select runs, graphite time-series graph (d3), and scale graph (threads vs TPS/Latency/TPS-per-DBU).
- **Thread scaling runs** (1-2xCPU): Loops from 1 to 2×cores doubling threads. Each step logged as individual entry with `isScale=true` and shared `scaleGroup` timestamp. Prepare/cleanup steps also logged.
- **Test type selector**: Dropdown for oltp_read_write (default), oltp_read_only, oltp_update_index, oltp_update_non_index, tpcc.
- **API cleanup**: `/topology/logs/{logType}` alias for typed logs, sysbench as log type. Deprecated `/topology/http-logs/`.
- **HTTP/2 (h2c)**: Plain TCP h2c support on port 10001 for reverse proxies. Includes h2 Extended CONNECT (RFC 8441) adapter as safety net for WebSocket over h2.
- **OpenSVC**: Add no128krowmaxsize replication tag moduleset.

## Test plan
- [ ] Run single sysbench test from GUI, verify entry in Compare Benchmarks modal
- [ ] Run 1-2xCPU scale test, verify scale chart with threads on X-axis
- [ ] Compare two runs via Graphite Graph button
- [ ] Terminal/mytop works through HAProxy with h2 ALPN (requires HAProxy >= 3.3.10)
- [ ] `make pro` builds cleanly