### PR TITLE
feat(restic): add archive backend selector and SFTP support

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -705,6 +705,7 @@ func (cluster *Cluster) InitFromConf() {
 	cluster.initScheduler()
 	cluster.CheckDefaultUser(true)
 	cluster.RefreshToolVersions()
+	cluster.initResticLocalDir()
 	cluster.StartResticManager()
 
 	cluster.Conf.TopologyTarget = cluster.GetTopologyFromConf()

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -450,6 +450,7 @@ func (cluster *Cluster) Init(confs *config.ConfVersion, cfgGroup string, tlog *s
 	go cluster.ConsumeMessageChan()
 
 	*cluster.Conf = confs.ConfInit
+	cluster.Conf.NormalizeBackupArchiveMode()
 
 	cluster.tlog = tlog
 	cluster.htlog = loghttp

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -34,14 +34,6 @@ var splitDumpTimestampRegex = regexp.MustCompile(`^\d+$`)
 // sftp:[user@]host:path, e.g. sftp:backup@10.0.0.1:/srv/restic-repo
 var resticSftpRepoRegex = regexp.MustCompile(`^sftp:[^:@\s]+(@[^:@\s]+)?:.+$`)
 
-func isS3ResticRepository(repoPath string) bool {
-	return strings.HasPrefix(strings.TrimSpace(repoPath), "s3:")
-}
-
-func isSftpResticRepository(repoPath string) bool {
-	return strings.HasPrefix(strings.TrimSpace(repoPath), "sftp:")
-}
-
 // ValidateResticSftpRepository checks that repoPath matches the
 // sftp:[user@]host:/path syntax expected by restic's sftp backend, so a
 // malformed value is rejected with a clear error instead of an opaque
@@ -310,7 +302,7 @@ func filterResticEnv(cluster *Cluster, baseEnv []string, repoPath, password, cac
 		overrides = make(map[string]string)
 		allowlist = make(map[string]struct{})
 	}
-	isS3 := isS3ResticRepository(repoPath)
+	isS3 := config.IsS3ResticRepository(repoPath)
 	defaultRegion := ""
 	optionalAwsEnv := make(map[string]string)
 	// Reserved env vars cannot be overridden via backup-restic-additional-env.
@@ -435,7 +427,7 @@ func (cluster *Cluster) ResticGetEnv() []string {
 		} else {
 			repoPath = filepath.Join(cluster.Conf.WorkingDir, config.ConstStreamingSubDir, "archive", cluster.Name)
 		}
-		if !isSftpResticRepository(repoPath) {
+		if !config.IsSftpResticRepository(repoPath) {
 			if _, err := os.Stat(repoPath); os.IsNotExist(err) {
 				err := os.MkdirAll(repoPath, os.ModePerm)
 				if err != nil {

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -34,6 +34,10 @@ func isS3ResticRepository(repoPath string) bool {
 	return strings.HasPrefix(strings.TrimSpace(repoPath), "s3:")
 }
 
+func isSftpResticRepository(repoPath string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(repoPath)), "sftp:")
+}
+
 func buildResticS3RepoSpec(endpoint, bucket, prefix, clusterName string, appendCluster bool) (string, string) {
 	bucket = strings.TrimSpace(bucket)
 	prefix = strings.Trim(prefix, "/")
@@ -415,10 +419,12 @@ func (cluster *Cluster) ResticGetEnv() []string {
 		} else {
 			repoPath = filepath.Join(cluster.Conf.WorkingDir, config.ConstStreamingSubDir, "archive", cluster.Name)
 		}
-		if _, err := os.Stat(repoPath); os.IsNotExist(err) {
-			err := os.MkdirAll(repoPath, os.ModePerm)
-			if err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Create archive directory failed: %s,%s", repoPath, err)
+		if !isSftpResticRepository(repoPath) {
+			if _, err := os.Stat(repoPath); os.IsNotExist(err) {
+				err := os.MkdirAll(repoPath, os.ModePerm)
+				if err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Create archive directory failed: %s,%s", repoPath, err)
+				}
 			}
 		}
 	}

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -30,12 +30,28 @@ import (
 
 var splitDumpTimestampRegex = regexp.MustCompile(`^\d+$`)
 
+// resticSftpRepoRegex matches the restic sftp backend repository syntax,
+// sftp:[user@]host:path, e.g. sftp:backup@10.0.0.1:/srv/restic-repo
+var resticSftpRepoRegex = regexp.MustCompile(`^sftp:[^:@\s]+(@[^:@\s]+)?:.+$`)
+
 func isS3ResticRepository(repoPath string) bool {
 	return strings.HasPrefix(strings.TrimSpace(repoPath), "s3:")
 }
 
 func isSftpResticRepository(repoPath string) bool {
-	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(repoPath)), "sftp:")
+	return strings.HasPrefix(strings.TrimSpace(repoPath), "sftp:")
+}
+
+// ValidateResticSftpRepository checks that repoPath matches the
+// sftp:[user@]host:/path syntax expected by restic's sftp backend, so a
+// malformed value is rejected with a clear error instead of an opaque
+// restic failure.
+func ValidateResticSftpRepository(repoPath string) error {
+	repoPath = strings.TrimSpace(repoPath)
+	if !resticSftpRepoRegex.MatchString(repoPath) {
+		return config.NewValidationError("backup-restic-local-repository", repoPath, "expected sftp:[user@]host:/path")
+	}
+	return nil
 }
 
 func buildResticS3RepoSpec(endpoint, bucket, prefix, clusterName string, appendCluster bool) (string, string) {

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -1613,14 +1613,27 @@ func (cluster *Cluster) GetVaultToken() {
 	}
 }
 
+// GetResticLocalDir returns a local filesystem directory to use for disk usage
+// checks ahead of a restic backup. For non-local repositories (s3:, sftp:),
+// backup-restic-local-repository holds the remote spec rather than a local
+// path, so the default per-cluster archive directory is used instead.
 func (cluster *Cluster) GetResticLocalDir() string {
-	if cluster.Conf.BackupResticLocalRepository != "" {
-		return cluster.Conf.BackupResticLocalRepository // To support sftp repository e.g. sftp:user@host:/path/to/repo
+	repo := strings.TrimSpace(cluster.Conf.BackupResticLocalRepository)
+	if repo != "" && !isSftpResticRepository(repo) && !isS3ResticRepository(repo) {
+		return repo
 	}
 
-	// Persist the restic local repo path to prevent wrong paths if WorkingDir change during runtime
-	cluster.Conf.BackupResticLocalRepository = cluster.Conf.WorkingDir + "/" + config.ConstStreamingSubDir + "/archive/" + cluster.Name
-	return cluster.Conf.BackupResticLocalRepository
+	defaultDir := cluster.Conf.WorkingDir + "/" + config.ConstStreamingSubDir + "/archive/" + cluster.Name
+	if repo == "" {
+		// Persist the restic local repo path to prevent wrong paths if WorkingDir change during runtime
+		cluster.Conf.BackupResticLocalRepository = defaultDir
+	}
+	if _, err := os.Stat(defaultDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(defaultDir, os.ModePerm); err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Create archive directory failed: %s,%s", defaultDir, err)
+		}
+	}
+	return defaultDir
 }
 
 func (cluster *Cluster) GetExecEnv() []string {

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -1613,14 +1613,17 @@ func (cluster *Cluster) GetVaultToken() {
 	}
 }
 
-// GetResticLocalDir returns a local filesystem directory to use for disk usage
-// checks ahead of a restic backup. For non-local repositories (s3:, sftp:),
-// backup-restic-local-repository holds the remote spec rather than a local
-// path, so the default per-cluster archive directory is used instead.
-func (cluster *Cluster) GetResticLocalDir() string {
-	repo := strings.TrimSpace(cluster.Conf.BackupResticLocalRepository)
-	if repo != "" && !isSftpResticRepository(repo) && !isS3ResticRepository(repo) {
-		return repo
+// initResticLocalDir resolves the default local restic archive directory used
+// for disk usage checks ahead of a restic backup and, when no repository has
+// been configured, persists it into BackupResticLocalRepository so later
+// WorkingDir changes don't shift the configured path. It also ensures the
+// directory exists on disk. This is called once from InitFromConf() at
+// startup; GetResticLocalDir is a pure read and can be called repeatedly
+// afterwards without side effects.
+func (cluster *Cluster) initResticLocalDir() {
+	repo := cluster.Conf.BackupResticLocalRepository
+	if repo != "" && !config.IsSftpResticRepository(repo) && !config.IsS3ResticRepository(repo) {
+		return
 	}
 
 	defaultDir := cluster.Conf.WorkingDir + "/" + config.ConstStreamingSubDir + "/archive/" + cluster.Name
@@ -1633,7 +1636,20 @@ func (cluster *Cluster) GetResticLocalDir() string {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Create archive directory failed: %s,%s", defaultDir, err)
 		}
 	}
-	return defaultDir
+}
+
+// GetResticLocalDir returns a local filesystem directory to use for disk usage
+// checks ahead of a restic backup. For non-local repositories (s3:, sftp:),
+// backup-restic-local-repository holds the remote spec rather than a local
+// path, so the default per-cluster archive directory is returned instead.
+// This is a pure read; initResticLocalDir performs the one-time directory
+// creation and config persistence during startup.
+func (cluster *Cluster) GetResticLocalDir() string {
+	repo := cluster.Conf.BackupResticLocalRepository
+	if repo != "" && !config.IsSftpResticRepository(repo) && !config.IsS3ResticRepository(repo) {
+		return repo
+	}
+	return cluster.Conf.WorkingDir + "/" + config.ConstStreamingSubDir + "/archive/" + cluster.Name
 }
 
 func (cluster *Cluster) GetExecEnv() []string {

--- a/cluster/cluster_tgl.go
+++ b/cluster/cluster_tgl.go
@@ -159,6 +159,10 @@ func (cluster *Cluster) SetBackupArchiveMode(mode string) error {
 	cluster.CheckResticInstallation()
 	if cluster.ResticManager == nil {
 		cluster.StartResticManager()
+	} else {
+		// Repository backend/path may have changed, drop the stale snapshot
+		// list and stats until the next fetch against the new repository.
+		cluster.ResticManager.ClearSnapshotList()
 	}
 	cluster.ReloadResticEnv()
 	return nil

--- a/cluster/cluster_tgl.go
+++ b/cluster/cluster_tgl.go
@@ -149,6 +149,21 @@ func (cluster *Cluster) SwitchBackupResticAws() {
 	cluster.ReloadResticEnv()
 }
 
+// SetBackupArchiveMode sets the canonical backup-archive-mode (none, restic-local,
+// restic-aws, restic-sftp), deriving backup-restic / backup-restic-aws, and
+// applies the same side effects as toggling those legacy switches.
+func (cluster *Cluster) SetBackupArchiveMode(mode string) error {
+	if err := cluster.Conf.ApplyBackupArchiveMode(mode); err != nil {
+		return err
+	}
+	cluster.CheckResticInstallation()
+	if cluster.ResticManager == nil {
+		cluster.StartResticManager()
+	}
+	cluster.ReloadResticEnv()
+	return nil
+}
+
 func (cluster *Cluster) SwitchBackupBinlogs() {
 	cluster.Conf.BackupBinlogs = !cluster.Conf.BackupBinlogs
 	if cluster.Conf.BackupBinlogs {

--- a/cluster/cluster_tgl.go
+++ b/cluster/cluster_tgl.go
@@ -135,18 +135,28 @@ func (cluster *Cluster) SwitchProvDockerDaemonPrivate() {
 	cluster.Conf.ProvDockerDaemonPrivate = !cluster.Conf.ProvDockerDaemonPrivate
 }
 
+// SwitchBackupRestic toggles the legacy backup-restic flag, mapping the
+// resulting (backup-restic, backup-restic-aws) combination to its canonical
+// backup-archive-mode and applying it via SetBackupArchiveMode so the two
+// representations never drift out of sync.
 func (cluster *Cluster) SwitchBackupRestic() {
-	cluster.Conf.BackupRestic = !cluster.Conf.BackupRestic
-	cluster.CheckResticInstallation()
-	if cluster.ResticManager == nil {
-		cluster.StartResticManager()
+	newBackupRestic := !cluster.Conf.BackupRestic
+	mode := cluster.Conf.DeriveBackupArchiveModeFromFlags(newBackupRestic, cluster.Conf.BackupResticAws)
+	if err := cluster.SetBackupArchiveMode(mode); err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Failed to switch backup-restic to mode %s: %s", mode, err)
 	}
-	cluster.ReloadResticEnv()
 }
 
+// SwitchBackupResticAws toggles the legacy backup-restic-aws flag, mapping the
+// resulting (backup-restic, backup-restic-aws) combination to its canonical
+// backup-archive-mode and applying it via SetBackupArchiveMode so the two
+// representations never drift out of sync.
 func (cluster *Cluster) SwitchBackupResticAws() {
-	cluster.Conf.BackupResticAws = !cluster.Conf.BackupResticAws
-	cluster.ReloadResticEnv()
+	newBackupResticAws := !cluster.Conf.BackupResticAws
+	mode := cluster.Conf.DeriveBackupArchiveModeFromFlags(cluster.Conf.BackupRestic, newBackupResticAws)
+	if err := cluster.SetBackupArchiveMode(mode); err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Failed to switch backup-restic-aws to mode %s: %s", mode, err)
+	}
 }
 
 // SetBackupArchiveMode sets the canonical backup-archive-mode (none, restic-local,

--- a/cluster/cluster_tgl_test.go
+++ b/cluster/cluster_tgl_test.go
@@ -1,0 +1,92 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/backupmgr"
+	"github.com/signal18/replication-manager/utils/version"
+)
+
+// newArchiveModeTestCluster builds a minimal Cluster sufficient to exercise
+// SetBackupArchiveMode's side effects (CheckResticInstallation,
+// StartResticManager/ClearSnapshotList, ReloadResticEnv) without touching a
+// real restic binary. The "restic" entry in VersionsMap makes
+// CheckResticInstallation skip RefreshResticVersion, which would otherwise
+// shell out to backup-restic-binary-path.
+func newArchiveModeTestCluster(t *testing.T) *Cluster {
+	cluster := &Cluster{
+		Name: "cluster1",
+		Conf: &config.Config{
+			WorkingDir: t.TempDir(),
+		},
+		VersionsMap: config.NewVersionsMap(),
+	}
+	v, _ := version.NewVersion("restic", 0, 17, 0)
+	cluster.VersionsMap.Set("restic", v)
+	return cluster
+}
+
+// TestSetBackupArchiveModeNoneToResticSftp covers the none -> restic-sftp
+// transition, which flips backup-restic on while ResticManager is still nil,
+// so SetBackupArchiveMode must take the StartResticManager branch.
+func TestSetBackupArchiveModeNoneToResticSftp(t *testing.T) {
+	cluster := newArchiveModeTestCluster(t)
+	cluster.Conf.BackupArchiveMode = config.ConstBackupArchiveModeNone
+	cluster.Conf.BackupResticLocalRepository = "sftp:backup@10.0.0.1:/srv/restic-repo"
+
+	if err := cluster.SetBackupArchiveMode(config.ConstBackupArchiveModeResticSftp); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cluster.Conf.BackupArchiveMode != config.ConstBackupArchiveModeResticSftp {
+		t.Fatalf("BackupArchiveMode = %q, want %q", cluster.Conf.BackupArchiveMode, config.ConstBackupArchiveModeResticSftp)
+	}
+	if !cluster.Conf.BackupRestic {
+		t.Fatalf("expected BackupRestic=true")
+	}
+	if cluster.Conf.BackupResticAws {
+		t.Fatalf("expected BackupResticAws=false")
+	}
+	if cluster.ResticManager == nil {
+		t.Fatalf("expected StartResticManager to set ResticManager")
+	}
+}
+
+// TestSetBackupArchiveModeResticLocalToNone covers the restic-local -> none
+// transition, which flips backup-restic off while a ResticManager already
+// exists, so SetBackupArchiveMode must take the ClearSnapshotList branch
+// rather than replacing the manager via StartResticManager.
+func TestSetBackupArchiveModeResticLocalToNone(t *testing.T) {
+	cluster := newArchiveModeTestCluster(t)
+	cluster.Conf.BackupArchiveMode = config.ConstBackupArchiveModeResticLocal
+	cluster.Conf.BackupRestic = true
+
+	existingManager := backupmgr.NewResticRepo("", nil, config.ConstLogModRestic)
+	existingManager.UpdateSnapshotList([]backupmgr.BackupSnapshot{{Id: "snap-1"}})
+	cluster.ResticManager = existingManager
+
+	if err := cluster.SetBackupArchiveMode(config.ConstBackupArchiveModeNone); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cluster.Conf.BackupArchiveMode != config.ConstBackupArchiveModeNone {
+		t.Fatalf("BackupArchiveMode = %q, want %q", cluster.Conf.BackupArchiveMode, config.ConstBackupArchiveModeNone)
+	}
+	if cluster.Conf.BackupRestic {
+		t.Fatalf("expected BackupRestic=false")
+	}
+	if cluster.Conf.BackupResticAws {
+		t.Fatalf("expected BackupResticAws=false")
+	}
+	if cluster.ResticManager != existingManager {
+		t.Fatalf("expected existing ResticManager to be reused, not replaced")
+	}
+	if len(cluster.ResticManager.Backups) != 0 {
+		t.Fatalf("expected ClearSnapshotList to clear snapshots, got %d", len(cluster.ResticManager.Backups))
+	}
+}

--- a/config/backup_archive_mode_test.go
+++ b/config/backup_archive_mode_test.go
@@ -1,0 +1,201 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+
+package config
+
+import "testing"
+
+func TestIsS3ResticRepository(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"s3 prefix", "s3:bucket/path", true},
+		{"uppercase scheme is not matched", "S3:bucket/path", false},
+		{"sftp prefix", "sftp:user@host:/path", false},
+		{"local path", "/var/backups/restic", false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsS3ResticRepository(tt.path); got != tt.want {
+				t.Errorf("IsS3ResticRepository(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSftpResticRepository(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"sftp prefix", "sftp:user@host:/path", true},
+		{"uppercase scheme is not matched", "SFTP:user@host:/path", false},
+		{"s3 prefix", "s3:bucket/path", false},
+		{"local path", "/var/backups/restic", false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSftpResticRepository(tt.path); got != tt.want {
+				t.Errorf("IsSftpResticRepository(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeBackupArchiveMode(t *testing.T) {
+	tests := []struct {
+		name string
+		conf Config
+		// expected results after NormalizeBackupArchiveMode
+		wantMode      string
+		wantRestic    bool
+		wantResAws    bool
+		wantLocalRepo string
+	}{
+		{
+			name: "invalid mode with legacy flags unset migrates to none",
+			conf: Config{
+				BackupArchiveMode: "not-a-real-mode",
+			},
+			wantMode:   ConstBackupArchiveModeNone,
+			wantRestic: false,
+			wantResAws: false,
+		},
+		{
+			name: "empty mode with backup-restic-aws migrates to restic-aws",
+			conf: Config{
+				BackupArchiveMode: "",
+				BackupRestic:      true,
+				BackupResticAws:   true,
+			},
+			wantMode:   ConstBackupArchiveModeResticAws,
+			wantRestic: true,
+			wantResAws: true,
+		},
+		{
+			name: "none with legacy backup-restic=true and sftp local repo migrates to restic-sftp",
+			conf: Config{
+				BackupArchiveMode:           ConstBackupArchiveModeNone,
+				BackupRestic:                true,
+				BackupResticAws:             false,
+				BackupResticLocalRepository: "sftp:backup@10.0.0.1:/srv/restic-repo",
+			},
+			wantMode:      ConstBackupArchiveModeResticSftp,
+			wantRestic:    true,
+			wantResAws:    false,
+			wantLocalRepo: "sftp:backup@10.0.0.1:/srv/restic-repo",
+		},
+		{
+			name: "none with legacy backup-restic=true and no sftp prefix migrates to restic-local",
+			conf: Config{
+				BackupArchiveMode:           ConstBackupArchiveModeNone,
+				BackupRestic:                true,
+				BackupResticAws:             false,
+				BackupResticLocalRepository: "/var/lib/replication-manager/archive",
+			},
+			wantMode:   ConstBackupArchiveModeResticLocal,
+			wantRestic: true,
+			wantResAws: false,
+		},
+		{
+			name: "valid mode is left untouched and resyncs legacy flags",
+			conf: Config{
+				BackupArchiveMode: ConstBackupArchiveModeResticLocal,
+				BackupRestic:      false,
+				BackupResticAws:   true,
+			},
+			wantMode:   ConstBackupArchiveModeResticLocal,
+			wantRestic: true,
+			wantResAws: false,
+		},
+		{
+			name: "backup-restic-local-repository is trimmed",
+			conf: Config{
+				BackupArchiveMode:           ConstBackupArchiveModeNone,
+				BackupRestic:                true,
+				BackupResticLocalRepository: "  sftp:backup@10.0.0.1:/srv/restic-repo  ",
+			},
+			wantMode:      ConstBackupArchiveModeResticSftp,
+			wantRestic:    true,
+			wantResAws:    false,
+			wantLocalRepo: "sftp:backup@10.0.0.1:/srv/restic-repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := tt.conf
+			conf.NormalizeBackupArchiveMode()
+
+			if conf.BackupArchiveMode != tt.wantMode {
+				t.Errorf("BackupArchiveMode = %q, want %q", conf.BackupArchiveMode, tt.wantMode)
+			}
+			if conf.BackupRestic != tt.wantRestic {
+				t.Errorf("BackupRestic = %v, want %v", conf.BackupRestic, tt.wantRestic)
+			}
+			if conf.BackupResticAws != tt.wantResAws {
+				t.Errorf("BackupResticAws = %v, want %v", conf.BackupResticAws, tt.wantResAws)
+			}
+			if tt.wantLocalRepo != "" && conf.BackupResticLocalRepository != tt.wantLocalRepo {
+				t.Errorf("BackupResticLocalRepository = %q, want %q", conf.BackupResticLocalRepository, tt.wantLocalRepo)
+			}
+		})
+	}
+}
+
+func TestApplyBackupArchiveMode(t *testing.T) {
+	conf := &Config{}
+
+	if err := conf.ApplyBackupArchiveMode(ConstBackupArchiveModeResticAws); err != nil {
+		t.Fatalf("unexpected error applying restic-aws: %v", err)
+	}
+	if conf.BackupArchiveMode != ConstBackupArchiveModeResticAws {
+		t.Fatalf("BackupArchiveMode = %q, want %q", conf.BackupArchiveMode, ConstBackupArchiveModeResticAws)
+	}
+	if !conf.BackupRestic || !conf.BackupResticAws {
+		t.Fatalf("expected BackupRestic=true BackupResticAws=true, got %v/%v", conf.BackupRestic, conf.BackupResticAws)
+	}
+
+	// An invalid mode is rejected and leaves the previous mode/flags intact.
+	if err := conf.ApplyBackupArchiveMode("bogus"); err == nil {
+		t.Fatalf("expected error for invalid backup-archive-mode")
+	}
+	if conf.BackupArchiveMode != ConstBackupArchiveModeResticAws {
+		t.Fatalf("BackupArchiveMode changed after invalid input: %q", conf.BackupArchiveMode)
+	}
+}
+
+func TestDeriveBackupArchiveModeFromFlags(t *testing.T) {
+	tests := []struct {
+		name            string
+		backupRestic    bool
+		backupResticAws bool
+		localRepo       string
+		want            string
+	}{
+		{"restic disabled maps to none", false, false, "", ConstBackupArchiveModeNone},
+		{"restic disabled ignores aws/local repo", false, true, "sftp:user@host:/path", ConstBackupArchiveModeNone},
+		{"aws flag maps to restic-aws", true, true, "", ConstBackupArchiveModeResticAws},
+		{"sftp local repo maps to restic-sftp", true, false, "sftp:user@host:/path", ConstBackupArchiveModeResticSftp},
+		{"non-sftp local repo maps to restic-local", true, false, "/var/lib/archive", ConstBackupArchiveModeResticLocal},
+		{"empty local repo maps to restic-local", true, false, "", ConstBackupArchiveModeResticLocal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := &Config{BackupResticLocalRepository: tt.localRepo}
+			if got := conf.DeriveBackupArchiveModeFromFlags(tt.backupRestic, tt.backupResticAws); got != tt.want {
+				t.Errorf("DeriveBackupArchiveModeFromFlags(%v, %v) with localRepo %q = %q, want %q",
+					tt.backupRestic, tt.backupResticAws, tt.localRepo, got, tt.want)
+			}
+		})
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -3458,6 +3458,24 @@ func (conf *Config) ApplyBackupArchiveMode(mode string) error {
 	return nil
 }
 
+// IsS3ResticRepository reports whether repoPath uses restic's S3 backend
+// ("s3:" prefix). repoPath is expected to already be trimmed of surrounding
+// whitespace, as is the case for BackupResticLocalRepository after
+// NormalizeBackupArchiveMode has run. Restic treats the scheme prefix as
+// case-sensitive, so this match is exact-case to match restic's own behavior.
+func IsS3ResticRepository(repoPath string) bool {
+	return strings.HasPrefix(repoPath, "s3:")
+}
+
+// IsSftpResticRepository reports whether repoPath uses restic's sftp backend
+// ("sftp:" prefix). repoPath is expected to already be trimmed of surrounding
+// whitespace, as is the case for BackupResticLocalRepository after
+// NormalizeBackupArchiveMode has run. Restic treats the scheme prefix as
+// case-sensitive, so this match is exact-case to match restic's own behavior.
+func IsSftpResticRepository(repoPath string) bool {
+	return strings.HasPrefix(repoPath, "sftp:")
+}
+
 // DeriveBackupArchiveModeFromFlags computes the canonical backup-archive-mode
 // for the given backup-restic / backup-restic-aws flag values. For the
 // restic-local vs restic-sftp ambiguity (both map to backup-restic=true,
@@ -3472,7 +3490,7 @@ func (conf *Config) DeriveBackupArchiveModeFromFlags(backupRestic, backupResticA
 		return ConstBackupArchiveModeNone
 	case backupResticAws:
 		return ConstBackupArchiveModeResticAws
-	case strings.HasPrefix(strings.TrimSpace(conf.BackupResticLocalRepository), "sftp:"):
+	case IsSftpResticRepository(conf.BackupResticLocalRepository):
 		return ConstBackupArchiveModeResticSftp
 	default:
 		return ConstBackupArchiveModeResticLocal
@@ -3484,7 +3502,18 @@ func (conf *Config) DeriveBackupArchiveModeFromFlags(backupRestic, backupResticA
 // backup-restic-local-repository (sftp: prefix), so an empty or "none" value
 // contradicted by a legacy backup-restic=true is re-derived from those flags.
 // Once resolved, backup-restic / backup-restic-aws are kept in sync with it.
+// It also trims BackupResticLocalRepository so IsS3ResticRepository /
+// IsSftpResticRepository can match prefixes without re-trimming.
+//
+// This is only called from Cluster.Init() at startup. If the server gains
+// support for hot-reloading TOML configuration, a backup-archive-mode (or
+// backup-restic-local-repository) value added or changed while the server is
+// running would be loaded by Viper but never normalized/trimmed here, and
+// callers reading these fields directly may see stale or inconsistent state
+// until the cluster is reinitialized.
 func (conf *Config) NormalizeBackupArchiveMode() {
+	conf.BackupResticLocalRepository = strings.TrimSpace(conf.BackupResticLocalRepository)
+
 	invalidValue := conf.ValidateBackupArchiveMode(conf.BackupArchiveMode) != nil
 	needsMigration := invalidValue ||
 		(conf.BackupArchiveMode == ConstBackupArchiveModeNone && conf.BackupRestic)

--- a/config/config.go
+++ b/config/config.go
@@ -3458,26 +3458,43 @@ func (conf *Config) ApplyBackupArchiveMode(mode string) error {
 	return nil
 }
 
+// DeriveBackupArchiveModeFromFlags computes the canonical backup-archive-mode
+// for the given backup-restic / backup-restic-aws flag values. For the
+// restic-local vs restic-sftp ambiguity (both map to backup-restic=true,
+// backup-restic-aws=false), the configured repository path is inspected for
+// an "sftp:" prefix. Callers that mutate the legacy flags should compute the
+// resulting mode with this helper and apply it via ApplyBackupArchiveMode (or
+// Cluster.SetBackupArchiveMode) so backup-restic / backup-restic-aws stay in
+// a combination the canonical mode can represent.
+func (conf *Config) DeriveBackupArchiveModeFromFlags(backupRestic, backupResticAws bool) string {
+	switch {
+	case !backupRestic:
+		return ConstBackupArchiveModeNone
+	case backupResticAws:
+		return ConstBackupArchiveModeResticAws
+	case strings.HasPrefix(strings.TrimSpace(conf.BackupResticLocalRepository), "sftp:"):
+		return ConstBackupArchiveModeResticSftp
+	default:
+		return ConstBackupArchiveModeResticLocal
+	}
+}
+
 // NormalizeBackupArchiveMode resolves backup-archive-mode at startup. Configs
 // predating this setting only have backup-restic / backup-restic-aws /
 // backup-restic-local-repository (sftp: prefix), so an empty or "none" value
 // contradicted by a legacy backup-restic=true is re-derived from those flags.
 // Once resolved, backup-restic / backup-restic-aws are kept in sync with it.
 func (conf *Config) NormalizeBackupArchiveMode() {
-	needsMigration := conf.ValidateBackupArchiveMode(conf.BackupArchiveMode) != nil ||
+	invalidValue := conf.ValidateBackupArchiveMode(conf.BackupArchiveMode) != nil
+	needsMigration := invalidValue ||
 		(conf.BackupArchiveMode == ConstBackupArchiveModeNone && conf.BackupRestic)
 
 	if needsMigration {
-		switch {
-		case !conf.BackupRestic:
-			conf.BackupArchiveMode = ConstBackupArchiveModeNone
-		case conf.BackupResticAws:
-			conf.BackupArchiveMode = ConstBackupArchiveModeResticAws
-		case strings.HasPrefix(strings.TrimSpace(conf.BackupResticLocalRepository), "sftp:"):
-			conf.BackupArchiveMode = ConstBackupArchiveModeResticSftp
-		default:
-			conf.BackupArchiveMode = ConstBackupArchiveModeResticLocal
+		if invalidValue {
+			log.WithFields(log.Fields{"cluster": "none", "type": "log", "module": "config"}).
+				Warnf("Invalid backup-archive-mode value %q, migrating from legacy backup-restic/backup-restic-aws settings", conf.BackupArchiveMode)
 		}
+		conf.BackupArchiveMode = conf.DeriveBackupArchiveModeFromFlags(conf.BackupRestic, conf.BackupResticAws)
 	}
 
 	conf.applyBackupArchiveModeFlags()

--- a/config/config.go
+++ b/config/config.go
@@ -801,6 +801,7 @@ type Config struct {
 	BackupResticPurgePruneRepackCacheableOnly bool                         `mapstructure:"backup-restic-purge-prune-repack-cacheable-only" toml:"backup-restic-purge-prune-repack-cacheable-only" json:"backupResticPurgePruneRepackCacheableOnly"`
 	BackupResticPurgePruneRepackSmall         bool                         `mapstructure:"backup-restic-purge-prune-repack-small" toml:"backup-restic-purge-prune-repack-small" json:"backupResticPurgePruneRepackSmall"`
 	BackupResticPurgePruneRepackUncompressed  bool                         `mapstructure:"backup-restic-purge-prune-repack-uncompressed" toml:"backup-restic-purge-prune-repack-uncompressed" json:"backupResticPurgePruneRepackUncompressed"`
+	BackupArchiveMode                         string                       `mapstructure:"backup-archive-mode" toml:"backup-archive-mode" json:"backupArchiveMode"`
 	BackupRestic                              bool                         `mapstructure:"backup-restic" toml:"backup-restic" json:"backupRestic"`
 	BackupResticBinaryPath                    string                       `mapstructure:"backup-restic-binary-path" toml:"backup-restic-binary-path" json:"backupResticBinaryPath"`
 	BackupResticLocalRepository               string                       `mapstructure:"backup-restic-local-repository" toml:"backup-restic-local-repository" json:"backupResticLocalRepository"`
@@ -1194,6 +1195,14 @@ const (
 
 const (
 	ConstStreamingSubDir string = "backups"
+)
+
+// Backup archive mode picker: selects the Restic archive backend (or disables it).
+const (
+	ConstBackupArchiveModeNone        string = "none"
+	ConstBackupArchiveModeResticLocal string = "restic-local"
+	ConstBackupArchiveModeResticAws   string = "restic-aws"
+	ConstBackupArchiveModeResticSftp  string = "restic-sftp"
 )
 const (
 	ConstProxyMaxscale    string = "maxscale"
@@ -3408,6 +3417,70 @@ func parseResticMode(value int, defaultMode os.FileMode) os.FileMode {
 	}
 
 	return os.FileMode(parsed)
+}
+
+// ValidateBackupArchiveMode checks that mode is one of the supported
+// backup-archive-mode values: none, restic-local, restic-aws, restic-sftp.
+func (conf *Config) ValidateBackupArchiveMode(mode string) error {
+	switch mode {
+	case ConstBackupArchiveModeNone, ConstBackupArchiveModeResticLocal, ConstBackupArchiveModeResticAws, ConstBackupArchiveModeResticSftp:
+		return nil
+	default:
+		return NewValidationError("backup-archive-mode", mode, "expected one of: none, restic-local, restic-aws, restic-sftp")
+	}
+}
+
+// applyBackupArchiveModeFlags derives the legacy backup-restic / backup-restic-aws
+// flags from the canonical backup-archive-mode so existing Restic code paths
+// keep working unchanged.
+func (conf *Config) applyBackupArchiveModeFlags() {
+	switch conf.BackupArchiveMode {
+	case ConstBackupArchiveModeNone:
+		conf.BackupRestic = false
+		conf.BackupResticAws = false
+	case ConstBackupArchiveModeResticAws:
+		conf.BackupRestic = true
+		conf.BackupResticAws = true
+	case ConstBackupArchiveModeResticLocal, ConstBackupArchiveModeResticSftp:
+		conf.BackupRestic = true
+		conf.BackupResticAws = false
+	}
+}
+
+// ApplyBackupArchiveMode validates and sets backup-archive-mode, deriving the
+// underlying backup-restic / backup-restic-aws flags used by the Restic integration.
+func (conf *Config) ApplyBackupArchiveMode(mode string) error {
+	if err := conf.ValidateBackupArchiveMode(mode); err != nil {
+		return err
+	}
+	conf.BackupArchiveMode = mode
+	conf.applyBackupArchiveModeFlags()
+	return nil
+}
+
+// NormalizeBackupArchiveMode resolves backup-archive-mode at startup. Configs
+// predating this setting only have backup-restic / backup-restic-aws /
+// backup-restic-local-repository (sftp: prefix), so an empty or "none" value
+// contradicted by a legacy backup-restic=true is re-derived from those flags.
+// Once resolved, backup-restic / backup-restic-aws are kept in sync with it.
+func (conf *Config) NormalizeBackupArchiveMode() {
+	needsMigration := conf.ValidateBackupArchiveMode(conf.BackupArchiveMode) != nil ||
+		(conf.BackupArchiveMode == ConstBackupArchiveModeNone && conf.BackupRestic)
+
+	if needsMigration {
+		switch {
+		case !conf.BackupRestic:
+			conf.BackupArchiveMode = ConstBackupArchiveModeNone
+		case conf.BackupResticAws:
+			conf.BackupArchiveMode = ConstBackupArchiveModeResticAws
+		case strings.HasPrefix(strings.TrimSpace(conf.BackupResticLocalRepository), "sftp:"):
+			conf.BackupArchiveMode = ConstBackupArchiveModeResticSftp
+		default:
+			conf.BackupArchiveMode = ConstBackupArchiveModeResticLocal
+		}
+	}
+
+	conf.applyBackupArchiveModeFlags()
 }
 
 func (conf *Config) ValidateResticPermissions() error {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -3866,6 +3866,10 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 	case "log-level-file":
 		val, _ := strconv.Atoi(value)
 		mycluster.Conf.LogFileLevel = val
+	case "backup-archive-mode":
+		if err := mycluster.SetBackupArchiveMode(value); err != nil {
+			return err
+		}
 	case "backup-restic-local-repository":
 		val, err := base64.StdEncoding.DecodeString(value)
 		if err != nil {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -3875,7 +3875,13 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		if err != nil {
 			return errors.New("unable to decode")
 		}
-		mycluster.Conf.BackupResticLocalRepository = string(val)
+		repoPath := string(val)
+		if mycluster.Conf.BackupArchiveMode == config.ConstBackupArchiveModeResticSftp {
+			if err := cluster.ValidateResticSftpRepository(repoPath); err != nil {
+				return err
+			}
+		}
+		mycluster.Conf.BackupResticLocalRepository = repoPath
 		mycluster.ReloadResticEnv()
 	case "backup-restic-repository":
 		val, err := base64.StdEncoding.DecodeString(value)

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -4285,13 +4285,22 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 	case "prov-object-allow-overwrite":
 		mycluster.Conf.ProvObjectAllowOverwrite = applyIsActive(mycluster.Conf.ProvObjectAllowOverwrite, isactive)
 	case "backup-restic-aws":
-		mycluster.Conf.BackupResticAws = applyIsActive(mycluster.Conf.BackupResticAws, isactive)
+		oldValue := mycluster.Conf.BackupResticAws
+		newValue := applyIsActive(oldValue, isactive)
+		if oldValue != newValue {
+			mode := mycluster.Conf.DeriveBackupArchiveModeFromFlags(mycluster.Conf.BackupRestic, newValue)
+			if err = mycluster.SetBackupArchiveMode(mode); err != nil {
+				return err
+			}
+		}
 	case "backup-restic":
 		oldValue := mycluster.Conf.BackupRestic
 		newValue := applyIsActive(oldValue, isactive)
 		if oldValue != newValue {
-			mycluster.Conf.BackupRestic = newValue
-			mycluster.CheckResticInstallation()
+			mode := mycluster.Conf.DeriveBackupArchiveModeFromFlags(newValue, mycluster.Conf.BackupResticAws)
+			if err = mycluster.SetBackupArchiveMode(mode); err != nil {
+				return err
+			}
 		}
 	case "backup-restic-purge-prune":
 		mycluster.Conf.BackupResticPurgePrune = applyIsActive(mycluster.Conf.BackupResticPurgePrune, isactive)

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -3875,7 +3875,7 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		if err != nil {
 			return errors.New("unable to decode")
 		}
-		repoPath := string(val)
+		repoPath := strings.TrimSpace(string(val))
 		if mycluster.Conf.BackupArchiveMode == config.ConstBackupArchiveModeResticSftp {
 			if err := cluster.ValidateResticSftpRepository(repoPath); err != nil {
 				return err

--- a/server/server.go
+++ b/server/server.go
@@ -848,6 +848,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.BoolVar(&conf.BackupLogicalDumpSystemTables, "backup-logical-dump-system-tables", false, "Backup restore the mysql database")
 	flags.StringVar(&conf.BackupLogicalType, "backup-logical-type", "mysqldump", "type of logical backup: river|mysqldump|mydumper")
 	flags.StringVar(&conf.BackupPhysicalType, "backup-physical-type", "xtrabackup", "type of physical backup: xtrabackup|mariabackup")
+	flags.StringVar(&conf.BackupArchiveMode, "backup-archive-mode", "", "Restic archive backend: none, restic-local, restic-aws, restic-sftp (empty derives from legacy backup-restic flags)")
 	flags.BoolVar(&conf.BackupRestic, "backup-restic", false, "Use restic to archive and restore backups")
 	flags.StringVar(&conf.BackupResticTags, "backup-restic-tags", "tenant,cluster,engine,version,backup-type,backup-tool,line", "Comma-separated restic tags or templates (e.g. cluster,backup-type,line,env:prod). Quote a tag to keep it literal.")
 	flags.StringVar(&conf.BackupResticHost, "backup-restic-host", "", "Restic backup --host override. Empty uses restic default hostname (no alias).")

--- a/share/dashboard_react/src/Pages/Settings/ResticPurgeStrategy/index.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticPurgeStrategy/index.jsx
@@ -112,6 +112,93 @@ Use conservative values unless you know the repo layout.
 
   const ResticPurgePruneTooltip = `${ResticPurgeBehaviorTooltip}${ResticPurgePruneTuningTooltip}`
 
+  const ResticPurgeFilterHostHelp = `**Filter Host**
+
+Limits forget/prune selection to snapshots created on the listed host(s).
+Accepts a comma- or space-separated list; multiple values are OR'd together.
+Combined with Filter Tag and Filter Path using AND.
+
+Maps to one or more restic \`--host\` flags.
+
+Config: \`backup-restic-purge-host\``
+
+  const ResticPurgeFilterTagHelp = `**Filter Tag**
+
+Limits forget/prune selection to snapshots matching the given tag(s).
+Space-separated; commas inside a tag mean AND (quote tags containing commas).
+Combined with Filter Host and Filter Path using AND.
+
+Maps to one or more restic \`--tag\` flags.
+
+Config: \`backup-restic-purge-tag\``
+
+  const ResticPurgeFilterPathHelp = `**Filter Path**
+
+Limits forget/prune selection to snapshots that include the given absolute path(s).
+Accepts a comma- or space-separated list; multiple values are OR'd together.
+Combined with Filter Host and Filter Tag using AND.
+
+Maps to one or more restic \`--path\` flags.
+
+Config: \`backup-restic-purge-path\``
+
+  const ResticPurgePruneSwitchHelp = `**Prune**
+
+When enabled, \`restic prune\` runs after \`forget\` to reclaim space freed by removed snapshots.
+Pruning can take significantly longer and use more I/O/CPU than forget alone.
+
+Maps to the restic \`--prune\` flag.
+
+Config: \`backup-restic-purge-prune\``
+
+  const ResticPurgePruneCompactHelp = `**Prune Compact**
+
+When enabled (and Prune is on), pack files are rewritten even if they would only shrink slightly, keeping the repository more compact at the cost of extra I/O.
+
+Maps to the restic \`--compact\` flag (prune only).
+
+Config: \`backup-restic-purge-prune-compact\``
+
+  const ResticPurgePruneMaxUnusedHelp = `**Max Unused**
+
+Caps the amount of unused (no longer referenced) data restic tolerates in the repository after pruning, as an absolute size (e.g. \`5G\`) or percentage (e.g. \`10%\`). \`unlimited\` disables the limit.
+
+Maps to the restic \`--max-unused\` flag (prune only). Leave empty to use restic's default.
+
+Config: \`backup-restic-purge-prune-max-unused\``
+
+  const ResticPurgePruneMaxRepackSizeHelp = `**Max Repack Size**
+
+Caps the total size of pack files that may be repacked during a single prune run (e.g. \`5G\`). Useful to bound how long/expensive a prune operation can get.
+
+Maps to the restic \`--max-repack-size\` flag (prune only). Leave empty for no limit.
+
+Config: \`backup-restic-purge-prune-max-repack-size\``
+
+  const ResticPurgePruneRepackCacheableOnlyHelp = `**Repack Cacheable Only**
+
+When enabled (and Prune is on), only repacks pack files containing cacheable data (metadata), skipping data blobs. Speeds up pruning at the cost of reclaiming less space.
+
+Maps to the restic \`--repack-cacheable-only\` flag (prune only).
+
+Config: \`backup-restic-purge-prune-repack-cacheable-only\``
+
+  const ResticPurgePruneRepackSmallHelp = `**Repack Small**
+
+When enabled (and Prune is on), small pack files are repacked together to reduce the total number of files in the repository.
+
+Maps to the restic \`--repack-small\` flag (prune only).
+
+Config: \`backup-restic-purge-prune-repack-small\``
+
+  const ResticPurgePruneRepackUncompressedHelp = `**Repack Uncompressed**
+
+When enabled (and Prune is on), pack files written in restic's older uncompressed format are repacked into the compressed format, reducing repository size over time.
+
+Maps to the restic \`--repack-uncompressed\` flag (prune only).
+
+Config: \`backup-restic-purge-prune-repack-uncompressed\``
+
   const togglePanel = (panelKey) => {
     setOpenPanels((prev) => ({
       ...prev,
@@ -186,6 +273,19 @@ Use conservative values unless you know the repo layout.
     })
     openCommonModal()
   }
+
+  const h = (content, title) => (
+    <RMIconButton
+      icon={HiQuestionMarkCircle}
+      iconFontsize='1rem'
+      variant='ghost'
+      style={{ opacity: 0.5, minWidth: '1.5rem', height: '1.5rem' }}
+      onClick={(event) => {
+        event?.stopPropagation?.()
+        openInfoModal(title, content)
+      }}
+    />
+  )
 
   const toInt = (value) => {
     const parsed = Number(value)
@@ -442,9 +542,76 @@ Use conservative values unless you know the repo layout.
     closePurgeModal()
   }
 
+  const ResticKeepRecentHelp = `**Keep Recent**
+
+Baseline retention rule applied on top of the hourly/daily/weekly/monthly/yearly buckets below.
+
+- Keep the **N** most recent snapshots, regardless of when they were created.
+- Keep snapshots created **within** a recent time window (e.g. \`2d\`, \`1d2h\`).
+
+A snapshot is retained if it matches either rule. Set Keep Last N to 0 and leave Keep Within blank to disable this rule.
+
+Config: \`backup-keep-last\` / \`backup-keep-within\``
+
+  const ResticKeepHourlyHelp = `**Keep Hourly**
+
+Retains one snapshot per hour for the most recent hours, in addition to any other matching rules.
+
+- Keep the **N** most recent hourly snapshots.
+- Keep snapshots created **within** a recent time window (e.g. \`2h\`, \`1d\`) for this bucket.
+
+Set Keep Last N to 0 and leave Keep Within blank to disable hourly retention.
+
+Config: \`backup-keep-hourly\` / \`backup-keep-within-hourly\``
+
+  const ResticKeepDailyHelp = `**Keep Daily**
+
+Retains one snapshot per day for the most recent days, in addition to any other matching rules.
+
+- Keep the **N** most recent daily snapshots.
+- Keep snapshots created **within** a recent time window (e.g. \`7d\`) for this bucket.
+
+Set Keep Last N to 0 and leave Keep Within blank to disable daily retention.
+
+Config: \`backup-keep-daily\` / \`backup-keep-within-daily\``
+
+  const ResticKeepWeeklyHelp = `**Keep Weekly**
+
+Retains one snapshot per week for the most recent weeks, in addition to any other matching rules.
+
+- Keep the **N** most recent weekly snapshots.
+- Keep snapshots created **within** a recent time window (e.g. \`28d\`) for this bucket.
+
+Set Keep Last N to 0 and leave Keep Within blank to disable weekly retention.
+
+Config: \`backup-keep-weekly\` / \`backup-keep-within-weekly\``
+
+  const ResticKeepMonthlyHelp = `**Keep Monthly**
+
+Retains one snapshot per month for the most recent months, in addition to any other matching rules.
+
+- Keep the **N** most recent monthly snapshots.
+- Keep snapshots created **within** a recent time window (e.g. \`6m\`) for this bucket.
+
+Set Keep Last N to 0 and leave Keep Within blank to disable monthly retention.
+
+Config: \`backup-keep-monthly\` / \`backup-keep-within-monthly\``
+
+  const ResticKeepYearlyHelp = `**Keep Yearly**
+
+Retains one snapshot per year for the most recent years, in addition to any other matching rules.
+
+- Keep the **N** most recent yearly snapshots.
+- Keep snapshots created **within** a recent time window (e.g. \`5y\`) for this bucket.
+
+Set Keep Last N to 0 and leave Keep Within blank to disable yearly retention.
+
+Config: \`backup-keep-yearly\` / \`backup-keep-within-yearly\``
+
   const sections = [
     {
       title: "Keep Recent",
+      help: ResticKeepRecentHelp,
       colA: (
         <NumberInput containerClassName={styles.marginCenter} value={config?.backupKeepLast} confirmTitle={"Confirm update 'backup-keep-last':"} min={0} showEditButton={true} showConfirmModal={true} onConfirm={(v) => { handleSave('backup-keep-last', v) }} />
       ),
@@ -454,6 +621,7 @@ Use conservative values unless you know the repo layout.
     },
     {
       title: "Keep Hourly",
+      help: ResticKeepHourlyHelp,
       colA: (
         <NumberInput containerClassName={styles.marginCenter} value={config?.backupKeepHourly} confirmTitle={"Confirm update 'backup-keep-hourly':"} min={0} showEditButton={true} showConfirmModal={true} onConfirm={(v) => { handleSave('backup-keep-hourly', v) }} />
       ),
@@ -463,6 +631,7 @@ Use conservative values unless you know the repo layout.
     },
     {
       title: "Keep Daily",
+      help: ResticKeepDailyHelp,
       colA: (
         <NumberInput containerClassName={styles.marginCenter} value={config?.backupKeepDaily} confirmTitle={"Confirm update 'backup-keep-daily':"} min={0} showEditButton={true} showConfirmModal={true} onConfirm={(v) => { handleSave('backup-keep-daily', v) }} />
       ),
@@ -472,6 +641,7 @@ Use conservative values unless you know the repo layout.
     },
     {
       title: "Keep Weekly",
+      help: ResticKeepWeeklyHelp,
       colA: (
         <NumberInput containerClassName={styles.marginCenter} value={config?.backupKeepWeekly} confirmTitle={"Confirm update 'backup-keep-weekly':"} min={0} showEditButton={true} showConfirmModal={true} onConfirm={(v) => { handleSave('backup-keep-weekly', v) }} />
       ),
@@ -481,6 +651,7 @@ Use conservative values unless you know the repo layout.
     },
     {
       title: "Keep Monthly",
+      help: ResticKeepMonthlyHelp,
       colA: (
         <NumberInput containerClassName={styles.marginCenter} value={config?.backupKeepMonthly} confirmTitle={"Confirm update 'backup-keep-monthly':"} min={0} showEditButton={true} showConfirmModal={true} onConfirm={(v) => { handleSave('backup-keep-monthly', v) }} />
       ),
@@ -490,6 +661,7 @@ Use conservative values unless you know the repo layout.
     },
     {
       title: "Keep Yearly",
+      help: ResticKeepYearlyHelp,
       colA: (
         <NumberInput containerClassName={styles.marginCenter} value={config?.backupKeepYearly} confirmTitle={"Confirm update 'backup-keep-yearly':"} min={0} showEditButton={true} showConfirmModal={true} onConfirm={(v) => { handleSave('backup-keep-yearly', v) }} />
       ),
@@ -510,7 +682,7 @@ Use conservative values unless you know the repo layout.
       >
         <HStack spacing={2} className={styles.purgeSelectionInfo}>
           <Text className={styles.purgeSelectionTitle}>Purge selection</Text>
-          <RMIconButton icon={HiQuestionMarkCircle} onClick={() => openInfoModal('Purge Selection', ResticPurgeSelectionTooltip)} />
+          {h(ResticPurgeSelectionTooltip, 'Purge Selection')}
         </HStack>
         <HStack
           spacing={2}
@@ -551,7 +723,7 @@ Use conservative values unless you know the repo layout.
             <GridItem className={styles.rowLabel}>
               <HStack spacing={2}>
                 <Text>Group By</Text>
-                <RMIconButton icon={HiQuestionMarkCircle} onClick={() => openInfoModal('Restic Group By', ResticPurgeGroupByTooltip)} />
+                {h(ResticPurgeGroupByTooltip, 'Restic Group By')}
               </HStack>
             </GridItem>
             <GridItem className={styles.valueCell}>
@@ -568,7 +740,7 @@ Use conservative values unless you know the repo layout.
             <GridItem className={styles.rowLabel}>
               <HStack spacing={2}>
                 <Text>Keep Tag</Text>
-                <RMIconButton icon={HiQuestionMarkCircle} onClick={() => openInfoModal('Restic Keep Tag', ResticKeepTagTooltip)} />
+                {h(ResticKeepTagTooltip, 'Restic Keep Tag')}
               </HStack>
             </GridItem>
             <GridItem className={styles.valueCell}>
@@ -590,13 +762,7 @@ Use conservative values unless you know the repo layout.
         (
           <HStack spacing={2} className={styles.panelTitleRow}>
             <Text className={styles.panelTitle}>Filters</Text>
-            <RMIconButton
-              icon={HiQuestionMarkCircle}
-              onClick={(event) => {
-                event.stopPropagation()
-                openInfoModal('Restic Purge Filters', ResticPurgeFilterTooltip)
-              }}
-            />
+            {h(ResticPurgeFilterTooltip, 'Restic Purge Filters')}
           </HStack>
         ),
         (
@@ -608,8 +774,9 @@ Use conservative values unless you know the repo layout.
             w="full"
           >
             <GridItem className={styles.rowLabel}>
-              <HStack spacing={2}>
+              <HStack spacing={2} justify='space-between' width='full'>
                 <Text>Filter Host</Text>
+                {h(ResticPurgeFilterHostHelp, 'Filter Host')}
               </HStack>
             </GridItem>
             <GridItem className={styles.valueCell}>
@@ -621,8 +788,9 @@ Use conservative values unless you know the repo layout.
               />
             </GridItem>
             <GridItem className={styles.rowLabel}>
-              <HStack spacing={2}>
+              <HStack spacing={2} justify='space-between' width='full'>
                 <Text>Filter Tag</Text>
+                {h(ResticPurgeFilterTagHelp, 'Filter Tag')}
               </HStack>
             </GridItem>
             <GridItem className={styles.valueCell}>
@@ -634,8 +802,9 @@ Use conservative values unless you know the repo layout.
               />
             </GridItem>
             <GridItem className={styles.rowLabel}>
-              <HStack spacing={2}>
+              <HStack spacing={2} justify='space-between' width='full'>
                 <Text>Filter Path</Text>
+                {h(ResticPurgeFilterPathHelp, 'Filter Path')}
               </HStack>
             </GridItem>
             <GridItem className={styles.valueCell}>
@@ -654,13 +823,7 @@ Use conservative values unless you know the repo layout.
         (
           <HStack spacing={2} className={styles.panelTitleRow}>
             <Text className={styles.panelTitle}>Prune</Text>
-            <RMIconButton
-              icon={HiQuestionMarkCircle}
-              onClick={(event) => {
-                event.stopPropagation()
-                openInfoModal('Restic Prune Options', ResticPurgePruneTooltip)
-              }}
-            />
+            {h(ResticPurgePruneTooltip, 'Restic Prune Options')}
           </HStack>
         ),
         (
@@ -672,8 +835,9 @@ Use conservative values unless you know the repo layout.
             w="full"
           >
             <GridItem className={styles.rowLabel}>
-              <HStack spacing={2}>
+              <HStack spacing={2} justify='space-between' width='full'>
                 <Text>Prune</Text>
+                {h(ResticPurgePruneSwitchHelp, 'Prune')}
               </HStack>
             </GridItem>
             <GridItem className={styles.valueCell}>
@@ -688,8 +852,9 @@ Use conservative values unless you know the repo layout.
               />
             </GridItem>
             <GridItem className={styles.rowLabel}>
-              <HStack spacing={2}>
+              <HStack spacing={2} justify='space-between' width='full'>
                 <Text>Prune Compact</Text>
+                {h(ResticPurgePruneCompactHelp, 'Prune Compact')}
               </HStack>
             </GridItem>
             <GridItem className={styles.valueCell}>
@@ -705,8 +870,9 @@ Use conservative values unless you know the repo layout.
               />
             </GridItem>
             <GridItem className={styles.rowLabel}>
-              <HStack spacing={2}>
+              <HStack spacing={2} justify='space-between' width='full'>
                 <Text>Max Unused</Text>
+                {h(ResticPurgePruneMaxUnusedHelp, 'Max Unused')}
               </HStack>
             </GridItem>
             <GridItem className={styles.valueCell}>
@@ -719,8 +885,9 @@ Use conservative values unless you know the repo layout.
               />
             </GridItem>
             <GridItem className={styles.rowLabel}>
-              <HStack spacing={2}>
+              <HStack spacing={2} justify='space-between' width='full'>
                 <Text>Max Repack Size</Text>
+                {h(ResticPurgePruneMaxRepackSizeHelp, 'Max Repack Size')}
               </HStack>
             </GridItem>
             <GridItem className={styles.valueCell}>
@@ -733,8 +900,9 @@ Use conservative values unless you know the repo layout.
               />
             </GridItem>
             <GridItem className={styles.rowLabel}>
-              <HStack spacing={2}>
+              <HStack spacing={2} justify='space-between' width='full'>
                 <Text>Repack Cacheable Only</Text>
+                {h(ResticPurgePruneRepackCacheableOnlyHelp, 'Repack Cacheable Only')}
               </HStack>
             </GridItem>
             <GridItem className={styles.valueCell}>
@@ -750,8 +918,9 @@ Use conservative values unless you know the repo layout.
               />
             </GridItem>
             <GridItem className={styles.rowLabel}>
-              <HStack spacing={2}>
+              <HStack spacing={2} justify='space-between' width='full'>
                 <Text>Repack Small</Text>
+                {h(ResticPurgePruneRepackSmallHelp, 'Repack Small')}
               </HStack>
             </GridItem>
             <GridItem className={styles.valueCell}>
@@ -767,8 +936,9 @@ Use conservative values unless you know the repo layout.
               />
             </GridItem>
             <GridItem className={styles.rowLabel}>
-              <HStack spacing={2}>
+              <HStack spacing={2} justify='space-between' width='full'>
                 <Text>Repack Uncompressed</Text>
+                {h(ResticPurgePruneRepackUncompressedHelp, 'Repack Uncompressed')}
               </HStack>
             </GridItem>
             <GridItem className={styles.valueCell}>
@@ -800,17 +970,20 @@ Use conservative values unless you know the repo layout.
             <GridItem className={styles.headerCell} display={{ base: 'none', md: 'flex' }} />
             <GridItem className={styles.headerCell} display={{ base: 'none', md: 'flex' }}>
               <Text className={styles.headerText}>{columnTitles.keepLast}</Text>
-              <RMIconButton icon={HiQuestionMarkCircle} onClick={() => openInfoModal('Restic Keep Last N', ResticKeepLastNTooltip)} />
+              {h(ResticKeepLastNTooltip, 'Restic Keep Last N')}
             </GridItem>
             <GridItem className={styles.headerCell} display={{ base: 'none', md: 'flex' }}>
               <Text className={styles.headerText}>{columnTitles.keepWithin}</Text>
-              <RMIconButton icon={HiQuestionMarkCircle} onClick={() => openInfoModal('Restic Keep Within Duration', ResticKeepWithinTooltip)} />
+              {h(ResticKeepWithinTooltip, 'Restic Keep Within Duration')}
             </GridItem>
 
             {sections.map((section, index) => (
               <React.Fragment key={index}>
                 <GridItem className={styles.rowLabel}>
-                  {section.title}
+                  <HStack spacing={2} justify='space-between' width='full'>
+                    <Text>{section.title}</Text>
+                    {h(section.help, section.title)}
+                  </HStack>
                 </GridItem>
                 <GridItem className={styles.valueCell}>
                   <Text className={styles.mobileHeader} display={{ base: 'block', md: 'none' }}>

--- a/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
@@ -257,6 +257,7 @@ function ResticRepositorySettings({
   const [confirmEmptyPrefix, setConfirmEmptyPrefix] = useState(false)
   const archiveMode = config?.backupArchiveMode || 'none'
   const isAws = archiveMode === 'restic-aws'
+  const isSftp = archiveMode === 'restic-sftp'
   const awsBucket = (config?.backupResticAwsBucket || '').trim()
   const awsPrefix = (config?.backupResticAwsPrefix || '').trim()
   const awsEndpoint = (config?.backupResticAwsEndpoint || '').trim()
@@ -278,7 +279,7 @@ function ResticRepositorySettings({
     ? `s3:${trimmedEndpoint ? `${trimmedEndpoint}/` : ''}${awsBucket}${effectivePrefix ? `/${effectivePrefix}` : ''}`
     : effectiveLegacyRepoPath
   const isAwsPrefixEmpty = isAws && awsBucket && !awsPrefix
-  const isForceInitBlocked = initForce && isAwsPrefixEmpty && !confirmEmptyPrefix
+  const isForceInitBlocked = initForce && ((isAwsPrefixEmpty && !confirmEmptyPrefix) || isSftp)
 
   const handleSettingChange = (setting, value, encodeValue = false) =>
     dispatch(
@@ -977,7 +978,7 @@ function ResticRepositorySettings({
         body={
           <VStack align='start' spacing={3}>
             <Text>
-              Re-initialize the {archiveMode === 'restic-aws' ? 'S3/MinIO' : archiveMode === 'restic-sftp' ? 'SFTP' : 'local'} Restic repository:
+              Re-initialize the {isAws ? 'S3/MinIO' : isSftp ? 'SFTP' : 'local'} Restic repository:
             </Text>
             <Text 
               fontWeight='bold' 
@@ -993,15 +994,25 @@ function ResticRepositorySettings({
                 : config?.backupResticLocalRepository}
             </Text>
             <Divider />
-            <Checkbox
-              isChecked={initForce}
-              onChange={(e) => setInitForce(e.target.checked)}
-            >
-              <Text fontSize='sm'>
-                Force re-initialization (overwrite existing configuration)
-              </Text>
-            </Checkbox>
-            {initForce && (
+            {isSftp ? (
+              <Alert status='info' size='sm' borderRadius='md'>
+                <AlertIcon />
+                <Text fontSize='sm'>
+                  Force re-initialization is not supported for SFTP repositories. To re-initialize from
+                  scratch, remove the remote repository path manually over SSH first.
+                </Text>
+              </Alert>
+            ) : (
+              <Checkbox
+                isChecked={initForce}
+                onChange={(e) => setInitForce(e.target.checked)}
+              >
+                <Text fontSize='sm'>
+                  Force re-initialization (overwrite existing configuration)
+                </Text>
+              </Checkbox>
+            )}
+            {initForce && !isSftp && (
               <Alert status='warning' size='sm' borderRadius='md'>
                 <AlertIcon />
                 <Text fontSize='sm'>

--- a/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
@@ -5,6 +5,7 @@ import RMIconButton from '../../components/RMIconButton'
 import RMButton from '../../components/RMButton'
 import RMSwitch from '../../components/RMSwitch'
 import TextForm from '../../components/TextForm'
+import Dropdown from '../../components/Dropdown'
 import ConfirmModal from '../../components/Modals/ConfirmModal'
 import { setSetting, switchSetting } from '../../redux/settingsSlice'
 import { resticInitRepo } from '../../redux/clusterSlice'
@@ -57,6 +58,151 @@ Auto-skip rules when enabled:
 
 Note: custom local repo paths inside the default archive directory are ignored.`
 
+const ResticSftpHelp = `SFTP repositories are configured via backup-restic-local-repository using restic's sftp syntax:
+sftp:user@host:/path/to/repo
+sftp:user@host:path/to/repo  (relative to user's home directory)
+
+Authentication (SSH login to the remote host):
+- The "user" in the path above is the SSH login, NOT the restic repository password.
+- Only key-based SSH auth is supported: the account running the restic process needs a private key
+  (e.g. ~/.ssh/id_ed25519 with no passphrase, or loaded in ssh-agent) whose matching public key is listed
+  in that user's ~/.ssh/authorized_keys on the remote host.
+- Password-based SSH login is NOT supported - restic runs non-interactively and cannot prompt for one.
+- Non-default SSH ports or other per-host options are not part of the repository path; add a Host entry
+  to that user's ~/.ssh/config instead, e.g.:
+    Host myhost
+      HostName host
+      Port 2222
+      User user
+  ...then reference the Host alias (myhost) in the repository path (sftp:myhost:/path/to/repo).
+
+Repository encryption password:
+- "Backup restic password" (backup-restic-password, in Connection & credentials above) is unrelated to SSH.
+  It is the restic repository encryption passphrase (RESTIC_PASSWORD) and applies to every backend type.
+
+Other notes:
+- backup-restic-aws stays disabled while SFTP is selected.
+- Force re-init is not supported for SFTP repositories; remove the remote repository path manually over SSH
+  before re-initializing.`
+
+const ResticRepositoryTypeHelp = `**Restic Repository Type**
+
+Selects the Restic storage backend for this cluster's backups.
+
+- **None** disables Restic backups entirely.
+- **Local filesystem** and **SFTP** both use the path configured in "Backup restic local repository" (they differ only in path syntax: a plain filesystem path vs. \`sftp:user@host:/path\`).
+- **S3 / Object storage** uses the AWS/S3 settings in the Storage section below.
+
+Switching types does not erase the values stored for the other types, so you can switch back without re-entering them.
+
+Config: \`backup-archive-mode\``
+
+const ResticBinaryPathHelp = `**Backup Restic Binary Path**
+
+Filesystem path to the \`restic\` executable used for all backup, restore, and maintenance operations on this cluster.
+
+Leave empty to use \`restic\` resolved from the system PATH. The binary must exist and be executable by the replication-manager process.
+
+Config: \`backup-restic-binary-path\``
+
+const ResticPasswordHelp = `**Backup Restic Password**
+
+Encryption passphrase for the Restic repository (passed to restic as \`RESTIC_PASSWORD\`).
+
+Applies to every backend (local, SFTP, and S3) - the repository cannot be initialized, read, or written to without it. The value is stored encrypted.
+
+**Losing this password makes all existing snapshots permanently unreadable** - there is no recovery.
+
+Config: \`backup-restic-password\``
+
+const ResticLocalRepositoryHelp = `**Backup Restic Local Repository**
+
+Path to the Restic repository.
+
+- For **Local filesystem**, an absolute filesystem path (e.g. \`/var/lib/repman/backups/archive\`).
+- For **SFTP**, an \`sftp:user@host:/path\` URI - see the SFTP (?) help for authentication details.
+
+When "Backup restic repo append cluster" is enabled, the cluster name is appended to this path (unless it is already the last path segment).
+
+Config: \`backup-restic-local-repository\``
+
+const ResticAwsAccessKeyIdHelp = `**Backup Restic AWS Access Key ID**
+
+Access key ID used to authenticate to the S3 (or S3-compatible) bucket configured below.
+
+Leave empty to fall back to the default AWS credential chain (environment variables, shared credentials file, or instance role).
+
+Config: \`backup-restic-aws-access-key-id\``
+
+const ResticAwsAccessSecretHelp = `**Backup Restic AWS Access Secret**
+
+Secret access key paired with "Backup restic aws access key id". Stored encrypted.
+
+Leave empty to fall back to the default AWS credential chain.
+
+Config: \`backup-restic-aws-access-secret\``
+
+const ResticAwsRegionHelp = `**Backup Restic AWS Region**
+
+AWS region of the S3 bucket (e.g. \`us-east-1\`, \`eu-west-1\`).
+
+Some S3-compatible services require this even when a custom endpoint is set. Leave empty to use the AWS SDK's default region resolution.
+
+Config: \`backup-restic-aws-region\``
+
+const ResticAwsEndpointHelp = `**Backup Restic AWS Endpoint**
+
+Custom S3-compatible endpoint URL (e.g. \`https://minio.example.com\`).
+
+Leave empty to use AWS's default S3 endpoints. Must be an \`http://\` or \`https://\` URL with a host - do not use the \`s3://\` scheme here.
+
+Config: \`backup-restic-aws-endpoint\``
+
+const ResticAwsBucketHelp = `**Backup Restic AWS Bucket**
+
+Name of the S3 (or S3-compatible) bucket that stores the Restic repository.
+
+Must not contain a slash or backslash character. Combined with "Backup restic repo append cluster" to decide whether the cluster name is appended to the prefix instead of the bucket name.
+
+Config: \`backup-restic-aws-bucket\``
+
+const ResticAwsPrefixHelp = `**Backup Restic AWS Prefix**
+
+Optional path prefix within the bucket under which the Restic repository is stored (no leading slash).
+
+Combined with "Backup restic repo append cluster": if enabled and the last prefix segment does not already equal the cluster name, the cluster name is appended.
+
+Config: \`backup-restic-aws-prefix\``
+
+const ResticEffectiveS3RepoHelp = `**Effective S3 Repository**
+
+Read-only preview of the full \`s3:\` repository path that restic will use, built from the endpoint, bucket, and prefix above plus the append-cluster rule.
+
+This field is computed - it cannot be edited directly.`
+
+const ResticLegacyRepoUrlHelp = `**Legacy Repository URL (fallback)**
+
+Older single-field repository path, used only when S3 / Object storage is enabled and "Backup restic aws bucket" is empty.
+
+For custom S3-compatible services, you can set this directly to \`s3:https://server:port/bucket\`. New configurations should prefer the dedicated bucket/prefix/endpoint/region fields above.
+
+Config: \`backup-restic-repository\``
+
+const ResticAdditionalEnvHelp = `**Backup Restic Additional Env**
+
+Extra environment variables passed to the \`restic\` process, as a comma- or space-separated list of \`KEY\` or \`KEY=VALUE\` entries.
+
+Quote values that contain commas, e.g. \`NO_PROXY="host1,host2"\`. Useful for things like \`AWS_SESSION_TOKEN\` or proxy settings that restic/AWS SDK recognize.
+
+Config: \`backup-restic-additional-env\``
+
+const RESTIC_REPOSITORY_TYPE_OPTIONS = [
+  { value: 'none', name: 'None' },
+  { value: 'restic-local', name: 'Local filesystem' },
+  { value: 'restic-aws', name: 'S3 / Object storage' },
+  { value: 'restic-sftp', name: 'SFTP' }
+]
+
 function ResticRepositorySettings({
   clusterName,
   config,
@@ -64,6 +210,16 @@ function ResticRepositorySettings({
   dispatch,
   onOpenInfoModal
 }) {
+  const h = (content, title) => (
+    <RMIconButton
+      icon={HiQuestionMarkCircle}
+      iconFontsize='1rem'
+      variant='ghost'
+      style={{ opacity: 0.5, minWidth: '1.5rem', height: '1.5rem' }}
+      onClick={() => onOpenInfoModal(title, content)}
+    />
+  )
+
   const isBrowser = typeof window !== 'undefined'
   const storagePrefix = 'settings:restic-repository-settings'
   const getStorageKey = (section) => `${storagePrefix}:${section}`
@@ -99,7 +255,8 @@ function ResticRepositorySettings({
   } = useDisclosure()
   const [initForce, setInitForce] = useState(false)
   const [confirmEmptyPrefix, setConfirmEmptyPrefix] = useState(false)
-  const isAws = Boolean(config?.backupResticAws)
+  const archiveMode = config?.backupArchiveMode || 'none'
+  const isAws = archiveMode === 'restic-aws'
   const awsBucket = (config?.backupResticAwsBucket || '').trim()
   const awsPrefix = (config?.backupResticAwsPrefix || '').trim()
   const awsEndpoint = (config?.backupResticAwsEndpoint || '').trim()
@@ -139,6 +296,11 @@ function ResticRepositorySettings({
         setting
       })
     )
+
+  const handleArchiveModeChange = (nextMode) => {
+    if (nextMode === archiveMode) return
+    handleSettingChange('backup-archive-mode', nextMode)
+  }
 
   const handleResticInit = () => {
     setInitForce(false) // Reset force flag
@@ -262,15 +424,27 @@ function ResticRepositorySettings({
                 w='full'
               >
                 <GridItem className={styles.rowLabel}>
-                  <Text>Use Restic For Backup</Text>
+                  <HStack spacing={1} justify='space-between' width='full'>
+                    <Text>Restic repository type</Text>
+                    {h(ResticRepositoryTypeHelp, 'Restic Repository Type')}
+                  </HStack>
                 </GridItem>
                 <GridItem className={styles.valueCell}>
-                  <RMSwitch
-                    isChecked={config?.backupRestic}
-                    isDisabled={user?.grants['cluster-settings'] == false}
-                    confirmTitle={'Confirm switch settings for backup-restic?'}
-                    onChange={() => handleSwitchChange('backup-restic')}
-                  />
+                  <Flex className={styles.dropdownContainer}>
+                    <Dropdown
+                      options={RESTIC_REPOSITORY_TYPE_OPTIONS}
+                      className={styles.dropdownButton}
+                      selectedValue={archiveMode}
+                      isDisabled={user?.grants['cluster-settings'] == false}
+                      confirmTitle={'Confirm backup-archive-mode to'}
+                      onChange={(value) => handleArchiveModeChange(value)}
+                    />
+                  </Flex>
+                  <Text className={styles.helperText}>
+                    backup-archive-mode selects the Restic storage backend. None disables Restic backups. Local and
+                    SFTP use the local repository path (Storage section). S3 enables the AWS/S3 settings below.
+                    Switching does not erase the values stored for other types.
+                  </Text>
                 </GridItem>
               </Grid>
 
@@ -282,7 +456,10 @@ function ResticRepositorySettings({
                 w='full'
               >
                 <GridItem className={styles.rowLabel}>
-                  <Text>Backup restic binary path</Text>
+                  <HStack spacing={1} justify='space-between' width='full'>
+                    <Text>Backup restic binary path</Text>
+                    {h(ResticBinaryPathHelp, 'Backup Restic Binary Path')}
+                  </HStack>
                 </GridItem>
                 <GridItem className={styles.valueCell}>
                   <TextForm
@@ -303,7 +480,10 @@ function ResticRepositorySettings({
                 w='full'
               >
                 <GridItem className={styles.rowLabel}>
-                  <Text>Backup restic password</Text>
+                  <HStack spacing={1} justify='space-between' width='full'>
+                    <Text>Backup restic password</Text>
+                    {h(ResticPasswordHelp, 'Backup Restic Password')}
+                  </HStack>
                 </GridItem>
                 <GridItem className={styles.valueCell}>
                   <TextForm
@@ -328,337 +508,397 @@ function ResticRepositorySettings({
           controlsId: 'restic-repo-storage',
           content: (
             <Stack spacing={{ base: 2, md: 3 }}>
-              <Stack spacing={{ base: 1, md: 2 }}>
-                <Grid
-                  className={styles.resticMountGrid}
-                  templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
-                  columnGap={3}
-                  rowGap={1}
-                  w='full'
-                >
-                  <GridItem className={styles.rowLabel}>
-                    <Text>Backup restic local repository</Text>
-                  </GridItem>
-                  <GridItem className={styles.valueCell}>
-                    <HStack width='100%' spacing={2}>
+              {archiveMode === 'none' && (
+                <Text className={styles.helperText}>
+                  Restic backups are disabled (backup-archive-mode is set to none). Pick Local, S3, or SFTP in
+                  &quot;Restic repository type&quot; (Connection &amp; credentials) to configure storage.
+                </Text>
+              )}
+
+              {archiveMode === 'restic-local' && (
+                <Stack spacing={{ base: 1, md: 2 }}>
+                  <Grid
+                    className={styles.resticMountGrid}
+                    templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
+                    columnGap={3}
+                    rowGap={1}
+                    w='full'
+                  >
+                    <GridItem className={styles.rowLabel}>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>Backup restic local repository</Text>
+                        {h(ResticLocalRepositoryHelp, 'Backup Restic Local Repository')}
+                      </HStack>
+                    </GridItem>
+                    <GridItem className={styles.valueCell}>
+                      <HStack width='100%' spacing={2}>
+                        <TextForm
+                          value={config?.backupResticLocalRepository}
+                          confirmTitle={`Confirm backup-restic-local-repository to `}
+                          className={styles.textbox}
+                          size='sm'
+                          placeholder='/var/lib/repman/backups/archive'
+                          onSave={(value) => handleSettingChange('backup-restic-local-repository', value, true)}
+                        />
+                        <RMButton
+                          size='sm'
+                          colorScheme='blue'
+                          onClick={handleResticInit}
+                          isDisabled={user?.grants['cluster-settings'] === false}
+                          title="Re-initialize local repository"
+                        >
+                          <HiRefresh />
+                        </RMButton>
+                        {h(
+                          'Re-initialize the local Restic repository. This creates a new repository configuration at the specified path. Use with caution - only needed if the repository is corrupted or being set up for the first time.',
+                          'Re-initialize Local Repository'
+                        )}
+                      </HStack>
+                    </GridItem>
+                  </Grid>
+                </Stack>
+              )}
+
+              {archiveMode === 'restic-sftp' && (
+                <Stack spacing={{ base: 1, md: 2 }}>
+                  <Grid
+                    className={styles.resticMountGrid}
+                    templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
+                    columnGap={3}
+                    rowGap={1}
+                    w='full'
+                  >
+                    <GridItem className={styles.rowLabel}>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>SFTP repository path</Text>
+                        {h(ResticSftpHelp, 'SFTP Repository')}
+                      </HStack>
+                    </GridItem>
+                    <GridItem className={styles.valueCell}>
+                      <HStack width='100%' spacing={2}>
+                        <TextForm
+                          value={config?.backupResticLocalRepository}
+                          confirmTitle={`Confirm backup-restic-local-repository to `}
+                          className={styles.textbox}
+                          size='sm'
+                          placeholder='sftp:user@host:/path/to/repo'
+                          onSave={(value) => handleSettingChange('backup-restic-local-repository', value, true)}
+                        />
+                        <RMButton
+                          size='sm'
+                          colorScheme='blue'
+                          onClick={handleResticInit}
+                          isDisabled={user?.grants['cluster-settings'] === false}
+                          title="Re-initialize SFTP repository"
+                        >
+                          <HiRefresh />
+                        </RMButton>
+                        {h(
+                          'Re-initialize the SFTP Restic repository. This creates a new repository configuration at the configured sftp:user@host:/path. Force re-initialization is not supported for SFTP repositories - remove the remote repository path manually over SSH before re-initializing.',
+                          'Re-initialize SFTP Repository'
+                        )}
+                      </HStack>
+                      <Text className={styles.helperText}>
+                        Stored in backup-restic-local-repository using restic&apos;s sftp syntax
+                        (sftp:user@host:/path/to/repo). The user in the path is an SSH login authenticated via
+                        SSH key only (no password). See (?) for SSH key setup and how this differs from the
+                        repository password above.
+                      </Text>
+                    </GridItem>
+                  </Grid>
+                </Stack>
+              )}
+
+              {archiveMode === 'restic-aws' && (
+                <Stack spacing={{ base: 1, md: 2 }}>
+                  <Grid
+                    className={styles.resticMountGrid}
+                    templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
+                    columnGap={3}
+                    rowGap={1}
+                    w='full'
+                  >
+                    <GridItem className={styles.rowLabel}>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>Backup restic aws access key id</Text>
+                        {h(ResticAwsAccessKeyIdHelp, 'Backup Restic AWS Access Key ID')}
+                      </HStack>
+                    </GridItem>
+                    <GridItem className={styles.valueCell}>
                       <TextForm
-                        value={config?.backupResticLocalRepository}
-                        confirmTitle={`Confirm backup-restic-local-repository to `}
+                        value={config?.backupResticAwsAccessKeyId}
+                        confirmTitle={`Confirm backup-restic-aws-access-key-id to `}
                         className={styles.textbox}
                         size='sm'
-                        onSave={(value) => handleSettingChange('backup-restic-local-repository', value, true)}
+                        onSave={(value) => handleSettingChange('backup-restic-aws-access-key-id', value)}
                       />
-                      <RMButton
-                        size='sm'
-                        colorScheme='blue'
-                        onClick={handleResticInit}
-                        isDisabled={user?.grants['cluster-settings'] === false || config?.backupResticAws}
-                        title="Re-initialize local repository"
-                      >
-                        <HiRefresh />
-                      </RMButton>
-                      <RMIconButton
-                        icon={HiQuestionMarkCircle}
-                        onClick={() => {
-                          onOpenInfoModal(
-                            'Re-initialize Local Repository',
-                            'Re-initialize the local Restic repository. This creates a new repository configuration at the specified path. Use with caution - only needed if the repository is corrupted or being set up for the first time.'
-                          )
-                        }}
-                      />
-                    </HStack>
-                  </GridItem>
-                </Grid>
-              </Stack>
+                    </GridItem>
+                  </Grid>
 
-              <Stack spacing={{ base: 1, md: 2 }}>
-                <Grid
-                  className={styles.resticMountGrid}
-                  templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
-                  columnGap={3}
-                  rowGap={1}
-                  w='full'
-                >
-                  <GridItem className={styles.rowLabel}>
-                    <Text>Backup restic repo append cluster</Text>
-                  </GridItem>
-                  <GridItem className={styles.valueCell}>
-                    <HStack spacing={2} align='center'>
-                      <RMSwitch
-                        isChecked={config?.backupResticRepoAppendCluster}
-                        isDisabled={user?.grants['cluster-settings'] == false}
-                        confirmTitle={'Confirm switch settings for backup-restic-repo-append-cluster?'}
-                        onChange={() => handleSwitchChange('backup-restic-repo-append-cluster')}
-                      />
-                      <RMIconButton
-                        icon={HiQuestionMarkCircle}
-                        onClick={() => {
-                          onOpenInfoModal('Restic Repo Append Cluster', ResticRepoAppendClusterHelp)
-                        }}
-                      />
-                    </HStack>
-                  </GridItem>
-                </Grid>
-
-                <Grid
-                  className={styles.resticMountGrid}
-                  templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
-                  columnGap={3}
-                  rowGap={1}
-                  w='full'
-                >
-                  <GridItem className={styles.rowLabel}>
-                    <Text>Enable AWS/S3 repository</Text>
-                  </GridItem>
-                  <GridItem className={styles.valueCell}>
-                    <RMSwitch
-                      isChecked={config?.backupResticAws}
-                      isDisabled={user?.grants['cluster-settings'] == false}
-                      confirmTitle={'Confirm switch settings for backup-restic-aws?'}
-                      onChange={() => handleSwitchChange('backup-restic-aws')}
-                    />
-                    <Text className={styles.helperText}>
-                      Configure the AWS settings below before enabling.
-                    </Text>
-                  </GridItem>
-                </Grid>
-
-                <Grid
-                  className={styles.resticMountGrid}
-                  templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
-                  columnGap={3}
-                  rowGap={1}
-                  w='full'
-                >
-                  <GridItem className={styles.rowLabel}>
-                    <Text>Backup restic aws access key id</Text>
-                  </GridItem>
-                  <GridItem className={styles.valueCell}>
-                    <TextForm
-                      value={config?.backupResticAwsAccessKeyId}
-                      confirmTitle={`Confirm backup-restic-aws-access-key-id to `}
-                      className={styles.textbox}
-                      size='sm'
-                      onSave={(value) => handleSettingChange('backup-restic-aws-access-key-id', value)}
-                    />
-                  </GridItem>
-                </Grid>
-
-                <Grid
-                  className={styles.resticMountGrid}
-                  templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
-                  columnGap={3}
-                  rowGap={1}
-                  w='full'
-                >
-                  <GridItem className={styles.rowLabel}>
-                    <Text>Backup restic aws access secret</Text>
-                  </GridItem>
-                  <GridItem className={styles.valueCell}>
-                    <TextForm
-                      value={config?.backupResticAwsAccessSecret}
-                      confirmTitle={`Confirm backup-restic-aws-access-secret to `}
-                      className={styles.textbox}
-                      size='sm'
-                      onSave={(value) => handleSettingChange('backup-restic-aws-access-secret', value, true)}
-                    />
-                  </GridItem>
-                </Grid>
-
-                <Grid
-                  className={styles.resticMountGrid}
-                  templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
-                  columnGap={3}
-                  rowGap={1}
-                  w='full'
-                >
-                  <GridItem className={styles.rowLabel}>
-                    <Text>Backup restic aws region</Text>
-                  </GridItem>
-                  <GridItem className={styles.valueCell}>
-                    <TextForm
-                      value={config?.backupResticAwsRegion}
-                      confirmTitle={`Confirm backup-restic-aws-region to `}
-                      className={styles.textbox}
-                      size='sm'
-                      placeholder='us-east-1, eu-west-1, etc.'
-                      onSave={(value) => handleSettingChange('backup-restic-aws-region', value)}
-                    />
-                    <Text className={styles.helperText}>Empty uses AWS SDK default region resolution.</Text>
-                  </GridItem>
-                </Grid>
-
-                <Grid
-                  className={styles.resticMountGrid}
-                  templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
-                  columnGap={3}
-                  rowGap={1}
-                  w='full'
-                >
-                  <GridItem className={styles.rowLabel}>
-                    <Text>Backup restic aws endpoint</Text>
-                  </GridItem>
-                  <GridItem className={styles.valueCell}>
-                    <TextForm
-                      value={config?.backupResticAwsEndpoint}
-                      confirmTitle={`Confirm backup-restic-aws-endpoint to `}
-                      className={styles.textbox}
-                      size='sm'
-                      placeholder='https://s3.amazonaws.com or https://minio.example.com'
-                      regexPattern='^https?://[A-Za-z0-9.-]+(?::\\d+)?(?:/.*)?$'
-                      onSave={(value) => handleSettingChange('backup-restic-aws-endpoint', value, true)}
-                    />
-                    <Text className={styles.helperText}>
-                      Optional custom S3 endpoint (http/https with host; leave empty for AWS). Do not use s3:// here.
-                    </Text>
-                  </GridItem>
-                </Grid>
-
-                <Grid
-                  className={styles.resticMountGrid}
-                  templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
-                  columnGap={3}
-                  rowGap={1}
-                  w='full'
-                >
-                  <GridItem className={styles.rowLabel}>
-                    <Text>Backup restic aws bucket</Text>
-                  </GridItem>
-                  <GridItem className={styles.valueCell}>
-                    <TextForm
-                      value={config?.backupResticAwsBucket}
-                      confirmTitle={`Confirm backup-restic-aws-bucket to `}
-                      className={styles.textbox}
-                      size='sm'
-                      placeholder='bucket-name'
-                      regexPattern='^[^/\\\\]*$'
-                      onSave={(value) => handleSettingChange('backup-restic-aws-bucket', value)}
-                    />
-                    <Text className={styles.helperText}>Bucket name must not contain '/' or '\\'.</Text>
-                  </GridItem>
-                </Grid>
-
-                <Grid
-                  className={styles.resticMountGrid}
-                  templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
-                  columnGap={3}
-                  rowGap={1}
-                  w='full'
-                >
-                  <GridItem className={styles.rowLabel}>
-                    <Text>Backup restic aws prefix</Text>
-                  </GridItem>
-                  <GridItem className={styles.valueCell}>
-                    <TextForm
-                      value={config?.backupResticAwsPrefix}
-                      confirmTitle={`Confirm backup-restic-aws-prefix to `}
-                      className={styles.textbox}
-                      size='sm'
-                      placeholder='optional/prefix/path'
-                      onSave={(value) => handleSettingChange('backup-restic-aws-prefix', value, true)}
-                    />
-                    <Text className={styles.helperText}>Optional bucket prefix/path (no leading slash).</Text>
-                  </GridItem>
-                </Grid>
-
-                <Grid
-                  className={styles.resticMountGrid}
-                  templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
-                  columnGap={3}
-                  rowGap={1}
-                  w='full'
-                >
-                <GridItem className={styles.rowLabel}>
-                    <Text>Backup restic additional env</Text>
-                  </GridItem>
-                  <GridItem className={styles.valueCell}>
-                    <TextForm
-                      value={config?.backupResticAdditionalEnv}
-                      confirmTitle={`Confirm backup-restic-additional-env to `}
-                      className={styles.textbox}
-                      size='sm'
-                      placeholder='AWS_SESSION_TOKEN, NO_PROXY="host1,host2"'
-                      onSave={(value) => handleSettingChange('backup-restic-additional-env', value)}
-                    />
-                    <Text className={styles.helperText}>
-                      Optional env vars to pass to restic (comma or space separated KEY or KEY=VALUE). Quote values with commas.
-                    </Text>
-                  </GridItem>
-                </Grid>
-
-                <Grid
-                  className={styles.resticMountGrid}
-                  templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
-                  columnGap={3}
-                  rowGap={1}
-                  w='full'
-                >
-                  <GridItem className={styles.rowLabel}>
-                    <Text>Effective S3 repository</Text>
-                  </GridItem>
-                  <GridItem className={styles.valueCell}>
-                    <Text
-                      fontWeight='bold'
-                      fontSize='sm'
-                      fontFamily='monospace'
-                      bg='gray.100'
-                      p={2}
-                      borderRadius='md'
-                      wordBreak='break-all'
-                    >
-                      {awsRepoPath || 's3:<bucket>/<prefix>'}
-                    </Text>
-                    <Text className={styles.helperText}>
-                      Preview of the S3 repository path after applying append-cluster rules.
-                    </Text>
-                  </GridItem>
-                </Grid>
-
-                <Grid
-                  className={styles.resticMountGrid}
-                  templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
-                  columnGap={3}
-                  rowGap={1}
-                  w='full'
-                >
-                  <GridItem className={styles.rowLabel}>
-                    <Text>Legacy repository URL (fallback)</Text>
-                  </GridItem>
-                  <GridItem className={styles.valueCell}>
-                    <HStack width='100%' spacing={2}>
+                  <Grid
+                    className={styles.resticMountGrid}
+                    templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
+                    columnGap={3}
+                    rowGap={1}
+                    w='full'
+                  >
+                    <GridItem className={styles.rowLabel}>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>Backup restic aws access secret</Text>
+                        {h(ResticAwsAccessSecretHelp, 'Backup Restic AWS Access Secret')}
+                      </HStack>
+                    </GridItem>
+                    <GridItem className={styles.valueCell}>
                       <TextForm
-                        value={config?.backupResticRepository}
-                        confirmTitle={`Confirm backup-restic-repository to `}
+                        value={config?.backupResticAwsAccessSecret}
+                        confirmTitle={`Confirm backup-restic-aws-access-secret to `}
                         className={styles.textbox}
                         size='sm'
-                        onSave={(value) => handleSettingChange('backup-restic-repository', value, true)}
+                        onSave={(value) => handleSettingChange('backup-restic-aws-access-secret', value, true)}
                       />
-                      <RMButton
+                    </GridItem>
+                  </Grid>
+
+                  <Grid
+                    className={styles.resticMountGrid}
+                    templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
+                    columnGap={3}
+                    rowGap={1}
+                    w='full'
+                  >
+                    <GridItem className={styles.rowLabel}>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>Backup restic aws region</Text>
+                        {h(ResticAwsRegionHelp, 'Backup Restic AWS Region')}
+                      </HStack>
+                    </GridItem>
+                    <GridItem className={styles.valueCell}>
+                      <TextForm
+                        value={config?.backupResticAwsRegion}
+                        confirmTitle={`Confirm backup-restic-aws-region to `}
+                        className={styles.textbox}
                         size='sm'
-                        colorScheme='blue'
-                        onClick={handleResticInit}
-                        isDisabled={user?.grants['cluster-settings'] === false || !config?.backupResticAws}
-                        title="Re-initialize S3 repository"
-                      >
-                        <HiRefresh />
-                      </RMButton>
-                      <RMIconButton
-                        icon={HiQuestionMarkCircle}
-                        onClick={() => {
-                          onOpenInfoModal(
-                            'Re-initialize S3 Repository',
-                            'Re-initialize the S3/MinIO Restic repository. This creates a new repository configuration at the specified S3 bucket/path. Force re-initialization deletes all objects under the configured bucket/prefix. Ensure AWS credentials and bucket path are correct before initializing.'
-                          )
-                        }}
+                        placeholder='us-east-1, eu-west-1, etc.'
+                        onSave={(value) => handleSettingChange('backup-restic-aws-region', value)}
                       />
-                    </HStack>
-                    <Text className={styles.helperText}>
-                      Used only when AWS is enabled and the S3 bucket field is empty. For custom S3 services use
-                      s3:https://server:port/bucket in this field.
-                    </Text>
-                  </GridItem>
-                </Grid>
-              </Stack>
+                      <Text className={styles.helperText}>Empty uses AWS SDK default region resolution.</Text>
+                    </GridItem>
+                  </Grid>
+
+                  <Grid
+                    className={styles.resticMountGrid}
+                    templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
+                    columnGap={3}
+                    rowGap={1}
+                    w='full'
+                  >
+                    <GridItem className={styles.rowLabel}>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>Backup restic aws endpoint</Text>
+                        {h(ResticAwsEndpointHelp, 'Backup Restic AWS Endpoint')}
+                      </HStack>
+                    </GridItem>
+                    <GridItem className={styles.valueCell}>
+                      <TextForm
+                        value={config?.backupResticAwsEndpoint}
+                        confirmTitle={`Confirm backup-restic-aws-endpoint to `}
+                        className={styles.textbox}
+                        size='sm'
+                        placeholder='https://s3.amazonaws.com or https://minio.example.com'
+                        regexPattern='^https?://[A-Za-z0-9.-]+(?::\\d+)?(?:/.*)?$'
+                        onSave={(value) => handleSettingChange('backup-restic-aws-endpoint', value, true)}
+                      />
+                      <Text className={styles.helperText}>
+                        Optional custom S3 endpoint (http/https with host; leave empty for AWS). Do not use s3:// here.
+                      </Text>
+                    </GridItem>
+                  </Grid>
+
+                  <Grid
+                    className={styles.resticMountGrid}
+                    templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
+                    columnGap={3}
+                    rowGap={1}
+                    w='full'
+                  >
+                    <GridItem className={styles.rowLabel}>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>Backup restic aws bucket</Text>
+                        {h(ResticAwsBucketHelp, 'Backup Restic AWS Bucket')}
+                      </HStack>
+                    </GridItem>
+                    <GridItem className={styles.valueCell}>
+                      <TextForm
+                        value={config?.backupResticAwsBucket}
+                        confirmTitle={`Confirm backup-restic-aws-bucket to `}
+                        className={styles.textbox}
+                        size='sm'
+                        placeholder='bucket-name'
+                        regexPattern='^[^/\\\\]*$'
+                        onSave={(value) => handleSettingChange('backup-restic-aws-bucket', value)}
+                      />
+                      <Text className={styles.helperText}>Bucket name must not contain &apos;/&apos; or &apos;\\&apos;.</Text>
+                    </GridItem>
+                  </Grid>
+
+                  <Grid
+                    className={styles.resticMountGrid}
+                    templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
+                    columnGap={3}
+                    rowGap={1}
+                    w='full'
+                  >
+                    <GridItem className={styles.rowLabel}>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>Backup restic aws prefix</Text>
+                        {h(ResticAwsPrefixHelp, 'Backup Restic AWS Prefix')}
+                      </HStack>
+                    </GridItem>
+                    <GridItem className={styles.valueCell}>
+                      <TextForm
+                        value={config?.backupResticAwsPrefix}
+                        confirmTitle={`Confirm backup-restic-aws-prefix to `}
+                        className={styles.textbox}
+                        size='sm'
+                        placeholder='optional/prefix/path'
+                        onSave={(value) => handleSettingChange('backup-restic-aws-prefix', value, true)}
+                      />
+                      <Text className={styles.helperText}>Optional bucket prefix/path (no leading slash).</Text>
+                    </GridItem>
+                  </Grid>
+
+                  <Grid
+                    className={styles.resticMountGrid}
+                    templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
+                    columnGap={3}
+                    rowGap={1}
+                    w='full'
+                  >
+                    <GridItem className={styles.rowLabel}>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>Effective S3 repository</Text>
+                        {h(ResticEffectiveS3RepoHelp, 'Effective S3 Repository')}
+                      </HStack>
+                    </GridItem>
+                    <GridItem className={styles.valueCell}>
+                      <Text
+                        fontWeight='bold'
+                        fontSize='sm'
+                        fontFamily='monospace'
+                        bg='gray.100'
+                        p={2}
+                        borderRadius='md'
+                        wordBreak='break-all'
+                      >
+                        {awsRepoPath || 's3:<bucket>/<prefix>'}
+                      </Text>
+                      <Text className={styles.helperText}>
+                        Preview of the S3 repository path after applying append-cluster rules.
+                      </Text>
+                    </GridItem>
+                  </Grid>
+
+                  <Grid
+                    className={styles.resticMountGrid}
+                    templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
+                    columnGap={3}
+                    rowGap={1}
+                    w='full'
+                  >
+                    <GridItem className={styles.rowLabel}>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>Legacy repository URL (fallback)</Text>
+                        {h(ResticLegacyRepoUrlHelp, 'Legacy Repository URL (fallback)')}
+                      </HStack>
+                    </GridItem>
+                    <GridItem className={styles.valueCell}>
+                      <HStack width='100%' spacing={2}>
+                        <TextForm
+                          value={config?.backupResticRepository}
+                          confirmTitle={`Confirm backup-restic-repository to `}
+                          className={styles.textbox}
+                          size='sm'
+                          onSave={(value) => handleSettingChange('backup-restic-repository', value, true)}
+                        />
+                        <RMButton
+                          size='sm'
+                          colorScheme='blue'
+                          onClick={handleResticInit}
+                          isDisabled={user?.grants['cluster-settings'] === false}
+                          title="Re-initialize S3 repository"
+                        >
+                          <HiRefresh />
+                        </RMButton>
+                        {h(
+                          'Re-initialize the S3/MinIO Restic repository. This creates a new repository configuration at the specified S3 bucket/path. Force re-initialization deletes all objects under the configured bucket/prefix. Ensure AWS credentials and bucket path are correct before initializing.',
+                          'Re-initialize S3 Repository'
+                        )}
+                      </HStack>
+                      <Text className={styles.helperText}>
+                        Used only when AWS is enabled and the S3 bucket field is empty. For custom S3 services use
+                        s3:https://server:port/bucket in this field.
+                      </Text>
+                    </GridItem>
+                  </Grid>
+                </Stack>
+              )}
+
+              {archiveMode !== 'none' && (
+                <Stack spacing={{ base: 1, md: 2 }}>
+                  <Grid
+                    className={styles.resticMountGrid}
+                    templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
+                    columnGap={3}
+                    rowGap={1}
+                    w='full'
+                  >
+                    <GridItem className={styles.rowLabel}>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>Backup restic repo append cluster</Text>
+                        {h(ResticRepoAppendClusterHelp, 'Restic Repo Append Cluster')}
+                      </HStack>
+                    </GridItem>
+                    <GridItem className={styles.valueCell}>
+                      <HStack spacing={2} align='center'>
+                        <RMSwitch
+                          isChecked={config?.backupResticRepoAppendCluster}
+                          isDisabled={user?.grants['cluster-settings'] == false}
+                          confirmTitle={'Confirm switch settings for backup-restic-repo-append-cluster?'}
+                          onChange={() => handleSwitchChange('backup-restic-repo-append-cluster')}
+                        />
+                      </HStack>
+                    </GridItem>
+                  </Grid>
+
+                  <Grid
+                    className={styles.resticMountGrid}
+                    templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
+                    columnGap={3}
+                    rowGap={1}
+                    w='full'
+                  >
+                    <GridItem className={styles.rowLabel}>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>Backup restic additional env</Text>
+                        {h(ResticAdditionalEnvHelp, 'Backup Restic Additional Env')}
+                      </HStack>
+                    </GridItem>
+                    <GridItem className={styles.valueCell}>
+                      <TextForm
+                        value={config?.backupResticAdditionalEnv}
+                        confirmTitle={`Confirm backup-restic-additional-env to `}
+                        className={styles.textbox}
+                        size='sm'
+                        placeholder='AWS_SESSION_TOKEN, NO_PROXY="host1,host2"'
+                        onSave={(value) => handleSettingChange('backup-restic-additional-env', value)}
+                      />
+                      <Text className={styles.helperText}>
+                        Optional env vars to pass to restic (comma or space separated KEY or KEY=VALUE). Quote values with commas.
+                      </Text>
+                    </GridItem>
+                  </Grid>
+                </Stack>
+              )}
             </Stack>
           )
         })}
@@ -680,7 +920,10 @@ function ResticRepositorySettings({
                 w='full'
               >
                 <GridItem className={styles.rowLabel}>
-                  <Text>Backup restic host override</Text>
+                  <HStack spacing={1} justify='space-between' width='full'>
+                    <Text>Backup restic host override</Text>
+                    {h(ResticHostHelp, 'Restic Host Override')}
+                  </HStack>
                 </GridItem>
                 <GridItem className={styles.valueCell}>
                   <HStack width='100%'>
@@ -691,12 +934,6 @@ function ResticRepositorySettings({
                       size='sm'
                       placeholder='(empty = restic default host)'
                       onSave={(value) => handleSettingChange('backup-restic-host', value)}
-                    />
-                    <RMIconButton
-                      icon={HiQuestionMarkCircle}
-                      onClick={() => {
-                        onOpenInfoModal('Restic Host Override', ResticHostHelp)
-                      }}
                     />
                   </HStack>
                 </GridItem>
@@ -710,7 +947,10 @@ function ResticRepositorySettings({
                 w='full'
               >
                 <GridItem className={styles.rowLabel}>
-                  <Text>Backup restic tags</Text>
+                  <HStack spacing={1} justify='space-between' width='full'>
+                    <Text>Backup restic tags</Text>
+                    {h(ResticTagsHelp, 'Restic Tag Templates')}
+                  </HStack>
                 </GridItem>
                 <GridItem className={styles.valueCell}>
                   <HStack width='100%'>
@@ -721,12 +961,6 @@ function ResticRepositorySettings({
                       size='sm'
                       placeholder='tenant,cluster,engine,version,backup-type,backup-tool,line'
                       onSave={(value) => handleSettingChange('backup-restic-tags', value)}
-                    />
-                    <RMIconButton
-                      icon={HiQuestionMarkCircle}
-                      onClick={() => {
-                        onOpenInfoModal('Restic Tag Templates', ResticTagsHelp)
-                      }}
                     />
                   </HStack>
                 </GridItem>
@@ -743,7 +977,7 @@ function ResticRepositorySettings({
         body={
           <VStack align='start' spacing={3}>
             <Text>
-              Re-initialize the {config?.backupResticAws ? 'S3/MinIO' : 'local'} Restic repository:
+              Re-initialize the {archiveMode === 'restic-aws' ? 'S3/MinIO' : archiveMode === 'restic-sftp' ? 'SFTP' : 'local'} Restic repository:
             </Text>
             <Text 
               fontWeight='bold' 
@@ -754,8 +988,8 @@ function ResticRepositorySettings({
               borderRadius='md'
               wordBreak='break-all'
             >
-              {config?.backupResticAws 
-                ? awsRepoPath 
+              {isAws
+                ? awsRepoPath
                 : config?.backupResticLocalRepository}
             </Text>
             <Divider />
@@ -771,7 +1005,7 @@ function ResticRepositorySettings({
               <Alert status='warning' size='sm' borderRadius='md'>
                 <AlertIcon />
                 <Text fontSize='sm'>
-                  {config?.backupResticAws
+                  {isAws
                     ? 'Warning: Force re-initialization deletes all objects under the configured S3 bucket/prefix before creating a new repository.'
                     : 'Warning: This will overwrite the existing repository configuration.'}
                 </Text>

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -447,6 +447,19 @@ func (repo *ResticManager) UpdateSnapshotList(snapshots []BackupSnapshot) {
 	}
 }
 
+// ClearSnapshotList discards the cached snapshot list and stats.
+// Used when the repository configuration changes (e.g. backup-archive-mode
+// switches to a different backend/path) so stale snapshots from the
+// previous repository are no longer displayed until the next fetch.
+func (repo *ResticManager) ClearSnapshotList() {
+	repo.Mutex.Lock()
+	defer repo.Mutex.Unlock()
+
+	repo.Backups = make([]BackupSnapshot, 0)
+	repo.BackupMap = make(map[string]*BackupSnapshot)
+	repo.BackupStat = BackupStat{}
+}
+
 func (repo *ResticManager) GetSnapshot(snapshotId string) *BackupSnapshot {
 	repo.Mutex.Lock()
 	defer repo.Mutex.Unlock()

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -2844,6 +2844,11 @@ func isS3Repository(repoPath string) bool {
 	return strings.HasPrefix(repoPath, "s3:")
 }
 
+// isSftpRepository checks if repository path uses the sftp backend
+func isSftpRepository(repoPath string) bool {
+	return strings.HasPrefix(strings.ToLower(repoPath), "sftp:")
+}
+
 // parseS3URL parses S3 repository URL into components
 // Supports formats:
 //   - s3:https://endpoint/bucket/prefix (MinIO/custom endpoint)
@@ -3007,7 +3012,7 @@ func (repo *ResticManager) checkS3RepoFiles(bucket, prefix, endpoint string) err
 		}
 
 		// No config, no data - return error to require explicit init
-		repo.CanInitRepo = false
+		repo.CanInitRepo = true
 		err = errors.New(errstr)
 		repo.SetError(InitTask, err)
 		repo.setInitErrorBackoff(err)
@@ -3143,6 +3148,16 @@ func (repo *ResticManager) CheckRepoFiles() error {
 		return repo.checkS3RepoFiles(bucket, prefix, endpoint)
 	}
 
+	if isSftpRepository(repopath) {
+		// Repo lives on a remote host via SSH/SFTP; skip local filesystem
+		// existence checks and let actual restic commands surface
+		// init-required errors naturally.
+		repo.CanInitRepo = true
+		delete(repo.TaskErrors, InitTask)
+		repo.clearInitErrorBackoff()
+		return nil
+	}
+
 	// Existing local filesystem logic
 	if _, err := os.Stat(filepath.Join(repopath, "config")); os.IsNotExist(err) {
 		// Check the repo data
@@ -3160,8 +3175,8 @@ func (repo *ResticManager) CheckRepoFiles() error {
 			err = errors.New(errstr)
 			repo.SetError(InitTask, err)
 			return err
-		} else { // Repo data does not exist (explicit init required)
-			repo.CanInitRepo = false
+		} else { // Repo data does not exist (explicit init required, but possible)
+			repo.CanInitRepo = true
 			err = errors.New(errstr)
 			repo.SetError(InitTask, err)
 			return err
@@ -3372,6 +3387,12 @@ func (repo *ResticManager) InitRepoWithOptions(opt ResticInitOption) error {
 				repo.setInitErrorBackoff(err)
 				return err
 			}
+		} else if isSftpRepository(repopath) {
+			repo.CanInitRepo = false
+			err := fmt.Errorf("force re-initialization is not supported for sftp repositories; remove the remote repository path manually over ssh before re-initializing")
+			repo.SetError(InitTask, err)
+			repo.setInitErrorBackoff(err)
+			return err
 		} else {
 			err := os.RemoveAll(repopath)
 			if err != nil {

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -349,6 +349,7 @@ const resticTaskStateTTL = 60 * time.Second
 type ResticManager struct {
 	BinaryPath           string
 	Env                  []string
+	envMutex             *sync.RWMutex // Protects Env, read by RunCommand* concurrently with the worker
 	AwsAccessKeyID       string
 	AwsSecretAccessKey   string
 	AwsRegion            string
@@ -417,6 +418,7 @@ func NewResticRepo(binaryPath string, msgChan chan sharedlog.Message, logmodule 
 		LogModule:            logmodule,
 		TaskQueue:            make([]*ResticTask, 0),
 		Mutex:                &sync.Mutex{},
+		envMutex:             &sync.RWMutex{},
 		currentTaskMutex:     &sync.Mutex{},
 		mountRefMutex:        &sync.Mutex{},
 		mountUsers:           make(map[string]struct{}),
@@ -595,7 +597,19 @@ func (repo *ResticManager) ClearInitErrorBackoffManual() {
 }
 
 func (repo *ResticManager) SetEnv(env []string) {
+	repo.envMutex.Lock()
+	defer repo.envMutex.Unlock()
 	repo.Env = env
+}
+
+// getEnvCopy returns the process environment combined with repo.Env, suitable
+// for assigning to exec.Cmd.Env. It holds envMutex only long enough to copy
+// repo.Env, so it can be called freely from RunCommand* without contending
+// with SetEnv/UpdateEnvKey for the duration of the command.
+func (repo *ResticManager) getEnvCopy() []string {
+	repo.envMutex.RLock()
+	defer repo.envMutex.RUnlock()
+	return append(os.Environ(), repo.Env...)
 }
 
 // SetAwsConfig updates AWS settings for S3 repository handling.
@@ -610,6 +624,9 @@ func (repo *ResticManager) SetAwsConfig(accessKeyID, secretAccessKey, region, en
 
 // UpdateEnvKey updates the environment variable for the Restic repository
 func (repo *ResticManager) UpdateEnvKey(key, value string) {
+	repo.envMutex.Lock()
+	defer repo.envMutex.Unlock()
+
 	found := false
 	for i, env := range repo.Env {
 		if strings.HasPrefix(env, key+"=") {
@@ -625,6 +642,9 @@ func (repo *ResticManager) UpdateEnvKey(key, value string) {
 }
 
 func (repo *ResticManager) GetRepoPath() string {
+	repo.envMutex.RLock()
+	defer repo.envMutex.RUnlock()
+
 	for _, env := range repo.Env {
 		if strings.HasPrefix(env, "RESTIC_REPOSITORY") {
 			parts := strings.SplitN(env, "=", 2)
@@ -638,6 +658,9 @@ func (repo *ResticManager) GetRepoPath() string {
 }
 
 func (repo *ResticManager) GetCacheDirPath() string {
+	repo.envMutex.RLock()
+	defer repo.envMutex.RUnlock()
+
 	for _, env := range repo.Env {
 		if strings.HasPrefix(env, "RESTIC_CACHE_DIR") {
 			parts := strings.SplitN(env, "=", 2)
@@ -1442,7 +1465,7 @@ func (repo *ResticManager) DumpSnapshotWithOptions(opt ResticDumpOption, writer 
 	args = append(args, snapshotID, filePath)
 
 	cmd := exec.CommandContext(ctx, repo.BinaryPath, args...)
-	cmd.Env = append(os.Environ(), repo.Env...)
+	cmd.Env = repo.getEnvCopy()
 
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
@@ -1674,7 +1697,7 @@ func (repo *ResticManager) MountRepoWithOptions(opt ResticMountOption) error {
 	// Build command arguments
 	args := repo.buildMountArgs(opt)
 	cmd := exec.Command(repo.BinaryPath, args...)
-	cmd.Env = append(os.Environ(), repo.Env...)
+	cmd.Env = repo.getEnvCopy()
 
 	repo.Printf(logrus.InfoLevel, "Starting command: %s %v", repo.BinaryPath, args)
 	ptyFile, err := pty.Start(cmd)
@@ -2844,6 +2867,9 @@ func (repo *ResticManager) ShutdownWorker() {
 
 // getEnvValue extracts value from repo.Env slice by key
 func (repo *ResticManager) getEnvValue(key string) string {
+	repo.envMutex.RLock()
+	defer repo.envMutex.RUnlock()
+
 	prefix := key + "="
 	for _, env := range repo.Env {
 		if strings.HasPrefix(env, prefix) {
@@ -3205,7 +3231,7 @@ func (repo *ResticManager) CheckRepoFiles() error {
 func (repo *ResticManager) RunCommand(args []string, loglevel logrus.Level, captureOutput bool) ([]byte, []byte, error) {
 	// Set up the command
 	cmd := exec.Command(repo.BinaryPath, args...)
-	cmd.Env = append(os.Environ(), repo.Env...)
+	cmd.Env = repo.getEnvCopy()
 
 	// Buffers for stdout and stderr
 	var stdoutBuf, stderrBuf bytes.Buffer
@@ -3274,7 +3300,7 @@ func (repo *ResticManager) RunCommand(args []string, loglevel logrus.Level, capt
 func (repo *ResticManager) RunCommandWithContext(ctx context.Context, args []string, loglevel logrus.Level, captureOutput bool) ([]byte, []byte, error) {
 	// Set up the command with context
 	cmd := exec.CommandContext(ctx, repo.BinaryPath, args...)
-	cmd.Env = append(os.Environ(), repo.Env...)
+	cmd.Env = repo.getEnvCopy()
 
 	// Buffers for stdout and stderr
 	var stdoutBuf, stderrBuf bytes.Buffer
@@ -3924,7 +3950,7 @@ func (repo *ResticManager) BackupWithOptions(opt ResticBackupOption) (string, er
 // This minimizes memory usage for large backups that produce many JSON status lines
 func (repo *ResticManager) runBackupCommand(args []string) ([]byte, []byte, error) {
 	cmd := exec.Command(repo.BinaryPath, args...)
-	cmd.Env = append(os.Environ(), repo.Env...)
+	cmd.Env = repo.getEnvCopy()
 
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
@@ -4362,10 +4388,14 @@ func (repo *ResticManager) TestPassword(newpass string) error {
 	repo.SetCanFetch(false)
 	defer repo.SetCanFetch(true)
 
-	// Temporarily add the new password file to the environment
-	originalEnv := repo.Env
+	// Temporarily add the new password file to the environment. originalEnv is
+	// a copy, since UpdateEnvKey may overwrite the RESTIC_PASSWORD entry in
+	// place rather than appending, which would otherwise mutate it too.
+	repo.envMutex.RLock()
+	originalEnv := append([]string(nil), repo.Env...)
+	repo.envMutex.RUnlock()
 	repo.UpdateEnvKey("RESTIC_PASSWORD", newpass)
-	defer func() { repo.Env = originalEnv }() // Restore original env after function
+	defer repo.SetEnv(originalEnv) // Restore original env after function
 
 	// Test the new password by listing keys
 	args := []string{"key", "list", "--json"}

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/creack/pty"
+	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/misc"
 	sharedlog "github.com/signal18/replication-manager/utils/s18log/shared"
 	"github.com/signal18/replication-manager/utils/s3helper"
@@ -2852,16 +2853,6 @@ func (repo *ResticManager) getEnvValue(key string) string {
 	return ""
 }
 
-// isS3Repository checks if repository path uses S3 backend
-func isS3Repository(repoPath string) bool {
-	return strings.HasPrefix(repoPath, "s3:")
-}
-
-// isSftpRepository checks if repository path uses the sftp backend
-func isSftpRepository(repoPath string) bool {
-	return strings.HasPrefix(repoPath, "sftp:")
-}
-
 // parseS3URL parses S3 repository URL into components
 // Supports formats:
 //   - s3:https://endpoint/bucket/prefix (MinIO/custom endpoint)
@@ -3134,7 +3125,7 @@ func (repo *ResticManager) CheckRepoFiles() error {
 	}
 
 	repopath := repo.GetRepoPath()
-	if isS3Repository(repopath) || repo.AwsBucket != "" {
+	if config.IsS3ResticRepository(repopath) || repo.AwsBucket != "" {
 		bucket, prefix, endpoint, err := repo.resolveS3RepoSpec(repopath)
 		if err != nil {
 			repo.CanInitRepo = false
@@ -3161,7 +3152,7 @@ func (repo *ResticManager) CheckRepoFiles() error {
 		return repo.checkS3RepoFiles(bucket, prefix, endpoint)
 	}
 
-	if isSftpRepository(repopath) {
+	if config.IsSftpResticRepository(repopath) {
 		// Repo lives on a remote host via SSH/SFTP; skip local filesystem
 		// existence checks and let actual restic commands surface
 		// init-required errors naturally.
@@ -3362,7 +3353,7 @@ func (repo *ResticManager) InitRepo(force bool) error {
 func (repo *ResticManager) InitRepoWithOptions(opt ResticInitOption) error {
 	repopath := repo.GetRepoPath()
 	if opt.Force {
-		if isS3Repository(repopath) || repo.AwsBucket != "" {
+		if config.IsS3ResticRepository(repopath) || repo.AwsBucket != "" {
 			bucket, prefix, endpoint, err := repo.resolveS3RepoSpec(repopath)
 			if err != nil {
 				repo.CanInitRepo = false
@@ -3400,7 +3391,7 @@ func (repo *ResticManager) InitRepoWithOptions(opt ResticInitOption) error {
 				repo.setInitErrorBackoff(err)
 				return err
 			}
-		} else if isSftpRepository(repopath) {
+		} else if config.IsSftpResticRepository(repopath) {
 			repo.CanInitRepo = false
 			err := fmt.Errorf("force re-initialization is not supported for sftp repositories; remove the remote repository path manually over ssh before re-initializing")
 			repo.SetError(InitTask, err)

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -2859,7 +2859,7 @@ func isS3Repository(repoPath string) bool {
 
 // isSftpRepository checks if repository path uses the sftp backend
 func isSftpRepository(repoPath string) bool {
-	return strings.HasPrefix(strings.ToLower(repoPath), "sftp:")
+	return strings.HasPrefix(repoPath, "sftp:")
 }
 
 // parseS3URL parses S3 repository URL into components

--- a/utils/backupmgr/restic_test.go
+++ b/utils/backupmgr/restic_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/signal18/replication-manager/config"
 	sharedlog "github.com/signal18/replication-manager/utils/s18log/shared"
 	"github.com/sirupsen/logrus"
 )
@@ -1984,8 +1985,8 @@ func TestIsS3Repository(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isS3Repository(tt.repoPath); got != tt.want {
-				t.Errorf("isS3Repository(%q) = %v, want %v", tt.repoPath, got, tt.want)
+			if got := config.IsS3ResticRepository(tt.repoPath); got != tt.want {
+				t.Errorf("IsS3ResticRepository(%q) = %v, want %v", tt.repoPath, got, tt.want)
 			}
 		})
 	}

--- a/utils/backupmgr/restic_test.go
+++ b/utils/backupmgr/restic_test.go
@@ -404,21 +404,23 @@ func TestCheckRepoFiles(t *testing.T) {
 		"RESTIC_REPOSITORY=" + repoDir,
 	})
 
-	if err := repo.CheckRepoFiles(); err != nil {
-		t.Fatalf("expected init on missing config: %v", err)
+	// Fresh repo dir: no config, no data - explicit init required but still possible
+	if err := repo.CheckRepoFiles(); err == nil {
+		t.Fatalf("expected error when repo is not yet initialized")
 	}
-	if _, err := os.Stat(filepath.Join(repoDir, "config")); err != nil {
-		t.Fatalf("expected config after init: %v", err)
+	if !repo.CanInitRepo {
+		t.Fatalf("expected CanInitRepo true for a fresh, uninitialized repo")
 	}
 
-	if err := os.Remove(filepath.Join(repoDir, "config")); err != nil {
-		t.Fatalf("remove config: %v", err)
-	}
+	// Data exists without config: corrupted repo, cannot be auto/explicitly initialized
 	if err := os.MkdirAll(filepath.Join(repoDir, "data"), 0755); err != nil {
 		t.Fatalf("mkdir data: %v", err)
 	}
 	if err := repo.CheckRepoFiles(); err == nil {
 		t.Fatalf("expected error when config missing but data exists")
+	}
+	if repo.CanInitRepo {
+		t.Fatalf("expected CanInitRepo false when data exists without config")
 	}
 }
 

--- a/utils/backupmgr/restic_test.go
+++ b/utils/backupmgr/restic_test.go
@@ -425,6 +425,39 @@ func TestCheckRepoFiles(t *testing.T) {
 	}
 }
 
+func TestCheckRepoFilesSftp(t *testing.T) {
+	repo := newPausedRepo(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=sftp:backup@10.0.0.1:/srv/restic-repo",
+	})
+
+	// Simulate state left over from a prior failed init attempt, so we can
+	// verify the sftp branch clears it rather than just leaving CanInitRepo
+	// at its zero-value default of true. The backoff deadline is set in the
+	// past so it doesn't short-circuit this call to CheckRepoFiles.
+	repo.CanInitRepo = false
+	repo.SetError(InitTask, errors.New("previous init failure"))
+	repo.errorMutex.Lock()
+	repo.lastInitError = errors.New("previous init failure")
+	repo.initErrorCount = 1
+	repo.initBackoffUntil = time.Now().Add(-time.Second)
+	repo.errorMutex.Unlock()
+
+	if err := repo.CheckRepoFiles(); err != nil {
+		t.Fatalf("expected no error for sftp repository, got %v", err)
+	}
+	if !repo.CanInitRepo {
+		t.Fatalf("expected CanInitRepo true for sftp repository")
+	}
+	if _, ok := repo.TaskErrors[InitTask]; ok {
+		t.Fatalf("expected InitTask error to be cleared for sftp repository")
+	}
+	if repo.shouldSkipInitDueToBackoff() {
+		t.Fatalf("expected init backoff to be cleared for sftp repository")
+	}
+}
+
 func TestRunCommandAndInitRepo(t *testing.T) {
 	repo, repoDir, _, _ := newResticRepo(t, false)
 	if _, err := os.Stat(filepath.Join(repoDir, "config")); err != nil {


### PR DESCRIPTION
## Summary
- add a canonical `backup-archive-mode` setting with API/config wiring for local, S3, and SFTP restic repositories
- update the React restic settings UI to select repository type and show backend-specific help and configuration fields
- improve restic repository handling for fresh S3 repos, SFTP repos, and clear stale cached snapshots when switching repositories

## Testing
- go test ./utils/backupmgr -run "TestCheckRepoFiles|TestRunCommandAndInitRepo"
- go test ./utils/backupmgr -run "^$"
- go test ./cluster -run "^$"