### PR TITLE
feat: complete app volume v2 storage mapping support

### DIFF
--- a/cluster/app_get.go
+++ b/cluster/app_get.go
@@ -350,7 +350,18 @@ func (app *App) GetAppVolume(name string) (*config.Volume, int) {
 	return nil, -1
 }
 
+// GetAppVolumeName returns the runtime and provisioned volume name for pool.
+// Each OpenSVC pool has exactly one saved deployment.storages.volumes row
+// (see config.CanonicalizeAppVolumesTOML), and that row's Name is the actual
+// volume identity; pool is only used to look it up, not to derive it. If no
+// saved row exists yet (content that hasn't been through canonicalization),
+// fall back to the historical {name}-<pool> / <app>-<pool> convention.
 func (app *App) GetAppVolumeName(pool string, resolved bool) string {
+	if appcnf := app.GetAppConfig(); appcnf != nil {
+		if vol := appcnf.Deployment.GetVolumeByPool(pool); vol != nil && vol.Name != "" {
+			return vol.Name
+		}
+	}
 	if resolved {
 		return fmt.Sprintf("%s-%s", app.Name, pool)
 	}

--- a/cluster/app_get.go
+++ b/cluster/app_get.go
@@ -362,8 +362,10 @@ func (app *App) GetAppVolume(name string) (*config.Volume, int) {
 // to the historical {name}-<pool> / <app>-<pool> convention.
 func (app *App) GetAppVolumeName(pool string, resolved bool) string {
 	if appcnf := app.GetAppConfig(); appcnf != nil {
-		if vol := appcnf.Deployment.GetVolumeByPool(pool); vol != nil && vol.Name != "" {
-			return vol.Name
+		if appcnf.Deployment != nil {
+			if vol := appcnf.Deployment.GetVolumeByPool(pool); vol != nil && vol.Name != "" {
+				return vol.Name
+			}
 		}
 	}
 	if resolved {

--- a/cluster/app_get.go
+++ b/cluster/app_get.go
@@ -351,11 +351,15 @@ func (app *App) GetAppVolume(name string) (*config.Volume, int) {
 }
 
 // GetAppVolumeName returns the runtime and provisioned volume name for pool.
-// Each OpenSVC pool has exactly one saved deployment.storages.volumes row
-// (see config.CanonicalizeAppVolumesTOML), and that row's Name is the actual
-// volume identity; pool is only used to look it up, not to derive it. If no
-// saved row exists yet (content that hasn't been through canonicalization),
-// fall back to the historical {name}-<pool> / <app>-<pool> convention.
+// For V1/unflagged content, each OpenSVC pool has exactly one saved
+// deployment.storages.volumes row (see config.CanonicalizeAppVolumesTOML),
+// and that row's Name is the actual volume identity; pool is only used to
+// look it up, not to derive it. V2 content may have multiple intentional
+// rows for the same pool (see Deployment.GetVolumeByPool); this lookup
+// returns only the first one, so callers that need every row for a pool
+// (e.g. GetVolumes) must iterate Storages.Volumes directly. If no saved row
+// exists yet (content that hasn't been through canonicalization), fall back
+// to the historical {name}-<pool> / <app>-<pool> convention.
 func (app *App) GetAppVolumeName(pool string, resolved bool) string {
 	if appcnf := app.GetAppConfig(); appcnf != nil {
 		if vol := appcnf.Deployment.GetVolumeByPool(pool); vol != nil && vol.Name != "" {
@@ -395,13 +399,17 @@ func (app *App) GetVolumes(resolved bool) []string {
 		return volumes
 	}
 
+	// Each saved row's Name is its own identity (enforced unique by
+	// InsertVolume), so use it directly rather than re-deriving it via
+	// GetAppVolumeName, which is keyed by pool and would collapse multiple
+	// V2 rows sharing a pool down to the first row's name.
 	for _, v := range app.AppConfig.Deployment.Storages.Volumes {
-		if v.Name != "" {
-			volumeName := app.GetAppVolumeName(v.PoolName, resolved)
-			if _, exists := distinctVolumes[volumeName]; !exists {
-				volumes = append(volumes, volumeName)
-				distinctVolumes[volumeName] = true
-			}
+		if v.Name == "" {
+			continue
+		}
+		if _, exists := distinctVolumes[v.Name]; !exists {
+			volumes = append(volumes, v.Name)
+			distinctVolumes[v.Name] = true
 		}
 	}
 

--- a/cluster/app_get_opensvc_env_test.go
+++ b/cluster/app_get_opensvc_env_test.go
@@ -72,3 +72,41 @@ func TestOpenSVCGetAppS3MountContainerSectionUsesWildcardEnvironmentReferences(t
 		t.Fatalf("expected wildcard configs_environment, got %q", got)
 	}
 }
+
+// TestOpenSVCGetAppS3MountContainerSectionMountsChosenVolumePlacement covers
+// Phase 15 task 7: the generated OpenSVC S3 mount container must mount
+// "<VolumeName>/<VolumeDir>:/mnt" using the chosen saved volume row and
+// directory, including a resolved Volume pointer with a non-"mnt" explicit
+// V2 placement.
+func TestOpenSVCGetAppS3MountContainerSectionMountsChosenVolumePlacement(t *testing.T) {
+	cluster := &Cluster{Conf: &config.Config{ProvType: "docker"}}
+	app := &App{Name: "app1", ClusterGroup: cluster}
+
+	vol := &config.Volume{Name: "myapp-logs", PoolName: "logs", VolumeDir: "log"}
+	s3m := &config.S3Mount{Name: "media", VolumeName: "myapp-logs", VolumeDir: "log/media", Volume: vol}
+
+	section := cluster.OpenSVCGetAppS3MountContainerSection(app, s3m)
+
+	want := "myapp-logs/log/media:/mnt:rw,rshared"
+	if got := section["volume_mounts"]; got != want {
+		t.Fatalf("expected volume_mounts %q, got %q", want, got)
+	}
+}
+
+// TestOpenSVCGetAppS3MountContainerSectionMountsVolumeNameWhenUnresolved
+// covers the lazily-resolved fallback in S3Mount.GetSourceVolumeName(): when
+// Volume has not yet been resolved to a pointer, the container mount still
+// uses VolumeName/VolumeDir as persisted.
+func TestOpenSVCGetAppS3MountContainerSectionMountsVolumeNameWhenUnresolved(t *testing.T) {
+	cluster := &Cluster{Conf: &config.Config{ProvType: "docker"}}
+	app := &App{Name: "app1", ClusterGroup: cluster}
+
+	s3m := &config.S3Mount{Name: "media", VolumeName: "myapp-logs", VolumeDir: "log/media"}
+
+	section := cluster.OpenSVCGetAppS3MountContainerSection(app, s3m)
+
+	want := "myapp-logs/log/media:/mnt:rw,rshared"
+	if got := section["volume_mounts"]; got != want {
+		t.Fatalf("expected volume_mounts %q, got %q", want, got)
+	}
+}

--- a/cluster/app_get_volume_test.go
+++ b/cluster/app_get_volume_test.go
@@ -47,6 +47,20 @@ func TestGetAppVolumeName_FallsBackWhenNoSavedRow(t *testing.T) {
 	}
 }
 
+func TestGetAppVolumeName_NilDeploymentFallsBack(t *testing.T) {
+	app := &App{
+		Name:      "myapp",
+		AppConfig: &config.AppConfig{},
+	}
+
+	if got := app.GetAppVolumeName("data", true); got != "myapp-data" {
+		t.Fatalf("expected resolved fallback myapp-data, got %q", got)
+	}
+	if got := app.GetAppVolumeName("data", false); got != "{name}-data" {
+		t.Fatalf("expected template fallback {name}-data, got %q", got)
+	}
+}
+
 func TestGetVolumes_ReturnsDistinctSavedRowNames(t *testing.T) {
 	app := &App{
 		Name: "myapp",

--- a/cluster/app_get_volume_test.go
+++ b/cluster/app_get_volume_test.go
@@ -68,3 +68,32 @@ func TestGetVolumes_ReturnsDistinctSavedRowNames(t *testing.T) {
 		t.Fatalf("expected %v, got %v", want, got)
 	}
 }
+
+// TestGetVolumes_ReturnsDistinctNamesForMultiRowSamePool covers Phase 11 task
+// 5: two intentional V2 rows sharing a poolname must both be returned, each
+// under its own Name. Before the fix, GetVolumes deduped via
+// GetAppVolumeName(v.PoolName, ...), which is keyed by pool and returns only
+// the first row's name for both entries, silently dropping the second
+// volume.
+func TestGetVolumes_ReturnsDistinctNamesForMultiRowSamePool(t *testing.T) {
+	app := &App{
+		Name: "myapp",
+		AppConfig: &config.AppConfig{
+			AppConfigVersion: config.AppConfigVersionV2,
+			Deployment: &config.Deployment{
+				Storages: config.StorageMapping{
+					Volumes: config.Volumes{
+						{Name: "myapp-data", PoolName: "data", VolumeDir: "etc"},
+						{Name: "myapp-data-logs", PoolName: "data", VolumeDir: "log"},
+					},
+				},
+			},
+		},
+	}
+
+	got := app.GetVolumes(true)
+	want := []string{"myapp-data", "myapp-data-logs"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}

--- a/cluster/app_get_volume_test.go
+++ b/cluster/app_get_volume_test.go
@@ -1,0 +1,70 @@
+package cluster
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+)
+
+func TestGetAppVolumeName_UsesSavedRowName(t *testing.T) {
+	app := &App{
+		Name: "myapp",
+		AppConfig: &config.AppConfig{
+			Deployment: &config.Deployment{
+				Storages: config.StorageMapping{
+					Volumes: config.Volumes{
+						{Name: "myapp-data", PoolName: "data", VolumeDir: "data"},
+					},
+				},
+			},
+		},
+	}
+
+	// The saved row's Name is the actual identity regardless of the
+	// historical {name}-<pool> / <app>-<pool> convention encoded by resolved.
+	if got := app.GetAppVolumeName("data", true); got != "myapp-data" {
+		t.Fatalf("expected saved row name myapp-data, got %q", got)
+	}
+	if got := app.GetAppVolumeName("data", false); got != "myapp-data" {
+		t.Fatalf("expected saved row name myapp-data regardless of resolved, got %q", got)
+	}
+}
+
+func TestGetAppVolumeName_FallsBackWhenNoSavedRow(t *testing.T) {
+	app := &App{
+		Name: "myapp",
+		AppConfig: &config.AppConfig{
+			Deployment: config.NewDeploymentConfig(),
+		},
+	}
+
+	if got := app.GetAppVolumeName("missing", true); got != "myapp-missing" {
+		t.Fatalf("expected resolved fallback myapp-missing, got %q", got)
+	}
+	if got := app.GetAppVolumeName("missing", false); got != "{name}-missing" {
+		t.Fatalf("expected template fallback {name}-missing, got %q", got)
+	}
+}
+
+func TestGetVolumes_ReturnsDistinctSavedRowNames(t *testing.T) {
+	app := &App{
+		Name: "myapp",
+		AppConfig: &config.AppConfig{
+			Deployment: &config.Deployment{
+				Storages: config.StorageMapping{
+					Volumes: config.Volumes{
+						{Name: "myapp-data", PoolName: "data", VolumeDir: "data"},
+						{Name: "myapp-logs", PoolName: "logs", VolumeDir: "logs"},
+					},
+				},
+			},
+		},
+	}
+
+	got := app.GetVolumes(true)
+	want := []string{"myapp-data", "myapp-logs"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}

--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -451,14 +451,14 @@ func (cluster *Cluster) WithdrawConflictedGatewayRoutes() {
 	}
 }
 
-// canonicalizeAppContent runs the legacy path/level migration followed by the
+// CanonicalizeAppContent runs the legacy path/level migration followed by the
 // app-volume row merge over app/template TOML content. appName selects the
 // volume naming convention used by CanonicalizeAppVolumesTOML: "" for
 // template content ("{name}-<pool>"), or the resolved app's name for app
 // config content ("<app>-<pool>"). The combined result reports Changed if
 // either pass rewrote the content, so callers can drive a single atomic
 // rewrite from it.
-func canonicalizeAppContent(content []byte, appName string) ([]byte, config.AppTemplateCanonicalizationResult, error) {
+func CanonicalizeAppContent(content []byte, appName string) ([]byte, config.AppTemplateCanonicalizationResult, error) {
 	pathContent, res, err := config.CanonicalizeAppTemplateTOML(content)
 	if err != nil {
 		return nil, res, err
@@ -499,7 +499,7 @@ func (cluster *Cluster) LoadAppConfig(dirname, appname string) error {
 		return err
 	}
 
-	canonicalContent, canonicalRes, err := canonicalizeAppContent(rawContent, appname)
+	canonicalContent, canonicalRes, err := CanonicalizeAppContent(rawContent, appname)
 	if err != nil {
 		return err
 	}
@@ -916,7 +916,7 @@ func (cluster *Cluster) AddSeededApp(srv, port, dockerImg, template string) erro
 			return err
 		}
 
-		canonicalContent, _, err := canonicalizeAppContent(resolvedContent, app.Name)
+		canonicalContent, _, err := CanonicalizeAppContent(resolvedContent, app.Name)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlWarn,
 				"Error canonicalizing parsed template content for %s: %s", template, err)
@@ -1413,7 +1413,7 @@ func (cluster *Cluster) loadAndValidateLocalTemplate(path, normalizedName string
 	if err != nil {
 		return nil, err
 	}
-	canonicalContent, canonicalRes, canonErr := canonicalizeAppContent(content, "")
+	canonicalContent, canonicalRes, canonErr := CanonicalizeAppContent(content, "")
 	if canonErr != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlWarn,
 			"Error canonicalizing local template file %s: %s", path, canonErr)
@@ -1474,7 +1474,7 @@ func (cluster *Cluster) getTemplateContent(template string, forceRefresh bool) (
 		}
 	}
 
-	canonicalContent, _, err := canonicalizeAppContent(content, "")
+	canonicalContent, _, err := CanonicalizeAppContent(content, "")
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlWarn,
 			"Error canonicalizing template file %s: %s", normalizedTemplateName, err)

--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -451,6 +451,32 @@ func (cluster *Cluster) WithdrawConflictedGatewayRoutes() {
 	}
 }
 
+// canonicalizeAppContent runs the legacy path/level migration followed by the
+// app-volume row merge over app/template TOML content. appName selects the
+// volume naming convention used by CanonicalizeAppVolumesTOML: "" for
+// template content ("{name}-<pool>"), or the resolved app's name for app
+// config content ("<app>-<pool>"). The combined result reports Changed if
+// either pass rewrote the content, so callers can drive a single atomic
+// rewrite from it.
+func canonicalizeAppContent(content []byte, appName string) ([]byte, config.AppTemplateCanonicalizationResult, error) {
+	pathContent, res, err := config.CanonicalizeAppTemplateTOML(content)
+	if err != nil {
+		return nil, res, err
+	}
+
+	volContent, volRes, err := config.CanonicalizeAppVolumesTOML(pathContent, appName)
+	if err != nil {
+		return nil, res, err
+	}
+
+	res.Changed = res.Changed || volRes.Changed
+	res.MergedVolumePools = volRes.MergedVolumePools
+	res.MergedVolumeRows = volRes.MergedVolumeRows
+	res.RewrittenVolumeReferences = volRes.RewrittenVolumeReferences
+
+	return volContent, res, nil
+}
+
 // LoadConfig loads the configuration from a file to the configuration struct.
 // If the file does not exist, it will return an error.
 // If the file exists but cannot be read, it will return the old configuration and the error.
@@ -473,7 +499,7 @@ func (cluster *Cluster) LoadAppConfig(dirname, appname string) error {
 		return err
 	}
 
-	canonicalContent, canonicalRes, err := config.CanonicalizeAppTemplateTOML(rawContent)
+	canonicalContent, canonicalRes, err := canonicalizeAppContent(rawContent, appname)
 	if err != nil {
 		return err
 	}
@@ -890,7 +916,7 @@ func (cluster *Cluster) AddSeededApp(srv, port, dockerImg, template string) erro
 			return err
 		}
 
-		canonicalContent, _, err := config.CanonicalizeAppTemplateTOML(resolvedContent)
+		canonicalContent, _, err := canonicalizeAppContent(resolvedContent, app.Name)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlWarn,
 				"Error canonicalizing parsed template content for %s: %s", template, err)
@@ -1387,7 +1413,7 @@ func (cluster *Cluster) loadAndValidateLocalTemplate(path, normalizedName string
 	if err != nil {
 		return nil, err
 	}
-	canonicalContent, canonicalRes, canonErr := config.CanonicalizeAppTemplateTOML(content)
+	canonicalContent, canonicalRes, canonErr := canonicalizeAppContent(content, "")
 	if canonErr != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlWarn,
 			"Error canonicalizing local template file %s: %s", path, canonErr)
@@ -1448,7 +1474,7 @@ func (cluster *Cluster) getTemplateContent(template string, forceRefresh bool) (
 		}
 	}
 
-	canonicalContent, _, err := config.CanonicalizeAppTemplateTOML(content)
+	canonicalContent, _, err := canonicalizeAppContent(content, "")
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlWarn,
 			"Error canonicalizing template file %s: %s", normalizedTemplateName, err)

--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -451,13 +451,14 @@ func (cluster *Cluster) WithdrawConflictedGatewayRoutes() {
 	}
 }
 
-// CanonicalizeAppContent runs the legacy path/level migration followed by the
-// app-volume row merge over app/template TOML content. appName selects the
-// volume naming convention used by CanonicalizeAppVolumesTOML: "" for
-// template content ("{name}-<pool>"), or the resolved app's name for app
-// config content ("<app>-<pool>"). The combined result reports Changed if
-// either pass rewrote the content, so callers can drive a single atomic
-// rewrite from it.
+// CanonicalizeAppContent runs the legacy path/level migration and the
+// app-volume row merge over app/template TOML content, then stamps the
+// result with the explicit app-config-version marker (see
+// config.StampAppConfigVersionTOML). appName selects the volume naming
+// convention used by CanonicalizeAppVolumesTOML: "" for template content
+// ("{name}-<pool>"), or the resolved app's name for app config content
+// ("<app>-<pool>"). The combined result reports Changed if any pass rewrote
+// the content, so callers can drive a single atomic rewrite from it.
 func CanonicalizeAppContent(content []byte, appName string) ([]byte, config.AppTemplateCanonicalizationResult, error) {
 	pathContent, res, err := config.CanonicalizeAppTemplateTOML(content)
 	if err != nil {
@@ -474,7 +475,15 @@ func CanonicalizeAppContent(content []byte, appName string) ([]byte, config.AppT
 	res.MergedVolumeRows = volRes.MergedVolumeRows
 	res.RewrittenVolumeReferences = volRes.RewrittenVolumeReferences
 
-	return volContent, res, nil
+	versionedContent, versionRes, err := config.StampAppConfigVersionTOML(volContent)
+	if err != nil {
+		return nil, res, err
+	}
+
+	res.Changed = res.Changed || versionRes.Changed
+	res.StampedAppConfigVersion = versionRes.StampedAppConfigVersion
+
+	return versionedContent, res, nil
 }
 
 // LoadConfig loads the configuration from a file to the configuration struct.

--- a/cluster/cluster_app_template_migration_test.go
+++ b/cluster/cluster_app_template_migration_test.go
@@ -604,6 +604,95 @@ func TestLoadAppConfig_MergesMultiRowVolumePoolWithResolvedName(t *testing.T) {
 	}
 }
 
+// TestLoadAppConfig_RewritesLegacyConfigOnlyOnce covers Phase 9 task 1/2: a
+// legacy multi-row-pool app config is canonicalized and rewritten to disk on
+// the first load, but a second load of the now-canonical file must not
+// trigger another rewrite (CanonicalizeAppContent reports Changed=false on
+// already-canonical content).
+func TestLoadAppConfig_RewritesLegacyConfigOnlyOnce(t *testing.T) {
+	workingDir := t.TempDir()
+	appsDir := filepath.Join(workingDir, "apps")
+	if err := os.MkdirAll(appsDir, 0o755); err != nil {
+		t.Fatalf("mkdir apps dir failed: %v", err)
+	}
+
+	appFile := filepath.Join(appsDir, "legacy-vol.toml")
+	content := "app-host = \"legacy-vol\"\napp-port = \"8080\"\nprov-app-memory = \"128M\"\nprov-app-disk-size = \"1G\"\n" + legacyMultiRowPoolVolumesTOML
+	if err := os.WriteFile(appFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("write legacy app file failed: %v", err)
+	}
+
+	newCluster := func() *Cluster {
+		return &Cluster{
+			Name:       "test-cluster",
+			WorkingDir: workingDir,
+			crcTable:   crc64.MakeTable(crc64.ECMA),
+			Conf: &config.Config{
+				WorkingDir:     workingDir,
+				Apps:           make([]*config.AppConfig, 0),
+				DefaultFlagMap: map[string]interface{}{"prov-app-memory": "128M", "prov-app-disk-size": "1G"},
+			},
+		}
+	}
+
+	if err := newCluster().LoadAppConfig(appsDir, "legacy-vol"); err != nil && err.Error() != "" {
+		t.Fatalf("first LoadAppConfig failed: %v", err)
+	}
+	firstPass, err := os.ReadFile(appFile)
+	if err != nil {
+		t.Fatalf("read app file after first load failed: %v", err)
+	}
+
+	if err := newCluster().LoadAppConfig(appsDir, "legacy-vol"); err != nil && err.Error() != "" {
+		t.Fatalf("second LoadAppConfig failed: %v", err)
+	}
+	secondPass, err := os.ReadFile(appFile)
+	if err != nil {
+		t.Fatalf("read app file after second load failed: %v", err)
+	}
+
+	if string(firstPass) != string(secondPass) {
+		t.Fatalf("expected second load not to rewrite already-canonical config\nfirst:\n%s\nsecond:\n%s", firstPass, secondPass)
+	}
+}
+
+// TestGetTemplateContent_RewritesLegacyTemplateOnlyOnce covers Phase 9 task
+// 1/2: a legacy multi-row-pool template is canonicalized and rewritten to the
+// local cache on the first load, but a second load of the now-canonical cache
+// must not trigger another rewrite.
+func TestGetTemplateContent_RewritesLegacyTemplateOnlyOnce(t *testing.T) {
+	workingDir := t.TempDir()
+	localPath := filepath.Join(workingDir, ".templates", "apps", "legacy-vol.toml")
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		t.Fatalf("mkdir local template dir failed: %v", err)
+	}
+	if err := os.WriteFile(localPath, []byte(legacyMultiRowPoolVolumesTOML), 0o644); err != nil {
+		t.Fatalf("write local legacy template failed: %v", err)
+	}
+
+	cluster := &Cluster{Conf: &config.Config{WorkingDir: workingDir}}
+
+	if _, err := cluster.GetTemplateContent("legacy-vol"); err != nil {
+		t.Fatalf("first GetTemplateContent failed: %v", err)
+	}
+	firstPass, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read local template after first load failed: %v", err)
+	}
+
+	if _, err := cluster.GetTemplateContent("legacy-vol"); err != nil {
+		t.Fatalf("second GetTemplateContent failed: %v", err)
+	}
+	secondPass, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read local template after second load failed: %v", err)
+	}
+
+	if string(firstPass) != string(secondPass) {
+		t.Fatalf("expected second load not to rewrite already-canonical template\nfirst:\n%s\nsecond:\n%s", firstPass, secondPass)
+	}
+}
+
 func TestGetTemplateContent_MergesMultiRowVolumePoolWithTemplateName(t *testing.T) {
 	workingDir := t.TempDir()
 	localPath := filepath.Join(workingDir, ".templates", "apps", "legacy-vol.toml")

--- a/cluster/cluster_app_template_migration_test.go
+++ b/cluster/cluster_app_template_migration_test.go
@@ -778,6 +778,153 @@ func TestAddSeededApp_MergesMultiRowVolumePoolWithResolvedName(t *testing.T) {
 	}
 }
 
+// TestLoadAppConfig_StampsAppConfigVersionOnLegacyContent covers Phase 10
+// tasks 1, 3, 4 and 5 for the app config load flow: loading unversioned
+// legacy app config content stamps app-config-version = 2 into both the
+// rewritten file and the unmarshalled AppConfig, and a second load of the
+// now-V2 content does not rewrite the file again.
+func TestLoadAppConfig_StampsAppConfigVersionOnLegacyContent(t *testing.T) {
+	workingDir := t.TempDir()
+	appsDir := filepath.Join(workingDir, "apps")
+	if err := os.MkdirAll(appsDir, 0o755); err != nil {
+		t.Fatalf("mkdir apps dir failed: %v", err)
+	}
+
+	appFile := filepath.Join(appsDir, "legacy-version.toml")
+	content := "app-host = \"legacy-version\"\napp-port = \"8080\"\nprov-app-memory = \"128M\"\nprov-app-disk-size = \"1G\"\n" + legacyAppTemplateTOML
+	if err := os.WriteFile(appFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("write legacy app file failed: %v", err)
+	}
+
+	newCluster := func() *Cluster {
+		return &Cluster{
+			Name:       "test-cluster",
+			WorkingDir: workingDir,
+			crcTable:   crc64.MakeTable(crc64.ECMA),
+			Conf: &config.Config{
+				WorkingDir:     workingDir,
+				Apps:           make([]*config.AppConfig, 0),
+				DefaultFlagMap: map[string]interface{}{"prov-app-memory": "128M", "prov-app-disk-size": "1G"},
+			},
+		}
+	}
+
+	first := newCluster()
+	if err := first.LoadAppConfig(appsDir, "legacy-version"); err != nil && err.Error() != "" {
+		t.Fatalf("first LoadAppConfig failed: %v", err)
+	}
+	if len(first.Conf.Apps) != 1 {
+		t.Fatalf("expected 1 app config to load, got %d", len(first.Conf.Apps))
+	}
+	if got := first.Conf.Apps[0].AppConfigVersion; got != config.AppConfigVersionV2 {
+		t.Fatalf("expected AppConfigVersion %d, got %d", config.AppConfigVersionV2, got)
+	}
+
+	firstPass, err := os.ReadFile(appFile)
+	if err != nil {
+		t.Fatalf("read rewritten app file failed: %v", err)
+	}
+	if !strings.Contains(string(firstPass), "app-config-version = 2") {
+		t.Fatalf("expected app-config-version = 2 in rewritten file, got:\n%s", firstPass)
+	}
+
+	second := newCluster()
+	if err := second.LoadAppConfig(appsDir, "legacy-version"); err != nil && err.Error() != "" {
+		t.Fatalf("second LoadAppConfig failed: %v", err)
+	}
+	secondPass, err := os.ReadFile(appFile)
+	if err != nil {
+		t.Fatalf("read app file after second load failed: %v", err)
+	}
+	if string(firstPass) != string(secondPass) {
+		t.Fatalf("expected second load not to rewrite already-V2 config\nfirst:\n%s\nsecond:\n%s", firstPass, secondPass)
+	}
+	if got := second.Conf.Apps[0].AppConfigVersion; got != config.AppConfigVersionV2 {
+		t.Fatalf("expected AppConfigVersion %d on second load, got %d", config.AppConfigVersionV2, got)
+	}
+}
+
+// TestGetTemplateContent_StampsAppConfigVersionOnLocalCache covers Phase 10
+// tasks 1, 3 and 4 for the template load flow: an unversioned local template
+// is rewritten with app-config-version = 2, and a second load of the now-V2
+// cache does not rewrite the file again.
+func TestGetTemplateContent_StampsAppConfigVersionOnLocalCache(t *testing.T) {
+	workingDir := t.TempDir()
+	localPath := filepath.Join(workingDir, ".templates", "apps", "legacy-version.toml")
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		t.Fatalf("mkdir local template dir failed: %v", err)
+	}
+	if err := os.WriteFile(localPath, []byte(legacyAppTemplateTOML), 0o644); err != nil {
+		t.Fatalf("write local legacy template failed: %v", err)
+	}
+
+	cluster := &Cluster{Conf: &config.Config{WorkingDir: workingDir}}
+
+	content, err := cluster.GetTemplateContent("legacy-version")
+	if err != nil {
+		t.Fatalf("GetTemplateContent failed: %v", err)
+	}
+	if !strings.Contains(string(content), "app-config-version = 2") {
+		t.Fatalf("expected app-config-version = 2 in returned content, got:\n%s", content)
+	}
+
+	firstPass, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read rewritten local template failed: %v", err)
+	}
+	if !strings.Contains(string(firstPass), "app-config-version = 2") {
+		t.Fatalf("expected app-config-version = 2 in rewritten local cache, got:\n%s", firstPass)
+	}
+
+	if _, err := cluster.GetTemplateContent("legacy-version"); err != nil {
+		t.Fatalf("second GetTemplateContent failed: %v", err)
+	}
+	secondPass, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read local template after second load failed: %v", err)
+	}
+	if string(firstPass) != string(secondPass) {
+		t.Fatalf("expected second load not to rewrite already-V2 template\nfirst:\n%s\nsecond:\n%s", firstPass, secondPass)
+	}
+}
+
+// TestAddSeededApp_StampsAppConfigVersion covers Phase 10 task 5 for the
+// seeded-app creation flow: a seeded app resolved from an unversioned
+// template ends up flagged with AppConfigVersion = config.AppConfigVersionV2.
+func TestAddSeededApp_StampsAppConfigVersion(t *testing.T) {
+	workingDir := t.TempDir()
+	localPath := filepath.Join(workingDir, ".templates", "apps", "legacy-version-seed.toml")
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		t.Fatalf("mkdir local template dir failed: %v", err)
+	}
+	template := "app-port = \"8080\"\nprov-app-docker-img = \"nginx:latest\"\n" + legacyAppTemplateTOML
+	if err := os.WriteFile(localPath, []byte(template), 0o644); err != nil {
+		t.Fatalf("write local seed template failed: %v", err)
+	}
+
+	cluster := &Cluster{
+		Name:       "test-cluster",
+		WorkingDir: workingDir,
+		crcTable:   crc64.MakeTable(crc64.ECMA),
+		Conf: &config.Config{
+			WorkingDir: workingDir,
+			Apps:       make([]*config.AppConfig, 0),
+		},
+	}
+
+	if err := cluster.AddSeededApp("seed-version-host", "8080", "nginx:latest", "legacy-version-seed"); err != nil {
+		t.Fatalf("AddSeededApp failed: %v", err)
+	}
+
+	seeded := cluster.GetAppConfig("seed-version-host", "8080")
+	if seeded == nil {
+		t.Fatalf("expected seeded app config to be loaded")
+	}
+	if got := seeded.AppConfigVersion; got != config.AppConfigVersionV2 {
+		t.Fatalf("expected AppConfigVersion %d, got %d", config.AppConfigVersionV2, got)
+	}
+}
+
 func TestRefreshTemplateContent_RepoSyncFailureWithoutCacheReturnsError(t *testing.T) {
 	workingDir := t.TempDir()
 

--- a/cluster/cluster_app_template_migration_test.go
+++ b/cluster/cluster_app_template_migration_test.go
@@ -30,6 +30,35 @@ parentname = "/var/www/html"
 dockerpath = "/var/www/html/assets"
 `
 
+const legacyMultiRowPoolVolumesTOML = `
+[deployment.storages]
+[[deployment.storages.volumes]]
+name = "data-volume"
+poolname = "data"
+volumedir = "data"
+
+[[deployment.storages.volumes]]
+name = "logs-volume"
+poolname = "data"
+volumedir = "logs"
+
+[[deployment.paths]]
+name = "web-root"
+dockerpath = "/var/www/html"
+srctype = "volume"
+srcname = "data-volume"
+volumename = "data-volume"
+srcpath = "."
+
+[[deployment.paths]]
+name = "log-dir"
+dockerpath = "/var/log/app"
+srctype = "volume"
+srcname = "logs-volume"
+volumename = "logs-volume"
+srcpath = "."
+`
+
 const invalidLegacyTemplateTOML = `
 [deployment.storages]
 
@@ -507,6 +536,156 @@ func TestRefreshTemplateContent_RepoSyncFailureFallsBackToStaleCache(t *testing.
 	localPath := filepath.Join(workingDir, ".templates", "apps", "repo-only.toml")
 	if _, err := os.Stat(localPath); !os.IsNotExist(err) {
 		t.Fatalf("expected no local template write from repo cache read, err=%v", err)
+	}
+}
+
+func TestLoadAppConfig_MergesMultiRowVolumePoolWithResolvedName(t *testing.T) {
+	workingDir := t.TempDir()
+	appsDir := filepath.Join(workingDir, "apps")
+	if err := os.MkdirAll(appsDir, 0o755); err != nil {
+		t.Fatalf("mkdir apps dir failed: %v", err)
+	}
+
+	appFile := filepath.Join(appsDir, "legacy-vol.toml")
+	content := "app-host = \"legacy-vol\"\napp-port = \"8080\"\nprov-app-memory = \"128M\"\nprov-app-disk-size = \"1G\"\n" + legacyMultiRowPoolVolumesTOML
+	if err := os.WriteFile(appFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("write legacy app file failed: %v", err)
+	}
+
+	cluster := &Cluster{
+		Name:       "test-cluster",
+		WorkingDir: workingDir,
+		crcTable:   crc64.MakeTable(crc64.ECMA),
+		Conf: &config.Config{
+			WorkingDir:     workingDir,
+			Apps:           make([]*config.AppConfig, 0),
+			DefaultFlagMap: map[string]interface{}{"prov-app-memory": "128M", "prov-app-disk-size": "1G"},
+		},
+	}
+
+	if err := cluster.LoadAppConfig(appsDir, "legacy-vol"); err != nil && err.Error() != "" {
+		t.Fatalf("LoadAppConfig failed: %v", err)
+	}
+
+	if len(cluster.Conf.Apps) != 1 {
+		t.Fatalf("expected 1 app config to load, got %d", len(cluster.Conf.Apps))
+	}
+	appcnf := cluster.Conf.Apps[0]
+	if len(appcnf.Deployment.Storages.Volumes) != 1 {
+		t.Fatalf("expected volumes merged into 1 row, got %d", len(appcnf.Deployment.Storages.Volumes))
+	}
+	vol := appcnf.Deployment.Storages.Volumes[0]
+	if vol.Name != "legacy-vol-data" {
+		t.Fatalf("expected resolved volume name legacy-vol-data, got %q", vol.Name)
+	}
+	if vol.VolumeDir != "data logs" {
+		t.Fatalf("expected merged volumedir 'data logs', got %q", vol.VolumeDir)
+	}
+
+	for _, p := range appcnf.Deployment.Paths {
+		if p.SourceName != "legacy-vol-data" {
+			t.Fatalf("expected srcname rewritten to legacy-vol-data, got %q", p.SourceName)
+		}
+		if p.VolumeName != "legacy-vol-data" {
+			t.Fatalf("expected volumename rewritten to legacy-vol-data, got %q", p.VolumeName)
+		}
+	}
+
+	updated, err := os.ReadFile(appFile)
+	if err != nil {
+		t.Fatalf("read rewritten app file failed: %v", err)
+	}
+	got := string(updated)
+	if !strings.Contains(got, `name = "legacy-vol-data"`) {
+		t.Fatalf("expected canonical volume name in rewritten file, got:\n%s", got)
+	}
+	if !strings.Contains(got, `volumedir = "data logs"`) {
+		t.Fatalf("expected merged volumedir in rewritten file, got:\n%s", got)
+	}
+}
+
+func TestGetTemplateContent_MergesMultiRowVolumePoolWithTemplateName(t *testing.T) {
+	workingDir := t.TempDir()
+	localPath := filepath.Join(workingDir, ".templates", "apps", "legacy-vol.toml")
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		t.Fatalf("mkdir local template dir failed: %v", err)
+	}
+	if err := os.WriteFile(localPath, []byte(legacyMultiRowPoolVolumesTOML), 0o644); err != nil {
+		t.Fatalf("write local legacy template failed: %v", err)
+	}
+
+	cluster := &Cluster{Conf: &config.Config{WorkingDir: workingDir}}
+
+	content, err := cluster.GetTemplateContent("legacy-vol")
+	if err != nil {
+		t.Fatalf("GetTemplateContent failed: %v", err)
+	}
+
+	got := string(content)
+	if !strings.Contains(got, `name = "{name}-data"`) {
+		t.Fatalf("expected canonical template volume name {name}-data, got:\n%s", got)
+	}
+	if !strings.Contains(got, `volumedir = "data logs"`) {
+		t.Fatalf("expected merged volumedir, got:\n%s", got)
+	}
+
+	rewritten, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read rewritten local template failed: %v", err)
+	}
+	if !strings.Contains(string(rewritten), `name = "{name}-data"`) {
+		t.Fatalf("expected local cache rewrite to canonical volume name, got:\n%s", string(rewritten))
+	}
+}
+
+func TestAddSeededApp_MergesMultiRowVolumePoolWithResolvedName(t *testing.T) {
+	workingDir := t.TempDir()
+	localPath := filepath.Join(workingDir, ".templates", "apps", "legacy-vol-seed.toml")
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		t.Fatalf("mkdir local template dir failed: %v", err)
+	}
+	template := "app-port = \"8080\"\nprov-app-docker-img = \"nginx:latest\"\n" + legacyMultiRowPoolVolumesTOML
+	if err := os.WriteFile(localPath, []byte(template), 0o644); err != nil {
+		t.Fatalf("write local seed template failed: %v", err)
+	}
+
+	cluster := &Cluster{
+		Name:       "test-cluster",
+		WorkingDir: workingDir,
+		crcTable:   crc64.MakeTable(crc64.ECMA),
+		Conf: &config.Config{
+			WorkingDir: workingDir,
+			Apps:       make([]*config.AppConfig, 0),
+		},
+	}
+
+	if err := cluster.AddSeededApp("seed-vol-host", "8080", "nginx:latest", "legacy-vol-seed"); err != nil {
+		t.Fatalf("AddSeededApp failed: %v", err)
+	}
+
+	seeded := cluster.GetAppConfig("seed-vol-host", "8080")
+	if seeded == nil || seeded.Deployment == nil {
+		t.Fatalf("expected seeded app deployment to be loaded")
+	}
+
+	if len(seeded.Deployment.Storages.Volumes) != 1 {
+		t.Fatalf("expected volumes merged into 1 row, got %d", len(seeded.Deployment.Storages.Volumes))
+	}
+	vol := seeded.Deployment.Storages.Volumes[0]
+	if vol.Name != "seed-vol-host-data" {
+		t.Fatalf("expected resolved volume name seed-vol-host-data, got %q", vol.Name)
+	}
+	if vol.VolumeDir != "data logs" {
+		t.Fatalf("expected merged volumedir 'data logs', got %q", vol.VolumeDir)
+	}
+
+	for _, p := range seeded.Deployment.Paths {
+		if p.SourceName != "seed-vol-host-data" {
+			t.Fatalf("expected srcname rewritten to seed-vol-host-data, got %q", p.SourceName)
+		}
+		if p.VolumeName != "seed-vol-host-data" {
+			t.Fatalf("expected volumename rewritten to seed-vol-host-data, got %q", p.VolumeName)
+		}
 	}
 }
 

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -1741,10 +1741,15 @@ func (cluster *Cluster) GetAppConfig(apphost, port string) *config.AppConfig {
 	return cnf
 }
 
+// SetAppLocalVolume finds the saved app volume row whose VolumeDir tokens
+// include dir (e.g. "mnt"), matching whole directory tokens rather than a
+// string prefix so a merged row (e.g. "data mnt") matches on "mnt".
 func (cluster *Cluster) SetAppLocalVolume(app *App, dir string) (*config.Volume, error) {
 	for _, volume := range app.AppConfig.Deployment.Storages.Volumes {
-		if strings.HasPrefix(volume.VolumeDir, dir) {
-			return volume, nil
+		for _, d := range volume.GetVolumeDirs() {
+			if d == dir {
+				return volume, nil
+			}
 		}
 	}
 
@@ -1752,7 +1757,7 @@ func (cluster *Cluster) SetAppLocalVolume(app *App, dir string) (*config.Volume,
 }
 
 func (cluster *Cluster) SetAppLocalMountVolume(app *App) (*config.Volume, error) {
-	return cluster.SetAppLocalVolume(app, "mnt")
+	return cluster.SetAppLocalVolume(app, config.AppMountVolumeDir)
 }
 
 func (cluster *Cluster) GetOpenSVCStats() ([]opensvc.DaemonNodeStats, error) {

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -1743,21 +1743,48 @@ func (cluster *Cluster) GetAppConfig(apphost, port string) *config.AppConfig {
 
 // SetAppLocalVolume finds the saved app volume row whose VolumeDir tokens
 // include dir (e.g. "mnt"), matching whole directory tokens rather than a
-// string prefix so a merged row (e.g. "data mnt") matches on "mnt".
+// string prefix so a merged row (e.g. "data mnt") matches on "mnt". Under an
+// intentional V2 multi-volume layout, more than one saved row may expose dir;
+// in that case SetAppLocalVolume fails closed instead of silently returning
+// the first match, so callers must require an explicit volume selection.
 func (cluster *Cluster) SetAppLocalVolume(app *App, dir string) (*config.Volume, error) {
+	var match *config.Volume
 	for _, volume := range app.AppConfig.Deployment.Storages.Volumes {
 		for _, d := range volume.GetVolumeDirs() {
 			if d == dir {
-				return volume, nil
+				if match != nil {
+					return nil, fmt.Errorf("multiple saved app volumes expose directory %q: explicit volume selection is required", dir)
+				}
+				match = volume
+				break
 			}
 		}
 	}
 
-	return nil, fmt.Errorf("no existing app volume found for directory %q: explicit volume/pool selection is required", dir)
+	if match == nil {
+		return nil, fmt.Errorf("no existing app volume found for directory %q: explicit volume/pool selection is required", dir)
+	}
+
+	return match, nil
 }
 
+// SetAppLocalMountVolume returns the default saved volume row to place an
+// ad-hoc S3 mount on when the caller has not specified VolumeName/VolumeDir
+// explicitly. Selection is fail-closed under ambiguity (Phase 14):
+//   - if exactly one saved volume row exposes the "mnt" directory token, use it
+//   - else if the app has exactly one saved volume row in total, use it
+//   - otherwise return an error: explicit placement is required
 func (cluster *Cluster) SetAppLocalMountVolume(app *App) (*config.Volume, error) {
-	return cluster.SetAppLocalVolume(app, config.AppMountVolumeDir)
+	vol, err := cluster.SetAppLocalVolume(app, config.AppMountVolumeDir)
+	if err == nil {
+		return vol, nil
+	}
+
+	if volumes := app.AppConfig.Deployment.Storages.Volumes; len(volumes) == 1 {
+		return volumes[0], nil
+	}
+
+	return nil, fmt.Errorf("default S3 mount volume is ambiguous: %w", err)
 }
 
 func (cluster *Cluster) GetOpenSVCStats() ([]opensvc.DaemonNodeStats, error) {

--- a/cluster/cluster_get_app_volume_test.go
+++ b/cluster/cluster_get_app_volume_test.go
@@ -1,0 +1,81 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+)
+
+// TestSetAppLocalVolume_TokenAwareMatch covers Phase 6 task 1:
+// SetAppLocalVolume must match dir against VolumeDir's whitespace-separated
+// tokens, not as a string prefix, so a merged row (e.g. "data mnt") matches
+// on "mnt" even though "mnt" is not a prefix of "data mnt".
+func TestSetAppLocalVolume_TokenAwareMatch(t *testing.T) {
+	cluster := &Cluster{Name: "test", Conf: &config.Config{}}
+	app := &App{
+		Name: "myapp",
+		AppConfig: &config.AppConfig{
+			Deployment: &config.Deployment{
+				Storages: config.StorageMapping{
+					Volumes: config.Volumes{
+						{Name: "myapp-data", PoolName: "data", VolumeDir: "data mnt"},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := cluster.SetAppLocalVolume(app, "mnt")
+	if err != nil {
+		t.Fatalf("expected token match for \"mnt\", got error: %v", err)
+	}
+	if got.Name != "myapp-data" {
+		t.Fatalf("expected myapp-data, got %q", got.Name)
+	}
+}
+
+// TestSetAppLocalVolume_NoPrefixFalsePositive ensures a volume whose only
+// directory token merely starts with dir (e.g. "mntlogs") is not matched.
+func TestSetAppLocalVolume_NoPrefixFalsePositive(t *testing.T) {
+	cluster := &Cluster{Name: "test", Conf: &config.Config{}}
+	app := &App{
+		Name: "myapp",
+		AppConfig: &config.AppConfig{
+			Deployment: &config.Deployment{
+				Storages: config.StorageMapping{
+					Volumes: config.Volumes{
+						{Name: "myapp-data", PoolName: "data", VolumeDir: "mntlogs"},
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := cluster.SetAppLocalVolume(app, "mnt"); err == nil {
+		t.Fatalf("expected no match for \"mnt\" against directory token \"mntlogs\"")
+	}
+}
+
+func TestSetAppLocalMountVolume_UsesMntToken(t *testing.T) {
+	cluster := &Cluster{Name: "test", Conf: &config.Config{}}
+	app := &App{
+		Name: "myapp",
+		AppConfig: &config.AppConfig{
+			Deployment: &config.Deployment{
+				Storages: config.StorageMapping{
+					Volumes: config.Volumes{
+						{Name: "myapp-shared", PoolName: "shared", VolumeDir: "etc mnt"},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := cluster.SetAppLocalMountVolume(app)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "myapp-shared" {
+		t.Fatalf("expected myapp-shared, got %q", got.Name)
+	}
+}

--- a/cluster/cluster_get_app_volume_test.go
+++ b/cluster/cluster_get_app_volume_test.go
@@ -79,3 +79,107 @@ func TestSetAppLocalMountVolume_UsesMntToken(t *testing.T) {
 		t.Fatalf("expected myapp-shared, got %q", got.Name)
 	}
 }
+
+// TestSetAppLocalVolume_AmbiguousMntTokenFails covers Phase 14 task 6:
+// if more than one saved volume row exposes the same directory token,
+// SetAppLocalVolume must fail closed instead of returning the first match.
+func TestSetAppLocalVolume_AmbiguousMntTokenFails(t *testing.T) {
+	cluster := &Cluster{Name: "test", Conf: &config.Config{}}
+	app := &App{
+		Name: "myapp",
+		AppConfig: &config.AppConfig{
+			Deployment: &config.Deployment{
+				Storages: config.StorageMapping{
+					Volumes: config.Volumes{
+						{Name: "myapp-data", PoolName: "data", VolumeDir: "data mnt"},
+						{Name: "myapp-shared", PoolName: "shared", VolumeDir: "etc mnt"},
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := cluster.SetAppLocalVolume(app, "mnt"); err == nil {
+		t.Fatalf("expected ambiguity error when multiple rows expose \"mnt\"")
+	}
+}
+
+// TestSetAppLocalMountVolume_UniqueMntAmongMultiple covers Phase 14's
+// recommended auto-selection rule: when multiple saved volume rows exist but
+// only one exposes "mnt", that row is the unambiguous default.
+func TestSetAppLocalMountVolume_UniqueMntAmongMultiple(t *testing.T) {
+	cluster := &Cluster{Name: "test", Conf: &config.Config{}}
+	app := &App{
+		Name: "myapp",
+		AppConfig: &config.AppConfig{
+			Deployment: &config.Deployment{
+				Storages: config.StorageMapping{
+					Volumes: config.Volumes{
+						{Name: "myapp-data", PoolName: "data", VolumeDir: "data"},
+						{Name: "myapp-shared", PoolName: "shared", VolumeDir: "etc mnt"},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := cluster.SetAppLocalMountVolume(app)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "myapp-shared" {
+		t.Fatalf("expected myapp-shared (the only row exposing \"mnt\"), got %q", got.Name)
+	}
+}
+
+// TestSetAppLocalMountVolume_SingleVolumeFallback covers Phase 14's
+// recommended auto-selection rule: when no row exposes "mnt" but the app has
+// exactly one saved volume row in total, that row is the unambiguous default.
+func TestSetAppLocalMountVolume_SingleVolumeFallback(t *testing.T) {
+	cluster := &Cluster{Name: "test", Conf: &config.Config{}}
+	app := &App{
+		Name: "myapp",
+		AppConfig: &config.AppConfig{
+			Deployment: &config.Deployment{
+				Storages: config.StorageMapping{
+					Volumes: config.Volumes{
+						{Name: "myapp-data", PoolName: "data", VolumeDir: "data"},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := cluster.SetAppLocalMountVolume(app)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "myapp-data" {
+		t.Fatalf("expected myapp-data (the only saved volume row), got %q", got.Name)
+	}
+}
+
+// TestSetAppLocalMountVolume_AmbiguousMultiVolumeFails covers Phase 14 task 6:
+// when multiple saved volume rows exist, none expose "mnt", and there is no
+// unique default, SetAppLocalMountVolume must fail closed rather than
+// silently returning the first row.
+func TestSetAppLocalMountVolume_AmbiguousMultiVolumeFails(t *testing.T) {
+	cluster := &Cluster{Name: "test", Conf: &config.Config{}}
+	app := &App{
+		Name: "myapp",
+		AppConfig: &config.AppConfig{
+			Deployment: &config.Deployment{
+				Storages: config.StorageMapping{
+					Volumes: config.Volumes{
+						{Name: "myapp-data", PoolName: "data", VolumeDir: "data"},
+						{Name: "myapp-logs", PoolName: "logs", VolumeDir: "log"},
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := cluster.SetAppLocalMountVolume(app); err == nil {
+		t.Fatalf("expected ambiguity error when multiple rows exist and none expose \"mnt\"")
+	}
+}

--- a/cluster/path_mapping_compat_test.go
+++ b/cluster/path_mapping_compat_test.go
@@ -45,9 +45,11 @@ func TestGetOpenSVCDeploymentPathMappingRendersMultiVolumeMounts(t *testing.T) {
 		t.Fatalf("expected 2 mount mappings, got %d: %q", len(tokens), got)
 	}
 
+	// GetAppVolumeName now returns the saved row's Name directly (the
+	// runtime/provisioned identity), not a pool-derived {name}-<pool> name.
 	expected := map[string]bool{
-		"{name}-data:/var/www/html":      false,
-		"{name}-docs:/var/www/documents": false,
+		"data-volume:/var/www/html":      false,
+		"docs-volume:/var/www/documents": false,
 	}
 	for _, token := range tokens {
 		if _, ok := expected[token]; ok {

--- a/cluster/path_mapping_compat_test.go
+++ b/cluster/path_mapping_compat_test.go
@@ -586,6 +586,53 @@ func TestResolvePath_SrcTypeTransition_ClearsStaleVolumeName(t *testing.T) {
 	}
 }
 
+// TestResolvePaths_ChildOfUnresolvedParentReportsInheritedError covers the
+// hardening fix in ResolvePaths pass 2: when a parent path's direct source
+// fails to resolve, a child path that depends on inherited VolumeName should
+// not silently keep/accept an empty binding. The child now reports its own
+// inherited-resolution error as well.
+func TestResolvePaths_ChildOfUnresolvedParentReportsInheritedError(t *testing.T) {
+	deployment := config.NewDeploymentConfig()
+	deployment.Paths = config.PathMaps{
+		{
+			Name:       "web-root",
+			DockerPath: "/var/www/html",
+			SourceType: config.SourceVolume,
+			SourceName: "missing-volume",
+			SourcePath: ".",
+			VolumeName: "stale-volume",
+		},
+		{
+			Name:       "assets",
+			ParentName: "web-root",
+			DockerPath: "/var/www/html/assets",
+			VolumeName: "stale-volume",
+		},
+	}
+
+	errs := deployment.ResolvePaths()
+	if len(errs) < 2 {
+		t.Fatalf("expected parent and child resolution errors, got %v", errs)
+	}
+	if deployment.Paths[0].VolumeName != "" {
+		t.Fatalf("expected unresolved parent volumename cleared, got %q", deployment.Paths[0].VolumeName)
+	}
+	if deployment.Paths[1].VolumeName != "" {
+		t.Fatalf("expected child inherited volumename cleared, got %q", deployment.Paths[1].VolumeName)
+	}
+
+	foundChildErr := false
+	for _, err := range errs {
+		if strings.Contains(err.Error(), "inherited volume not resolved") && strings.Contains(err.Error(), "web-root") {
+			foundChildErr = true
+			break
+		}
+	}
+	if !foundChildErr {
+		t.Fatalf("expected inherited child resolution error in %v", errs)
+	}
+}
+
 // TestOpenSVCAppVolumeSection_MultiDirectoryVolumeDir covers Phase 5/9: a
 // merged multi-pool volume row (VolumeDir = "etc log var data") must be
 // rendered as separate OpenSVC "directories" entries, not a single literal

--- a/cluster/path_mapping_compat_test.go
+++ b/cluster/path_mapping_compat_test.go
@@ -181,6 +181,49 @@ func TestResolvePathsRootSourcePathSlash_IsRejected(t *testing.T) {
 	}
 }
 
+// TestOpenSVCAppVolumeSection_MultiDirectoryVolumeDir covers Phase 5/9: a
+// merged multi-pool volume row (VolumeDir = "etc log var data") must be
+// rendered as separate OpenSVC "directories" entries, not a single literal
+// directory name containing spaces.
+func TestOpenSVCAppVolumeSection_MultiDirectoryVolumeDir(t *testing.T) {
+	vol := &config.Volume{Name: "myapp-data", PoolName: "data", VolumeDir: "etc log var data"}
+
+	got := openSVCAppVolumeSection(vol, nil, true)
+
+	if got["name"] != "myapp-data" {
+		t.Fatalf("expected name myapp-data, got %q", got["name"])
+	}
+	if got["pool"] != "data" {
+		t.Fatalf("expected pool data, got %q", got["pool"])
+	}
+	if got["shared"] != "true" {
+		t.Fatalf("expected shared=true for shared pool, got %q", got["shared"])
+	}
+	if want := "data etc log var"; got["directories"] != want {
+		t.Fatalf("expected directories %q, got %q", want, got["directories"])
+	}
+}
+
+// TestOpenSVCAppVolumeSection_PathDerivedDirectoryMergedWithVolumeDir covers
+// merging VolumeDir tokens with directories derived from
+// deployment.Paths.GetVolumeDirs(), deduplicated and sorted, and confirms the
+// "shared" key is omitted for a non-shared pool.
+func TestOpenSVCAppVolumeSection_PathDerivedDirectoryMergedWithVolumeDir(t *testing.T) {
+	vol := &config.Volume{Name: "myapp-data", PoolName: "data", VolumeDir: "data"}
+	pathmap := map[string][]string{
+		"myapp-data": {"data/uploads/file.txt", "logs/"},
+	}
+
+	got := openSVCAppVolumeSection(vol, pathmap, false)
+
+	if _, ok := got["shared"]; ok {
+		t.Fatalf("expected no shared key for non-shared pool, got %q", got["shared"])
+	}
+	if want := "data data/uploads logs"; got["directories"] != want {
+		t.Fatalf("expected directories %q, got %q", want, got["directories"])
+	}
+}
+
 func TestPathMapsSort_UsesLevelThenPath(t *testing.T) {
 	paths := config.PathMaps{
 		{Name: "child-b", Level: 1, ParentName: "root", DockerPath: "/root/b"},

--- a/cluster/path_mapping_compat_test.go
+++ b/cluster/path_mapping_compat_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -98,6 +99,71 @@ func TestGetOpenSVCDeploymentPathMappingUsesPathsOwnVolumeRow(t *testing.T) {
 	want := "second-row:/var/www/html"
 	if got != want {
 		t.Fatalf("expected mount mapping %q, got %q", want, got)
+	}
+}
+
+// TestGetOpenSVCDeploymentPathMappingRendersMultiRowSamePoolMounts covers
+// Phase 11 task 7: two intentional V2 rows sharing a poolname, each
+// referenced by its own deployment.Paths entry, must both resolve and both
+// produce their own "<rowName>:<dockerpath>" mount mapping.
+func TestGetOpenSVCDeploymentPathMappingRendersMultiRowSamePoolMounts(t *testing.T) {
+	deployment := config.NewDeploymentConfig()
+	deployment.Storages.Volumes = config.Volumes{
+		{Name: "myapp-data", PoolName: "data", VolumeDir: "etc"},
+		{Name: "myapp-data-logs", PoolName: "data", VolumeDir: "log"},
+	}
+	deployment.Paths = config.PathMaps{
+		{
+			Name:       "web-root",
+			DockerPath: "/var/www/html",
+			SourceType: config.SourceVolume,
+			SourceName: "myapp-data",
+			SourcePath: ".",
+			VolumeName: "myapp-data",
+		},
+		{
+			Name:       "log-dir",
+			DockerPath: "/var/log/app",
+			SourceType: config.SourceVolume,
+			SourceName: "myapp-data-logs",
+			SourcePath: ".",
+			VolumeName: "myapp-data-logs",
+		},
+	}
+
+	if errs := deployment.ResolvePaths(); len(errs) > 0 {
+		t.Fatalf("expected deployment paths to resolve, got %v", errs)
+	}
+
+	appcnf := &config.AppConfig{AppConfigVersion: config.AppConfigVersionV2, Deployment: deployment}
+	cluster := &Cluster{Name: "test", Conf: &config.Config{}}
+	app := &App{Name: "myapp", AppConfig: appcnf}
+
+	got := cluster.GetOpenSVCDeploymentPathMapping(app)
+	tokens := strings.Fields(got)
+	if len(tokens) != 2 {
+		t.Fatalf("expected 2 mount mappings, got %d: %q", len(tokens), got)
+	}
+
+	expected := map[string]bool{
+		"myapp-data:/var/www/html":     false,
+		"myapp-data-logs:/var/log/app": false,
+	}
+	for _, token := range tokens {
+		if _, ok := expected[token]; ok {
+			expected[token] = true
+		}
+	}
+	for token, found := range expected {
+		if !found {
+			t.Fatalf("expected mount mapping %q in %q", token, got)
+		}
+	}
+
+	volumes := app.GetVolumes(true)
+	wantVolumes := []string{"myapp-data", "myapp-data-logs"}
+	if len(volumes) != len(wantVolumes) || volumes[0] != wantVolumes[0] || volumes[1] != wantVolumes[1] {
+		t.Fatalf("expected GetVolumes() = %v, got %v", wantVolumes, volumes)
 	}
 }
 
@@ -221,6 +287,36 @@ func TestOpenSVCAppVolumeSection_PathDerivedDirectoryMergedWithVolumeDir(t *test
 	}
 	if want := "data data/uploads logs"; got["directories"] != want {
 		t.Fatalf("expected directories %q, got %q", want, got["directories"])
+	}
+}
+
+// TestOpenSVCAppVolumeSection_MultiRowSamePoolDistinctSections covers Phase
+// 11 task 8: two intentional V2 rows sharing a poolname must each produce
+// their own "volume#N" section -- mirroring the per-row loop in
+// OpenSVCGetAppVolumeSections -- with distinct name/directories but the same
+// pool.
+func TestOpenSVCAppVolumeSection_MultiRowSamePoolDistinctSections(t *testing.T) {
+	volumes := config.Volumes{
+		{Name: "myapp-data", PoolName: "data", VolumeDir: "etc"},
+		{Name: "myapp-data-logs", PoolName: "data", VolumeDir: "log"},
+	}
+
+	basemap := make(map[string]map[string]string)
+	for i, vol := range volumes {
+		basemap["volume#"+strconv.Itoa(i+1)] = openSVCAppVolumeSection(vol, nil, true)
+	}
+
+	first := basemap["volume#1"]
+	second := basemap["volume#2"]
+
+	if first["name"] != "myapp-data" || second["name"] != "myapp-data-logs" {
+		t.Fatalf("expected distinct names, got %q and %q", first["name"], second["name"])
+	}
+	if first["pool"] != "data" || second["pool"] != "data" {
+		t.Fatalf("expected both rows to share pool %q, got %q and %q", "data", first["pool"], second["pool"])
+	}
+	if first["directories"] != "etc" || second["directories"] != "log" {
+		t.Fatalf("expected distinct directories, got %q and %q", first["directories"], second["directories"])
 	}
 }
 

--- a/cluster/path_mapping_compat_test.go
+++ b/cluster/path_mapping_compat_test.go
@@ -63,6 +63,44 @@ func TestGetOpenSVCDeploymentPathMappingRendersMultiVolumeMounts(t *testing.T) {
 	}
 }
 
+// TestGetOpenSVCDeploymentPathMappingUsesPathsOwnVolumeRow covers Phase 5
+// task 5: the disk name for a path mapping must come from the volume row
+// resolved by the path's own VolumeName (deployment.GetVolumeByName), not
+// from a pool-derived lookup. With a legacy, not-yet-canonicalized config
+// where multiple rows still share a pool, GetVolumeByPool would return the
+// first row for that pool, which can differ from the row the path actually
+// references.
+func TestGetOpenSVCDeploymentPathMappingUsesPathsOwnVolumeRow(t *testing.T) {
+	deployment := config.NewDeploymentConfig()
+	deployment.Storages.Volumes = config.Volumes{
+		{Name: "first-row", PoolName: "data", VolumeDir: "etc"},
+		{Name: "second-row", PoolName: "data", VolumeDir: "data"},
+	}
+	deployment.Paths = config.PathMaps{
+		{
+			Name:       "web-root",
+			DockerPath: "/var/www/html",
+			SourceType: config.SourceVolume,
+			SourceName: "second-row",
+			SourcePath: ".",
+			VolumeName: "second-row",
+		},
+	}
+
+	if errs := deployment.ResolvePaths(); len(errs) > 0 {
+		t.Fatalf("expected deployment paths to resolve, got %v", errs)
+	}
+
+	cluster := &Cluster{Name: "test", Conf: &config.Config{}}
+	app := &App{Name: "dolibarr", AppConfig: &config.AppConfig{Deployment: deployment}}
+
+	got := cluster.GetOpenSVCDeploymentPathMapping(app)
+	want := "second-row:/var/www/html"
+	if got != want {
+		t.Fatalf("expected mount mapping %q, got %q", want, got)
+	}
+}
+
 func TestResolvePathsParentNameByPathName(t *testing.T) {
 	deployment := config.NewDeploymentConfig()
 	deployment.Storages.Volumes = config.Volumes{

--- a/cluster/path_mapping_compat_test.go
+++ b/cluster/path_mapping_compat_test.go
@@ -247,6 +247,345 @@ func TestResolvePathsRootSourcePathSlash_IsRejected(t *testing.T) {
 	}
 }
 
+// TestResolvePath_DirectVolumeSourceChange_UpdatesVolumeName covers Path
+// Storage Mapping Fix Plan Test Plan item 1: switching a direct volume path
+// from one saved volume row to another must refresh VolumeName from the new
+// source, not retain the old binding.
+func TestResolvePath_DirectVolumeSourceChange_UpdatesVolumeName(t *testing.T) {
+	deployment := config.NewDeploymentConfig()
+	deployment.Storages.Volumes = config.Volumes{
+		{Name: "vol-a", PoolName: "a", VolumeDir: "data"},
+		{Name: "vol-b", PoolName: "b", VolumeDir: "docs"},
+	}
+
+	path := &config.PathMapping{
+		Name:       "web-root",
+		DockerPath: "/var/www/html",
+		SourceType: config.SourceVolume,
+		SourceName: "vol-a",
+		SourcePath: ".",
+		VolumeName: "vol-a",
+	}
+	deployment.Paths = config.PathMaps{path}
+
+	if errs := deployment.ResolvePaths(); len(errs) > 0 {
+		t.Fatalf("expected initial resolve to succeed, got %v", errs)
+	}
+	if path.VolumeName != "vol-a" {
+		t.Fatalf("expected initial volumename vol-a, got %q", path.VolumeName)
+	}
+
+	// Simulate the "srcname" modify branch switching the direct volume source.
+	path.SourceName = "vol-b"
+	path.SourcePath = "."
+	if err := deployment.ResolvePath(path); err != nil {
+		t.Fatalf("expected resolve to succeed, got %v", err)
+	}
+	if path.VolumeName != "vol-b" {
+		t.Fatalf("expected volumename to follow source change to vol-b, got %q", path.VolumeName)
+	}
+}
+
+// TestResolvePath_GitSourceChange_UpdatesVolumeName covers Test Plan item 1: a
+// git-backed path switched to a git clone hosted on a different volume row
+// must refresh VolumeName accordingly.
+func TestResolvePath_GitSourceChange_UpdatesVolumeName(t *testing.T) {
+	deployment := config.NewDeploymentConfig()
+	deployment.Storages.Volumes = config.Volumes{
+		{Name: "vol-a", PoolName: "a", VolumeDir: "data"},
+		{Name: "vol-b", PoolName: "b", VolumeDir: "docs"},
+	}
+	gitA := &config.GitClone{Name: "git-a", VolumeName: "vol-a", VolumeDir: "repo-a"}
+	gitB := &config.GitClone{Name: "git-b", VolumeName: "vol-b", VolumeDir: "repo-b"}
+	deployment.Storages.GitClones = config.GitClones{gitA, gitB}
+
+	path := &config.PathMapping{
+		Name:       "src",
+		DockerPath: "/app/src",
+		SourceType: config.SourceGit,
+		SourceName: "git-a",
+		SourcePath: gitA.GetSourcePath(),
+		VolumeName: "vol-a",
+	}
+	deployment.Paths = config.PathMaps{path}
+
+	if errs := deployment.ResolvePaths(); len(errs) > 0 {
+		t.Fatalf("expected initial resolve to succeed, got %v", errs)
+	}
+	if path.VolumeName != "vol-a" {
+		t.Fatalf("expected initial volumename vol-a, got %q", path.VolumeName)
+	}
+
+	path.SourceName = "git-b"
+	path.SourcePath = gitB.GetSourcePath()
+	if err := deployment.ResolvePath(path); err != nil {
+		t.Fatalf("expected resolve to succeed, got %v", err)
+	}
+	if path.VolumeName != "vol-b" {
+		t.Fatalf("expected volumename to follow git source change to vol-b, got %q", path.VolumeName)
+	}
+}
+
+// TestResolvePath_S3SourceChange_UpdatesVolumeName covers Test Plan item 1: an
+// s3-backed path switched to an s3 mount hosted on a different volume row
+// must refresh VolumeName accordingly.
+func TestResolvePath_S3SourceChange_UpdatesVolumeName(t *testing.T) {
+	deployment := config.NewDeploymentConfig()
+	deployment.Storages.Volumes = config.Volumes{
+		{Name: "vol-a", PoolName: "a", VolumeDir: "data"},
+		{Name: "vol-b", PoolName: "b", VolumeDir: "docs"},
+	}
+	s3A := &config.S3Mount{Name: "s3-a", VolumeName: "vol-a", VolumeDir: "uploads-a"}
+	s3B := &config.S3Mount{Name: "s3-b", VolumeName: "vol-b", VolumeDir: "uploads-b"}
+	deployment.Storages.S3Mounts = config.S3Mounts{s3A, s3B}
+
+	path := &config.PathMapping{
+		Name:       "uploads",
+		DockerPath: "/app/uploads",
+		SourceType: config.SourceS3,
+		SourceName: "s3-a",
+		SourcePath: s3A.GetSourcePath(),
+		VolumeName: "vol-a",
+	}
+	deployment.Paths = config.PathMaps{path}
+
+	if errs := deployment.ResolvePaths(); len(errs) > 0 {
+		t.Fatalf("expected initial resolve to succeed, got %v", errs)
+	}
+	if path.VolumeName != "vol-a" {
+		t.Fatalf("expected initial volumename vol-a, got %q", path.VolumeName)
+	}
+
+	path.SourceName = "s3-b"
+	path.SourcePath = s3B.GetSourcePath()
+	if err := deployment.ResolvePath(path); err != nil {
+		t.Fatalf("expected resolve to succeed, got %v", err)
+	}
+	if path.VolumeName != "vol-b" {
+		t.Fatalf("expected volumename to follow s3 source change to vol-b, got %q", path.VolumeName)
+	}
+}
+
+// TestVolumeRename_PropagatesToDependentAndChildPaths covers Test Plan item 2
+// (volume rename refreshes dependent path volume binding) and item 8 (child
+// paths inherit the refreshed VolumeName via cascade), plus item 6
+// (provisioning follows the refreshed VolumeName).
+func TestVolumeRename_PropagatesToDependentAndChildPaths(t *testing.T) {
+	deployment := config.NewDeploymentConfig()
+	vol := &config.Volume{Name: "data-volume", PoolName: "data", VolumeDir: "data"}
+	deployment.Storages.Volumes = config.Volumes{vol}
+
+	parent := &config.PathMapping{
+		Name:       "web-root",
+		DockerPath: "/var/www/html",
+		SourceType: config.SourceVolume,
+		SourceName: "data-volume",
+		SourcePath: ".",
+		VolumeName: "data-volume",
+	}
+	child := &config.PathMapping{
+		Name:       "assets",
+		ParentName: "web-root",
+		DockerPath: "/var/www/html/assets",
+	}
+	deployment.Paths = config.PathMaps{parent, child}
+
+	if errs := deployment.ResolvePaths(); len(errs) > 0 {
+		t.Fatalf("expected initial resolve to succeed, got %v", errs)
+	}
+	if parent.VolumeName != "data-volume" || child.VolumeName != "data-volume" {
+		t.Fatalf("expected both paths bound to data-volume initially, got parent=%q child=%q", parent.VolumeName, child.VolumeName)
+	}
+
+	// Simulate the volumes "name" modify handler's rename flow: paths whose
+	// current VolumeName matches the old name are re-resolved, but only direct
+	// volume-source paths rewrite SourceName to the new row name. Inherited
+	// child paths keep empty source fields and pick up the renamed VolumeName
+	// via ResolvePath()'s parent cascade.
+	oldName := vol.Name
+	paths := deployment.GetVolumePaths(oldName)
+	vol.Name = "renamed-volume"
+	for _, p := range paths {
+		if p.SourceType == config.SourceVolume && p.SourceName == oldName {
+			p.SourceName = vol.Name
+		}
+		deployment.ResolvePath(p)
+	}
+
+	if parent.VolumeName != "renamed-volume" {
+		t.Fatalf("expected parent volumename to follow rename, got %q", parent.VolumeName)
+	}
+	if child.VolumeName != "renamed-volume" {
+		t.Fatalf("expected child volumename to follow rename via cascade, got %q", child.VolumeName)
+	}
+
+	cluster := &Cluster{Name: "test", Conf: &config.Config{}}
+	app := &App{Name: "myapp", AppConfig: &config.AppConfig{Deployment: deployment}}
+	got := cluster.GetOpenSVCDeploymentPathMapping(app)
+	tokens := strings.Fields(got)
+	if len(tokens) != 2 {
+		t.Fatalf("expected 2 mount mappings, got %d: %q", len(tokens), got)
+	}
+	expected := map[string]bool{
+		"renamed-volume:/var/www/html":        false,
+		"renamed-volume:/var/www/html/assets": false,
+	}
+	for _, token := range tokens {
+		if _, ok := expected[token]; ok {
+			expected[token] = true
+		}
+	}
+	for token, found := range expected {
+		if !found {
+			t.Fatalf("expected mount mapping %q in %q", token, got)
+		}
+	}
+}
+
+// TestResolveGitPaths_VolumeNameReassignment_UpdatesDependentPath covers Test
+// Plan item 2: a Git Clone volumename reassignment must refresh the
+// VolumeName of paths that source from it.
+func TestResolveGitPaths_VolumeNameReassignment_UpdatesDependentPath(t *testing.T) {
+	deployment := config.NewDeploymentConfig()
+	volA := &config.Volume{Name: "vol-a", PoolName: "a", VolumeDir: "data"}
+	volB := &config.Volume{Name: "vol-b", PoolName: "b", VolumeDir: "docs"}
+	deployment.Storages.Volumes = config.Volumes{volA, volB}
+
+	gc := &config.GitClone{Name: "git-x", VolumeName: "vol-a", VolumeDir: "repo"}
+	deployment.Storages.GitClones = config.GitClones{gc}
+
+	path := &config.PathMapping{
+		Name:       "src",
+		DockerPath: "/app/src",
+		SourceType: config.SourceGit,
+		SourceName: "git-x",
+		SourcePath: gc.GetSourcePath(),
+		VolumeName: "vol-a",
+	}
+	deployment.Paths = config.PathMaps{path}
+
+	if errs := deployment.ResolvePaths(); len(errs) > 0 {
+		t.Fatalf("expected initial resolve to succeed, got %v", errs)
+	}
+	if path.VolumeName != "vol-a" {
+		t.Fatalf("expected initial volumename vol-a, got %q", path.VolumeName)
+	}
+
+	// Simulate the gitClones "volumename" modify handler.
+	gc.VolumeName = "vol-b"
+	gc.Volume = volB
+	deployment.ResolveGitPaths(gc.Name)
+
+	if path.VolumeName != "vol-b" {
+		t.Fatalf("expected dependent path volumename to follow git clone reassignment, got %q", path.VolumeName)
+	}
+}
+
+// TestResolveS3MountPaths_VolumeNameReassignment_UpdatesDependentPath covers
+// Test Plan item 2: an S3 Mount volumename reassignment must refresh the
+// VolumeName of paths that source from it.
+func TestResolveS3MountPaths_VolumeNameReassignment_UpdatesDependentPath(t *testing.T) {
+	deployment := config.NewDeploymentConfig()
+	volA := &config.Volume{Name: "vol-a", PoolName: "a", VolumeDir: "data"}
+	volB := &config.Volume{Name: "vol-b", PoolName: "b", VolumeDir: "docs"}
+	deployment.Storages.Volumes = config.Volumes{volA, volB}
+
+	s3m := &config.S3Mount{Name: "s3-x", VolumeName: "vol-a", VolumeDir: "uploads"}
+	deployment.Storages.S3Mounts = config.S3Mounts{s3m}
+
+	path := &config.PathMapping{
+		Name:       "uploads",
+		DockerPath: "/app/uploads",
+		SourceType: config.SourceS3,
+		SourceName: "s3-x",
+		SourcePath: s3m.GetSourcePath(),
+		VolumeName: "vol-a",
+	}
+	deployment.Paths = config.PathMaps{path}
+
+	if errs := deployment.ResolvePaths(); len(errs) > 0 {
+		t.Fatalf("expected initial resolve to succeed, got %v", errs)
+	}
+	if path.VolumeName != "vol-a" {
+		t.Fatalf("expected initial volumename vol-a, got %q", path.VolumeName)
+	}
+
+	// Simulate the s3Mounts "volumename" modify handler.
+	s3m.VolumeName = "vol-b"
+	s3m.Volume = volB
+	deployment.ResolveS3MountPaths(s3m.Name)
+
+	if path.VolumeName != "vol-b" {
+		t.Fatalf("expected dependent path volumename to follow s3 mount reassignment, got %q", path.VolumeName)
+	}
+}
+
+// TestResolvePath_UnresolvedSource_ClearsStaleVolumeName covers Test Plan item
+// 5: a path edit that fails re-resolution because its source no longer
+// exists must not leave a stale VolumeName behind, so provisioning does not
+// silently mount the wrong volume.
+func TestResolvePath_UnresolvedSource_ClearsStaleVolumeName(t *testing.T) {
+	deployment := config.NewDeploymentConfig()
+	deployment.Storages.Volumes = config.Volumes{
+		{Name: "vol-a", PoolName: "a", VolumeDir: "data"},
+	}
+
+	path := &config.PathMapping{
+		Name:       "web-root",
+		DockerPath: "/var/www/html",
+		SourceType: config.SourceVolume,
+		SourceName: "nonexistent-vol",
+		SourcePath: ".",
+		VolumeName: "vol-a", // stale binding from before the source changed
+	}
+	deployment.Paths = config.PathMaps{path}
+
+	if err := deployment.ResolvePath(path); err == nil {
+		t.Fatalf("expected resolve error for unresolved source, got nil")
+	}
+	if path.VolumeName != "" {
+		t.Fatalf("expected stale volumename to be cleared on unresolved source, got %q", path.VolumeName)
+	}
+}
+
+// TestResolvePath_SrcTypeTransition_ClearsStaleVolumeName covers Test Plan
+// item 7: changing srctype must not leave a stale VolumeName from the
+// previous source type, even while the row is momentarily incomplete pending
+// a follow-up srcname edit.
+func TestResolvePath_SrcTypeTransition_ClearsStaleVolumeName(t *testing.T) {
+	deployment := config.NewDeploymentConfig()
+	deployment.Storages.Volumes = config.Volumes{
+		{Name: "vol-a", PoolName: "a", VolumeDir: "data"},
+	}
+
+	path := &config.PathMapping{
+		Name:       "web-root",
+		DockerPath: "/var/www/html",
+		SourceType: config.SourceVolume,
+		SourceName: "vol-a",
+		SourcePath: ".",
+		VolumeName: "vol-a",
+	}
+	deployment.Paths = config.PathMaps{path}
+	if errs := deployment.ResolvePaths(); len(errs) > 0 {
+		t.Fatalf("expected initial resolve to succeed, got %v", errs)
+	}
+
+	// Simulate the "srctype" modify handler's volume -> git transition: reset
+	// source name/path/volume together.
+	path.SourceType = config.SourceGit
+	path.SourceName = ""
+	path.SourcePath = ""
+	path.VolumeName = ""
+
+	if err := deployment.ResolvePath(path); err == nil {
+		t.Fatalf("expected resolve error for incomplete srctype transition, got nil")
+	}
+	if path.VolumeName != "" {
+		t.Fatalf("expected no stale volumename to survive srctype transition, got %q", path.VolumeName)
+	}
+}
+
 // TestOpenSVCAppVolumeSection_MultiDirectoryVolumeDir covers Phase 5/9: a
 // merged multi-pool volume row (VolumeDir = "etc log var data") must be
 // rendered as separate OpenSVC "directories" entries, not a single literal

--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -513,43 +513,54 @@ func (cluster *Cluster) OpenSVCGetAppVolumeSections(basemap map[string]map[strin
 			return nil, fmt.Errorf("OpenSVC pool %q not found in runtime pool list", vol.PoolName)
 		}
 
-		svcvol := make(map[string]string)
-		svcvol["name"] = vol.Name
-		svcvol["pool"] = vol.PoolName
-		svcvol["size"] = "{env.size}"
-		if poolInfo.Shared {
-			svcvol["shared"] = "true"
-		}
-
-		// Use set to avoid duplicate directories
-		directorySet := make(map[string]struct{})
-
-		for _, baseDir := range vol.GetVolumeDirs() {
-			directorySet[baseDir] = struct{}{}
-		}
-		if mappedPaths, ok := pathmap[vol.Name]; ok {
-			for _, path := range mappedPaths {
-				// if path is not end with "/", get parent directory
-				if !strings.HasSuffix(path, "/") {
-					path = filepath.Dir(path) + "/"
-				}
-				directorySet[filepath.Join(path)] = struct{}{}
-			}
-		}
-
-		// Join unique directory list
-		dirs := make([]string, 0, len(directorySet))
-		for dir := range directorySet {
-			dirs = append(dirs, dir)
-		}
-
-		sort.Strings(dirs) // Optional: consistent order
-		svcvol["directories"] = strings.Join(dirs, " ")
-		basemap["volume#"+strconv.Itoa(seq)] = svcvol
+		basemap["volume#"+strconv.Itoa(seq)] = openSVCAppVolumeSection(vol, pathmap, poolInfo.Shared)
 		seq++
 	}
 
 	return basemap, nil
+}
+
+// openSVCAppVolumeSection builds the OpenSVC "volume#N" section for a single
+// saved app volume row. It merges the row's own VolumeDir tokens (split via
+// vol.GetVolumeDirs(), one OpenSVC "directories" entry per token) with any
+// extra directories derived from deployment.Paths.GetVolumeDirs(), so a
+// merged multi-pool row (e.g. VolumeDir = "etc log var data") is emitted as
+// separate top-level directories instead of one literal name containing
+// spaces.
+func openSVCAppVolumeSection(vol *config.Volume, pathmap map[string][]string, shared bool) map[string]string {
+	svcvol := make(map[string]string)
+	svcvol["name"] = vol.Name
+	svcvol["pool"] = vol.PoolName
+	svcvol["size"] = "{env.size}"
+	if shared {
+		svcvol["shared"] = "true"
+	}
+
+	// Use set to avoid duplicate directories
+	directorySet := make(map[string]struct{})
+
+	for _, baseDir := range vol.GetVolumeDirs() {
+		directorySet[baseDir] = struct{}{}
+	}
+	if mappedPaths, ok := pathmap[vol.Name]; ok {
+		for _, path := range mappedPaths {
+			// if path is not end with "/", get parent directory
+			if !strings.HasSuffix(path, "/") {
+				path = filepath.Dir(path) + "/"
+			}
+			directorySet[filepath.Join(path)] = struct{}{}
+		}
+	}
+
+	// Join unique directory list
+	dirs := make([]string, 0, len(directorySet))
+	for dir := range directorySet {
+		dirs = append(dirs, dir)
+	}
+
+	sort.Strings(dirs) // Optional: consistent order
+	svcvol["directories"] = strings.Join(dirs, " ")
+	return svcvol
 }
 
 func (cluster *Cluster) OpenSVCFoundAppAgent(app *App) (opensvc.Host, error) {

--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -489,7 +489,6 @@ func (cluster *Cluster) OpenSVCGetAppVolumeSections(basemap map[string]map[strin
 	}
 
 	deployment.Paths.Sort()
-	volumemap := deployment.Storages.Volumes.GroupByPool()
 	pathmap := deployment.Paths.GetVolumeDirs()
 
 	poolList, err := cluster.OpenSVCGetPoolInfoListFresh()
@@ -508,15 +507,15 @@ func (cluster *Cluster) OpenSVCGetAppVolumeSections(basemap map[string]map[strin
 	}
 
 	seq := 1
-	for pool, volumes := range volumemap {
-		poolInfo, ok := poolSet[pool]
+	for _, vol := range deployment.Storages.Volumes {
+		poolInfo, ok := poolSet[vol.PoolName]
 		if !ok {
-			return nil, fmt.Errorf("OpenSVC pool %q not found in runtime pool list", pool)
+			return nil, fmt.Errorf("OpenSVC pool %q not found in runtime pool list", vol.PoolName)
 		}
 
 		svcvol := make(map[string]string)
-		svcvol["name"] = app.GetAppVolumeName(pool, false)
-		svcvol["pool"] = pool
+		svcvol["name"] = vol.Name
+		svcvol["pool"] = vol.PoolName
 		svcvol["size"] = "{env.size}"
 		if poolInfo.Shared {
 			svcvol["shared"] = "true"
@@ -525,18 +524,16 @@ func (cluster *Cluster) OpenSVCGetAppVolumeSections(basemap map[string]map[strin
 		// Use set to avoid duplicate directories
 		directorySet := make(map[string]struct{})
 
-		for volName, baseDir := range volumes {
-			if baseDir != "" {
-				directorySet[baseDir] = struct{}{}
-			}
-			if mappedPaths, ok := pathmap[volName]; ok {
-				for _, path := range mappedPaths {
-					// if path is not end with "/", get parent directory
-					if !strings.HasSuffix(path, "/") {
-						path = filepath.Dir(path) + "/"
-					}
-					directorySet[filepath.Join(path)] = struct{}{}
+		for _, baseDir := range vol.GetVolumeDirs() {
+			directorySet[baseDir] = struct{}{}
+		}
+		if mappedPaths, ok := pathmap[vol.Name]; ok {
+			for _, path := range mappedPaths {
+				// if path is not end with "/", get parent directory
+				if !strings.HasSuffix(path, "/") {
+					path = filepath.Dir(path) + "/"
 				}
+				directorySet[filepath.Join(path)] = struct{}{}
 			}
 		}
 
@@ -703,7 +700,7 @@ func (cluster *Cluster) OpenSVCGetAppGitInitContainerSection(app *App, gc *confi
 	svccontainer := make(map[string]string)
 	if cluster.Conf.ProvType == "docker" || cluster.Conf.ProvType == "podman" {
 		svccontainer = cluster.OpenSVCGetAppGitInitDefaultSection(app)
-		svccontainer["volume_mounts"] = fmt.Sprintf("/etc/localtime:/etc/localtime:ro %s:/bootstrap", app.GetAppVolumeName(gc.GetSourcePoolName(), false))
+		svccontainer["volume_mounts"] = fmt.Sprintf("/etc/localtime:/etc/localtime:ro %s:/bootstrap", gc.GetSourceVolumeName())
 		svccontainer["secrets_environment"] = app.GetOpenSVCDeploymentAppEnv(config.VariableTypeSecret)
 		svccontainer["configs_environment"] = app.GetOpenSVCDeploymentAppEnv(config.VariableTypeEnv)
 		dirname := filepath.Join("/bootstrap", gc.GetSourcePath())
@@ -739,7 +736,7 @@ func (cluster *Cluster) OpenSVCGetAppS3MountContainerSection(app *App, s3m *conf
 		svccontainer["privileged"] = "true"
 		svccontainer["secrets_environment"] = app.GetOpenSVCDeploymentAppEnv(config.VariableTypeSecret)
 		svccontainer["configs_environment"] = app.GetOpenSVCDeploymentAppEnv(config.VariableTypeEnv)
-		diskname := app.GetAppVolumeName(s3m.GetSourcePoolName(), false)
+		diskname := s3m.GetSourceVolumeName()
 		svccontainer["volume_mounts"] = fmt.Sprintf("%s:/mnt:rw,rshared", filepath.Join(diskname, s3m.VolumeDir))
 		svccontainer["run_command"] = "-o allow_other -o nonempty --use-content-type --uid 33 --gid 33 -f"
 		svccontainer["blocking_post_provision"] = "sleep 3"
@@ -853,8 +850,7 @@ func (cluster *Cluster) GetOpenSVCDeploymentPathMapping(app *App) string {
 			continue
 		}
 
-		diskname := app.GetAppVolumeName(vol.PoolName, false)
-		results = append(results, path.GetDockerMapping(diskname))
+		results = append(results, path.GetDockerMapping(vol.Name))
 	}
 
 	return strings.Join(results, " ")

--- a/config/app_template_canonical.go
+++ b/config/app_template_canonical.go
@@ -28,7 +28,21 @@ type AppTemplateCanonicalizationResult struct {
 	// srcname/volumename fields retargeted to a merged volume's canonical
 	// name. An entry with both fields rewritten is still counted once.
 	RewrittenVolumeReferences int
+
+	// StampedAppConfigVersion reports whether the top-level
+	// app-config-version marker was missing or stale and was (re)written to
+	// AppConfigVersionV2.
+	StampedAppConfigVersion bool
 }
+
+// AppConfigVersionV2 is the persisted app-config-version value that marks
+// app/template TOML content as already matching the V1 -> V2 migration
+// baseline implemented by CanonicalizeAppTemplateRaw/CanonicalizeAppVolumesRaw.
+const AppConfigVersionV2 = 2
+
+// appConfigVersionKey is the top-level TOML key holding the persisted
+// app-config-version marker.
+const appConfigVersionKey = "app-config-version"
 
 func CanonicalizeAppTemplateTOML(content []byte) ([]byte, AppTemplateCanonicalizationResult, error) {
 	var res AppTemplateCanonicalizationResult
@@ -593,4 +607,57 @@ func rewriteVolumeNameReferences(storages map[string]any, key string, renames ma
 	}
 
 	return nil
+}
+
+// AppConfigVersionFromRaw returns the top-level app-config-version marker
+// from raw TOML content, or 0 if it is missing or not an integer.
+func AppConfigVersionFromRaw(raw map[string]any) int {
+	return pmToInt(raw[appConfigVersionKey], 0)
+}
+
+// StampAppConfigVersionRaw sets the top-level app-config-version marker to
+// AppConfigVersionV2 if it is missing or older than AppConfigVersionV2.
+// Already-V2 (or newer) content is left untouched. Returns true if raw was
+// modified.
+func StampAppConfigVersionRaw(raw map[string]any) bool {
+	if AppConfigVersionFromRaw(raw) >= AppConfigVersionV2 {
+		return false
+	}
+	raw[appConfigVersionKey] = AppConfigVersionV2
+	return true
+}
+
+// StampAppConfigVersionTOML ensures content carries a top-level
+// app-config-version marker at or above AppConfigVersionV2, rewriting
+// content only when the marker is missing or stale. Content whose marker is
+// already >= AppConfigVersionV2 is returned unchanged (byte-identical), so
+// repeated canonicalization passes over already-flagged V2 content do not
+// keep rewriting it.
+func StampAppConfigVersionTOML(content []byte) ([]byte, AppTemplateCanonicalizationResult, error) {
+	var res AppTemplateCanonicalizationResult
+
+	t, err := toml.LoadBytes(content)
+	if err != nil {
+		return nil, res, err
+	}
+
+	raw := t.ToMap()
+	if !StampAppConfigVersionRaw(raw) {
+		return content, res, nil
+	}
+
+	res.Changed = true
+	res.StampedAppConfigVersion = true
+
+	t, err = toml.TreeFromMap(raw)
+	if err != nil {
+		return nil, res, err
+	}
+
+	var buf bytes.Buffer
+	if _, err := t.WriteTo(&buf); err != nil {
+		return nil, res, err
+	}
+
+	return buf.Bytes(), res, nil
 }

--- a/config/app_template_canonical.go
+++ b/config/app_template_canonical.go
@@ -366,6 +366,11 @@ func pmToInt(v any, def int) int {
 // untouched: both are paths relative to the pool's OpenSVC volume mount
 // (named via App.GetAppVolumeName(pool, ...)), which is keyed by poolname
 // and therefore identical before and after merging same-pool rows.
+//
+// Collapsing multiple rows on the same pool into one only applies to
+// unflagged/V1 content (app-config-version < AppConfigVersionV2); see
+// CanonicalizeAppVolumesRaw for the V2 gate and the template-placeholder
+// rename exception that still applies to V2 content.
 func CanonicalizeAppVolumesTOML(content []byte, appName string) ([]byte, AppTemplateCanonicalizationResult, error) {
 	var res AppTemplateCanonicalizationResult
 
@@ -401,6 +406,16 @@ func CanonicalizeAppVolumesTOML(content []byte, appName string) ([]byte, AppTemp
 // each poolname has exactly one row named per the historical
 // App.GetAppVolumeName convention, and rewrites references accordingly. See
 // CanonicalizeAppVolumesTOML for details.
+//
+// Phase 11 V2 gate: once content is flagged app-config-version >=
+// AppConfigVersionV2, multiple rows sharing a poolname are intentional and
+// are no longer collapsed into one. The one exception is template-variable
+// resolution: canonicalizeAppVolumes still renames a lone row that is still
+// named with the unresolved OpenSVC "{name}-<pool>" placeholder to
+// "<appName>-<pool>" when appName is non-empty -- that is instantiating or
+// resetting a template for a specific app, not an ambiguous V1 duplicate.
+// Unflagged/V1 content (app-config-version < AppConfigVersionV2) always goes
+// through the full merge below, regardless of row count.
 func CanonicalizeAppVolumesRaw(raw map[string]any, appName string) (AppTemplateCanonicalizationResult, error) {
 	var res AppTemplateCanonicalizationResult
 
@@ -427,7 +442,9 @@ func CanonicalizeAppVolumesRaw(raw map[string]any, appName string) (AppTemplateC
 		return res, nil
 	}
 
-	if err := canonicalizeAppVolumes(deployment, storages, volumes, appName, &res); err != nil {
+	isV1 := AppConfigVersionFromRaw(raw) < AppConfigVersionV2
+
+	if err := canonicalizeAppVolumes(deployment, storages, volumes, appName, isV1, &res); err != nil {
 		return res, err
 	}
 
@@ -443,7 +460,7 @@ func canonicalVolumeName(appName, pool string) string {
 	return "{name}-" + pool
 }
 
-func canonicalizeAppVolumes(deployment, storages map[string]any, volumes []any, appName string, res *AppTemplateCanonicalizationResult) error {
+func canonicalizeAppVolumes(deployment, storages map[string]any, volumes []any, appName string, isV1 bool, res *AppTemplateCanonicalizationResult) error {
 	type volumeRow struct {
 		raw  map[string]any
 		name string
@@ -487,6 +504,20 @@ func canonicalizeAppVolumes(deployment, storages map[string]any, volumes []any, 
 			}
 			newVolumes = append(newVolumes, row.raw)
 			continue
+		}
+
+		if !isV1 {
+			// V2: the only rewrite left is resolving a lone unresolved
+			// "{name}-<pool>" template placeholder to "<appName>-<pool>" for
+			// a specific app. Multiple rows on this pool, or a single row
+			// with an intentionally custom name, are left as-is.
+			placeholderName := canonicalVolumeName("", pool)
+			if !(len(rows) == 1 && appName != "" && rows[0].name == placeholderName) {
+				for _, row := range rows {
+					newVolumes = append(newVolumes, row.raw)
+				}
+				continue
+			}
 		}
 
 		merged := make(map[string]any, len(rows[0].raw))

--- a/config/app_template_canonical.go
+++ b/config/app_template_canonical.go
@@ -16,6 +16,18 @@ type AppTemplateCanonicalizationResult struct {
 	UpdatedRootSourcePaths     int
 	UpdatedEmptySourcePaths    int
 	UnresolvedParentReferences []string
+
+	// MergedVolumePools is the number of deployment.storages.volumes pools
+	// whose legacy rows were canonicalized into a single row.
+	MergedVolumePools int
+	// MergedVolumeRows is the total number of legacy volume rows absorbed
+	// across all merged pools (including the row that becomes canonical).
+	MergedVolumeRows int
+	// RewrittenVolumeReferences is the number of entries (deployment.paths,
+	// git-clones, s3-mounts rows) that had at least one of their
+	// srcname/volumename fields retargeted to a merged volume's canonical
+	// name. An entry with both fields rewritten is still counted once.
+	RewrittenVolumeReferences int
 }
 
 func CanonicalizeAppTemplateTOML(content []byte) ([]byte, AppTemplateCanonicalizationResult, error) {
@@ -326,4 +338,277 @@ func pmToInt(v any, def int) int {
 	default:
 		return def
 	}
+}
+
+// CanonicalizeAppVolumesTOML rewrites deployment.storages.volumes so that
+// each OpenSVC pool is represented by a single row, named using the
+// convention historically produced at runtime by App.GetAppVolumeName:
+// "{name}-<pool>" for template content (appName == "") or "<appName>-<pool>"
+// for resolved app content (appName != ""). References in
+// deployment.paths, deployment.storages.git-clones and
+// deployment.storages.s3-mounts are rewritten to the merged row's name.
+//
+// srcpath (on paths) and volumedir (on git-clones/s3-mounts) are left
+// untouched: both are paths relative to the pool's OpenSVC volume mount
+// (named via App.GetAppVolumeName(pool, ...)), which is keyed by poolname
+// and therefore identical before and after merging same-pool rows.
+func CanonicalizeAppVolumesTOML(content []byte, appName string) ([]byte, AppTemplateCanonicalizationResult, error) {
+	var res AppTemplateCanonicalizationResult
+
+	t, err := toml.LoadBytes(content)
+	if err != nil {
+		return nil, res, err
+	}
+
+	raw := t.ToMap()
+	res, err = CanonicalizeAppVolumesRaw(raw, appName)
+	if err != nil {
+		return nil, res, err
+	}
+
+	if !res.Changed {
+		return content, res, nil
+	}
+
+	t, err = toml.TreeFromMap(raw)
+	if err != nil {
+		return nil, res, err
+	}
+
+	var buf bytes.Buffer
+	if _, err := t.WriteTo(&buf); err != nil {
+		return nil, res, err
+	}
+
+	return buf.Bytes(), res, nil
+}
+
+// CanonicalizeAppVolumesRaw merges deployment.storages.volumes rows so that
+// each poolname has exactly one row named per the historical
+// App.GetAppVolumeName convention, and rewrites references accordingly. See
+// CanonicalizeAppVolumesTOML for details.
+func CanonicalizeAppVolumesRaw(raw map[string]any, appName string) (AppTemplateCanonicalizationResult, error) {
+	var res AppTemplateCanonicalizationResult
+
+	deployment, ok := asAnyMap(raw["deployment"])
+	if !ok {
+		return res, nil
+	}
+
+	storages, ok := asAnyMap(deployment["storages"])
+	if !ok {
+		return res, nil
+	}
+
+	rawVolumes, ok := storages["volumes"]
+	if !ok {
+		return res, nil
+	}
+
+	volumes, ok := asAnySlice(rawVolumes)
+	if !ok {
+		return res, errors.New("deployment.storages.volumes must be an array")
+	}
+	if len(volumes) == 0 {
+		return res, nil
+	}
+
+	if err := canonicalizeAppVolumes(deployment, storages, volumes, appName, &res); err != nil {
+		return res, err
+	}
+
+	return res, nil
+}
+
+// canonicalVolumeName mirrors App.GetAppVolumeName: template content keeps
+// the OpenSVC "{name}" placeholder, resolved app content uses the app name.
+func canonicalVolumeName(appName, pool string) string {
+	if appName != "" {
+		return appName + "-" + pool
+	}
+	return "{name}-" + pool
+}
+
+// normalizeVolumeDirs merges one or more whitespace-separated directory
+// lists into a single deduplicated, whitespace-separated list, preserving
+// first-seen order across all inputs.
+func normalizeVolumeDirs(dirs ...string) string {
+	tokens := make([]string, 0, len(dirs))
+	seen := make(map[string]struct{}, len(dirs))
+	for _, dir := range dirs {
+		for _, tok := range strings.Fields(dir) {
+			if _, dup := seen[tok]; dup {
+				continue
+			}
+			seen[tok] = struct{}{}
+			tokens = append(tokens, tok)
+		}
+	}
+	return strings.Join(tokens, " ")
+}
+
+func canonicalizeAppVolumes(deployment, storages map[string]any, volumes []any, appName string, res *AppTemplateCanonicalizationResult) error {
+	type volumeRow struct {
+		raw  map[string]any
+		name string
+		dir  string
+	}
+
+	poolOrder := make([]string, 0, len(volumes))
+	rowsByPool := make(map[string][]volumeRow, len(volumes))
+
+	for _, v := range volumes {
+		vm, ok := asAnyMap(v)
+		if !ok {
+			return errors.New("deployment.storages.volumes entries must be tables")
+		}
+		pool := asTrimmedString(vm["poolname"])
+		if pool == "" {
+			return errors.New("deployment.storages.volumes entry missing poolname")
+		}
+		if _, seen := rowsByPool[pool]; !seen {
+			poolOrder = append(poolOrder, pool)
+		}
+		rowsByPool[pool] = append(rowsByPool[pool], volumeRow{
+			raw:  vm,
+			name: asTrimmedString(vm["name"]),
+			dir:  asTrimmedString(vm["volumedir"]),
+		})
+	}
+
+	renames := make(map[string]string)
+	newVolumes := make([]any, 0, len(poolOrder))
+
+	for _, pool := range poolOrder {
+		rows := rowsByPool[pool]
+		canonicalName := canonicalVolumeName(appName, pool)
+
+		if len(rows) == 1 && rows[0].name == canonicalName {
+			row := rows[0]
+			if normalized := normalizeVolumeDirs(row.dir); normalized != row.dir {
+				row.raw["volumedir"] = normalized
+				res.Changed = true
+			}
+			newVolumes = append(newVolumes, row.raw)
+			continue
+		}
+
+		merged := make(map[string]any, len(rows[0].raw))
+		for k, v := range rows[0].raw {
+			merged[k] = v
+		}
+
+		dirs := make([]string, 0, len(rows))
+		for _, row := range rows {
+			dirs = append(dirs, row.dir)
+		}
+
+		merged["name"] = canonicalName
+		merged["poolname"] = pool
+		merged["volumedir"] = normalizeVolumeDirs(dirs...)
+
+		newVolumes = append(newVolumes, merged)
+
+		res.Changed = true
+		res.MergedVolumePools++
+		res.MergedVolumeRows += len(rows)
+
+		for _, row := range rows {
+			if row.name == "" || row.name == canonicalName {
+				continue
+			}
+			renames[row.name] = canonicalName
+		}
+	}
+
+	if !res.Changed {
+		return nil
+	}
+
+	storages["volumes"] = newVolumes
+
+	if rawPaths, ok := deployment["paths"]; ok {
+		paths, ok := asAnySlice(rawPaths)
+		if !ok {
+			return errors.New("deployment.paths must be an array")
+		}
+		for _, p := range paths {
+			pm, ok := asAnyMap(p)
+			if !ok {
+				continue
+			}
+
+			rewritten := false
+
+			if SourceType(asTrimmedString(pm["srctype"])) == SourceVolume {
+				if srcName := asTrimmedString(pm["srcname"]); srcName != "" {
+					if newName, found := renames[srcName]; found {
+						pm["srcname"] = newName
+						rewritten = true
+					}
+				}
+			}
+
+			// volumename is rewritten independently of srctype/srcname: it is the
+			// field GetOpenSVCDeploymentPathMapping actually resolves against
+			// (deployment.GetVolumeByName). Paths sourced from a git-clone or
+			// s3-mount, or that inherited volumename from a parent path, persist
+			// their own volumename distinct from srcname (see InsertPath/ResolvePath),
+			// so it must be checked against renames on its own.
+			if volName := asTrimmedString(pm["volumename"]); volName != "" {
+				if newName, found := renames[volName]; found {
+					pm["volumename"] = newName
+					rewritten = true
+				}
+			}
+
+			if rewritten {
+				res.RewrittenVolumeReferences++
+			}
+		}
+	}
+
+	if err := rewriteVolumeNameReferences(storages, "git-clones", renames, res); err != nil {
+		return err
+	}
+	if err := rewriteVolumeNameReferences(storages, "s3-mounts", renames, res); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// rewriteVolumeNameReferences retargets volumename on entries under
+// deployment.storages[key] (git-clones or s3-mounts) that reference a
+// renamed volume. volumedir is left untouched: it is a path relative to the
+// pool's OpenSVC volume mount, which does not change when same-pool rows are
+// merged.
+func rewriteVolumeNameReferences(storages map[string]any, key string, renames map[string]string, res *AppTemplateCanonicalizationResult) error {
+	rawEntries, ok := storages[key]
+	if !ok {
+		return nil
+	}
+
+	entries, ok := asAnySlice(rawEntries)
+	if !ok {
+		return errors.New("deployment.storages." + key + " must be an array")
+	}
+
+	for _, e := range entries {
+		em, ok := asAnyMap(e)
+		if !ok {
+			continue
+		}
+
+		oldName := asTrimmedString(em["volumename"])
+		newName, found := renames[oldName]
+		if !found {
+			continue
+		}
+
+		em["volumename"] = newName
+		res.RewrittenVolumeReferences++
+	}
+
+	return nil
 }

--- a/config/app_template_canonical.go
+++ b/config/app_template_canonical.go
@@ -429,24 +429,6 @@ func canonicalVolumeName(appName, pool string) string {
 	return "{name}-" + pool
 }
 
-// normalizeVolumeDirs merges one or more whitespace-separated directory
-// lists into a single deduplicated, whitespace-separated list, preserving
-// first-seen order across all inputs.
-func normalizeVolumeDirs(dirs ...string) string {
-	tokens := make([]string, 0, len(dirs))
-	seen := make(map[string]struct{}, len(dirs))
-	for _, dir := range dirs {
-		for _, tok := range strings.Fields(dir) {
-			if _, dup := seen[tok]; dup {
-				continue
-			}
-			seen[tok] = struct{}{}
-			tokens = append(tokens, tok)
-		}
-	}
-	return strings.Join(tokens, " ")
-}
-
 func canonicalizeAppVolumes(deployment, storages map[string]any, volumes []any, appName string, res *AppTemplateCanonicalizationResult) error {
 	type volumeRow struct {
 		raw  map[string]any
@@ -485,7 +467,7 @@ func canonicalizeAppVolumes(deployment, storages map[string]any, volumes []any, 
 
 		if len(rows) == 1 && rows[0].name == canonicalName {
 			row := rows[0]
-			if normalized := normalizeVolumeDirs(row.dir); normalized != row.dir {
+			if normalized := NormalizeVolumeDirs(row.dir); normalized != row.dir {
 				row.raw["volumedir"] = normalized
 				res.Changed = true
 			}
@@ -505,7 +487,7 @@ func canonicalizeAppVolumes(deployment, storages map[string]any, volumes []any, 
 
 		merged["name"] = canonicalName
 		merged["poolname"] = pool
-		merged["volumedir"] = normalizeVolumeDirs(dirs...)
+		merged["volumedir"] = NormalizeVolumeDirs(dirs...)
 
 		newVolumes = append(newVolumes, merged)
 

--- a/config/app_template_canonical.go
+++ b/config/app_template_canonical.go
@@ -520,6 +520,14 @@ func canonicalizeAppVolumes(deployment, storages map[string]any, volumes []any, 
 			}
 		}
 
+		// V1 same-pool duplicates are treated as one ambiguous logical volume, not
+		// as independently meaningful persisted objects. The first row becomes the
+		// canonical baseline carrier for any extra/raw fields, while later rows
+		// contribute only to the merged directory set and row-name rewrite map.
+		// Unknown/raw fields present only on rows[1..n] are intentionally not
+		// merged, because there is no defined V1 conflict-resolution rule for them
+		// and the canonicalization goal is to collapse the duplicates to one
+		// deterministic baseline row.
 		merged := make(map[string]any, len(rows[0].raw))
 		for k, v := range rows[0].raw {
 			merged[k] = v

--- a/config/app_template_canonical_test.go
+++ b/config/app_template_canonical_test.go
@@ -117,6 +117,578 @@ dockerpath = "/var/www/html"
 	}
 }
 
+// loadVolumesAndPaths parses content and returns deployment.storages.volumes
+// and deployment.paths as slices of maps for convenient assertions.
+func loadVolumesAndPaths(t *testing.T, content []byte) ([]map[string]any, []map[string]any) {
+	tree, err := toml.LoadBytes(content)
+	if err != nil {
+		t.Fatalf("load toml failed: %v", err)
+	}
+	raw := tree.ToMap()
+
+	deployment, ok := asAnyMap(raw["deployment"])
+	if !ok {
+		t.Fatalf("missing deployment map")
+	}
+	storages, ok := asAnyMap(deployment["storages"])
+	if !ok {
+		t.Fatalf("missing deployment.storages map")
+	}
+
+	volumesAny, ok := asAnySlice(storages["volumes"])
+	if !ok {
+		t.Fatalf("missing deployment.storages.volumes array")
+	}
+	volumes := make([]map[string]any, 0, len(volumesAny))
+	for _, v := range volumesAny {
+		vm, ok := asAnyMap(v)
+		if !ok {
+			t.Fatalf("volume entry is not a table")
+		}
+		volumes = append(volumes, vm)
+	}
+
+	var paths []map[string]any
+	if pathsRaw, ok := deployment["paths"]; ok {
+		pathsAny, ok := asAnySlice(pathsRaw)
+		if !ok {
+			t.Fatalf("deployment.paths is not an array")
+		}
+		paths = make([]map[string]any, 0, len(pathsAny))
+		for _, p := range pathsAny {
+			pm, ok := asAnyMap(p)
+			if !ok {
+				t.Fatalf("path entry is not a table")
+			}
+			paths = append(paths, pm)
+		}
+	}
+
+	return volumes, paths
+}
+
+func TestCanonicalizeAppVolumesTOML_SingleRowRenamedTemplateMode(t *testing.T) {
+	legacy := []byte(`
+[deployment.storages]
+[[deployment.storages.volumes]]
+name = "data-volume"
+poolname = "data"
+volumedir = "data"
+
+[[deployment.paths]]
+name = "web-root"
+dockerpath = "/var/www/html"
+srctype = "volume"
+srcname = "data-volume"
+volumename = "data-volume"
+srcpath = "."
+`)
+
+	canonical, res, err := CanonicalizeAppVolumesTOML(legacy, "")
+	if err != nil {
+		t.Fatalf("canonicalize failed: %v", err)
+	}
+	if !res.Changed {
+		t.Fatalf("expected canonicalization to report changes")
+	}
+	if res.MergedVolumePools != 1 || res.MergedVolumeRows != 1 {
+		t.Fatalf("expected 1 merged pool/row, got pools=%d rows=%d", res.MergedVolumePools, res.MergedVolumeRows)
+	}
+	if res.RewrittenVolumeReferences != 1 {
+		t.Fatalf("expected 1 rewritten reference, got %d", res.RewrittenVolumeReferences)
+	}
+
+	volumes, paths := loadVolumesAndPaths(t, canonical)
+	if len(volumes) != 1 {
+		t.Fatalf("expected 1 volume row, got %d", len(volumes))
+	}
+	if name := asTrimmedString(volumes[0]["name"]); name != "{name}-data" {
+		t.Fatalf("expected canonical volume name {name}-data, got %q", name)
+	}
+	if dir := asTrimmedString(volumes[0]["volumedir"]); dir != "data" {
+		t.Fatalf("expected volumedir 'data', got %q", dir)
+	}
+
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 path, got %d", len(paths))
+	}
+	if srcname := asTrimmedString(paths[0]["srcname"]); srcname != "{name}-data" {
+		t.Fatalf("expected srcname {name}-data, got %q", srcname)
+	}
+	if volname := asTrimmedString(paths[0]["volumename"]); volname != "{name}-data" {
+		t.Fatalf("expected volumename {name}-data, got %q", volname)
+	}
+	if srcpath := asTrimmedString(paths[0]["srcpath"]); srcpath != "." {
+		t.Fatalf("expected srcpath '.' (unchanged, relative to pool volume mount), got %q", srcpath)
+	}
+}
+
+func TestCanonicalizeAppVolumesTOML_SingleRowRenamedResolvedMode(t *testing.T) {
+	legacy := []byte(`
+[deployment.storages]
+[[deployment.storages.volumes]]
+name = "data-volume"
+poolname = "data"
+volumedir = "data"
+
+[[deployment.paths]]
+name = "web-root"
+dockerpath = "/var/www/html"
+srctype = "volume"
+srcname = "data-volume"
+volumename = "data-volume"
+srcpath = "."
+`)
+
+	canonical, res, err := CanonicalizeAppVolumesTOML(legacy, "myapp")
+	if err != nil {
+		t.Fatalf("canonicalize failed: %v", err)
+	}
+	if !res.Changed {
+		t.Fatalf("expected canonicalization to report changes")
+	}
+
+	volumes, paths := loadVolumesAndPaths(t, canonical)
+	if name := asTrimmedString(volumes[0]["name"]); name != "myapp-data" {
+		t.Fatalf("expected canonical volume name myapp-data, got %q", name)
+	}
+	if srcname := asTrimmedString(paths[0]["srcname"]); srcname != "myapp-data" {
+		t.Fatalf("expected srcname myapp-data, got %q", srcname)
+	}
+	if volname := asTrimmedString(paths[0]["volumename"]); volname != "myapp-data" {
+		t.Fatalf("expected volumename myapp-data, got %q", volname)
+	}
+	if srcpath := asTrimmedString(paths[0]["srcpath"]); srcpath != "." {
+		t.Fatalf("expected srcpath '.' (unchanged, relative to pool volume mount), got %q", srcpath)
+	}
+}
+
+func TestCanonicalizeAppVolumesTOML_MultiRowMergedIntoOnePool(t *testing.T) {
+	legacy := []byte(`
+[deployment.storages]
+[[deployment.storages.volumes]]
+name = "data-volume"
+poolname = "data"
+volumedir = "data"
+
+[[deployment.storages.volumes]]
+name = "logs-volume"
+poolname = "data"
+volumedir = "logs"
+
+[[deployment.paths]]
+name = "web-root"
+dockerpath = "/var/www/html"
+srctype = "volume"
+srcname = "data-volume"
+volumename = "data-volume"
+srcpath = "."
+
+[[deployment.paths]]
+name = "log-dir"
+dockerpath = "/var/log/app"
+srctype = "volume"
+srcname = "logs-volume"
+volumename = "logs-volume"
+srcpath = "."
+`)
+
+	canonical, res, err := CanonicalizeAppVolumesTOML(legacy, "")
+	if err != nil {
+		t.Fatalf("canonicalize failed: %v", err)
+	}
+	if !res.Changed {
+		t.Fatalf("expected canonicalization to report changes")
+	}
+	if res.MergedVolumePools != 1 {
+		t.Fatalf("expected 1 merged pool, got %d", res.MergedVolumePools)
+	}
+	if res.MergedVolumeRows != 2 {
+		t.Fatalf("expected 2 merged rows, got %d", res.MergedVolumeRows)
+	}
+	if res.RewrittenVolumeReferences != 2 {
+		t.Fatalf("expected 2 rewritten references, got %d", res.RewrittenVolumeReferences)
+	}
+
+	volumes, paths := loadVolumesAndPaths(t, canonical)
+	if len(volumes) != 1 {
+		t.Fatalf("expected volumes to be merged into 1 row, got %d", len(volumes))
+	}
+	if name := asTrimmedString(volumes[0]["name"]); name != "{name}-data" {
+		t.Fatalf("expected canonical volume name {name}-data, got %q", name)
+	}
+	if dir := asTrimmedString(volumes[0]["volumedir"]); dir != "data logs" {
+		t.Fatalf("expected merged volumedir 'data logs', got %q", dir)
+	}
+
+	srcpaths := make(map[string]string, len(paths))
+	for _, p := range paths {
+		if srcname := asTrimmedString(p["srcname"]); srcname != "{name}-data" {
+			t.Fatalf("expected srcname {name}-data, got %q", srcname)
+		}
+		if volname := asTrimmedString(p["volumename"]); volname != "{name}-data" {
+			t.Fatalf("expected volumename {name}-data, got %q", volname)
+		}
+		srcpaths[asTrimmedString(p["name"])] = asTrimmedString(p["srcpath"])
+	}
+	// srcpath is relative to the pool's OpenSVC volume mount, which is keyed
+	// by poolname and unchanged by merging same-pool rows, so both stay ".".
+	if srcpaths["web-root"] != "." {
+		t.Fatalf("expected web-root srcpath '.', got %q", srcpaths["web-root"])
+	}
+	if srcpaths["log-dir"] != "." {
+		t.Fatalf("expected log-dir srcpath '.', got %q", srcpaths["log-dir"])
+	}
+}
+
+func TestCanonicalizeAppVolumesTOML_Idempotent(t *testing.T) {
+	legacy := []byte(`
+[deployment.storages]
+[[deployment.storages.volumes]]
+name = "data-volume"
+poolname = "data"
+volumedir = "data"
+
+[[deployment.storages.volumes]]
+name = "logs-volume"
+poolname = "data"
+volumedir = "logs"
+
+[[deployment.paths]]
+name = "web-root"
+dockerpath = "/var/www/html"
+srctype = "volume"
+srcname = "data-volume"
+volumename = "data-volume"
+srcpath = "."
+
+[[deployment.paths]]
+name = "log-dir"
+dockerpath = "/var/log/app"
+srctype = "volume"
+srcname = "logs-volume"
+volumename = "logs-volume"
+srcpath = "."
+`)
+
+	first, res1, err := CanonicalizeAppVolumesTOML(legacy, "")
+	if err != nil {
+		t.Fatalf("first canonicalize failed: %v", err)
+	}
+	if !res1.Changed {
+		t.Fatalf("expected first pass to report changes")
+	}
+
+	second, res2, err := CanonicalizeAppVolumesTOML(first, "")
+	if err != nil {
+		t.Fatalf("second canonicalize failed: %v", err)
+	}
+	if res2.Changed {
+		t.Fatalf("expected second pass to report no changes, got %+v", res2)
+	}
+	if string(second) != string(first) {
+		t.Fatalf("expected second pass output to be unchanged:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+func TestCanonicalizeAppVolumesTOML_GitCloneAndS3MountReferencesRewritten(t *testing.T) {
+	legacy := []byte(`
+[deployment.storages]
+[[deployment.storages.volumes]]
+name = "data-volume"
+poolname = "data"
+volumedir = "data"
+
+[[deployment.storages.git-clones]]
+name = "app-src"
+volumename = "data-volume"
+volumedir = "data/app-src"
+
+[[deployment.storages.s3-mounts]]
+name = "media"
+volumename = "data-volume"
+volumedir = "data/media"
+`)
+
+	canonical, res, err := CanonicalizeAppVolumesTOML(legacy, "")
+	if err != nil {
+		t.Fatalf("canonicalize failed: %v", err)
+	}
+	if !res.Changed {
+		t.Fatalf("expected canonicalization to report changes")
+	}
+	if res.RewrittenVolumeReferences != 2 {
+		t.Fatalf("expected 2 rewritten references, got %d", res.RewrittenVolumeReferences)
+	}
+
+	tree, err := toml.LoadBytes(canonical)
+	if err != nil {
+		t.Fatalf("load canonical toml failed: %v", err)
+	}
+	raw := tree.ToMap()
+	deployment, _ := asAnyMap(raw["deployment"])
+	storages, _ := asAnyMap(deployment["storages"])
+
+	gitClonesAny, ok := asAnySlice(storages["git-clones"])
+	if !ok || len(gitClonesAny) != 1 {
+		t.Fatalf("expected 1 git-clone entry")
+	}
+	gc, _ := asAnyMap(gitClonesAny[0])
+	if v := asTrimmedString(gc["volumename"]); v != "{name}-data" {
+		t.Fatalf("expected git-clone volumename {name}-data, got %q", v)
+	}
+	// volumedir is already relative to the pool volume mount (it was built as
+	// filepath.Join(volume.VolumeDir, gc.Name)); it must not be re-prefixed.
+	if v := asTrimmedString(gc["volumedir"]); v != "data/app-src" {
+		t.Fatalf("expected git-clone volumedir to stay 'data/app-src', got %q", v)
+	}
+
+	s3MountsAny, ok := asAnySlice(storages["s3-mounts"])
+	if !ok || len(s3MountsAny) != 1 {
+		t.Fatalf("expected 1 s3-mount entry")
+	}
+	s3, _ := asAnyMap(s3MountsAny[0])
+	if v := asTrimmedString(s3["volumename"]); v != "{name}-data" {
+		t.Fatalf("expected s3-mount volumename {name}-data, got %q", v)
+	}
+	if v := asTrimmedString(s3["volumedir"]); v != "data/media" {
+		t.Fatalf("expected s3-mount volumedir to stay 'data/media', got %q", v)
+	}
+}
+
+// TestCanonicalizeAppVolumesTOML_MergeWithExistingCanonicalRowLeavesItsReferencesUnchanged
+// covers a pool that already contains a row named like the canonical name
+// alongside another legacy row. References to the already-canonical row must
+// be left untouched (both name and srcpath), while references to the other
+// row are retargeted to the (unchanged) canonical name.
+func TestCanonicalizeAppVolumesTOML_MergeWithExistingCanonicalRowLeavesItsReferencesUnchanged(t *testing.T) {
+	legacy := []byte(`
+[deployment.storages]
+[[deployment.storages.volumes]]
+name = "{name}-data"
+poolname = "data"
+volumedir = "data"
+
+[[deployment.storages.volumes]]
+name = "logs-volume"
+poolname = "data"
+volumedir = "logs"
+
+[[deployment.paths]]
+name = "web-root"
+dockerpath = "/var/www/html"
+srctype = "volume"
+srcname = "{name}-data"
+volumename = "{name}-data"
+srcpath = "."
+
+[[deployment.paths]]
+name = "log-dir"
+dockerpath = "/var/log/app"
+srctype = "volume"
+srcname = "logs-volume"
+volumename = "logs-volume"
+srcpath = "."
+`)
+
+	canonical, res, err := CanonicalizeAppVolumesTOML(legacy, "")
+	if err != nil {
+		t.Fatalf("canonicalize failed: %v", err)
+	}
+	if !res.Changed {
+		t.Fatalf("expected canonicalization to report changes")
+	}
+	if res.MergedVolumePools != 1 || res.MergedVolumeRows != 2 {
+		t.Fatalf("expected 1 merged pool of 2 rows, got pools=%d rows=%d", res.MergedVolumePools, res.MergedVolumeRows)
+	}
+	if res.RewrittenVolumeReferences != 1 {
+		t.Fatalf("expected only the logs-volume reference to be rewritten, got %d", res.RewrittenVolumeReferences)
+	}
+
+	volumes, paths := loadVolumesAndPaths(t, canonical)
+	if len(volumes) != 1 {
+		t.Fatalf("expected volumes to be merged into 1 row, got %d", len(volumes))
+	}
+	if name := asTrimmedString(volumes[0]["name"]); name != "{name}-data" {
+		t.Fatalf("expected canonical volume name {name}-data, got %q", name)
+	}
+	if dir := asTrimmedString(volumes[0]["volumedir"]); dir != "data logs" {
+		t.Fatalf("expected merged volumedir 'data logs', got %q", dir)
+	}
+
+	srcpaths := make(map[string]string, len(paths))
+	for _, p := range paths {
+		if srcname := asTrimmedString(p["srcname"]); srcname != "{name}-data" {
+			t.Fatalf("expected srcname {name}-data, got %q", srcname)
+		}
+		srcpaths[asTrimmedString(p["name"])] = asTrimmedString(p["srcpath"])
+	}
+	if srcpaths["web-root"] != "." {
+		t.Fatalf("expected web-root srcpath to stay '.', got %q", srcpaths["web-root"])
+	}
+	if srcpaths["log-dir"] != "." {
+		t.Fatalf("expected log-dir srcpath to stay '.', got %q", srcpaths["log-dir"])
+	}
+}
+
+// TestCanonicalizeAppVolumesTOML_NormalizesVolumeDirOnAlreadyCanonicalSingleRow
+// covers a pool with a single row that already has the canonical name but an
+// un-normalized volumedir (duplicate tokens / irregular whitespace). The
+// merge fast-path for single canonical rows must still normalize volumedir.
+func TestCanonicalizeAppVolumesTOML_NormalizesVolumeDirOnAlreadyCanonicalSingleRow(t *testing.T) {
+	legacy := []byte(`
+[deployment.storages]
+[[deployment.storages.volumes]]
+name = "{name}-data"
+poolname = "data"
+volumedir = "data   logs data"
+
+[[deployment.paths]]
+name = "web-root"
+dockerpath = "/var/www/html"
+srctype = "volume"
+srcname = "{name}-data"
+volumename = "{name}-data"
+srcpath = "."
+`)
+
+	canonical, res, err := CanonicalizeAppVolumesTOML(legacy, "")
+	if err != nil {
+		t.Fatalf("canonicalize failed: %v", err)
+	}
+	if !res.Changed {
+		t.Fatalf("expected canonicalization to report changes")
+	}
+	if res.MergedVolumePools != 0 || res.MergedVolumeRows != 0 {
+		t.Fatalf("expected no row merges, got pools=%d rows=%d", res.MergedVolumePools, res.MergedVolumeRows)
+	}
+
+	volumes, _ := loadVolumesAndPaths(t, canonical)
+	if len(volumes) != 1 {
+		t.Fatalf("expected 1 volume row, got %d", len(volumes))
+	}
+	if name := asTrimmedString(volumes[0]["name"]); name != "{name}-data" {
+		t.Fatalf("expected canonical volume name {name}-data, got %q", name)
+	}
+	if dir := asTrimmedString(volumes[0]["volumedir"]); dir != "data logs" {
+		t.Fatalf("expected normalized volumedir 'data logs', got %q", dir)
+	}
+
+	second, res2, err := CanonicalizeAppVolumesTOML(canonical, "")
+	if err != nil {
+		t.Fatalf("second canonicalize failed: %v", err)
+	}
+	if res2.Changed {
+		t.Fatalf("expected second pass to report no changes, got %+v", res2)
+	}
+	if string(second) != string(canonical) {
+		t.Fatalf("expected second pass output to be unchanged:\nfirst:\n%s\nsecond:\n%s", canonical, second)
+	}
+}
+
+func TestCanonicalizeAppVolumesTOML_AlreadyCanonicalNoOp(t *testing.T) {
+	canonical := []byte(`
+[deployment.storages]
+[[deployment.storages.volumes]]
+name = "{name}-data"
+poolname = "data"
+volumedir = "data"
+
+[[deployment.paths]]
+name = "web-root"
+dockerpath = "/var/www/html"
+srctype = "volume"
+srcname = "{name}-data"
+volumename = "{name}-data"
+srcpath = "data"
+`)
+
+	out, res, err := CanonicalizeAppVolumesTOML(canonical, "")
+	if err != nil {
+		t.Fatalf("canonicalize failed: %v", err)
+	}
+	if res.Changed {
+		t.Fatalf("expected no changes for already-canonical input, got %+v", res)
+	}
+	if string(out) != string(canonical) {
+		t.Fatalf("expected output to equal input unchanged")
+	}
+}
+
+// TestCanonicalizeAppVolumesTOML_GitSourcedPathVolumeNameRewritten covers a
+// deployment.paths entry sourced from a git-clone (srctype = "git"). Its
+// volumename is persisted independently of srcname at InsertPath time
+// (config/deployment.go) and must be retargeted when the underlying volume
+// row is renamed, even though srctype != "volume" and srcname never matches
+// a volume row name.
+func TestCanonicalizeAppVolumesTOML_GitSourcedPathVolumeNameRewritten(t *testing.T) {
+	legacy := []byte(`
+[deployment.storages]
+[[deployment.storages.volumes]]
+name = "data-volume"
+poolname = "data"
+volumedir = "data"
+
+[[deployment.storages.volumes]]
+name = "logs-volume"
+poolname = "data"
+volumedir = "logs"
+
+[[deployment.storages.git-clones]]
+name = "app-src"
+volumename = "data-volume"
+volumedir = "data/app-src"
+
+[[deployment.paths]]
+name = "web-root"
+dockerpath = "/var/www/html"
+srctype = "git"
+srcname = "app-src"
+srcpath = "."
+volumename = "data-volume"
+`)
+
+	canonical, res, err := CanonicalizeAppVolumesTOML(legacy, "")
+	if err != nil {
+		t.Fatalf("canonicalize failed: %v", err)
+	}
+	if !res.Changed {
+		t.Fatalf("expected canonicalization to report changes")
+	}
+	if res.RewrittenVolumeReferences != 2 {
+		t.Fatalf("expected 2 rewritten references (git-clone + path), got %d", res.RewrittenVolumeReferences)
+	}
+
+	tree, err := toml.LoadBytes(canonical)
+	if err != nil {
+		t.Fatalf("load canonical toml failed: %v", err)
+	}
+	raw := tree.ToMap()
+	deployment, _ := asAnyMap(raw["deployment"])
+	storages, _ := asAnyMap(deployment["storages"])
+
+	gitClonesAny, ok := asAnySlice(storages["git-clones"])
+	if !ok || len(gitClonesAny) != 1 {
+		t.Fatalf("expected 1 git-clone entry")
+	}
+	gc, _ := asAnyMap(gitClonesAny[0])
+	if v := asTrimmedString(gc["volumename"]); v != "{name}-data" {
+		t.Fatalf("expected git-clone volumename {name}-data, got %q", v)
+	}
+
+	pathsAny, ok := asAnySlice(deployment["paths"])
+	if !ok || len(pathsAny) != 1 {
+		t.Fatalf("expected 1 path entry")
+	}
+	pm, _ := asAnyMap(pathsAny[0])
+	if v := asTrimmedString(pm["srcname"]); v != "app-src" {
+		t.Fatalf("expected path srcname to remain 'app-src' (git source), got %q", v)
+	}
+	if v := asTrimmedString(pm["volumename"]); v != "{name}-data" {
+		t.Fatalf("expected path volumename rewritten to {name}-data, got %q", v)
+	}
+}
+
 func TestCanonicalizeAppTemplateRaw_UnresolvedParentReportedOnce(t *testing.T) {
 	raw := map[string]any{
 		"deployment": map[string]any{

--- a/config/app_template_canonical_test.go
+++ b/config/app_template_canonical_test.go
@@ -341,6 +341,64 @@ srcpath = "."
 	}
 }
 
+// TestCanonicalizeAppVolumesTOML_V2FlaggedMultiRowPoolNotMerged covers Phase
+// 11 task 1: once content is flagged app-config-version = 2, intentional
+// multiple deployment.storages.volumes rows sharing a poolname are left
+// untouched -- contrast with
+// TestCanonicalizeAppVolumesTOML_MultiRowMergedIntoOnePool, which still
+// merges same-pool rows for unflagged/V1 content.
+func TestCanonicalizeAppVolumesTOML_V2FlaggedMultiRowPoolNotMerged(t *testing.T) {
+	versioned := []byte(`
+app-config-version = 2
+
+[deployment.storages]
+[[deployment.storages.volumes]]
+name = "myapp-data"
+poolname = "data"
+volumedir = "data"
+
+[[deployment.storages.volumes]]
+name = "myapp-data-logs"
+poolname = "data"
+volumedir = "logs"
+
+[[deployment.paths]]
+name = "web-root"
+dockerpath = "/var/www/html"
+srctype = "volume"
+srcname = "myapp-data"
+volumename = "myapp-data"
+srcpath = "."
+
+[[deployment.paths]]
+name = "log-dir"
+dockerpath = "/var/log/app"
+srctype = "volume"
+srcname = "myapp-data-logs"
+volumename = "myapp-data-logs"
+srcpath = "."
+`)
+
+	out, res, err := CanonicalizeAppVolumesTOML(versioned, "myapp")
+	if err != nil {
+		t.Fatalf("canonicalize failed: %v", err)
+	}
+	if res.Changed {
+		t.Fatalf("expected no changes for already-V2 multi-row content, got %+v", res)
+	}
+	if string(out) != string(versioned) {
+		t.Fatalf("expected output to equal input unchanged:\nin:\n%s\nout:\n%s", versioned, out)
+	}
+
+	volumes, paths := loadVolumesAndPaths(t, out)
+	if len(volumes) != 2 {
+		t.Fatalf("expected both volume rows to be preserved, got %d", len(volumes))
+	}
+	if len(paths) != 2 {
+		t.Fatalf("expected both path references to be preserved, got %d", len(paths))
+	}
+}
+
 func TestCanonicalizeAppVolumesTOML_Idempotent(t *testing.T) {
 	legacy := []byte(`
 [deployment.storages]

--- a/config/app_template_canonical_test.go
+++ b/config/app_template_canonical_test.go
@@ -399,6 +399,53 @@ srcpath = "."
 	}
 }
 
+// TestCanonicalizeAppVolumesTOML_MultiRowMergedUsesFirstRowAsBaseline
+// documents the intentional V1 merge policy for same-pool duplicate rows: the
+// first row acts as the canonical/raw-field baseline carrier, while later rows
+// contribute only their directories and row-name rewrite information. Unknown
+// raw fields present only on later rows are intentionally not merged because
+// V1 duplicates are treated as one ambiguous logical volume, not as distinct
+// persisted objects with a field-by-field conflict-resolution contract.
+func TestCanonicalizeAppVolumesTOML_MultiRowMergedUsesFirstRowAsBaseline(t *testing.T) {
+	legacy := []byte(`
+[deployment.storages]
+[[deployment.storages.volumes]]
+name = "data-volume"
+poolname = "data"
+volumedir = "data"
+firstonly = "keep-me"
+
+[[deployment.storages.volumes]]
+name = "logs-volume"
+poolname = "data"
+volumedir = "logs"
+secondonly = "drop-me"
+`)
+
+	canonical, res, err := CanonicalizeAppVolumesTOML(legacy, "")
+	if err != nil {
+		t.Fatalf("canonicalize failed: %v", err)
+	}
+	if !res.Changed {
+		t.Fatalf("expected canonicalization to report changes")
+	}
+
+	volumes, _ := loadVolumesAndPaths(t, canonical)
+	if len(volumes) != 1 {
+		t.Fatalf("expected volumes to merge into one row, got %d", len(volumes))
+	}
+	merged := volumes[0]
+	if got := asTrimmedString(merged["firstonly"]); got != "keep-me" {
+		t.Fatalf("expected first-row raw field preserved as baseline, got %q", got)
+	}
+	if _, ok := merged["secondonly"]; ok {
+		t.Fatalf("expected later-row raw field to be intentionally dropped, got %+v", merged["secondonly"])
+	}
+	if got := asTrimmedString(merged["volumedir"]); got != "data logs" {
+		t.Fatalf("expected merged volumedir 'data logs', got %q", got)
+	}
+}
+
 // TestCanonicalizeAppVolumesTOML_V2SameVolumeRowsGitCloneReferencePreserved is
 // a Phase 11 follow-up to
 // TestCanonicalizeAppVolumesTOML_V2FlaggedMultiRowPoolNotMerged: a git-clone

--- a/config/app_template_canonical_test.go
+++ b/config/app_template_canonical_test.go
@@ -713,3 +713,83 @@ func TestCanonicalizeAppTemplateRaw_UnresolvedParentReportedOnce(t *testing.T) {
 		t.Fatalf("expected unresolved parent %q, got %q", "missing-parent", res.UnresolvedParentReferences[0])
 	}
 }
+
+// TestStampAppConfigVersionTOML_UnversionedContentIsStamped covers Phase 10
+// task 1/3: content with no app-config-version marker is rewritten with
+// app-config-version = 2.
+func TestStampAppConfigVersionTOML_UnversionedContentIsStamped(t *testing.T) {
+	unversioned := []byte(`
+app-host = "myapp"
+app-port = "8080"
+`)
+
+	out, res, err := StampAppConfigVersionTOML(unversioned)
+	if err != nil {
+		t.Fatalf("stamp failed: %v", err)
+	}
+	if !res.Changed {
+		t.Fatalf("expected stamping to report changes")
+	}
+	if !res.StampedAppConfigVersion {
+		t.Fatalf("expected StampedAppConfigVersion to be true")
+	}
+	if !strings.Contains(string(out), "app-config-version = 2") {
+		t.Fatalf("expected app-config-version = 2 in output, got:\n%s", out)
+	}
+}
+
+// TestStampAppConfigVersionTOML_AlreadyV2NoOp covers Phase 10 task 4:
+// content already marked app-config-version = 2 must remain byte-identical.
+func TestStampAppConfigVersionTOML_AlreadyV2NoOp(t *testing.T) {
+	versioned := []byte(`
+app-config-version = 2
+app-host = "myapp"
+app-port = "8080"
+`)
+
+	out, res, err := StampAppConfigVersionTOML(versioned)
+	if err != nil {
+		t.Fatalf("stamp failed: %v", err)
+	}
+	if res.Changed {
+		t.Fatalf("expected no changes for already-V2 content, got %+v", res)
+	}
+	if res.StampedAppConfigVersion {
+		t.Fatalf("expected StampedAppConfigVersion to be false for already-V2 content")
+	}
+	if string(out) != string(versioned) {
+		t.Fatalf("expected output to equal input unchanged:\nin:\n%s\nout:\n%s", versioned, out)
+	}
+}
+
+// TestStampAppConfigVersionTOML_StaleVersionIsBumped covers a marker older
+// than AppConfigVersionV2 being bumped up to the current version.
+func TestStampAppConfigVersionTOML_StaleVersionIsBumped(t *testing.T) {
+	stale := []byte(`
+app-config-version = 1
+app-host = "myapp"
+`)
+
+	out, res, err := StampAppConfigVersionTOML(stale)
+	if err != nil {
+		t.Fatalf("stamp failed: %v", err)
+	}
+	if !res.Changed || !res.StampedAppConfigVersion {
+		t.Fatalf("expected stale version to be bumped, got %+v", res)
+	}
+	if !strings.Contains(string(out), "app-config-version = 2") {
+		t.Fatalf("expected app-config-version = 2 in output, got:\n%s", out)
+	}
+}
+
+func TestAppConfigVersionFromRaw(t *testing.T) {
+	if v := AppConfigVersionFromRaw(map[string]any{}); v != 0 {
+		t.Fatalf("expected 0 for missing marker, got %d", v)
+	}
+	if v := AppConfigVersionFromRaw(map[string]any{"app-config-version": int64(2)}); v != 2 {
+		t.Fatalf("expected 2 for int64 marker, got %d", v)
+	}
+	if v := AppConfigVersionFromRaw(map[string]any{"app-config-version": "not-a-number"}); v != 0 {
+		t.Fatalf("expected 0 for non-numeric marker, got %d", v)
+	}
+}

--- a/config/app_template_canonical_test.go
+++ b/config/app_template_canonical_test.go
@@ -399,6 +399,130 @@ srcpath = "."
 	}
 }
 
+// TestCanonicalizeAppVolumesTOML_V2SameVolumeRowsGitCloneReferencePreserved is
+// a Phase 11 follow-up to
+// TestCanonicalizeAppVolumesTOML_V2FlaggedMultiRowPoolNotMerged: a git-clone
+// row referencing the *second* row of a V2-flagged same-pool pair must keep
+// pointing at that row's own name. Under the V1 merge
+// (TestCanonicalizeAppVolumesTOML_GitCloneAndS3MountReferencesRewritten) the
+// two rows would be merged into one and the git-clone's volumename rewritten
+// to the merged name; for V2 content there is no merge, so the reference must
+// stay untouched and distinct from the other row.
+func TestCanonicalizeAppVolumesTOML_V2SameVolumeRowsGitCloneReferencePreserved(t *testing.T) {
+	versioned := []byte(`
+app-config-version = 2
+
+[deployment.storages]
+[[deployment.storages.volumes]]
+name = "myapp-data"
+poolname = "data"
+volumedir = "data"
+
+[[deployment.storages.volumes]]
+name = "myapp-data-logs"
+poolname = "data"
+volumedir = "logs"
+
+[[deployment.storages.git-clones]]
+name = "app-src"
+volumename = "myapp-data-logs"
+volumedir = "logs/app-src"
+`)
+
+	out, res, err := CanonicalizeAppVolumesTOML(versioned, "myapp")
+	if err != nil {
+		t.Fatalf("canonicalize failed: %v", err)
+	}
+	if res.Changed {
+		t.Fatalf("expected no changes for already-V2 multi-row content, got %+v", res)
+	}
+	if string(out) != string(versioned) {
+		t.Fatalf("expected output to equal input unchanged:\nin:\n%s\nout:\n%s", versioned, out)
+	}
+
+	tree, err := toml.LoadBytes(out)
+	if err != nil {
+		t.Fatalf("load canonical toml failed: %v", err)
+	}
+	raw := tree.ToMap()
+	deployment, _ := asAnyMap(raw["deployment"])
+	storages, _ := asAnyMap(deployment["storages"])
+
+	volumesAny, ok := asAnySlice(storages["volumes"])
+	if !ok || len(volumesAny) != 2 {
+		t.Fatalf("expected both volume rows to be preserved, got %d", len(volumesAny))
+	}
+
+	gitClonesAny, ok := asAnySlice(storages["git-clones"])
+	if !ok || len(gitClonesAny) != 1 {
+		t.Fatalf("expected 1 git-clone entry")
+	}
+	gc, _ := asAnyMap(gitClonesAny[0])
+	if v := asTrimmedString(gc["volumename"]); v != "myapp-data-logs" {
+		t.Fatalf("expected git-clone volumename to remain myapp-data-logs, got %q", v)
+	}
+}
+
+// TestCanonicalizeAppVolumesTOML_V2SameVolumeRowsS3MountReferencePreserved
+// mirrors
+// TestCanonicalizeAppVolumesTOML_V2SameVolumeRowsGitCloneReferencePreserved
+// for an s3-mount row referencing the second row of a V2-flagged same-pool
+// pair.
+func TestCanonicalizeAppVolumesTOML_V2SameVolumeRowsS3MountReferencePreserved(t *testing.T) {
+	versioned := []byte(`
+app-config-version = 2
+
+[deployment.storages]
+[[deployment.storages.volumes]]
+name = "myapp-data"
+poolname = "data"
+volumedir = "data"
+
+[[deployment.storages.volumes]]
+name = "myapp-data-logs"
+poolname = "data"
+volumedir = "logs"
+
+[[deployment.storages.s3-mounts]]
+name = "media"
+volumename = "myapp-data-logs"
+volumedir = "logs/media"
+`)
+
+	out, res, err := CanonicalizeAppVolumesTOML(versioned, "myapp")
+	if err != nil {
+		t.Fatalf("canonicalize failed: %v", err)
+	}
+	if res.Changed {
+		t.Fatalf("expected no changes for already-V2 multi-row content, got %+v", res)
+	}
+	if string(out) != string(versioned) {
+		t.Fatalf("expected output to equal input unchanged:\nin:\n%s\nout:\n%s", versioned, out)
+	}
+
+	tree, err := toml.LoadBytes(out)
+	if err != nil {
+		t.Fatalf("load canonical toml failed: %v", err)
+	}
+	raw := tree.ToMap()
+	deployment, _ := asAnyMap(raw["deployment"])
+	storages, _ := asAnyMap(deployment["storages"])
+
+	volumesAny, ok := asAnySlice(storages["volumes"])
+	if !ok || len(volumesAny) != 2 {
+		t.Fatalf("expected both volume rows to be preserved, got %d", len(volumesAny))
+	}
+
+	s3MountsAny, ok := asAnySlice(storages["s3-mounts"])
+	if !ok || len(s3MountsAny) != 1 {
+		t.Fatalf("expected 1 s3-mount entry")
+	}
+	s3, _ := asAnyMap(s3MountsAny[0])
+	if v := asTrimmedString(s3["volumename"]); v != "myapp-data-logs" {
+		t.Fatalf("expected s3-mount volumename to remain myapp-data-logs, got %q", v)
+	}
+}
+
 func TestCanonicalizeAppVolumesTOML_Idempotent(t *testing.T) {
 	legacy := []byte(`
 [deployment.storages]

--- a/config/config.go
+++ b/config/config.go
@@ -1002,31 +1002,36 @@ func init() {
 }
 
 type AppConfig struct {
-	ProvAppType           string      `mapstructure:"prov-app-service-type" toml:"prov-app-service-type" json:"provAppServiceType"`
-	ProvAppMem            string      `measurement:"M,bytes,required" mapstructure:"prov-app-memory" toml:"prov-app-memory" json:"provAppMemory"`
-	ProvAppCpuCores       string      `mapstructure:"prov-app-cpu-cores" toml:"prov-app-cpu-cores" json:"provAppCpuCores"`
-	ProvAppDisk           string      `measurement:"G,bytes,required" mapstructure:"prov-app-disk-size" toml:"prov-app-disk-size" json:"provAppDiskSize"`
-	ProvAppDiskType       string      `mapstructure:"prov-app-disk-type" toml:"prov-app-disk-type" json:"provAppDiskType"`
-	ProvAppDockerImg      string      `mapstructure:"prov-app-docker-img" toml:"prov-app-docker-img" json:"provAppDockerImg"`
-	ProvAppDockerCmd      string      `mapstructure:"prov-app-docker-cmd" toml:"prov-app-docker-cmd" json:"provAppDockerCmd"`
-	ProvAppRouteAddr      string      `mapstructure:"prov-app-route-addr" toml:"prov-app-route-addr" json:"provAppRouteAddr"`
-	ProvAppRoutePort      string      `mapstructure:"prov-app-route-port" toml:"prov-app-route-port" json:"provAppRoutePort"`
-	ProvAppRouteMask      string      `mapstructure:"prov-app-route-mask" toml:"prov-app-route-mask" json:"provAppRouteMask"`
-	ProvAppTemplate       string      `mapstructure:"prov-app-template" toml:"prov-app-template" json:"provAppTemplate"`
-	ProvAppAgents         string      `mapstructure:"prov-app-agents" toml:"prov-app-agents" json:"provAppAgents"`
-	ProvAppHATopology     string      `mapstructure:"prov-app-ha-topology" toml:"prov-app-ha-topology" json:"provAppHaTopology"`
-	ProvAppAgentsFailover string      `mapstructure:"prov-app-agents-failover" toml:"prov-app-agents-failover" json:"provAppAgentsFailover"`
-	ProvAppCreditUsed     int         `mapstructure:"prov-app-credit-used" toml:"prov-app-credit-used" json:"provAppCreditUsed"`
-	ProvAppCreditPlanned  int         `mapstructure:"prov-app-credit-planned" toml:"prov-app-credit-planned" json:"provAppCreditPlanned"`
-	AppHost               string      `mapstructure:"app-host" toml:"app-host" json:"appHost"`
-	AppHostsIPV6          string      `mapstructure:"app-hosts-ipv6" toml:"app-hosts-ipv6" json:"appHostsIpv6"`
-	AppPort               string      `mapstructure:"app-port" toml:"app-port" json:"appPort"`
-	AppDbUser             string      `mapstructure:"app-db-user" toml:"app-db-user" json:"appDbUser" groups:"apps"`
-	AppDbPass             string      `mapstructure:"app-db-pass" toml:"app-db-pass" json:"appDbPass" groups:"apps"`
-	AppDbPassClear        string      `mapstructure:"app-db-pass-clear" toml:"-" json:"-" app:"-"`
-	AppDbSchema           string      `mapstructure:"app-db-schema" toml:"app-db-schema" json:"appDbSchema" groups:"apps"`
-	AppS3Provider         bool        `mapstructure:"app-s3-provider" toml:"app-s3-provider" json:"appS3Provider"`
-	Deployment            *Deployment `mapstructure:"deployment" toml:"deployment" json:"deployment" groups:"apps"`
+	ProvAppType           string `mapstructure:"prov-app-service-type" toml:"prov-app-service-type" json:"provAppServiceType"`
+	ProvAppMem            string `measurement:"M,bytes,required" mapstructure:"prov-app-memory" toml:"prov-app-memory" json:"provAppMemory"`
+	ProvAppCpuCores       string `mapstructure:"prov-app-cpu-cores" toml:"prov-app-cpu-cores" json:"provAppCpuCores"`
+	ProvAppDisk           string `measurement:"G,bytes,required" mapstructure:"prov-app-disk-size" toml:"prov-app-disk-size" json:"provAppDiskSize"`
+	ProvAppDiskType       string `mapstructure:"prov-app-disk-type" toml:"prov-app-disk-type" json:"provAppDiskType"`
+	ProvAppDockerImg      string `mapstructure:"prov-app-docker-img" toml:"prov-app-docker-img" json:"provAppDockerImg"`
+	ProvAppDockerCmd      string `mapstructure:"prov-app-docker-cmd" toml:"prov-app-docker-cmd" json:"provAppDockerCmd"`
+	ProvAppRouteAddr      string `mapstructure:"prov-app-route-addr" toml:"prov-app-route-addr" json:"provAppRouteAddr"`
+	ProvAppRoutePort      string `mapstructure:"prov-app-route-port" toml:"prov-app-route-port" json:"provAppRoutePort"`
+	ProvAppRouteMask      string `mapstructure:"prov-app-route-mask" toml:"prov-app-route-mask" json:"provAppRouteMask"`
+	ProvAppTemplate       string `mapstructure:"prov-app-template" toml:"prov-app-template" json:"provAppTemplate"`
+	ProvAppAgents         string `mapstructure:"prov-app-agents" toml:"prov-app-agents" json:"provAppAgents"`
+	ProvAppHATopology     string `mapstructure:"prov-app-ha-topology" toml:"prov-app-ha-topology" json:"provAppHaTopology"`
+	ProvAppAgentsFailover string `mapstructure:"prov-app-agents-failover" toml:"prov-app-agents-failover" json:"provAppAgentsFailover"`
+	ProvAppCreditUsed     int    `mapstructure:"prov-app-credit-used" toml:"prov-app-credit-used" json:"provAppCreditUsed"`
+	ProvAppCreditPlanned  int    `mapstructure:"prov-app-credit-planned" toml:"prov-app-credit-planned" json:"provAppCreditPlanned"`
+	AppHost               string `mapstructure:"app-host" toml:"app-host" json:"appHost"`
+	AppHostsIPV6          string `mapstructure:"app-hosts-ipv6" toml:"app-hosts-ipv6" json:"appHostsIpv6"`
+	AppPort               string `mapstructure:"app-port" toml:"app-port" json:"appPort"`
+	AppDbUser             string `mapstructure:"app-db-user" toml:"app-db-user" json:"appDbUser" groups:"apps"`
+	AppDbPass             string `mapstructure:"app-db-pass" toml:"app-db-pass" json:"appDbPass" groups:"apps"`
+	AppDbPassClear        string `mapstructure:"app-db-pass-clear" toml:"-" json:"-" app:"-"`
+	AppDbSchema           string `mapstructure:"app-db-schema" toml:"app-db-schema" json:"appDbSchema" groups:"apps"`
+	AppS3Provider         bool   `mapstructure:"app-s3-provider" toml:"app-s3-provider" json:"appS3Provider"`
+	// AppConfigVersion is the explicit persisted migration marker stamped by
+	// cluster.CanonicalizeAppContent. 0/missing means unflagged legacy (V1)
+	// content; AppConfigVersionV2 means content already matches the V1 -> V2
+	// migration baseline and does not need re-canonicalizing for shape alone.
+	AppConfigVersion int         `mapstructure:"app-config-version" toml:"app-config-version" json:"appConfigVersion"`
+	Deployment       *Deployment `mapstructure:"deployment" toml:"deployment" json:"deployment" groups:"apps"`
 }
 
 func (appcnf *AppConfig) GetDeploymentVariables(name string) *VariableMapping {
@@ -1520,8 +1525,8 @@ const (
 
 // TaskDef describes a task's execution capabilities and default mode.
 type TaskDef struct {
-	Name       TaskName
-	Capability TaskExecCapability
+	Name          TaskName
+	Capability    TaskExecCapability
 	DefaultRemote bool // When Capability is TaskCapBoth, true = remote by default
 }
 
@@ -1532,32 +1537,32 @@ type TaskDef struct {
 // Both:       user chooses via scheduler-jobs-exec-{task} config (default in DefaultRemote).
 var TaskRegistry = map[TaskName]TaskDef{
 	// RemoteOnly — requires DB host filesystem or system access
-	ConstTaskXB:                {Name: ConstTaskXB, Capability: TaskCapRemoteOnly},
-	ConstTaskMB:                {Name: ConstTaskMB, Capability: TaskCapRemoteOnly},
-	ConstTaskReseedXB:          {Name: ConstTaskReseedXB, Capability: TaskCapRemoteOnly},
-	ConstTaskReseedMB:          {Name: ConstTaskReseedMB, Capability: TaskCapRemoteOnly},
-	ConstTaskFlashXB:           {Name: ConstTaskFlashXB, Capability: TaskCapRemoteOnly},
-	ConstTaskFlashMB:           {Name: ConstTaskFlashMB, Capability: TaskCapRemoteOnly},
+	ConstTaskXB:       {Name: ConstTaskXB, Capability: TaskCapRemoteOnly},
+	ConstTaskMB:       {Name: ConstTaskMB, Capability: TaskCapRemoteOnly},
+	ConstTaskReseedXB: {Name: ConstTaskReseedXB, Capability: TaskCapRemoteOnly},
+	ConstTaskReseedMB: {Name: ConstTaskReseedMB, Capability: TaskCapRemoteOnly},
+	ConstTaskFlashXB:  {Name: ConstTaskFlashXB, Capability: TaskCapRemoteOnly},
+	ConstTaskFlashMB:  {Name: ConstTaskFlashMB, Capability: TaskCapRemoteOnly},
 	// Both — orchestrator API (OpenSVC/K8S) handles locally, dbjobs uses systemctl
-	ConstTaskRestart:           {Name: ConstTaskRestart, Capability: TaskCapBoth, DefaultRemote: true},
-	ConstTaskStop:              {Name: ConstTaskStop, Capability: TaskCapBoth, DefaultRemote: true},
-	ConstTaskStart:             {Name: ConstTaskStart, Capability: TaskCapBoth, DefaultRemote: true},
-	ConstTaskError:             {Name: ConstTaskError, Capability: TaskCapRemoteOnly},
-	ConstTaskSlowQuery:         {Name: ConstTaskSlowQuery, Capability: TaskCapRemoteOnly},
-	ConstTaskSqlError:          {Name: ConstTaskSqlError, Capability: TaskCapRemoteOnly},
-	ConstTaskAuditLog:          {Name: ConstTaskAuditLog, Capability: TaskCapRemoteOnly},
-	ConstTaskZFS:               {Name: ConstTaskZFS, Capability: TaskCapRemoteOnly},
-	ConstTaskJobsCheck:         {Name: ConstTaskJobsCheck, Capability: TaskCapRemoteOnly},
-	ConstTaskJobsUpgrade:       {Name: ConstTaskJobsUpgrade, Capability: TaskCapRemoteOnly},
+	ConstTaskRestart:            {Name: ConstTaskRestart, Capability: TaskCapBoth, DefaultRemote: true},
+	ConstTaskStop:               {Name: ConstTaskStop, Capability: TaskCapBoth, DefaultRemote: true},
+	ConstTaskStart:              {Name: ConstTaskStart, Capability: TaskCapBoth, DefaultRemote: true},
+	ConstTaskError:              {Name: ConstTaskError, Capability: TaskCapRemoteOnly},
+	ConstTaskSlowQuery:          {Name: ConstTaskSlowQuery, Capability: TaskCapRemoteOnly},
+	ConstTaskSqlError:           {Name: ConstTaskSqlError, Capability: TaskCapRemoteOnly},
+	ConstTaskAuditLog:           {Name: ConstTaskAuditLog, Capability: TaskCapRemoteOnly},
+	ConstTaskZFS:                {Name: ConstTaskZFS, Capability: TaskCapRemoteOnly},
+	ConstTaskJobsCheck:          {Name: ConstTaskJobsCheck, Capability: TaskCapRemoteOnly},
+	ConstTaskJobsUpgrade:        {Name: ConstTaskJobsUpgrade, Capability: TaskCapRemoteOnly},
 	ConstTaskPrintCurrentConfig: {Name: ConstTaskPrintCurrentConfig, Capability: TaskCapRemoteOnly},
-	ConstTaskPrintDummyConfig:  {Name: ConstTaskPrintDummyConfig, Capability: TaskCapRemoteOnly},
+	ConstTaskPrintDummyConfig:   {Name: ConstTaskPrintDummyConfig, Capability: TaskCapRemoteOnly},
 
 	// Both — user can choose local (repman) or remote (dbjobs)
-	ConstTaskDump:      {Name: ConstTaskDump, Capability: TaskCapBoth, DefaultRemote: false},
-	ConstTaskMydumper:  {Name: ConstTaskMydumper, Capability: TaskCapBoth, DefaultRemote: false},
-	ConstTaskOptimize:  {Name: ConstTaskOptimize, Capability: TaskCapBoth, DefaultRemote: true},
+	ConstTaskDump:       {Name: ConstTaskDump, Capability: TaskCapBoth, DefaultRemote: false},
+	ConstTaskMydumper:   {Name: ConstTaskMydumper, Capability: TaskCapBoth, DefaultRemote: false},
+	ConstTaskOptimize:   {Name: ConstTaskOptimize, Capability: TaskCapBoth, DefaultRemote: true},
 	ConstTaskReseedDump: {Name: ConstTaskReseedDump, Capability: TaskCapBoth, DefaultRemote: false},
-	ConstTaskFlashDump: {Name: ConstTaskFlashDump, Capability: TaskCapBoth, DefaultRemote: false},
+	ConstTaskFlashDump:  {Name: ConstTaskFlashDump, Capability: TaskCapBoth, DefaultRemote: false},
 }
 
 // IsRemoteTask returns true if the task should be dispatched to the dbjobs

--- a/config/deployment.go
+++ b/config/deployment.go
@@ -1401,12 +1401,25 @@ func (v *Volume) Validate() error {
 	return nil
 }
 
+// GetSourcePath returns a legacy-compatible single-path view of VolumeDir for
+// callers that still expect a Volume to expose one path prefix. For a
+// multi-token VolumeDir (for example "data logs"), only the first token is
+// returned so legacy callers never receive the invalid literal path
+// "/data logs". Modern direct-volume path mappings must not use this helper to
+// derive root semantics: they are rooted at the saved volume row itself and use
+// "." explicitly.
 func (v *Volume) GetSourcePath() string {
-	// Ensure the volume directory starts with a slash
-	if !strings.HasPrefix(v.VolumeDir, "/") {
-		return "/" + v.VolumeDir
+	dir := v.DefaultSubdir()
+	if dir == "" {
+		// Preserve the historical empty-value shape as closely as possible for
+		// deprecated callers. Validate() rejects empty VolumeDir for saved rows,
+		// so this is only for defensive compatibility.
+		return "/"
 	}
-	return v.VolumeDir
+	if !strings.HasPrefix(dir, "/") {
+		return "/" + dir
+	}
+	return dir
 }
 
 func (v *Volume) GetSourceName() string {

--- a/config/deployment.go
+++ b/config/deployment.go
@@ -363,13 +363,20 @@ func (d *Deployment) ResolvePath(p *PathMapping) error {
 		return err
 	}
 
+	var childErrs []error
 	if p.VolumeName != oldVolumeName && p.Name != "" {
 		for _, child := range d.Paths {
 			if child == p || child.SourceType != "" || child.ParentName != p.Name {
 				continue
 			}
-			d.ResolvePath(child)
+			if err := d.ResolvePath(child); err != nil {
+				childErrs = append(childErrs, err)
+			}
 		}
+	}
+
+	if len(childErrs) > 0 {
+		return errors.Join(childErrs...)
 	}
 
 	return nil
@@ -405,6 +412,12 @@ func (d *Deployment) ResolvePaths() []error {
 		}
 	}
 
+	for _, p := range d.Paths {
+		if p.SourceType == "" && p.Parent != nil {
+			p.VolumeName = ""
+		}
+	}
+
 	// Pass 2: propagate VolumeName from parents to children with no direct
 	// source, iterating to a fixed point so inheritance converges regardless
 	// of d.Paths ordering.
@@ -414,6 +427,9 @@ func (d *Deployment) ResolvePaths() []error {
 			if p.SourceType != "" || p.Parent == nil {
 				continue
 			}
+			if p.Parent.VolumeName == "" {
+				continue
+			}
 			if p.VolumeName != p.Parent.VolumeName {
 				p.VolumeName = p.Parent.VolumeName
 				changed = true
@@ -421,6 +437,12 @@ func (d *Deployment) ResolvePaths() []error {
 		}
 		if !changed {
 			break
+		}
+	}
+
+	for _, p := range d.Paths {
+		if p.SourceType == "" && p.Parent != nil && p.VolumeName == "" {
+			appendErr(fmt.Errorf("inherited volume not resolved for path mapping %s via parent %s", p.DockerPath, p.ParentName))
 		}
 	}
 

--- a/config/deployment.go
+++ b/config/deployment.go
@@ -44,8 +44,14 @@ func (d *Deployment) GetVolumeByName(name string) (*Volume, error) {
 	return nil, fmt.Errorf("volume %s not found", name)
 }
 
-// findVolumeByPool returns the saved row for poolName, or nil if none
+// findVolumeByPool returns the first saved row for poolName, or nil if none
 // exists. Callers must hold d.Mutex.
+//
+// This is a single-row lookup: for V1 content (app-config-version <
+// AppConfigVersionV2) a pool has at most one row, so "first" is "only". For
+// V2 content a pool may legitimately have multiple intentional rows (see
+// Phase 11); this function only ever returns the first one. Callers that need
+// to consider all rows for a pool must iterate d.Storages.Volumes directly.
 func (d *Deployment) findVolumeByPool(poolName string) *Volume {
 	for _, v := range d.Storages.Volumes {
 		if v.PoolName == poolName {
@@ -55,10 +61,12 @@ func (d *Deployment) findVolumeByPool(poolName string) *Volume {
 	return nil
 }
 
-// GetVolumeByPool returns the saved row for poolName, or nil if none exists.
-// It backs the one-row-per-pool invariant on writes: InsertVolume rejects new
-// rows for a pool that already has one, and poolname edits must not move a
-// row onto a pool another row already owns.
+// GetVolumeByPool returns the first saved row for poolName, or nil if none
+// exists. It backs the one-row-per-pool invariant on writes for V1 content:
+// InsertVolume rejects new rows for a pool that already has one, and poolname
+// edits must not move a row onto a pool another row already owns -- but only
+// while appConfigVersion < AppConfigVersionV2. V2 content may have multiple
+// rows per pool; see findVolumeByPool.
 func (d *Deployment) GetVolumeByPool(poolName string) *Volume {
 	d.Mutex.RLock()
 	defer d.Mutex.RUnlock()
@@ -66,7 +74,17 @@ func (d *Deployment) GetVolumeByPool(poolName string) *Volume {
 	return d.findVolumeByPool(poolName)
 }
 
-func (d *Deployment) InsertVolume(v *Volume) error {
+// InsertVolume appends v to Storages.Volumes after normalizing and
+// validating it. appConfigVersion is the owning AppConfig's persisted
+// app-config-version marker (config.AppConfig.AppConfigVersion):
+//
+//   - appConfigVersion < AppConfigVersionV2 (V1/unflagged): a pool may back at
+//     most one saved row, matching the canonicalization migration's
+//     one-row-per-pool invariant.
+//   - appConfigVersion >= AppConfigVersionV2: multiple intentional rows per
+//     pool are allowed (Phase 11). The row's Name must still be globally
+//     unique.
+func (d *Deployment) InsertVolume(v *Volume, appConfigVersion int) error {
 	// Use a mutex to protect concurrent access
 	d.Mutex.Lock()
 	defer d.Mutex.Unlock()
@@ -78,19 +96,18 @@ func (d *Deployment) InsertVolume(v *Volume) error {
 		return err
 	}
 
-	// Check if the volume already exists. A row is now canonical per pool, so
-	// any existing row for the same pool is a duplicate regardless of name or
-	// directory. Legacy configs with multiple rows per pool are still readable
-	// via GroupByPool and are consolidated by the canonicalization migration;
-	// this check only guards new writes.
+	// Check if the volume already exists. Name is the row's identity and must
+	// be globally unique regardless of app-config-version.
 	for _, existingVolume := range d.Storages.Volumes {
 		if existingVolume.Name == v.Name {
 			return fmt.Errorf("volume already exists: %s", v.Name)
 		}
 	}
 
-	if existing := d.findVolumeByPool(v.PoolName); existing != nil {
-		return fmt.Errorf("a volume for pool %q already exists: %s", v.PoolName, existing.Name)
+	if appConfigVersion < AppConfigVersionV2 {
+		if existing := d.findVolumeByPool(v.PoolName); existing != nil {
+			return fmt.Errorf("a volume for pool %q already exists: %s", v.PoolName, existing.Name)
+		}
 	}
 
 	// Add the new volume

--- a/config/deployment.go
+++ b/config/deployment.go
@@ -281,6 +281,44 @@ func (d *Deployment) GetGitPaths(name string) []*PathMapping {
 	return paths
 }
 
+// syncPathVolumeName applies the canonical PathMapping.VolumeName resolution
+// rule once pointers have been resolved via ResolvePointers:
+//
+//  1. a path with a resolved direct Source always has VolumeName refreshed
+//     from Source.GetSourceVolumeName(), overwriting any stale value
+//  2. a path that declares a SourceType but whose Source did not resolve has
+//     VolumeName cleared, so provisioning does not fall back to a stale or
+//     mismatched volume
+//  3. a path with no direct source inherits VolumeName from its Parent, if any
+//  4. a root path with neither a source nor a parent is left untouched
+func syncPathVolumeName(p *PathMapping) {
+	switch {
+	case p.Source != nil:
+		p.VolumeName = p.Source.GetSourceVolumeName()
+	case p.SourceType != "":
+		p.VolumeName = ""
+	case p.Parent != nil:
+		p.VolumeName = p.Parent.VolumeName
+	}
+}
+
+// resolvePathMapping resolves p's Parent/Source pointers and synchronizes its
+// VolumeName via syncPathVolumeName. It does not lock d.Mutex; callers are
+// responsible for any required locking.
+func (d *Deployment) resolvePathMapping(p *PathMapping) error {
+	if err := p.ResolvePointers(d.Storages.Volumes, d.Storages.GitClones, d.Storages.S3Mounts, d.Paths); err != nil {
+		return err
+	}
+
+	syncPathVolumeName(p)
+
+	if p.SourceType != "" && p.Source == nil {
+		return fmt.Errorf("source %s not found for path mapping %s", p.SourceName, p.DockerPath)
+	}
+
+	return nil
+}
+
 func (d *Deployment) InsertPath(p PathMapping) error {
 	// Use a mutex to protect concurrent access
 	d.Mutex.Lock()
@@ -291,21 +329,13 @@ func (d *Deployment) InsertPath(p PathMapping) error {
 		if existingPath.DockerPath == p.DockerPath {
 			return fmt.Errorf("path mapping already exists for target path: %s", p.DockerPath)
 		}
-
-		if existingPath.Name == p.ParentName {
-			// If the parent name matches, set the parent pointer
-			p.Parent = existingPath
-		}
 	}
 
-	// Validate the path mapping
-	p.ResolvePointers(d.Storages.Volumes, d.Storages.GitClones, d.Storages.S3Mounts, d.Paths)
-	if p.SourceName != "" && p.Source == nil {
-		return fmt.Errorf("source %s not found for path mapping %s", p.SourceName, p.DockerPath)
-	} else if p.Source != nil {
-		p.VolumeName = p.Source.GetSourceVolumeName() // Use the source's volume name if available
-	} else {
-		p.VolumeName = p.Parent.VolumeName // Inherit volume name from parent if no source is specified
+	if err := d.resolvePathMapping(&p); err != nil {
+		return err
+	}
+	if p.SourceType == "" && p.SourceName != "" {
+		return fmt.Errorf("source type is required for path mapping %s", p.DockerPath)
 	}
 
 	// Add the new path mapping
@@ -321,21 +351,25 @@ func (d *Deployment) ResolveGitPaths(gitname string) {
 	}
 }
 
+// ResolvePath resolves p's pointers and VolumeName via resolvePathMapping. If
+// p's VolumeName changes as a result, the change is cascaded to any child
+// paths (matched by ParentName) that have no direct source of their own, so
+// inherited bindings stay in sync immediately after a source or backing
+// volume change.
 func (d *Deployment) ResolvePath(p *PathMapping) error {
-	err := p.ResolvePointers(d.Storages.Volumes, d.Storages.GitClones, d.Storages.S3Mounts, d.Paths)
-	if err != nil {
+	oldVolumeName := p.VolumeName
+
+	if err := d.resolvePathMapping(p); err != nil {
 		return err
 	}
 
-	if p.Parent != nil {
-		if p.VolumeName == "" {
-			p.VolumeName = p.Parent.VolumeName // Inherit volume name from parent if no source is specified
+	if p.VolumeName != oldVolumeName && p.Name != "" {
+		for _, child := range d.Paths {
+			if child == p || child.SourceType != "" || child.ParentName != p.Name {
+				continue
+			}
+			d.ResolvePath(child)
 		}
-	}
-
-	// If the path is not resolved, log a warning
-	if p.SourceType != "" && p.Source == nil {
-		return fmt.Errorf("source %s not found for path mapping %s", p.SourceName, p.DockerPath)
 	}
 
 	return nil
@@ -347,31 +381,49 @@ func (d *Deployment) ResolvePaths() []error {
 	d.Mutex.Lock()
 	defer d.Mutex.Unlock()
 
+	appendErr := func(err error) {
+		if errs == nil {
+			errs = make([]error, 0)
+		}
+		errs = append(errs, err)
+	}
+
+	// Pass 1: resolve pointers for every path and synchronize VolumeName for
+	// paths with a direct source. Paths without a direct source keep their
+	// current VolumeName until the inheritance pass below.
 	for _, p := range d.Paths {
-		// Resolve pointers for each path mapping
-		err := p.ResolvePointers(d.Storages.Volumes, d.Storages.GitClones, d.Storages.S3Mounts, d.Paths)
-		if err != nil {
-			if errs == nil {
-				errs = make([]error, 0)
-			}
-			errs = append(errs, err)
+		if err := p.ResolvePointers(d.Storages.Volumes, d.Storages.GitClones, d.Storages.S3Mounts, d.Paths); err != nil {
+			appendErr(err)
 			continue
 		}
 
-		if p.Parent != nil {
-			if p.VolumeName == "" {
-				p.VolumeName = p.Parent.VolumeName // Inherit volume name from parent if no source is specified
+		if p.SourceType != "" {
+			syncPathVolumeName(p)
+			if p.Source == nil {
+				appendErr(fmt.Errorf("source %s not found for path mapping %s", p.SourceName, p.DockerPath))
 			}
-		}
-
-		// If the path is not resolved, log a warning
-		if p.SourceType != "" && p.Source == nil {
-			if errs == nil {
-				errs = make([]error, 0)
-			}
-			errs = append(errs, fmt.Errorf("source %s not found for path mapping %s", p.SourceName, p.DockerPath))
 		}
 	}
+
+	// Pass 2: propagate VolumeName from parents to children with no direct
+	// source, iterating to a fixed point so inheritance converges regardless
+	// of d.Paths ordering.
+	for i := 0; i < len(d.Paths); i++ {
+		changed := false
+		for _, p := range d.Paths {
+			if p.SourceType != "" || p.Parent == nil {
+				continue
+			}
+			if p.VolumeName != p.Parent.VolumeName {
+				p.VolumeName = p.Parent.VolumeName
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+
 	return errs
 }
 
@@ -654,7 +706,7 @@ type Route struct {
 	Primary  bool   `mapstructure:"primary" toml:"primary" json:"primary" groups:"apps"`
 
 	// Explicit source/destination fields.
-	Mode            string `mapstructure:"mode" toml:"mode" json:"mode" groups:"apps"`            // host | port
+	Mode            string `mapstructure:"mode" toml:"mode" json:"mode" groups:"apps"` // host | port
 	SourcePort      string `mapstructure:"sourceport" toml:"sourceport" json:"sourcePort" groups:"apps"`
 	DestinationPort string `mapstructure:"destport" toml:"destport" json:"destPort" groups:"apps"`
 
@@ -1090,6 +1142,12 @@ func (p PathMapping) GetDockerMapping(volname string) string {
 }
 
 func (pm *PathMapping) ResolvePointers(volumes Volumes, gits GitClones, s3s S3Mounts, parents PathMaps) error {
+	// Clear any previously resolved pointers before re-resolving. Path mappings
+	// are mutated in place across API edits, so stale Parent/Source pointers must
+	// not survive a source or parent change.
+	pm.Parent = nil
+	pm.Source = nil
+
 	// Resolve Parent
 	if pm.ParentName != "" {
 		for _, parent := range parents {

--- a/config/deployment.go
+++ b/config/deployment.go
@@ -1239,12 +1239,44 @@ type Volume struct {
 	VolumeDir string `mapstructure:"volumedir" toml:"volumedir" json:"volumedir" options:"etc|log|var|data" groups:"apps"`
 }
 
+// AppMountVolumeDir is the directory token used to select (or seed) the app
+// volume that backs ad-hoc S3 mounts created via SetAppLocalMountVolume.
+const AppMountVolumeDir = "mnt"
+
 // GetVolumeDirs returns VolumeDir split into its whitespace-separated
 // directory tokens. A legacy single-directory value (e.g. "data") returns
 // a single token; a merged row (e.g. "etc log var data") returns one token
 // per directory.
 func (v *Volume) GetVolumeDirs() []string {
 	return strings.Fields(v.VolumeDir)
+}
+
+// DefaultSubdir returns the first directory token of VolumeDir, used as the
+// default subdirectory when autofilling VolumeDir for a git clone or S3
+// mount that is placed on this volume. Returns "" if VolumeDir has no
+// tokens (a saved row always has at least one, per Validate).
+func (v *Volume) DefaultSubdir() string {
+	dirs := v.GetVolumeDirs()
+	if len(dirs) == 0 {
+		return ""
+	}
+	return dirs[0]
+}
+
+// S3MountSubdir returns the directory token to use as the default
+// <subdir>/<resource-name> base when autofilling VolumeDir for an S3 mount
+// placed on this volume. If VolumeDir contains the AppMountVolumeDir token
+// ("mnt"), that token is returned regardless of its position, keeping S3
+// mounts grouped under "mnt" the same way SetAppLocalMountVolume seeds new
+// mounts on a merged row (e.g. "data mnt" -> "mnt"). Otherwise falls back to
+// DefaultSubdir().
+func (v *Volume) S3MountSubdir() string {
+	for _, dir := range v.GetVolumeDirs() {
+		if dir == AppMountVolumeDir {
+			return AppMountVolumeDir
+		}
+	}
+	return v.DefaultSubdir()
 }
 
 // NormalizeVolumeDirs merges one or more whitespace-separated directory

--- a/config/deployment.go
+++ b/config/deployment.go
@@ -44,34 +44,53 @@ func (d *Deployment) GetVolumeByName(name string) (*Volume, error) {
 	return nil, fmt.Errorf("volume %s not found", name)
 }
 
+// findVolumeByPool returns the saved row for poolName, or nil if none
+// exists. Callers must hold d.Mutex.
+func (d *Deployment) findVolumeByPool(poolName string) *Volume {
+	for _, v := range d.Storages.Volumes {
+		if v.PoolName == poolName {
+			return v
+		}
+	}
+	return nil
+}
+
+// GetVolumeByPool returns the saved row for poolName, or nil if none exists.
+// It backs the one-row-per-pool invariant on writes: InsertVolume rejects new
+// rows for a pool that already has one, and poolname edits must not move a
+// row onto a pool another row already owns.
+func (d *Deployment) GetVolumeByPool(poolName string) *Volume {
+	d.Mutex.RLock()
+	defer d.Mutex.RUnlock()
+
+	return d.findVolumeByPool(poolName)
+}
+
 func (d *Deployment) InsertVolume(v *Volume) error {
 	// Use a mutex to protect concurrent access
 	d.Mutex.Lock()
 	defer d.Mutex.Unlock()
 
-	// Validate the volume
-	if v.Name == "" {
-		return errors.New("volume name is required")
+	// Normalize before validating so duplicate/empty tokens don't slip in.
+	v.VolumeDir = NormalizeVolumeDirs(v.VolumeDir)
+
+	if err := v.Validate(); err != nil {
+		return err
 	}
 
-	if v.VolumeDir == "" {
-		return errors.New("volume directory is required")
-	}
-
-	// Check if the volume directory is valid
-	if strings.Contains(v.VolumeDir, "..") {
-		return fmt.Errorf("invalid volume directory: %s", v.VolumeDir)
-	}
-
-	// Check if the volume already exists
+	// Check if the volume already exists. A row is now canonical per pool, so
+	// any existing row for the same pool is a duplicate regardless of name or
+	// directory. Legacy configs with multiple rows per pool are still readable
+	// via GroupByPool and are consolidated by the canonicalization migration;
+	// this check only guards new writes.
 	for _, existingVolume := range d.Storages.Volumes {
 		if existingVolume.Name == v.Name {
 			return fmt.Errorf("volume already exists: %s", v.Name)
 		}
+	}
 
-		if existingVolume.VolumeDir == v.VolumeDir && existingVolume.PoolName == v.PoolName {
-			return fmt.Errorf("volume with same directory and pool already exists: %s", v.VolumeDir)
-		}
+	if existing := d.findVolumeByPool(v.PoolName); existing != nil {
+		return fmt.Errorf("a volume for pool %q already exists: %s", v.PoolName, existing.Name)
 	}
 
 	// Add the new volume
@@ -1226,6 +1245,61 @@ type Volume struct {
 	Name      string `mapstructure:"name" toml:"name" json:"name" groups:"apps"`
 	PoolName  string `mapstructure:"poolname" toml:"poolname" json:"poolname" groups:"apps"`
 	VolumeDir string `mapstructure:"volumedir" toml:"volumedir" json:"volumedir" options:"etc|log|var|data" groups:"apps"`
+}
+
+// GetVolumeDirs returns VolumeDir split into its whitespace-separated
+// directory tokens. A legacy single-directory value (e.g. "data") returns
+// a single token; a merged row (e.g. "etc log var data") returns one token
+// per directory.
+func (v *Volume) GetVolumeDirs() []string {
+	return strings.Fields(v.VolumeDir)
+}
+
+// NormalizeVolumeDirs merges one or more whitespace-separated directory
+// lists into a single deduplicated, whitespace-separated list, preserving
+// first-seen order across all inputs.
+func NormalizeVolumeDirs(dirs ...string) string {
+	tokens := make([]string, 0, len(dirs))
+	seen := make(map[string]struct{}, len(dirs))
+	for _, dir := range dirs {
+		for _, tok := range strings.Fields(dir) {
+			if _, dup := seen[tok]; dup {
+				continue
+			}
+			seen[tok] = struct{}{}
+			tokens = append(tokens, tok)
+		}
+	}
+	return strings.Join(tokens, " ")
+}
+
+// Validate checks that the volume row is structurally sound: it has a name,
+// a pool, and VolumeDir resolves to at least one relative, non-traversal
+// directory token.
+func (v *Volume) Validate() error {
+	if v.Name == "" {
+		return errors.New("volume name is required")
+	}
+
+	if v.PoolName == "" {
+		return errors.New("volume pool name is required")
+	}
+
+	dirs := v.GetVolumeDirs()
+	if len(dirs) == 0 {
+		return errors.New("volume directory is required")
+	}
+
+	for _, dir := range dirs {
+		if strings.Contains(dir, "..") {
+			return fmt.Errorf("invalid volume directory: %s", dir)
+		}
+		if strings.HasPrefix(dir, "/") {
+			return fmt.Errorf("volume directory must be relative: %s", dir)
+		}
+	}
+
+	return nil
 }
 
 func (v *Volume) GetSourcePath() string {

--- a/config/deployment.go
+++ b/config/deployment.go
@@ -1172,14 +1172,6 @@ func (gc *GitClone) GetSourceVolumeName() string {
 	return gc.VolumeName
 }
 
-func (gc *GitClone) GetSourcePoolName() string {
-	// Return the volume name associated with the git clone
-	if gc.Volume != nil {
-		return gc.Volume.PoolName
-	}
-	return ""
-}
-
 var gitVariableReplacer = strings.NewReplacer("-", "_", ".", "_", "/", "_")
 
 const GitVarSuffixRepo = "REPO"
@@ -1451,12 +1443,4 @@ func (s *S3Mount) GetSourceVolumeName() string {
 		return s.Volume.Name
 	}
 	return s.VolumeName
-}
-
-func (s *S3Mount) GetSourcePoolName() string {
-	// Return the volume name associated with the S3 mount
-	if s.Volume != nil {
-		return s.Volume.PoolName
-	}
-	return "" // Return an empty string if the volume is not set
 }

--- a/config/deployment_test.go
+++ b/config/deployment_test.go
@@ -131,7 +131,7 @@ func TestDeployment_InsertVolume_NormalizesVolumeDir(t *testing.T) {
 	d := NewDeploymentConfig()
 	d.Storages = *NewStorageMapping()
 
-	err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "data", VolumeDir: "data data  log"})
+	err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "data", VolumeDir: "data data  log"}, 0)
 	if err != nil {
 		t.Fatalf("InsertVolume() error = %v", err)
 	}
@@ -149,16 +149,16 @@ func TestDeployment_InsertVolume_RejectsInvalidRow(t *testing.T) {
 	d := NewDeploymentConfig()
 	d.Storages = *NewStorageMapping()
 
-	if err := d.InsertVolume(&Volume{Name: "", PoolName: "data", VolumeDir: "data"}); err == nil {
+	if err := d.InsertVolume(&Volume{Name: "", PoolName: "data", VolumeDir: "data"}, 0); err == nil {
 		t.Fatalf("expected error for missing name")
 	}
-	if err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "", VolumeDir: "data"}); err == nil {
+	if err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "", VolumeDir: "data"}, 0); err == nil {
 		t.Fatalf("expected error for missing pool name")
 	}
-	if err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "data", VolumeDir: ""}); err == nil {
+	if err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "data", VolumeDir: ""}, 0); err == nil {
 		t.Fatalf("expected error for missing volume directory")
 	}
-	if err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "data", VolumeDir: "../etc"}); err == nil {
+	if err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "data", VolumeDir: "../etc"}, 0); err == nil {
 		t.Fatalf("expected error for traversal volume directory")
 	}
 }
@@ -167,30 +167,56 @@ func TestDeployment_InsertVolume_RejectsDuplicateName(t *testing.T) {
 	d := NewDeploymentConfig()
 	d.Storages = *NewStorageMapping()
 
-	if err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "data", VolumeDir: "data"}); err != nil {
+	if err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "data", VolumeDir: "data"}, 0); err != nil {
 		t.Fatalf("first InsertVolume() error = %v", err)
 	}
 
-	err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "other", VolumeDir: "log"})
+	err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "other", VolumeDir: "log"}, 0)
 	if err == nil {
 		t.Fatalf("expected error for duplicate volume name")
 	}
 }
 
-// TestDeployment_InsertVolume_RejectsDuplicatePool covers Phase 2 task 4:
-// new writes for a pool that already has a saved row are rejected, even
-// when the name and directory differ from the existing row.
-func TestDeployment_InsertVolume_RejectsDuplicatePool(t *testing.T) {
+// TestDeployment_InsertVolume_RejectsDuplicatePoolWhenV1 covers Phase 2 task
+// 4: for unflagged/V1 content (appConfigVersion < AppConfigVersionV2), new
+// writes for a pool that already has a saved row are rejected, even when the
+// name and directory differ from the existing row.
+func TestDeployment_InsertVolume_RejectsDuplicatePoolWhenV1(t *testing.T) {
 	d := NewDeploymentConfig()
 	d.Storages = *NewStorageMapping()
 
-	if err := d.InsertVolume(&Volume{Name: "app-data", PoolName: "data", VolumeDir: "etc"}); err != nil {
+	if err := d.InsertVolume(&Volume{Name: "app-data", PoolName: "data", VolumeDir: "etc"}, 0); err != nil {
 		t.Fatalf("first InsertVolume() error = %v", err)
 	}
 
-	err := d.InsertVolume(&Volume{Name: "app-data-2", PoolName: "data", VolumeDir: "log"})
+	err := d.InsertVolume(&Volume{Name: "app-data-2", PoolName: "data", VolumeDir: "log"}, 0)
 	if err == nil {
 		t.Fatalf("expected error inserting a second row for an existing pool")
+	}
+}
+
+// TestDeployment_InsertVolume_AllowsMultipleRowsPerPoolWhenV2 covers Phase 11
+// task 1: once content is flagged V2 (appConfigVersion >= AppConfigVersionV2),
+// intentional additional rows for a pool that already has one are allowed.
+func TestDeployment_InsertVolume_AllowsMultipleRowsPerPoolWhenV2(t *testing.T) {
+	d := NewDeploymentConfig()
+	d.Storages = *NewStorageMapping()
+
+	if err := d.InsertVolume(&Volume{Name: "app-data", PoolName: "data", VolumeDir: "etc"}, AppConfigVersionV2); err != nil {
+		t.Fatalf("first InsertVolume() error = %v", err)
+	}
+
+	if err := d.InsertVolume(&Volume{Name: "app-data-2", PoolName: "data", VolumeDir: "log"}, AppConfigVersionV2); err != nil {
+		t.Fatalf("second InsertVolume() for an existing pool error = %v, want nil", err)
+	}
+
+	if len(d.Storages.Volumes) != 2 {
+		t.Fatalf("len(Storages.Volumes) = %d, want 2", len(d.Storages.Volumes))
+	}
+
+	// Name remains a global identity constraint regardless of version.
+	if err := d.InsertVolume(&Volume{Name: "app-data", PoolName: "other", VolumeDir: "var"}, AppConfigVersionV2); err == nil {
+		t.Fatalf("expected error inserting a duplicate volume name")
 	}
 }
 
@@ -201,7 +227,7 @@ func TestDeployment_GetVolumeByPool(t *testing.T) {
 	d := NewDeploymentConfig()
 	d.Storages = *NewStorageMapping()
 
-	if err := d.InsertVolume(&Volume{Name: "app-data", PoolName: "data", VolumeDir: "etc"}); err != nil {
+	if err := d.InsertVolume(&Volume{Name: "app-data", PoolName: "data", VolumeDir: "etc"}, 0); err != nil {
 		t.Fatalf("InsertVolume() error = %v", err)
 	}
 
@@ -217,10 +243,10 @@ func TestDeployment_InsertVolume_AllowsDistinctPools(t *testing.T) {
 	d := NewDeploymentConfig()
 	d.Storages = *NewStorageMapping()
 
-	if err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "data", VolumeDir: "data"}); err != nil {
+	if err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "data", VolumeDir: "data"}, 0); err != nil {
 		t.Fatalf("InsertVolume(data) error = %v", err)
 	}
-	if err := d.InsertVolume(&Volume{Name: "docs-volume", PoolName: "docs", VolumeDir: "docs"}); err != nil {
+	if err := d.InsertVolume(&Volume{Name: "docs-volume", PoolName: "docs", VolumeDir: "docs"}, 0); err != nil {
 		t.Fatalf("InsertVolume(docs) error = %v", err)
 	}
 

--- a/config/deployment_test.go
+++ b/config/deployment_test.go
@@ -76,6 +76,27 @@ func TestVolume_S3MountSubdir(t *testing.T) {
 	}
 }
 
+func TestVolume_GetSourcePath(t *testing.T) {
+	cases := []struct {
+		name string
+		dir  string
+		want string
+	}{
+		{"single token row", "data", "/data"},
+		{"multi-token row uses first token", "data logs", "/data"},
+		{"empty row preserves root slash", "", "/"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := &Volume{VolumeDir: tc.dir}
+			if got := v.GetSourcePath(); got != tc.want {
+				t.Fatalf("GetSourcePath() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestNormalizeVolumeDirs(t *testing.T) {
 	cases := []struct {
 		name string

--- a/config/deployment_test.go
+++ b/config/deployment_test.go
@@ -30,6 +30,52 @@ func TestVolume_GetVolumeDirs(t *testing.T) {
 	}
 }
 
+func TestVolume_DefaultSubdir(t *testing.T) {
+	cases := []struct {
+		name string
+		dir  string
+		want string
+	}{
+		{"empty", "", ""},
+		{"single", "data", "data"},
+		{"merged returns first token", "etc log var data", "etc"},
+		{"mnt merged after data returns first token", "data mnt", "data"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := &Volume{VolumeDir: tc.dir}
+			if got := v.DefaultSubdir(); got != tc.want {
+				t.Fatalf("DefaultSubdir() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestVolume_S3MountSubdir(t *testing.T) {
+	cases := []struct {
+		name string
+		dir  string
+		want string
+	}{
+		{"empty", "", ""},
+		{"single non-mnt", "data", "data"},
+		{"single mnt", "mnt", "mnt"},
+		{"mnt merged after data returns mnt token", "data mnt", "mnt"},
+		{"mnt merged before others returns mnt token", "mnt etc", "mnt"},
+		{"no mnt token falls back to first token", "etc log var data", "etc"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := &Volume{VolumeDir: tc.dir}
+			if got := v.S3MountSubdir(); got != tc.want {
+				t.Fatalf("S3MountSubdir() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestNormalizeVolumeDirs(t *testing.T) {
 	cases := []struct {
 		name string

--- a/config/deployment_test.go
+++ b/config/deployment_test.go
@@ -1,0 +1,209 @@
+package config
+
+import "testing"
+
+func TestVolume_GetVolumeDirs(t *testing.T) {
+	cases := []struct {
+		name string
+		dir  string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single", "data", []string{"data"}},
+		{"merged", "etc log var data", []string{"etc", "log", "var", "data"}},
+		{"extra whitespace", "  etc   log  ", []string{"etc", "log"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := &Volume{VolumeDir: tc.dir}
+			got := v.GetVolumeDirs()
+			if len(got) != len(tc.want) {
+				t.Fatalf("GetVolumeDirs() = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("GetVolumeDirs() = %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeVolumeDirs(t *testing.T) {
+	cases := []struct {
+		name string
+		dirs []string
+		want string
+	}{
+		{"single", []string{"data"}, "data"},
+		{"dedup within one input", []string{"data data"}, "data"},
+		{"dedup across inputs preserves first-seen order", []string{"etc log", "log var", "data"}, "etc log var data"},
+		{"empty inputs", []string{"", "  "}, ""},
+		{"trims surrounding whitespace", []string{"  data  "}, "data"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeVolumeDirs(tc.dirs...); got != tc.want {
+				t.Fatalf("NormalizeVolumeDirs(%v) = %q, want %q", tc.dirs, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestVolume_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		vol     Volume
+		wantErr bool
+	}{
+		{"valid single dir", Volume{Name: "data-volume", PoolName: "data", VolumeDir: "data"}, false},
+		{"valid merged dirs", Volume{Name: "app-data", PoolName: "data", VolumeDir: "etc log var data"}, false},
+		{"missing name", Volume{PoolName: "data", VolumeDir: "data"}, true},
+		{"missing pool", Volume{Name: "data-volume", VolumeDir: "data"}, true},
+		{"missing volumedir", Volume{Name: "data-volume", PoolName: "data"}, true},
+		{"blank volumedir", Volume{Name: "data-volume", PoolName: "data", VolumeDir: "   "}, true},
+		{"traversal in one token", Volume{Name: "data-volume", PoolName: "data", VolumeDir: "data ../etc"}, true},
+		{"absolute token", Volume{Name: "data-volume", PoolName: "data", VolumeDir: "/data"}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.vol.Validate()
+			if tc.wantErr && err == nil {
+				t.Fatalf("Validate() = nil, want error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("Validate() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestDeployment_InsertVolume_NormalizesVolumeDir(t *testing.T) {
+	d := NewDeploymentConfig()
+	d.Storages = *NewStorageMapping()
+
+	err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "data", VolumeDir: "data data  log"})
+	if err != nil {
+		t.Fatalf("InsertVolume() error = %v", err)
+	}
+
+	got, err := d.GetVolumeByName("data-volume")
+	if err != nil {
+		t.Fatalf("GetVolumeByName() error = %v", err)
+	}
+	if got.VolumeDir != "data log" {
+		t.Fatalf("VolumeDir = %q, want %q", got.VolumeDir, "data log")
+	}
+}
+
+func TestDeployment_InsertVolume_RejectsInvalidRow(t *testing.T) {
+	d := NewDeploymentConfig()
+	d.Storages = *NewStorageMapping()
+
+	if err := d.InsertVolume(&Volume{Name: "", PoolName: "data", VolumeDir: "data"}); err == nil {
+		t.Fatalf("expected error for missing name")
+	}
+	if err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "", VolumeDir: "data"}); err == nil {
+		t.Fatalf("expected error for missing pool name")
+	}
+	if err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "data", VolumeDir: ""}); err == nil {
+		t.Fatalf("expected error for missing volume directory")
+	}
+	if err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "data", VolumeDir: "../etc"}); err == nil {
+		t.Fatalf("expected error for traversal volume directory")
+	}
+}
+
+func TestDeployment_InsertVolume_RejectsDuplicateName(t *testing.T) {
+	d := NewDeploymentConfig()
+	d.Storages = *NewStorageMapping()
+
+	if err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "data", VolumeDir: "data"}); err != nil {
+		t.Fatalf("first InsertVolume() error = %v", err)
+	}
+
+	err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "other", VolumeDir: "log"})
+	if err == nil {
+		t.Fatalf("expected error for duplicate volume name")
+	}
+}
+
+// TestDeployment_InsertVolume_RejectsDuplicatePool covers Phase 2 task 4:
+// new writes for a pool that already has a saved row are rejected, even
+// when the name and directory differ from the existing row.
+func TestDeployment_InsertVolume_RejectsDuplicatePool(t *testing.T) {
+	d := NewDeploymentConfig()
+	d.Storages = *NewStorageMapping()
+
+	if err := d.InsertVolume(&Volume{Name: "app-data", PoolName: "data", VolumeDir: "etc"}); err != nil {
+		t.Fatalf("first InsertVolume() error = %v", err)
+	}
+
+	err := d.InsertVolume(&Volume{Name: "app-data-2", PoolName: "data", VolumeDir: "log"})
+	if err == nil {
+		t.Fatalf("expected error inserting a second row for an existing pool")
+	}
+}
+
+// TestDeployment_GetVolumeByPool covers the shared lookup used by both
+// InsertVolume and the volume "poolname" edit path in server/api_app.go to
+// enforce the one-row-per-pool invariant.
+func TestDeployment_GetVolumeByPool(t *testing.T) {
+	d := NewDeploymentConfig()
+	d.Storages = *NewStorageMapping()
+
+	if err := d.InsertVolume(&Volume{Name: "app-data", PoolName: "data", VolumeDir: "etc"}); err != nil {
+		t.Fatalf("InsertVolume() error = %v", err)
+	}
+
+	if got := d.GetVolumeByPool("data"); got == nil || got.Name != "app-data" {
+		t.Fatalf("GetVolumeByPool(data) = %v, want app-data", got)
+	}
+	if got := d.GetVolumeByPool("docs"); got != nil {
+		t.Fatalf("GetVolumeByPool(docs) = %v, want nil", got)
+	}
+}
+
+func TestDeployment_InsertVolume_AllowsDistinctPools(t *testing.T) {
+	d := NewDeploymentConfig()
+	d.Storages = *NewStorageMapping()
+
+	if err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "data", VolumeDir: "data"}); err != nil {
+		t.Fatalf("InsertVolume(data) error = %v", err)
+	}
+	if err := d.InsertVolume(&Volume{Name: "docs-volume", PoolName: "docs", VolumeDir: "docs"}); err != nil {
+		t.Fatalf("InsertVolume(docs) error = %v", err)
+	}
+
+	if len(d.Storages.Volumes) != 2 {
+		t.Fatalf("len(Storages.Volumes) = %d, want 2", len(d.Storages.Volumes))
+	}
+}
+
+// TestVolumes_GroupByPool_SupportsLegacyDuplicateRows covers Phase 2 task 5:
+// GroupByPool is a read path and must keep grouping multiple legacy rows
+// that share a poolname, even though InsertVolume now rejects creating new
+// duplicates. Legacy duplicates are consolidated by the canonicalization
+// migration on load, not by removing read-side support.
+func TestVolumes_GroupByPool_SupportsLegacyDuplicateRows(t *testing.T) {
+	legacy := Volumes{
+		{Name: "app-etc", PoolName: "data", VolumeDir: "etc"},
+		{Name: "app-log", PoolName: "data", VolumeDir: "log"},
+		{Name: "docs-volume", PoolName: "docs", VolumeDir: "docs"},
+	}
+
+	grouped := legacy.GroupByPool()
+
+	if len(grouped["data"]) != 2 {
+		t.Fatalf("grouped[data] = %v, want 2 entries", grouped["data"])
+	}
+	if grouped["data"]["app-etc"] != "etc" || grouped["data"]["app-log"] != "log" {
+		t.Fatalf("grouped[data] = %v, want app-etc=etc and app-log=log", grouped["data"])
+	}
+	if len(grouped["docs"]) != 1 || grouped["docs"]["docs-volume"] != "docs" {
+		t.Fatalf("grouped[docs] = %v, want docs-volume=docs", grouped["docs"])
+	}
+}

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -2185,7 +2185,7 @@ func (repman *ReplicationManager) handlerMuxAddStorage(w http.ResponseWriter, r 
 			return
 		}
 
-		err := deployment.InsertVolume(row)
+		err := deployment.InsertVolume(row, node.AppConfig.AppConfigVersion)
 		if err != nil {
 			http.Error(w, "Error inserting volume mapping: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -2537,11 +2537,14 @@ func (repman *ReplicationManager) handlerMuxModifyStorageField(w http.ResponseWr
 						return
 					}
 
-					// A row is canonical per pool: reject moving this row onto a
-					// pool that another saved row already owns.
-					if existing := deployment.GetVolumeByPool(newValue); existing != nil && existing != vol {
-						http.Error(w, fmt.Sprintf("a volume for pool %q already exists: %s", newValue, existing.Name), http.StatusInternalServerError)
-						return
+					// A row is canonical per pool for V1/unflagged content: reject
+					// moving this row onto a pool that another saved row already
+					// owns. V2 apps allow intentional multiple rows per pool.
+					if node.AppConfig.AppConfigVersion < config.AppConfigVersionV2 {
+						if existing := deployment.GetVolumeByPool(newValue); existing != nil && existing != vol {
+							http.Error(w, fmt.Sprintf("a volume for pool %q already exists: %s", newValue, existing.Name), http.StatusInternalServerError)
+							return
+						}
 					}
 
 					oldPoolName := vol.PoolName

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -1644,9 +1644,15 @@ func (repman *ReplicationManager) handlerMuxModifyDeploymentField(w http.Respons
 
 					switch newValue {
 					case string(config.SourceGit), string(config.SourceS3), string(config.SourceVolume):
-						// Reset source name and path if type changes
+						// Reset source name/path/volume together so the row never
+						// carries stale values from the previous source type. The
+						// row is intentionally left incomplete (SourceType set,
+						// SourceName empty) until a follow-up "srcname" edit
+						// supplies the new source.
 						pm.SourceType = newSourceType
-						pm.SourceName = "" // Reset source name if type changes
+						pm.SourceName = ""
+						pm.SourcePath = ""
+						pm.VolumeName = ""
 						if node.HasProvisionCookie() {
 							node.SetReprovCookie()
 						}
@@ -1677,9 +1683,11 @@ func (repman *ReplicationManager) handlerMuxModifyDeploymentField(w http.Respons
 							pm.SourcePath = source.GetSourcePath()
 						}
 					case config.SourceVolume:
-						source, err := deployment.GetVolumeByName(newValue)
-						if err == nil {
-							pm.SourcePath = source.GetSourcePath()
+						// Phase 8 model: direct volume sources are relative to
+						// the volume root, represented as "." -- not
+						// Volume.GetSourcePath() (raw volumedir).
+						if _, err := deployment.GetVolumeByName(newValue); err == nil {
+							pm.SourcePath = "."
 						}
 					default:
 						http.Error(w, "Invalid source type. Must be 'git', 's3', or 'volume'", http.StatusInternalServerError)
@@ -1697,21 +1705,24 @@ func (repman *ReplicationManager) handlerMuxModifyDeploymentField(w http.Respons
 					if newValue != "" && newValue != "/" {
 						pm.SourcePath = newValue
 					} else if pm.SourceName != "" {
+						// Reset/blank srcpath: derive the default from the path's
+						// CURRENT source identity (pm.SourceName/pm.SourceType),
+						// not from the just-submitted reset value ("" or "/").
 						switch pm.SourceType {
 						case config.SourceGit:
-							source, err := deployment.GetGitClone(newValue)
+							source, err := deployment.GetGitClone(pm.SourceName)
 							if err == nil {
 								pm.SourcePath = source.GetSourcePath()
 							}
 						case config.SourceS3:
-							source, err := deployment.GetS3Mount(newValue)
+							source, err := deployment.GetS3Mount(pm.SourceName)
 							if err == nil {
 								pm.SourcePath = source.GetSourcePath()
 							}
 						case config.SourceVolume:
-							source, err := deployment.GetVolumeByName(newValue)
-							if err == nil {
-								pm.SourcePath = source.GetSourcePath()
+							// Phase 8 model: direct volume root is "."
+							if _, err := deployment.GetVolumeByName(pm.SourceName); err == nil {
+								pm.SourcePath = "."
 							}
 						default:
 							http.Error(w, "Invalid source type. Must be 'git', 's3', or 'volume'", http.StatusInternalServerError)
@@ -1727,6 +1738,11 @@ func (repman *ReplicationManager) handlerMuxModifyDeploymentField(w http.Respons
 					return
 				}
 
+				// Resolve failures are warning-only and do not abort persistence:
+				// field-by-field edits (e.g. "srctype" followed later by
+				// "srcname") intentionally pass through a momentarily incomplete
+				// row, and GetOpenSVCDeploymentPathMapping already skips
+				// unresolved/incomplete path mappings at provisioning time.
 				err := deployment.ResolvePath(pm)
 				if err != nil {
 					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "API Error resolving path after modification: ", err)
@@ -2556,10 +2572,13 @@ func (repman *ReplicationManager) handlerMuxModifyStorageField(w http.ResponseWr
 						return
 					}
 
-					paths := deployment.GetVolumePaths(vol.Name)
+					oldName := vol.Name
+					paths := deployment.GetVolumePaths(oldName)
 					vol.Name = newValue
 					for _, p := range paths {
-						p.SourceName = vol.Name
+						if p.SourceType == config.SourceVolume && p.SourceName == oldName {
+							p.SourceName = vol.Name
+						}
 						deployment.ResolvePath(p)
 					}
 
@@ -3122,7 +3141,6 @@ func (repman *ReplicationManager) handlerMuxGitRepoTree(w http.ResponseWriter, r
 		return
 	}
 }
-
 
 // handlerMuxGitCheckRepo validates a git repository URL, branch, and credentials
 // before the user creates path mappings. Uses git ls-remote internally.

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -2508,6 +2508,11 @@ func (repman *ReplicationManager) handlerMuxModifyStorageField(w http.ResponseWr
 						return
 					}
 
+					if newValue == "" {
+						http.Error(w, "Name cannot be empty", http.StatusInternalServerError)
+						return
+					}
+
 					old, _ := deployment.GetVolumeByName(newValue)
 					if old != nil {
 						http.Error(w, "Cannot duplicate volume with same name", http.StatusInternalServerError)
@@ -2531,18 +2536,41 @@ func (repman *ReplicationManager) handlerMuxModifyStorageField(w http.ResponseWr
 						http.Error(w, "PoolName cannot be empty", http.StatusInternalServerError)
 						return
 					}
+
+					// A row is canonical per pool: reject moving this row onto a
+					// pool that another saved row already owns.
+					if existing := deployment.GetVolumeByPool(newValue); existing != nil && existing != vol {
+						http.Error(w, fmt.Sprintf("a volume for pool %q already exists: %s", newValue, existing.Name), http.StatusInternalServerError)
+						return
+					}
+
+					oldPoolName := vol.PoolName
 					vol.PoolName = newValue
+					if err := vol.Validate(); err != nil {
+						vol.PoolName = oldPoolName
+						http.Error(w, "Error validating volume: "+err.Error(), http.StatusInternalServerError)
+						return
+					}
 
 				case "volumedir":
-					if vol.VolumeDir == newValue {
+					normalized := config.NormalizeVolumeDirs(newValue)
+					if normalized == vol.VolumeDir {
 						http.Error(w, "VolumeDir is the same as the current volume dir", http.StatusInternalServerError)
 						return
 					}
-					if newValue == "" {
+					if normalized == "" {
 						http.Error(w, "VolumeDir cannot be empty", http.StatusInternalServerError)
 						return
 					}
-					vol.VolumeDir = newValue
+
+					oldVolumeDir := vol.VolumeDir
+					vol.VolumeDir = normalized
+					if err := vol.Validate(); err != nil {
+						vol.VolumeDir = oldVolumeDir
+						http.Error(w, "Error validating volume: "+err.Error(), http.StatusInternalServerError)
+						return
+					}
+
 					deployment.ResolveVolumePaths(vol.Name)
 
 				default:

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -2598,7 +2598,7 @@ func (repman *ReplicationManager) handlerMuxModifyStorageField(w http.ResponseWr
 					// owns. V2 apps allow intentional multiple rows per pool.
 					if node.AppConfig.AppConfigVersion < config.AppConfigVersionV2 {
 						if existing := deployment.GetVolumeByPool(newValue); existing != nil && existing != vol {
-							http.Error(w, fmt.Sprintf("a volume for pool %q already exists: %s", newValue, existing.Name), http.StatusInternalServerError)
+							http.Error(w, fmt.Sprintf("a volume for pool %q already exists: %s", newValue, existing.Name), http.StatusBadRequest)
 							return
 						}
 					}

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -2273,7 +2273,7 @@ func (repman *ReplicationManager) handlerMuxAddStorage(w http.ResponseWriter, r 
 				return
 			}
 			row.VolumeName = row.Volume.Name
-			row.VolumeDir = filepath.Join(row.Volume.VolumeDir, row.Name)
+			row.VolumeDir = filepath.Join(config.AppMountVolumeDir, row.Name)
 		}
 
 		err = deployment.InsertS3Mount(row)
@@ -2441,7 +2441,7 @@ func (repman *ReplicationManager) handlerMuxModifyStorageField(w http.ResponseWr
 					}
 					// Check for duplicate git volume path
 					if deployment.HasDuplicateGitVolumePath(gc.Name, newValue, gc.VolumeDir) {
-						gc.VolumeDir = filepath.Join(newvol.VolumeDir, gc.Name)
+						gc.VolumeDir = filepath.Join(newvol.DefaultSubdir(), gc.Name)
 					}
 					gc.VolumeName = newValue
 					gc.Volume = newvol
@@ -2455,7 +2455,7 @@ func (repman *ReplicationManager) handlerMuxModifyStorageField(w http.ResponseWr
 							http.Error(w, "Error getting volume by name: "+err.Error(), http.StatusInternalServerError)
 							return
 						}
-						newValue = filepath.Join(curvol.VolumeDir, gc.Name)
+						newValue = filepath.Join(curvol.DefaultSubdir(), gc.Name)
 					}
 
 					if gc.VolumeDir == newValue {
@@ -2697,7 +2697,7 @@ func (repman *ReplicationManager) handlerMuxModifyStorageField(w http.ResponseWr
 					}
 
 					if deployment.HasDuplicateS3VolumePath(newValue, s3Mount.VolumeDir) {
-						s3Mount.VolumeDir = filepath.Join(newvol.VolumeDir, s3Mount.Name)
+						s3Mount.VolumeDir = filepath.Join(newvol.S3MountSubdir(), s3Mount.Name)
 					}
 					s3Mount.VolumeName = newValue
 
@@ -2720,7 +2720,7 @@ func (repman *ReplicationManager) handlerMuxModifyStorageField(w http.ResponseWr
 							http.Error(w, "Error getting volume by name: "+err.Error(), http.StatusInternalServerError)
 							return
 						}
-						newValue = filepath.Join(curvol.VolumeDir, s3Mount.Name)
+						newValue = filepath.Join(curvol.S3MountSubdir(), s3Mount.Name)
 					}
 
 					if deployment.HasDuplicateS3VolumePath(s3Mount.VolumeName, newValue) {

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -524,6 +524,22 @@ func hydrateS3MountFromProvider(mycluster *cluster.Cluster, mount *config.S3Moun
 	return nil
 }
 
+// volumeHasDirectoryToken reports whether dir is exactly one of vol's
+// whitespace-separated VolumeDir tokens (e.g. "data" in "data mnt"), as
+// opposed to a full relative path (e.g. "data/custom-media"). Used to detect
+// an explicit bare directory-token S3 mount placement (Phase 16).
+func volumeHasDirectoryToken(vol *config.Volume, dir string) bool {
+	if vol == nil {
+		return false
+	}
+	for _, tok := range vol.GetVolumeDirs() {
+		if tok == dir {
+			return true
+		}
+	}
+	return false
+}
+
 // @Summary Shows the apps for that specific named cluster
 // @Description Shows the apps for that specific named cluster
 // @Tags Apps
@@ -2287,6 +2303,13 @@ func (repman *ReplicationManager) handlerMuxAddStorage(w http.ResponseWriter, r 
 			}
 			if row.VolumeDir == "" {
 				row.VolumeDir = filepath.Join(row.Volume.S3MountSubdir(), row.Name)
+			} else if volumeHasDirectoryToken(row.Volume, row.VolumeDir) {
+				// Phase 16: the "Add new" form has no Name field yet, so an
+				// explicit directory-token choice with no subdirectory is
+				// submitted as the bare token (e.g. "data"). Append the
+				// generated mount name so this explicit token choice is
+				// preserved instead of being mistaken for "unspecified".
+				row.VolumeDir = filepath.Join(row.VolumeDir, row.Name)
 			}
 		}
 

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -2267,13 +2267,27 @@ func (repman *ReplicationManager) handlerMuxAddStorage(w http.ResponseWriter, r 
 		}
 
 		if row.VolumeName == "" {
+			// Phase 14 task 1: legacy-compatible autofill, only when S3 placement is unspecified.
 			row.Volume, err = mycluster.SetAppLocalMountVolume(node)
 			if err != nil {
 				http.Error(w, "Volume selection required before adding storage: "+err.Error(), http.StatusBadRequest)
 				return
 			}
 			row.VolumeName = row.Volume.Name
-			row.VolumeDir = filepath.Join(config.AppMountVolumeDir, row.Name)
+			row.VolumeDir = filepath.Join(row.Volume.S3MountSubdir(), row.Name)
+		} else {
+			// Phase 14 task 2/3: explicit V2 placement - resolve and preserve the
+			// selected saved volume row, defaulting VolumeDir via S3MountSubdir()
+			// (mnt as suggestion only, task 4) when the caller picked a volume but
+			// left the directory unspecified.
+			row.Volume, err = deployment.GetVolumeByName(row.VolumeName)
+			if err != nil {
+				http.Error(w, "Error getting volume by name: "+err.Error(), http.StatusBadRequest)
+				return
+			}
+			if row.VolumeDir == "" {
+				row.VolumeDir = filepath.Join(row.Volume.S3MountSubdir(), row.Name)
+			}
 		}
 
 		err = deployment.InsertS3Mount(row)
@@ -2703,6 +2717,7 @@ func (repman *ReplicationManager) handlerMuxModifyStorageField(w http.ResponseWr
 						s3Mount.VolumeDir = filepath.Join(newvol.S3MountSubdir(), s3Mount.Name)
 					}
 					s3Mount.VolumeName = newValue
+					s3Mount.Volume = newvol
 
 					deployment.ResolveS3MountPaths(s3Mount.Name)
 				case "region":

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -3526,7 +3526,7 @@ func buildValidatedTempAppConfigFromTemplate(mycluster *cluster.Cluster, node *c
 		return nil, err
 	}
 
-	canonicalContent, _, err := config.CanonicalizeAppTemplateTOML(parsedContent)
+	canonicalContent, _, err := cluster.CanonicalizeAppContent(parsedContent, node.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -3959,7 +3959,7 @@ func (repman *ReplicationManager) handlerMuxAppTemplateContentSave(w http.Respon
 		return
 	}
 
-	canonicalContent, _, err := config.CanonicalizeAppTemplateTOML([]byte(body.Content))
+	canonicalContent, _, err := cluster.CanonicalizeAppContent([]byte(body.Content), "")
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Error canonicalizing template content: %v", err), http.StatusBadRequest)
 		return
@@ -4093,7 +4093,7 @@ func createLocalTemplateCopyFromTemplate(mycluster *cluster.Cluster, templateNam
 		return err
 	}
 
-	canonicalContent, _, err := config.CanonicalizeAppTemplateTOML(content)
+	canonicalContent, _, err := cluster.CanonicalizeAppContent(content, "")
 	if err != nil {
 		return err
 	}

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -3578,11 +3578,20 @@ func applyTemplateOwnedProjection(dst, src *config.AppConfig, templateName strin
 	//   AppHost, AppPort, AppHostsIPV6, AppDbUser, AppDbPass, AppDbSchema,
 	//   AppS3Provider, ProvAppCreditUsed, ProvAppCreditPlanned.
 	// - Template-owned (overwritten from validated template):
-	//   Deployment, ProvAppTemplate, ProvAppDockerImg, ProvAppDockerCmd, ProvAppType,
-	//   ProvAppMem, ProvAppCpuCores, ProvAppDisk, ProvAppDiskType, ProvAppRouteAddr,
-	//   ProvAppRoutePort, ProvAppRouteMask, ProvAppAgents, ProvAppHATopology,
+	//   Deployment, AppConfigVersion, ProvAppTemplate, ProvAppDockerImg,
+	//   ProvAppDockerCmd, ProvAppType, ProvAppMem, ProvAppCpuCores,
+	//   ProvAppDisk, ProvAppDiskType, ProvAppRouteAddr, ProvAppRoutePort,
+	//   ProvAppRouteMask, ProvAppAgents, ProvAppHATopology,
 	//   ProvAppAgentsFailover.
+	//
+	// AppConfigVersion travels with Deployment: src.Deployment was
+	// canonicalized under src.AppConfigVersion's V1/V2 gate
+	// (CanonicalizeAppVolumesRaw), so leaving dst.AppConfigVersion at a stale
+	// value would let the next load/save canonicalization pass
+	// re-interpret an intentional V2 multi-row Deployment as V1 and merge it
+	// back to one row per pool.
 	dst.Deployment = src.Deployment
+	dst.AppConfigVersion = src.AppConfigVersion
 	dst.ProvAppTemplate = templateName
 	dst.ProvAppDockerImg = src.ProvAppDockerImg
 	dst.ProvAppDockerCmd = src.ProvAppDockerCmd

--- a/server/api_app_path_mapping_test.go
+++ b/server/api_app_path_mapping_test.go
@@ -1,0 +1,234 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/signal18/replication-manager/cluster"
+	"github.com/signal18/replication-manager/config"
+)
+
+func newPathMappingTestSetup(t *testing.T) (*ReplicationManager, *cluster.Cluster, *cluster.App) {
+	t.Helper()
+
+	repman, cl, app := newVolumeTestSetupWithVolumes(t, config.AppConfigVersionV2, config.Volumes{
+		{Name: "vol-a", PoolName: "data", VolumeDir: "data"},
+		{Name: "vol-b", PoolName: "docs", VolumeDir: "docs"},
+	})
+
+	app.AppConfig.Deployment.Storages.GitClones = config.GitClones{
+		{Name: "git-a", VolumeName: "vol-a", VolumeDir: "repo-a"},
+		{Name: "git-b", VolumeName: "vol-b", VolumeDir: "repo-b"},
+	}
+	app.AppConfig.Deployment.Storages.S3Mounts = config.S3Mounts{
+		{Name: "s3-a", VolumeName: "vol-a", VolumeDir: "uploads-a"},
+		{Name: "s3-b", VolumeName: "vol-b", VolumeDir: "uploads-b"},
+	}
+
+	return repman, cl, app
+}
+
+func newModifyPathFieldRequest(t *testing.T, repman *ReplicationManager, cl *cluster.Cluster, index int, key, newValue string) *http.Request {
+	t.Helper()
+	tok := issueVolumeTestJWT(t, repman)
+	body, _ := json.Marshal(map[string]string{"value": newValue})
+	url := fmt.Sprintf("/api/clusters/%s/apps/%s/deployment/paths/index/%d/%s/modify", cl.Name, volumeTestAppId, index, key)
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req = setMuxVars(req, map[string]string{
+		"clusterName": cl.Name,
+		"appName":     volumeTestAppId,
+		"field":       "paths",
+		"index":       fmt.Sprintf("%d", index),
+		"key":         key,
+	})
+	return req
+}
+
+func newModifyVolumeNameRequest(t *testing.T, repman *ReplicationManager, cl *cluster.Cluster, index int, newName string) *http.Request {
+	t.Helper()
+	tok := issueVolumeTestJWT(t, repman)
+	body, _ := json.Marshal(map[string]string{"value": newName})
+	url := fmt.Sprintf("/api/clusters/%s/apps/%s/storages/volumes/index/%d/name/modify", cl.Name, volumeTestAppId, index)
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req = setMuxVars(req, map[string]string{
+		"clusterName": cl.Name,
+		"appName":     volumeTestAppId,
+		"field":       "volumes",
+		"index":       fmt.Sprintf("%d", index),
+		"key":         "name",
+	})
+	return req
+}
+
+// TestModifyPathField_SrcTypeTransitionClearsStaleFields_WarningOnly verifies
+// the API's explicit warning-only choice for field-by-field srctype edits:
+// switching source type clears SourceName/SourcePath/VolumeName, returns 200,
+// and persists the intentionally incomplete row for a follow-up srcname edit.
+func TestModifyPathField_SrcTypeTransitionClearsStaleFields_WarningOnly(t *testing.T) {
+	repman, cl, app := newPathMappingTestSetup(t)
+	app.AppConfig.Deployment.Paths = config.PathMaps{
+		{Name: "web-root", DockerPath: "/var/www/html", SourceType: config.SourceVolume, SourceName: "vol-a", SourcePath: ".", VolumeName: "vol-a"},
+	}
+	if errs := app.AppConfig.Deployment.ResolvePaths(); len(errs) > 0 {
+		t.Fatalf("initial ResolvePaths: %v", errs)
+	}
+
+	req := newModifyPathFieldRequest(t, repman, cl, 0, "srctype", string(config.SourceGit))
+	w := httptest.NewRecorder()
+	repman.handlerMuxModifyDeploymentField(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for srctype transition, got %d: %s", w.Code, w.Body.String())
+	}
+	got := app.AppConfig.Deployment.Paths[0]
+	if got.SourceType != config.SourceGit {
+		t.Fatalf("expected SourceType git, got %q", got.SourceType)
+	}
+	if got.SourceName != "" || got.SourcePath != "" || got.VolumeName != "" {
+		t.Fatalf("expected incomplete transition with cleared source fields, got srcname=%q srcpath=%q volumename=%q", got.SourceName, got.SourcePath, got.VolumeName)
+	}
+}
+
+// TestModifyPathField_VolumeSourceChangeUpdatesVolumeName covers the actual
+// path modify API flow: choosing another direct saved volume row should update
+// SourcePath to "." and refresh VolumeName to the selected row.
+func TestModifyPathField_VolumeSourceChangeUpdatesVolumeName(t *testing.T) {
+	repman, cl, app := newPathMappingTestSetup(t)
+	app.AppConfig.Deployment.Paths = config.PathMaps{
+		{Name: "web-root", DockerPath: "/var/www/html", SourceType: config.SourceVolume, SourceName: "vol-a", SourcePath: ".", VolumeName: "vol-a"},
+	}
+	if errs := app.AppConfig.Deployment.ResolvePaths(); len(errs) > 0 {
+		t.Fatalf("initial ResolvePaths: %v", errs)
+	}
+
+	req := newModifyPathFieldRequest(t, repman, cl, 0, "srcname", "vol-b")
+	w := httptest.NewRecorder()
+	repman.handlerMuxModifyDeploymentField(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for direct volume source change, got %d: %s", w.Code, w.Body.String())
+	}
+	got := app.AppConfig.Deployment.Paths[0]
+	if got.SourceName != "vol-b" || got.SourcePath != "." || got.VolumeName != "vol-b" {
+		t.Fatalf("expected srcname=vol-b srcpath='.' volumename=vol-b, got srcname=%q srcpath=%q volumename=%q", got.SourceName, got.SourcePath, got.VolumeName)
+	}
+}
+
+// TestModifyPathField_SrcPathBlankResetUsesCurrentSource covers the actual API
+// reset branch for all three source types.
+func TestModifyPathField_SrcPathBlankResetUsesCurrentSource(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     *config.PathMapping
+		wantPath string
+	}{
+		{
+			name:     "volume",
+			path:     &config.PathMapping{Name: "web-root", DockerPath: "/var/www/html", SourceType: config.SourceVolume, SourceName: "vol-a", SourcePath: "custom/sub", VolumeName: "vol-a"},
+			wantPath: ".",
+		},
+		{
+			name:     "git",
+			path:     &config.PathMapping{Name: "src", DockerPath: "/app/src", SourceType: config.SourceGit, SourceName: "git-a", SourcePath: "custom/sub", VolumeName: "vol-a"},
+			wantPath: "/repo-a",
+		},
+		{
+			name:     "s3",
+			path:     &config.PathMapping{Name: "uploads", DockerPath: "/app/uploads", SourceType: config.SourceS3, SourceName: "s3-a", SourcePath: "custom/sub", VolumeName: "vol-a"},
+			wantPath: "/uploads-a",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repman, cl, app := newPathMappingTestSetup(t)
+			app.AppConfig.Deployment.Paths = config.PathMaps{tc.path}
+			if errs := app.AppConfig.Deployment.ResolvePaths(); len(errs) > 0 {
+				t.Fatalf("initial ResolvePaths: %v", errs)
+			}
+
+			req := newModifyPathFieldRequest(t, repman, cl, 0, "srcpath", "")
+			w := httptest.NewRecorder()
+			repman.handlerMuxModifyDeploymentField(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200 resetting srcpath, got %d: %s", w.Code, w.Body.String())
+			}
+			got := app.AppConfig.Deployment.Paths[0]
+			if got.SourcePath != tc.wantPath {
+				t.Fatalf("expected reset srcpath %q, got %q", tc.wantPath, got.SourcePath)
+			}
+		})
+	}
+}
+
+// TestModifyPathField_UnresolvedSourceName_WarningOnlyClearsVolumeName
+// verifies the API's warning-only persistence contract for an unresolved
+// srcname edit: the new source name is persisted, stale VolumeName is cleared,
+// and the request still returns 200.
+func TestModifyPathField_UnresolvedSourceName_WarningOnlyClearsVolumeName(t *testing.T) {
+	repman, cl, app := newPathMappingTestSetup(t)
+	app.AppConfig.Deployment.Paths = config.PathMaps{
+		{Name: "web-root", DockerPath: "/var/www/html", SourceType: config.SourceVolume, SourceName: "vol-a", SourcePath: ".", VolumeName: "vol-a"},
+	}
+	if errs := app.AppConfig.Deployment.ResolvePaths(); len(errs) > 0 {
+		t.Fatalf("initial ResolvePaths: %v", errs)
+	}
+
+	req := newModifyPathFieldRequest(t, repman, cl, 0, "srcname", "missing-vol")
+	w := httptest.NewRecorder()
+	repman.handlerMuxModifyDeploymentField(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for unresolved source warning-only path edit, got %d: %s", w.Code, w.Body.String())
+	}
+	got := app.AppConfig.Deployment.Paths[0]
+	if got.SourceName != "missing-vol" {
+		t.Fatalf("expected SourceName missing-vol, got %q", got.SourceName)
+	}
+	if got.VolumeName != "" {
+		t.Fatalf("expected stale VolumeName cleared for unresolved source, got %q", got.VolumeName)
+	}
+}
+
+// TestModifyVolumeName_PreservesInheritedChildSourceFields verifies the API
+// rename flow does not rewrite inherited child paths as if they had a direct
+// volume source of their own, while still refreshing both parent and child
+// VolumeName to the renamed row.
+func TestModifyVolumeName_PreservesInheritedChildSourceFields(t *testing.T) {
+	repman, cl, app := newPathMappingTestSetup(t)
+	app.AppConfig.Deployment.Paths = config.PathMaps{
+		{Name: "web-root", DockerPath: "/var/www/html", SourceType: config.SourceVolume, SourceName: "vol-a", SourcePath: ".", VolumeName: "vol-a"},
+		{Name: "assets", ParentName: "web-root", DockerPath: "/var/www/html/assets"},
+	}
+	if errs := app.AppConfig.Deployment.ResolvePaths(); len(errs) > 0 {
+		t.Fatalf("initial ResolvePaths: %v", errs)
+	}
+
+	req := newModifyVolumeNameRequest(t, repman, cl, 0, "vol-renamed")
+	w := httptest.NewRecorder()
+	repman.handlerMuxModifyStorageField(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 renaming volume, got %d: %s", w.Code, w.Body.String())
+	}
+	parent := app.AppConfig.Deployment.Paths[0]
+	child := app.AppConfig.Deployment.Paths[1]
+	if parent.SourceName != "vol-renamed" || parent.VolumeName != "vol-renamed" {
+		t.Fatalf("expected parent to follow rename, got srcname=%q volumename=%q", parent.SourceName, parent.VolumeName)
+	}
+	if child.SourceType != "" || child.SourceName != "" || child.SourcePath != "" {
+		t.Fatalf("expected inherited child source fields unchanged/empty, got srctype=%q srcname=%q srcpath=%q", child.SourceType, child.SourceName, child.SourcePath)
+	}
+	if child.VolumeName != "vol-renamed" {
+		t.Fatalf("expected child inherited volumename vol-renamed, got %q", child.VolumeName)
+	}
+}

--- a/server/api_app_s3_mount_v2_test.go
+++ b/server/api_app_s3_mount_v2_test.go
@@ -1,0 +1,445 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/signal18/replication-manager/cluster"
+	"github.com/signal18/replication-manager/config"
+)
+
+// newVolumeTestSetupWithVolumes is a variant of newVolumeTestSetup that seeds
+// an arbitrary set of saved deployment.storages.volumes rows, for tests that
+// need more than one row to exercise V2 multi-volume S3 mount placement.
+func newVolumeTestSetupWithVolumes(t *testing.T, appConfigVersion int, volumes config.Volumes) (*ReplicationManager, *cluster.Cluster, *cluster.App) {
+	t.Helper()
+
+	appCnf := &config.AppConfig{
+		AppHost:          "app-a",
+		AppPort:          "8080",
+		AppConfigVersion: appConfigVersion,
+		Deployment: &config.Deployment{
+			Storages: config.StorageMapping{
+				Volumes: volumes,
+			},
+		},
+	}
+	app := &cluster.App{
+		Id:        volumeTestAppId,
+		Name:      volumeTestAppId,
+		Host:      "app-a",
+		Port:      "8080",
+		AppConfig: appCnf,
+		Mutex:     &sync.Mutex{},
+	}
+	cl := &cluster.Cluster{
+		Name: volumeTestCluster,
+		Conf: &config.Config{
+			WorkingDir: t.TempDir(),
+		},
+		WorkingDir: t.TempDir(),
+	}
+	cl.Conf.Apps = []*config.AppConfig{appCnf}
+	cl.Apps = []*cluster.App{app}
+	cl.ConfigManager = newConfigManagerForTest()
+	cl.APIUsers = map[string]cluster.APIUser{
+		volumeTestUser: {
+			User:     volumeTestUser,
+			Password: "enc",
+			Grants:   map[string]bool{config.GrantAppDeployment: true},
+		},
+	}
+
+	repman := &ReplicationManager{
+		Clusters:    map[string]*cluster.Cluster{cl.Name: cl},
+		ClusterList: []string{cl.Name},
+		Conf:        &config.Config{TokenTimeout: 1},
+	}
+	repman.initKeys()
+	return repman, cl, app
+}
+
+// newModifyS3MountFieldRequest builds a POST request equivalent to
+// /api/clusters/{cluster}/apps/{app}/storages/s3Mounts/index/{index}/{key}/modify
+// with {"value": newValue} as JSON body.
+func newModifyS3MountFieldRequest(t *testing.T, repman *ReplicationManager, cl *cluster.Cluster, index int, key, newValue string) *http.Request {
+	t.Helper()
+	tok := issueVolumeTestJWT(t, repman)
+	body, _ := json.Marshal(map[string]string{"value": newValue})
+	url := fmt.Sprintf("/api/clusters/%s/apps/%s/storages/s3Mounts/index/%d/%s/modify", cl.Name, volumeTestAppId, index, key)
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req = setMuxVars(req, map[string]string{
+		"clusterName": cl.Name,
+		"appName":     volumeTestAppId,
+		"field":       "s3Mounts",
+		"index":       fmt.Sprintf("%d", index),
+		"key":         key,
+	})
+	return req
+}
+
+// TestAddStorageS3Mount_V2_OmittedPlacementUsesUniqueMntRow covers Phase 15
+// task 1: for a V2 app with several saved volume rows, omitting S3 placement
+// still auto-selects the single row that exposes "mnt" via
+// SetAppLocalMountVolume, and the autofilled VolumeDir is seeded under that
+// row's "mnt" token.
+func TestAddStorageS3Mount_V2_OmittedPlacementUsesUniqueMntRow(t *testing.T) {
+	repman, cl, app := newVolumeTestSetupWithVolumes(t, config.AppConfigVersionV2, config.Volumes{
+		{Name: "myapp-data", PoolName: "data", VolumeDir: "data"},
+		{Name: "myapp-shared", PoolName: "shared", VolumeDir: "etc mnt"},
+	})
+
+	mount := config.S3Mount{
+		Endpoint:  "https://minio.example.com",
+		Bucket:    "backups",
+		AccessKey: "AKIAEXAMPLE",
+		SecretKey: "SECRETEXAMPLE",
+	}
+	req := newAddS3MountRequest(t, repman, cl, mount)
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddStorage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 adding S3 mount, got %d: %s", w.Code, w.Body.String())
+	}
+
+	mounts := app.AppConfig.Deployment.Storages.S3Mounts
+	if len(mounts) != 1 {
+		t.Fatalf("expected 1 S3 mount, got %d", len(mounts))
+	}
+	got := mounts[0]
+	if got.VolumeName != "myapp-shared" {
+		t.Fatalf("expected default placement on myapp-shared (the only row exposing \"mnt\"), got %q", got.VolumeName)
+	}
+	wantDir := "mnt/" + got.Name
+	if got.VolumeDir != wantDir {
+		t.Fatalf("expected VolumeDir %q, got %q", wantDir, got.VolumeDir)
+	}
+}
+
+// TestAddStorageS3Mount_V2_OmittedPlacementAmbiguousFails covers Phase 15
+// tasks 5/6: for a V2 app with multiple saved volume rows where none expose
+// "mnt" and there is no unique default, omitting S3 placement must not
+// silently pick the first row -- the add request fails with 400 and no
+// S3 mount is created.
+func TestAddStorageS3Mount_V2_OmittedPlacementAmbiguousFails(t *testing.T) {
+	repman, cl, app := newVolumeTestSetupWithVolumes(t, config.AppConfigVersionV2, config.Volumes{
+		{Name: "myapp-data", PoolName: "data", VolumeDir: "data"},
+		{Name: "myapp-logs", PoolName: "logs", VolumeDir: "log"},
+	})
+
+	mount := config.S3Mount{
+		Endpoint:  "https://minio.example.com",
+		Bucket:    "backups",
+		AccessKey: "AKIAEXAMPLE",
+		SecretKey: "SECRETEXAMPLE",
+	}
+	req := newAddS3MountRequest(t, repman, cl, mount)
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddStorage(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for ambiguous default S3 mount placement, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(app.AppConfig.Deployment.Storages.S3Mounts) != 0 {
+		t.Fatalf("expected no S3 mount added on ambiguous default placement, got %+v", app.AppConfig.Deployment.Storages.S3Mounts)
+	}
+}
+
+// TestAddStorageS3Mount_V2_ExplicitVolumeNameSelectsNonDefaultRow covers
+// Phase 15 task 2: a V2 app can explicitly place an S3 mount on a saved
+// volume row other than the one SetAppLocalMountVolume would default to
+// (here myapp-data exposes "mnt" and would be the default, but the caller
+// explicitly selects myapp-logs instead).
+func TestAddStorageS3Mount_V2_ExplicitVolumeNameSelectsNonDefaultRow(t *testing.T) {
+	repman, cl, app := newVolumeTestSetupWithVolumes(t, config.AppConfigVersionV2, config.Volumes{
+		{Name: "myapp-data", PoolName: "data", VolumeDir: "data mnt"},
+		{Name: "myapp-logs", PoolName: "logs", VolumeDir: "log"},
+	})
+
+	mount := config.S3Mount{
+		Endpoint:   "https://minio.example.com",
+		Bucket:     "backups",
+		AccessKey:  "AKIAEXAMPLE",
+		SecretKey:  "SECRETEXAMPLE",
+		VolumeName: "myapp-logs",
+	}
+	req := newAddS3MountRequest(t, repman, cl, mount)
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddStorage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 adding S3 mount, got %d: %s", w.Code, w.Body.String())
+	}
+
+	mounts := app.AppConfig.Deployment.Storages.S3Mounts
+	if len(mounts) != 1 {
+		t.Fatalf("expected 1 S3 mount, got %d", len(mounts))
+	}
+	got := mounts[0]
+	if got.VolumeName != "myapp-logs" {
+		t.Fatalf("expected explicitly selected row myapp-logs (not the \"mnt\"-exposing myapp-data), got %q", got.VolumeName)
+	}
+	wantDir := "log/" + got.Name
+	if got.VolumeDir != wantDir {
+		t.Fatalf("expected VolumeDir %q (selected row's own S3MountSubdir()), got %q", wantDir, got.VolumeDir)
+	}
+}
+
+// TestAddStorageS3Mount_V2_ExplicitVolumeDirPreservedExactly covers Phase 15
+// task 3: a V2 app can explicitly choose a directory token (and a relative
+// subdirectory beneath it) other than "mnt" inside the selected row, and the
+// resulting VolumeDir is persisted exactly as given.
+func TestAddStorageS3Mount_V2_ExplicitVolumeDirPreservedExactly(t *testing.T) {
+	repman, cl, app := newVolumeTestSetupWithVolumes(t, config.AppConfigVersionV2, config.Volumes{
+		{Name: "myapp-data", PoolName: "data", VolumeDir: "data mnt extra"},
+	})
+
+	mount := config.S3Mount{
+		Endpoint:   "https://minio.example.com",
+		Bucket:     "backups",
+		AccessKey:  "AKIAEXAMPLE",
+		SecretKey:  "SECRETEXAMPLE",
+		VolumeName: "myapp-data",
+		VolumeDir:  "extra/custom-media",
+	}
+	req := newAddS3MountRequest(t, repman, cl, mount)
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddStorage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 adding S3 mount, got %d: %s", w.Code, w.Body.String())
+	}
+
+	mounts := app.AppConfig.Deployment.Storages.S3Mounts
+	if len(mounts) != 1 {
+		t.Fatalf("expected 1 S3 mount, got %d", len(mounts))
+	}
+	got := mounts[0]
+	if got.VolumeName != "myapp-data" {
+		t.Fatalf("expected VolumeName myapp-data, got %q", got.VolumeName)
+	}
+	if got.VolumeDir != "extra/custom-media" {
+		t.Fatalf("expected explicit VolumeDir \"extra/custom-media\" preserved exactly (not snapped to \"mnt/...\"), got %q", got.VolumeDir)
+	}
+}
+
+// TestAddStorageS3Mount_V2_ExplicitBareDirectoryTokenAppendsGeneratedName
+// covers Phase 16: the "Add new" form has no Name field yet, so an explicit
+// directory-token choice with a blank Sub Dir is submitted as the bare token
+// (e.g. "data") rather than a full "<token>/<name>" path. The generated
+// mount name must be appended under that explicit token, preserving the
+// user's choice instead of falling back to the row's mnt-biased
+// S3MountSubdir() suggestion.
+func TestAddStorageS3Mount_V2_ExplicitBareDirectoryTokenAppendsGeneratedName(t *testing.T) {
+	repman, cl, app := newVolumeTestSetupWithVolumes(t, config.AppConfigVersionV2, config.Volumes{
+		{Name: "myapp-data", PoolName: "data", VolumeDir: "data mnt"},
+	})
+
+	mount := config.S3Mount{
+		Endpoint:   "https://minio.example.com",
+		Bucket:     "backups",
+		AccessKey:  "AKIAEXAMPLE",
+		SecretKey:  "SECRETEXAMPLE",
+		VolumeName: "myapp-data",
+		VolumeDir:  "data",
+	}
+	req := newAddS3MountRequest(t, repman, cl, mount)
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddStorage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 adding S3 mount, got %d: %s", w.Code, w.Body.String())
+	}
+
+	mounts := app.AppConfig.Deployment.Storages.S3Mounts
+	if len(mounts) != 1 {
+		t.Fatalf("expected 1 S3 mount, got %d", len(mounts))
+	}
+	got := mounts[0]
+	if got.VolumeName != "myapp-data" {
+		t.Fatalf("expected VolumeName myapp-data, got %q", got.VolumeName)
+	}
+	wantDir := "data/" + got.Name
+	if got.VolumeDir != wantDir {
+		t.Fatalf("expected VolumeDir %q (explicit \"data\" token + generated mount name, not the mnt-biased S3MountSubdir() suggestion), got %q", wantDir, got.VolumeDir)
+	}
+}
+
+// TestModifyS3Mount_VolumeName_PreservesExplicitVolumeDirWhenNoDuplicate
+// covers Phase 15 tasks 4/6: moving an S3 mount with an explicit non-"mnt"
+// VolumeDir onto a different saved volume row must preserve that VolumeDir
+// unchanged (and refresh the resolved Volume pointer) as long as the
+// (newVolumeName, VolumeDir) pair is not already used by another mount.
+func TestModifyS3Mount_VolumeName_PreservesExplicitVolumeDirWhenNoDuplicate(t *testing.T) {
+	repman, cl, app := newVolumeTestSetupWithVolumes(t, config.AppConfigVersionV2, config.Volumes{
+		{Name: "myapp-data", PoolName: "data", VolumeDir: "data mnt"},
+		{Name: "myapp-logs", PoolName: "logs", VolumeDir: "log"},
+	})
+	app.AppConfig.Deployment.Storages.S3Mounts = config.S3Mounts{
+		{
+			Name:       "media",
+			Endpoint:   "https://minio.example.com",
+			Bucket:     "backups",
+			AccessKey:  "AKIAEXAMPLE",
+			SecretKey:  "SECRETEXAMPLE",
+			VolumeName: "myapp-data",
+			VolumeDir:  "custom/sub",
+		},
+	}
+
+	req := newModifyS3MountFieldRequest(t, repman, cl, 0, "volumename", "myapp-logs")
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxModifyStorageField(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 modifying volumename, got %d: %s", w.Code, w.Body.String())
+	}
+
+	got := app.AppConfig.Deployment.Storages.S3Mounts[0]
+	if got.VolumeName != "myapp-logs" {
+		t.Fatalf("expected VolumeName myapp-logs, got %q", got.VolumeName)
+	}
+	if got.VolumeDir != "custom/sub" {
+		t.Fatalf("expected explicit non-default VolumeDir \"custom/sub\" preserved across volumename change, got %q", got.VolumeDir)
+	}
+	if got.Volume == nil || got.Volume.Name != "myapp-logs" {
+		t.Fatalf("expected resolved Volume pointer refreshed to myapp-logs, got %+v", got.Volume)
+	}
+}
+
+// TestModifyS3Mount_VolumeName_ResetsVolumeDirOnDuplicatePath covers Phase 15
+// task 6: if moving an S3 mount onto a new saved volume row would collide
+// with another mount already occupying the same (VolumeName, VolumeDir)
+// pair, VolumeDir is reset via the new row's S3MountSubdir() rather than
+// silently leaving a duplicate path.
+func TestModifyS3Mount_VolumeName_ResetsVolumeDirOnDuplicatePath(t *testing.T) {
+	repman, cl, app := newVolumeTestSetupWithVolumes(t, config.AppConfigVersionV2, config.Volumes{
+		{Name: "myapp-data", PoolName: "data", VolumeDir: "data mnt"},
+		{Name: "myapp-logs", PoolName: "logs", VolumeDir: "log mnt"},
+	})
+	app.AppConfig.Deployment.Storages.S3Mounts = config.S3Mounts{
+		{
+			Name:       "mediaA",
+			Endpoint:   "https://minio.example.com",
+			Bucket:     "backups-a",
+			AccessKey:  "AKIAEXAMPLE",
+			SecretKey:  "SECRETEXAMPLE",
+			VolumeName: "myapp-logs",
+			VolumeDir:  "mnt/shared",
+		},
+		{
+			Name:       "mediaB",
+			Endpoint:   "https://minio.example.com",
+			Bucket:     "backups-b",
+			AccessKey:  "AKIAEXAMPLE",
+			SecretKey:  "SECRETEXAMPLE",
+			VolumeName: "myapp-data",
+			VolumeDir:  "mnt/shared",
+		},
+	}
+
+	req := newModifyS3MountFieldRequest(t, repman, cl, 1, "volumename", "myapp-logs")
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxModifyStorageField(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 modifying volumename, got %d: %s", w.Code, w.Body.String())
+	}
+
+	got := app.AppConfig.Deployment.Storages.S3Mounts[1]
+	if got.VolumeName != "myapp-logs" {
+		t.Fatalf("expected VolumeName myapp-logs, got %q", got.VolumeName)
+	}
+	wantDir := "mnt/" + got.Name
+	if got.VolumeDir != wantDir {
+		t.Fatalf("expected VolumeDir reset to %q on duplicate path collision, got %q", wantDir, got.VolumeDir)
+	}
+}
+
+// TestModifyS3Mount_VolumeDir_BlankResetUsesVolumeS3MountSubdir covers Phase
+// 15 tasks 4/6: resetting VolumeDir to blank on the modify path must default
+// via the current row's S3MountSubdir() (mnt as a suggestion only), not a
+// hardcoded "mnt/<name>".
+func TestModifyS3Mount_VolumeDir_BlankResetUsesVolumeS3MountSubdir(t *testing.T) {
+	repman, cl, app := newVolumeTestSetupWithVolumes(t, config.AppConfigVersionV2, config.Volumes{
+		{Name: "myapp-data", PoolName: "data", VolumeDir: "etc"},
+	})
+	app.AppConfig.Deployment.Storages.S3Mounts = config.S3Mounts{
+		{
+			Name:       "media",
+			Endpoint:   "https://minio.example.com",
+			Bucket:     "backups",
+			AccessKey:  "AKIAEXAMPLE",
+			SecretKey:  "SECRETEXAMPLE",
+			VolumeName: "myapp-data",
+			VolumeDir:  "mnt/old-media",
+		},
+	}
+
+	req := newModifyS3MountFieldRequest(t, repman, cl, 0, "volumedir", "")
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxModifyStorageField(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 resetting volumedir, got %d: %s", w.Code, w.Body.String())
+	}
+
+	got := app.AppConfig.Deployment.Storages.S3Mounts[0]
+	wantDir := "etc/" + got.Name
+	if got.VolumeDir != wantDir {
+		t.Fatalf("expected blank volumedir reset to %q (Volume.S3MountSubdir(), not hardcoded \"mnt/...\"), got %q", wantDir, got.VolumeDir)
+	}
+}
+
+// TestModifyS3Mount_OtherFieldChange_PreservesExplicitNonMntPlacement covers
+// Phase 15 task 4: modifying an unrelated field (e.g. region) must not snap
+// an explicit non-"mnt" VolumeName/VolumeDir placement back to a default.
+func TestModifyS3Mount_OtherFieldChange_PreservesExplicitNonMntPlacement(t *testing.T) {
+	repman, cl, app := newVolumeTestSetupWithVolumes(t, config.AppConfigVersionV2, config.Volumes{
+		{Name: "myapp-data", PoolName: "data", VolumeDir: "data mnt"},
+	})
+	app.AppConfig.Deployment.Storages.S3Mounts = config.S3Mounts{
+		{
+			Name:       "media",
+			Endpoint:   "https://minio.example.com",
+			Bucket:     "backups",
+			AccessKey:  "AKIAEXAMPLE",
+			SecretKey:  "SECRETEXAMPLE",
+			VolumeName: "myapp-data",
+			VolumeDir:  "data/custom-media",
+		},
+	}
+
+	req := newModifyS3MountFieldRequest(t, repman, cl, 0, "region", "eu-west-1")
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxModifyStorageField(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 modifying region, got %d: %s", w.Code, w.Body.String())
+	}
+
+	got := app.AppConfig.Deployment.Storages.S3Mounts[0]
+	if got.VolumeName != "myapp-data" || got.VolumeDir != "data/custom-media" {
+		t.Fatalf("expected explicit placement myapp-data/data/custom-media preserved, got %q/%q", got.VolumeName, got.VolumeDir)
+	}
+	if got.Region != "eu-west-1" {
+		t.Fatalf("expected region updated to eu-west-1, got %q", got.Region)
+	}
+}

--- a/server/api_app_s3_placement_test.go
+++ b/server/api_app_s3_placement_test.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"testing"
+
+	"github.com/signal18/replication-manager/cluster"
+	"github.com/signal18/replication-manager/config"
+)
+
+// newAddS3MountRequest builds a POST request equivalent to
+// /api/clusters/{cluster}/apps/{app}/storages/s3Mounts/add with the given S3
+// mount row as JSON body.
+func newAddS3MountRequest(t *testing.T, repman *ReplicationManager, cl *cluster.Cluster, mount config.S3Mount) *http.Request {
+	t.Helper()
+	tok := issueVolumeTestJWT(t, repman)
+	body, _ := json.Marshal(mount)
+	url := fmt.Sprintf("/api/clusters/%s/apps/%s/storages/s3Mounts/add", cl.Name, volumeTestAppId)
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req = setMuxVars(req, map[string]string{
+		"clusterName": cl.Name,
+		"appName":     volumeTestAppId,
+		"field":       "s3Mounts",
+	})
+	return req
+}
+
+// TestAddStorageS3Mount_LegacyAutofillUsesVolumeS3MountSubdir covers the
+// blocking issue raised after Phase 14: when S3 placement is unspecified
+// (legacy autofill, task 1) and SetAppLocalMountVolume falls back to the
+// app's single saved volume row (Phase 14 task 6) even though that row does
+// not expose "mnt", the autofilled VolumeDir must be derived from the
+// selected row's Volume.S3MountSubdir() (here "etc", the row's only/first
+// token), not hardcoded to "mnt/<mount-name>".
+func TestAddStorageS3Mount_LegacyAutofillUsesVolumeS3MountSubdir(t *testing.T) {
+	// newVolumeTestSetup seeds a single saved volume row
+	// {Name: "myapp-data", PoolName: "data", VolumeDir: "etc"} - no "mnt" token.
+	repman, cl, app := newVolumeTestSetup(t, 0)
+
+	mount := config.S3Mount{
+		Endpoint:  "https://minio.example.com",
+		Bucket:    "backups",
+		AccessKey: "AKIAEXAMPLE",
+		SecretKey: "SECRETEXAMPLE",
+	}
+	req := newAddS3MountRequest(t, repman, cl, mount)
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddStorage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 adding S3 mount, got %d: %s", w.Code, w.Body.String())
+	}
+
+	mounts := app.AppConfig.Deployment.Storages.S3Mounts
+	if len(mounts) != 1 {
+		t.Fatalf("expected 1 S3 mount, got %d", len(mounts))
+	}
+	got := mounts[0]
+	if got.VolumeName != "myapp-data" {
+		t.Fatalf("expected VolumeName myapp-data (the app's single saved volume row), got %q", got.VolumeName)
+	}
+	wantDir := "etc/" + got.Name
+	if got.VolumeDir != wantDir {
+		t.Fatalf("expected VolumeDir %q (Volume.S3MountSubdir() + mount name), got %q", wantDir, got.VolumeDir)
+	}
+}
+
+// TestAddStorageS3Mount_ExplicitVolumeNameDerivesDirFromRowToken covers the
+// Phase 14 blocking issue: when the caller explicitly selects a saved volume
+// row via VolumeName but leaves VolumeDir blank, the defaulted VolumeDir must
+// follow that row's own Volume.S3MountSubdir() (here "etc", the row's
+// only/first token, since the row has no "mnt" token), not the hardcoded
+// legacy "mnt/<mount-name>" default.
+func TestAddStorageS3Mount_ExplicitVolumeNameDerivesDirFromRowToken(t *testing.T) {
+	// newVolumeTestSetup seeds a single saved volume row
+	// {Name: "myapp-data", PoolName: "data", VolumeDir: "etc"} - no "mnt" token.
+	repman, cl, app := newVolumeTestSetup(t, 0)
+
+	mount := config.S3Mount{
+		Endpoint:   "https://minio.example.com",
+		Bucket:     "backups",
+		AccessKey:  "AKIAEXAMPLE",
+		SecretKey:  "SECRETEXAMPLE",
+		VolumeName: "myapp-data",
+	}
+	req := newAddS3MountRequest(t, repman, cl, mount)
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddStorage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 adding S3 mount, got %d: %s", w.Code, w.Body.String())
+	}
+
+	mounts := app.AppConfig.Deployment.Storages.S3Mounts
+	if len(mounts) != 1 {
+		t.Fatalf("expected 1 S3 mount, got %d", len(mounts))
+	}
+	got := mounts[0]
+	if got.VolumeName != "myapp-data" {
+		t.Fatalf("expected VolumeName myapp-data (explicitly selected row), got %q", got.VolumeName)
+	}
+	wantDir := "etc/" + got.Name
+	if got.VolumeDir != wantDir {
+		t.Fatalf("expected VolumeDir %q (selected row's Volume.S3MountSubdir() + mount name), got %q", wantDir, got.VolumeDir)
+	}
+}

--- a/server/api_app_template_content_lifecycle_test.go
+++ b/server/api_app_template_content_lifecycle_test.go
@@ -186,6 +186,67 @@ level = 0
 	}
 }
 
+// TestAppTemplateContentSave_V2FlaggedMultiRowPoolPreserved covers Phase 11
+// task 10: a V2-flagged template with two intentional same-pool volume rows
+// stays multi-row through CanonicalizeAppContent and
+// validateCanonicalTemplateContentForSave -- contrast with
+// TestAppTemplateContentSave_MergesMultiRowVolumePool, which is V1 and still
+// merges same-pool rows into one.
+func TestAppTemplateContentSave_V2FlaggedMultiRowPoolPreserved(t *testing.T) {
+	cl := &cluster.Cluster{Conf: &config.Config{WorkingDir: t.TempDir()}}
+
+	submitted := []byte(`
+app-config-version = 2
+
+[[deployment.storages.volumes]]
+name = "myapp-data"
+poolname = "data"
+volumedir = "etc"
+
+[[deployment.storages.volumes]]
+name = "myapp-data-logs"
+poolname = "data"
+volumedir = "log"
+
+[[deployment.paths]]
+name = "web-root"
+dockerpath = "/var/www/html"
+srctype = "volume"
+srcname = "myapp-data"
+volumename = "myapp-data"
+srcpath = "."
+level = 0
+
+[[deployment.paths]]
+name = "log-dir"
+dockerpath = "/var/log/app"
+srctype = "volume"
+srcname = "myapp-data-logs"
+volumename = "myapp-data-logs"
+srcpath = "."
+level = 0
+`)
+
+	canonicalContent, res, err := cluster.CanonicalizeAppContent(submitted, "")
+	if err != nil {
+		t.Fatalf("CanonicalizeAppContent failed: %v", err)
+	}
+	if res.Changed {
+		t.Fatalf("expected no changes for already-V2 multi-row content, got %+v", res)
+	}
+	if err := validateCanonicalTemplateContentForSave(cl, "local/v2-multi-row", canonicalContent); err != nil {
+		t.Fatalf("validateCanonicalTemplateContentForSave failed: %v", err)
+	}
+
+	got := string(canonicalContent)
+	if !strings.Contains(got, `name = "myapp-data"`) || !strings.Contains(got, `name = "myapp-data-logs"`) {
+		t.Fatalf("expected both volume rows preserved, got:\n%s", got)
+	}
+	if strings.Contains(got, `volumedir = "etc log"`) {
+		t.Fatalf("expected rows not merged, got:\n%s", got)
+	}
+}
+
 func TestWriteTemplateContentAtomically(t *testing.T) {
 	workDir := t.TempDir()
 	path := filepath.Join(workDir, ".templates", "apps", "local", "custom.toml")

--- a/server/api_app_template_content_lifecycle_test.go
+++ b/server/api_app_template_content_lifecycle_test.go
@@ -146,6 +146,44 @@ srcpath = "."
 	if strings.Contains(got, `"data-volume"`) || strings.Contains(got, `"logs-volume"`) {
 		t.Fatalf("expected legacy volume names rewritten away, got:\n%s", got)
 	}
+	if !strings.Contains(got, "app-config-version = 2") {
+		t.Fatalf("expected app-config-version = 2 to be stamped on save, got:\n%s", got)
+	}
+}
+
+// TestAppTemplateContentSave_AlreadyV2NoOp covers Phase 10 task 4 for the
+// template save flow: re-saving already-V2 canonical content does not
+// produce a second rewrite of the version marker (CanonicalizeAppContent is
+// idempotent on already-flagged content).
+func TestAppTemplateContentSave_AlreadyV2NoOp(t *testing.T) {
+	versioned := []byte(`
+app-config-version = 2
+
+[[deployment.storages.volumes]]
+name = "{name}-data"
+poolname = "data"
+volumedir = "data"
+
+[[deployment.paths]]
+name = "web-root"
+dockerpath = "/var/www/html"
+srctype = "volume"
+srcname = "{name}-data"
+volumename = "{name}-data"
+srcpath = "."
+level = 0
+`)
+
+	canonicalContent, res, err := cluster.CanonicalizeAppContent(versioned, "")
+	if err != nil {
+		t.Fatalf("CanonicalizeAppContent failed: %v", err)
+	}
+	if res.Changed {
+		t.Fatalf("expected no changes for already-V2 canonical content, got %+v", res)
+	}
+	if string(canonicalContent) != string(versioned) {
+		t.Fatalf("expected output to equal input unchanged:\nin:\n%s\nout:\n%s", versioned, canonicalContent)
+	}
 }
 
 func TestWriteTemplateContentAtomically(t *testing.T) {
@@ -198,6 +236,16 @@ srcpath = "."
 	localPath := filepath.Join(workDir, ".templates", "apps", "local", "copyme.toml")
 	if _, err := os.Stat(localPath); err != nil {
 		t.Fatalf("expected local template copy at %s, err=%v", localPath, err)
+	}
+
+	// Phase 10 task 5: the local copy is created via CanonicalizeAppContent,
+	// so it must carry the app-config-version = 2 marker.
+	copied, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read local template copy failed: %v", err)
+	}
+	if !strings.Contains(string(copied), "app-config-version = 2") {
+		t.Fatalf("expected app-config-version = 2 in local template copy, got:\n%s", copied)
 	}
 }
 

--- a/server/api_app_template_content_lifecycle_test.go
+++ b/server/api_app_template_content_lifecycle_test.go
@@ -208,6 +208,11 @@ name = "myapp-data-logs"
 poolname = "data"
 volumedir = "log"
 
+[[deployment.storages.s3-mounts]]
+name = "media"
+volumename = "myapp-data-logs"
+volumedir = "log/media"
+
 [[deployment.paths]]
 name = "web-root"
 dockerpath = "/var/www/html"
@@ -244,6 +249,11 @@ level = 0
 	}
 	if strings.Contains(got, `volumedir = "etc log"`) {
 		t.Fatalf("expected rows not merged, got:\n%s", got)
+	}
+	// Phase 15 task 4: an explicit non-"mnt" S3 mount placement must survive
+	// the canonicalize/save round trip unchanged.
+	if !strings.Contains(got, `volumedir = "log/media"`) {
+		t.Fatalf("expected s3-mount explicit volumedir \"log/media\" preserved, got:\n%s", got)
 	}
 }
 

--- a/server/api_app_template_content_lifecycle_test.go
+++ b/server/api_app_template_content_lifecycle_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/signal18/replication-manager/cluster"
@@ -86,6 +87,64 @@ dockerpath = "/srv/app/child"
 `)
 	if err := validateCanonicalTemplateContentForSave(cl, "local/invalid", invalidTemplate); err == nil {
 		t.Fatalf("expected invalid template content to fail validation")
+	}
+}
+
+// TestAppTemplateContentSave_MergesMultiRowVolumePool covers Phase 7: saving
+// edited template content must pass through the same canonical merge as
+// GetTemplateContent (CanonicalizeAppContent with appName=""), not just the
+// path/level migration. Otherwise a hand-edited template with two rows for
+// the same pool would be persisted un-merged, only to be silently rewritten
+// (and reported as a separate "Changed" canonicalization) the next time
+// GetTemplateContent loads it.
+func TestAppTemplateContentSave_MergesMultiRowVolumePool(t *testing.T) {
+	cl := &cluster.Cluster{Conf: &config.Config{WorkingDir: t.TempDir()}}
+
+	submitted := []byte(`
+[[deployment.storages.volumes]]
+name = "data-volume"
+poolname = "data"
+volumedir = "data"
+
+[[deployment.storages.volumes]]
+name = "logs-volume"
+poolname = "data"
+volumedir = "logs"
+
+[[deployment.paths]]
+name = "web-root"
+dockerpath = "/var/www/html"
+srctype = "volume"
+srcname = "data-volume"
+volumename = "data-volume"
+srcpath = "."
+
+[[deployment.paths]]
+name = "log-dir"
+dockerpath = "/var/log/app"
+srctype = "volume"
+srcname = "logs-volume"
+volumename = "logs-volume"
+srcpath = "."
+`)
+
+	canonicalContent, _, err := cluster.CanonicalizeAppContent(submitted, "")
+	if err != nil {
+		t.Fatalf("CanonicalizeAppContent failed: %v", err)
+	}
+	if err := validateCanonicalTemplateContentForSave(cl, "local/merge-on-save", canonicalContent); err != nil {
+		t.Fatalf("validateCanonicalTemplateContentForSave failed: %v", err)
+	}
+
+	got := string(canonicalContent)
+	if !strings.Contains(got, `name = "{name}-data"`) {
+		t.Fatalf("expected merged volume row named {name}-data, got:\n%s", got)
+	}
+	if !strings.Contains(got, `volumedir = "data logs"`) {
+		t.Fatalf("expected merged volumedir 'data logs', got:\n%s", got)
+	}
+	if strings.Contains(got, `"data-volume"`) || strings.Contains(got, `"logs-volume"`) {
+		t.Fatalf("expected legacy volume names rewritten away, got:\n%s", got)
 	}
 }
 

--- a/server/api_app_template_reset_test.go
+++ b/server/api_app_template_reset_test.go
@@ -247,6 +247,48 @@ volumename = "data-volume"
 	}
 }
 
+// TestBuildValidatedTempAppConfigFromTemplate_StampsAppConfigVersion covers
+// Phase 10 task 5 for the template reset/preview flow: the temp config built
+// from an unversioned template's canonicalized content (CanonicalizeAppContent
+// via buildValidatedTempAppConfigFromTemplate) is flagged with
+// AppConfigVersion = config.AppConfigVersionV2.
+func TestBuildValidatedTempAppConfigFromTemplate_StampsAppConfigVersion(t *testing.T) {
+	cl := &cluster.Cluster{Conf: &config.Config{WorkingDir: t.TempDir()}}
+	node := &cluster.App{
+		Name:                 "myapp",
+		AppConfig:            seedAppConfigForTemplateResetTests(),
+		AppClusterSubstitute: `{}`,
+	}
+
+	if err := writeLocalAppTemplate(cl.Conf.WorkingDir, "version-stamp", `
+prov-app-docker-img = "templated/new:9"
+
+[deployment]
+[[deployment.storages.volumes]]
+name = "data-volume"
+poolname = "data"
+volumedir = "data"
+
+[[deployment.paths]]
+name = "root"
+dockerpath = "/srv/app"
+srctype = "volume"
+srcname = "data-volume"
+srcpath = "."
+volumename = "data-volume"
+`); err != nil {
+		t.Fatalf("writeLocalAppTemplate: %v", err)
+	}
+
+	tempConfig, err := buildValidatedTempAppConfigFromTemplate(cl, node, "version-stamp", false)
+	if err != nil {
+		t.Fatalf("buildValidatedTempAppConfigFromTemplate: %v", err)
+	}
+	if got := tempConfig.AppConfigVersion; got != config.AppConfigVersionV2 {
+		t.Fatalf("expected AppConfigVersion %d, got %d", config.AppConfigVersionV2, got)
+	}
+}
+
 func TestBuildTemplateProjectionImpact_ReportsChangedTemplateOwnedFields(t *testing.T) {
 	current := seedAppConfigForTemplateResetTests()
 	projected := seedAppConfigForTemplateResetTests()

--- a/server/api_app_template_reset_test.go
+++ b/server/api_app_template_reset_test.go
@@ -190,6 +190,63 @@ volumename = "data-volume"
 	}
 }
 
+// TestResetAppFromTemplate_VolumeNamesResolvedToAppName covers Phase 7: the
+// reset/preview projection must run the same canonical volume merge as
+// AddSeededApp/LoadAppConfig (CanonicalizeAppContent with appName =
+// node.Name), so a template-owned volume row ends up named "<app>-<pool>"
+// (the resolved-app convention) rather than left as the template's
+// "{name}-<pool>" placeholder or its original pre-canonical name.
+func TestResetAppFromTemplate_VolumeNamesResolvedToAppName(t *testing.T) {
+	cl := &cluster.Cluster{Conf: &config.Config{WorkingDir: t.TempDir()}}
+	node := &cluster.App{
+		Name:                 "myapp",
+		AppConfig:            seedAppConfigForTemplateResetTests(),
+		AppClusterSubstitute: `{}`,
+	}
+
+	if err := writeLocalAppTemplate(cl.Conf.WorkingDir, "vol-naming", `
+prov-app-docker-img = "templated/new:9"
+
+[deployment]
+[[deployment.storages.volumes]]
+name = "data-volume"
+poolname = "data"
+volumedir = "data"
+
+[[deployment.paths]]
+name = "root"
+dockerpath = "/srv/app"
+srctype = "volume"
+srcname = "data-volume"
+srcpath = "."
+volumename = "data-volume"
+`); err != nil {
+		t.Fatalf("writeLocalAppTemplate: %v", err)
+	}
+
+	if err := resetAppFromTemplateWithProjection(cl, node, "vol-naming", false); err != nil {
+		t.Fatalf("resetAppFromTemplateWithProjection: %v", err)
+	}
+
+	dep := node.AppConfig.Deployment
+	if dep == nil || len(dep.Storages.Volumes) != 1 {
+		t.Fatalf("expected 1 merged volume row, got %+v", dep)
+	}
+	if got := dep.Storages.Volumes[0].Name; got != "myapp-data" {
+		t.Fatalf("expected volume name resolved to myapp-data, got %q", got)
+	}
+
+	if len(dep.Paths) != 1 {
+		t.Fatalf("expected 1 path, got %d", len(dep.Paths))
+	}
+	if got := dep.Paths[0].SourceName; got != "myapp-data" {
+		t.Fatalf("expected path srcname resolved to myapp-data, got %q", got)
+	}
+	if got := dep.Paths[0].VolumeName; got != "myapp-data" {
+		t.Fatalf("expected path volumename resolved to myapp-data, got %q", got)
+	}
+}
+
 func TestBuildTemplateProjectionImpact_ReportsChangedTemplateOwnedFields(t *testing.T) {
 	current := seedAppConfigForTemplateResetTests()
 	projected := seedAppConfigForTemplateResetTests()

--- a/server/api_app_template_reset_test.go
+++ b/server/api_app_template_reset_test.go
@@ -336,6 +336,11 @@ level = 0
 	if len(dep.Storages.S3Mounts) != 1 || dep.Storages.S3Mounts[0].VolumeName != "myapp-data-logs" {
 		t.Fatalf("expected s3-mount to keep referencing myapp-data-logs, got %+v", dep.Storages.S3Mounts)
 	}
+	// Phase 15 task 4: explicit non-"mnt" S3 placement must survive the reset
+	// flow unchanged, not be snapped back to a "mnt/..." default.
+	if dep.Storages.S3Mounts[0].VolumeDir != "logs/media" {
+		t.Fatalf("expected s3-mount explicit volumedir \"logs/media\" preserved, got %q", dep.Storages.S3Mounts[0].VolumeDir)
+	}
 
 	if len(dep.Paths) != 2 {
 		t.Fatalf("expected 2 paths, got %d", len(dep.Paths))

--- a/server/api_app_template_reset_test.go
+++ b/server/api_app_template_reset_test.go
@@ -247,6 +247,108 @@ volumename = "data-volume"
 	}
 }
 
+// TestResetAppFromTemplate_V2MultiRowSamePoolPreserved is a Phase 11
+// follow-up to TestResetAppFromTemplate_VolumeNamesResolvedToAppName: a
+// V2-flagged template with two intentional same-pool volume rows (plus a
+// git-clone and an s3-mount referencing those rows) must reset onto an app
+// with both rows preserved -- not merged into the single "<app>-<pool>" row
+// the V1 path produces -- and with each path/git-clone/s3-mount reference
+// staying pointed at its own distinct row.
+func TestResetAppFromTemplate_V2MultiRowSamePoolPreserved(t *testing.T) {
+	cl := &cluster.Cluster{Conf: &config.Config{WorkingDir: t.TempDir()}}
+	node := &cluster.App{
+		Name:                 "myapp",
+		AppConfig:            seedAppConfigForTemplateResetTests(),
+		AppClusterSubstitute: `{}`,
+	}
+
+	if err := writeLocalAppTemplate(cl.Conf.WorkingDir, "v2-multi-row", `
+app-config-version = 2
+
+prov-app-docker-img = "templated/new:9"
+
+[deployment]
+[[deployment.storages.volumes]]
+name = "myapp-data"
+poolname = "data"
+volumedir = "data"
+
+[[deployment.storages.volumes]]
+name = "myapp-data-logs"
+poolname = "data"
+volumedir = "logs"
+
+[[deployment.storages.git-clones]]
+name = "app-src"
+volumename = "myapp-data"
+volumedir = "data/app-src"
+
+[[deployment.storages.s3-mounts]]
+name = "media"
+volumename = "myapp-data-logs"
+volumedir = "logs/media"
+
+[[deployment.paths]]
+name = "root"
+dockerpath = "/srv/app"
+srctype = "volume"
+srcname = "myapp-data"
+srcpath = "."
+volumename = "myapp-data"
+level = 0
+
+[[deployment.paths]]
+name = "log-dir"
+dockerpath = "/srv/log"
+srctype = "volume"
+srcname = "myapp-data-logs"
+srcpath = "."
+volumename = "myapp-data-logs"
+level = 0
+`); err != nil {
+		t.Fatalf("writeLocalAppTemplate: %v", err)
+	}
+
+	if err := resetAppFromTemplateWithProjection(cl, node, "v2-multi-row", false); err != nil {
+		t.Fatalf("resetAppFromTemplateWithProjection: %v", err)
+	}
+
+	if got := node.AppConfig.AppConfigVersion; got != config.AppConfigVersionV2 {
+		t.Fatalf("expected AppConfigVersion %d, got %d", config.AppConfigVersionV2, got)
+	}
+
+	dep := node.AppConfig.Deployment
+	if dep == nil || len(dep.Storages.Volumes) != 2 {
+		t.Fatalf("expected both volume rows preserved, got %+v", dep)
+	}
+	if dep.Storages.Volumes[0].Name != "myapp-data" || dep.Storages.Volumes[1].Name != "myapp-data-logs" {
+		t.Fatalf("expected distinct volume row names myapp-data/myapp-data-logs, got %q/%q",
+			dep.Storages.Volumes[0].Name, dep.Storages.Volumes[1].Name)
+	}
+	if dep.Storages.Volumes[0].VolumeDir != "data" || dep.Storages.Volumes[1].VolumeDir != "logs" {
+		t.Fatalf("expected volumedir left unmerged (data/logs), got %q/%q",
+			dep.Storages.Volumes[0].VolumeDir, dep.Storages.Volumes[1].VolumeDir)
+	}
+
+	if len(dep.Storages.GitClones) != 1 || dep.Storages.GitClones[0].VolumeName != "myapp-data" {
+		t.Fatalf("expected git-clone to keep referencing myapp-data, got %+v", dep.Storages.GitClones)
+	}
+	if len(dep.Storages.S3Mounts) != 1 || dep.Storages.S3Mounts[0].VolumeName != "myapp-data-logs" {
+		t.Fatalf("expected s3-mount to keep referencing myapp-data-logs, got %+v", dep.Storages.S3Mounts)
+	}
+
+	if len(dep.Paths) != 2 {
+		t.Fatalf("expected 2 paths, got %d", len(dep.Paths))
+	}
+	srcnames := map[string]string{}
+	for _, p := range dep.Paths {
+		srcnames[p.Name] = p.SourceName
+	}
+	if srcnames["root"] != "myapp-data" || srcnames["log-dir"] != "myapp-data-logs" {
+		t.Fatalf("expected distinct path srcnames, got %+v", srcnames)
+	}
+}
+
 // TestBuildValidatedTempAppConfigFromTemplate_StampsAppConfigVersion covers
 // Phase 10 task 5 for the template reset/preview flow: the temp config built
 // from an unversioned template's canonicalized content (CanonicalizeAppContent

--- a/server/api_app_volume_v2_test.go
+++ b/server/api_app_volume_v2_test.go
@@ -1,0 +1,213 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/signal18/replication-manager/cluster"
+	"github.com/signal18/replication-manager/config"
+)
+
+const (
+	volumeTestUser    = "volumetestuser"
+	volumeTestCluster = "volume-test-cluster"
+	volumeTestAppId   = "volume-test-app"
+)
+
+// newVolumeTestSetup builds a minimal ReplicationManager/Cluster/App with a
+// single saved deployment.storages.volumes row on pool "data", and an
+// app-config-version of either 0 (V1) or config.AppConfigVersionV2,
+// depending on appConfigVersion.
+func newVolumeTestSetup(t *testing.T, appConfigVersion int) (*ReplicationManager, *cluster.Cluster, *cluster.App) {
+	t.Helper()
+
+	appCnf := &config.AppConfig{
+		AppHost:          "app-a",
+		AppPort:          "8080",
+		AppConfigVersion: appConfigVersion,
+		Deployment: &config.Deployment{
+			Storages: config.StorageMapping{
+				Volumes: config.Volumes{
+					{Name: "myapp-data", PoolName: "data", VolumeDir: "etc"},
+				},
+			},
+		},
+	}
+	app := &cluster.App{
+		Id:        volumeTestAppId,
+		Name:      volumeTestAppId,
+		Host:      "app-a",
+		Port:      "8080",
+		AppConfig: appCnf,
+		Mutex:     &sync.Mutex{},
+	}
+	cl := &cluster.Cluster{
+		Name: volumeTestCluster,
+		Conf: &config.Config{
+			WorkingDir: t.TempDir(),
+		},
+		WorkingDir: t.TempDir(),
+	}
+	cl.Conf.Apps = []*config.AppConfig{appCnf}
+	cl.Apps = []*cluster.App{app}
+	cl.ConfigManager = newConfigManagerForTest()
+	cl.APIUsers = map[string]cluster.APIUser{
+		volumeTestUser: {
+			User:     volumeTestUser,
+			Password: "enc",
+			Grants:   map[string]bool{config.GrantAppDeployment: true},
+		},
+	}
+
+	repman := &ReplicationManager{
+		Clusters:    map[string]*cluster.Cluster{cl.Name: cl},
+		ClusterList: []string{cl.Name},
+		Conf:        &config.Config{TokenTimeout: 1},
+	}
+	repman.initKeys()
+	return repman, cl, app
+}
+
+func issueVolumeTestJWT(t *testing.T, repman *ReplicationManager) string {
+	t.Helper()
+	tok, err := repman.issueJWT(struct {
+		Name     string
+		Role     string
+		Password string
+	}{volumeTestUser, "Member", "enc"}, "")
+	if err != nil {
+		t.Fatalf("issueJWT: %v", err)
+	}
+	return tok
+}
+
+// newAddVolumeRequest builds a POST request equivalent to
+// /api/clusters/{cluster}/apps/{app}/storages/volumes/add with the given
+// volume row as JSON body.
+func newAddVolumeRequest(t *testing.T, repman *ReplicationManager, cl *cluster.Cluster, vol config.Volume) *http.Request {
+	t.Helper()
+	tok := issueVolumeTestJWT(t, repman)
+	body, _ := json.Marshal(vol)
+	url := fmt.Sprintf("/api/clusters/%s/apps/%s/storages/volumes/add", cl.Name, volumeTestAppId)
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req = setMuxVars(req, map[string]string{
+		"clusterName": cl.Name,
+		"appName":     volumeTestAppId,
+		"field":       "volumes",
+	})
+	return req
+}
+
+// newModifyVolumePoolnameRequest builds a POST request equivalent to
+// /api/clusters/{cluster}/apps/{app}/storages/volumes/index/{index}/poolname/modify.
+func newModifyVolumePoolnameRequest(t *testing.T, repman *ReplicationManager, cl *cluster.Cluster, index int, newPool string) *http.Request {
+	t.Helper()
+	tok := issueVolumeTestJWT(t, repman)
+	body, _ := json.Marshal(map[string]string{"value": newPool})
+	url := fmt.Sprintf("/api/clusters/%s/apps/%s/storages/volumes/index/%d/poolname/modify", cl.Name, volumeTestAppId, index)
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req = setMuxVars(req, map[string]string{
+		"clusterName": cl.Name,
+		"appName":     volumeTestAppId,
+		"field":       "volumes",
+		"index":       fmt.Sprintf("%d", index),
+		"key":         "poolname",
+	})
+	return req
+}
+
+// TestAddStorageVolume_RejectsSecondRowOnUsedPoolWhenV1 covers Phase 11: for
+// unflagged/V1 content (AppConfigVersion == 0), adding a second volume row
+// on a pool that already has a saved row is rejected, matching the
+// one-row-per-pool invariant enforced by InsertVolume.
+func TestAddStorageVolume_RejectsSecondRowOnUsedPoolWhenV1(t *testing.T) {
+	repman, cl, app := newVolumeTestSetup(t, 0)
+	req := newAddVolumeRequest(t, repman, cl, config.Volume{Name: "myapp-data-logs", PoolName: "data", VolumeDir: "log"})
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddStorage(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for duplicate pool on V1, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(app.AppConfig.Deployment.Storages.Volumes) != 1 {
+		t.Fatalf("expected volumes unchanged at 1 row, got %d", len(app.AppConfig.Deployment.Storages.Volumes))
+	}
+}
+
+// TestAddStorageVolume_AllowsSecondRowOnUsedPoolWhenV2 covers Phase 11 task
+// 9/10: once AppConfigVersion >= AppConfigVersionV2, adding a second
+// intentional volume row on a pool that already has a saved row succeeds.
+func TestAddStorageVolume_AllowsSecondRowOnUsedPoolWhenV2(t *testing.T) {
+	repman, cl, app := newVolumeTestSetup(t, config.AppConfigVersionV2)
+	req := newAddVolumeRequest(t, repman, cl, config.Volume{Name: "myapp-data-logs", PoolName: "data", VolumeDir: "log"})
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddStorage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for duplicate pool on V2, got %d: %s", w.Code, w.Body.String())
+	}
+	volumes := app.AppConfig.Deployment.Storages.Volumes
+	if len(volumes) != 2 {
+		t.Fatalf("expected 2 volume rows, got %d", len(volumes))
+	}
+	if volumes[1].Name != "myapp-data-logs" || volumes[1].PoolName != "data" {
+		t.Fatalf("expected second row myapp-data-logs on pool data, got %+v", volumes[1])
+	}
+}
+
+// TestModifyVolumePoolname_RejectsMoveOntoUsedPoolWhenV1 covers Phase 11: for
+// unflagged/V1 content, moving a row's poolname onto a pool another saved
+// row already occupies is rejected.
+func TestModifyVolumePoolname_RejectsMoveOntoUsedPoolWhenV1(t *testing.T) {
+	repman, cl, app := newVolumeTestSetup(t, 0)
+	app.AppConfig.Deployment.Storages.Volumes = append(app.AppConfig.Deployment.Storages.Volumes,
+		&config.Volume{Name: "myapp-docs", PoolName: "docs", VolumeDir: "docs"})
+
+	req := newModifyVolumePoolnameRequest(t, repman, cl, 1, "data")
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxModifyStorageField(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 moving onto used pool on V1, got %d: %s", w.Code, w.Body.String())
+	}
+	if app.AppConfig.Deployment.Storages.Volumes[1].PoolName != "docs" {
+		t.Fatalf("expected second row poolname unchanged, got %q", app.AppConfig.Deployment.Storages.Volumes[1].PoolName)
+	}
+}
+
+// TestModifyVolumePoolname_AllowsMoveOntoUsedPoolWhenV2 covers Phase 11 task
+// 9/10: for V2 content, moving a row's poolname onto a pool another saved
+// row already occupies succeeds, producing two rows on the same pool.
+func TestModifyVolumePoolname_AllowsMoveOntoUsedPoolWhenV2(t *testing.T) {
+	repman, cl, app := newVolumeTestSetup(t, config.AppConfigVersionV2)
+	app.AppConfig.Deployment.Storages.Volumes = append(app.AppConfig.Deployment.Storages.Volumes,
+		&config.Volume{Name: "myapp-docs", PoolName: "docs", VolumeDir: "docs"})
+
+	req := newModifyVolumePoolnameRequest(t, repman, cl, 1, "data")
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxModifyStorageField(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 moving onto used pool on V2, got %d: %s", w.Code, w.Body.String())
+	}
+	volumes := app.AppConfig.Deployment.Storages.Volumes
+	if volumes[0].PoolName != "data" || volumes[1].PoolName != "data" {
+		t.Fatalf("expected both rows on pool data, got %q and %q", volumes[0].PoolName, volumes[1].PoolName)
+	}
+	if volumes[1].Name != "myapp-docs" {
+		t.Fatalf("expected second row name unchanged, got %q", volumes[1].Name)
+	}
+}

--- a/server/api_app_volume_v2_test.go
+++ b/server/api_app_volume_v2_test.go
@@ -179,8 +179,8 @@ func TestModifyVolumePoolname_RejectsMoveOntoUsedPoolWhenV1(t *testing.T) {
 	w := httptest.NewRecorder()
 	repman.handlerMuxModifyStorageField(w, req)
 
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("expected 500 moving onto used pool on V1, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 moving onto used pool on V1, got %d: %s", w.Code, w.Body.String())
 	}
 	if app.AppConfig.Deployment.Storages.Volumes[1].PoolName != "docs" {
 		t.Fatalf("expected second row poolname unchanged, got %q", app.AppConfig.Deployment.Storages.Volumes[1].PoolName)

--- a/share/dashboard_react/package.json
+++ b/share/dashboard_react/package.json
@@ -11,7 +11,8 @@
     "test:terminal-rid": "node src/Pages/Terminal/__tests__/ridUtils.test.js",
     "test:s3-provider-picker": "node src/Pages/ClusterApp/components/Storage/__tests__/s3DirectoryProviderPicker.test.js",
     "test:s3-provider-bulk-sync": "node src/Pages/Settings/__tests__/s3ProviderBulkSyncUtils.test.js",
-    "test:sync-diff-utils": "node src/components/__tests__/syncDiffUtils.test.js"
+    "test:sync-diff-utils": "node src/components/__tests__/syncDiffUtils.test.js",
+    "test:volume-dir-tokens": "node src/Pages/ClusterApp/components/Storage/__tests__/volumeDirTokens.test.js"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.10.5",

--- a/share/dashboard_react/package.json
+++ b/share/dashboard_react/package.json
@@ -12,7 +12,9 @@
     "test:s3-provider-picker": "node src/Pages/ClusterApp/components/Storage/__tests__/s3DirectoryProviderPicker.test.js",
     "test:s3-provider-bulk-sync": "node src/Pages/Settings/__tests__/s3ProviderBulkSyncUtils.test.js",
     "test:sync-diff-utils": "node src/components/__tests__/syncDiffUtils.test.js",
-    "test:volume-dir-tokens": "node src/Pages/ClusterApp/components/Storage/__tests__/volumeDirTokens.test.js"
+    "test:volume-dir-tokens": "node src/Pages/ClusterApp/components/Storage/__tests__/volumeDirTokens.test.js",
+    "test:git-clone-volume-dir": "node src/Pages/ClusterApp/components/Storage/__tests__/gitCloneVolumeDir.test.js",
+    "test:s3-volume-dir": "node src/Pages/ClusterApp/components/Storage/__tests__/s3VolumeDir.test.js"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.10.5",

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Overview/Paths.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Overview/Paths.jsx
@@ -13,6 +13,11 @@ import { showErrorToast } from '../../../../redux/toastSlice';
 import { getDockerTree, getGitTree, hashMurmur } from '../../../../redux/pathSlice';
 import { createColumnHelper } from '@tanstack/react-table';
 import { DataTable } from '../../../../components/DataTable';
+import {
+  composeSourcePath,
+  getDisplaySubPath,
+  getVolumeDirTokens,
+} from '../Storage/volumeDirUtils';
 
 const sourceTypes = [
   { value: '', name: 'Select Source', isChildOption: true },
@@ -35,40 +40,6 @@ const defaultPath = {
 
 const nodeToValue = (node) => (node.type === "directory" && !node.path.endsWith("/") ? node.path + "/" : node.path);
 const nodeToString = (node) => node.name || node.path;
-
-const normalizeSubPath = (value) => {
-  const raw = typeof value === 'string' ? value.trim() : '';
-  if (!raw || raw === '/' || raw === '.') return '/';
-  return raw.startsWith('/') ? raw : `/${raw}`;
-};
-
-const composeSourcePath = (srcbasepath, subpath) => {
-  const normalizedSubPath = normalizeSubPath(subpath);
-  if (!srcbasepath) {
-    // Volume-type sources have no single base path: srcpath is relative to
-    // the pool's disk root, where "." denotes the root itself.
-    return normalizedSubPath === '/' ? '.' : normalizedSubPath.slice(1);
-  }
-  if (normalizedSubPath === '/') return srcbasepath;
-  return `${srcbasepath}${normalizedSubPath}`.replace('//', '/');
-};
-
-// volumedir lists the pool's available top-level directories as a
-// whitespace-separated string (see config.Volume.GetVolumeDirs()).
-const getVolumeDirTokens = (volumedir) =>
-  typeof volumedir === 'string' ? volumedir.split(/\s+/).filter(Boolean) : [];
-
-const getDisplaySubPath = (srcpath, srcbasepath) => {
-  const sourcePath = typeof srcpath === 'string' ? srcpath : '';
-  const basePath = typeof srcbasepath === 'string' ? srcbasepath : '';
-
-  if (basePath && sourcePath && sourcePath.startsWith(basePath)) {
-    const rel = sourcePath.slice(basePath.length);
-    return normalizeSubPath(rel);
-  }
-
-  return normalizeSubPath(sourcePath);
-};
 
 const columnHelper = createColumnHelper()
 

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Overview/Paths.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Overview/Paths.jsx
@@ -38,16 +38,25 @@ const nodeToString = (node) => node.name || node.path;
 
 const normalizeSubPath = (value) => {
   const raw = typeof value === 'string' ? value.trim() : '';
-  if (!raw || raw === '/') return '/';
+  if (!raw || raw === '/' || raw === '.') return '/';
   return raw.startsWith('/') ? raw : `/${raw}`;
 };
 
 const composeSourcePath = (srcbasepath, subpath) => {
   const normalizedSubPath = normalizeSubPath(subpath);
-  if (!srcbasepath) return normalizedSubPath;
+  if (!srcbasepath) {
+    // Volume-type sources have no single base path: srcpath is relative to
+    // the pool's disk root, where "." denotes the root itself.
+    return normalizedSubPath === '/' ? '.' : normalizedSubPath.slice(1);
+  }
   if (normalizedSubPath === '/') return srcbasepath;
   return `${srcbasepath}${normalizedSubPath}`.replace('//', '/');
 };
+
+// volumedir lists the pool's available top-level directories as a
+// whitespace-separated string (see config.Volume.GetVolumeDirs()).
+const getVolumeDirTokens = (volumedir) =>
+  typeof volumedir === 'string' ? volumedir.split(/\s+/).filter(Boolean) : [];
 
 const getDisplaySubPath = (srcpath, srcbasepath) => {
   const sourcePath = typeof srcpath === 'string' ? srcpath : '';
@@ -102,10 +111,14 @@ const PathSection = ({
     const vol = srctype === "volume" ? volumeOptions.find(opt => opt.name === srcname) : null;
     const gc = srctype === "git" ? gitOptions.find(opt => opt.value === srcname) : null;
     const s3 = srctype === "s3" ? s3Options.find(opt => opt.value === srcname) : null;
-    const srcbasepath = srctype === "volume" ? vol?.volumedir || "" : srctype === "git" ? gc?.volumedir || "" : srctype === "s3" ? s3?.volumedir || "" : "";
+    // Volume-type sources have no single base path: vol.volumedir lists the
+    // pool's available top-level directories, not a literal srcpath prefix.
+    const srcbasepath = srctype === "git" ? gc?.volumedir || "" : srctype === "s3" ? s3?.volumedir || "" : "";
+    const availableDirs = srctype === "volume" ? getVolumeDirTokens(vol?.volumedir) : [];
     return {
       ...row,
       srcbasepath: srcbasepath,
+      availableDirs,
       subpath: getDisplaySubPath(srcpath, srcbasepath),
       parentname: parentname || parent.value,
       parentpath: parent.dockerpath || parent.srcpath,
@@ -156,7 +169,7 @@ const PathSection = ({
       columnHelper.accessor((row) => row.srcname, {
         header: 'Source Name'
       }),
-      columnHelper.accessor((row) => row.srcbasepath, {
+      columnHelper.accessor((row) => row.srctype === 'volume' ? (row.availableDirs || []).join(', ') : row.srcbasepath, {
         header: 'Storage Base Path'
       }),
       columnHelper.accessor((row) => row.subpath, {
@@ -266,16 +279,22 @@ const PathRowForm = React.memo(({ fieldName, path, index, clusterName, appId, gi
   }, [parentsrctype, parentGitTree, dockerTree, parentpath, parentsrcpath]);
 
   const { srcTree, srcbasepath } = useMemo(() => {
-    if (srctype === "vol" && vol) {
-      return { srcTree: dockerTree, srcbasepath: vol?.volumedir || "" };
-    } else if (srctype === "git" && gc) {
+    if (srctype === "git" && gc) {
       return { srcTree: gitTree, srcbasepath: gc?.volumedir || "" };
     } else if (srctype === "s3" && s3) {
       return { srcTree: s3Tree, srcbasepath: s3?.volumedir || "" };
     } else {
+      // Volume-type sources (and the unset/default state) have no single
+      // base path: vol.volumedir lists the pool's available top-level
+      // directories, and srcpath is itself relative to the pool disk root.
       return { srcTree: dockerTree, srcbasepath: "" };
     }
-  }, [srctype, gitTree, s3Tree, dockerTree]);
+  }, [srctype, gc, s3, gitTree, s3Tree, dockerTree]);
+
+  const availableDirs = useMemo(
+    () => srctype === "volume" ? getVolumeDirTokens(vol?.volumedir) : [],
+    [srctype, vol]
+  );
 
   const subpath = useMemo(() => {
     return getDisplaySubPath(srcpath, srcbasepath);
@@ -338,9 +357,10 @@ const PathRowForm = React.memo(({ fieldName, path, index, clusterName, appId, gi
         <Text mb={1}>{srcLabel}</Text>
         <Dropdown key={srctype} confirmTitle={"Source changed"} placeholder="Source" options={srcOptions} selectedValue={srcname} onChange={(value) => onRowArrayChange(fieldName, index, "srcname", value)} />
         {srcbasepath && (<Text key={srcname} mb={1} fontSize="sm" color="gray.500">Basepath: {srcbasepath}</Text>)}
+        {srctype === 'volume' && availableDirs.length > 0 && (<Text key={`${srcname}-dirs`} mb={1} fontSize="sm" color="gray.500">Available directories: {availableDirs.join(', ')}</Text>)}
       </Flex>
     );
-  }, [srctype, volumeOptions, gitOptions, s3Options]);
+  }, [srctype, volumeOptions, gitOptions, s3Options, srcname, srcbasepath, availableDirs]);
 
   const handleOnTreeSelect = useCallback((subpaths) => {
     if (typeof subpaths === 'string') {
@@ -432,6 +452,11 @@ const PathNewForm = React.memo(({ clusterName, appId, parentRow, gitOptions, vol
     [srctype, srcname, s3Options]
   );
 
+  const availableDirs = useMemo(
+    () => srctype === "volume" ? getVolumeDirTokens(vol?.volumedir) : [],
+    [srctype, vol]
+  );
+
   const srcDropdown = useMemo(() => {
     let srcOptions = [];
     let srcLabel = '';
@@ -457,9 +482,10 @@ const PathNewForm = React.memo(({ clusterName, appId, parentRow, gitOptions, vol
         <Text mb={1}>{srcLabel}</Text>
         <Dropdown key={srctype} placeholder="Source" options={srcOptions} selectedValue={srcname} onChange={(option) => handleArrayChange("srcname", option.value)} />
         {srcbasepath && (<Text key={srcname} mb={1} fontSize="sm" color="gray.500">Basepath: {srcbasepath}</Text>)}
+        {srctype === 'volume' && availableDirs.length > 0 && (<Text key={`${srcname}-dirs`} mb={1} fontSize="sm" color="gray.500">Available directories: {availableDirs.join(', ')}</Text>)}
       </Flex>
     );
-  }, [srctype, volumeOptions, gitOptions, s3Options]);
+  }, [srctype, volumeOptions, gitOptions, s3Options, srcname, srcbasepath, availableDirs]);
 
   const parent = useMemo(() => (parentRow || { name: "", dockerpath: "", srcpath: "", srctype: "", srcname: "" }), [parentRow]);
   const { name: parentname, dockerpath: parentpath, srctype: parentsrctype, srcname: parentsrcname, srcpath: parentsrcpath } = parent;
@@ -510,16 +536,16 @@ const PathNewForm = React.memo(({ clusterName, appId, parentRow, gitOptions, vol
       } else if (key === "dockersubpath") {
         newPath.dockersubpath = (parentpath + (value.startsWith("/") ? value : `/${value}`)).replace("//", "/");
       } else if (key === "srcname") {
-        if (prev.srctype === "volume") {
-          const found = volumeOptions.find(opt => opt.name === value);
-          newPath.srcbasepath = found ? found.volumedir : "";
-        } else if (prev.srctype === "git") {
+        if (prev.srctype === "git") {
           const found = gitOptions.find(opt => opt.value === value);
           newPath.srcbasepath = found ? found.volumedir : "";
         } else if (prev.srctype === "s3") {
           const found = s3Options.find(opt => opt.value === value);
           newPath.srcbasepath = found ? found.volumedir : "";
         } else {
+          // Volume-type sources (and the unset/default state) have no
+          // single base path: vol.volumedir lists the pool's available
+          // top-level directories, not a literal srcpath prefix.
           newPath.srcbasepath = "";
         }
         newPath.srcpath = composeSourcePath(newPath.srcbasepath, newPath.subpath);

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Overview/Paths.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Overview/Paths.jsx
@@ -107,7 +107,7 @@ const PathSection = ({
 
   const resolvedRows = useMemo(() => rows.map((row) => {
     const { srctype, srcname, srcpath, parentname } = row;
-    const parent = rows.find(r => r.name === row.name) || { dockerpath: "", srcpath: "", srctype: "", srcname: "" };
+    const parent = rows.find(r => r.name === row.parentname) || { dockerpath: "", srcpath: "", srctype: "", srcname: "" };
     const vol = srctype === "volume" ? volumeOptions.find(opt => opt.name === srcname) : null;
     const gc = srctype === "git" ? gitOptions.find(opt => opt.value === srcname) : null;
     const s3 = srctype === "s3" ? s3Options.find(opt => opt.value === srcname) : null;

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/GitClone.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/GitClone.jsx
@@ -44,6 +44,25 @@ const maskString = (str, mask = '*') => {
     return str.replaceAll(/./g, mask)
 }
 
+// volumedir lists the volume's available top-level directories as a
+// whitespace-separated string (see config.Volume.GetVolumeDirs()).
+const getVolumeDirTokens = (volumedir) =>
+    typeof volumedir === "string" ? volumedir.split(/\s+/).filter(Boolean) : [];
+
+// Mirrors config.Volume.DefaultSubdir(): the first directory token, used as
+// the default base path when assigning a volume to a git clone.
+const defaultSubdir = (volumedir) => getVolumeDirTokens(volumedir)[0] || "";
+
+// Finds which of the volume's directory tokens `path` is rooted under
+// (either equal to the token or "<token>/..."), falling back to the
+// volume's default subdir if no token matches (e.g. legacy paths predating
+// the multi-directory volume merge).
+const matchVolumeDirToken = (path, volumedir) => {
+    const dirs = getVolumeDirTokens(volumedir);
+    const match = dirs.find((dir) => path === dir || path.startsWith(`${dir}/`));
+    return match || defaultSubdir(volumedir);
+};
+
 const GitCloneSection = React.memo(function GitCloneSection({
     rows = [],
     volumeOptions = [],
@@ -183,12 +202,14 @@ const GitRowForm = React.memo(function GitRowForm({ fieldName, gitClone, index, 
     }, [gc.name]);
 
     const vol = useMemo(() => volumeOptions.find((opt) => opt.value === volumename), [volumeOptions, volumename]);
-    const srcbasepath = vol ? vol.volumedir : "";
+    const availableDirs = useMemo(() => getVolumeDirTokens(vol?.volumedir), [vol]);
+    const srcbasepath = useMemo(() => matchVolumeDirToken(volumedir, vol?.volumedir), [volumedir, vol]);
     const subpath = useMemo(() => volumedir.startsWith(srcbasepath) ? volumedir.substring(srcbasepath.length + 1) : volumedir, [volumedir, srcbasepath]);
 
     const handleVolume = useCallback((value) => {
         const vol = volumeOptions.find((opt) => opt.value === value);
-        const newValue = vol ? vol.volumedir + (subpath.startsWith("/") ? subpath : "/" + subpath) : volumedir;
+        const base = defaultSubdir(vol?.volumedir);
+        const newValue = vol ? base + (subpath.startsWith("/") ? subpath : "/" + subpath) : volumedir;
         onChange(fieldName, index, "volumename", vol ? vol.value : "");
         onChange(fieldName, index, "volumedir", newValue);
     }, [fieldName, index, volumeOptions, subpath, volumedir, onChange]);
@@ -261,6 +282,7 @@ const GitRowForm = React.memo(function GitRowForm({ fieldName, gitClone, index, 
                     <Text mb={1}>Volume:</Text>
                     <Dropdown key={`volume-${index}`} placeholder="Volume" confirmTitle="Change Volume" options={volumeOptions} selectedValue={volumename} onChange={(value) => handleVolume(value)} />
                     {srcbasepath && (<Text key={volumename} mb={1} fontSize="sm" color="gray.500">Basepath: {srcbasepath}</Text>)}
+                    {availableDirs.length > 1 && (<Text key={`${volumename}-dirs`} mb={1} fontSize="sm" color="gray.500">Volume directories: {availableDirs.join(', ')}</Text>)}
                 </Flex>
                 <Flex direction="column" flex="1">
                     <Text mb={1}>Sub Dir:</Text>
@@ -278,9 +300,14 @@ const GitNewForm = React.memo(function GitNewForm({ volumeOptions, onSave = () =
     const { theme } = useTheme();
     const { name, repo, branch, user, pass, volumename, volumedir, subpath } = gc;
 
+    const availableDirs = useMemo(() => {
+        const vol = volumeOptions.find((opt) => opt.value === volumename);
+        return getVolumeDirTokens(vol?.volumedir);
+    }, [volumeOptions, volumename]);
+
     const srcbasepath = useMemo(() => {
         const vol = volumeOptions.find((opt) => opt.value === volumename);
-        return vol ? vol.volumedir : "";
+        return defaultSubdir(vol?.volumedir);
     }, [volumeOptions, volumename]);
 
     const valid = useMemo(() => name && repo && branch && volumedir, [name, repo, branch, volumedir]);
@@ -300,7 +327,8 @@ const GitNewForm = React.memo(function GitNewForm({ volumeOptions, onSave = () =
 
     const handleVolume = useCallback((option) => {
         const newSubpath = !subpath.trim() || subpath.trim() === "/" ? name : subpath;
-        const newValue = option.volumedir + (newSubpath.startsWith("/") ? newSubpath : "/" + newSubpath);
+        const base = defaultSubdir(option.volumedir);
+        const newValue = base + (newSubpath.startsWith("/") ? newSubpath : "/" + newSubpath);
         handleArrayChange("volumename", option.value);
         handleArrayChange("volumedir", newValue);
     }, [name, subpath, handleArrayChange]);
@@ -376,6 +404,7 @@ const GitNewForm = React.memo(function GitNewForm({ volumeOptions, onSave = () =
                     <Text mb={1}>Volume:</Text>
                     <Dropdown key={`volume-new`} placeholder="Volume" options={volumeOptions} selectedValue={volumename} onChange={(option) => handleVolume(option)} />
                     {srcbasepath && (<Text key={volumename} mb={1} fontSize="sm" color="gray.500">Basepath: {srcbasepath}</Text>)}
+                    {availableDirs.length > 1 && (<Text key={`${volumename}-dirs`} mb={1} fontSize="sm" color="gray.500">Volume directories: {availableDirs.join(', ')}</Text>)}
                 </Flex>
                 <Flex direction="column" flex="1">
                     <Text mb={1}>Volume Dir:</Text>

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/GitClone.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/GitClone.jsx
@@ -11,6 +11,13 @@ import Dropdown from "../../../../components/Dropdown";
 import { DataTable } from "../../../../components/DataTable";
 import { HiTrash } from "react-icons/hi";
 import { useTheme } from "../../../../ThemeProvider";
+import {
+    buildVolumeDir,
+    defaultSubdir,
+    extractSubDir,
+    getVolumeDirTokens,
+    matchVolumeDirToken,
+} from "./volumeDirUtils";
 
 const defaultGit = {
     name: "",
@@ -43,46 +50,6 @@ const formatGitError = (err) => {
 const maskString = (str, mask = '*') => {
     return str.replaceAll(/./g, mask)
 }
-
-// volumedir lists the volume's available top-level directories as a
-// whitespace-separated string (see config.Volume.GetVolumeDirs()).
-const getVolumeDirTokens = (volumedir) =>
-    typeof volumedir === "string" ? volumedir.split(/\s+/).filter(Boolean) : [];
-
-// Mirrors config.Volume.DefaultSubdir(): the first directory token, used as
-// the default base path when assigning a volume to a git clone.
-const defaultSubdir = (volumedir) => getVolumeDirTokens(volumedir)[0] || "";
-
-// Finds which of the volume's directory tokens `path` is rooted under
-// (either equal to the token or "<token>/..."), falling back to the
-// volume's default subdir if no token matches (e.g. legacy paths predating
-// the multi-directory volume merge).
-const matchVolumeDirToken = (path, volumedir) => {
-    const dirs = getVolumeDirTokens(volumedir);
-    const match = dirs.find((dir) => path === dir || path.startsWith(`${dir}/`));
-    return match || defaultSubdir(volumedir);
-};
-
-// Splits a persisted GitClone.volumedir into the portion beneath
-// `baseDirToken`, the inverse of buildVolumeDir. Falls back to the full value
-// when it isn't rooted under baseDirToken (e.g. a legacy path predating the
-// multi-directory volume merge, or a volume with no directory tokens at all).
-const extractSubDir = (volumedir, baseDirToken) => {
-    if (!baseDirToken) return volumedir;
-    if (volumedir === baseDirToken) return "";
-    if (volumedir.startsWith(`${baseDirToken}/`)) return volumedir.substring(baseDirToken.length + 1);
-    return volumedir;
-};
-
-// Builds the full GitClone.volumedir to persist from a selected base
-// directory token and a subdirectory beneath it, defaulting a blank
-// subdirectory to `cloneNameFallback` (the git clone name).
-const buildVolumeDir = (baseDirToken, subDir, cloneNameFallback) => {
-    const trimmed = typeof subDir === "string" ? subDir.trim() : "";
-    const sub = !trimmed || trimmed === "/" ? cloneNameFallback : subDir;
-    const cleanSub = sub.startsWith("/") ? sub.slice(1) : sub;
-    return baseDirToken ? `${baseDirToken}/${cleanSub}` : cleanSub;
-};
 
 const GitCloneSection = React.memo(function GitCloneSection({
     rows = [],
@@ -224,7 +191,7 @@ const GitRowForm = React.memo(function GitRowForm({ fieldName, gitClone, index, 
 
     const vol = useMemo(() => volumeOptions.find((opt) => opt.value === volumename), [volumeOptions, volumename]);
     const availableDirs = useMemo(() => getVolumeDirTokens(vol?.volumedir), [vol]);
-    const srcbasepath = useMemo(() => matchVolumeDirToken(volumedir, vol?.volumedir), [volumedir, vol]);
+    const srcbasepath = useMemo(() => matchVolumeDirToken(volumedir, vol?.volumedir, defaultSubdir), [volumedir, vol]);
     const subpath = useMemo(() => extractSubDir(volumedir, srcbasepath), [volumedir, srcbasepath]);
 
     const handleVolume = useCallback((value) => {
@@ -339,7 +306,7 @@ const GitNewForm = React.memo(function GitNewForm({ volumeOptions, onSave = () =
 
     const vol = useMemo(() => volumeOptions.find((opt) => opt.value === volumename), [volumeOptions, volumename]);
     const availableDirs = useMemo(() => getVolumeDirTokens(vol?.volumedir), [vol]);
-    const srcbasepath = useMemo(() => matchVolumeDirToken(volumedir, vol?.volumedir), [volumedir, vol]);
+    const srcbasepath = useMemo(() => matchVolumeDirToken(volumedir, vol?.volumedir, defaultSubdir), [volumedir, vol]);
 
     const valid = useMemo(() => name && repo && branch && volumedir, [name, repo, branch, volumedir]);
 

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/GitClone.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/GitClone.jsx
@@ -63,6 +63,27 @@ const matchVolumeDirToken = (path, volumedir) => {
     return match || defaultSubdir(volumedir);
 };
 
+// Splits a persisted GitClone.volumedir into the portion beneath
+// `baseDirToken`, the inverse of buildVolumeDir. Falls back to the full value
+// when it isn't rooted under baseDirToken (e.g. a legacy path predating the
+// multi-directory volume merge, or a volume with no directory tokens at all).
+const extractSubDir = (volumedir, baseDirToken) => {
+    if (!baseDirToken) return volumedir;
+    if (volumedir === baseDirToken) return "";
+    if (volumedir.startsWith(`${baseDirToken}/`)) return volumedir.substring(baseDirToken.length + 1);
+    return volumedir;
+};
+
+// Builds the full GitClone.volumedir to persist from a selected base
+// directory token and a subdirectory beneath it, defaulting a blank
+// subdirectory to `cloneNameFallback` (the git clone name).
+const buildVolumeDir = (baseDirToken, subDir, cloneNameFallback) => {
+    const trimmed = typeof subDir === "string" ? subDir.trim() : "";
+    const sub = !trimmed || trimmed === "/" ? cloneNameFallback : subDir;
+    const cleanSub = sub.startsWith("/") ? sub.slice(1) : sub;
+    return baseDirToken ? `${baseDirToken}/${cleanSub}` : cleanSub;
+};
+
 const GitCloneSection = React.memo(function GitCloneSection({
     rows = [],
     volumeOptions = [],
@@ -204,21 +225,24 @@ const GitRowForm = React.memo(function GitRowForm({ fieldName, gitClone, index, 
     const vol = useMemo(() => volumeOptions.find((opt) => opt.value === volumename), [volumeOptions, volumename]);
     const availableDirs = useMemo(() => getVolumeDirTokens(vol?.volumedir), [vol]);
     const srcbasepath = useMemo(() => matchVolumeDirToken(volumedir, vol?.volumedir), [volumedir, vol]);
-    const subpath = useMemo(() => volumedir.startsWith(srcbasepath) ? volumedir.substring(srcbasepath.length + 1) : volumedir, [volumedir, srcbasepath]);
+    const subpath = useMemo(() => extractSubDir(volumedir, srcbasepath), [volumedir, srcbasepath]);
 
     const handleVolume = useCallback((value) => {
-        const vol = volumeOptions.find((opt) => opt.value === value);
-        const base = defaultSubdir(vol?.volumedir);
-        const newValue = vol ? base + (subpath.startsWith("/") ? subpath : "/" + subpath) : volumedir;
-        onChange(fieldName, index, "volumename", vol ? vol.value : "");
+        const newVol = volumeOptions.find((opt) => opt.value === value);
+        const newDirs = getVolumeDirTokens(newVol?.volumedir);
+        const newBase = newDirs.includes(srcbasepath) ? srcbasepath : defaultSubdir(newVol?.volumedir);
+        const newValue = newVol ? buildVolumeDir(newBase, subpath, name) : volumedir;
+        onChange(fieldName, index, "volumename", newVol ? newVol.value : "");
         onChange(fieldName, index, "volumedir", newValue);
-    }, [fieldName, index, volumeOptions, subpath, volumedir, onChange]);
+    }, [fieldName, index, volumeOptions, srcbasepath, subpath, name, volumedir, onChange]);
+
+    const handleBaseDir = useCallback((value) => {
+        onChange(fieldName, index, "volumedir", buildVolumeDir(value, subpath, name));
+    }, [fieldName, index, subpath, name, onChange]);
 
     const handleSubPath = useCallback((value) => {
-        value = !value.trim() || value.trim() === "/" ? name : value;
-        const newValue = srcbasepath + (value.startsWith("/") ? value : "/" + value);
-        onChange(fieldName, index, "volumedir", newValue);
-    }, [fieldName, index, name, srcbasepath, onChange]);
+        onChange(fieldName, index, "volumedir", buildVolumeDir(srcbasepath, value, name));
+    }, [fieldName, index, srcbasepath, name, onChange]);
 
     const handleCheckConnection = useCallback(async () => {
         if (!onCheckGit || !gc.name) return;
@@ -281,9 +305,22 @@ const GitRowForm = React.memo(function GitRowForm({ fieldName, gitClone, index, 
                 <Flex direction="column" flex="1">
                     <Text mb={1}>Volume:</Text>
                     <Dropdown key={`volume-${index}`} placeholder="Volume" confirmTitle="Change Volume" options={volumeOptions} selectedValue={volumename} onChange={(value) => handleVolume(value)} />
-                    {srcbasepath && (<Text key={volumename} mb={1} fontSize="sm" color="gray.500">Basepath: {srcbasepath}</Text>)}
-                    {availableDirs.length > 1 && (<Text key={`${volumename}-dirs`} mb={1} fontSize="sm" color="gray.500">Volume directories: {availableDirs.join(', ')}</Text>)}
                 </Flex>
+                {availableDirs.length > 1 ? (
+                    <Flex direction="column" flex="1">
+                        <Text mb={1}>Volume Dir:</Text>
+                        <Dropdown
+                            key={`git-basedir-${index}`}
+                            placeholder="Volume Dir"
+                            confirmTitle="Change Volume Dir"
+                            options={availableDirs.map((dir) => ({ value: dir, name: dir }))}
+                            selectedValue={srcbasepath}
+                            onChange={(value) => handleBaseDir(value)}
+                        />
+                    </Flex>
+                ) : (
+                    srcbasepath && (<Text key={`${volumename}-basepath`} mb={1} fontSize="sm" color="gray.500">Basepath: {srcbasepath}</Text>)
+                )}
                 <Flex direction="column" flex="1">
                     <Text mb={1}>Sub Dir:</Text>
                     <TextForm key={`volume-dir-${index}`} placeholder="Volume Sub Dir" confirmTitle="Change Volume Sub Dir" value={subpath} onSave={(value) => handleSubPath(value)} />
@@ -300,15 +337,9 @@ const GitNewForm = React.memo(function GitNewForm({ volumeOptions, onSave = () =
     const { theme } = useTheme();
     const { name, repo, branch, user, pass, volumename, volumedir, subpath } = gc;
 
-    const availableDirs = useMemo(() => {
-        const vol = volumeOptions.find((opt) => opt.value === volumename);
-        return getVolumeDirTokens(vol?.volumedir);
-    }, [volumeOptions, volumename]);
-
-    const srcbasepath = useMemo(() => {
-        const vol = volumeOptions.find((opt) => opt.value === volumename);
-        return defaultSubdir(vol?.volumedir);
-    }, [volumeOptions, volumename]);
+    const vol = useMemo(() => volumeOptions.find((opt) => opt.value === volumename), [volumeOptions, volumename]);
+    const availableDirs = useMemo(() => getVolumeDirTokens(vol?.volumedir), [vol]);
+    const srcbasepath = useMemo(() => matchVolumeDirToken(volumedir, vol?.volumedir), [volumedir, vol]);
 
     const valid = useMemo(() => name && repo && branch && volumedir, [name, repo, branch, volumedir]);
 
@@ -326,18 +357,19 @@ const GitNewForm = React.memo(function GitNewForm({ volumeOptions, onSave = () =
     }, [onCancel]);
 
     const handleVolume = useCallback((option) => {
-        const newSubpath = !subpath.trim() || subpath.trim() === "/" ? name : subpath;
-        const base = defaultSubdir(option.volumedir);
-        const newValue = base + (newSubpath.startsWith("/") ? newSubpath : "/" + newSubpath);
+        const newDirs = getVolumeDirTokens(option?.volumedir);
+        const newBase = newDirs.includes(srcbasepath) ? srcbasepath : defaultSubdir(option?.volumedir);
         handleArrayChange("volumename", option.value);
-        handleArrayChange("volumedir", newValue);
-    }, [name, subpath, handleArrayChange]);
+        handleArrayChange("volumedir", buildVolumeDir(newBase, subpath, name));
+    }, [name, subpath, srcbasepath, handleArrayChange]);
+
+    const handleBaseDir = useCallback((option) => {
+        handleArrayChange("volumedir", buildVolumeDir(option.value, subpath, name));
+    }, [subpath, name, handleArrayChange]);
 
     const handleSubPath = useCallback((value) => {
         handleArrayChange("subpath", value);
-        const newSubpath = !value.trim() || value.trim() === "/" ? name : value;
-        const newValue = srcbasepath + (newSubpath.startsWith("/") ? newSubpath : "/" + newSubpath);
-        handleArrayChange("volumedir", newValue);
+        handleArrayChange("volumedir", buildVolumeDir(srcbasepath, value, name));
     }, [name, srcbasepath, handleArrayChange]);
 
     const handleCheckRepo = useCallback(async () => {
@@ -403,12 +435,24 @@ const GitNewForm = React.memo(function GitNewForm({ volumeOptions, onSave = () =
                 <Flex direction="column" flex="1">
                     <Text mb={1}>Volume:</Text>
                     <Dropdown key={`volume-new`} placeholder="Volume" options={volumeOptions} selectedValue={volumename} onChange={(option) => handleVolume(option)} />
-                    {srcbasepath && (<Text key={volumename} mb={1} fontSize="sm" color="gray.500">Basepath: {srcbasepath}</Text>)}
-                    {availableDirs.length > 1 && (<Text key={`${volumename}-dirs`} mb={1} fontSize="sm" color="gray.500">Volume directories: {availableDirs.join(', ')}</Text>)}
                 </Flex>
+                {availableDirs.length > 1 ? (
+                    <Flex direction="column" flex="1">
+                        <Text mb={1}>Volume Dir:</Text>
+                        <Dropdown
+                            key={`git-basedir-new`}
+                            placeholder="Volume Dir"
+                            options={availableDirs.map((dir) => ({ value: dir, name: dir }))}
+                            selectedValue={srcbasepath}
+                            onChange={(option) => handleBaseDir(option)}
+                        />
+                    </Flex>
+                ) : (
+                    srcbasepath && (<Text key={`${volumename}-basepath`} mb={1} fontSize="sm" color="gray.500">Basepath: {srcbasepath}</Text>)
+                )}
                 <Flex direction="column" flex="1">
-                    <Text mb={1}>Volume Dir:</Text>
-                    <Input key={`volume-dir-new`} placeholder="Volume Dir" value={subpath} onChange={(e) => handleSubPath(e.target.value)} />
+                    <Text mb={1}>Sub Dir:</Text>
+                    <Input key={`volume-dir-new`} placeholder="Volume Sub Dir" value={subpath} onChange={(e) => handleSubPath(e.target.value)} />
                     <Text>Fullpath: {volumedir}</Text>
                 </Flex>
                 <Flex direction="column" flex="1">

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/S3Directory.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/S3Directory.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { VStack, Input, HStack, Heading, Flex, Box, Text } from "@chakra-ui/react";
 import styles from "./styles.module.scss";
 import TextForm from "../../../../components/TextForm";
@@ -11,7 +11,7 @@ import Dropdown from "../../../../components/Dropdown";
 import SyncDiffTable from "../../../../components/SyncDiffTable";
 import { extractApiErrorMessage, redactSensitiveInfo } from "../../../../utils/apiError";
 
-const defaultS3 = { name: "", endpoint: "", bucket: "", region: "", accesskey: "", secretkey: "", providerName: "" };
+const defaultS3 = { name: "", endpoint: "", bucket: "", region: "", accesskey: "", secretkey: "", providerName: "", volumename: "", volumedir: "", subpath: "" };
 const providerSourceOptions = [
   { value: "app", name: "Sibling App" },
   { value: "custom", name: "Custom Endpoint" },
@@ -34,6 +34,62 @@ const getDuplicateProviderAdvisory = (name, clusterS3Providers = []) => {
 const hasCustomBlankCredentials = (providerSource, s3 = {}) => {
   if (providerSource !== "custom") return false;
   return !s3.accesskey && !s3.secretkey;
+};
+
+// volumedir lists the volume's available top-level directories as a
+// whitespace-separated string (see config.Volume.GetVolumeDirs()).
+const getVolumeDirTokens = (volumedir) =>
+  typeof volumedir === "string" ? volumedir.split(/\s+/).filter(Boolean) : [];
+
+// Mirrors config.Volume.DefaultSubdir(): the first directory token.
+const defaultSubdir = (volumedir) => getVolumeDirTokens(volumedir)[0] || "";
+
+const APP_MOUNT_VOLUME_DIR = "mnt";
+
+// Mirrors config.Volume.S3MountSubdir(): "mnt" is the default *suggestion*
+// for S3 mount placement when the volume exposes it, falling back to the
+// volume's first directory token otherwise. This is only a suggestion
+// (Phase 14 task 4) - explicit volumename/volumedir placement always wins.
+const defaultS3Subdir = (volumedir) => {
+  const dirs = getVolumeDirTokens(volumedir);
+  return dirs.includes(APP_MOUNT_VOLUME_DIR) ? APP_MOUNT_VOLUME_DIR : defaultSubdir(volumedir);
+};
+
+// Finds which of the volume's directory tokens `path` is rooted under
+// (either equal to the token or "<token>/..."), falling back to the
+// volume's mnt-biased default suggestion if no token matches (e.g. an
+// unplaced new mount, or a legacy path predating the multi-dir merge).
+const matchVolumeDirToken = (path, volumedir) => {
+  const dirs = getVolumeDirTokens(volumedir);
+  const match = dirs.find((dir) => path === dir || path.startsWith(`${dir}/`));
+  return match || defaultS3Subdir(volumedir);
+};
+
+// Splits a persisted S3Mount.volumedir into the portion beneath
+// `baseDirToken`, the inverse of buildVolumeDir. Falls back to the full value
+// when it isn't rooted under baseDirToken (legacy path, or a volume with no
+// directory tokens at all).
+const extractSubDir = (volumedir, baseDirToken) => {
+  if (!baseDirToken) return volumedir;
+  if (volumedir === baseDirToken) return "";
+  if (volumedir.startsWith(`${baseDirToken}/`)) return volumedir.substring(baseDirToken.length + 1);
+  return volumedir;
+};
+
+// Builds the full S3Mount.volumedir to persist from a selected base directory
+// token and a subdirectory beneath it. A blank/"/" subdirectory defers to the
+// backend default (Volume.S3MountSubdir() + generated mount name, Phase 14
+// task 1) by returning "" when mountNameFallback is unknown (the "Add" form
+// has no Name field yet); otherwise the subdirectory defaults to
+// mountNameFallback, matching the saved-row behaviour.
+const buildVolumeDir = (baseDirToken, subDir, mountNameFallback) => {
+  const trimmed = typeof subDir === "string" ? subDir.trim() : "";
+  if (!trimmed || trimmed === "/") {
+    if (!mountNameFallback) return "";
+    return baseDirToken ? `${baseDirToken}/${mountNameFallback}` : mountNameFallback;
+  }
+  const cleanSub = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed;
+  return baseDirToken ? `${baseDirToken}/${cleanSub}` : cleanSub;
 };
 
 const columnHelper = createColumnHelper()
@@ -69,6 +125,7 @@ const S3DirectorySection = ({
     rows = [],
     appId = "",
     fieldName = "s3Mounts",
+    volumeOptions = [],
     s3ProvOptions = [],
     clusterS3Providers = [],
     onRowArrayChange,
@@ -128,13 +185,13 @@ const S3DirectorySection = ({
                 header: '',
                 meta: {
                     renderExpansion: (row) => {
-                        return (<S3DirectoryRowForm appId={appId} fieldName={fieldName} s3ProvOptions={s3ProvOptions} clusterS3Providers={clusterS3Providers} s3directory={row.original} index={row.index} onChange={onRowArrayChange} onSaveAsProvider={onSaveAsProvider} onPreviewSync={onPreviewSync} onApplySync={onApplySync} />);
+                        return (<S3DirectoryRowForm appId={appId} fieldName={fieldName} volumeOptions={volumeOptions} s3ProvOptions={s3ProvOptions} clusterS3Providers={clusterS3Providers} s3directory={row.original} index={row.index} onChange={onRowArrayChange} onSaveAsProvider={onSaveAsProvider} onPreviewSync={onPreviewSync} onApplySync={onApplySync} />);
                     },
                 },
                 cell: () => null,
             }
         ],
-        [appId, fieldName, onRowArrayChange, onRowDropIndex, s3ProvOptions, clusterS3Providers, onSaveAsProvider, onPreviewSync, onApplySync]
+        [appId, fieldName, volumeOptions, onRowArrayChange, onRowDropIndex, s3ProvOptions, clusterS3Providers, onSaveAsProvider, onPreviewSync, onApplySync]
     )
 
     return (
@@ -153,7 +210,7 @@ const S3DirectorySection = ({
                         Add New S3 Directory
                     </Heading>
                     <Box className={styles.tableContainer}>
-                        <S3DirectoryNewForm s3ProvOptions={s3ProvOptions} clusterS3Providers={clusterS3Providers} onSave={handleSaveAdd} onCancel={handleCancel} onSaveAsProvider={onSaveAsProvider} />
+                        <S3DirectoryNewForm volumeOptions={volumeOptions} s3ProvOptions={s3ProvOptions} clusterS3Providers={clusterS3Providers} onSave={handleSaveAdd} onCancel={handleCancel} onSaveAsProvider={onSaveAsProvider} />
                     </Box>
                 </VStack>
             ) : (
@@ -171,8 +228,9 @@ const S3DirectorySection = ({
 
 export default React.memo(S3DirectorySection);
 
-const S3DirectoryRowForm = React.memo(({ appId = "", fieldName, s3ProvOptions, clusterS3Providers = [], s3directory, index, onChange, onSaveAsProvider = () => Promise.resolve(), onPreviewSync = () => Promise.resolve(), onApplySync = () => Promise.resolve() }) => {
+const S3DirectoryRowForm = React.memo(({ appId = "", fieldName, volumeOptions = [], s3ProvOptions, clusterS3Providers = [], s3directory, index, onChange, onSaveAsProvider = () => Promise.resolve(), onPreviewSync = () => Promise.resolve(), onApplySync = () => Promise.resolve() }) => {
     const s3 = s3directory || defaultS3;
+    const { volumename, volumedir } = s3;
     const [providerSource, setProviderSource] = useState(() =>
       endpointExistsInProviders(s3.endpoint, s3ProvOptions) ? "app" : "custom"
     );
@@ -218,6 +276,31 @@ const S3DirectoryRowForm = React.memo(({ appId = "", fieldName, s3ProvOptions, c
       () => !!s3.providerName && !(clusterS3Providers || []).some((p) => p.name === s3.providerName),
       [s3.providerName, clusterS3Providers]
     );
+
+    // Phase 14: explicit V2 S3 mount placement - selected saved volume row,
+    // selected directory token within that row, and selected relative
+    // subdirectory beneath that token.
+    const vol = useMemo(() => volumeOptions.find((opt) => opt.value === volumename), [volumeOptions, volumename]);
+    const availableDirs = useMemo(() => getVolumeDirTokens(vol?.volumedir), [vol]);
+    const srcbasepath = useMemo(() => matchVolumeDirToken(volumedir, vol?.volumedir), [volumedir, vol]);
+    const subpath = useMemo(() => extractSubDir(volumedir, srcbasepath), [volumedir, srcbasepath]);
+
+    const handleVolume = useCallback((value) => {
+      const newVol = volumeOptions.find((opt) => opt.value === value);
+      const newDirs = getVolumeDirTokens(newVol?.volumedir);
+      const newBase = newDirs.includes(srcbasepath) ? srcbasepath : defaultS3Subdir(newVol?.volumedir);
+      const newValue = newVol ? buildVolumeDir(newBase, subpath, s3.name) : volumedir;
+      onChange(fieldName, index, "volumename", newVol ? newVol.value : "");
+      onChange(fieldName, index, "volumedir", newValue);
+    }, [fieldName, index, volumeOptions, srcbasepath, subpath, s3.name, volumedir, onChange]);
+
+    const handleBaseDir = useCallback((value) => {
+      onChange(fieldName, index, "volumedir", buildVolumeDir(value, subpath, s3.name));
+    }, [fieldName, index, subpath, s3.name, onChange]);
+
+    const handleSubPath = useCallback((value) => {
+      onChange(fieldName, index, "volumedir", buildVolumeDir(srcbasepath, value, s3.name));
+    }, [fieldName, index, srcbasepath, s3.name, onChange]);
 
     const handleProviderSourceChange = (option) => {
       const nextSource = option?.value || option;
@@ -420,6 +503,30 @@ const S3DirectoryRowForm = React.memo(({ appId = "", fieldName, s3ProvOptions, c
                     <Text mb={1}>Bucket:</Text>
                     <TextForm placeholder="Bucket" value={s3.bucket} onSave={(value) => onChange(fieldName, index, "bucket", value)} />
                 </Flex>
+                <Flex direction="column" flex="1">
+                    <Text mb={1}>Volume:</Text>
+                    <Dropdown key={`s3-volume-${index}`} placeholder="Volume" confirmTitle="Change Volume" options={volumeOptions} selectedValue={volumename} onChange={(value) => handleVolume(value)} />
+                </Flex>
+                {availableDirs.length > 1 ? (
+                    <Flex direction="column" flex="1">
+                        <Text mb={1}>Volume Dir:</Text>
+                        <Dropdown
+                          key={`s3-basedir-${index}`}
+                          placeholder="Volume Dir"
+                          confirmTitle="Change Volume Dir"
+                          options={availableDirs.map((dir) => ({ value: dir, name: dir }))}
+                          selectedValue={srcbasepath}
+                          onChange={(value) => handleBaseDir(value)}
+                        />
+                    </Flex>
+                ) : (
+                    srcbasepath && (<Text key={`${volumename}-basepath`} mb={1} fontSize="sm" color="gray.500">Basepath: {srcbasepath}</Text>)
+                )}
+                <Flex direction="column" flex="1">
+                    <Text mb={1}>Sub Dir:</Text>
+                    <TextForm key={`s3-subdir-${index}`} placeholder="Volume Sub Dir" confirmTitle="Change Volume Sub Dir" value={subpath} onSave={(value) => handleSubPath(value)} />
+                    <Text>Fullpath: {volumedir || "(auto-assigned on save)"}</Text>
+                </Flex>
                 <Flex direction="column" flex="1" gap={1}>
                     <Text
                       as="button"
@@ -514,17 +621,23 @@ const S3DirectoryRowForm = React.memo(({ appId = "", fieldName, s3ProvOptions, c
     )
 })
 
-const S3DirectoryNewForm = React.memo(({ s3ProvOptions = [], clusterS3Providers = [], onSave = () => { }, onCancel = () => { }, onSaveAsProvider = () => Promise.resolve() }) => {
+const S3DirectoryNewForm = React.memo(({ s3ProvOptions = [], clusterS3Providers = [], volumeOptions = [], onSave = () => { }, onCancel = () => { }, onSaveAsProvider = () => Promise.resolve() }) => {
     const [s3, setS3] = useState(defaultS3);
     const [providerSource, setProviderSource] = useState(s3ProvOptions?.length ? "app" : "custom");
     const [showSaveProviderUI, setShowSaveProviderUI] = useState(false);
     const [providerName, setProviderName] = useState("");
     const [saveProviderError, setSaveProviderError] = useState("");
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const { volumename, volumedir, subpath } = s3;
     const duplicateProviderAdvisory = useMemo(
       () => getDuplicateProviderAdvisory(providerName, clusterS3Providers),
       [providerName, clusterS3Providers]
     );
+
+    // Phase 14: explicit V2 S3 mount placement for the "Add new" form.
+    const vol = useMemo(() => volumeOptions.find((opt) => opt.value === volumename), [volumeOptions, volumename]);
+    const availableDirs = useMemo(() => getVolumeDirTokens(vol?.volumedir), [vol]);
+    const srcbasepath = useMemo(() => matchVolumeDirToken(volumedir, vol?.volumedir), [volumedir, vol]);
 
     const valid = useMemo(() => {
         return s3.endpoint && s3.bucket;
@@ -544,6 +657,28 @@ const S3DirectoryNewForm = React.memo(({ s3ProvOptions = [], clusterS3Providers 
     const handleArrayChange = (key, value) => {
         setS3((prev) => ({ ...prev, [key]: value }));
     }
+
+    const handleVolume = (option) => {
+        const newDirs = getVolumeDirTokens(option?.volumedir);
+        const newBase = newDirs.includes(srcbasepath) ? srcbasepath : defaultS3Subdir(option?.volumedir);
+        setS3((prev) => ({
+            ...prev,
+            volumename: option?.value || "",
+            volumedir: buildVolumeDir(newBase, subpath, ""),
+        }));
+    };
+
+    const handleBaseDir = (option) => {
+        handleArrayChange("volumedir", buildVolumeDir(option?.value, subpath, ""));
+    };
+
+    const handleSubPath = (value) => {
+        setS3((prev) => ({
+            ...prev,
+            subpath: value,
+            volumedir: buildVolumeDir(srcbasepath, value, ""),
+        }));
+    };
 
     const handleProviderSourceChange = (option) => {
       const nextSource = option?.value || option;
@@ -662,6 +797,29 @@ const S3DirectoryNewForm = React.memo(({ s3ProvOptions = [], clusterS3Providers 
                 <Flex direction="column" flex="1">
                     <Text mb={1}>Region:</Text>
                     <Input placeholder="e.g. us-east-1" value={s3.region} onChange={(e) => handleArrayChange("region", e.target.value)} />
+                </Flex>
+                <Flex direction="column" flex="1">
+                    <Text mb={1}>Volume:</Text>
+                    <Dropdown key="s3-volume-new" placeholder="Volume" options={volumeOptions} selectedValue={volumename} onChange={(option) => handleVolume(option)} />
+                </Flex>
+                {availableDirs.length > 1 ? (
+                    <Flex direction="column" flex="1">
+                        <Text mb={1}>Volume Dir:</Text>
+                        <Dropdown
+                          key="s3-basedir-new"
+                          placeholder="Volume Dir"
+                          options={availableDirs.map((dir) => ({ value: dir, name: dir }))}
+                          selectedValue={srcbasepath}
+                          onChange={(option) => handleBaseDir(option)}
+                        />
+                    </Flex>
+                ) : (
+                    srcbasepath && (<Text key={`${volumename}-basepath`} mb={1} fontSize="sm" color="gray.500">Basepath: {srcbasepath}</Text>)
+                )}
+                <Flex direction="column" flex="1">
+                    <Text mb={1}>Sub Dir:</Text>
+                    <Input key="s3-subdir-new" placeholder="Volume Sub Dir" value={subpath} onChange={(e) => handleSubPath(e.target.value)} />
+                    <Text>Fullpath: {volumedir || "(auto-assigned on save)"}</Text>
                 </Flex>
                 {providerSource === "custom" && (
                   <>

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/S3Directory.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/S3Directory.jsx
@@ -77,16 +77,23 @@ const extractSubDir = (volumedir, baseDirToken) => {
 };
 
 // Builds the full S3Mount.volumedir to persist from a selected base directory
-// token and a subdirectory beneath it. A blank/"/" subdirectory defers to the
-// backend default (Volume.S3MountSubdir() + generated mount name, Phase 14
-// task 1) by returning "" when mountNameFallback is unknown (the "Add" form
-// has no Name field yet); otherwise the subdirectory defaults to
-// mountNameFallback, matching the saved-row behaviour.
+// token and a subdirectory beneath it. A blank/"/" subdirectory defaults the
+// subdirectory to mountNameFallback when known (saved-row behaviour). On the
+// "Add" form mountNameFallback is unknown (no Name field yet), so a blank
+// subdirectory instead persists the bare baseDirToken (Phase 16): the backend
+// appends the generated mount name to an explicit bare-token VolumeDir
+// (Volume.S3MountSubdir() + generated mount name, Phase 14 task 1, applies the
+// same way to an explicit token). This preserves the user's explicit
+// directory-token choice instead of discarding it as "" - which the backend
+// would otherwise treat as fully unspecified and re-default to the mnt-biased
+// suggestion. Returns "" only when no directory token is selected at all.
 const buildVolumeDir = (baseDirToken, subDir, mountNameFallback) => {
   const trimmed = typeof subDir === "string" ? subDir.trim() : "";
   if (!trimmed || trimmed === "/") {
-    if (!mountNameFallback) return "";
-    return baseDirToken ? `${baseDirToken}/${mountNameFallback}` : mountNameFallback;
+    if (mountNameFallback) {
+      return baseDirToken ? `${baseDirToken}/${mountNameFallback}` : mountNameFallback;
+    }
+    return baseDirToken || "";
   }
   const cleanSub = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed;
   return baseDirToken ? `${baseDirToken}/${cleanSub}` : cleanSub;
@@ -639,6 +646,16 @@ const S3DirectoryNewForm = React.memo(({ s3ProvOptions = [], clusterS3Providers 
     const availableDirs = useMemo(() => getVolumeDirTokens(vol?.volumedir), [vol]);
     const srcbasepath = useMemo(() => matchVolumeDirToken(volumedir, vol?.volumedir), [volumedir, vol]);
 
+    // Phase 16: a bare directory-token volumedir (no Sub Dir typed yet) gets
+    // the generated mount name appended server-side, so preview that here
+    // rather than showing the bare token as if it were the final path.
+    const fullpathPreview = useMemo(() => {
+      if (!volumedir) return "(auto-assigned on save)";
+      const trimmedSub = typeof subpath === "string" ? subpath.trim() : "";
+      if (!trimmedSub || trimmedSub === "/") return `${volumedir}/<name auto-assigned on save>`;
+      return volumedir;
+    }, [volumedir, subpath]);
+
     const valid = useMemo(() => {
         return s3.endpoint && s3.bucket;
     }, [s3.endpoint, s3.bucket]);
@@ -819,7 +836,7 @@ const S3DirectoryNewForm = React.memo(({ s3ProvOptions = [], clusterS3Providers 
                 <Flex direction="column" flex="1">
                     <Text mb={1}>Sub Dir:</Text>
                     <Input key="s3-subdir-new" placeholder="Volume Sub Dir" value={subpath} onChange={(e) => handleSubPath(e.target.value)} />
-                    <Text>Fullpath: {volumedir || "(auto-assigned on save)"}</Text>
+                    <Text>Fullpath: {fullpathPreview}</Text>
                 </Flex>
                 {providerSource === "custom" && (
                   <>

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/S3Directory.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/S3Directory.jsx
@@ -10,6 +10,13 @@ import { HiTrash } from "react-icons/hi";
 import Dropdown from "../../../../components/Dropdown";
 import SyncDiffTable from "../../../../components/SyncDiffTable";
 import { extractApiErrorMessage, redactSensitiveInfo } from "../../../../utils/apiError";
+import {
+  buildVolumeDir,
+  defaultS3Subdir,
+  extractSubDir,
+  getVolumeDirTokens,
+  matchVolumeDirToken,
+} from "./volumeDirUtils";
 
 const defaultS3 = { name: "", endpoint: "", bucket: "", region: "", accesskey: "", secretkey: "", providerName: "", volumename: "", volumedir: "", subpath: "" };
 const providerSourceOptions = [
@@ -34,69 +41,6 @@ const getDuplicateProviderAdvisory = (name, clusterS3Providers = []) => {
 const hasCustomBlankCredentials = (providerSource, s3 = {}) => {
   if (providerSource !== "custom") return false;
   return !s3.accesskey && !s3.secretkey;
-};
-
-// volumedir lists the volume's available top-level directories as a
-// whitespace-separated string (see config.Volume.GetVolumeDirs()).
-const getVolumeDirTokens = (volumedir) =>
-  typeof volumedir === "string" ? volumedir.split(/\s+/).filter(Boolean) : [];
-
-// Mirrors config.Volume.DefaultSubdir(): the first directory token.
-const defaultSubdir = (volumedir) => getVolumeDirTokens(volumedir)[0] || "";
-
-const APP_MOUNT_VOLUME_DIR = "mnt";
-
-// Mirrors config.Volume.S3MountSubdir(): "mnt" is the default *suggestion*
-// for S3 mount placement when the volume exposes it, falling back to the
-// volume's first directory token otherwise. This is only a suggestion
-// (Phase 14 task 4) - explicit volumename/volumedir placement always wins.
-const defaultS3Subdir = (volumedir) => {
-  const dirs = getVolumeDirTokens(volumedir);
-  return dirs.includes(APP_MOUNT_VOLUME_DIR) ? APP_MOUNT_VOLUME_DIR : defaultSubdir(volumedir);
-};
-
-// Finds which of the volume's directory tokens `path` is rooted under
-// (either equal to the token or "<token>/..."), falling back to the
-// volume's mnt-biased default suggestion if no token matches (e.g. an
-// unplaced new mount, or a legacy path predating the multi-dir merge).
-const matchVolumeDirToken = (path, volumedir) => {
-  const dirs = getVolumeDirTokens(volumedir);
-  const match = dirs.find((dir) => path === dir || path.startsWith(`${dir}/`));
-  return match || defaultS3Subdir(volumedir);
-};
-
-// Splits a persisted S3Mount.volumedir into the portion beneath
-// `baseDirToken`, the inverse of buildVolumeDir. Falls back to the full value
-// when it isn't rooted under baseDirToken (legacy path, or a volume with no
-// directory tokens at all).
-const extractSubDir = (volumedir, baseDirToken) => {
-  if (!baseDirToken) return volumedir;
-  if (volumedir === baseDirToken) return "";
-  if (volumedir.startsWith(`${baseDirToken}/`)) return volumedir.substring(baseDirToken.length + 1);
-  return volumedir;
-};
-
-// Builds the full S3Mount.volumedir to persist from a selected base directory
-// token and a subdirectory beneath it. A blank/"/" subdirectory defaults the
-// subdirectory to mountNameFallback when known (saved-row behaviour). On the
-// "Add" form mountNameFallback is unknown (no Name field yet), so a blank
-// subdirectory instead persists the bare baseDirToken (Phase 16): the backend
-// appends the generated mount name to an explicit bare-token VolumeDir
-// (Volume.S3MountSubdir() + generated mount name, Phase 14 task 1, applies the
-// same way to an explicit token). This preserves the user's explicit
-// directory-token choice instead of discarding it as "" - which the backend
-// would otherwise treat as fully unspecified and re-default to the mnt-biased
-// suggestion. Returns "" only when no directory token is selected at all.
-const buildVolumeDir = (baseDirToken, subDir, mountNameFallback) => {
-  const trimmed = typeof subDir === "string" ? subDir.trim() : "";
-  if (!trimmed || trimmed === "/") {
-    if (mountNameFallback) {
-      return baseDirToken ? `${baseDirToken}/${mountNameFallback}` : mountNameFallback;
-    }
-    return baseDirToken || "";
-  }
-  const cleanSub = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed;
-  return baseDirToken ? `${baseDirToken}/${cleanSub}` : cleanSub;
 };
 
 const columnHelper = createColumnHelper()
@@ -289,7 +233,7 @@ const S3DirectoryRowForm = React.memo(({ appId = "", fieldName, volumeOptions = 
     // subdirectory beneath that token.
     const vol = useMemo(() => volumeOptions.find((opt) => opt.value === volumename), [volumeOptions, volumename]);
     const availableDirs = useMemo(() => getVolumeDirTokens(vol?.volumedir), [vol]);
-    const srcbasepath = useMemo(() => matchVolumeDirToken(volumedir, vol?.volumedir), [volumedir, vol]);
+    const srcbasepath = useMemo(() => matchVolumeDirToken(volumedir, vol?.volumedir, defaultS3Subdir), [volumedir, vol]);
     const subpath = useMemo(() => extractSubDir(volumedir, srcbasepath), [volumedir, srcbasepath]);
 
     const handleVolume = useCallback((value) => {
@@ -644,7 +588,7 @@ const S3DirectoryNewForm = React.memo(({ s3ProvOptions = [], clusterS3Providers 
     // Phase 14: explicit V2 S3 mount placement for the "Add new" form.
     const vol = useMemo(() => volumeOptions.find((opt) => opt.value === volumename), [volumeOptions, volumename]);
     const availableDirs = useMemo(() => getVolumeDirTokens(vol?.volumedir), [vol]);
-    const srcbasepath = useMemo(() => matchVolumeDirToken(volumedir, vol?.volumedir), [volumedir, vol]);
+    const srcbasepath = useMemo(() => matchVolumeDirToken(volumedir, vol?.volumedir, defaultS3Subdir), [volumedir, vol]);
 
     // Phase 16: a bare directory-token volumedir (no Sub Dir typed yet) gets
     // the generated mount name appended server-side, so preview that here
@@ -681,19 +625,19 @@ const S3DirectoryNewForm = React.memo(({ s3ProvOptions = [], clusterS3Providers 
         setS3((prev) => ({
             ...prev,
             volumename: option?.value || "",
-            volumedir: buildVolumeDir(newBase, subpath, ""),
+            volumedir: buildVolumeDir(newBase, subpath, "", { preserveBareToken: true }),
         }));
     };
 
     const handleBaseDir = (option) => {
-        handleArrayChange("volumedir", buildVolumeDir(option?.value, subpath, ""));
+        handleArrayChange("volumedir", buildVolumeDir(option?.value, subpath, "", { preserveBareToken: true }));
     };
 
     const handleSubPath = (value) => {
         setS3((prev) => ({
             ...prev,
             subpath: value,
-            volumedir: buildVolumeDir(srcbasepath, value, ""),
+            volumedir: buildVolumeDir(srcbasepath, value, "", { preserveBareToken: true }),
         }));
     };
 

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/Volume.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/Volume.jsx
@@ -14,6 +14,11 @@ const defaultVol = { name: "", poolname: "", volumedir: "" };
 
 const columnHelper = createColumnHelper()
 
+// volumedir lists the volume's top-level directories as a whitespace-separated
+// string (see config.Volume.GetVolumeDirs()).
+const getVolumeDirTokens = (volumedir) =>
+    typeof volumedir === "string" ? volumedir.split(/\s+/).filter(Boolean) : [];
+
 const VolumeSection = ({
     rows = [],
     opensvcPools = [],
@@ -74,6 +79,14 @@ const VolumeSection = ({
         return options.sort((a, b) => a.name.localeCompare(b.name));
     }, [opensvcPools, appHaTopology]);
 
+    // A pool can back at most one saved volume row (config.Deployment.InsertVolume /
+    // the "poolname" modify case both enforce this). Used to keep the pool
+    // dropdowns from offering pools already claimed by another row.
+    const usedPoolNames = useMemo(
+        () => new Set((rows || []).map((row) => row.poolname).filter(Boolean)),
+        [rows]
+    );
+
     const handleAddItem = () => {
         setIsVisible(true);
         onPauseAutoReload();
@@ -102,7 +115,7 @@ const VolumeSection = ({
             columnHelper.accessor((row) => row.poolname, {
                 header: 'Pool Name'
             }),
-            columnHelper.accessor((row) => row.volumedir, {
+            columnHelper.accessor((row) => getVolumeDirTokens(row.volumedir).join(', '), {
                 header: 'Volume Dir'
             }),
             columnHelper.display({
@@ -120,13 +133,13 @@ const VolumeSection = ({
                 header: '',
                 meta: {
                     renderExpansion: (row) => {
-                        return (<VolumeRowForm poolOptions={poolOptions} fieldName={fieldName} volume={row.original} index={row.index} onChange={onRowArrayChange} />);
+                        return (<VolumeRowForm poolOptions={poolOptions} usedPoolNames={usedPoolNames} fieldName={fieldName} volume={row.original} index={row.index} onChange={onRowArrayChange} />);
                     },
                 },
                 cell: () => null,
             }
         ],
-        [fieldName, onRowArrayChange, onRowDropIndex, poolOptions]
+        [fieldName, onRowArrayChange, onRowDropIndex, poolOptions, usedPoolNames]
     )
 
     return (
@@ -145,7 +158,7 @@ const VolumeSection = ({
                         {newTitle}
                     </Heading>
                     <Box className={styles.tableContainer}>
-                        <VolumeNewForm onSave={handleSaveAdd} onCancel={handleCancel} saveCaption={saveCaption} poolOptions={poolOptions} />
+                        <VolumeNewForm onSave={handleSaveAdd} onCancel={handleCancel} saveCaption={saveCaption} poolOptions={poolOptions} usedPoolNames={usedPoolNames} />
                     </Box>
                 </VStack>
             ) : (
@@ -163,8 +176,21 @@ const VolumeSection = ({
 
 export default React.memo(VolumeSection);
 
-const VolumeRowForm = React.memo(({ fieldName, volume, index, poolOptions = [], onChange }) => {
+const VolumeRowForm = React.memo(({ fieldName, volume, index, poolOptions = [], usedPoolNames, onChange }) => {
     const vol = volume || defaultVol;
+
+    const availableDirs = useMemo(() => getVolumeDirTokens(vol.volumedir), [vol.volumedir]);
+
+    // Exclude pools already claimed by another row, but always keep this row's
+    // own pool selectable even if it was filtered out of poolOptions upstream
+    // (e.g. a non-shared pool no longer reported by opensvcPools).
+    const rowPoolOptions = useMemo(() => {
+        const filtered = poolOptions.filter((opt) => opt.value === vol.poolname || !usedPoolNames?.has(opt.value));
+        if (vol.poolname && !filtered.some((opt) => opt.value === vol.poolname)) {
+            return [...filtered, { value: vol.poolname, name: vol.poolname }];
+        }
+        return filtered;
+    }, [poolOptions, usedPoolNames, vol.poolname]);
 
     return (
         <Flex className={styles.variableRowForm} w="100%" align="flex-start" gap={4}>
@@ -175,19 +201,28 @@ const VolumeRowForm = React.memo(({ fieldName, volume, index, poolOptions = [], 
                 </Flex>
                 <Flex direction="column" flex="1">
                     <Text mb={1}>Pool Name:</Text>
-                    <Dropdown placeholder="Pool Name" confirmTitle="Change Pool Name" options={poolOptions} selectedValue={vol.poolname} onChange={(value) => onChange(fieldName, index, "poolname", value)} />
+                    <Dropdown placeholder="Pool Name" confirmTitle="Change Pool Name" options={rowPoolOptions} selectedValue={vol.poolname} onChange={(value) => onChange(fieldName, index, "poolname", value)} />
                 </Flex>
                 <Flex direction="column" flex="1">
                     <Text mb={1}>Volume Dir:</Text>
                     <TextForm placeholder="Volume Dir" confirmTitle="Change Volume Dir" value={vol.volumedir} onSave={(value) => onChange(fieldName, index, "volumedir", value)} />
+                    {availableDirs.length > 1 && (<Text mb={1} fontSize="sm" color="gray.500">Directories: {availableDirs.join(', ')}</Text>)}
                 </Flex>
             </Flex>
         </Flex>
     )
 })
 
-const VolumeNewForm = React.memo(({ saveCaption = "Save Volume", onSave = () => { }, poolOptions = [], onCancel = () => { } }) => {
+const VolumeNewForm = React.memo(({ saveCaption = "Save Volume", onSave = () => { }, poolOptions = [], usedPoolNames, onCancel = () => { } }) => {
     const [vol, setVol] = useState(defaultVol);
+
+    const availableDirs = useMemo(() => getVolumeDirTokens(vol.volumedir), [vol.volumedir]);
+
+    // A new row can only target a pool not already claimed by an existing row.
+    const availablePoolOptions = useMemo(
+        () => poolOptions.filter((opt) => !usedPoolNames?.has(opt.value)),
+        [poolOptions, usedPoolNames]
+    );
 
     const valid = useMemo(() => {
         return vol.name && vol.poolname && vol.volumedir;
@@ -217,11 +252,12 @@ const VolumeNewForm = React.memo(({ saveCaption = "Save Volume", onSave = () => 
                 </Flex>
                 <Flex direction="column" flex="1">
                     <Text mb={1}>Pool Name:</Text>
-                    <Dropdown placeholder="Pool Name" options={poolOptions} selectedValue={vol.poolname} onChange={(option) => handleArrayChange("poolname", option.value)} />
+                    <Dropdown placeholder="Pool Name" options={availablePoolOptions} selectedValue={vol.poolname} onChange={(option) => handleArrayChange("poolname", option.value)} />
                 </Flex>
                 <Flex direction="column" flex="1">
                     <Text mb={1}>Volume Dir:</Text>
                     <Input placeholder="Volume Dir" value={vol.volumedir} onChange={(e) => handleArrayChange("volumedir", e.target.value)} />
+                    {availableDirs.length > 1 && (<Text mb={1} fontSize="sm" color="gray.500">Directories: {availableDirs.join(', ')}</Text>)}
                 </Flex>
                 <Flex direction="column" flex="1">
                     <HStack spacing={2} mt={4}>

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/Volume.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/Volume.jsx
@@ -8,6 +8,7 @@ import RMIconButton from "../../../../components/RMIconButton";
 import Dropdown from "../../../../components/Dropdown";
 import { DataTable } from "../../../../components/DataTable";
 import { HiTrash } from "react-icons/hi";
+import { getVolumeDirTokens } from "./volumeDirUtils";
 
 
 const defaultVol = { name: "", poolname: "", volumedir: "" };
@@ -18,11 +19,6 @@ const defaultVol = { name: "", poolname: "", volumedir: "" };
 const AppConfigVersionV2 = 2;
 
 const columnHelper = createColumnHelper()
-
-// volumedir lists the volume's top-level directories as a whitespace-separated
-// string (see config.Volume.GetVolumeDirs()).
-const getVolumeDirTokens = (volumedir) =>
-    typeof volumedir === "string" ? volumedir.split(/\s+/).filter(Boolean) : [];
 
 const VolumeSection = ({
     rows = [],

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/Volume.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/Volume.jsx
@@ -12,6 +12,11 @@ import { HiTrash } from "react-icons/hi";
 
 const defaultVol = { name: "", poolname: "", volumedir: "" };
 
+// AppConfigVersionV2 mirrors config.AppConfigVersionV2 (config/app_template_canonical.go):
+// the app-config-version marker at/above which intentional multiple volume
+// rows per pool are allowed (Phase 11).
+const AppConfigVersionV2 = 2;
+
 const columnHelper = createColumnHelper()
 
 // volumedir lists the volume's top-level directories as a whitespace-separated
@@ -23,6 +28,7 @@ const VolumeSection = ({
     rows = [],
     opensvcPools = [],
     appHaTopology = '',
+    appConfigVersion = 0,
     fieldName = "volumes",
     title = "Saved Volumes",
     newTitle = "Add New Volume",
@@ -79,13 +85,18 @@ const VolumeSection = ({
         return options.sort((a, b) => a.name.localeCompare(b.name));
     }, [opensvcPools, appHaTopology]);
 
-    // A pool can back at most one saved volume row (config.Deployment.InsertVolume /
-    // the "poolname" modify case both enforce this). Used to keep the pool
-    // dropdowns from offering pools already claimed by another row.
-    const usedPoolNames = useMemo(
-        () => new Set((rows || []).map((row) => row.poolname).filter(Boolean)),
-        [rows]
-    );
+    // A pool can back at most one saved volume row for unflagged/V1 content
+    // (config.Deployment.InsertVolume / the "poolname" modify case both
+    // enforce this below AppConfigVersionV2). Used to keep the pool
+    // dropdowns from offering pools already claimed by another row. Once an
+    // app is flagged V2 (Phase 11), multiple intentional rows per pool are
+    // allowed, so this stays empty and every pool remains selectable.
+    const usedPoolNames = useMemo(() => {
+        if (appConfigVersion >= AppConfigVersionV2) {
+            return new Set();
+        }
+        return new Set((rows || []).map((row) => row.poolname).filter(Boolean));
+    }, [rows, appConfigVersion]);
 
     const handleAddItem = () => {
         setIsVisible(true);

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/__tests__/gitCloneVolumeDir.test.js
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/__tests__/gitCloneVolumeDir.test.js
@@ -1,0 +1,295 @@
+// Git Clone Volume-Dir Token Selection Tests
+// Verifies the GitClone.jsx base-directory-token selection logic added in
+// Phase 12 (Git clone explicit volume-dir token selection) against the
+// Phase 13 (Git clone volume-dir UX hardening and verification) tasks and
+// acceptance checks.
+//
+// Run with: node src/Pages/ClusterApp/components/Storage/__tests__/gitCloneVolumeDir.test.js
+// Or via: npm run test:git-clone-volume-dir
+
+// --- Pure helpers copied from GitClone.jsx for isolated testing ---
+
+const getVolumeDirTokens = (volumedir) =>
+  typeof volumedir === "string" ? volumedir.split(/\s+/).filter(Boolean) : [];
+
+const defaultSubdir = (volumedir) => getVolumeDirTokens(volumedir)[0] || "";
+
+const matchVolumeDirToken = (path, volumedir) => {
+  const dirs = getVolumeDirTokens(volumedir);
+  const match = dirs.find((dir) => path === dir || path.startsWith(`${dir}/`));
+  return match || defaultSubdir(volumedir);
+};
+
+const extractSubDir = (volumedir, baseDirToken) => {
+  if (!baseDirToken) return volumedir;
+  if (volumedir === baseDirToken) return "";
+  if (volumedir.startsWith(`${baseDirToken}/`)) return volumedir.substring(baseDirToken.length + 1);
+  return volumedir;
+};
+
+const buildVolumeDir = (baseDirToken, subDir, cloneNameFallback) => {
+  const trimmed = typeof subDir === "string" ? subDir.trim() : "";
+  const sub = !trimmed || trimmed === "/" ? cloneNameFallback : subDir;
+  const cleanSub = sub.startsWith("/") ? sub.slice(1) : sub;
+  return baseDirToken ? `${baseDirToken}/${cleanSub}` : cleanSub;
+};
+
+// --- GitRowForm (existing-row editor) state derivation/handlers, mirroring GitClone.jsx ---
+
+function rowView(gc, volumeOptions) {
+  const { volumename, volumedir } = gc;
+  const vol = volumeOptions.find((opt) => opt.value === volumename);
+  const availableDirs = getVolumeDirTokens(vol?.volumedir);
+  const srcbasepath = matchVolumeDirToken(volumedir, vol?.volumedir);
+  const subpath = extractSubDir(volumedir, srcbasepath);
+  return { vol, availableDirs, srcbasepath, subpath };
+}
+
+function rowHandleVolume(gc, volumeOptions, newVolumeValue) {
+  const { name, volumedir } = gc;
+  const { srcbasepath, subpath } = rowView(gc, volumeOptions);
+  const newVol = volumeOptions.find((opt) => opt.value === newVolumeValue);
+  const newDirs = getVolumeDirTokens(newVol?.volumedir);
+  const newBase = newDirs.includes(srcbasepath) ? srcbasepath : defaultSubdir(newVol?.volumedir);
+  const newValue = newVol ? buildVolumeDir(newBase, subpath, name) : volumedir;
+  return { ...gc, volumename: newVol ? newVol.value : "", volumedir: newValue };
+}
+
+function rowHandleBaseDir(gc, volumeOptions, baseDirToken) {
+  const { name } = gc;
+  const { subpath } = rowView(gc, volumeOptions);
+  return { ...gc, volumedir: buildVolumeDir(baseDirToken, subpath, name) };
+}
+
+function rowHandleSubPath(gc, volumeOptions, value) {
+  const { name } = gc;
+  const { srcbasepath } = rowView(gc, volumeOptions);
+  return { ...gc, volumedir: buildVolumeDir(srcbasepath, value, name) };
+}
+
+// --- GitNewForm (add-row form) state derivation/handlers, mirroring GitClone.jsx ---
+// Unlike GitRowForm, the new-row form tracks a raw `subpath` field in local
+// state (the literal Sub Dir input value) separately from `volumedir`.
+
+function newView(gc, volumeOptions) {
+  const { volumename, volumedir } = gc;
+  const vol = volumeOptions.find((opt) => opt.value === volumename);
+  const availableDirs = getVolumeDirTokens(vol?.volumedir);
+  const srcbasepath = matchVolumeDirToken(volumedir, vol?.volumedir);
+  return { vol, availableDirs, srcbasepath };
+}
+
+function newHandleVolume(gc, volumeOptions, newVolumeValue) {
+  const { name, subpath } = gc;
+  const { srcbasepath } = newView(gc, volumeOptions);
+  const newVol = volumeOptions.find((opt) => opt.value === newVolumeValue);
+  const newDirs = getVolumeDirTokens(newVol?.volumedir);
+  const newBase = newDirs.includes(srcbasepath) ? srcbasepath : defaultSubdir(newVol?.volumedir);
+  return { ...gc, volumename: newVol ? newVol.value : "", volumedir: buildVolumeDir(newBase, subpath, name) };
+}
+
+function newHandleBaseDir(gc, baseDirToken) {
+  const { name, subpath } = gc;
+  return { ...gc, volumedir: buildVolumeDir(baseDirToken, subpath, name) };
+}
+
+function newHandleSubPath(gc, volumeOptions, value) {
+  const { name } = gc;
+  const { srcbasepath } = newView(gc, volumeOptions);
+  return { ...gc, subpath: value, volumedir: buildVolumeDir(srcbasepath, value, name) };
+}
+
+// --- Test fixtures ---
+// Mirrors the `volumeOptions` shape built by Storage/index.jsx:
+// volumes.map((vol) => ({ value: vol.name, name: vol.name, volumedir: vol.volumedir }))
+
+const volumeOptions = [
+  { value: "app-data", name: "app-data", volumedir: "data" },
+  { value: "app-shared", name: "app-shared", volumedir: "etc log" },
+  { value: "app-multi", name: "app-multi", volumedir: "data mnt" },
+  { value: "app-multi2", name: "app-multi2", volumedir: "mnt log" },
+];
+
+// --- Test Runner ---
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, description) {
+  if (condition) {
+    passed++;
+    console.log(`  ✓ ${description}`);
+  } else {
+    failed++;
+    console.log(`  ✗ ${description}`);
+  }
+}
+
+function assertEqual(actual, expected, description) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) {
+    passed++;
+    console.log(`  ✓ ${description}`);
+  } else {
+    failed++;
+    console.log(`  ✗ ${description}`);
+    console.log(`      Expected: ${JSON.stringify(expected)}`);
+    console.log(`      Actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+// --- Tests ---
+
+console.log("\nTest Suite: Task 1 — single-directory volumes keep the current simple behavior");
+{
+  const gc = { name: "my-repo", volumename: "app-data", volumedir: "data/my-repo" };
+  const { availableDirs, srcbasepath, subpath } = rowView(gc, volumeOptions);
+  assertEqual(availableDirs, ["data"], "single-directory volume exposes exactly one token");
+  assert(!(availableDirs.length > 1), "Volume Dir dropdown is not shown for a single-token volume");
+  assertEqual(srcbasepath, "data", "srcbasepath resolves to the lone token");
+  assertEqual(subpath, "my-repo", "subpath is the path beneath the lone token");
+
+  const edited = rowHandleSubPath(gc, volumeOptions, "renamed-repo");
+  assertEqual(edited.volumedir, "data/renamed-repo", "editing Sub Dir rewrites under the same single token");
+  assertEqual(rowView(edited, volumeOptions).srcbasepath, "data", "single token remains selected after Sub Dir edit");
+}
+
+console.log("\nTest Suite: Task 2 — multi-directory volumes allow explicit token selection (etc/my-repo, log/my-repo)");
+{
+  const gc = { name: "my-repo", volumename: "app-shared", volumedir: "etc/my-repo" };
+  const { availableDirs, srcbasepath, subpath } = rowView(gc, volumeOptions);
+  assertEqual(availableDirs, ["etc", "log"], "multi-directory volume exposes both tokens");
+  assert(availableDirs.length > 1, "Volume Dir dropdown is shown for a multi-token volume");
+  assertEqual(srcbasepath, "etc", "initial volumedir resolves to the etc token");
+  assertEqual(subpath, "my-repo", "subpath beneath the etc token");
+
+  const toLog = rowHandleBaseDir(gc, volumeOptions, "log");
+  assertEqual(toLog.volumedir, "log/my-repo", "selecting the log token persists log/my-repo");
+  assertEqual(rowView(toLog, volumeOptions).srcbasepath, "log", "selected token updates to log");
+
+  const backToEtc = rowHandleBaseDir(toLog, volumeOptions, "etc");
+  assertEqual(backToEtc.volumedir, "etc/my-repo", "switching back to etc restores etc/my-repo");
+}
+
+console.log("\nTest Suite: Task 3 — existing git clones rooted under a non-first token (log/app-src) load without snapping back");
+{
+  const gc = { name: "app-src", volumename: "app-shared", volumedir: "log/app-src" };
+  const { availableDirs, srcbasepath, subpath } = rowView(gc, volumeOptions);
+  assertEqual(srcbasepath, "log", "srcbasepath resolves to log, not the first token (etc)");
+  assertEqual(subpath, "app-src", "subpath extracted beneath the log token");
+  assert(availableDirs.includes("log") && availableDirs.includes("etc"), "both tokens remain selectable");
+
+  const edited = rowHandleSubPath(gc, volumeOptions, "app-src-v2");
+  assertEqual(edited.volumedir, "log/app-src-v2", "editing Sub Dir keeps the log token");
+  assertEqual(rowView(edited, volumeOptions).srcbasepath, "log", "log token remains selected after editing the subdirectory");
+}
+
+console.log("\nTest Suite: Task 4 — switching volumes preserves subdirectory and base token when available");
+{
+  // app-multi = "data mnt"; the row currently lives under "mnt".
+  const gc = { name: "uploads", volumename: "app-multi", volumedir: "mnt/uploads" };
+  assertEqual(rowView(gc, volumeOptions).srcbasepath, "mnt", "starts rooted under the mnt token");
+
+  // Switching to app-multi2 = "mnt log", which also has "mnt": token preserved.
+  const switched = rowHandleVolume(gc, volumeOptions, "app-multi2");
+  assertEqual(switched.volumename, "app-multi2", "volumename updates to app-multi2");
+  assertEqual(switched.volumedir, "mnt/uploads", "mnt token and uploads subdir are both preserved");
+  assertEqual(rowView(switched, volumeOptions).srcbasepath, "mnt", "mnt remains the selected token");
+
+  // Switching to app-shared = "etc log", which has no "mnt": falls back to its
+  // first token (etc), while the "uploads" subdirectory is preserved.
+  const fallback = rowHandleVolume(gc, volumeOptions, "app-shared");
+  assertEqual(fallback.volumedir, "etc/uploads", "falls back to the new volume's first token (etc) when mnt is unavailable");
+  assertEqual(rowView(fallback, volumeOptions).srcbasepath, "etc", "etc becomes the selected token");
+}
+
+console.log("\nTest Suite: Task 5 — blank Sub Dir falls back to the git clone name under the currently selected token");
+{
+  const gc = { name: "my-clone", volumename: "app-shared", volumedir: "log/old-path" };
+  assertEqual(rowView(gc, volumeOptions).srcbasepath, "log", "starts rooted under the log token");
+
+  const blanked = rowHandleSubPath(gc, volumeOptions, "");
+  assertEqual(blanked.volumedir, "log/my-clone", "blank Sub Dir falls back to the clone name under log, not etc");
+
+  const slashed = rowHandleSubPath(gc, volumeOptions, "/");
+  assertEqual(slashed.volumedir, "log/my-clone", "a bare '/' Sub Dir is treated the same as blank");
+}
+
+console.log("\nTest Suite: Task 6 — Storage/index.jsx volumeOptions contract is unchanged");
+{
+  // index.jsx builds volumeOptions as { value, name, volumedir } per saved
+  // volume row. Confirm this remains sufficient for every helper above.
+  const opt = volumeOptions[1]; // app-shared
+  assert("value" in opt && "name" in opt && "volumedir" in opt, "volumeOptions entries expose value/name/volumedir");
+  assertEqual(getVolumeDirTokens(opt.volumedir), ["etc", "log"], "volumedir alone is sufficient to derive directory tokens");
+}
+
+console.log("\nTest Suite: GitNewForm — token selection mirrors GitRowForm and Fullpath always matches persisted volumedir");
+{
+  let gc = { name: "new-repo", volumename: "", volumedir: "", subpath: "" };
+
+  // Selecting a multi-directory volume before typing a subdir defaults the
+  // base token to the volume's first token, and Fullpath falls back to the clone name.
+  gc = newHandleVolume(gc, volumeOptions, "app-shared");
+  assertEqual(gc.volumedir, "etc/new-repo", "selecting app-shared with blank subdir defaults to etc/<name>");
+  assertEqual(newView(gc, volumeOptions).srcbasepath, "etc", "srcbasepath resolves to etc");
+  assert(newView(gc, volumeOptions).availableDirs.length > 1, "Volume Dir dropdown is available on the new-row form too");
+
+  // Switching the base token to "log" keeps the same fallback subdir.
+  gc = newHandleBaseDir(gc, "log");
+  assertEqual(gc.volumedir, "log/new-repo", "selecting the log token persists log/new-repo");
+
+  // Typing an explicit Sub Dir overrides the fallback and is reflected in Fullpath.
+  gc = newHandleSubPath(gc, volumeOptions, "src");
+  assertEqual(gc.volumedir, "log/src", "explicit Sub Dir overrides the clone-name fallback");
+  assertEqual(gc.subpath, "src", "raw Sub Dir input mirrors the typed value");
+
+  // Switching to a single-directory volume collapses to its lone token, preserving the subdir.
+  gc = newHandleVolume(gc, volumeOptions, "app-data");
+  assertEqual(gc.volumedir, "data/src", "switching to a single-token volume falls back to its lone token, keeping the subdir");
+  assertEqual(newView(gc, volumeOptions).availableDirs.length, 1, "single-token volume exposes no Volume Dir dropdown");
+}
+
+console.log("\nTest Suite: Phase 13 acceptance checks");
+{
+  // 1. A volume with volumedir = "etc log" must let the user explicitly
+  //    choose either etc or log in both the existing-row editor and the new-row form.
+  const sharedDirs = getVolumeDirTokens("etc log");
+  assertEqual(sharedDirs, ["etc", "log"], "volume with volumedir 'etc log' exposes both etc and log tokens");
+  assert(sharedDirs.length > 1, "both forms render a Volume Dir dropdown for this volume");
+
+  // 2. Selecting log with subdirectory app-src must persist volumedir = log/app-src.
+  const row = rowHandleBaseDir({ name: "app-src", volumename: "app-shared", volumedir: "etc/app-src" }, volumeOptions, "log");
+  assertEqual(row.volumedir, "log/app-src", "existing-row editor: log + app-src -> log/app-src");
+
+  let added = newHandleSubPath({ name: "app-src", volumename: "app-shared", volumedir: "etc/app-src", subpath: "app-src" }, volumeOptions, "app-src");
+  added = newHandleBaseDir(added, "log");
+  assertEqual(added.volumedir, "log/app-src", "new-row form: log + app-src -> log/app-src");
+
+  // 3. Changing only the subdirectory must not silently switch the selected token.
+  const subOnly = rowHandleSubPath({ name: "app-src", volumename: "app-shared", volumedir: "log/app-src" }, volumeOptions, "renamed");
+  assertEqual(rowView(subOnly, volumeOptions).srcbasepath, "log", "changing the subdirectory alone leaves the selected token (log) unchanged");
+
+  // 4. Changing the selected volume must not automatically force the git
+  //    clone back to the first token unless the current token is unavailable in the new volume.
+  const keepsToken = rowHandleVolume({ name: "uploads", volumename: "app-multi", volumedir: "mnt/uploads" }, volumeOptions, "app-multi2");
+  assertEqual(rowView(keepsToken, volumeOptions).srcbasepath, "mnt", "volume switch preserves the current token (mnt) when the new volume also has it");
+
+  const fallsBack = rowHandleVolume({ name: "uploads", volumename: "app-multi", volumedir: "mnt/uploads" }, volumeOptions, "app-shared");
+  assertEqual(rowView(fallsBack, volumeOptions).srcbasepath, "etc", "volume switch falls back to the new volume's first token only when the current token is unavailable");
+
+  // 5. The Fullpath preview must always match the value sent back through
+  //    onRowArrayChange / onSaveAdd: every handler above returns the exact
+  //    `volumedir` value that is both dispatched and shown as "Fullpath: {volumedir}".
+  assert(row.volumedir === "log/app-src" && added.volumedir === "log/app-src", "Fullpath preview value is identical to the dispatched volumedir in both forms");
+}
+
+// --- Summary ---
+console.log(`\n========================================`);
+console.log(`Total: ${passed + failed} tests`);
+console.log(`Passed: ${passed}`);
+console.log(`Failed: ${failed}`);
+
+if (typeof require !== "undefined" && require.main === module) {
+  process.exit(failed === 0 ? 0 : 1);
+}

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/__tests__/gitCloneVolumeDir.test.js
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/__tests__/gitCloneVolumeDir.test.js
@@ -7,32 +7,13 @@
 // Run with: node src/Pages/ClusterApp/components/Storage/__tests__/gitCloneVolumeDir.test.js
 // Or via: npm run test:git-clone-volume-dir
 
-// --- Pure helpers copied from GitClone.jsx for isolated testing ---
-
-const getVolumeDirTokens = (volumedir) =>
-  typeof volumedir === "string" ? volumedir.split(/\s+/).filter(Boolean) : [];
-
-const defaultSubdir = (volumedir) => getVolumeDirTokens(volumedir)[0] || "";
-
-const matchVolumeDirToken = (path, volumedir) => {
-  const dirs = getVolumeDirTokens(volumedir);
-  const match = dirs.find((dir) => path === dir || path.startsWith(`${dir}/`));
-  return match || defaultSubdir(volumedir);
-};
-
-const extractSubDir = (volumedir, baseDirToken) => {
-  if (!baseDirToken) return volumedir;
-  if (volumedir === baseDirToken) return "";
-  if (volumedir.startsWith(`${baseDirToken}/`)) return volumedir.substring(baseDirToken.length + 1);
-  return volumedir;
-};
-
-const buildVolumeDir = (baseDirToken, subDir, cloneNameFallback) => {
-  const trimmed = typeof subDir === "string" ? subDir.trim() : "";
-  const sub = !trimmed || trimmed === "/" ? cloneNameFallback : subDir;
-  const cleanSub = sub.startsWith("/") ? sub.slice(1) : sub;
-  return baseDirToken ? `${baseDirToken}/${cleanSub}` : cleanSub;
-};
+const {
+  buildVolumeDir,
+  defaultSubdir,
+  extractSubDir,
+  getVolumeDirTokens,
+  matchVolumeDirToken,
+} = await import('../volumeDirUtils.js');
 
 // --- GitRowForm (existing-row editor) state derivation/handlers, mirroring GitClone.jsx ---
 
@@ -40,7 +21,7 @@ function rowView(gc, volumeOptions) {
   const { volumename, volumedir } = gc;
   const vol = volumeOptions.find((opt) => opt.value === volumename);
   const availableDirs = getVolumeDirTokens(vol?.volumedir);
-  const srcbasepath = matchVolumeDirToken(volumedir, vol?.volumedir);
+  const srcbasepath = matchVolumeDirToken(volumedir, vol?.volumedir, defaultSubdir);
   const subpath = extractSubDir(volumedir, srcbasepath);
   return { vol, availableDirs, srcbasepath, subpath };
 }
@@ -75,7 +56,7 @@ function newView(gc, volumeOptions) {
   const { volumename, volumedir } = gc;
   const vol = volumeOptions.find((opt) => opt.value === volumename);
   const availableDirs = getVolumeDirTokens(vol?.volumedir);
-  const srcbasepath = matchVolumeDirToken(volumedir, vol?.volumedir);
+  const srcbasepath = matchVolumeDirToken(volumedir, vol?.volumedir, defaultSubdir);
   return { vol, availableDirs, srcbasepath };
 }
 

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/__tests__/s3VolumeDir.test.js
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/__tests__/s3VolumeDir.test.js
@@ -8,44 +8,13 @@
 // Run with: node src/Pages/ClusterApp/components/Storage/__tests__/s3VolumeDir.test.js
 // Or via: npm run test:s3-volume-dir
 
-// --- Pure helpers copied from S3Directory.jsx for isolated testing ---
-
-const getVolumeDirTokens = (volumedir) =>
-  typeof volumedir === "string" ? volumedir.split(/\s+/).filter(Boolean) : [];
-
-const defaultSubdir = (volumedir) => getVolumeDirTokens(volumedir)[0] || "";
-
-const APP_MOUNT_VOLUME_DIR = "mnt";
-
-const defaultS3Subdir = (volumedir) => {
-  const dirs = getVolumeDirTokens(volumedir);
-  return dirs.includes(APP_MOUNT_VOLUME_DIR) ? APP_MOUNT_VOLUME_DIR : defaultSubdir(volumedir);
-};
-
-const matchVolumeDirToken = (path, volumedir) => {
-  const dirs = getVolumeDirTokens(volumedir);
-  const match = dirs.find((dir) => path === dir || path.startsWith(`${dir}/`));
-  return match || defaultS3Subdir(volumedir);
-};
-
-const extractSubDir = (volumedir, baseDirToken) => {
-  if (!baseDirToken) return volumedir;
-  if (volumedir === baseDirToken) return "";
-  if (volumedir.startsWith(`${baseDirToken}/`)) return volumedir.substring(baseDirToken.length + 1);
-  return volumedir;
-};
-
-const buildVolumeDir = (baseDirToken, subDir, mountNameFallback) => {
-  const trimmed = typeof subDir === "string" ? subDir.trim() : "";
-  if (!trimmed || trimmed === "/") {
-    if (mountNameFallback) {
-      return baseDirToken ? `${baseDirToken}/${mountNameFallback}` : mountNameFallback;
-    }
-    return baseDirToken || "";
-  }
-  const cleanSub = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed;
-  return baseDirToken ? `${baseDirToken}/${cleanSub}` : cleanSub;
-};
+const {
+  buildVolumeDir,
+  defaultS3Subdir,
+  extractSubDir,
+  getVolumeDirTokens,
+  matchVolumeDirToken,
+} = await import('../volumeDirUtils.js');
 
 // --- S3DirectoryRowForm (existing-mount editor) state derivation/handlers ---
 
@@ -53,7 +22,7 @@ function rowView(s3, volumeOptions) {
   const { volumename, volumedir } = s3;
   const vol = volumeOptions.find((opt) => opt.value === volumename);
   const availableDirs = getVolumeDirTokens(vol?.volumedir);
-  const srcbasepath = matchVolumeDirToken(volumedir, vol?.volumedir);
+  const srcbasepath = matchVolumeDirToken(volumedir, vol?.volumedir, defaultS3Subdir);
   const subpath = extractSubDir(volumedir, srcbasepath);
   return { vol, availableDirs, srcbasepath, subpath };
 }
@@ -92,7 +61,7 @@ function newView(s3, volumeOptions) {
   const { volumename, volumedir } = s3;
   const vol = volumeOptions.find((opt) => opt.value === volumename);
   const availableDirs = getVolumeDirTokens(vol?.volumedir);
-  const srcbasepath = matchVolumeDirToken(volumedir, vol?.volumedir);
+  const srcbasepath = matchVolumeDirToken(volumedir, vol?.volumedir, defaultS3Subdir);
   return { vol, availableDirs, srcbasepath };
 }
 
@@ -102,17 +71,17 @@ function newHandleVolume(s3, volumeOptions, newVolumeValue) {
   const newVol = volumeOptions.find((opt) => opt.value === newVolumeValue);
   const newDirs = getVolumeDirTokens(newVol?.volumedir);
   const newBase = newDirs.includes(srcbasepath) ? srcbasepath : defaultS3Subdir(newVol?.volumedir);
-  return { ...s3, volumename: newVol ? newVol.value : "", volumedir: buildVolumeDir(newBase, subpath, "") };
+  return { ...s3, volumename: newVol ? newVol.value : "", volumedir: buildVolumeDir(newBase, subpath, "", { preserveBareToken: true }) };
 }
 
 function newHandleBaseDir(s3, baseDirToken) {
   const { subpath } = s3;
-  return { ...s3, volumedir: buildVolumeDir(baseDirToken, subpath, "") };
+  return { ...s3, volumedir: buildVolumeDir(baseDirToken, subpath, "", { preserveBareToken: true }) };
 }
 
 function newHandleSubPath(s3, volumeOptions, value) {
   const { srcbasepath } = newView(s3, volumeOptions);
-  return { ...s3, subpath: value, volumedir: buildVolumeDir(srcbasepath, value, "") };
+  return { ...s3, subpath: value, volumedir: buildVolumeDir(srcbasepath, value, "", { preserveBareToken: true }) };
 }
 
 // --- Test fixtures ---
@@ -167,11 +136,11 @@ console.log("\nTest Suite: defaultS3Subdir — mnt is the default suggestion, no
 
 console.log("\nTest Suite: matchVolumeDirToken — exact token match wins, mnt-biased default is only the fallback");
 {
-  assertEqual(matchVolumeDirToken("data/uploads", "data mnt"), "data", "a path rooted under 'data' resolves to 'data', not the mnt suggestion");
-  assertEqual(matchVolumeDirToken("mnt/uploads", "data mnt"), "mnt", "a path rooted under 'mnt' resolves to 'mnt'");
-  assertEqual(matchVolumeDirToken("", "data mnt"), "mnt", "an unplaced mount (blank path) on a volume with mnt suggests mnt");
-  assertEqual(matchVolumeDirToken("", "data log"), "data", "an unplaced mount on a volume without mnt suggests the first token");
-  assertEqual(matchVolumeDirToken("legacy-bucket-name", "data mnt"), "mnt", "a legacy path with no '/' (predating multi-dir merge) falls back to the mnt suggestion");
+  assertEqual(matchVolumeDirToken("data/uploads", "data mnt", defaultS3Subdir), "data", "a path rooted under 'data' resolves to 'data', not the mnt suggestion");
+  assertEqual(matchVolumeDirToken("mnt/uploads", "data mnt", defaultS3Subdir), "mnt", "a path rooted under 'mnt' resolves to 'mnt'");
+  assertEqual(matchVolumeDirToken("", "data mnt", defaultS3Subdir), "mnt", "an unplaced mount (blank path) on a volume with mnt suggests mnt");
+  assertEqual(matchVolumeDirToken("", "data log", defaultS3Subdir), "data", "an unplaced mount on a volume without mnt suggests the first token");
+  assertEqual(matchVolumeDirToken("legacy-bucket-name", "data mnt", defaultS3Subdir), "mnt", "a legacy path with no '/' (predating multi-dir merge) falls back to the mnt suggestion");
 }
 
 console.log("\nTest Suite: extractSubDir — splits a persisted volumedir into token + subdirectory");
@@ -183,9 +152,9 @@ console.log("\nTest Suite: extractSubDir — splits a persisted volumedir into t
 
 console.log("\nTest Suite: buildVolumeDir — Task 1/Phase 16, blank placement persists the selected token, deferring only when none is selected");
 {
-  assertEqual(buildVolumeDir("mnt", "", ""), "mnt", "blank Sub Dir with no mount-name fallback (Add form) persists the bare selected token");
-  assertEqual(buildVolumeDir("mnt", "/", ""), "mnt", "a bare '/' Sub Dir is treated the same as blank");
-  assertEqual(buildVolumeDir("", "", ""), "", "no token selected and no mount-name fallback fully defers volumedir to the backend");
+  assertEqual(buildVolumeDir("mnt", "", "", { preserveBareToken: true }), "mnt", "blank Sub Dir with no mount-name fallback (Add form) persists the bare selected token");
+  assertEqual(buildVolumeDir("mnt", "/", "", { preserveBareToken: true }), "mnt", "a bare '/' Sub Dir is treated the same as blank");
+  assertEqual(buildVolumeDir("", "", "", { preserveBareToken: true }), "", "no token selected and no mount-name fallback fully defers volumedir to the backend");
   assertEqual(buildVolumeDir("mnt", "", "my-mount"), "mnt/my-mount", "blank Sub Dir on an existing row falls back to the mount's own name");
   assertEqual(buildVolumeDir("mnt", "uploads", ""), "mnt/uploads", "an explicit Sub Dir always wins, even with no mount-name fallback");
   assertEqual(buildVolumeDir("", "uploads", ""), "uploads", "no base token still persists the explicit subdirectory");

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/__tests__/s3VolumeDir.test.js
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/__tests__/s3VolumeDir.test.js
@@ -1,0 +1,333 @@
+// S3 Mount Volume-Dir Placement Tests
+// Verifies the S3Directory.jsx explicit V2 S3 mount placement logic added in
+// Phase 14 (V2 explicit S3 mount placement): selecting a saved volume row, a
+// directory token within that row (mnt-biased default suggestion only), and
+// a relative subdirectory beneath that token, with a Fullpath preview that
+// always matches the persisted volumedir.
+//
+// Run with: node src/Pages/ClusterApp/components/Storage/__tests__/s3VolumeDir.test.js
+// Or via: npm run test:s3-volume-dir
+
+// --- Pure helpers copied from S3Directory.jsx for isolated testing ---
+
+const getVolumeDirTokens = (volumedir) =>
+  typeof volumedir === "string" ? volumedir.split(/\s+/).filter(Boolean) : [];
+
+const defaultSubdir = (volumedir) => getVolumeDirTokens(volumedir)[0] || "";
+
+const APP_MOUNT_VOLUME_DIR = "mnt";
+
+const defaultS3Subdir = (volumedir) => {
+  const dirs = getVolumeDirTokens(volumedir);
+  return dirs.includes(APP_MOUNT_VOLUME_DIR) ? APP_MOUNT_VOLUME_DIR : defaultSubdir(volumedir);
+};
+
+const matchVolumeDirToken = (path, volumedir) => {
+  const dirs = getVolumeDirTokens(volumedir);
+  const match = dirs.find((dir) => path === dir || path.startsWith(`${dir}/`));
+  return match || defaultS3Subdir(volumedir);
+};
+
+const extractSubDir = (volumedir, baseDirToken) => {
+  if (!baseDirToken) return volumedir;
+  if (volumedir === baseDirToken) return "";
+  if (volumedir.startsWith(`${baseDirToken}/`)) return volumedir.substring(baseDirToken.length + 1);
+  return volumedir;
+};
+
+const buildVolumeDir = (baseDirToken, subDir, mountNameFallback) => {
+  const trimmed = typeof subDir === "string" ? subDir.trim() : "";
+  if (!trimmed || trimmed === "/") {
+    if (mountNameFallback) {
+      return baseDirToken ? `${baseDirToken}/${mountNameFallback}` : mountNameFallback;
+    }
+    return baseDirToken || "";
+  }
+  const cleanSub = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed;
+  return baseDirToken ? `${baseDirToken}/${cleanSub}` : cleanSub;
+};
+
+// --- S3DirectoryRowForm (existing-mount editor) state derivation/handlers ---
+
+function rowView(s3, volumeOptions) {
+  const { volumename, volumedir } = s3;
+  const vol = volumeOptions.find((opt) => opt.value === volumename);
+  const availableDirs = getVolumeDirTokens(vol?.volumedir);
+  const srcbasepath = matchVolumeDirToken(volumedir, vol?.volumedir);
+  const subpath = extractSubDir(volumedir, srcbasepath);
+  return { vol, availableDirs, srcbasepath, subpath };
+}
+
+function rowHandleVolume(s3, volumeOptions, newVolumeValue) {
+  const { name, volumedir } = s3;
+  const { srcbasepath, subpath } = rowView(s3, volumeOptions);
+  const newVol = volumeOptions.find((opt) => opt.value === newVolumeValue);
+  const newDirs = getVolumeDirTokens(newVol?.volumedir);
+  const newBase = newDirs.includes(srcbasepath) ? srcbasepath : defaultS3Subdir(newVol?.volumedir);
+  const newValue = newVol ? buildVolumeDir(newBase, subpath, name) : volumedir;
+  return { ...s3, volumename: newVol ? newVol.value : "", volumedir: newValue };
+}
+
+function rowHandleBaseDir(s3, volumeOptions, baseDirToken) {
+  const { name } = s3;
+  const { subpath } = rowView(s3, volumeOptions);
+  return { ...s3, volumedir: buildVolumeDir(baseDirToken, subpath, name) };
+}
+
+function rowHandleSubPath(s3, volumeOptions, value) {
+  const { name } = s3;
+  const { srcbasepath } = rowView(s3, volumeOptions);
+  return { ...s3, volumedir: buildVolumeDir(srcbasepath, value, name) };
+}
+
+// --- S3DirectoryNewForm (add-mount form) state derivation/handlers ---
+// Unlike S3DirectoryRowForm, the new-mount form has no `name` field yet, so a
+// blank/"/" Sub Dir persists volumedir as the bare selected directory token
+// (Phase 16; resolved server-side by appending the generated mount name to
+// that token). When no directory token is selected at all, volumedir stays
+// "" (fully unspecified, resolved server-side via
+// Volume.S3MountSubdir() + the generated mount name).
+
+function newView(s3, volumeOptions) {
+  const { volumename, volumedir } = s3;
+  const vol = volumeOptions.find((opt) => opt.value === volumename);
+  const availableDirs = getVolumeDirTokens(vol?.volumedir);
+  const srcbasepath = matchVolumeDirToken(volumedir, vol?.volumedir);
+  return { vol, availableDirs, srcbasepath };
+}
+
+function newHandleVolume(s3, volumeOptions, newVolumeValue) {
+  const { subpath } = s3;
+  const { srcbasepath } = newView(s3, volumeOptions);
+  const newVol = volumeOptions.find((opt) => opt.value === newVolumeValue);
+  const newDirs = getVolumeDirTokens(newVol?.volumedir);
+  const newBase = newDirs.includes(srcbasepath) ? srcbasepath : defaultS3Subdir(newVol?.volumedir);
+  return { ...s3, volumename: newVol ? newVol.value : "", volumedir: buildVolumeDir(newBase, subpath, "") };
+}
+
+function newHandleBaseDir(s3, baseDirToken) {
+  const { subpath } = s3;
+  return { ...s3, volumedir: buildVolumeDir(baseDirToken, subpath, "") };
+}
+
+function newHandleSubPath(s3, volumeOptions, value) {
+  const { srcbasepath } = newView(s3, volumeOptions);
+  return { ...s3, subpath: value, volumedir: buildVolumeDir(srcbasepath, value, "") };
+}
+
+// --- Test fixtures ---
+// Mirrors the `volumeOptions` shape built by Storage/index.jsx:
+// volumes.map((vol) => ({ value: vol.name, name: vol.name, volumedir: vol.volumedir }))
+
+const volumeOptions = [
+  { value: "app-data", name: "app-data", volumedir: "data" },
+  { value: "app-shared", name: "app-shared", volumedir: "etc log" },
+  { value: "app-multi", name: "app-multi", volumedir: "data mnt" },
+  { value: "app-onlymnt", name: "app-onlymnt", volumedir: "mnt" },
+];
+
+// --- Test Runner ---
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, description) {
+  if (condition) {
+    passed++;
+    console.log(`  ✓ ${description}`);
+  } else {
+    failed++;
+    console.log(`  ✗ ${description}`);
+  }
+}
+
+function assertEqual(actual, expected, description) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) {
+    passed++;
+    console.log(`  ✓ ${description}`);
+  } else {
+    failed++;
+    console.log(`  ✗ ${description}`);
+    console.log(`      Expected: ${JSON.stringify(expected)}`);
+    console.log(`      Actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+// --- Tests ---
+
+console.log("\nTest Suite: defaultS3Subdir — mnt is the default suggestion, not a hard rule");
+{
+  assertEqual(defaultS3Subdir("data mnt"), "mnt", "a volume exposing mnt suggests mnt, regardless of token order");
+  assertEqual(defaultS3Subdir("mnt log"), "mnt", "mnt is preferred even when it is not the first token");
+  assertEqual(defaultS3Subdir("data log"), "data", "a volume without mnt falls back to its first token");
+  assertEqual(defaultS3Subdir(""), "", "an empty volumedir yields no suggestion");
+  assertEqual(defaultS3Subdir(undefined), "", "an undefined volumedir (no volume selected) yields no suggestion");
+}
+
+console.log("\nTest Suite: matchVolumeDirToken — exact token match wins, mnt-biased default is only the fallback");
+{
+  assertEqual(matchVolumeDirToken("data/uploads", "data mnt"), "data", "a path rooted under 'data' resolves to 'data', not the mnt suggestion");
+  assertEqual(matchVolumeDirToken("mnt/uploads", "data mnt"), "mnt", "a path rooted under 'mnt' resolves to 'mnt'");
+  assertEqual(matchVolumeDirToken("", "data mnt"), "mnt", "an unplaced mount (blank path) on a volume with mnt suggests mnt");
+  assertEqual(matchVolumeDirToken("", "data log"), "data", "an unplaced mount on a volume without mnt suggests the first token");
+  assertEqual(matchVolumeDirToken("legacy-bucket-name", "data mnt"), "mnt", "a legacy path with no '/' (predating multi-dir merge) falls back to the mnt suggestion");
+}
+
+console.log("\nTest Suite: extractSubDir — splits a persisted volumedir into token + subdirectory");
+{
+  assertEqual(extractSubDir("mnt/my-bucket", "mnt"), "my-bucket", "subdirectory beneath the mnt token");
+  assertEqual(extractSubDir("mnt", "mnt"), "", "a volumedir equal to the token has an empty subdirectory");
+  assertEqual(extractSubDir("legacy-bucket-name", ""), "legacy-bucket-name", "a falsy base token returns the full legacy value unchanged");
+}
+
+console.log("\nTest Suite: buildVolumeDir — Task 1/Phase 16, blank placement persists the selected token, deferring only when none is selected");
+{
+  assertEqual(buildVolumeDir("mnt", "", ""), "mnt", "blank Sub Dir with no mount-name fallback (Add form) persists the bare selected token");
+  assertEqual(buildVolumeDir("mnt", "/", ""), "mnt", "a bare '/' Sub Dir is treated the same as blank");
+  assertEqual(buildVolumeDir("", "", ""), "", "no token selected and no mount-name fallback fully defers volumedir to the backend");
+  assertEqual(buildVolumeDir("mnt", "", "my-mount"), "mnt/my-mount", "blank Sub Dir on an existing row falls back to the mount's own name");
+  assertEqual(buildVolumeDir("mnt", "uploads", ""), "mnt/uploads", "an explicit Sub Dir always wins, even with no mount-name fallback");
+  assertEqual(buildVolumeDir("", "uploads", ""), "uploads", "no base token still persists the explicit subdirectory");
+}
+
+console.log("\nTest Suite: S3DirectoryRowForm — single-token volume (Basepath text, no dropdown)");
+{
+  const s3 = { name: "my-bucket-mount", volumename: "app-onlymnt", volumedir: "mnt/my-bucket-mount" };
+  const { availableDirs, srcbasepath, subpath } = rowView(s3, volumeOptions);
+  assertEqual(availableDirs, ["mnt"], "app-onlymnt exposes exactly one token");
+  assert(!(availableDirs.length > 1), "Volume Dir dropdown is not shown for a single-token volume");
+  assertEqual(srcbasepath, "mnt", "srcbasepath resolves to the lone mnt token");
+  assertEqual(subpath, "my-bucket-mount", "subpath is the path beneath the lone token");
+
+  const edited = rowHandleSubPath(s3, volumeOptions, "renamed-mount");
+  assertEqual(edited.volumedir, "mnt/renamed-mount", "editing Sub Dir rewrites under the same single token");
+  assertEqual(rowView(edited, volumeOptions).srcbasepath, "mnt", "single token remains selected after Sub Dir edit");
+}
+
+console.log("\nTest Suite: S3DirectoryRowForm — multi-token volume allows explicit, non-mnt placement (Task 4)");
+{
+  // app-multi = "data mnt"; the mount currently lives under "mnt" (the default suggestion).
+  const s3 = { name: "uploads", volumename: "app-multi", volumedir: "mnt/uploads" };
+  const view = rowView(s3, volumeOptions);
+  assertEqual(view.availableDirs, ["data", "mnt"], "app-multi exposes both data and mnt tokens");
+  assert(view.availableDirs.length > 1, "Volume Dir dropdown is shown for a multi-token volume");
+  assertEqual(view.srcbasepath, "mnt", "initially placed under the mnt suggestion");
+
+  // The user explicitly overrides the suggestion to "data" - mnt is only a default, not a hard rule.
+  const toData = rowHandleBaseDir(s3, volumeOptions, "data");
+  assertEqual(toData.volumedir, "data/uploads", "explicitly selecting 'data' persists data/uploads, overriding the mnt suggestion");
+  assertEqual(rowView(toData, volumeOptions).srcbasepath, "data", "selected token updates to data and is not snapped back to mnt");
+
+  const backToMnt = rowHandleBaseDir(toData, volumeOptions, "mnt");
+  assertEqual(backToMnt.volumedir, "mnt/uploads", "switching back to mnt restores mnt/uploads");
+}
+
+console.log("\nTest Suite: S3DirectoryRowForm — switching volumes preserves subdir, mnt-biased fallback when unavailable");
+{
+  // app-multi = "data mnt"; mount lives under "data".
+  const s3 = { name: "files", volumename: "app-multi", volumedir: "data/files" };
+  assertEqual(rowView(s3, volumeOptions).srcbasepath, "data", "starts rooted under the data token");
+
+  // Switching to app-onlymnt = "mnt": data is unavailable, falls back to the mnt-biased default.
+  const toOnlyMnt = rowHandleVolume(s3, volumeOptions, "app-onlymnt");
+  assertEqual(toOnlyMnt.volumename, "app-onlymnt", "volumename updates to app-onlymnt");
+  assertEqual(toOnlyMnt.volumedir, "mnt/files", "falls back to the new volume's mnt token, preserving the 'files' subdir");
+
+  // Switching to app-shared = "etc log" (no mnt at all): falls back to the first token.
+  const toShared = rowHandleVolume(s3, volumeOptions, "app-shared");
+  assertEqual(toShared.volumedir, "etc/files", "falls back to the new volume's first token (etc) when neither the current token nor mnt is available");
+
+  // Switching between app-multi and app-onlymnt while rooted under mnt preserves the mnt token directly.
+  const mntRooted = { name: "uploads", volumename: "app-multi", volumedir: "mnt/uploads" };
+  const stillMnt = rowHandleVolume(mntRooted, volumeOptions, "app-onlymnt");
+  assertEqual(stillMnt.volumedir, "mnt/uploads", "mnt token is preserved directly when the new volume also exposes it");
+}
+
+console.log("\nTest Suite: S3DirectoryRowForm — legacy unplaced mount (volumename blank, volumedir is a bare name)");
+{
+  // Pre-Phase-14 autofilled mounts have volumename="" and volumedir set to just the mount name (no '/').
+  const s3 = { name: "legacy-bucket-mount", volumename: "", volumedir: "legacy-bucket-mount" };
+  const { vol, availableDirs, srcbasepath, subpath } = rowView(s3, volumeOptions);
+  assertEqual(vol, undefined, "no saved volume row matches a blank volumename");
+  assertEqual(availableDirs, [], "no directory tokens are available without a resolved volume");
+  assertEqual(srcbasepath, "", "srcbasepath is empty for an unresolved volume");
+  assertEqual(subpath, "legacy-bucket-mount", "the full legacy volumedir is shown as the subpath, unchanged");
+}
+
+console.log("\nTest Suite: S3DirectoryNewForm — Task 1, unspecified placement defers to backend autofill");
+{
+  let s3 = { volumename: "", volumedir: "", subpath: "" };
+  const view = newView(s3, volumeOptions);
+  assertEqual(view.vol, undefined, "no volume selected initially");
+  assertEqual(view.srcbasepath, "", "no base token suggested without a selected volume");
+
+  // Selecting a multi-token volume with mnt before typing a Sub Dir persists
+  // volumedir as the bare suggested token "mnt" (server appends the
+  // generated mount name, Phase 16).
+  s3 = newHandleVolume(s3, volumeOptions, "app-multi");
+  assertEqual(s3.volumename, "app-multi", "volumename updates to app-multi");
+  assertEqual(s3.volumedir, "mnt", "blank Sub Dir persists the mnt-biased suggested token as a bare value");
+  assertEqual(newView(s3, volumeOptions).srcbasepath, "mnt", "the suggested base token is the mnt-biased default (mnt)");
+  assert(newView(s3, volumeOptions).availableDirs.length > 1, "Volume Dir dropdown is available on the new-mount form too");
+}
+
+console.log("\nTest Suite: S3DirectoryNewForm — Phase 16, explicit non-default token selection is preserved with a blank Sub Dir");
+{
+  // app-multi = "data mnt"; selecting it before typing a Sub Dir suggests "mnt".
+  let s3 = { volumename: "", volumedir: "", subpath: "" };
+  s3 = newHandleVolume(s3, volumeOptions, "app-multi");
+  assertEqual(newView(s3, volumeOptions).srcbasepath, "mnt", "initially suggests the mnt-biased default token");
+
+  // The user explicitly overrides the suggestion to "data" without typing a Sub Dir.
+  s3 = newHandleBaseDir(s3, "data");
+  assertEqual(s3.volumedir, "data", "explicitly selecting 'data' persists the bare 'data' token, not '' or 'mnt'");
+  assertEqual(newView(s3, volumeOptions).srcbasepath, "data", "the dropdown does not snap back to the mnt suggestion");
+
+  // Switching back to mnt is also preserved as a bare token.
+  s3 = newHandleBaseDir(s3, "mnt");
+  assertEqual(s3.volumedir, "mnt", "switching back to mnt persists the bare 'mnt' token");
+  assertEqual(newView(s3, volumeOptions).srcbasepath, "mnt", "srcbasepath tracks the explicit selection, not just the suggestion");
+}
+
+console.log("\nTest Suite: S3DirectoryNewForm — Task 2/3, explicit placement becomes first-class once Sub Dir is set");
+{
+  let s3 = { volumename: "app-multi", volumedir: "", subpath: "" };
+
+  // Typing an explicit Sub Dir resolves volumedir under the suggested (mnt) token.
+  s3 = newHandleSubPath(s3, volumeOptions, "my-mount");
+  assertEqual(s3.volumedir, "mnt/my-mount", "explicit Sub Dir is placed under the mnt-biased default token");
+  assertEqual(s3.subpath, "my-mount", "raw Sub Dir input mirrors the typed value");
+
+  // The user can still override the base token explicitly (mnt is only a suggestion).
+  s3 = newHandleBaseDir(s3, "data");
+  assertEqual(s3.volumedir, "data/my-mount", "explicitly selecting 'data' persists data/my-mount, overriding the mnt suggestion");
+
+  // Switching to a single-token volume (app-onlymnt = "mnt") collapses to its lone token, preserving the subdir.
+  s3 = newHandleVolume(s3, volumeOptions, "app-onlymnt");
+  assertEqual(s3.volumedir, "mnt/my-mount", "switching to a single-token volume falls back to its lone token, keeping the subdir");
+  assertEqual(newView(s3, volumeOptions).availableDirs.length, 1, "single-token volume exposes no Volume Dir dropdown");
+}
+
+console.log("\nTest Suite: Fullpath preview always matches the persisted volumedir");
+{
+  const row = rowHandleBaseDir({ name: "app-src", volumename: "app-multi", volumedir: "mnt/app-src" }, volumeOptions, "data");
+  assertEqual(row.volumedir, "data/app-src", "row form: explicit placement -> data/app-src");
+
+  let added = { volumename: "app-multi", volumedir: "", subpath: "" };
+  added = newHandleSubPath(added, volumeOptions, "app-src");
+  added = newHandleBaseDir(added, "data");
+  assertEqual(added.volumedir, "data/app-src", "new form: explicit placement -> data/app-src");
+
+  assert(row.volumedir === "data/app-src" && added.volumedir === "data/app-src", "Fullpath preview value is identical to the persisted volumedir in both forms");
+}
+
+// --- Summary ---
+console.log(`\n========================================`);
+console.log(`Total: ${passed + failed} tests`);
+console.log(`Passed: ${passed}`);
+console.log(`Failed: ${failed}`);
+
+if (typeof require !== "undefined" && require.main === module) {
+  process.exit(failed === 0 ? 0 : 1);
+}

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/__tests__/volumeDirTokens.test.js
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/__tests__/volumeDirTokens.test.js
@@ -6,35 +6,13 @@
 // Run with: node src/Pages/ClusterApp/components/Storage/__tests__/volumeDirTokens.test.js
 // Or via: npm run test:volume-dir-tokens
 
-// --- Logic copied from GitClone.jsx / Volume.jsx / Paths.jsx for isolated testing ---
-
-const getVolumeDirTokens = (volumedir) =>
-  typeof volumedir === "string" ? volumedir.split(/\s+/).filter(Boolean) : [];
-
-const defaultSubdir = (volumedir) => getVolumeDirTokens(volumedir)[0] || "";
-
-const matchVolumeDirToken = (path, volumedir) => {
-  const dirs = getVolumeDirTokens(volumedir);
-  const match = dirs.find((dir) => path === dir || path.startsWith(`${dir}/`));
-  return match || defaultSubdir(volumedir);
-};
-
-// --- Logic copied from Paths.jsx for isolated testing ---
-
-const normalizeSubPath = (value) => {
-  const raw = typeof value === 'string' ? value.trim() : '';
-  if (!raw || raw === '/' || raw === '.') return '/';
-  return raw.startsWith('/') ? raw : `/${raw}`;
-};
-
-const composeSourcePath = (srcbasepath, subpath) => {
-  const normalizedSubPath = normalizeSubPath(subpath);
-  if (!srcbasepath) {
-    return normalizedSubPath === '/' ? '.' : normalizedSubPath.slice(1);
-  }
-  if (normalizedSubPath === '/') return srcbasepath;
-  return `${srcbasepath}${normalizedSubPath}`.replace('//', '/');
-};
+const {
+  composeSourcePath,
+  defaultSubdir,
+  getVolumeDirTokens,
+  matchVolumeDirToken,
+  normalizeSubPath,
+} = await import('../volumeDirUtils.js');
 
 // --- Test Runner ---
 

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/__tests__/volumeDirTokens.test.js
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/__tests__/volumeDirTokens.test.js
@@ -1,0 +1,118 @@
+// Volume Directory Tokenization Logic Tests
+// Tests the pure helper functions added in Phase 8 (Frontend compatibility) of the
+// app volume migration: parsing/merging-aware handling of Volume.volumedir as a
+// whitespace-separated list of top-level directories, mirroring the Go helpers in
+// config/deployment.go (Volume.GetVolumeDirs, Volume.DefaultSubdir).
+// Run with: node src/Pages/ClusterApp/components/Storage/__tests__/volumeDirTokens.test.js
+// Or via: npm run test:volume-dir-tokens
+
+// --- Logic copied from GitClone.jsx / Volume.jsx / Paths.jsx for isolated testing ---
+
+const getVolumeDirTokens = (volumedir) =>
+  typeof volumedir === "string" ? volumedir.split(/\s+/).filter(Boolean) : [];
+
+const defaultSubdir = (volumedir) => getVolumeDirTokens(volumedir)[0] || "";
+
+const matchVolumeDirToken = (path, volumedir) => {
+  const dirs = getVolumeDirTokens(volumedir);
+  const match = dirs.find((dir) => path === dir || path.startsWith(`${dir}/`));
+  return match || defaultSubdir(volumedir);
+};
+
+// --- Logic copied from Paths.jsx for isolated testing ---
+
+const normalizeSubPath = (value) => {
+  const raw = typeof value === 'string' ? value.trim() : '';
+  if (!raw || raw === '/' || raw === '.') return '/';
+  return raw.startsWith('/') ? raw : `/${raw}`;
+};
+
+const composeSourcePath = (srcbasepath, subpath) => {
+  const normalizedSubPath = normalizeSubPath(subpath);
+  if (!srcbasepath) {
+    return normalizedSubPath === '/' ? '.' : normalizedSubPath.slice(1);
+  }
+  if (normalizedSubPath === '/') return srcbasepath;
+  return `${srcbasepath}${normalizedSubPath}`.replace('//', '/');
+};
+
+// --- Test Runner ---
+
+let passed = 0;
+let failed = 0;
+
+function assertEqual(actual, expected, description) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) {
+    passed++;
+    console.log(`  ✓ ${description}`);
+  } else {
+    failed++;
+    console.log(`  ✗ ${description}`);
+    console.log(`      Expected: ${JSON.stringify(expected)}`);
+    console.log(`      Actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+// --- Tests ---
+
+console.log("\nTest Suite: getVolumeDirTokens — splits whitespace-separated VolumeDir");
+{
+  assertEqual(getVolumeDirTokens("data"), ["data"], "single token");
+  assertEqual(getVolumeDirTokens("data mnt"), ["data", "mnt"], "merged two-token row");
+  assertEqual(getVolumeDirTokens("etc  log\tvar data"), ["etc", "log", "var", "data"], "collapses runs of whitespace/tabs");
+  assertEqual(getVolumeDirTokens(""), [], "empty string yields no tokens");
+  assertEqual(getVolumeDirTokens(undefined), [], "undefined yields no tokens");
+  assertEqual(getVolumeDirTokens(null), [], "null yields no tokens");
+}
+
+console.log("\nTest Suite: defaultSubdir — mirrors config.Volume.DefaultSubdir()");
+{
+  assertEqual(defaultSubdir("data"), "data", "single-token row returns that token");
+  assertEqual(defaultSubdir("data mnt"), "data", "merged row returns first token");
+  assertEqual(defaultSubdir(""), "", "empty VolumeDir returns empty string");
+  assertEqual(defaultSubdir(undefined), "", "undefined VolumeDir returns empty string");
+}
+
+console.log("\nTest Suite: matchVolumeDirToken — finds which directory token a path is rooted under");
+{
+  assertEqual(matchVolumeDirToken("data/myrepo", "data mnt"), "data", "path under first token matches that token");
+  assertEqual(matchVolumeDirToken("mnt/mybucket", "data mnt"), "mnt", "path under second token matches that token");
+  assertEqual(matchVolumeDirToken("mnt", "data mnt"), "mnt", "path equal to a token matches that token exactly");
+  assertEqual(matchVolumeDirToken("mntlogs/x", "data mnt"), "data", "no false-positive on a token that is merely a prefix; falls back to default");
+  assertEqual(matchVolumeDirToken("legacy/path", "data mnt"), "data", "legacy path predating multi-dir merge falls back to default subdir");
+  assertEqual(matchVolumeDirToken("data", "data"), "data", "single-token volume matches its only token");
+}
+
+console.log("\nTest Suite: normalizeSubPath — round-trips srcpath display values");
+{
+  assertEqual(normalizeSubPath(""), "/", "empty string normalizes to root");
+  assertEqual(normalizeSubPath("."), "/", "dot normalizes to root");
+  assertEqual(normalizeSubPath("/"), "/", "slash stays root");
+  assertEqual(normalizeSubPath("data"), "/data", "relative path gets leading slash");
+  assertEqual(normalizeSubPath("/data/myrepo"), "/data/myrepo", "already-absolute path is unchanged");
+  assertEqual(normalizeSubPath("  data  "), "/data", "surrounding whitespace is trimmed before normalizing");
+}
+
+console.log("\nTest Suite: composeSourcePath — volume-type sources (no single base path)");
+{
+  assertEqual(composeSourcePath("", "/"), ".", "root subpath composes to '.' (pool disk root) when there is no base path");
+  assertEqual(composeSourcePath("", "/data/myrepo"), "data/myrepo", "absolute subpath becomes relative srcpath when there is no base path");
+  assertEqual(composeSourcePath("", "/mnt"), "mnt", "single top-level directory becomes a relative srcpath");
+}
+
+console.log("\nTest Suite: composeSourcePath — git/s3 sources with a single base path");
+{
+  assertEqual(composeSourcePath("/repo-data", "/"), "/repo-data", "root subpath resolves to the base path itself");
+  assertEqual(composeSourcePath("/repo-data", "/sub"), "/repo-data/sub", "subpath is appended to the base path");
+}
+
+// --- Summary ---
+console.log(`\n========================================`);
+console.log(`Total: ${passed + failed} tests`);
+console.log(`Passed: ${passed}`);
+console.log(`Failed: ${failed}`);
+
+if (typeof require !== "undefined" && require.main === module) {
+  process.exit(failed === 0 ? 0 : 1);
+}

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/index.jsx
@@ -208,6 +208,7 @@ export default function StoragePage({ clusterName, appId, appConfig }) {
       <VolumeSection
         opensvcPools={opensvcPools}
         appHaTopology={appConfig?.provAppHaTopology}
+        appConfigVersion={appConfig?.appConfigVersion}
         fieldName="volumes"
         title="Saved Volumes"
         newTitle="Add New Volume"
@@ -216,7 +217,7 @@ export default function StoragePage({ clusterName, appId, appConfig }) {
         rows={volumes}
         {...actionProps}
       />
-  ), [volumes, opensvcPools, appConfig?.provAppHaTopology, actionProps]);
+  ), [volumes, opensvcPools, appConfig?.provAppHaTopology, appConfig?.appConfigVersion, actionProps]);
 
   const s3Component = useMemo(() => (
       <S3DirectorySection appId={appId} rows={s3Mounts} s3ProvOptions={s3ProvOptions} clusterS3Providers={clusterS3Providers} {...actionProps} />

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/index.jsx
@@ -220,8 +220,8 @@ export default function StoragePage({ clusterName, appId, appConfig }) {
   ), [volumes, opensvcPools, appConfig?.provAppHaTopology, appConfig?.appConfigVersion, actionProps]);
 
   const s3Component = useMemo(() => (
-      <S3DirectorySection appId={appId} rows={s3Mounts} s3ProvOptions={s3ProvOptions} clusterS3Providers={clusterS3Providers} {...actionProps} />
-  ), [appId, s3Mounts, s3ProvOptions, clusterS3Providers, actionProps]);
+      <S3DirectorySection appId={appId} rows={s3Mounts} s3ProvOptions={s3ProvOptions} clusterS3Providers={clusterS3Providers} volumeOptions={volumeOptions} {...actionProps} />
+  ), [appId, s3Mounts, s3ProvOptions, clusterS3Providers, volumeOptions, actionProps]);
 
   return (
     <Flex direction="column" className={styles.sectionWrapper}>

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/volumeDirUtils.js
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/volumeDirUtils.js
@@ -1,0 +1,76 @@
+const APP_MOUNT_VOLUME_DIR = "mnt";
+
+const getVolumeDirTokens = (volumedir) =>
+  typeof volumedir === "string" ? volumedir.split(/\s+/).filter(Boolean) : [];
+
+const defaultSubdir = (volumedir) => getVolumeDirTokens(volumedir)[0] || "";
+
+const defaultS3Subdir = (volumedir) => {
+  const dirs = getVolumeDirTokens(volumedir);
+  return dirs.includes(APP_MOUNT_VOLUME_DIR) ? APP_MOUNT_VOLUME_DIR : defaultSubdir(volumedir);
+};
+
+const matchVolumeDirToken = (path, volumedir, fallback = defaultSubdir) => {
+  const dirs = getVolumeDirTokens(volumedir);
+  const match = dirs.find((dir) => path === dir || path.startsWith(`${dir}/`));
+  return match || fallback(volumedir);
+};
+
+const extractSubDir = (volumedir, baseDirToken) => {
+  if (!baseDirToken) return volumedir;
+  if (volumedir === baseDirToken) return "";
+  if (volumedir.startsWith(`${baseDirToken}/`)) return volumedir.substring(baseDirToken.length + 1);
+  return volumedir;
+};
+
+const buildVolumeDir = (baseDirToken, subDir, nameFallback, { preserveBareToken = false } = {}) => {
+  const trimmed = typeof subDir === "string" ? subDir.trim() : "";
+  if (!trimmed || trimmed === "/") {
+    if (nameFallback) {
+      return baseDirToken ? `${baseDirToken}/${nameFallback}` : nameFallback;
+    }
+    return preserveBareToken ? (baseDirToken || "") : "";
+  }
+  const cleanSub = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed;
+  return baseDirToken ? `${baseDirToken}/${cleanSub}` : cleanSub;
+};
+
+const normalizeSubPath = (value) => {
+  const raw = typeof value === "string" ? value.trim() : "";
+  if (!raw || raw === "/" || raw === ".") return "/";
+  return raw.startsWith("/") ? raw : `/${raw}`;
+};
+
+const composeSourcePath = (srcbasepath, subpath) => {
+  const normalizedSubPath = normalizeSubPath(subpath);
+  if (!srcbasepath) {
+    return normalizedSubPath === "/" ? "." : normalizedSubPath.slice(1);
+  }
+  if (normalizedSubPath === "/") return srcbasepath;
+  return `${srcbasepath}${normalizedSubPath}`.replace("//", "/");
+};
+
+const getDisplaySubPath = (srcpath, srcbasepath) => {
+  const sourcePath = typeof srcpath === "string" ? srcpath : "";
+  const basePath = typeof srcbasepath === "string" ? srcbasepath : "";
+
+  if (basePath && sourcePath && sourcePath.startsWith(basePath)) {
+    const rel = sourcePath.slice(basePath.length);
+    return normalizeSubPath(rel);
+  }
+
+  return normalizeSubPath(sourcePath);
+};
+
+export {
+  APP_MOUNT_VOLUME_DIR,
+  buildVolumeDir,
+  composeSourcePath,
+  defaultS3Subdir,
+  defaultSubdir,
+  extractSubDir,
+  getDisplaySubPath,
+  getVolumeDirTokens,
+  matchVolumeDirToken,
+  normalizeSubPath,
+};


### PR DESCRIPTION
## Summary
- complete the V2 app-volume migration follow-ups for multi-row volumes, git clone and S3 placement, and explicit path storage mapping
- keep path `volumename` bindings in sync across source changes, volume renames, and inherited child paths
- add frontend support and regression coverage for multi-directory volume handling across volume, git, s3, and path flows

## Testing
- go test -tags server ./server -run 'TestModifyPathField|TestModifyVolumeName_PreservesInheritedChildSourceFields|TestAddStorageVolume|TestModifyVolumePoolname' -v
- go test -tags server ./cluster -run 'TestResolvePath_|TestVolumeRename_|TestResolveGitPaths_|TestResolveS3MountPaths_|TestResolvePaths' -v