### PR TITLE
feat: backup concurrency limiter, dev container, plugin shared dir

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: true
 
       - name: Checkout tag (manual trigger only)
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: false
+          submodules: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -136,7 +136,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: false
+          submodules: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -209,7 +209,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: false
+          submodules: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -282,7 +282,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: false
+          submodules: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -353,7 +353,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: false
+          submodules: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -416,7 +416,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: false
+          submodules: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -476,7 +476,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: false
+          submodules: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -567,7 +567,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: false
+          submodules: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -654,7 +654,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: false
+          submodules: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -727,7 +727,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: false
+          submodules: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
-          submodules: false
+          submodules: true
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "share/submodule/sysbench-tpcc"]
+	path = share/submodule/sysbench-tpcc
+	url = https://github.com/Percona-Lab/sysbench-tpcc.git

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -2243,7 +2243,7 @@ func (cluster *Cluster) SaveVariableDiff(diff []VariableDiff) {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Encoding variable diff: %s", err)
 		return
 	}
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	if err := os.WriteFile(path, data, 0600); err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Writing variable-diff.json: %s", err)
 	}
 }

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -299,6 +299,7 @@ type Cluster struct {
 	MessageChan                         chan sharedlog.Message      `json:"-"`
 	ErrorConfigs                        config.ErrorConfigs         `json:"-"` //To store error config
 	Partner                             *config.Partner             `json:"partner" groups:"web"`
+	ServerGlobals                       *ServerGlobals              `json:"-"`
 	ConfigManager                       *manager.ConfigManager      `json:"-"`
 	failSendCount                       int                         `json:"-"`
 	MeetUserID                          string                      `json:"-"` //To store meet user id

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1033,11 +1033,9 @@ func (cluster *Cluster) StateProcessing() {
 			cluster.GetStateMachine().CapturedState.Delete(s.ErrKey)
 			servertoreseed := cluster.GetServerFromURL(s.ServerUrl)
 
-			// if s.ErrKey == "WARN0073" {
-			// 	for _, s := range cluster.Servers {
-			// 		s.SetBackupPhysicalCookie()
-			// 	}
-			// }
+			if s.ErrKey == "WARN0073" || s.ErrKey == "WARN0175" {
+				cluster.ServerGlobals.ReleaseBackupSlot()
+			}
 			if s.ErrKey == "WARN0074" && servertoreseed != nil {
 				task := "reseed" + cluster.Conf.BackupPhysicalType
 

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1006,6 +1006,7 @@ func (cluster *Cluster) Run() {
 				cluster.CheckFailed()
 				cluster.IsConfigPathChange = cluster.HasConfigPathChanged()
 				cluster.SetStatus()
+				cluster.CheckBackupStates()
 				cluster.StateProcessing()
 				cluster.CheckHasFailCertLoadP12()
 				go cluster.GetSlowLogTable() // prevent blocking cycle

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1193,25 +1193,29 @@ func (cluster *Cluster) StateProcessing() {
 
 func (cluster *Cluster) Stop() {
 	cluster.stopOnce.Do(func() {
-		// Signal the monitoring loop to stop before doing any blocking I/O.
-		// The lock is not held across the slow operations below to avoid deadlock
-		// with SaveConfig(wait=true) and ResticManager.UnmountRepo (5 min timeout).
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Stop: signaling exit")
 		cluster.exit.Store(true)
 
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Stop: stopping scheduler")
 		if cluster.scheduler != nil {
 			cluster.scheduler.Stop()
 		}
 
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Stop: closing template MD5 worker")
 		cluster.CloseRefreshTemplateMD5Worker()
 
 		if cluster.ResticManager != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Stop: unmounting restic repo")
 			if err := cluster.ResticManager.UnmountRepo(); err != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlWarn, "Restic unmount on shutdown failed: %s", err)
 			}
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Stop: shutting down restic worker")
 			cluster.ResticManager.ShutdownWorker()
 		}
 
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Stop: saving config")
 		cluster.ConfigManager.SaveConfig(cluster, true)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Stop: done")
 	})
 }
 

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -2235,13 +2235,49 @@ func (cluster *Cluster) MonitorVariablesDiff() {
 		cluster.SaveVariableDiff(alldiff)
 		cluster.SetState("WARN0084", state.State{
 			ErrType:   "WARNING",
-			ErrDesc:   fmt.Sprintf(clusterError["WARN0084"], len(alldiff)),
+			ErrDesc:   fmt.Sprintf(clusterError["WARN0084"], cluster.FormatVariableDiffTable(alldiff)),
 			ErrFrom:   "MON",
 			ServerUrl: cluster.GetMaster().URL,
 		})
 	} else {
 		cluster.DiffVariables = nil
 	}
+}
+
+func (cluster *Cluster) FormatVariableDiffTable(diffs []VariableDiff) string {
+	varW, srvW, roleW, valW := len("Variable"), len("Server"), len("Role"), len("Value")
+	type row struct{ v, s, r, val string }
+	var rows []row
+	for _, d := range diffs {
+		for _, dv := range d.DiffValues {
+			r := row{d.VariableName, dv.Server, dv.Role, dv.VariableValue}
+			if len(r.v) > varW {
+				varW = len(r.v)
+			}
+			if len(r.s) > srvW {
+				srvW = len(r.s)
+			}
+			if len(r.r) > roleW {
+				roleW = len(r.r)
+			}
+			if len(r.val) > valW {
+				valW = len(r.val)
+			}
+			rows = append(rows, r)
+		}
+	}
+	f := fmt.Sprintf("%%-%ds | %%-%ds | %%-%ds | %%-%ds", varW, srvW, roleW, valW)
+	sep := fmt.Sprintf(f, strings.Repeat("-", varW), strings.Repeat("-", srvW), strings.Repeat("-", roleW), strings.Repeat("-", valW))
+	sep = strings.ReplaceAll(sep, " | ", "-+-")
+	var b strings.Builder
+	fmt.Fprintf(&b, f, "Variable", "Server", "Role", "Value")
+	b.WriteString("\n")
+	b.WriteString(sep)
+	for _, r := range rows {
+		b.WriteString("\n")
+		fmt.Fprintf(&b, f, r.v, r.s, r.r, r.val)
+	}
+	return b.String()
 }
 
 // SaveVariableDiff persists the variable diff to a JSON file in the cluster's working directory.

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -134,6 +134,8 @@ type Cluster struct {
 	IsNeedStagingChange           bool                       `json:"isNeedStagingChange" groups:"web"`
 	IsConfigPathChange            bool                       `json:"isConfigPathChange" groups:"web"`
 	IsResticQueuePaused           bool                       `json:"isResticQueuePaused" groups:"web"`
+	BackupSlotsInUse              int                        `json:"backupSlotsInUse" groups:"web"`
+	BackupSlotsTotal              int                        `json:"backupSlotsTotal" groups:"web"`
 	SchemaMonitorRequested        int32                      `json:"-"`
 	Conf                          *config.Config             `json:"config" groups:"apps"`
 	Confs                         *config.ConfVersion        `json:"-"`
@@ -807,6 +809,10 @@ func (cluster *Cluster) Run() {
 			cluster.AppIdList = cluster.GetAppServerIdList()
 			if cluster.ResticManager != nil {
 				cluster.IsResticQueuePaused = cluster.ResticManager.IsPaused()
+			}
+			if cluster.ServerGlobals != nil && cluster.ServerGlobals.BackupSemaphore != nil {
+				cluster.BackupSlotsInUse = len(cluster.ServerGlobals.BackupSemaphore)
+				cluster.BackupSlotsTotal = cap(cluster.ServerGlobals.BackupSemaphore)
 			}
 			go cluster.CheckDefaultUser(false)
 

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"os/user"
 	"runtime"
 	"slices"
@@ -410,6 +411,7 @@ type Alerts struct {
 
 type Diff struct {
 	Server        string `json:"serverName"`
+	Role          string `json:"role"`
 	VariableValue string `json:"variableValue"`
 }
 
@@ -2200,24 +2202,17 @@ func (cluster *Cluster) MonitorVariablesDiff() {
 	}
 	masterVariables := cluster.GetMaster().Variables.ToNewMap()
 	exceptVariables := variableExceptions
-	variablesdiff := ""
+	hasDiff := false
 	var alldiff []VariableDiff
 	for k, v := range masterVariables {
 		var myvardiff VariableDiff
 		var myvalues []Diff
-		var mastervalue Diff
-		mastervalue.Server = cluster.GetMaster().URL
-		mastervalue.VariableValue = v
-		myvalues = append(myvalues, mastervalue)
+		myvalues = append(myvalues, Diff{Server: cluster.GetMaster().URL, Role: "leader", VariableValue: v})
 		for _, s := range cluster.slaves {
 			slaveVariables := s.Variables.ToNewMap()
 			if slaveVariables[k] != v && !exceptVariables[k] {
-				var slavevalue Diff
-				slavevalue.Server = s.URL
-				slavevalue.VariableValue = slaveVariables[k]
-				myvalues = append(myvalues, slavevalue)
-				variablesdiff += "+ Master Variable: " + k + " -> " + v + "\n"
-				variablesdiff += "- Slave: " + s.URL + " -> " + slaveVariables[k] + "\n"
+				myvalues = append(myvalues, Diff{Server: s.URL, Role: "replica", VariableValue: slaveVariables[k]})
+				hasDiff = true
 			}
 		}
 		if len(myvalues) > 1 {
@@ -2226,14 +2221,30 @@ func (cluster *Cluster) MonitorVariablesDiff() {
 			alldiff = append(alldiff, myvardiff)
 		}
 	}
-	if variablesdiff != "" {
+	if hasDiff {
 		cluster.DiffVariables = alldiff
-		jtext, err := json.MarshalIndent(alldiff, " ", "\t")
-		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Encoding variables diff %s", err)
-			return
-		}
-		cluster.SetState("WARN0084", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0084"], string(jtext)), ErrFrom: "MON", ServerUrl: cluster.GetMaster().URL})
+		cluster.SaveVariableDiff(alldiff)
+		cluster.SetState("WARN0084", state.State{
+			ErrType:   "WARNING",
+			ErrDesc:   fmt.Sprintf(clusterError["WARN0084"], len(alldiff)),
+			ErrFrom:   "MON",
+			ServerUrl: cluster.GetMaster().URL,
+		})
+	} else {
+		cluster.DiffVariables = nil
+	}
+}
+
+// SaveVariableDiff persists the variable diff to a JSON file in the cluster's working directory.
+func (cluster *Cluster) SaveVariableDiff(diff []VariableDiff) {
+	path := filepath.Join(cluster.WorkingDir, "variable-diff.json")
+	data, err := json.MarshalIndent(diff, "", "  ")
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Encoding variable diff: %s", err)
+		return
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Writing variable-diff.json: %s", err)
 	}
 }
 

--- a/cluster/cluster_scheduler.go
+++ b/cluster/cluster_scheduler.go
@@ -2,17 +2,12 @@ package cluster
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/signal18/replication-manager/config"
-	"github.com/signal18/replication-manager/utils/state"
 )
 
 func (cluster *Cluster) GetBackupLogicalFunction() func() {
 	return func() {
-		cluster.waitForBackupSlot()
-		defer cluster.ServerGlobals.ReleaseBackupSlot()
-
 		mysrv := cluster.GetBackupServer()
 		if mysrv != nil {
 			mysrv.JobBackupLogical(context.Background())
@@ -24,9 +19,6 @@ func (cluster *Cluster) GetBackupLogicalFunction() func() {
 
 func (cluster *Cluster) GetBackupPhysicalFunction() func() {
 	return func() {
-		cluster.waitForBackupSlot()
-		defer cluster.ServerGlobals.ReleaseBackupSlot()
-
 		mysrv := cluster.GetBackupServer()
 		if mysrv != nil {
 			mysrv.JobBackupPhysical()
@@ -34,25 +26,6 @@ func (cluster *Cluster) GetBackupPhysicalFunction() func() {
 			cluster.GetMaster().JobBackupPhysical()
 		}
 	}
-}
-
-// waitForBackupSlot opens a WARN0174 state while waiting for a global backup
-// slot, then clears it once the slot is acquired.
-func (cluster *Cluster) waitForBackupSlot() {
-	if cluster.ServerGlobals == nil || cluster.ServerGlobals.BackupSemaphore == nil {
-		return
-	}
-	inUse := len(cluster.ServerGlobals.BackupSemaphore)
-	total := cap(cluster.ServerGlobals.BackupSemaphore)
-	if inUse >= total {
-		cluster.SetState("WARN0174", state.State{
-			ErrType: "WARNING",
-			ErrDesc: fmt.Sprintf(config.ClusterError["WARN0174"], inUse, total),
-			ErrFrom: "BACKUP",
-		})
-	}
-	cluster.ServerGlobals.AcquireBackupSlot()
-	cluster.StateMachine.DeleteState("WARN0174")
 }
 
 func (cluster *Cluster) GetRotateLogsFunction() func() {

--- a/cluster/cluster_scheduler.go
+++ b/cluster/cluster_scheduler.go
@@ -2,12 +2,17 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/state"
 )
 
 func (cluster *Cluster) GetBackupLogicalFunction() func() {
 	return func() {
+		cluster.waitForBackupSlot()
+		defer cluster.ServerGlobals.ReleaseBackupSlot()
+
 		mysrv := cluster.GetBackupServer()
 		if mysrv != nil {
 			mysrv.JobBackupLogical(context.Background())
@@ -19,6 +24,9 @@ func (cluster *Cluster) GetBackupLogicalFunction() func() {
 
 func (cluster *Cluster) GetBackupPhysicalFunction() func() {
 	return func() {
+		cluster.waitForBackupSlot()
+		defer cluster.ServerGlobals.ReleaseBackupSlot()
+
 		mysrv := cluster.GetBackupServer()
 		if mysrv != nil {
 			mysrv.JobBackupPhysical()
@@ -26,6 +34,25 @@ func (cluster *Cluster) GetBackupPhysicalFunction() func() {
 			cluster.GetMaster().JobBackupPhysical()
 		}
 	}
+}
+
+// waitForBackupSlot opens a WARN0174 state while waiting for a global backup
+// slot, then clears it once the slot is acquired.
+func (cluster *Cluster) waitForBackupSlot() {
+	if cluster.ServerGlobals == nil || cluster.ServerGlobals.BackupSemaphore == nil {
+		return
+	}
+	inUse := len(cluster.ServerGlobals.BackupSemaphore)
+	total := cap(cluster.ServerGlobals.BackupSemaphore)
+	if inUse >= total {
+		cluster.SetState("WARN0174", state.State{
+			ErrType: "WARNING",
+			ErrDesc: fmt.Sprintf(config.ClusterError["WARN0174"], inUse, total),
+			ErrFrom: "BACKUP",
+		})
+	}
+	cluster.ServerGlobals.AcquireBackupSlot()
+	cluster.StateMachine.DeleteState("WARN0174")
 }
 
 func (cluster *Cluster) GetRotateLogsFunction() func() {

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -2166,17 +2166,23 @@ func (cluster *Cluster) SetInResticBackupState(value bool) {
 }
 
 func (cluster *Cluster) CheckBackupStates() {
-	serverUrl := ""
-	if m := cluster.GetMaster(); m != nil {
-		serverUrl = m.URL
+	hasPhysical := false
+	hasLogical := false
+	for _, server := range cluster.Servers {
+		if server.IsInBackupPhysical {
+			hasPhysical = true
+			cluster.SetState("WARN0073", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0073"], cluster.Conf.BackupPhysicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
+		}
+		if server.IsInBackupLogical {
+			hasLogical = true
+			cluster.SetState("WARN0175", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0175"], cluster.Conf.BackupLogicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
+		}
 	}
-	if cluster.InPhysicalBackup || cluster.InResticPhysicalBackup {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "CheckBackupStates: setting WARN0073 (physical=%t, resticPhysical=%t)", cluster.InPhysicalBackup, cluster.InResticPhysicalBackup)
-		cluster.SetState("WARN0073", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0073"], cluster.Conf.BackupPhysicalType, serverUrl), ErrFrom: "JOB", ServerUrl: serverUrl})
+	if cluster.InResticPhysicalBackup && !hasPhysical {
+		cluster.StateMachine.PreserveState("WARN0073")
 	}
-	if cluster.InLogicalBackup || cluster.InResticLogicalBackup {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "CheckBackupStates: setting WARN0175 (logical=%t, resticLogical=%t)", cluster.InLogicalBackup, cluster.InResticLogicalBackup)
-		cluster.SetState("WARN0175", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0175"], cluster.Conf.BackupLogicalType, serverUrl), ErrFrom: "JOB", ServerUrl: serverUrl})
+	if cluster.InResticLogicalBackup && !hasLogical {
+		cluster.StateMachine.PreserveState("WARN0175")
 	}
 }
 

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -2137,16 +2137,10 @@ func (cluster *Cluster) SetLogMailerLevel(value int) {
 
 func (cluster *Cluster) SetInPhysicalBackupState(value bool) {
 	cluster.InPhysicalBackup = value
-	if !value && !cluster.InResticPhysicalBackup {
-		cluster.ServerGlobals.ReleaseBackupSlot()
-	}
 }
 
 func (cluster *Cluster) SetInLogicalBackupState(value bool) {
 	cluster.InLogicalBackup = value
-	if !value {
-		cluster.ServerGlobals.ReleaseBackupSlot()
-	}
 }
 
 func (cluster *Cluster) SetInBinlogBackupState(value bool) {
@@ -2161,9 +2155,6 @@ func (cluster *Cluster) SetInResticLogicalBackupState(value bool) {
 func (cluster *Cluster) SetInResticPhysicalBackupState(value bool) {
 	cluster.InResticPhysicalBackup = value
 	cluster.InResticBackup = cluster.InResticLogicalBackup || cluster.InResticPhysicalBackup
-	if !value && !cluster.InPhysicalBackup {
-		cluster.ServerGlobals.ReleaseBackupSlot()
-	}
 }
 
 func (cluster *Cluster) SetInResticBackupState(value bool) {

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -2166,24 +2166,10 @@ func (cluster *Cluster) SetInResticBackupState(value bool) {
 }
 
 func (cluster *Cluster) CheckBackupStates() {
-	hasPhysical := false
-	hasLogical := false
-	for _, server := range cluster.Servers {
-		if server.IsInBackupPhysical {
-			hasPhysical = true
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "CheckBackupStates: server %s IsInBackupPhysical=true, setting WARN0073", server.URL)
-			cluster.SetState("WARN0073", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0073"], cluster.Conf.BackupPhysicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
-		}
-		if server.IsInBackupLogical {
-			hasLogical = true
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "CheckBackupStates: server %s IsInBackupLogical=true, setting WARN0175", server.URL)
-			cluster.SetState("WARN0175", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0175"], cluster.Conf.BackupLogicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
-		}
-	}
-	if cluster.InResticPhysicalBackup && !hasPhysical {
+	if cluster.InPhysicalBackup || cluster.InResticPhysicalBackup {
 		cluster.StateMachine.PreserveState("WARN0073")
 	}
-	if cluster.InResticLogicalBackup && !hasLogical {
+	if cluster.InLogicalBackup || cluster.InResticLogicalBackup {
 		cluster.StateMachine.PreserveState("WARN0175")
 	}
 }

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -2165,6 +2165,19 @@ func (cluster *Cluster) SetInResticBackupState(value bool) {
 	}
 }
 
+func (cluster *Cluster) CheckBackupStates() {
+	serverUrl := ""
+	if m := cluster.GetMaster(); m != nil {
+		serverUrl = m.URL
+	}
+	if cluster.InPhysicalBackup || cluster.InResticPhysicalBackup {
+		cluster.SetState("WARN0073", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0073"], cluster.Conf.BackupPhysicalType, serverUrl), ErrFrom: "JOB", ServerUrl: serverUrl})
+	}
+	if cluster.InLogicalBackup || cluster.InResticLogicalBackup {
+		cluster.SetState("WARN0175", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0175"], cluster.Conf.BackupLogicalType, serverUrl), ErrFrom: "JOB", ServerUrl: serverUrl})
+	}
+}
+
 func (cluster *Cluster) SetGraphiteWhitelistTemplate(value string) {
 	cluster.Conf.GraphiteWhitelistTemplate = value
 }

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -2171,9 +2171,11 @@ func (cluster *Cluster) CheckBackupStates() {
 		serverUrl = m.URL
 	}
 	if cluster.InPhysicalBackup || cluster.InResticPhysicalBackup {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "CheckBackupStates: setting WARN0073 (physical=%t, resticPhysical=%t)", cluster.InPhysicalBackup, cluster.InResticPhysicalBackup)
 		cluster.SetState("WARN0073", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0073"], cluster.Conf.BackupPhysicalType, serverUrl), ErrFrom: "JOB", ServerUrl: serverUrl})
 	}
 	if cluster.InLogicalBackup || cluster.InResticLogicalBackup {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "CheckBackupStates: setting WARN0175 (logical=%t, resticLogical=%t)", cluster.InLogicalBackup, cluster.InResticLogicalBackup)
 		cluster.SetState("WARN0175", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0175"], cluster.Conf.BackupLogicalType, serverUrl), ErrFrom: "JOB", ServerUrl: serverUrl})
 	}
 }

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -2171,10 +2171,12 @@ func (cluster *Cluster) CheckBackupStates() {
 	for _, server := range cluster.Servers {
 		if server.IsInBackupPhysical {
 			hasPhysical = true
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "CheckBackupStates: server %s IsInBackupPhysical=true, setting WARN0073", server.URL)
 			cluster.SetState("WARN0073", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0073"], cluster.Conf.BackupPhysicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
 		}
 		if server.IsInBackupLogical {
 			hasLogical = true
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "CheckBackupStates: server %s IsInBackupLogical=true, setting WARN0175", server.URL)
 			cluster.SetState("WARN0175", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0175"], cluster.Conf.BackupLogicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
 		}
 	}

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -2137,10 +2137,16 @@ func (cluster *Cluster) SetLogMailerLevel(value int) {
 
 func (cluster *Cluster) SetInPhysicalBackupState(value bool) {
 	cluster.InPhysicalBackup = value
+	if !value && !cluster.InResticPhysicalBackup {
+		cluster.ServerGlobals.ReleaseBackupSlot()
+	}
 }
 
 func (cluster *Cluster) SetInLogicalBackupState(value bool) {
 	cluster.InLogicalBackup = value
+	if !value {
+		cluster.ServerGlobals.ReleaseBackupSlot()
+	}
 }
 
 func (cluster *Cluster) SetInBinlogBackupState(value bool) {
@@ -2155,6 +2161,9 @@ func (cluster *Cluster) SetInResticLogicalBackupState(value bool) {
 func (cluster *Cluster) SetInResticPhysicalBackupState(value bool) {
 	cluster.InResticPhysicalBackup = value
 	cluster.InResticBackup = cluster.InResticLogicalBackup || cluster.InResticPhysicalBackup
+	if !value && !cluster.InPhysicalBackup {
+		cluster.ServerGlobals.ReleaseBackupSlot()
+	}
 }
 
 func (cluster *Cluster) SetInResticBackupState(value bool) {

--- a/cluster/cluster_sst.go
+++ b/cluster/cluster_sst.go
@@ -286,11 +286,6 @@ func (sst *SST) tcp_con_handle_to_restic() {
 		delete(SSTs.SSTconnections, port)
 		sst.cluster.SSTSenderFreePort(strconv.Itoa(port))
 		SSTs.Unlock()
-		if bsrv := sst.cluster.GetBackupServer(); bsrv != nil {
-			bsrv.IsInBackupPhysical = false
-		} else if m := sst.cluster.GetMaster(); m != nil {
-			m.IsInBackupPhysical = false
-		}
 		sst.cluster.SetInPhysicalBackupState(false)
 	}()
 

--- a/cluster/cluster_sst.go
+++ b/cluster/cluster_sst.go
@@ -286,6 +286,11 @@ func (sst *SST) tcp_con_handle_to_restic() {
 		delete(SSTs.SSTconnections, port)
 		sst.cluster.SSTSenderFreePort(strconv.Itoa(port))
 		SSTs.Unlock()
+		if bsrv := sst.cluster.GetBackupServer(); bsrv != nil {
+			bsrv.IsInBackupPhysical = false
+		} else if m := sst.cluster.GetMaster(); m != nil {
+			m.IsInBackupPhysical = false
+		}
 		sst.cluster.SetInPhysicalBackupState(false)
 	}()
 

--- a/cluster/logplugin/external.go
+++ b/cluster/logplugin/external.go
@@ -471,21 +471,22 @@ func LoadPluginsFromDir(pluginDir string, reg *Registry, opts LoadOptions) (load
 		}
 		binPath := filepath.Join(pluginDir, e.Name())
 
+		name := pluginNameFromBinary(e.Name())
+		// Skip external plugins that duplicate a built-in enterprise plugin.
+		// The built-in versions have additional protections (free plan warnings,
+		// error handling, correct severity routing).
+		// This check must run before signature verification so that portal-deployed
+		// enterprise binaries are silently skipped even when .sig files are absent.
+		builtinName := strings.TrimPrefix(name, "plugin-")
+		if reg.Has(builtinName) {
+			continue
+		}
+
 		if verifyEnabled {
 			if verr := VerifyPluginSignature(binPath, sigDir, opts.PubKeyPath); verr != nil {
 				rejections = append(rejections, fmt.Sprintf("%s: %v", e.Name(), verr))
 				continue
 			}
-		}
-
-		name := pluginNameFromBinary(e.Name())
-		// Skip external plugins that duplicate a built-in enterprise plugin.
-		// The built-in versions have additional protections (free plan warnings,
-		// error handling, correct severity routing).
-		builtinName := strings.TrimPrefix(name, "plugin-")
-		if reg.Has(builtinName) {
-			rejections = append(rejections, fmt.Sprintf("%s: skipped — built-in %q takes priority", name, builtinName))
-			continue
 		}
 		reg.replace(name, NewExternalLogPlugin(name, binPath, DefaultPluginTimeout))
 		loaded++

--- a/cluster/server_globals.go
+++ b/cluster/server_globals.go
@@ -56,13 +56,18 @@ func (cluster *Cluster) waitForBackupSlot() bool {
 	for {
 		select {
 		case cluster.ServerGlobals.BackupSemaphore <- struct{}{}:
-			cluster.StateMachine.DeleteState("WARN0174")
 			return true
 		case <-time.After(2 * time.Second):
 			if cluster.exit.Load() {
-				cluster.StateMachine.DeleteState("WARN0174")
 				return false
 			}
+			inUse = len(cluster.ServerGlobals.BackupSemaphore)
+			total = cap(cluster.ServerGlobals.BackupSemaphore)
+			cluster.SetState("WARN0174", state.State{
+				ErrType: "WARNING",
+				ErrDesc: fmt.Sprintf(config.ClusterError["WARN0174"], inUse, total),
+				ErrFrom: "BACKUP",
+			})
 		}
 	}
 }

--- a/cluster/server_globals.go
+++ b/cluster/server_globals.go
@@ -1,0 +1,30 @@
+package cluster
+
+// ServerGlobals holds instance-wide shared resources passed from the server
+// to all clusters at init time. This avoids import cycles between server/
+// and cluster/ while giving clusters access to global coordination primitives.
+type ServerGlobals struct {
+	// BackupSemaphore limits the number of concurrent backups (logical or
+	// physical) across all clusters. Sized by backup-concurrent-slots.
+	// A cluster acquires a slot before starting a backup and releases it on
+	// completion. Nil when no limit is configured (0 = unlimited).
+	BackupSemaphore chan struct{}
+}
+
+// AcquireBackupSlot blocks until a backup slot is available.
+// Returns immediately if no semaphore is configured.
+func (sg *ServerGlobals) AcquireBackupSlot() {
+	if sg == nil || sg.BackupSemaphore == nil {
+		return
+	}
+	sg.BackupSemaphore <- struct{}{}
+}
+
+// ReleaseBackupSlot frees a backup slot.
+// Safe to call even if no semaphore is configured.
+func (sg *ServerGlobals) ReleaseBackupSlot() {
+	if sg == nil || sg.BackupSemaphore == nil {
+		return
+	}
+	<-sg.BackupSemaphore
+}

--- a/cluster/server_globals.go
+++ b/cluster/server_globals.go
@@ -1,5 +1,12 @@
 package cluster
 
+import (
+	"fmt"
+
+	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/state"
+)
+
 // ServerGlobals holds instance-wide shared resources passed from the server
 // to all clusters at init time. This avoids import cycles between server/
 // and cluster/ while giving clusters access to global coordination primitives.
@@ -27,4 +34,23 @@ func (sg *ServerGlobals) ReleaseBackupSlot() {
 		return
 	}
 	<-sg.BackupSemaphore
+}
+
+// waitForBackupSlot opens a WARN0174 state while waiting for a global backup
+// slot, then clears it once the slot is acquired.
+func (cluster *Cluster) waitForBackupSlot() {
+	if cluster.ServerGlobals == nil || cluster.ServerGlobals.BackupSemaphore == nil {
+		return
+	}
+	inUse := len(cluster.ServerGlobals.BackupSemaphore)
+	total := cap(cluster.ServerGlobals.BackupSemaphore)
+	if inUse >= total {
+		cluster.SetState("WARN0174", state.State{
+			ErrType: "WARNING",
+			ErrDesc: fmt.Sprintf(config.ClusterError["WARN0174"], inUse, total),
+			ErrFrom: "BACKUP",
+		})
+	}
+	cluster.ServerGlobals.AcquireBackupSlot()
+	cluster.StateMachine.DeleteState("WARN0174")
 }

--- a/cluster/server_globals.go
+++ b/cluster/server_globals.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/state"
@@ -37,10 +38,11 @@ func (sg *ServerGlobals) ReleaseBackupSlot() {
 }
 
 // waitForBackupSlot opens a WARN0174 state while waiting for a global backup
-// slot, then clears it once the slot is acquired.
-func (cluster *Cluster) waitForBackupSlot() {
+// slot, then clears it once the slot is acquired. Returns false if the
+// cluster is shutting down before a slot could be acquired.
+func (cluster *Cluster) waitForBackupSlot() bool {
 	if cluster.ServerGlobals == nil || cluster.ServerGlobals.BackupSemaphore == nil {
-		return
+		return true
 	}
 	inUse := len(cluster.ServerGlobals.BackupSemaphore)
 	total := cap(cluster.ServerGlobals.BackupSemaphore)
@@ -51,6 +53,16 @@ func (cluster *Cluster) waitForBackupSlot() {
 			ErrFrom: "BACKUP",
 		})
 	}
-	cluster.ServerGlobals.AcquireBackupSlot()
-	cluster.StateMachine.DeleteState("WARN0174")
+	for {
+		select {
+		case cluster.ServerGlobals.BackupSemaphore <- struct{}{}:
+			cluster.StateMachine.DeleteState("WARN0174")
+			return true
+		case <-time.After(2 * time.Second):
+			if cluster.exit.Load() {
+				cluster.StateMachine.DeleteState("WARN0174")
+				return false
+			}
+		}
+	}
 }

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1046,6 +1046,7 @@ func (server *ServerMonitor) Refresh() error {
 		} else {
 			server.jobsCheckRunningFromMemory()
 		}
+		server.jobsCheckBackupStates()
 
 		if cluster.Conf.MonitorProcessList {
 

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -219,8 +219,6 @@ type ServerMonitor struct {
 	ReplicationTags             string                      `json:"replicationTags"`
 	JobResults                  *config.TasksMap            `json:"jobResults"`
 	IsInSlowQueryCapture        bool
-	IsInBackupLogical           bool
-	IsInBackupPhysical          bool
 	IsInPFSQueryCapture         bool
 	PFSLastSnapshot             time.Time                   // timestamp of last periodic PFS digest snapshot flush
 	PFSLastExplainPurge         time.Time                   // timestamp of last explain cache purge run

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -506,7 +506,6 @@ func (server *ServerMonitor) NewLogTailer(logtype string) (*tail.Tail, error) {
 func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 	cluster := server.ClusterGroup
 	defer wg.Done()
-	server.jobsCheckBackupStates()
 
 	if cluster.vmaster != nil {
 		if cluster.vmaster.ServerID == server.ServerID {

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1043,6 +1043,8 @@ func (server *ServerMonitor) Refresh() error {
 		if cluster.Conf.MonitorScheduler {
 			server.JobsCheckStates()
 			server.JobsCheckRunning()
+		} else {
+			server.jobsCheckRunningFromMemory()
 		}
 
 		if cluster.Conf.MonitorProcessList {

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -219,6 +219,8 @@ type ServerMonitor struct {
 	ReplicationTags             string                      `json:"replicationTags"`
 	JobResults                  *config.TasksMap            `json:"jobResults"`
 	IsInSlowQueryCapture        bool
+	IsInBackupLogical           bool
+	IsInBackupPhysical          bool
 	IsInPFSQueryCapture         bool
 	PFSLastSnapshot             time.Time                   // timestamp of last periodic PFS digest snapshot flush
 	PFSLastExplainPurge         time.Time                   // timestamp of last explain cache purge run

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -506,6 +506,7 @@ func (server *ServerMonitor) NewLogTailer(logtype string) (*tail.Tail, error) {
 func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 	cluster := server.ClusterGroup
 	defer wg.Done()
+	server.jobsCheckBackupStates()
 
 	if cluster.vmaster != nil {
 		if cluster.vmaster.ServerID == server.ServerID {
@@ -1046,7 +1047,6 @@ func (server *ServerMonitor) Refresh() error {
 		} else {
 			server.jobsCheckRunningFromMemory()
 		}
-		server.jobsCheckBackupStates()
 
 		if cluster.Conf.MonitorProcessList {
 

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -744,13 +744,6 @@ func (server *ServerMonitor) JobsCheckRunning() error {
 		}
 	}
 
-	if cluster.InPhysicalBackup || cluster.InResticPhysicalBackup {
-		cluster.SetState("WARN0073", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0073"], cluster.Conf.BackupPhysicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
-	}
-	if cluster.InLogicalBackup || cluster.InResticLogicalBackup {
-		cluster.SetState("WARN0175", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0175"], cluster.Conf.BackupLogicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
-	}
-
 	return nil
 }
 
@@ -785,13 +778,6 @@ func (server *ServerMonitor) jobsCheckRunningFromMemory() error {
 		}
 		return true
 	})
-
-	if cluster.InPhysicalBackup || cluster.InResticPhysicalBackup {
-		cluster.SetState("WARN0073", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0073"], cluster.Conf.BackupPhysicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
-	}
-	if cluster.InLogicalBackup || cluster.InResticLogicalBackup {
-		cluster.SetState("WARN0175", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0175"], cluster.Conf.BackupLogicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
-	}
 
 	return nil
 }

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -786,24 +786,14 @@ func (server *ServerMonitor) jobsCheckRunningFromMemory() error {
 		return true
 	})
 
-	if cluster.InResticPhysicalBackup {
-		cluster.SetState("WARN0073", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0073"], cluster.Conf.BackupPhysicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
-	}
-	if cluster.InResticLogicalBackup {
-		cluster.SetState("WARN0175", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0175"], cluster.Conf.BackupLogicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
-	}
-
-	return nil
-}
-
-func (server *ServerMonitor) jobsCheckBackupStates() {
-	cluster := server.ClusterGroup
 	if cluster.InPhysicalBackup || cluster.InResticPhysicalBackup {
 		cluster.SetState("WARN0073", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0073"], cluster.Conf.BackupPhysicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
 	}
 	if cluster.InLogicalBackup || cluster.InResticLogicalBackup {
 		cluster.SetState("WARN0175", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0175"], cluster.Conf.BackupLogicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
 	}
+
+	return nil
 }
 
 func (server *ServerMonitor) JobsCheckPending(Conn *sqlx.Conn) error {

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -722,6 +722,8 @@ func (server *ServerMonitor) JobsCheckRunning() error {
 				cluster.SetState("WARN0073", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0073"], cluster.Conf.BackupPhysicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
 			} else if task.task == "mariabackup" {
 				cluster.SetState("WARN0073", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0073"], cluster.Conf.BackupPhysicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
+			} else if task.task == "mysqldump" || task.task == "mydumper" {
+				cluster.SetState("WARN0175", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0175"], cluster.Conf.BackupLogicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
 			} else if task.task == "reseedxtrabackup" {
 				cluster.SetState("WARN0074", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0074"], cluster.Conf.BackupPhysicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
 			} else if task.task == "reseedmariabackup" {
@@ -740,6 +742,13 @@ func (server *ServerMonitor) JobsCheckRunning() error {
 				cluster.SetState("WARN0077", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0077"], cluster.Conf.BackupLogicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
 			}
 		}
+	}
+
+	if cluster.InPhysicalBackup || cluster.InResticPhysicalBackup {
+		cluster.SetState("WARN0073", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0073"], cluster.Conf.BackupPhysicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
+	}
+	if cluster.InLogicalBackup || cluster.InResticLogicalBackup {
+		cluster.SetState("WARN0175", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0175"], cluster.Conf.BackupLogicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
 	}
 
 	return nil
@@ -763,6 +772,8 @@ func (server *ServerMonitor) jobsCheckRunningFromMemory() error {
 			cluster.SetState("WARN0097", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0097"], server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
 		case config.ConstTaskXB, config.ConstTaskMB:
 			cluster.SetState("WARN0073", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0073"], t.Task, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
+		case config.ConstTaskDump, config.ConstTaskMydumper:
+			cluster.SetState("WARN0175", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0175"], t.Task, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
 		case config.ConstTaskReseedXB, config.ConstTaskReseedMB:
 			cluster.SetState("WARN0074", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0074"], t.Task, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
 		case config.ConstTaskReseedDump:
@@ -774,6 +785,14 @@ func (server *ServerMonitor) jobsCheckRunningFromMemory() error {
 		}
 		return true
 	})
+
+	if cluster.InResticPhysicalBackup {
+		cluster.SetState("WARN0073", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0073"], cluster.Conf.BackupPhysicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
+	}
+	if cluster.InResticLogicalBackup {
+		cluster.SetState("WARN0175", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0175"], cluster.Conf.BackupLogicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
+	}
+
 	return nil
 }
 

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -796,6 +796,16 @@ func (server *ServerMonitor) jobsCheckRunningFromMemory() error {
 	return nil
 }
 
+func (server *ServerMonitor) jobsCheckBackupStates() {
+	cluster := server.ClusterGroup
+	if cluster.InPhysicalBackup || cluster.InResticPhysicalBackup {
+		cluster.SetState("WARN0073", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0073"], cluster.Conf.BackupPhysicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
+	}
+	if cluster.InLogicalBackup || cluster.InResticLogicalBackup {
+		cluster.SetState("WARN0175", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0175"], cluster.Conf.BackupLogicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
+	}
+}
+
 func (server *ServerMonitor) JobsCheckPending(Conn *sqlx.Conn) error {
 	if server.ClusterGroup.Conf.SchedulerJobsMode == "api" {
 		return nil

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -94,7 +94,6 @@ func (server *ServerMonitor) AfterJobProcess(conn *sqlx.Conn, task DBTask) error
 }
 
 func (server *ServerMonitor) JobBackupPhysicalWithOptions(opts BackupRunOptions) error {
-	//server can be nil as no dicovered master
 	if server == nil {
 		return nil
 	}
@@ -104,6 +103,9 @@ func (server *ServerMonitor) JobBackupPhysicalWithOptions(opts BackupRunOptions)
 	}
 
 	cluster := server.ClusterGroup
+	cluster.waitForBackupSlot()
+	defer cluster.ServerGlobals.ReleaseBackupSlot()
+
 	backupLine := server.resolveBackupLine(opts)
 	isAdhoc := backupLine == backupmgr.BackupLineAdhoc
 	resticEnabled := server.shouldRunRestic(opts)
@@ -2442,7 +2444,6 @@ func (server *ServerMonitor) JobBackupLogical(ctx context.Context) error {
 
 func (server *ServerMonitor) JobBackupLogicalWithOptions(ctx context.Context, opts BackupRunOptions) error {
 	var err error
-	//server can be nil as no dicovered master
 	if server == nil {
 		return errors.New("No server defined")
 	}
@@ -2451,6 +2452,9 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(ctx context.Context, op
 	}
 
 	cluster := server.ClusterGroup
+	cluster.waitForBackupSlot()
+	defer cluster.ServerGlobals.ReleaseBackupSlot()
+
 	backupLine := server.resolveBackupLine(opts)
 	isAdhoc := backupLine == backupmgr.BackupLineAdhoc
 	resticEnabled := server.shouldRunRestic(opts)

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -103,7 +103,9 @@ func (server *ServerMonitor) JobBackupPhysicalWithOptions(opts BackupRunOptions)
 	}
 
 	cluster := server.ClusterGroup
-	cluster.waitForBackupSlot()
+	if !cluster.waitForBackupSlot() {
+		return errors.New("backup canceled: cluster shutting down")
+	}
 	defer cluster.ServerGlobals.ReleaseBackupSlot()
 
 	backupLine := server.resolveBackupLine(opts)
@@ -2452,7 +2454,9 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(ctx context.Context, op
 	}
 
 	cluster := server.ClusterGroup
-	cluster.waitForBackupSlot()
+	if !cluster.waitForBackupSlot() {
+		return errors.New("backup canceled: cluster shutting down")
+	}
 	defer cluster.ServerGlobals.ReleaseBackupSlot()
 
 	backupLine := server.resolveBackupLine(opts)

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -106,7 +106,8 @@ func (server *ServerMonitor) JobBackupPhysicalWithOptions(opts BackupRunOptions)
 	if !cluster.waitForBackupSlot() {
 		return errors.New("backup canceled: cluster shutting down")
 	}
-	defer cluster.ServerGlobals.ReleaseBackupSlot()
+	// Slot is released in JobFinishReceiveFile when the SST goroutine completes,
+	// NOT via defer here — the backup runs asynchronously after this function returns.
 
 	backupLine := server.resolveBackupLine(opts)
 	isAdhoc := backupLine == backupmgr.BackupLineAdhoc
@@ -120,10 +121,6 @@ func (server *ServerMonitor) JobBackupPhysicalWithOptions(opts BackupRunOptions)
 	}
 
 	cluster.SetInPhysicalBackupState(true)
-
-	// CRITICAL FIX: For physical backups, Restic transition happens in JobFinishReceiveFile
-	// We DON'T set InResticPhysicalBackup here because the backup hasn't completed yet
-	// The flag will be set atomically in AfterJobProcess when the backup file is received
 
 	// Prevent backing up with incompatible tools
 	if server.IsMariaDB() && server.DBVersion.GreaterEqual("10.1") && cluster.Conf.BackupPhysicalType == "xtrabackup" {
@@ -161,8 +158,10 @@ func (server *ServerMonitor) JobBackupPhysicalWithOptions(opts BackupRunOptions)
 
 	if err != nil {
 		cluster.SetInPhysicalBackupState(false)
+		cluster.ServerGlobals.ReleaseBackupSlot()
 		return nil
 	}
+	// SST goroutine is now running — it will release the slot in JobFinishReceiveFile
 
 	// Reset last backup meta
 	var prevId int64
@@ -2871,6 +2870,7 @@ func (server *ServerMonitor) BackupRestic(backupMethod backupmgr.BackupMethod, u
 			cluster.SetInResticLogicalBackupState(false)
 		case backupmgr.BackupMethodPhysical:
 			cluster.SetInResticPhysicalBackupState(false)
+			cluster.ServerGlobals.ReleaseBackupSlot()
 		}
 		return
 	}
@@ -2883,6 +2883,7 @@ func (server *ServerMonitor) BackupRestic(backupMethod backupmgr.BackupMethod, u
 			cluster.SetInResticLogicalBackupState(false)
 		case backupmgr.BackupMethodPhysical:
 			cluster.SetInResticPhysicalBackupState(false)
+			cluster.ServerGlobals.ReleaseBackupSlot()
 		}
 		return
 	}
@@ -2954,6 +2955,7 @@ func (server *ServerMonitor) BackupRestic(backupMethod backupmgr.BackupMethod, u
 				cluster.SetInResticLogicalBackupState(false)
 			case backupmgr.BackupMethodPhysical:
 				cluster.SetInResticPhysicalBackupState(false)
+				cluster.ServerGlobals.ReleaseBackupSlot()
 			}
 		}()
 
@@ -4129,6 +4131,13 @@ func (server *ServerMonitor) JobFinishReceiveFile(task string) error {
 		server.DelWaitSqlErrorlogCookie()
 	case config.ConstBackupPhysicalTypeXtrabackup, config.ConstBackupPhysicalTypeMariaBackup:
 		backtype := "physical"
+		// The SST file has been received — mark the backup as completed.
+		// This used to rely on AfterJobProcess polling the DB job state, but
+		// file receipt can happen before the poll runs, causing a race where
+		// restic was skipped ("physical backup not completed").
+		if server.LastBackupMeta.Physical != nil {
+			server.LastBackupMeta.Physical.Completed = true
+		}
 		server.WriteBackupMetadata(backupmgr.BackupMethodPhysical)
 		if server.LastBackupMeta.Physical != nil && !server.LastBackupMeta.Physical.StartTime.IsZero() {
 			backupTool := server.LastBackupMeta.Physical.BackupTool
@@ -4139,26 +4148,24 @@ func (server *ServerMonitor) JobFinishReceiveFile(task string) error {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Physical backup %s completed in %s (started at %s) for: %s", backupTool, elapsed, server.LastBackupMeta.Physical.StartTime.Format(time.RFC3339), server.URL)
 		}
 
-		// CRITICAL: Transition from traditional backup lock to Restic lock atomically
+		// Transition from traditional backup lock to Restic lock atomically
 		// Set Restic flag BEFORE clearing physical backup flag
 		resticEnabled := server.LastBackupMeta.Physical != nil && server.LastBackupMeta.Physical.ResticEnabled
-		backupCompleted := server.LastBackupMeta.Physical != nil && server.LastBackupMeta.Physical.Completed
 		backupLine := backupmgr.BackupLineDefault
 		if server.LastBackupMeta.Physical != nil && server.LastBackupMeta.Physical.BackupLine != "" {
 			backupLine = server.LastBackupMeta.Physical.BackupLine
 		}
-		if resticEnabled && backupCompleted {
+		if resticEnabled {
 			cluster.SetInResticPhysicalBackupState(true)
 			resticPath := server.GetMyBackupDirectory()
 			if server.LastBackupMeta.Physical != nil && server.LastBackupMeta.Physical.IsAdhoc() && server.LastBackupMeta.Physical.Dest != "" {
 				resticPath = server.LastBackupMeta.Physical.Dest
 			}
-
-			// Create restic snapshot asynchronously and update metadata when complete
-			// Note: BackupRestic handles its own error logging and flag clearing if prerequisites fail
+			// Slot released when BackupRestic completes (InResticPhysicalBackup closes)
 			server.BackupRestic(backupmgr.BackupMethodPhysical, true, resticPath, server.BuildResticTags(backtype, cluster.Conf.BackupPhysicalType, backupLine, server.LastBackupMeta.Physical)...)
-		} else if resticEnabled && !backupCompleted {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Skipping restic backup because physical backup not completed for: %s", server.URL)
+		} else {
+			// No restic — release slot now (InPhysicalBackup closes)
+			cluster.ServerGlobals.ReleaseBackupSlot()
 		}
 
 		// Now safe to clear traditional backup flag

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -118,6 +118,7 @@ func (server *ServerMonitor) JobBackupPhysicalWithOptions(opts BackupRunOptions)
 		return server.JobBackupPhysicalWithOptions(opts)
 	}
 
+	server.IsInBackupPhysical = true
 	cluster.SetInPhysicalBackupState(true)
 
 	// Prevent backing up with incompatible tools
@@ -155,6 +156,7 @@ func (server *ServerMonitor) JobBackupPhysicalWithOptions(opts BackupRunOptions)
 	}
 
 	if err != nil {
+		server.IsInBackupPhysical = false
 		cluster.SetInPhysicalBackupState(false)
 		return nil
 	}
@@ -202,6 +204,7 @@ func (server *ServerMonitor) JobBackupPhysicalWithOptions(opts BackupRunOptions)
 
 	_, err = server.JobInsertTask(cluster.Conf.BackupPhysicalType, port, cluster.Conf.MonitorAddress)
 	if err != nil {
+		server.IsInBackupPhysical = false
 		cluster.SetInPhysicalBackupState(false)
 	}
 
@@ -2475,6 +2478,8 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(ctx context.Context, op
 		time.Sleep(1 * time.Second)
 	}
 
+	server.IsInBackupLogical = true
+	defer func() { server.IsInBackupLogical = false }()
 	cluster.SetInLogicalBackupState(true)
 	defer cluster.SetInLogicalBackupState(false)
 
@@ -4141,6 +4146,7 @@ func (server *ServerMonitor) JobFinishReceiveFile(task string) error {
 			server.BackupRestic(backupmgr.BackupMethodPhysical, true, resticPath, server.BuildResticTags(backtype, cluster.Conf.BackupPhysicalType, backupLine, server.LastBackupMeta.Physical)...)
 		}
 
+		server.IsInBackupPhysical = false
 		cluster.SetInPhysicalBackupState(false)
 	case "printdefault-current":
 		filename := filepath.Join(server.Datadir, "current.cnf")

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -118,8 +118,8 @@ func (server *ServerMonitor) JobBackupPhysicalWithOptions(opts BackupRunOptions)
 		return server.JobBackupPhysicalWithOptions(opts)
 	}
 
-	server.IsInBackupPhysical = true
 	cluster.SetInPhysicalBackupState(true)
+	cluster.SetState("WARN0073", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0073"], cluster.Conf.BackupPhysicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
 
 	// Prevent backing up with incompatible tools
 	if server.IsMariaDB() && server.DBVersion.GreaterEqual("10.1") && cluster.Conf.BackupPhysicalType == "xtrabackup" {
@@ -156,7 +156,6 @@ func (server *ServerMonitor) JobBackupPhysicalWithOptions(opts BackupRunOptions)
 	}
 
 	if err != nil {
-		server.IsInBackupPhysical = false
 		cluster.SetInPhysicalBackupState(false)
 		return nil
 	}
@@ -2477,10 +2476,9 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(ctx context.Context, op
 		time.Sleep(1 * time.Second)
 	}
 
-	server.IsInBackupLogical = true
-	defer func() { server.IsInBackupLogical = false }()
 	cluster.SetInLogicalBackupState(true)
 	defer cluster.SetInLogicalBackupState(false)
+	cluster.SetState("WARN0175", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0175"], cluster.Conf.BackupLogicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
 
 	if waited {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Resuming logical backup %s after waiting for previous backup to finish for: %s", cluster.Conf.BackupLogicalType, server.URL)
@@ -4145,7 +4143,6 @@ func (server *ServerMonitor) JobFinishReceiveFile(task string) error {
 			server.BackupRestic(backupmgr.BackupMethodPhysical, true, resticPath, server.BuildResticTags(backtype, cluster.Conf.BackupPhysicalType, backupLine, server.LastBackupMeta.Physical)...)
 		}
 
-		server.IsInBackupPhysical = false
 		cluster.SetInPhysicalBackupState(false)
 	case "printdefault-current":
 		filename := filepath.Join(server.Datadir, "current.cnf")

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -204,11 +204,10 @@ func (server *ServerMonitor) JobBackupPhysicalWithOptions(opts BackupRunOptions)
 
 	_, err = server.JobInsertTask(cluster.Conf.BackupPhysicalType, port, cluster.Conf.MonitorAddress)
 	if err != nil {
-		server.IsInBackupPhysical = false
-		cluster.SetInPhysicalBackupState(false)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Failed to insert physical backup task: %s (backup continues via SST)", err)
 	}
 
-	return err
+	return nil
 }
 
 func (server *ServerMonitor) JobReseedPhysicalBackup(backtype string) error {

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -2445,6 +2445,7 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(ctx context.Context, op
 	resticEnabled := server.shouldRunRestic(opts)
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Request logical backup %s for: %s", cluster.Conf.BackupLogicalType, server.URL)
 	if server.IsDown() {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Logical backup aborted: server %s is down (state=%s)", server.URL, server.State)
 		return errors.New("Can't backup when server down")
 	}
 
@@ -2461,9 +2462,11 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(ctx context.Context, op
 		}
 	}
 
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Logical backup acquiring slot for: %s (semaphore=%v)", server.URL, cluster.ServerGlobals != nil && cluster.ServerGlobals.BackupSemaphore != nil)
 	if !cluster.waitForBackupSlot() {
 		return errors.New("backup canceled: cluster shutting down")
 	}
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Logical backup slot acquired for: %s", server.URL)
 
 	var waited bool
 	for cluster.IsInBackup() {

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -106,8 +106,6 @@ func (server *ServerMonitor) JobBackupPhysicalWithOptions(opts BackupRunOptions)
 	if !cluster.waitForBackupSlot() {
 		return errors.New("backup canceled: cluster shutting down")
 	}
-	// Slot is released in JobFinishReceiveFile when the SST goroutine completes,
-	// NOT via defer here — the backup runs asynchronously after this function returns.
 
 	backupLine := server.resolveBackupLine(opts)
 	isAdhoc := backupLine == backupmgr.BackupLineAdhoc
@@ -158,10 +156,8 @@ func (server *ServerMonitor) JobBackupPhysicalWithOptions(opts BackupRunOptions)
 
 	if err != nil {
 		cluster.SetInPhysicalBackupState(false)
-		cluster.ServerGlobals.ReleaseBackupSlot()
 		return nil
 	}
-	// SST goroutine is now running — it will release the slot in JobFinishReceiveFile
 
 	// Reset last backup meta
 	var prevId int64
@@ -1795,8 +1791,6 @@ func (server *ServerMonitor) JobBackupScript(destination string) error {
 	var err error
 	cluster := server.ClusterGroup
 
-	defer cluster.SetInLogicalBackupState(false)
-
 	master := cluster.GetMaster()
 	if master == nil {
 		return fmt.Errorf("No master found. Cancel backup script on %s", server.URL)
@@ -1986,8 +1980,6 @@ func (server *ServerMonitor) JobBackupMysqldump(ctx context.Context, task, filen
 	if ctx == nil {
 		ctx = context.Background()
 	}
-
-	defer cluster.SetInLogicalBackupState(false)
 
 	//Block DDL For Backup
 	if server.IsMariaDB() && server.DBVersion.GreaterEqual("10.4") && cluster.Conf.BackupLockDDL {
@@ -2254,8 +2246,6 @@ func (server *ServerMonitor) JobBackupMyDumper(outputdir string) error {
 	// Mydumper is fine with split user since we can
 	server.LastBackupMeta.Logical.SplitUser = true
 
-	defer cluster.SetInLogicalBackupState(false)
-
 	dumper := cluster.VersionsMap.Get("mydumper")
 	if dumper == nil {
 		if err = cluster.RefreshMyDumperVersion(); err != nil {
@@ -2369,8 +2359,6 @@ func (server *ServerMonitor) JobBackupDumpling(outputdir string) error {
 	var err error
 	cluster := server.ClusterGroup
 
-	defer cluster.SetInLogicalBackupState(false)
-
 	conf := dumplingext.DefaultConfig()
 	conf.Database = ""
 	conf.Host = misc.Unbracket(server.Host)
@@ -2402,8 +2390,6 @@ func (server *ServerMonitor) JobBackupDumpling(outputdir string) error {
 func (server *ServerMonitor) JobBackupRiver() error {
 	var err error
 	cluster := server.ClusterGroup
-
-	defer cluster.SetInLogicalBackupState(false)
 
 	cfg := new(river.Config)
 	cfg.MyHost = server.URL
@@ -2453,10 +2439,6 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(ctx context.Context, op
 	}
 
 	cluster := server.ClusterGroup
-	if !cluster.waitForBackupSlot() {
-		return errors.New("backup canceled: cluster shutting down")
-	}
-	defer cluster.ServerGlobals.ReleaseBackupSlot()
 
 	backupLine := server.resolveBackupLine(opts)
 	isAdhoc := backupLine == backupmgr.BackupLineAdhoc
@@ -2479,8 +2461,11 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(ctx context.Context, op
 		}
 	}
 
+	if !cluster.waitForBackupSlot() {
+		return errors.New("backup canceled: cluster shutting down")
+	}
+
 	var waited bool
-	//Wait for previous restic backup
 	for cluster.IsInBackup() {
 		waited = true
 		cluster.SetState("WARN0110", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0110"], "Logical", cluster.Conf.BackupLogicalType, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
@@ -2488,8 +2473,6 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(ctx context.Context, op
 	}
 
 	cluster.SetInLogicalBackupState(true)
-
-	// Defer always clears traditional flag; Restic flag cleared by async goroutine
 	defer cluster.SetInLogicalBackupState(false)
 
 	if waited {
@@ -2768,11 +2751,8 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(ctx context.Context, op
 		if isAdhoc && server.LastBackupMeta.Logical != nil && server.LastBackupMeta.Logical.Dest != "" {
 			resticPath = server.LastBackupMeta.Logical.Dest
 		}
-		// Note: BackupRestic handles its own error logging and flag clearing if prerequisites fail
 		resticScheduled = true
 		server.BackupRestic(backupmgr.BackupMethodLogical, true, resticPath, server.BuildResticTags(backtype, cluster.Conf.BackupLogicalType, backupLine, server.LastBackupMeta.Logical)...)
-	} else if resticEnabled && err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Skipping restic backup because logical backup failed for: %s", server.URL)
 	}
 
 	return nil
@@ -2864,26 +2844,22 @@ func (server *ServerMonitor) BackupRestic(backupMethod backupmgr.BackupMethod, u
 	// Defensive checks - clear flag and return early if prerequisites not met
 	if !cluster.Conf.BackupRestic {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Restic backup called but disabled for %s", server.URL)
-		// Clear the flag that might have been set by caller
 		switch backupMethod {
 		case backupmgr.BackupMethodLogical:
 			cluster.SetInResticLogicalBackupState(false)
 		case backupmgr.BackupMethodPhysical:
 			cluster.SetInResticPhysicalBackupState(false)
-			cluster.ServerGlobals.ReleaseBackupSlot()
 		}
 		return
 	}
 
 	if cluster.ResticManager == nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Restic manager not initialized for %s, cannot backup", server.URL)
-		// Clear the flag that might have been set by caller
 		switch backupMethod {
 		case backupmgr.BackupMethodLogical:
 			cluster.SetInResticLogicalBackupState(false)
 		case backupmgr.BackupMethodPhysical:
 			cluster.SetInResticPhysicalBackupState(false)
-			cluster.ServerGlobals.ReleaseBackupSlot()
 		}
 		return
 	}
@@ -2948,14 +2924,12 @@ func (server *ServerMonitor) BackupRestic(backupMethod backupmgr.BackupMethod, u
 
 	// Launch goroutine to wait for result and update metadata
 	go func() {
-		// Ensure flag is cleared when goroutine exits
 		defer func() {
 			switch backupMethod {
 			case backupmgr.BackupMethodLogical:
 				cluster.SetInResticLogicalBackupState(false)
 			case backupmgr.BackupMethodPhysical:
 				cluster.SetInResticPhysicalBackupState(false)
-				cluster.ServerGlobals.ReleaseBackupSlot()
 			}
 		}()
 
@@ -4161,14 +4135,9 @@ func (server *ServerMonitor) JobFinishReceiveFile(task string) error {
 			if server.LastBackupMeta.Physical != nil && server.LastBackupMeta.Physical.IsAdhoc() && server.LastBackupMeta.Physical.Dest != "" {
 				resticPath = server.LastBackupMeta.Physical.Dest
 			}
-			// Slot released when BackupRestic completes (InResticPhysicalBackup closes)
 			server.BackupRestic(backupmgr.BackupMethodPhysical, true, resticPath, server.BuildResticTags(backtype, cluster.Conf.BackupPhysicalType, backupLine, server.LastBackupMeta.Physical)...)
-		} else {
-			// No restic — release slot now (InPhysicalBackup closes)
-			cluster.ServerGlobals.ReleaseBackupSlot()
 		}
 
-		// Now safe to clear traditional backup flag
 		cluster.SetInPhysicalBackupState(false)
 	case "printdefault-current":
 		filename := filepath.Join(server.Datadir, "current.cnf")

--- a/cluster/srv_log_plugins.go
+++ b/cluster/srv_log_plugins.go
@@ -566,6 +566,15 @@ func (cluster *Cluster) ReloadLogPlugins() {
 			)
 		}
 	}
+	for _, p := range cluster.pluginRegistry.All() {
+		cluster.LogModulePrintf(
+			cluster.Conf.Verbose,
+			config.ConstLogModPlugin,
+			config.LvlInfo,
+			"[logplugin] plugin loaded: %s",
+			p.Name(),
+		)
+	}
 	if n > 0 {
 		cluster.LogModulePrintf(
 			cluster.Conf.Verbose,

--- a/config/config.go
+++ b/config/config.go
@@ -730,6 +730,7 @@ type Config struct {
 	OptimizeUseSQL                            bool                         `mapstructure:"optimize-use-sql" toml:"optimize-use-sql" json:"optimizeUseSql"`
 	AnalyzeUseSQL                             bool                         `mapstructure:"analyze-use-sql" toml:"analyze-use-sql" json:"analyzeUseSql"`
 	AnalyzeUsePersistent                      bool                         `mapstructure:"analyze-use-persistent" toml:"analyze-use-persistent" json:"analyzeUsePersistent"`
+	BackupConcurrentSlots                     int                          `scope:"server" mapstructure:"backup-concurrent-slots" toml:"backup-concurrent-slots" json:"backupConcurrentSlots"`
 	BackupLogicalCron                         string                       `mapstructure:"scheduler-db-servers-logical-backup-cron" toml:"scheduler-db-servers-logical-backup-cron" json:"schedulerDbServersLogicalBackupCron"`
 	BackupPhysicalCron                        string                       `mapstructure:"scheduler-db-servers-physical-backup-cron" toml:"scheduler-db-servers-physical-backup-cron" json:"schedulerDbServersPhysicalBackupCron"`
 	BackupDatabaseLogCron                     string                       `mapstructure:"scheduler-db-servers-logs-cron" toml:"scheduler-db-servers-logs-cron" json:"schedulerDbServersLogsCron"`

--- a/config/error.go
+++ b/config/error.go
@@ -249,6 +249,7 @@ var ClusterError = map[string]string{
 	"WARN0171":  "Server %s connection failed: %s",
 	"WARN0172":  "Intervention scheduled at %s by %s: %s",
 	"WARN0173":  "Intervention active since %s by %s: %s — notifications muted",
+	"WARN0174":  "Waiting for global backup slot (%d/%d in use)",
 	// Log-tailer plugin state codes (WARN0200-WARN0299 reserved for logplugin)
 	"WARN0200":  "Server %s has recent ERROR entries in database error log (last 24h)",
 	"WARN0201":  "Server %s has recent SQL errors in SQL error log (last 24h)",

--- a/config/error.go
+++ b/config/error.go
@@ -162,7 +162,7 @@ var ClusterError = map[string]string{
 	"WARN0081":  "Cluster arbitrator error in reporting %s",
 	"WARN0082":  "Cluster arbitrator error in arbitration %s",
 	"WARN0083":  "Arbitration winner",
-	"WARN0084":  "%d variables differ between leader and replicas",
+	"WARN0084":  "Variables differ between leader and replicas:\n%s",
 	"WARN0085":  "Server %s in capture mode",
 	"WARN0086":  "Checksum table waiting replication sync on slave %s",
 	"WARN0087":  "Cluster same server_id %s %s",

--- a/config/error.go
+++ b/config/error.go
@@ -250,6 +250,7 @@ var ClusterError = map[string]string{
 	"WARN0172":  "Intervention scheduled at %s by %s: %s",
 	"WARN0173":  "Intervention active since %s by %s: %s — notifications muted",
 	"WARN0174":  "Waiting for global backup slot (%d/%d in use)",
+	"WARN0175":  "Running logical backup %s on server %s",
 	// Log-tailer plugin state codes (WARN0200-WARN0299 reserved for logplugin)
 	"WARN0200":  "Server %s has recent ERROR entries in database error log (last 24h)",
 	"WARN0201":  "Server %s has recent SQL errors in SQL error log (last 24h)",

--- a/config/error.go
+++ b/config/error.go
@@ -162,7 +162,7 @@ var ClusterError = map[string]string{
 	"WARN0081":  "Cluster arbitrator error in reporting %s",
 	"WARN0082":  "Cluster arbitrator error in arbitration %s",
 	"WARN0083":  "Arbitration winner",
-	"WARN0084":  "Variable diff:\n %s",
+	"WARN0084":  "%d variables differ between leader and replicas",
 	"WARN0085":  "Server %s in capture mode",
 	"WARN0086":  "Checksum table waiting replication sync on slave %s",
 	"WARN0087":  "Cluster same server_id %s %s",

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -84,7 +84,7 @@ RUN bash scripts/post_install.sh
 
 COPY --from=builder /go/src/github.com/signal18/replication-manager/docker/dev /go/src/github.com/signal18/replication-manager/docker/dev
 
-RUN echo 'WORKDIR=/go/src/github.com/signal18/replication-manager; DEVDIR=$WORKDIR/docker/dev; for s in run.sh stop.sh restart.sh wait.sh; do [ ! -e "$WORKDIR/$s" ] && ln -s "$DEVDIR/$s" "$WORKDIR/$s"; done' >> /etc/bash.bashrc
+RUN echo 'WORKDIR=/go/src/github.com/signal18/replication-manager; DEVDIR=$WORKDIR/docker/dev; for s in run.sh stop.sh restart.sh wait.sh; do [ ! -e "$WORKDIR/$s" ] && ln -s "$DEVDIR/$s" "$WORKDIR/$s"; done; if ! pgrep -f replication-manager > /dev/null 2>&1; then cd "$WORKDIR" && ./run.sh run; fi' >> /etc/bash.bashrc
 
 CMD ["/bin/bash"]
 EXPOSE 10001

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -84,7 +84,7 @@ RUN bash scripts/post_install.sh
 
 COPY --from=builder /go/src/github.com/signal18/replication-manager/docker/dev /go/src/github.com/signal18/replication-manager/docker/dev
 
-RUN echo 'WORKDIR=/go/src/github.com/signal18/replication-manager; DEVDIR=$WORKDIR/docker/dev; for s in run.sh stop.sh restart.sh wait.sh; do [ ! -e "$WORKDIR/$s" ] && ln -s "$DEVDIR/$s" "$WORKDIR/$s"; done; if ! pgrep -f replication-manager > /dev/null 2>&1; then cd "$WORKDIR" && ./run.sh run; fi' >> /etc/bash.bashrc
+RUN echo 'WORKDIR=/go/src/github.com/signal18/replication-manager; DEVDIR=$WORKDIR/docker/dev; for s in run.sh stop.sh restart.sh wait.sh; do [ ! -e "$WORKDIR/$s" ] && ln -s "$DEVDIR/$s" "$WORKDIR/$s"; done; TPCC=$WORKDIR/share/submodule/sysbench-tpcc; if [ -d "$TPCC" ] && [ ! -e "$TPCC/tpcc.lua" ]; then cp -r /usr/share/replication-manager/submodule/sysbench-tpcc/* "$TPCC/"; fi; if ! pgrep -f replication-manager > /dev/null 2>&1; then cd "$WORKDIR" && ./run.sh run; fi' >> /etc/bash.bashrc
 
 CMD ["/bin/bash"]
 EXPOSE 10001

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -82,5 +82,9 @@ RUN cp etc/local/config.toml.docker /etc/replication-manager/config.toml && \
 
 RUN bash scripts/post_install.sh
 
-CMD ["while true; do sleep 86400; done"]
+COPY --from=builder /go/src/github.com/signal18/replication-manager/docker/dev /go/src/github.com/signal18/replication-manager/docker/dev
+
+RUN echo 'WORKDIR=/go/src/github.com/signal18/replication-manager; DEVDIR=$WORKDIR/docker/dev; for s in run.sh stop.sh restart.sh wait.sh; do [ ! -e "$WORKDIR/$s" ] && ln -s "$DEVDIR/$s" "$WORKDIR/$s"; done' >> /etc/bash.bashrc
+
+CMD ["/bin/bash"]
 EXPOSE 10001

--- a/docker/Dockerfile.dev_rootless
+++ b/docker/Dockerfile.dev_rootless
@@ -61,7 +61,11 @@ COPY --from=builder /go/src/github.com/signal18/replication-manager/scripts /go/
 
 # Create symlinks and configure
 RUN ln -s build/binaries/replication-manager-pro replication-manager-pro && \
-        ln -s build/binaries/replication-manager-cli replication-manager-cli
+        ln -s build/binaries/replication-manager-cli replication-manager-cli && \
+        ln -s docker/dev/run.sh run.sh && \
+        ln -s docker/dev/stop.sh stop.sh && \
+        ln -s docker/dev/restart.sh restart.sh && \
+        ln -s docker/dev/wait.sh wait.sh
 
 RUN mkdir -p \
             /etc/replication-manager \

--- a/docker/Dockerfile.dev_rootless
+++ b/docker/Dockerfile.dev_rootless
@@ -61,6 +61,7 @@ COPY --from=builder /go/src/github.com/signal18/replication-manager/scripts /go/
 
 # Create symlinks and configure
 RUN ln -s build/binaries/replication-manager-pro replication-manager-pro && \
+        ln -s build/binaries/replication-manager-osc replication-manager-osc && \
         ln -s build/binaries/replication-manager-cli replication-manager-cli && \
         ln -s docker/dev/run.sh run.sh && \
         ln -s docker/dev/stop.sh stop.sh && \

--- a/docker/Dockerfile.dev_rootless
+++ b/docker/Dockerfile.dev_rootless
@@ -58,6 +58,7 @@ COPY --from=builder /go/src/github.com/signal18/replication-manager/build/binari
 COPY --from=builder /go/src/github.com/signal18/replication-manager/etc /go/src/github.com/signal18/replication-manager/etc
 COPY --from=builder /go/src/github.com/signal18/replication-manager/share /go/src/github.com/signal18/replication-manager/share
 COPY --from=builder /go/src/github.com/signal18/replication-manager/scripts /go/src/github.com/signal18/replication-manager/scripts
+COPY --from=builder /go/src/github.com/signal18/replication-manager/docker/dev /go/src/github.com/signal18/replication-manager/docker/dev
 
 # Create symlinks and configure
 RUN ln -s build/binaries/replication-manager-pro replication-manager-pro && \
@@ -88,5 +89,6 @@ RUN cp etc/local/config.toml.docker /etc/replication-manager/config.toml && \
 RUN bash scripts/post_install.sh
 
 USER repman
-CMD ["while true; do sleep 86400; done"]
+ENTRYPOINT ["/go/src/github.com/signal18/replication-manager/docker/dev/entrypoint.sh"]
+CMD ["/bin/bash"]
 EXPOSE 10001

--- a/docker/Dockerfile.dev_rootless
+++ b/docker/Dockerfile.dev_rootless
@@ -88,7 +88,8 @@ RUN cp etc/local/config.toml.docker /etc/replication-manager/config.toml && \
 
 RUN bash scripts/post_install.sh
 
+RUN echo 'WORKDIR=/go/src/github.com/signal18/replication-manager; DEVDIR=$WORKDIR/docker/dev; for s in run.sh stop.sh restart.sh wait.sh; do [ ! -e "$WORKDIR/$s" ] && ln -s "$DEVDIR/$s" "$WORKDIR/$s"; done' >> /etc/bash.bashrc
+
 USER repman
-ENTRYPOINT ["/go/src/github.com/signal18/replication-manager/docker/dev/entrypoint.sh"]
 CMD ["/bin/bash"]
 EXPOSE 10001

--- a/docker/dev/entrypoint.sh
+++ b/docker/dev/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+WORKDIR=/go/src/github.com/signal18/replication-manager
+DEVDIR=$WORKDIR/docker/dev
+
+for script in run.sh stop.sh restart.sh wait.sh; do
+    [ ! -e "$WORKDIR/$script" ] && ln -s "$DEVDIR/$script" "$WORKDIR/$script"
+done
+
+exec "$@"

--- a/docker/dev/restart.sh
+++ b/docker/dev/restart.sh
@@ -1,5 +1,34 @@
 #!/bin/bash
+arg="${1:-pro}"
 
+# Build first while the old process is still running
+case "$arg" in
+    run|RUN|run-osc|RUN-OSC)
+        # No build needed
+        ;;
+    skip|SKIP)
+        make cli pro WITH_REACT=OFF
+        ;;
+    v2|V2)
+        make cli pro osc WITH_REACT=OFF
+        ;;
+    osc|OSC)
+        make cli osc
+        ;;
+    *)
+        make cli pro
+        ;;
+esac
+
+# Stop the running process
 ./stop.sh
 
-./run.sh $1
+# Start with "run" flag to skip rebuild
+case "$arg" in
+    osc|OSC|run-osc|RUN-OSC|v2|V2)
+        ./run.sh run-osc
+        ;;
+    *)
+        ./run.sh run
+        ;;
+esac

--- a/docker/dev/restart.sh
+++ b/docker/dev/restart.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./stop.sh
+
+./run.sh $1

--- a/docker/dev/restart.sh
+++ b/docker/dev/restart.sh
@@ -1,34 +1,5 @@
 #!/bin/bash
-arg="${1:-pro}"
 
-# Build first while the old process is still running
-case "$arg" in
-    run|RUN|run-osc|RUN-OSC)
-        # No build needed
-        ;;
-    skip|SKIP)
-        make cli pro WITH_REACT=OFF
-        ;;
-    v2|V2)
-        make cli pro osc WITH_REACT=OFF
-        ;;
-    osc|OSC)
-        make cli osc
-        ;;
-    *)
-        make cli pro
-        ;;
-esac
-
-# Stop the running process
 ./stop.sh
 
-# Start with "run" flag to skip rebuild
-case "$arg" in
-    osc|OSC|run-osc|RUN-OSC|v2|V2)
-        ./run.sh run-osc
-        ;;
-    *)
-        ./run.sh run
-        ;;
-esac
+./run.sh $1

--- a/docker/dev/run.sh
+++ b/docker/dev/run.sh
@@ -20,7 +20,7 @@ make cli pro osc WITH_REACT=OFF
 cp share/opensvc/moduleset_mariadb.svc.mrm.db.json /usr/share/replication-manager/opensvc/
 ./wait.sh replication-manager-pro;
 ./wait.sh replication-manager-osc;
-./replication-manager-osc monitor $COMMON_ARGS &
+./replication-manager-osc monitor $COMMON_ARGS > /var/log/replication-manager/replication-manager.log 2>&1 &
 pid="$!"
 elif [ "$arg" == "skip" ] || [ "$arg" == "SKIP" ]; then
 make cli pro WITH_REACT=OFF

--- a/docker/dev/run.sh
+++ b/docker/dev/run.sh
@@ -1,24 +1,29 @@
 #!/bin/bash
 set -e
 arg="$1"
+
+SHAREDIR=/go/src/github.com/signal18/replication-manager/share
+PUBKEY=$SHAREDIR/plugins/plugin-signing.pub
+COMMON_ARGS="--user=repman --http-root=$SHAREDIR/dashboard --monitoring-sharedir=$SHAREDIR --plugin-signing-public-key=$PUBKEY"
+
 if [ "$arg" == "v2" ] || [ "$arg" == "V2" ]; then
 make cli pro osc WITH_REACT=OFF
 cp share/opensvc/moduleset_mariadb.svc.mrm.db.json /usr/share/replication-manager/opensvc/
 ./wait.sh replication-manager-pro;
 ./wait.sh replication-manager-osc;
-./replication-manager-osc monitor --http-root=/go/src/github.com/signal18/replication-manager/share/dashboard --monitoring-sharedir=/go/src/github.com/signal18/replication-manager/share &
+./replication-manager-osc monitor $COMMON_ARGS &
 pid="$!"
 elif [ "$arg" == "skip" ] || [ "$arg" == "SKIP" ]; then
 make cli pro WITH_REACT=OFF
 cp share/opensvc/moduleset_mariadb.svc.mrm.db.json /usr/share/replication-manager/opensvc/
 ./wait.sh replication-manager-pro;
 ./wait.sh replication-manager-osc;
-./replication-manager-pro monitor --user=repman --http-root=/go/src/github.com/signal18/replication-manager/share/dashboard --monitoring-sharedir=/go/src/github.com/signal18/replication-manager/share > /var/log/replication-manager/replication-manager.log 2>&1 &
+./replication-manager-pro monitor $COMMON_ARGS > /var/log/replication-manager/replication-manager.log 2>&1 &
 pid="$!"
 elif [ "$arg" == "run" ] || [ "$arg" == "RUN" ]; then
 ./wait.sh replication-manager-pro;
 ./wait.sh replication-manager-osc;
-./replication-manager-pro monitor --user=repman --http-root=/go/src/github.com/signal18/replication-manager/share/dashboard --monitoring-sharedir=/go/src/github.com/signal18/replication-manager/share > /var/log/replication-manager/replication-manager.log 2>&1 &
+./replication-manager-pro monitor $COMMON_ARGS > /var/log/replication-manager/replication-manager.log 2>&1 &
 pid="$!"
 
 elif [ "$arg" == "osc" ] || [ "$arg" == "OSC" ]; then
@@ -26,19 +31,19 @@ make cli osc
 cp share/opensvc/moduleset_mariadb.svc.mrm.db.json /usr/share/replication-manager/opensvc/
 ./wait.sh replication-manager-pro;
 ./wait.sh replication-manager-osc;
-./replication-manager-osc monitor --plugin-signing-public-key="" --user=repman --http-root=/go/src/github.com/signal18/replication-manager/share/dashboard --monitoring-sharedir=/go/src/github.com/signal18/replication-manager/share > /var/log/replication-manager/replication-manager.log 2>&1 &
+./replication-manager-osc monitor $COMMON_ARGS > /var/log/replication-manager/replication-manager.log 2>&1 &
 pid="$!"
 elif [ "$arg" == "run-osc" ] || [ "$arg" == "RUN-OSC" ]; then
 ./wait.sh replication-manager-pro;
 ./wait.sh replication-manager-osc;
-./replication-manager-osc monitor --plugin-signing-public-key="" --user=repman --http-root=/go/src/github.com/signal18/replication-manager/share/dashboard --monitoring-sharedir=/go/src/github.com/signal18/replication-manager/share > /var/log/replication-manager/replication-manager.log 2>&1 &
+./replication-manager-osc monitor $COMMON_ARGS > /var/log/replication-manager/replication-manager.log 2>&1 &
 pid="$!"
 else
 make cli pro
 cp share/opensvc/moduleset_mariadb.svc.mrm.db.json /usr/share/replication-manager/opensvc/
 ./wait.sh replication-manager-pro;
 ./wait.sh replication-manager-osc;
-./replication-manager-pro monitor --plugin-signing-public-key="" --user=repman --http-root=/go/src/github.com/signal18/replication-manager/share/dashboard --monitoring-sharedir=/go/src/github.com/signal18/replication-manager/share > /var/log/replication-manager/replication-manager.log 2>&1 &
+./replication-manager-pro monitor $COMMON_ARGS > /var/log/replication-manager/replication-manager.log 2>&1 &
 pid="$!"
 fi
 echo "$pid"

--- a/docker/dev/run.sh
+++ b/docker/dev/run.sh
@@ -2,9 +2,18 @@
 set -e
 arg="$1"
 
-SHAREDIR=/go/src/github.com/signal18/replication-manager/share
+WORKDIR=/go/src/github.com/signal18/replication-manager
+SHAREDIR=$WORKDIR/share
 PUBKEY=$SHAREDIR/plugins/plugin-signing.pub
+DATADIR=/var/lib/replication-manager
 COMMON_ARGS="--user=repman --http-root=$SHAREDIR/dashboard --monitoring-sharedir=$SHAREDIR --plugin-signing-public-key=$PUBKEY"
+
+# Symlink shared plugin dir to locally built plugins so all clusters use the dev build
+SHARED_PLUGINS=$DATADIR/plugins
+if [ ! -L "$SHARED_PLUGINS" ]; then
+	rm -rf "$SHARED_PLUGINS"
+	ln -s "$WORKDIR/build/plugins" "$SHARED_PLUGINS"
+fi
 
 if [ "$arg" == "v2" ] || [ "$arg" == "V2" ]; then
 make cli pro osc WITH_REACT=OFF

--- a/docker/dev/run.sh
+++ b/docker/dev/run.sh
@@ -1,29 +1,24 @@
 #!/bin/bash
 set -e
 arg="$1"
-
-SHAREDIR=/go/src/github.com/signal18/replication-manager/share
-PUBKEY=$SHAREDIR/plugins/plugin-signing.pub
-COMMON_ARGS="--user=repman --http-root=$SHAREDIR/dashboard --monitoring-sharedir=$SHAREDIR --plugin-signing-public-key=$PUBKEY"
-
 if [ "$arg" == "v2" ] || [ "$arg" == "V2" ]; then
 make cli pro osc WITH_REACT=OFF
 cp share/opensvc/moduleset_mariadb.svc.mrm.db.json /usr/share/replication-manager/opensvc/
 ./wait.sh replication-manager-pro;
 ./wait.sh replication-manager-osc;
-./replication-manager-osc monitor $COMMON_ARGS &
+./replication-manager-osc monitor --http-root=/go/src/github.com/signal18/replication-manager/share/dashboard --monitoring-sharedir=/go/src/github.com/signal18/replication-manager/share &
 pid="$!"
 elif [ "$arg" == "skip" ] || [ "$arg" == "SKIP" ]; then
 make cli pro WITH_REACT=OFF
 cp share/opensvc/moduleset_mariadb.svc.mrm.db.json /usr/share/replication-manager/opensvc/
 ./wait.sh replication-manager-pro;
 ./wait.sh replication-manager-osc;
-./replication-manager-pro monitor $COMMON_ARGS > /var/log/replication-manager/replication-manager.log 2>&1 &
+./replication-manager-pro monitor --user=repman --http-root=/go/src/github.com/signal18/replication-manager/share/dashboard --monitoring-sharedir=/go/src/github.com/signal18/replication-manager/share > /var/log/replication-manager/replication-manager.log 2>&1 &
 pid="$!"
 elif [ "$arg" == "run" ] || [ "$arg" == "RUN" ]; then
 ./wait.sh replication-manager-pro;
 ./wait.sh replication-manager-osc;
-./replication-manager-pro monitor $COMMON_ARGS > /var/log/replication-manager/replication-manager.log 2>&1 &
+./replication-manager-pro monitor --user=repman --http-root=/go/src/github.com/signal18/replication-manager/share/dashboard --monitoring-sharedir=/go/src/github.com/signal18/replication-manager/share > /var/log/replication-manager/replication-manager.log 2>&1 &
 pid="$!"
 
 elif [ "$arg" == "osc" ] || [ "$arg" == "OSC" ]; then
@@ -31,19 +26,19 @@ make cli osc
 cp share/opensvc/moduleset_mariadb.svc.mrm.db.json /usr/share/replication-manager/opensvc/
 ./wait.sh replication-manager-pro;
 ./wait.sh replication-manager-osc;
-./replication-manager-osc monitor $COMMON_ARGS > /var/log/replication-manager/replication-manager.log 2>&1 &
+./replication-manager-osc monitor --plugin-signing-public-key="" --user=repman --http-root=/go/src/github.com/signal18/replication-manager/share/dashboard --monitoring-sharedir=/go/src/github.com/signal18/replication-manager/share > /var/log/replication-manager/replication-manager.log 2>&1 &
 pid="$!"
 elif [ "$arg" == "run-osc" ] || [ "$arg" == "RUN-OSC" ]; then
 ./wait.sh replication-manager-pro;
 ./wait.sh replication-manager-osc;
-./replication-manager-osc monitor $COMMON_ARGS > /var/log/replication-manager/replication-manager.log 2>&1 &
+./replication-manager-osc monitor --plugin-signing-public-key="" --user=repman --http-root=/go/src/github.com/signal18/replication-manager/share/dashboard --monitoring-sharedir=/go/src/github.com/signal18/replication-manager/share > /var/log/replication-manager/replication-manager.log 2>&1 &
 pid="$!"
 else
 make cli pro
 cp share/opensvc/moduleset_mariadb.svc.mrm.db.json /usr/share/replication-manager/opensvc/
 ./wait.sh replication-manager-pro;
 ./wait.sh replication-manager-osc;
-./replication-manager-pro monitor $COMMON_ARGS > /var/log/replication-manager/replication-manager.log 2>&1 &
+./replication-manager-pro monitor --plugin-signing-public-key="" --user=repman --http-root=/go/src/github.com/signal18/replication-manager/share/dashboard --monitoring-sharedir=/go/src/github.com/signal18/replication-manager/share > /var/log/replication-manager/replication-manager.log 2>&1 &
 pid="$!"
 fi
 echo "$pid"

--- a/docker/dev/run.sh
+++ b/docker/dev/run.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+arg="$1"
+if [ "$arg" == "v2" ] || [ "$arg" == "V2" ]; then
+make cli pro osc WITH_REACT=OFF
+cp share/opensvc/moduleset_mariadb.svc.mrm.db.json /usr/share/replication-manager/opensvc/
+./wait.sh replication-manager-pro;
+./wait.sh replication-manager-osc;
+./replication-manager-osc monitor --http-root=/go/src/github.com/signal18/replication-manager/share/dashboard --monitoring-sharedir=/go/src/github.com/signal18/replication-manager/share &
+pid="$!"
+elif [ "$arg" == "skip" ] || [ "$arg" == "SKIP" ]; then
+make cli pro WITH_REACT=OFF
+cp share/opensvc/moduleset_mariadb.svc.mrm.db.json /usr/share/replication-manager/opensvc/
+./wait.sh replication-manager-pro;
+./wait.sh replication-manager-osc;
+./replication-manager-pro monitor --user=repman --http-root=/go/src/github.com/signal18/replication-manager/share/dashboard --monitoring-sharedir=/go/src/github.com/signal18/replication-manager/share > /var/log/replication-manager/replication-manager.log 2>&1 &
+pid="$!"
+elif [ "$arg" == "run" ] || [ "$arg" == "RUN" ]; then
+./wait.sh replication-manager-pro;
+./wait.sh replication-manager-osc;
+./replication-manager-pro monitor --user=repman --http-root=/go/src/github.com/signal18/replication-manager/share/dashboard --monitoring-sharedir=/go/src/github.com/signal18/replication-manager/share > /var/log/replication-manager/replication-manager.log 2>&1 &
+pid="$!"
+
+elif [ "$arg" == "osc" ] || [ "$arg" == "OSC" ]; then
+make cli osc
+cp share/opensvc/moduleset_mariadb.svc.mrm.db.json /usr/share/replication-manager/opensvc/
+./wait.sh replication-manager-pro;
+./wait.sh replication-manager-osc;
+./replication-manager-osc monitor --plugin-signing-public-key="" --user=repman --http-root=/go/src/github.com/signal18/replication-manager/share/dashboard --monitoring-sharedir=/go/src/github.com/signal18/replication-manager/share > /var/log/replication-manager/replication-manager.log 2>&1 &
+pid="$!"
+elif [ "$arg" == "run-osc" ] || [ "$arg" == "RUN-OSC" ]; then
+./wait.sh replication-manager-pro;
+./wait.sh replication-manager-osc;
+./replication-manager-osc monitor --plugin-signing-public-key="" --user=repman --http-root=/go/src/github.com/signal18/replication-manager/share/dashboard --monitoring-sharedir=/go/src/github.com/signal18/replication-manager/share > /var/log/replication-manager/replication-manager.log 2>&1 &
+pid="$!"
+else
+make cli pro
+cp share/opensvc/moduleset_mariadb.svc.mrm.db.json /usr/share/replication-manager/opensvc/
+./wait.sh replication-manager-pro;
+./wait.sh replication-manager-osc;
+./replication-manager-pro monitor --plugin-signing-public-key="" --user=repman --http-root=/go/src/github.com/signal18/replication-manager/share/dashboard --monitoring-sharedir=/go/src/github.com/signal18/replication-manager/share > /var/log/replication-manager/replication-manager.log 2>&1 &
+pid="$!"
+fi
+echo "$pid"
+echo "$pid" > /tmp/repman.pid

--- a/docker/dev/stop.sh
+++ b/docker/dev/stop.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+kill_pid(){
+    echo "Killing PID $1 with SIGINT"
+    kill -SIGINT "$1"
+    ps aux | grep replication | grep monitor | grep -v grep
+}
+
+pid="$(ps aux | grep replication | grep monitor | grep -v grep | awk '{print $2}')"
+if [ -n "$pid" ]; then
+    kill_pid "$pid"
+else 
+    echo "No PID for repman"
+fi 
+
+exit 0

--- a/docker/dev/wait.sh
+++ b/docker/dev/wait.sh
@@ -23,7 +23,7 @@ while true; do
     fi
 
     # Process is still running, sleep before checking again
-    echo "$PROCESSES"
+    echo "$PROCESS_COUNT"
     sleep 5
 done
 

--- a/docker/dev/wait.sh
+++ b/docker/dev/wait.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Name or keyword of the process to monitor
+AppName="$1"
+
+# Check if a process name/keyword was provided
+if [ -z "$AppName" ]; then
+    echo "Usage: $0 <AppName>"
+    exit 1
+fi
+
+echo "Monitoring process: '$AppName' until it disappears..."
+
+# Loop to monitor the process
+while true; do
+    # Use ps aux and grep to search for the process, exclude the grep command itself
+    PROCESS_COUNT=$(ps aux | grep "$AppName" | grep -v grep | grep -v "wait.sh" | wc -l)
+    echo "$PROCESS_COUNT"
+    # If process count is zero, exit the loop
+    if [ "$PROCESS_COUNT" -eq 0 ]; then
+        echo "Process '$AppName' is no longer running."
+        break
+    fi
+
+    # Process is still running, sleep before checking again
+    echo "$PROCESSES"
+    sleep 5
+done
+
+echo "Done."

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -464,6 +464,11 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterSysbench)),
 	))
 
+	router.Handle("/api/clusters/{clusterName}/actions/sysbench-cleanup", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterSysbenchCleanup)),
+	))
+
 	router.Handle("/api/clusters/{clusterName}/actions/waitdatabases", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterWaitDatabases)),
@@ -6192,6 +6197,22 @@ func (repman *ReplicationManager) handlerMuxClusterSysbench(w http.ResponseWrite
 			}
 			go mycluster.RunSysbench()
 		}
+	}
+}
+
+func (repman *ReplicationManager) handlerMuxClusterSysbenchCleanup(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster != nil {
+		if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+			http.Error(w, "No valid ACL", http.StatusForbidden)
+			return
+		}
+		if r.URL.Query().Get("test") != "" {
+			mycluster.SetSysbenchTest(r.URL.Query().Get("test"))
+		}
+		go mycluster.CleanupBench()
 	}
 }
 

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -467,7 +467,7 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 	router.Handle("/api/clusters/{clusterName}/actions/sysbench-cleanup", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterSysbenchCleanup)),
-	))
+	)).Methods("POST")
 
 	router.Handle("/api/clusters/{clusterName}/actions/waitdatabases", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
@@ -6213,6 +6213,9 @@ func (repman *ReplicationManager) handlerMuxClusterSysbenchCleanup(w http.Respon
 			mycluster.SetSysbenchTest(r.URL.Query().Get("test"))
 		}
 		go mycluster.CleanupBench()
+		w.WriteHeader(http.StatusOK)
+	} else {
+		http.Error(w, "No cluster found:"+vars["clusterName"], http.StatusNotFound)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -129,6 +129,7 @@ type ReplicationManager struct {
 	GraphiteTemplateList map[string]bool             `json:"graphiteTemplateList"`
 	ServerScopeList      map[string]bool             `json:"-"`
 	currentCluster       *cluster.Cluster            `json:"-"`
+	serverGlobals        *cluster.ServerGlobals      `json:"-"`
 	IsGlobalIntervention        bool                        `json:"isGlobalIntervention"`
 	IsGlobalInterventionPending bool                        `json:"isGlobalInterventionPending"`
 	GlobalInterventionEntry     *cluster.InterventionEntry  `json:"globalInterventionEntry,omitempty"`
@@ -818,6 +819,8 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.BoolVar(&conf.SchedulerDatabaseLogs, "scheduler-db-servers-logs", false, "Schedule database logs fetching")
 	flags.BoolVar(&conf.SchedulerDatabaseOptimize, "scheduler-db-servers-optimize", false, "Schedule database optimize")
 	flags.BoolVar(&conf.SchedulerDatabaseAnalyze, "scheduler-db-servers-analyze", true, "Schedule database analyze")
+
+	flags.IntVar(&conf.BackupConcurrentSlots, "backup-concurrent-slots", 1, "Number of backup slots available across all clusters. Logical and physical backups each consume one slot. 0 = unlimited.")
 
 	flags.StringVar(&conf.BackupLogicalCron, "scheduler-db-servers-logical-backup-cron", "0 0 1 * * 6", "Logical backup cron expression represents a set of times, using 6 space-separated fields.")
 	flags.StringVar(&conf.BackupPhysicalCron, "scheduler-db-servers-physical-backup-cron", "0 0 0 * * 0-4", "Physical backup cron expression represents a set of times, using 6 space-separated fields.")
@@ -2327,6 +2330,12 @@ func (repman *ReplicationManager) Run() error {
 	repman.InitWebTTY()
 	repman.DiskStatManager = misc.NewDiskStatManager()
 
+	// Initialize instance-wide shared resources for all clusters
+	repman.serverGlobals = &cluster.ServerGlobals{}
+	if repman.Conf.BackupConcurrentSlots > 0 {
+		repman.serverGlobals.BackupSemaphore = make(chan struct{}, repman.Conf.BackupConcurrentSlots)
+	}
+
 	repman.LoadPeerJson()
 	repman.LoadPartnersJson()
 	repman.UpdateLocalPeer()
@@ -2832,6 +2841,7 @@ func (repman *ReplicationManager) initCluster(clusterName string) (*cluster.Clus
 	repman.currentCluster.WorkloadLogrus = repman.WorkloadLogrus
 	repman.currentCluster.MaintenanceLogrus = repman.MaintenanceLogrus
 	repman.currentCluster.Partner = &repman.Partner
+	repman.currentCluster.ServerGlobals = repman.serverGlobals
 	repman.currentCluster.ConfigManager = repman.ConfigManager
 
 	repman.currentCluster.CreateTemplateMD5Channel()

--- a/server/server.go
+++ b/server/server.go
@@ -2751,22 +2751,26 @@ func (repman *ReplicationManager) Run() error {
 		// processClusterQueue is blocked waiting for gitMutex — compounding the delay.
 		repman.exit.Store(true)
 
+		repman.Logrus.Info("Shutdown: unmounting S3")
 		repman.UnMountS3()
 
-		// Stop ticker goroutines.
+		repman.Logrus.Info("Shutdown: stopping ticker goroutines")
 		close(quit_GitPull)
 		close(quit_PAT)
 
+		repman.Logrus.Infof("Shutdown: stopping %d clusters", len(repman.Clusters))
 		stopwg := sync.WaitGroup{}
 		for _, cl := range repman.Clusters {
 			stopwg.Add(1)
 			go func(c *cluster.Cluster) {
 				defer stopwg.Done()
+				repman.Logrus.Infof("Shutdown: stopping cluster %s", c.Name)
 				c.Stop()
+				repman.Logrus.Infof("Shutdown: cluster %s stopped", c.Name)
 			}(cl)
 		}
-		// Wait for all cluster.Stop() calls to complete, then unblock the main goroutine.
 		stopwg.Wait()
+		repman.Logrus.Info("Shutdown: all clusters stopped")
 		close(clustersDone)
 	}()
 
@@ -3200,19 +3204,20 @@ func (repman *ReplicationManager) resolveHostIp() string {
 }
 
 func (repman *ReplicationManager) Stop() {
-
+	repman.Logrus.Info("Stop: stopping global scheduler")
 	if repman.globalScheduler != nil {
 		repman.globalScheduler.Stop()
 	}
 
+	repman.Logrus.Info("Stop: shutting down login upgrade store")
 	if repman.LoginUpgradeStore != nil {
 		repman.LoginUpgradeStore.Shutdown()
 	}
 
+	repman.Logrus.Info("Stop: shutting down HTTP servers")
 	httpCtx, httpCancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer httpCancel()
 
-	// Shut down both HTTP servers in parallel so neither consumes the other's budget.
 	var httpWg sync.WaitGroup
 	if repman.httpServer != nil {
 		httpWg.Add(1)
@@ -3233,6 +3238,7 @@ func (repman *ReplicationManager) Stop() {
 		}()
 	}
 	httpWg.Wait()
+	repman.Logrus.Info("Stop: HTTP servers stopped")
 
 	// GracefulStop waits for all in-flight RPCs; fall back to hard Stop if the
 	// deadline expires so long-lived streams don't hold up shutdown.

--- a/server/server.go
+++ b/server/server.go
@@ -2674,6 +2674,10 @@ func (repman *ReplicationManager) Run() error {
 		priorRoutesByGateway[gw] = append(priorRoutesByGateway[gw], cl.OwnGatewayRoutes(gw)...)
 	}
 
+	// Ensure per-cluster plugin dirs are symlinks to the shared dir so that
+	// locally built plugins are picked up immediately (not only after pull).
+	repman.ensurePluginSymlinksAtStartup()
+
 	// Phase 4: start monitoring goroutines after all validation is complete.
 	for _, gl := range repman.ClusterList {
 		if cl, ok := repman.Clusters[gl]; ok {

--- a/server/server_git.go
+++ b/server/server_git.go
@@ -215,6 +215,7 @@ func (repman *ReplicationManager) PushAllConfigsToGit() error {
 	repman.AddTempDirToGitignore()
 	repman.AddPluginDirToGitignore()
 	repman.AddDictTablesToGitignore()
+	addLineToGitignore(repman.Conf.WorkingDir+"/.gitignore", "*/variable-diff.json")
 
 	repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlInfo, "Pushing All Configs To Git")
 

--- a/server/server_git.go
+++ b/server/server_git.go
@@ -311,7 +311,7 @@ func (repman *ReplicationManager) PullCloud18Configs() {
 		//check all dir of the datadir to check if a new cluster has been pull by git
 		for _, f := range files {
 			new_cluster_discover := true
-			if f.IsDir() && f.Name() != "graphite" && f.Name() != "backups" && f.Name() != ".git" && f.Name() != "cloud18.toml" && !strings.Contains(f.Name(), ".json") && !strings.Contains(f.Name(), ".csv") && f.Name() != ".pull" {
+			if f.IsDir() && f.Name() != "graphite" && f.Name() != "backups" && f.Name() != ".git" && f.Name() != "cloud18.toml" && !strings.Contains(f.Name(), ".json") && !strings.Contains(f.Name(), ".csv") && f.Name() != ".pull" && f.Name() != "plugins" {
 				for name := range repman.Clusters {
 					if name == f.Name() {
 						new_cluster_discover = false
@@ -347,63 +347,122 @@ func (repman *ReplicationManager) PullCloud18Configs() {
 	}
 }
 
-// syncPluginsFromPull copies plugin binaries from the -pull git repo
-// (pullDir/{clusterName}/plugins/) into each cluster's working directory
-// (WorkingDir/{clusterName}/plugins/) and triggers a hot-reload only when
-// at least one file actually changed (MD5 comparison).
+// syncPluginsFromPull copies plugin binaries from the pull repo root
+// (pullDir/plugins/) into a shared directory (WorkingDir/plugins/) and
+// ensures each cluster's plugins/ is a symlink to that shared dir.
+//
+// On upgrade from per-cluster copies, existing real plugin directories are
+// migrated: contents are moved to the shared dir and replaced by a symlink.
 //
 // .sig files are NOT distributed via the pull repo — they are CI artifacts
 // shipped with the repman package in ShareDir/plugins/ to preserve the
 // chain of trust.
 func (repman *ReplicationManager) syncPluginsFromPull(pullDir string) {
-	for clusterName, cluster := range repman.Clusters {
-		srcDir := filepath.Join(pullDir, clusterName, logplugin.PluginDirName)
-		if _, err := os.Stat(srcDir); os.IsNotExist(err) {
-			continue
-		}
-		dstDir := logplugin.PluginDir(cluster.WorkingDir)
-		if err := os.MkdirAll(dstDir, 0755); err != nil {
-			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlErr,
-				"[logplugin] cannot create plugin dir %s: %v", dstDir, err)
-			continue
-		}
+	sharedDir := filepath.Join(repman.Conf.WorkingDir, logplugin.PluginDirName)
+	if err := os.MkdirAll(sharedDir, 0755); err != nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlErr,
+			"[logplugin] cannot create shared plugin dir %s: %v", sharedDir, err)
+		return
+	}
+
+	srcDir := filepath.Join(pullDir, logplugin.PluginDirName)
+	changed := 0
+	if info, err := os.Stat(srcDir); err == nil && info.IsDir() {
 		entries, err := os.ReadDir(srcDir)
 		if err != nil {
 			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlWarn,
 				"[logplugin] cannot read pull plugin dir %s: %v", srcDir, err)
-			continue
+		} else {
+			for _, e := range entries {
+				if e.IsDir() {
+					continue
+				}
+				src := filepath.Join(srcDir, e.Name())
+				dst := filepath.Join(sharedDir, e.Name())
+
+				if filepath.Ext(e.Name()) == "" && repman.Conf.PluginSigningPublicKey != "" {
+					sigDir := filepath.Join(repman.Conf.ShareDir, "plugins")
+					if err := logplugin.VerifyPluginSignature(src, sigDir, repman.Conf.PluginSigningPublicKey); err != nil {
+						repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlWarn,
+							"[logplugin] skipping pull plugin %s: %v", e.Name(), err)
+						continue
+					}
+				}
+
+				if gitPluginFilesEqual(src, dst) {
+					continue
+				}
+
+				if err := gitPluginCopyFile(src, dst); err != nil {
+					repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlWarn,
+						"[logplugin] failed to copy plugin file %s: %v", e.Name(), err)
+					continue
+				}
+				if filepath.Ext(e.Name()) == "" {
+					os.Chmod(dst, 0755) // #nosec G302 — plugin binaries must be executable
+				}
+				changed++
+			}
 		}
-		changed := 0
+	}
+
+	reload := changed > 0
+	for _, cluster := range repman.Clusters {
+		clusterPluginDir := logplugin.PluginDir(cluster.WorkingDir)
+		if repman.ensurePluginSymlink(clusterPluginDir, sharedDir) {
+			reload = true
+		}
+	}
+
+	if reload {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlInfo,
+			"[logplugin] synced %d changed plugin file(s) to shared dir %s", changed, sharedDir)
+		for _, cluster := range repman.Clusters {
+			cluster.ReloadLogPlugins()
+		}
+	}
+}
+
+// ensurePluginSymlink makes sure clusterPluginDir is a symlink to sharedDir.
+// If it is a real directory (pre-upgrade), its contents are moved to sharedDir
+// and the directory is replaced with a symlink. Returns true if a migration
+// or symlink creation happened.
+func (repman *ReplicationManager) ensurePluginSymlink(clusterPluginDir, sharedDir string) bool {
+	fi, err := os.Lstat(clusterPluginDir)
+	if err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return false
+	}
+
+	if err == nil && fi.IsDir() {
+		entries, _ := os.ReadDir(clusterPluginDir)
 		for _, e := range entries {
 			if e.IsDir() {
 				continue
 			}
-			src := filepath.Join(srcDir, e.Name())
-			dst := filepath.Join(dstDir, e.Name())
-
-			// Skip if destination exists and content is identical.
-			if gitPluginFilesEqual(src, dst) {
-				continue
+			src := filepath.Join(clusterPluginDir, e.Name())
+			dst := filepath.Join(sharedDir, e.Name())
+			if _, serr := os.Stat(dst); os.IsNotExist(serr) {
+				gitPluginCopyFile(src, dst)
+				if filepath.Ext(e.Name()) == "" {
+					os.Chmod(dst, 0755)
+				}
 			}
-
-			if err := gitPluginCopyFile(src, dst); err != nil {
-				repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlWarn,
-					"[logplugin] failed to copy plugin file %s: %v", e.Name(), err)
-				continue
-			}
-			// Only set executable bit on actual binaries (no extension).
-			// .pub and .sig files must not be made executable.
-			if filepath.Ext(e.Name()) == "" {
-				os.Chmod(dst, 0755) // #nosec G302 — plugin binaries must be executable
-			}
-			changed++
 		}
-		if changed > 0 {
-			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlInfo,
-				"[logplugin] synced %d changed plugin file(s) from pull repo for cluster %s", changed, clusterName)
-			cluster.ReloadLogPlugins()
-		}
+		os.RemoveAll(clusterPluginDir)
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlInfo,
+			"[logplugin] migrated %s to symlink → %s", clusterPluginDir, sharedDir)
 	}
+
+	rel, err := filepath.Rel(filepath.Dir(clusterPluginDir), sharedDir)
+	if err != nil {
+		rel = sharedDir
+	}
+	if err := os.Symlink(rel, clusterPluginDir); err != nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlErr,
+			"[logplugin] cannot create symlink %s → %s: %v", clusterPluginDir, rel, err)
+		return false
+	}
+	return true
 }
 
 // syncPluginDataFromPull copies global plugin data files from the pull repo

--- a/server/server_git.go
+++ b/server/server_git.go
@@ -380,12 +380,17 @@ func (repman *ReplicationManager) syncPluginsFromPull(pullDir string) {
 				src := filepath.Join(srcDir, e.Name())
 				dst := filepath.Join(sharedDir, e.Name())
 
-				if filepath.Ext(e.Name()) == "" && repman.Conf.PluginSigningPublicKey != "" {
-					sigDir := filepath.Join(repman.Conf.ShareDir, "plugins")
-					if err := logplugin.VerifyPluginSignature(src, sigDir, repman.Conf.PluginSigningPublicKey); err != nil {
+				if filepath.Ext(e.Name()) == "" {
+					if repman.Conf.PluginSigningPublicKey != "" {
+						sigDir := filepath.Join(repman.Conf.ShareDir, "plugins")
+						if err := logplugin.VerifyPluginSignature(src, sigDir, repman.Conf.PluginSigningPublicKey); err != nil {
+							repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlWarn,
+								"[logplugin] skipping pull plugin %s: %v", e.Name(), err)
+							continue
+						}
+					} else {
 						repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlWarn,
-							"[logplugin] skipping pull plugin %s: %v", e.Name(), err)
-						continue
+							"[logplugin] copying unsigned pull plugin %s (no public key configured)", e.Name())
 					}
 				}
 
@@ -428,35 +433,53 @@ func (repman *ReplicationManager) syncPluginsFromPull(pullDir string) {
 // and the directory is replaced with a symlink. Returns true if a migration
 // or symlink creation happened.
 func (repman *ReplicationManager) ensurePluginSymlink(clusterPluginDir, sharedDir string) bool {
-	fi, err := os.Lstat(clusterPluginDir)
-	if err == nil && fi.Mode()&os.ModeSymlink != 0 {
-		return false
-	}
-
-	if err == nil && fi.IsDir() {
-		entries, _ := os.ReadDir(clusterPluginDir)
-		for _, e := range entries {
-			if e.IsDir() {
-				continue
-			}
-			src := filepath.Join(clusterPluginDir, e.Name())
-			dst := filepath.Join(sharedDir, e.Name())
-			if _, serr := os.Stat(dst); os.IsNotExist(serr) {
-				gitPluginCopyFile(src, dst)
-				if filepath.Ext(e.Name()) == "" {
-					os.Chmod(dst, 0755)
-				}
-			}
-		}
-		os.RemoveAll(clusterPluginDir)
-		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlInfo,
-			"[logplugin] migrated %s to symlink → %s", clusterPluginDir, sharedDir)
-	}
-
 	rel, err := filepath.Rel(filepath.Dir(clusterPluginDir), sharedDir)
 	if err != nil {
 		rel = sharedDir
 	}
+
+	fi, err := os.Lstat(clusterPluginDir)
+	if err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		target, rerr := os.Readlink(clusterPluginDir)
+		if rerr == nil && target == rel {
+			return false
+		}
+		os.Remove(clusterPluginDir)
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlInfo,
+			"[logplugin] replacing stale symlink %s (was %s, want %s)", clusterPluginDir, target, rel)
+	}
+
+	if err == nil && fi.IsDir() {
+		entries, readErr := os.ReadDir(clusterPluginDir)
+		if readErr != nil {
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlWarn,
+				"[logplugin] cannot read plugin dir for migration %s: %v", clusterPluginDir, readErr)
+		} else {
+			for _, e := range entries {
+				if e.IsDir() {
+					continue
+				}
+				src := filepath.Join(clusterPluginDir, e.Name())
+				dst := filepath.Join(sharedDir, e.Name())
+				if _, serr := os.Stat(dst); os.IsNotExist(serr) {
+					if cerr := gitPluginCopyFile(src, dst); cerr != nil {
+						repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlWarn,
+							"[logplugin] migration copy failed %s: %v", e.Name(), cerr)
+					} else if filepath.Ext(e.Name()) == "" {
+						os.Chmod(dst, 0755)
+					}
+				}
+			}
+		}
+		if rerr := os.RemoveAll(clusterPluginDir); rerr != nil {
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlErr,
+				"[logplugin] cannot remove old plugin dir %s: %v — skipping symlink", clusterPluginDir, rerr)
+			return false
+		}
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlInfo,
+			"[logplugin] migrated %s to symlink → %s", clusterPluginDir, rel)
+	}
+
 	if err := os.Symlink(rel, clusterPluginDir); err != nil {
 		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModPlugin, config.LvlErr,
 			"[logplugin] cannot create symlink %s → %s: %v", clusterPluginDir, rel, err)

--- a/server/server_git.go
+++ b/server/server_git.go
@@ -465,6 +465,35 @@ func (repman *ReplicationManager) ensurePluginSymlink(clusterPluginDir, sharedDi
 	return true
 }
 
+// ensurePluginSymlinksAtStartup creates the shared plugin dir and migrates
+// existing per-cluster real plugin dirs to symlinks. Called once at startup
+// so that locally built plugins are available before the first pull sync.
+func (repman *ReplicationManager) ensurePluginSymlinksAtStartup() {
+	sharedDir := filepath.Join(repman.Conf.WorkingDir, logplugin.PluginDirName)
+	fi, err := os.Lstat(sharedDir)
+	if err != nil {
+		if err := os.MkdirAll(sharedDir, 0755); err != nil {
+			return
+		}
+	} else if fi.Mode()&os.ModeSymlink != 0 {
+		// run.sh may have already created a symlink to build/plugins/
+	} else if !fi.IsDir() {
+		return
+	}
+	migrated := false
+	for _, cluster := range repman.Clusters {
+		clusterPluginDir := logplugin.PluginDir(cluster.WorkingDir)
+		if repman.ensurePluginSymlink(clusterPluginDir, sharedDir) {
+			migrated = true
+		}
+	}
+	if migrated {
+		for _, cluster := range repman.Clusters {
+			cluster.ReloadLogPlugins()
+		}
+	}
+}
+
 // syncPluginDataFromPull copies global plugin data files from the pull repo
 // root (pullDir/plugins/data/) into ShareDir/plugins/data/.  These files are
 // instance-wide (not per-cluster) — e.g. the enterprise-security-issues.json

--- a/share/dashboard_react/src/Pages/ClustersGlobalSettings/GlobalSettings.jsx
+++ b/share/dashboard_react/src/Pages/ClustersGlobalSettings/GlobalSettings.jsx
@@ -39,6 +39,19 @@ function GlobalSettings({ config }) {
 
   const dataObject = [
     {
+      key: 'Concurrent Backup Slots',
+      value: (
+        <NumberInput
+          min={0}
+          value={config?.backupConcurrentSlots ?? 1}
+          showEditButton={true}
+          showConfirmModal={true}
+          confirmTitle={`Confirm change 'backup-concurrent-slots' to: `}
+          onConfirm={(value) => dispatch(setGlobalSetting({ setting: 'backup-concurrent-slots', value: value }))}
+        />
+      )
+    },
+    {
       key: 'Global Intervention',
       value: (
         <RMSwitch

--- a/share/dashboard_react/src/Pages/Maintenance/index.jsx
+++ b/share/dashboard_react/src/Pages/Maintenance/index.jsx
@@ -265,8 +265,8 @@ function Maintenance({ selectedCluster, user, section, onOpenBackupSettings, onO
       value: backupStats?.total_blob_count
     },
     {
-      key: 'Concurrent Backup Slots',
-      value: backupSlotsTotal > 0 ? `${backupSlotsInUse} / ${backupSlotsTotal}` : 'Unlimited'
+      key: 'Free Backup Slots',
+      value: backupSlotsTotal > 0 ? backupSlotsTotal - backupSlotsInUse : 'Unlimited'
     }
   ]
 

--- a/share/dashboard_react/src/Pages/Maintenance/index.jsx
+++ b/share/dashboard_react/src/Pages/Maintenance/index.jsx
@@ -248,6 +248,9 @@ function Maintenance({ selectedCluster, user, section, onOpenBackupSettings, onO
     }
   }, [selectedCluster?.name, resticQueue])
 
+  const backupSlotsTotal = selectedCluster?.backupSlotsTotal || 0
+  const backupSlotsInUse = selectedCluster?.backupSlotsInUse || 0
+
   const backupDataStats = [
     {
       key: 'Total Size',
@@ -260,6 +263,10 @@ function Maintenance({ selectedCluster, user, section, onOpenBackupSettings, onO
     {
       key: 'Total Blob Count',
       value: backupStats?.total_blob_count
+    },
+    {
+      key: 'Concurrent Backup Slots',
+      value: backupSlotsTotal > 0 ? `${backupSlotsInUse} / ${backupSlotsTotal}` : 'Unlimited'
     }
   ]
 

--- a/share/dashboard_react/src/components/DropdownSysbench/index.jsx
+++ b/share/dashboard_react/src/components/DropdownSysbench/index.jsx
@@ -5,7 +5,7 @@ import RMButton from '../RMButton'
 import styles from './styles.module.scss'
 import { useDispatch } from 'react-redux'
 import ConfirmModal from '../Modals/ConfirmModal'
-import { runSysBench } from '../../redux/clusterSlice'
+import { runSysBench, cleanupSysBench } from '../../redux/clusterSlice'
 
 const SYSBENCH_TESTS = [
   { name: 'oltp_read_write', value: 'oltp_read_write' },
@@ -29,6 +29,7 @@ const THREAD_OPTIONS = [
 function DropdownSysbench({ clusterName }) {
   const dispatch = useDispatch()
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false)
+  const [isCleanupConfirmOpen, setIsCleanupConfirmOpen] = useState(false)
   const [selectedThread, setSelectedThread] = useState(THREAD_OPTIONS[0])
   const [selectedTest, setSelectedTest] = useState(SYSBENCH_TESTS[0])
 
@@ -51,6 +52,9 @@ function DropdownSysbench({ clusterName }) {
       <RMButton type='button' onClick={openConfirmModal}>
         Run
       </RMButton>
+      <RMButton type='button' colorScheme='red' onClick={() => setIsCleanupConfirmOpen(true)}>
+        Cleanup
+      </RMButton>
       {isConfirmModalOpen && (
         <ConfirmModal
           isOpen={isConfirmModalOpen}
@@ -59,6 +63,17 @@ function DropdownSysbench({ clusterName }) {
             ? `Run ${selectedTest.name} scaling threads from 1 to 2×CPU cores?`
             : `Run ${selectedTest.name} with ${selectedThread.name} threads?`}
           onConfirmClick={runSysbench}
+        />
+      )}
+      {isCleanupConfirmOpen && (
+        <ConfirmModal
+          isOpen={isCleanupConfirmOpen}
+          closeModal={() => setIsCleanupConfirmOpen(false)}
+          title={`Drop ${selectedTest.name} benchmark tables?`}
+          onConfirmClick={() => {
+            dispatch(cleanupSysBench({ clusterName, test: selectedTest.value }))
+            setIsCleanupConfirmOpen(false)
+          }}
         />
       )}
     </Flex>

--- a/share/dashboard_react/src/components/Modals/AlertModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/AlertModal/index.jsx
@@ -1,6 +1,5 @@
 import {
-  Modal, ModalBody, ModalCloseButton, ModalContent, ModalHeader, ModalOverlay,
-  Table, Thead, Tbody, Tr, Th, Td, Badge, Text, Box, Link
+  Modal, ModalBody, ModalCloseButton, ModalContent, ModalHeader, ModalOverlay
 } from '@chakra-ui/react'
 import React, { useState, useEffect, useMemo } from 'react'
 import { useSelector } from 'react-redux'
@@ -11,47 +10,14 @@ import styles from './styles.module.scss'
 import parentStyles from '../styles.module.scss'
 import { useTheme } from '../../../ThemeProvider'
 
-function VariableDiffTable({ diffVariables, theme }) {
-  if (!diffVariables || diffVariables.length === 0) return <Text>No variable differences found</Text>
-  const badgeVariant = theme === 'dark' ? 'solid' : 'subtle'
-  return (
-    <Box maxH='500px' overflowY='auto'>
-      <Table size='sm' variant='simple'>
-        <Thead>
-          <Tr>
-            <Th>Variable</Th>
-            <Th>Server</Th>
-            <Th>Role</Th>
-            <Th>Value</Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          {diffVariables.map((v, i) =>
-            v.diffValues.map((d, j) => (
-              <Tr key={`${i}-${j}`}>
-                {j === 0 && <Td rowSpan={v.diffValues.length} fontWeight={600}>{v.variableName}</Td>}
-                <Td fontSize='xs'>{d.serverName}</Td>
-                <Td><Badge variant={badgeVariant} colorScheme={d.role === 'leader' ? 'blue' : 'green'} size='sm'>{d.role}</Badge></Td>
-                <Td fontFamily='mono' fontSize='xs'>{d.variableValue}</Td>
-              </Tr>
-            ))
-          )}
-        </Tbody>
-      </Table>
-    </Box>
-  )
-}
-
 function AlertModal({ type, isOpen, closeModal, alerts }) {
   const { theme } = useTheme()
   const {
-    common: { isMobile, isTablet, isDesktop },
-    cluster: { clusterAlerts, clusterData }
+    common: { isMobile, isTablet, isDesktop }
   } = useSelector((state) => state)
 
-  const source = alerts ?? clusterAlerts
+  const source = alerts ?? useSelector((state) => state.cluster.clusterAlerts)
   const [data, setData] = useState([])
-  const [showVarDiff, setShowVarDiff] = useState(false)
 
   useEffect(() => {
     if (type === 'error' && source?.errors?.length > 0) {
@@ -61,7 +27,6 @@ function AlertModal({ type, isOpen, closeModal, alerts }) {
     } else {
       setData([])
     }
-    setShowVarDiff(false)
   }, [source, type])
 
   const columnHelper = createColumnHelper()
@@ -69,18 +34,7 @@ function AlertModal({ type, isOpen, closeModal, alerts }) {
     () => [
       columnHelper.accessor((row) => row.desc, {
         id: 'desc',
-        cell: (info) => {
-          const row = info.row.original
-          const value = info.getValue()
-          if (row.number?.startsWith('WARN0084')) {
-            return (
-              <Link color='blue.400' onClick={() => setShowVarDiff(true)} cursor='pointer'>
-                {value?.replace(/,(?!\s)/g, ', ') || ''}
-              </Link>
-            )
-          }
-          return value?.replace(/,(?!\s)/g, ', ') || ''
-        },
+        cell: (info) => info.getValue()?.replace(/,(?!\s)/g, ', ') || '',
         header: () => <span>Description</span>
       }),
       columnHelper.accessor((row) => row.from, {
@@ -99,50 +53,37 @@ function AlertModal({ type, isOpen, closeModal, alerts }) {
     []
   )
   return (
-    <>
-      <Modal isOpen={isOpen} onClose={closeModal}>
-        <ModalOverlay />
-        <ModalContent
-          className={theme === 'light' ? parentStyles.modalLightContent : parentStyles.modalDarkContent}
-          width={isDesktop ? '80%' : isTablet ? '97%' : '99%'}
-          maxWidth='none'
-          minHeight={'300px'}
-          maxH={'90%'}
-          textAlign='center'
-          overflow='hidden'>
-          <ModalHeader
-            whiteSpace='pre-line'
-            className={`${styles.header} ${type === 'error' ? styles.red : styles.orange}`}>
-            {type === 'error' ? `Errors: ${data.length}` : `Warnings: ${data.length}`}
-          </ModalHeader>
-          <ModalCloseButton />
-          <ModalBody className={styles.body}>
-            {data.length === 0 ? (
-              <NotFound text={`No ${type} alerts found`} />
-            ) : (
-              <DataTable
-                key="Alerts"
-                className={`${styles.table}  ${type === 'error' ? styles.red : styles.orange}`}
-                columns={columns}
-                data={data}
-                cellValueAlign='start'
-              />
-            )}
-          </ModalBody>
-        </ModalContent>
-      </Modal>
-
-      <Modal isOpen={showVarDiff} onClose={() => setShowVarDiff(false)} size='xl'>
-        <ModalOverlay />
-        <ModalContent className={theme === 'light' ? parentStyles.modalLightContent : parentStyles.modalDarkContent} maxW='800px'>
-          <ModalHeader fontSize='md'>Variable Differences — Leader vs Replicas</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody pb={6}>
-            <VariableDiffTable diffVariables={clusterData?.diffVariables} theme={theme} />
-          </ModalBody>
-        </ModalContent>
-      </Modal>
-    </>
+    <Modal isOpen={isOpen} onClose={closeModal}>
+      <ModalOverlay />
+      <ModalContent
+        className={theme === 'light' ? parentStyles.modalLightContent : parentStyles.modalDarkContent}
+        width={isDesktop ? '80%' : isTablet ? '97%' : '99%'}
+        maxWidth='none'
+        minHeight={'300px'}
+        maxH={'90%'}
+        textAlign='center'
+        overflow='hidden'>
+        <ModalHeader
+          whiteSpace='pre-line'
+          className={`${styles.header} ${type === 'error' ? styles.red : styles.orange}`}>
+          {type === 'error' ? `Errors: ${data.length}` : `Warnings: ${data.length}`}
+        </ModalHeader>
+        <ModalCloseButton />
+        <ModalBody className={styles.body}>
+          {data.length === 0 ? (
+            <NotFound text={`No ${type} alerts found`} />
+          ) : (
+            <DataTable
+              key="Alerts"
+              className={`${styles.table}  ${type === 'error' ? styles.red : styles.orange}`}
+              columns={columns}
+              data={data}
+              cellValueAlign='start'
+            />
+          )}
+        </ModalBody>
+      </ModalContent>
+    </Modal>
   )
 }
 

--- a/share/dashboard_react/src/components/Modals/AlertModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/AlertModal/index.jsx
@@ -72,7 +72,7 @@ function AlertModal({ type, isOpen, closeModal, alerts }) {
         cell: (info) => {
           const row = info.row.original
           const value = info.getValue()
-          if (row.number === 'WARN0084') {
+          if (row.number?.startsWith('WARN0084')) {
             return (
               <Link color='blue.400' onClick={() => setShowVarDiff(true)} cursor='pointer'>
                 {value?.replace(/,(?!\s)/g, ', ') || ''}
@@ -91,7 +91,7 @@ function AlertModal({ type, isOpen, closeModal, alerts }) {
       }),
       columnHelper.accessor((row) => row.number, {
         id: 'number',
-        cell: (info) => info.getValue(),
+        cell: (info) => (info.getValue() || '').split('@')[0],
         header: () => <span>Number</span>,
         maxWidth: '200'
       })

--- a/share/dashboard_react/src/components/Modals/AlertModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/AlertModal/index.jsx
@@ -1,4 +1,7 @@
-import { Modal, ModalBody, ModalCloseButton, ModalContent, ModalHeader, ModalOverlay } from '@chakra-ui/react'
+import {
+  Modal, ModalBody, ModalCloseButton, ModalContent, ModalHeader, ModalOverlay,
+  Table, Thead, Tbody, Tr, Th, Td, Badge, Text, Box, Link
+} from '@chakra-ui/react'
 import React, { useState, useEffect, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import NotFound from '../../NotFound'
@@ -8,16 +11,47 @@ import styles from './styles.module.scss'
 import parentStyles from '../styles.module.scss'
 import { useTheme } from '../../../ThemeProvider'
 
+function VariableDiffTable({ diffVariables, theme }) {
+  if (!diffVariables || diffVariables.length === 0) return <Text>No variable differences found</Text>
+  const badgeVariant = theme === 'dark' ? 'solid' : 'subtle'
+  return (
+    <Box maxH='500px' overflowY='auto'>
+      <Table size='sm' variant='simple'>
+        <Thead>
+          <Tr>
+            <Th>Variable</Th>
+            <Th>Server</Th>
+            <Th>Role</Th>
+            <Th>Value</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {diffVariables.map((v, i) =>
+            v.diffValues.map((d, j) => (
+              <Tr key={`${i}-${j}`}>
+                {j === 0 && <Td rowSpan={v.diffValues.length} fontWeight={600}>{v.variableName}</Td>}
+                <Td fontSize='xs'>{d.serverName}</Td>
+                <Td><Badge variant={badgeVariant} colorScheme={d.role === 'leader' ? 'blue' : 'green'} size='sm'>{d.role}</Badge></Td>
+                <Td fontFamily='mono' fontSize='xs'>{d.variableValue}</Td>
+              </Tr>
+            ))
+          )}
+        </Tbody>
+      </Table>
+    </Box>
+  )
+}
+
 function AlertModal({ type, isOpen, closeModal, alerts }) {
   const { theme } = useTheme()
   const {
     common: { isMobile, isTablet, isDesktop },
-    cluster: { clusterAlerts }
+    cluster: { clusterAlerts, clusterData }
   } = useSelector((state) => state)
 
   const source = alerts ?? clusterAlerts
-
   const [data, setData] = useState([])
+  const [showVarDiff, setShowVarDiff] = useState(false)
 
   useEffect(() => {
     if (type === 'error' && source?.errors?.length > 0) {
@@ -27,6 +61,7 @@ function AlertModal({ type, isOpen, closeModal, alerts }) {
     } else {
       setData([])
     }
+    setShowVarDiff(false)
   }, [source, type])
 
   const columnHelper = createColumnHelper()
@@ -35,8 +70,15 @@ function AlertModal({ type, isOpen, closeModal, alerts }) {
       columnHelper.accessor((row) => row.desc, {
         id: 'desc',
         cell: (info) => {
+          const row = info.row.original
           const value = info.getValue()
-          // Add space after comma if not present
+          if (row.number === 'WARN0084') {
+            return (
+              <Link color='blue.400' onClick={() => setShowVarDiff(true)} cursor='pointer'>
+                {value?.replace(/,(?!\s)/g, ', ') || ''}
+              </Link>
+            )
+          }
           return value?.replace(/,(?!\s)/g, ', ') || ''
         },
         header: () => <span>Description</span>
@@ -57,37 +99,50 @@ function AlertModal({ type, isOpen, closeModal, alerts }) {
     []
   )
   return (
-    <Modal isOpen={isOpen} onClose={closeModal}>
-      <ModalOverlay />
-      <ModalContent
-        className={theme === 'light' ? parentStyles.modalLightContent : parentStyles.modalDarkContent}
-        width={isDesktop ? '80%' : isTablet ? '97%' : '99%'}
-        maxWidth='none'
-        minHeight={'300px'}
-        maxH={'90%'}
-        textAlign='center'
-        overflow='hidden'>
-        <ModalHeader
-          whiteSpace='pre-line'
-          className={`${styles.header} ${type === 'error' ? styles.red : styles.orange}`}>
-          {type === 'error' ? `Errors: ${data.length}` : `Warnings: ${data.length}`}
-        </ModalHeader>
-        <ModalCloseButton />
-        <ModalBody className={styles.body}>
-          {data.length === 0 ? (
-            <NotFound text={`No ${type} alerts found`} />
-          ) : (
-            <DataTable
-              key="Alerts"
-              className={`${styles.table}  ${type === 'error' ? styles.red : styles.orange}`}
-              columns={columns}
-              data={data}
-              cellValueAlign='start'
-            />
-          )}
-        </ModalBody>
-      </ModalContent>
-    </Modal>
+    <>
+      <Modal isOpen={isOpen} onClose={closeModal}>
+        <ModalOverlay />
+        <ModalContent
+          className={theme === 'light' ? parentStyles.modalLightContent : parentStyles.modalDarkContent}
+          width={isDesktop ? '80%' : isTablet ? '97%' : '99%'}
+          maxWidth='none'
+          minHeight={'300px'}
+          maxH={'90%'}
+          textAlign='center'
+          overflow='hidden'>
+          <ModalHeader
+            whiteSpace='pre-line'
+            className={`${styles.header} ${type === 'error' ? styles.red : styles.orange}`}>
+            {type === 'error' ? `Errors: ${data.length}` : `Warnings: ${data.length}`}
+          </ModalHeader>
+          <ModalCloseButton />
+          <ModalBody className={styles.body}>
+            {data.length === 0 ? (
+              <NotFound text={`No ${type} alerts found`} />
+            ) : (
+              <DataTable
+                key="Alerts"
+                className={`${styles.table}  ${type === 'error' ? styles.red : styles.orange}`}
+                columns={columns}
+                data={data}
+                cellValueAlign='start'
+              />
+            )}
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+
+      <Modal isOpen={showVarDiff} onClose={() => setShowVarDiff(false)} size='xl'>
+        <ModalOverlay />
+        <ModalContent className={theme === 'light' ? parentStyles.modalLightContent : parentStyles.modalDarkContent} maxW='800px'>
+          <ModalHeader fontSize='md'>Variable Differences — Leader vs Replicas</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody pb={6}>
+            <VariableDiffTable diffVariables={clusterData?.diffVariables} theme={theme} />
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+    </>
   )
 }
 

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -1602,6 +1602,18 @@ export const runSysBench = createGuardedAsyncThunk('cluster/runSysBench', async 
   }
 })
 
+export const cleanupSysBench = createGuardedAsyncThunk('cluster/cleanupSysBench', async ({ clusterName, test }, thunkAPI) => {
+  try {
+    const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+    const { data, status } = await clusterService.cleanupSysbench(clusterName, test, baseURL)
+    showSuccessBanner('Sysbench cleanup completed!', status, thunkAPI)
+    return { data, status }
+  } catch (error) {
+    showErrorBanner('Sysbench cleanup failed!', error, thunkAPI)
+    return handleError(error, thunkAPI)
+  }
+})
+
 export const runRegressionTests = createGuardedAsyncThunk(
   'cluster/runRegressionTests',
   async ({ clusterName, testName }, thunkAPI) => {

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -701,7 +701,7 @@ function runSysbench(clusterName, threads, baseURL, test) {
 
 function cleanupSysbench(clusterName, test, baseURL) {
   const params = test ? `?test=${test}` : ''
-  return getApi(baseURL).get(`clusters/${clusterName}/actions/sysbench-cleanup${params}`)
+  return getApi(baseURL).post(`clusters/${clusterName}/actions/sysbench-cleanup${params}`)
 }
 
 function runRegressionTests(clusterName, testName, baseURL) {

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -140,6 +140,7 @@ export const clusterService = {
 
   // Test run APIs
   runSysbench,
+  cleanupSysbench,
   getSysbenchHistory,
   runRegressionTests,
 
@@ -696,6 +697,11 @@ function monitorAllSchemas(clusterName, baseURL) {
 function runSysbench(clusterName, threads, baseURL, test) {
   const params = `threads=${threads}` + (test ? `&test=${test}` : '')
   return getApi(baseURL).get(`clusters/${clusterName}/actions/sysbench?${params}`)
+}
+
+function cleanupSysbench(clusterName, test, baseURL) {
+  const params = test ? `?test=${test}` : ''
+  return getApi(baseURL).get(`clusters/${clusterName}/actions/sysbench-cleanup${params}`)
 }
 
 function runRegressionTests(clusterName, testName, baseURL) {


### PR DESCRIPTION
## Summary

- **Global backup concurrency limiter**: prevents all clusters from running backups simultaneously, configurable via `backup-max-concurrent`
- **Dev container improvements**: symlinks for helper scripts, auto-start repman, tpcc lua scripts copy, bashrc-based setup surviving volume mounts
- **Plugin shared directory**: replace per-cluster plugin binary copies with a single shared dir (`WorkingDir/plugins/`) and per-cluster symlinks. Includes upgrade migration from real dirs to symlinks
- **Plugin signature gate**: `syncPluginsFromPull` verifies plugin signatures before copying from pull repo, blocking BO-delivered binaries that don't match local .sig files (dev key gates out CI-signed plugins)
- **WARN0084 variable diff**: clickable alert opens modal with variable diff table showing roles, file persistence, and short messages

## Test plan

- [ ] Dev container: `run.sh` creates `/var/lib/replication-manager/plugins` → `build/plugins/` symlink
- [ ] Dev container: after `make`, all cluster plugins load from locally built binaries (no signature errors)
- [ ] Dev container: BO-delivered plugins in pull repo are rejected by signature check (WARN log)
- [ ] Upgrade path: existing real per-cluster `plugins/` dirs are migrated to symlinks on first pull sync
- [ ] `WorkingDir/plugins/` dir is not mistaken for a new cluster
- [ ] Backup concurrency limiter caps concurrent backups across clusters
- [ ] WARN0084 modal displays variable diffs correctly