### PR TITLE
feat(restic): add repo check flow and safer init handling

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -776,7 +776,7 @@ func (cluster *Cluster) initScheduler() {
 var pstates30 = []string{
 	"WARN0084",             // Variables diff
 	"ERR00090", "WARN0102", // Config related
-	"WARN0093", "WARN0095", "WARN0134", "WARN0145", // Restic related
+	"WARN0093", "WARN0134", "WARN0145", // Restic related
 	"WARN0101", "WARN0111", "WARN0112", // Backup related
 	"WARN0141", "WARN0142", "WARN0143", "WARN0150", "WARN0151", // Tresholds
 	"WARN0153",             // Job related
@@ -1012,6 +1012,7 @@ func (cluster *Cluster) Run() {
 				cluster.IsConfigPathChange = cluster.HasConfigPathChanged()
 				cluster.SetStatus()
 				cluster.CheckBackupStates()
+				cluster.CheckResticErrors()
 				cluster.StateProcessing()
 				cluster.CheckHasFailCertLoadP12()
 				go cluster.GetSlowLogTable() // prevent blocking cycle

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -450,36 +450,47 @@ func (cluster *Cluster) ResticGetEnv() []string {
 	)
 }
 
-func (cluster *Cluster) ReloadResticEnv() {
-	if cluster.ResticManager != nil {
-		cluster.ResticManager.SetEnv(cluster.ResticGetEnv())
-		bucket := ""
-		prefix := ""
-		endpoint := ""
-		if cluster.Conf.BackupResticAws && strings.TrimSpace(cluster.Conf.BackupResticAwsBucket) != "" {
-			_, appendCluster := resolveResticRepoPolicy(cluster.Conf, cluster.Conf.BackupResticLocalRepository, cluster)
-			_, prefix = buildResticS3RepoSpec(
-				cluster.Conf.BackupResticAwsEndpoint,
-				cluster.Conf.BackupResticAwsBucket,
-				cluster.Conf.BackupResticAwsPrefix,
-				cluster.Name,
-				appendCluster,
-			)
-			bucket = strings.TrimSpace(cluster.Conf.BackupResticAwsBucket)
-			endpoint = strings.TrimSpace(cluster.Conf.BackupResticAwsEndpoint)
-		}
-
-		cluster.ResticManager.SetAwsConfig(
-			cluster.Conf.BackupResticAwsAccessKeyId,
-			cluster.Conf.GetDecryptedValue("backup-restic-aws-access-secret"),
-			cluster.Conf.BackupResticAwsRegion,
-			endpoint,
-			bucket,
-			prefix,
+// reloadResticEnvCore updates the restic environment from current configuration.
+// When clearBackoff is true, the init error backoff counter is also reset
+// (used when credentials/config may have changed). When false (manual check path),
+// the backoff state is preserved to avoid resetting throttling unintentionally.
+func (cluster *Cluster) reloadResticEnvCore(clearBackoff bool) {
+	if cluster.ResticManager == nil {
+		return
+	}
+	cluster.ResticManager.SetEnv(cluster.ResticGetEnv())
+	bucket := ""
+	prefix := ""
+	endpoint := ""
+	if cluster.Conf.BackupResticAws && strings.TrimSpace(cluster.Conf.BackupResticAwsBucket) != "" {
+		_, appendCluster := resolveResticRepoPolicy(cluster.Conf, cluster.Conf.BackupResticLocalRepository, cluster)
+		_, prefix = buildResticS3RepoSpec(
+			cluster.Conf.BackupResticAwsEndpoint,
+			cluster.Conf.BackupResticAwsBucket,
+			cluster.Conf.BackupResticAwsPrefix,
+			cluster.Name,
+			appendCluster,
 		)
-		// Clear init error backoff when environment changes (credentials/config may be fixed)
+		bucket = strings.TrimSpace(cluster.Conf.BackupResticAwsBucket)
+		endpoint = strings.TrimSpace(cluster.Conf.BackupResticAwsEndpoint)
+	}
+	cluster.ResticManager.SetAwsConfig(
+		cluster.Conf.BackupResticAwsAccessKeyId,
+		cluster.Conf.GetDecryptedValue("backup-restic-aws-access-secret"),
+		cluster.Conf.BackupResticAwsRegion,
+		endpoint,
+		bucket,
+		prefix,
+	)
+	if clearBackoff {
 		cluster.ResticManager.ClearInitErrorBackoffManual()
 	}
+	cluster.ResticManager.ClearRepoState()
+	cluster.ResticManager.AutoInit = cluster.Conf.BackupResticAutoInit
+}
+
+func (cluster *Cluster) ReloadResticEnv() {
+	cluster.reloadResticEnvCore(true)
 }
 
 func (cluster *Cluster) CheckResticInstallation() {
@@ -501,17 +512,16 @@ func (cluster *Cluster) CheckResticErrors() {
 		cluster.StartResticManager()
 	}
 
-	// If repo cannot be initialized, all other errors are not relevant. So we just fetch the init repo errors
-	if !cluster.ResticManager.CanInitRepo && cluster.ResticManager.HasAnyError() {
-		err := cluster.ResticManager.FetchAndClearError(backupmgr.InitTask)
+	// Keep WARN0095 open persistently without consuming the error so it does not
+	// reopen on every monitor cycle. GetInitIssue covers both fresh TaskErrors
+	// and lastInitError that persists through backoff periods.
+	if err, hasIssue := cluster.ResticManager.GetInitIssue(); hasIssue {
 		cluster.SetState("WARN0095", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0095"], err), ErrFrom: "BACKUP"})
-		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Restic init error: %s", err)
-		}
 		return
 	}
 
-	for task, err := range cluster.ResticManager.FetchAndClearErrors() {
+	// Transient non-init task errors are one-shot and cleared each cycle.
+	for task, err := range cluster.ResticManager.FetchAndClearErrorsExcept(backupmgr.InitTask) {
 		switch task {
 		case backupmgr.FetchTask:
 			cluster.SetState("WARN0093", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0093"], err), ErrFrom: "BACKUP"})
@@ -526,7 +536,6 @@ func (cluster *Cluster) CheckResticErrors() {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Unknown restic task error: %s", err)
 		}
 	}
-
 }
 
 func (cluster *Cluster) CheckResticConfigBackup() {
@@ -539,11 +548,10 @@ func (cluster *Cluster) CheckResticConfigBackup() {
 	}
 }
 
-func (cluster *Cluster) StartResticManager() error {
-	if !cluster.Conf.BackupRestic {
-		return nil
-	}
-
+// ensureResticManagerBase creates a fresh ResticManager, applies configuration, assigns it
+// to cluster.ResticManager, and calls ReloadResticEnv. It has no startup side effects
+// (no mount recovery, no unlock/fetch queuing, no auto-init).
+func (cluster *Cluster) ensureResticManagerBase() {
 	resticManager := backupmgr.NewResticRepo(cluster.Conf.BackupResticBinaryPath, cluster.MessageChan, config.ConstLogModRestic)
 	if err := cluster.Conf.ValidateResticPermissions(); err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Invalid restic permission config: %s", err)
@@ -557,10 +565,18 @@ func (cluster *Cluster) StartResticManager() error {
 	resticManager.AutoDetectAndDisableMount()
 	cluster.ResticManager = resticManager
 	cluster.ReloadResticEnv()
+}
+
+func (cluster *Cluster) StartResticManager() error {
+	if !cluster.Conf.BackupRestic {
+		return nil
+	}
+
+	cluster.ensureResticManagerBase()
 	if cluster.ResticManager.RecoverMountStateOnStartup() {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlInfo, "Recovered restic mount state on startup")
 	}
-	resticManager.AddUnlockTask() // Queue unlock first to avoid fetch-before-unlock race on startup.
+	cluster.ResticManager.AddUnlockTask() // Queue unlock first to avoid fetch-before-unlock race on startup.
 	go cluster.ResticFetchRepo()
 	return nil
 }
@@ -733,10 +749,48 @@ func (cluster *Cluster) ResticFetchRepo() {
 		cluster.StartResticManager()
 	}
 
+	// Do not queue passive fetches when the repo is known to be uninitialized.
+	// The WARN0095 warning remains open via CheckResticErrors; fetch resumes
+	// after a successful manual check or init.
+	if cluster.ResticManager.GetRepoState() == backupmgr.ManualCheckStatusInitRequired {
+		return
+	}
+
 	// Check if no other fetch task queued
 	if !cluster.ResticManager.HasFetchQueue() {
 		cluster.ResticManager.AddFetchTask()
 	}
+}
+
+// ResticCheckConfigManual performs a read-only manual validation of the current restic
+// repository configuration. When cluster.ResticManager is nil it is created via
+// ensureResticManagerBase (no mount recovery, no unlock/fetch tasks, no auto-init).
+// Queues a fetch only when validation succeeds.
+func (cluster *Cluster) ResticCheckConfigManual() backupmgr.ManualCheckResult {
+	if !cluster.Conf.BackupRestic {
+		return backupmgr.ManualCheckResult{
+			Status:  backupmgr.ManualCheckStatusError,
+			Message: "restic backup is not enabled",
+		}
+	}
+
+	if cluster.ResticManager == nil {
+		cluster.ensureResticManagerBase()
+	} else {
+		// Refresh env config without clearing backoff: manual check is read-only
+		// and should not inadvertently reset init throttling state.
+		cluster.reloadResticEnvCore(false)
+	}
+
+	result := cluster.ResticManager.ValidateRepoConfigManual()
+
+	if result.Status == backupmgr.ManualCheckStatusOK {
+		cluster.ResticFetchRepo()
+		result.FetchQueued = true
+		result.Message = "Repository configuration verified. Snapshot refresh queued."
+	}
+
+	return result
 }
 
 func (cluster *Cluster) BackupResticConfig() error {

--- a/cluster/cluster_bck_test.go
+++ b/cluster/cluster_bck_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/backupmgr"
+	"github.com/signal18/replication-manager/utils/state"
 )
 
 func TestSplitResticKeepTagTemplates(t *testing.T) {
@@ -1049,5 +1051,192 @@ func TestResticS3EffectivePrefixForInit(t *testing.T) {
 	effective, ok = cluster.ResticS3EffectivePrefixForInit()
 	if ok {
 		t.Fatalf("expected no update when prefix already ends with cluster name")
+	}
+}
+
+func TestCheckResticErrors_InitTaskWithCanInitRepo(t *testing.T) {
+	sm := new(state.StateMachine)
+	sm.Init()
+
+	conf := &config.Config{BackupRestic: true}
+	rm := backupmgr.NewResticRepo("", nil, config.ConstLogModRestic)
+	rm.CanInitRepo = true
+	rm.SetError(backupmgr.InitTask, errors.New("repository initialization required: repo config is missing"))
+
+	cluster := &Cluster{
+		Name:          "test",
+		Conf:          conf,
+		StateMachine:  sm,
+		ResticManager: rm,
+	}
+
+	cluster.CheckResticErrors()
+
+	if !cluster.StateMachine.IsInState("WARN0095") {
+		t.Fatalf("expected WARN0095 to be set after CheckResticErrors with InitTask error")
+	}
+
+	st, ok := (*cluster.StateMachine.OldState)["WARN0095"]
+	if !ok {
+		t.Fatalf("expected WARN0095 entry in state machine")
+	}
+	if !strings.Contains(st.ErrDesc, "initialization required") {
+		t.Fatalf("expected WARN0095 ErrDesc to contain 'initialization required', got %q", st.ErrDesc)
+	}
+}
+
+// TestCheckResticErrors_WARN0095Lifecycle verifies that WARN0095 stays open
+// across monitor cycles while an init issue persists, produces no reopen churn
+// on the second cycle, and resolves exactly once after the issue is cleared.
+func TestCheckResticErrors_WARN0095Lifecycle(t *testing.T) {
+	sm := new(state.StateMachine)
+	sm.Init()
+
+	conf := &config.Config{BackupRestic: true}
+	rm := backupmgr.NewResticRepo("", nil, config.ConstLogModRestic)
+	rm.SetError(backupmgr.InitTask, errors.New("repo config is missing"))
+
+	cluster := &Cluster{
+		Name:          "test",
+		Conf:          conf,
+		StateMachine:  sm,
+		ResticManager: rm,
+	}
+
+	// Cycle 1: issue present → WARN0095 opens.
+	cluster.CheckResticErrors()
+	sm.ClearState() // OldState = CurState (has WARN0095), CurState = empty
+
+	if !sm.IsInState("WARN0095") {
+		t.Fatal("cycle 1: expected WARN0095 to be open")
+	}
+
+	// Cycle 2: issue still present → WARN0095 must remain open with no reopen event.
+	cluster.CheckResticErrors() // sets CurState again
+	newlyOpened := sm.GetLastOpenedStates()
+	if _, reopened := newlyOpened["WARN0095"]; reopened {
+		t.Fatal("cycle 2: WARN0095 should not reopen (no churn expected)")
+	}
+	sm.ClearState()
+
+	if !sm.IsInState("WARN0095") {
+		t.Fatal("cycle 2: expected WARN0095 to remain open")
+	}
+
+	// Simulate init success: clear both TaskErrors[InitTask] and lastInitError.
+	rm.FetchAndClearError(backupmgr.InitTask)
+	rm.ClearInitErrorBackoffManual()
+
+	// Cycle 3: no issue → WARN0095 must resolve.
+	cluster.CheckResticErrors() // does NOT set WARN0095
+	resolved := sm.GetLastResolvedStates()
+	found := false
+	for _, s := range resolved {
+		if s.ErrKey == "WARN0095" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("cycle 3: expected WARN0095 to appear in resolved states")
+	}
+	sm.ClearState()
+
+	if sm.IsInState("WARN0095") {
+		t.Fatal("cycle 3: expected WARN0095 to be gone after init success")
+	}
+}
+
+// TestCheckResticErrors_WARN0095ResolvesWithoutPstates30 proves that WARN0095
+// resolves in the very next cycle after the init issue clears, without relying
+// on pstates30 preservation to carry the state. This is the regression guard
+// for removing WARN0095 from pstates30.
+func TestCheckResticErrors_WARN0095ResolvesWithoutPstates30(t *testing.T) {
+	sm := new(state.StateMachine)
+	sm.Init()
+
+	conf := &config.Config{BackupRestic: true}
+	rm := backupmgr.NewResticRepo("", nil, config.ConstLogModRestic)
+	rm.SetError(backupmgr.InitTask, errors.New("repo config is missing"))
+
+	cluster := &Cluster{
+		Name:          "test",
+		Conf:          conf,
+		StateMachine:  sm,
+		ResticManager: rm,
+	}
+
+	// Cycle 1: issue present → open WARN0095, then end cycle.
+	cluster.CheckResticErrors()
+	sm.ClearState()
+
+	// Clear the init issue before cycle 2 (no pstates30 preservation applied).
+	rm.FetchAndClearError(backupmgr.InitTask)
+	rm.ClearInitErrorBackoffManual()
+
+	// Cycle 2: CheckResticErrors does not set WARN0095; it must resolve immediately.
+	cluster.CheckResticErrors()
+	resolved := sm.GetLastResolvedStates()
+	found := false
+	for _, s := range resolved {
+		if s.ErrKey == "WARN0095" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected WARN0095 to resolve in the same cycle the issue clears, without pstates30 preservation")
+	}
+}
+
+// TestCheckResticErrors_TransientErrorsCleared verifies that non-init task errors
+// (FetchTask, PurgeTask, UnlockTask) are consumed after one cycle and do not
+// prevent the state from resolving the following cycle.
+func TestCheckResticErrors_TransientErrorsCleared(t *testing.T) {
+	cases := []struct {
+		name     string
+		taskType backupmgr.TaskType
+		warnKey  string
+	}{
+		{"fetch", backupmgr.FetchTask, "WARN0093"},
+		{"purge", backupmgr.PurgeTask, "WARN0094"},
+		{"unlock", backupmgr.UnlockTask, "WARN0095"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sm := new(state.StateMachine)
+			sm.Init()
+			conf := &config.Config{BackupRestic: true}
+			rm := backupmgr.NewResticRepo("", nil, config.ConstLogModRestic)
+			rm.SetError(tc.taskType, errors.New("transient error"))
+
+			cluster := &Cluster{
+				Name:          "test",
+				Conf:          conf,
+				StateMachine:  sm,
+				ResticManager: rm,
+			}
+
+			// Cycle 1: error present → warning set.
+			cluster.CheckResticErrors()
+			sm.ClearState()
+			if !sm.IsInState(tc.warnKey) {
+				t.Fatalf("cycle 1: expected %s to be open", tc.warnKey)
+			}
+
+			// Cycle 2: error consumed, not re-raised → warning resolves.
+			cluster.CheckResticErrors()
+			resolved := sm.GetLastResolvedStates()
+			found := false
+			for _, s := range resolved {
+				if s.ErrKey == tc.warnKey {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("cycle 2: expected %s to resolve after transient error cleared", tc.warnKey)
+			}
+		})
 	}
 }

--- a/cluster/srv_job_restic_test.go
+++ b/cluster/srv_job_restic_test.go
@@ -3,12 +3,15 @@ package cluster
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/backupmgr"
+	sharedlog "github.com/signal18/replication-manager/utils/s18log/shared"
 )
 
 func TestPrepareResticReseedPathsUsesMetadataDest(t *testing.T) {
@@ -241,5 +244,217 @@ func TestBuildResticMountSnapshotCandidatesTimeTemplate(t *testing.T) {
 	}
 	if candidates[0].Path != filepath.Join(mountDir, "snapshots", "2026-02-01_10-00-00") {
 		t.Fatalf("unexpected candidate path %q", candidates[0].Path)
+	}
+}
+
+// TestResticCheckConfigManualNoSideEffects verifies that ResticCheckConfigManual:
+//   - returns initialization_required for a fresh (uninitialized) repo
+//   - does not create a repository config file
+//   - does not enqueue unlock or fetch tasks
+func TestResticCheckConfigManualNoSideEffects(t *testing.T) {
+	resticPath, err := exec.LookPath("restic")
+	if err != nil {
+		t.Skip("restic binary not found, skipping cluster manual-check test")
+	}
+
+	repoDir, err := os.MkdirTemp("", "cluster-restic-check-*")
+	if err != nil {
+		t.Fatalf("create temp repo dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(repoDir) })
+
+	msgChan := make(chan sharedlog.Message, 64)
+	t.Cleanup(func() {
+		for len(msgChan) > 0 {
+			<-msgChan
+		}
+	})
+
+	cl := &Cluster{
+		Conf: &config.Config{
+			BackupRestic:           true,
+			BackupResticBinaryPath: resticPath,
+			BackupResticPassword:   "testpassword",
+			BackupResticLocalRepository: repoDir,
+		},
+		BackupMetaMap: backupmgr.NewBackupMetaMap(),
+		MessageChan:   msgChan,
+	}
+	// Inject env so SetEnv inside ensureResticManagerBase picks up the right repo.
+	cl.Conf.BackupResticRepository = repoDir
+
+	if cl.ResticManager != nil {
+		t.Fatal("precondition: ResticManager should be nil before the call")
+	}
+
+	result := cl.ResticCheckConfigManual()
+
+	if result.Status != backupmgr.ManualCheckStatusInitRequired {
+		t.Fatalf("expected initialization_required, got %s: %s", result.Status, result.Message)
+	}
+	if result.FetchQueued {
+		t.Fatal("fetch must not be queued for initialization_required result")
+	}
+
+	// No repo config should have been created.
+	if _, statErr := os.Stat(filepath.Join(repoDir, "config")); statErr == nil {
+		t.Fatal("repository config must not be created during manual check")
+	}
+
+	if cl.ResticManager == nil {
+		t.Fatal("ResticManager should be set after manual check (ensureResticManagerBase ran)")
+	}
+
+	// No unlock or fetch tasks should be in the queue.
+	cl.ResticManager.Mutex.Lock()
+	queue := make([]*backupmgr.ResticTask, len(cl.ResticManager.TaskQueue))
+	copy(queue, cl.ResticManager.TaskQueue)
+	cl.ResticManager.Mutex.Unlock()
+
+	for _, task := range queue {
+		switch task.Type {
+		case backupmgr.UnlockTask:
+			t.Errorf("unexpected unlock task in queue after manual check")
+		case backupmgr.FetchTask:
+			t.Errorf("unexpected fetch task in queue after manual check")
+		}
+	}
+
+	// Confirm the string fields are populated.
+	if strings.TrimSpace(result.Message) == "" {
+		t.Fatal("expected non-empty message in result")
+	}
+	if !result.CanInit {
+		t.Fatal("expected CanInit true for fresh repo")
+	}
+}
+
+// TestResticCheckConfigManualSuppressesFetch verifies that after a manual check
+// returns initialization_required, a subsequent ResticFetchRepo call does not
+// enqueue a new fetch task.
+func TestResticCheckConfigManualSuppressesFetch(t *testing.T) {
+	resticPath, err := exec.LookPath("restic")
+	if err != nil {
+		t.Skip("restic binary not found, skipping cluster fetch-suppression test")
+	}
+
+	repoDir, err := os.MkdirTemp("", "cluster-restic-suppress-*")
+	if err != nil {
+		t.Fatalf("create temp repo dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(repoDir) })
+
+	msgChan := make(chan sharedlog.Message, 64)
+	t.Cleanup(func() {
+		for len(msgChan) > 0 {
+			<-msgChan
+		}
+	})
+
+	cl := &Cluster{
+		Conf: &config.Config{
+			BackupRestic:                true,
+			BackupResticBinaryPath:      resticPath,
+			BackupResticPassword:        "testpassword",
+			BackupResticLocalRepository: repoDir,
+			BackupResticRepository:      repoDir,
+		},
+		BackupMetaMap: backupmgr.NewBackupMetaMap(),
+		MessageChan:   msgChan,
+	}
+
+	// Manual check classifies the fresh repo and sets repoState = initialization_required.
+	result := cl.ResticCheckConfigManual()
+	if result.Status != backupmgr.ManualCheckStatusInitRequired {
+		t.Fatalf("precondition: expected initialization_required, got %s", result.Status)
+	}
+
+	// Drain any tasks queued during the check (there should be none, but guard anyway).
+	cl.ResticManager.Mutex.Lock()
+	cl.ResticManager.TaskQueue = cl.ResticManager.TaskQueue[:0]
+	cl.ResticManager.Mutex.Unlock()
+
+	// ResticFetchRepo must not enqueue a fetch when repo state is initialization_required.
+	cl.ResticFetchRepo()
+
+	cl.ResticManager.Mutex.Lock()
+	queueLen := len(cl.ResticManager.TaskQueue)
+	cl.ResticManager.Mutex.Unlock()
+
+	if queueLen != 0 {
+		t.Fatalf("expected no tasks queued after fetch on init-required repo, got %d", queueLen)
+	}
+}
+
+// TestReloadResticEnvClearsRepoState verifies that ReloadResticEnv resets a
+// stale initialization_required state so ResticFetchRepo is no longer suppressed.
+func TestReloadResticEnvClearsRepoState(t *testing.T) {
+	resticPath, err := exec.LookPath("restic")
+	if err != nil {
+		t.Skip("restic binary not found, skipping reload-clears-state test")
+	}
+
+	repoDir, err := os.MkdirTemp("", "cluster-restic-reload-*")
+	if err != nil {
+		t.Fatalf("create temp repo dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(repoDir) })
+
+	msgChan := make(chan sharedlog.Message, 64)
+	t.Cleanup(func() {
+		for len(msgChan) > 0 {
+			<-msgChan
+		}
+	})
+
+	cl := &Cluster{
+		Conf: &config.Config{
+			BackupRestic:                true,
+			BackupResticBinaryPath:      resticPath,
+			BackupResticPassword:        "testpassword",
+			BackupResticLocalRepository: repoDir,
+			BackupResticRepository:      repoDir,
+		},
+		BackupMetaMap: backupmgr.NewBackupMetaMap(),
+		MessageChan:   msgChan,
+	}
+
+	// Step 1: manual check classifies the fresh repo as initialization_required.
+	result := cl.ResticCheckConfigManual()
+	if result.Status != backupmgr.ManualCheckStatusInitRequired {
+		t.Fatalf("precondition: expected initialization_required, got %s", result.Status)
+	}
+	if cl.ResticManager.GetRepoState() != backupmgr.ManualCheckStatusInitRequired {
+		t.Fatal("precondition: repoState should be initialization_required after manual check")
+	}
+
+	// Step 2: simulate operator changing repo config (e.g. different path).
+	newRepoDir, err := os.MkdirTemp("", "cluster-restic-reload-new-*")
+	if err != nil {
+		t.Fatalf("create new temp repo dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(newRepoDir) })
+	cl.Conf.BackupResticLocalRepository = newRepoDir
+	cl.Conf.BackupResticRepository = newRepoDir
+
+	// Step 3: reload must clear the cached state.
+	cl.ReloadResticEnv()
+	if cl.ResticManager.GetRepoState() != "" {
+		t.Fatalf("expected repoState cleared after ReloadResticEnv, got %q", cl.ResticManager.GetRepoState())
+	}
+
+	// Step 4: ResticFetchRepo should now be unblocked (will enqueue a fetch task).
+	cl.ResticManager.Mutex.Lock()
+	cl.ResticManager.TaskQueue = cl.ResticManager.TaskQueue[:0]
+	cl.ResticManager.Mutex.Unlock()
+
+	cl.ResticFetchRepo()
+
+	cl.ResticManager.Mutex.Lock()
+	queueLen := len(cl.ResticManager.TaskQueue)
+	cl.ResticManager.Mutex.Unlock()
+
+	if queueLen == 0 {
+		t.Fatal("expected fetch task to be enqueued after repoState was cleared by ReloadResticEnv")
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -847,6 +847,7 @@ type Config struct {
 	BackupResticReseedCleanup              bool                   `mapstructure:"backup-restic-reseed-cleanup" toml:"backup-restic-reseed-cleanup" json:"backupResticReseedCleanup"`
 	BackupResticReseedTimeout              int                    `mapstructure:"backup-restic-reseed-timeout" toml:"backup-restic-reseed-timeout" json:"backupResticReseedTimeout"`
 	BackupResticAllowUnsafeMount           bool                   `mapstructure:"backup-restic-allow-unsafe-mount" toml:"backup-restic-allow-unsafe-mount" json:"backupResticAllowUnsafeMount"`
+	BackupResticAutoInit                   bool                   `mapstructure:"backup-restic-auto-init" toml:"backup-restic-auto-init" json:"backupResticAutoInit"`
 	BackupReconcileInterval                int                    `mapstructure:"backup-reconcile-interval" toml:"backup-reconcile-interval" json:"backupReconcileInterval"`
 	BackupReconcileAutoCleanup             bool                   `mapstructure:"backup-reconcile-auto-cleanup" toml:"backup-reconcile-auto-cleanup" json:"backupReconcileAutoCleanup"`
 	BackupStreaming                        bool                   `mapstructure:"backup-streaming" toml:"backup-streaming" json:"backupStreaming"`

--- a/config/error.go
+++ b/config/error.go
@@ -173,7 +173,7 @@ var ClusterError = map[string]string{
 	"WARN0092":  "ProxySQL could not load query rules from runtime (%s)",
 	"WARN0093":  "Restic fetch repo issue: %s",
 	"WARN0094":  "Restic purge repo issue: %s",
-	"WARN0095":  "Restic init repo issue: %s",
+	"WARN0095":  "Restic repository issue: %s",
 	"WARN0096":  "Restart database server via job request %s",
 	"WARN0097":  "Stop database server via job request %s",
 	"WARN0098":  "ProxySQL could not load global variables from runtime (%s)",

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -181,6 +181,11 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxResticUnlock)),
 	))
 
+	router.Handle("/api/clusters/{clusterName}/restic/check-config", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxResticCheckConfig)),
+	))
+
 	router.Handle("/api/clusters/{clusterName}/restic/init", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxResticInitRepo)),
@@ -8514,6 +8519,27 @@ func (repman *ReplicationManager) handlerMuxResticInitRepo(w http.ResponseWriter
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("Restic repository initialized"))
+	})
+}
+
+// handlerMuxResticCheckConfig handles the HTTP request to manually validate the restic
+// repository configuration for a given cluster.
+// @Summary Check Restic Repository Config
+// @Description Validates the current restic repository configuration read-only. Returns ok, initialization_required, or error.
+// @Tags ClusterRestic
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Success 200 {object} backupmgr.ManualCheckResult "Repository check result"
+// @Failure 403 {string} string "No valid ACL"
+// @Failure 500 {string} string "No cluster"
+// @Router /api/clusters/{clusterName}/restic/check-config [post]
+func (repman *ReplicationManager) handlerMuxResticCheckConfig(w http.ResponseWriter, r *http.Request) {
+	repman.withResticCluster(w, r, true, func(mycluster *cluster.Cluster, vars map[string]string) {
+		result := mycluster.ResticCheckConfigManual()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(result)
 	})
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -906,6 +906,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.BoolVar(&conf.BackupResticReseedCleanup, "backup-restic-reseed-cleanup", true, "Automatically cleanup temporary files after restic reseed")
 	flags.IntVar(&conf.BackupResticReseedTimeout, "backup-restic-reseed-timeout", 3600, "Timeout in seconds for restic reseed operations")
 	flags.BoolVar(&conf.BackupResticAllowUnsafeMount, "backup-restic-allow-unsafe-mount", false, "Allow using a restic mount created by another process (unsafe)")
+	flags.BoolVar(&conf.BackupResticAutoInit, "backup-restic-auto-init", false, "Automatically initialize fresh local and S3 restic repositories on first use. Does not apply to SFTP repositories.")
 	flags.BoolVar(&conf.BackupStreaming, "backup-streaming", false, "Backup streaming to cloud ")
 	flags.BoolVar(&conf.BackupStreamingDebug, "backup-streaming-debug", false, "Debug mode for streaming to cloud ")
 	flags.StringVar(&conf.BackupStreamingAwsAccessKeyId, "backup-streaming-aws-access-key-id", "admin", "Backup AWS key id")

--- a/share/dashboard_react/src/Pages/Settings/ResticMountSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticMountSettings.jsx
@@ -113,6 +113,53 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
     'backup-restic-mount-target-dir overrides the final mount target when set.'
   ].join('  \n')
 
+  const ResticMountVerboseHelp = `**Restic Mount Verbose Level**
+
+Controls how much output the restic mount command produces.
+
+- **0** (default): standard output.
+- **1–3**: progressively more detail; higher values log individual FUSE operations.
+
+Setting verbose > 0 while quiet mode is enabled is not allowed — quiet mode requires verbose = 0.
+
+Config: \`backup-restic-mount-verbose\``
+
+  const ResticMountAllowOtherHelp = `Passes \`--allow-other\` to the FUSE mount, making the mount point accessible to all local users on the host.
+
+Requires \`user_allow_other\` to be set in \`/etc/fuse.conf\`.
+
+**Security:** every local user on the host gains read access to the mounted snapshots.
+
+Config: \`backup-restic-mount-allow-other\``
+
+  const ResticMountNoDefaultPermissionsHelp = `Disables kernel \`default_permissions\` checks on the mounted filesystem.
+
+When enabled, Unix mode bits are ignored and the kernel does not enforce standard permission checks. Access control is handled entirely by the FUSE driver.
+
+Config: \`backup-restic-mount-no-default-permissions\``
+
+  const ResticMountOwnerRootHelp = `Reports all files in the mount as owned by root, regardless of the original backup owner.
+
+Config: \`backup-restic-mount-owner-root\``
+
+  const ResticMountNoLockHelp = `Skips repository locking during the mount operation.
+
+Useful when another process already holds the lock or when mounting a read-only copy. Without locking, concurrent writes to the repository may cause inconsistencies.
+
+Config: \`backup-restic-mount-no-lock\``
+
+  const ResticMountQuietHelp = `Suppresses most output; only minimal status messages are shown.
+
+Requires verbose level = 0. Setting verbose > 0 while quiet mode is active is not allowed.
+
+Config: \`backup-restic-mount-quiet\``
+
+  const ResticMountAllowUnsafeMountHelp = `Allows the manager to attach to an existing mount point that was created outside this process.
+
+Use with caution: if the external mount uses different repository credentials or options, data may appear inconsistent or inaccessible.
+
+Config: \`backup-restic-allow-unsafe-mount\``
+
   const openCommonModal = () => {
     setIsCommonModalOpen(true)
   }
@@ -132,6 +179,19 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
     })
     openCommonModal()
   }
+
+  const h = (content, title, stopPropagation = false) => (
+    <RMIconButton
+      icon={HiQuestionMarkCircle}
+      iconFontsize='1rem'
+      variant='ghost'
+      style={{ opacity: 0.5, minWidth: '1.5rem', height: '1.5rem' }}
+      onClick={(event) => {
+        if (stopPropagation) event.stopPropagation()
+        openInfoModal(title, content)
+      }}
+    />
+  )
 
   const handleSettingChange = (setting, value) =>
     dispatch(
@@ -296,13 +356,7 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
             title: (
               <HStack spacing={2} align='center'>
                 <Text className={styles.panelTitle}>Mount control</Text>
-                <RMIconButton
-                  icon={HiQuestionMarkCircle}
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    openInfoModal('Restic Mount Control', ResticMountControlHelp)
-                  }}
-                />
+                {h(ResticMountControlHelp, 'Restic Mount Control', true)}
               </HStack>
             ),
             description: 'Manually mount or unmount the restic repository using current settings.',
@@ -412,13 +466,7 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
             title: (
               <HStack spacing={2} align='center'>
                 <Text className={styles.panelTitle}>Mount destination</Text>
-                <RMIconButton
-                  icon={HiQuestionMarkCircle}
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    openInfoModal('Restic Mount Destination', ResticMountDestinationHelp)
-                  }}
-                />
+                {h(ResticMountDestinationHelp, 'Restic Mount Destination', true)}
               </HStack>
             ),
             description: 'Choose where restic mounts snapshots for inspection or restore.',
@@ -444,7 +492,6 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                       placeholder='(empty = default mount path)'
                       onSave={(value) => handleSettingChange('backup-restic-mount-target-dir', value)}
                     />
-                    <Text className={styles.helperText}>Empty value uses the default mount path.</Text>
                   </GridItem>
                 </Grid>
               </Stack>
@@ -458,13 +505,7 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
             title: (
               <HStack spacing={2} align='center'>
                 <Text className={styles.panelTitle}>Snapshot filters</Text>
-                <RMIconButton
-                  icon={HiQuestionMarkCircle}
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    openInfoModal('Restic Mount Filters', ResticMountFiltersHelp)
-                  }}
-                />
+                {h(ResticMountFiltersHelp, 'Restic Mount Filters', true)}
               </HStack>
             ),
             description: 'Limit which snapshots appear inside the mount.',
@@ -491,7 +532,6 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                         placeholder='host1,host2'
                         onSave={(value) => handleSettingChange('backup-restic-mount-host', value)}
                       />
-                      <Text className={styles.helperText}>Comma-separated hostnames; empty means no filter.</Text>
                     </GridItem>
                   </Grid>
 
@@ -514,9 +554,6 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                         placeholder='tag1 tag2'
                         onSave={(value) => handleSettingChange('backup-restic-mount-tag', value)}
                       />
-                      <Text className={styles.helperText}>
-                        Space-separated tags; commas inside a tag mean AND. Empty means no filter.
-                      </Text>
                     </GridItem>
                   </Grid>
 
@@ -539,7 +576,6 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                         placeholder='/var/lib/mysql,/srv/data'
                         onSave={(value) => handleSettingChange('backup-restic-mount-path', value)}
                       />
-                      <Text className={styles.helperText}>Absolute paths only; empty means no filter.</Text>
                     </GridItem>
                   </Grid>
                 </Stack>
@@ -554,13 +590,7 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
             title: (
               <HStack spacing={2} align='center'>
                 <Text className={styles.panelTitle}>Mount templates</Text>
-                <RMIconButton
-                  icon={HiQuestionMarkCircle}
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    openInfoModal('Restic Mount Templates', ResticMountTemplatesHelp)
-                  }}
-                />
+                {h(ResticMountTemplatesHelp, 'Restic Mount Templates', true)}
               </HStack>
             ),
             description: 'Control the virtual layout and timestamp formatting inside the mount.',
@@ -587,9 +617,6 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                         placeholder='(comma-separated templates)'
                         onSave={(value) => handleSettingChange('backup-restic-mount-path-template', value)}
                       />
-                      <Text className={styles.helperText}>
-                        Multiple templates allowed; leave empty for defaults.
-                      </Text>
                     </GridItem>
                   </Grid>
 
@@ -612,7 +639,6 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                         placeholder='2006-01-02T15:04:05Z07:00'
                         onSave={(value) => handleSettingChange('backup-restic-mount-time-template', value)}
                       />
-                      <Text className={styles.helperText}>Use Go time layout; leave empty for defaults.</Text>
                     </GridItem>
                   </Grid>
                 </Stack>
@@ -638,7 +664,10 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                     w='full'
                   >
                     <GridItem className={styles.rowLabel}>
-                      <Text>Restic mount allow other users</Text>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>Restic mount allow other users</Text>
+                        {h(ResticMountAllowOtherHelp, 'Restic Mount Allow Other Users')}
+                      </HStack>
                     </GridItem>
                     <GridItem className={styles.valueCell}>
                       <RMSwitch
@@ -663,7 +692,10 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                     w='full'
                   >
                     <GridItem className={styles.rowLabel}>
-                      <Text>Restic mount ignore default permissions</Text>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>Restic mount ignore default permissions</Text>
+                        {h(ResticMountNoDefaultPermissionsHelp, 'Restic Mount Ignore Default Permissions')}
+                      </HStack>
                     </GridItem>
                     <GridItem className={styles.valueCell}>
                       <RMSwitch
@@ -672,9 +704,6 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                         confirmTitle={'Confirm switch settings for backup-restic-mount-no-default-permissions?'}
                         onChange={() => handleSwitchChange('backup-restic-mount-no-default-permissions')}
                       />
-                      <Text className={styles.helperText}>
-                        Disables kernel permission checks (default_permissions) and ignores Unix mode bits.
-                      </Text>
                     </GridItem>
                   </Grid>
 
@@ -686,7 +715,10 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                     w='full'
                   >
                     <GridItem className={styles.rowLabel}>
-                      <Text>Restic mount owner root</Text>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>Restic mount owner root</Text>
+                        {h(ResticMountOwnerRootHelp, 'Restic Mount Owner Root')}
+                      </HStack>
                     </GridItem>
                     <GridItem className={styles.valueCell}>
                       <RMSwitch
@@ -695,7 +727,6 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                         confirmTitle={'Confirm switch settings for backup-restic-mount-owner-root?'}
                         onChange={() => handleSwitchChange('backup-restic-mount-owner-root')}
                       />
-                      <Text className={styles.helperText}>Show mounted files as owned by root.</Text>
                     </GridItem>
                   </Grid>
                 </Stack>
@@ -721,7 +752,10 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                     w='full'
                   >
                     <GridItem className={styles.rowLabel}>
-                      <Text>Restic mount no lock</Text>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>Restic mount no lock</Text>
+                        {h(ResticMountNoLockHelp, 'Restic Mount No Lock')}
+                      </HStack>
                     </GridItem>
                     <GridItem className={styles.valueCell}>
                       <RMSwitch
@@ -730,7 +764,6 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                         confirmTitle={'Confirm switch settings for backup-restic-mount-no-lock?'}
                         onChange={() => handleSwitchChange('backup-restic-mount-no-lock')}
                       />
-                      <Text className={styles.helperText}>Skip repository locking during mount.</Text>
                     </GridItem>
                   </Grid>
 
@@ -742,7 +775,10 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                     w='full'
                   >
                     <GridItem className={styles.rowLabel}>
-                      <Text>Restic mount verbose level (0-3)</Text>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>Restic mount verbose level (0-3)</Text>
+                        {h(ResticMountVerboseHelp, 'Restic Mount Verbose Level')}
+                      </HStack>
                     </GridItem>
                     <GridItem className={styles.valueCell}>
                       <NumberInput
@@ -754,9 +790,6 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                         confirmTitle={`Confirm backup-restic-mount-verbose to: `}
                         onConfirm={(value) => handleSettingChange('backup-restic-mount-verbose', value)}
                       />
-                      <Text className={styles.helperText}>
-                        Range 0-3; 0 is default, 1-3 increase detail (quiet requires 0).
-                      </Text>
                     </GridItem>
                   </Grid>
 
@@ -768,7 +801,10 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                     w='full'
                   >
                     <GridItem className={styles.rowLabel}>
-                      <Text>Restic mount quiet mode</Text>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>Restic mount quiet mode</Text>
+                        {h(ResticMountQuietHelp, 'Restic Mount Quiet Mode')}
+                      </HStack>
                     </GridItem>
                     <GridItem className={styles.valueCell}>
                       <RMSwitch
@@ -777,7 +813,6 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                         confirmTitle={'Confirm switch settings for backup-restic-mount-quiet?'}
                         onChange={() => handleSwitchChange('backup-restic-mount-quiet')}
                       />
-                      <Text className={styles.helperText}>Reduce output to minimal status messages.</Text>
                     </GridItem>
                   </Grid>
 
@@ -789,7 +824,10 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                     w='full'
                   >
                     <GridItem className={styles.rowLabel}>
-                      <Text>Allow unsafe restic mount (reuse external mount)</Text>
+                      <HStack spacing={1} justify='space-between' width='full'>
+                        <Text>Allow unsafe restic mount (reuse external mount)</Text>
+                        {h(ResticMountAllowUnsafeMountHelp, 'Allow Unsafe Restic Mount')}
+                      </HStack>
                     </GridItem>
                     <GridItem className={styles.valueCell}>
                       <RMSwitch
@@ -798,7 +836,6 @@ If a reseed is running, Unmount will wait until the job finishes before stopping
                         confirmTitle={'Confirm switch settings for backup-restic-allow-unsafe-mount?'}
                         onChange={() => handleSwitchChange('backup-restic-allow-unsafe-mount')}
                       />
-                      <Text className={styles.helperText}>Allow reuse of an existing mount point.</Text>
                     </GridItem>
                   </Grid>
                 </Stack>

--- a/share/dashboard_react/src/Pages/Settings/ResticPurgeStrategy/index.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticPurgeStrategy/index.jsx
@@ -733,9 +733,6 @@ Config: \`backup-keep-yearly\` / \`backup-keep-within-yearly\``
                 confirmTitle={"Confirm update 'backup-restic-purge-group-by':"}
                 onSave={(v) => { handleSave('backup-restic-purge-group-by', v) }}
               />
-              <Text className={styles.helperText}>
-                Allowed values: host, paths, tags. Comma-separated for multiple.
-              </Text>
             </GridItem>
             <GridItem className={styles.rowLabel}>
               <HStack spacing={2}>
@@ -750,9 +747,6 @@ Config: \`backup-keep-yearly\` / \`backup-keep-within-yearly\``
                 confirmTitle={"Confirm update 'backup-restic-purge-keep-tag':"}
                 onSave={(v) => { handleSave('backup-restic-purge-keep-tag', v) }}
               />
-              <Text className={styles.helperText}>
-                Space-separated tags, e.g. line:adhoc env:prod. Quote tags with commas.
-              </Text>
             </GridItem>
           </Grid>
         )

--- a/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
@@ -8,7 +8,7 @@ import TextForm from '../../components/TextForm'
 import Dropdown from '../../components/Dropdown'
 import ConfirmModal from '../../components/Modals/ConfirmModal'
 import { setSetting, switchSetting } from '../../redux/settingsSlice'
-import { resticInitRepo } from '../../redux/clusterSlice'
+import { resticInitRepo, resticCheckConfig } from '../../redux/clusterSlice'
 import styles from './styles.module.scss'
 import tableStyles from '../../components/TableType2/styles.module.scss'
 
@@ -286,6 +286,10 @@ function ResticRepositorySettings({
     setIsLegacyOpen(!awsBucket)
   }, [awsBucket])
 
+  useEffect(() => {
+    setCheckResult(null)
+  }, [archiveMode])
+
   const handleSettingChange = (setting, value, encodeValue = false) =>
     dispatch(
       setSetting({
@@ -326,6 +330,47 @@ function ResticRepositorySettings({
     } catch (error) {
       console.error('Failed to initialize repository:', error)
       onCloseInitModal()
+    }
+  }
+
+  // Check repository state
+  const [isCheckLoading, setIsCheckLoading] = useState(false)
+  const [checkResult, setCheckResult] = useState(null)
+  const {
+    isOpen: isChecklistModalOpen,
+    onOpen: onOpenChecklistModal,
+    onClose: onCloseChecklistModal
+  } = useDisclosure()
+  const [checklistConfirmedTarget, setChecklistConfirmedTarget] = useState(false)
+  const [checklistConfirmedNew, setChecklistConfirmedNew] = useState(false)
+  const isChecklistReady = checklistConfirmedTarget && checklistConfirmedNew
+
+  const handleCheckRepo = async () => {
+    setIsCheckLoading(true)
+    setCheckResult(null)
+    try {
+      const result = await dispatch(resticCheckConfig({ clusterName })).unwrap()
+      const data = result?.data
+      setCheckResult(data)
+      if (data?.status === 'initialization_required') {
+        setChecklistConfirmedTarget(false)
+        setChecklistConfirmedNew(false)
+        onOpenChecklistModal()
+      }
+    } catch (error) {
+      setCheckResult({ status: 'error', message: error?.errorMessage || error?.message || String(error) })
+    } finally {
+      setIsCheckLoading(false)
+    }
+  }
+
+  const handleChecklistConfirmInit = async () => {
+    onCloseChecklistModal()
+    try {
+      await dispatch(resticInitRepo({ clusterName, force: false })).unwrap()
+      setCheckResult({ status: 'ok', message: 'Repository initialized. Snapshot refresh queued.' })
+    } catch (error) {
+      setCheckResult({ status: 'error', message: error?.errorMessage || error?.message || String(error) })
     }
   }
 
@@ -446,11 +491,6 @@ function ResticRepositorySettings({
                       onChange={(value) => handleArchiveModeChange(value)}
                     />
                   </Flex>
-                  <Text className={styles.helperText}>
-                    backup-archive-mode selects the Restic storage backend. None disables Restic backups. Local and
-                    SFTP use the local repository path (Storage section). S3 enables the AWS/S3 settings below.
-                    Switching does not erase the values stored for other types.
-                  </Text>
                 </GridItem>
               </Grid>
 
@@ -537,29 +577,47 @@ function ResticRepositorySettings({
                       </HStack>
                     </GridItem>
                     <GridItem className={styles.valueCell}>
-                      <HStack width='100%' spacing={2}>
-                        <TextForm
-                          value={config?.backupResticLocalRepository}
-                          confirmTitle={`Confirm backup-restic-local-repository to `}
-                          className={styles.textbox}
-                          size='sm'
-                          placeholder='/var/lib/repman/backups/archive'
-                          onSave={(value) => handleSettingChange('backup-restic-local-repository', value, true)}
-                        />
-                        <RMButton
-                          size='sm'
-                          colorScheme='blue'
-                          onClick={handleResticInit}
-                          isDisabled={user?.grants['cluster-settings'] === false}
-                          title="Re-initialize local repository"
-                        >
-                          <HiRefresh />
-                        </RMButton>
-                        {h(
-                          'Re-initialize the local Restic repository. This creates a new repository configuration at the specified path. Use with caution - only needed if the repository is corrupted or being set up for the first time.',
-                          'Re-initialize Local Repository'
+                      <Stack spacing={1} width='100%'>
+                        <HStack width='100%' spacing={2}>
+                          <TextForm
+                            value={config?.backupResticLocalRepository}
+                            confirmTitle={`Confirm backup-restic-local-repository to `}
+                            className={styles.textbox}
+                            size='sm'
+                            placeholder='/var/lib/repman/backups/archive'
+                            onSave={(value) => handleSettingChange('backup-restic-local-repository', value, true)}
+                          />
+                          <RMButton
+                            size='sm'
+                            colorScheme='green'
+                            onClick={handleCheckRepo}
+                            isLoading={isCheckLoading}
+                            isDisabled={user?.grants['cluster-settings'] === false}
+                            title="Check local repository"
+                          >
+                            Check
+                          </RMButton>
+                          <RMButton
+                            size='sm'
+                            colorScheme='blue'
+                            onClick={handleResticInit}
+                            isDisabled={user?.grants['cluster-settings'] === false}
+                            title="Re-initialize local repository"
+                          >
+                            <HiRefresh />
+                          </RMButton>
+                          {h(
+                            'Re-initialize the local Restic repository. This creates a new repository configuration at the specified path. Use with caution - only needed if the repository is corrupted or being set up for the first time.',
+                            'Re-initialize Local Repository'
+                          )}
+                        </HStack>
+                        {checkResult && checkResult.status !== 'initialization_required' && (
+                          <Alert status={checkResult.status === 'ok' ? 'success' : 'error'} size='sm' borderRadius='md'>
+                            <AlertIcon />
+                            <Text fontSize='sm'>{checkResult.message}</Text>
+                          </Alert>
                         )}
-                      </HStack>
+                      </Stack>
                     </GridItem>
                   </Grid>
                 </Stack>
@@ -581,35 +639,47 @@ function ResticRepositorySettings({
                       </HStack>
                     </GridItem>
                     <GridItem className={styles.valueCell}>
-                      <HStack width='100%' spacing={2}>
-                        <TextForm
-                          value={config?.backupResticLocalRepository}
-                          confirmTitle={`Confirm backup-restic-local-repository to `}
-                          className={styles.textbox}
-                          size='sm'
-                          placeholder='sftp:user@host:/path/to/repo'
-                          onSave={(value) => handleSettingChange('backup-restic-local-repository', value, true)}
-                        />
-                        <RMButton
-                          size='sm'
-                          colorScheme='blue'
-                          onClick={handleResticInit}
-                          isDisabled={user?.grants['cluster-settings'] === false}
-                          title="Re-initialize SFTP repository"
-                        >
-                          <HiRefresh />
-                        </RMButton>
-                        {h(
-                          'Re-initialize the SFTP Restic repository. This creates a new repository configuration at the configured sftp:user@host:/path. Force re-initialization is not supported for SFTP repositories - remove the remote repository path manually over SSH before re-initializing.',
-                          'Re-initialize SFTP Repository'
+                      <Stack spacing={1} width='100%'>
+                        <HStack width='100%' spacing={2}>
+                          <TextForm
+                            value={config?.backupResticLocalRepository}
+                            confirmTitle={`Confirm backup-restic-local-repository to `}
+                            className={styles.textbox}
+                            size='sm'
+                            placeholder='sftp:user@host:/path/to/repo'
+                            onSave={(value) => handleSettingChange('backup-restic-local-repository', value, true)}
+                          />
+                          <RMButton
+                            size='sm'
+                            colorScheme='green'
+                            onClick={handleCheckRepo}
+                            isLoading={isCheckLoading}
+                            isDisabled={user?.grants['cluster-settings'] === false}
+                            title="Check SFTP repository"
+                          >
+                            Check
+                          </RMButton>
+                          <RMButton
+                            size='sm'
+                            colorScheme='blue'
+                            onClick={handleResticInit}
+                            isDisabled={user?.grants['cluster-settings'] === false}
+                            title="Re-initialize SFTP repository"
+                          >
+                            <HiRefresh />
+                          </RMButton>
+                          {h(
+                            'Re-initialize the SFTP Restic repository. This creates a new repository configuration at the configured sftp:user@host:/path. Force re-initialization is not supported for SFTP repositories - remove the remote repository path manually over SSH before re-initializing.',
+                            'Re-initialize SFTP Repository'
+                          )}
+                        </HStack>
+                        {checkResult && checkResult.status !== 'initialization_required' && (
+                          <Alert status={checkResult.status === 'ok' ? 'success' : 'error'} size='sm' borderRadius='md'>
+                            <AlertIcon />
+                            <Text fontSize='sm'>{checkResult.message}</Text>
+                          </Alert>
                         )}
-                      </HStack>
-                      <Text className={styles.helperText}>
-                        Stored in backup-restic-local-repository using restic&apos;s sftp syntax
-                        (sftp:user@host:/path/to/repo). The user in the path is an SSH login authenticated via
-                        SSH key only (no password). See (?) for SSH key setup and how this differs from the
-                        repository password above.
-                      </Text>
+                      </Stack>
                     </GridItem>
                   </Grid>
                 </Stack>
@@ -645,9 +715,6 @@ function ResticRepositorySettings({
                           regexPattern='^https?://[A-Za-z0-9.-]+(?::\\d+)?(?:/.*)?$'
                           onSave={(value) => handleSettingChange('backup-restic-aws-endpoint', value, true)}
                         />
-                        <Text className={styles.helperText}>
-                          Optional custom S3 endpoint (http/https with host; leave empty for AWS). Do not use s3:// here.
-                        </Text>
                       </GridItem>
                     </Grid>
 
@@ -673,9 +740,6 @@ function ResticRepositorySettings({
                           placeholder='us-east-1, eu-west-1, etc.'
                           onSave={(value) => handleSettingChange('backup-restic-aws-region', value)}
                         />
-                        <Text className={styles.helperText}>
-                          Leave empty only if the runtime environment already provides a usable AWS region (for example AWS_REGION or AWS_DEFAULT_REGION).
-                        </Text>
                       </GridItem>
                     </Grid>
                   </Stack>
@@ -732,9 +796,6 @@ function ResticRepositorySettings({
                         />
                       </GridItem>
                     </Grid>
-                    <Text className={styles.helperText}>
-                      Provide the access key and secret for this S3 repository configuration.
-                    </Text>
                   </Stack>
 
                   {/* 3. Repository target */}
@@ -845,9 +906,6 @@ function ResticRepositorySettings({
                         >
                           {awsRepoPath || 's3:<bucket>/<prefix>'}
                         </Text>
-                        <Text className={styles.helperText}>
-                          Preview of the S3 repository path after applying append-cluster rules.
-                        </Text>
                       </GridItem>
                     </Grid>
                   </Stack>
@@ -861,7 +919,16 @@ function ResticRepositorySettings({
                       <Text className={styles.helperText}>
                         Initialize the effective S3 repository shown in <strong>Repository target</strong> above.
                       </Text>
-                      <Box>
+                      <HStack spacing={2}>
+                        <RMButton
+                          size='sm'
+                          colorScheme='green'
+                          onClick={handleCheckRepo}
+                          isLoading={isCheckLoading}
+                          isDisabled={user?.grants['cluster-settings'] === false}
+                        >
+                          Check repository
+                        </RMButton>
                         <RMButton
                           size='sm'
                           colorScheme='blue'
@@ -870,7 +937,13 @@ function ResticRepositorySettings({
                         >
                           Initialize repository
                         </RMButton>
-                      </Box>
+                      </HStack>
+                      {checkResult && checkResult.status !== 'initialization_required' && (
+                        <Alert status={checkResult.status === 'ok' ? 'success' : 'error'} size='sm' borderRadius='md'>
+                          <AlertIcon />
+                          <Text fontSize='sm'>{checkResult.message}</Text>
+                        </Alert>
+                      )}
                     </Stack>
                   </Box>
 
@@ -911,11 +984,6 @@ function ResticRepositorySettings({
                               size='sm'
                               onSave={(value) => handleSettingChange('backup-restic-repository', value, true)}
                             />
-                            <Text className={styles.helperText}>
-                              Used only when the S3 bucket field is empty. For custom S3 services, use
-                              s3:https://server:port/bucket in this field. New configurations should prefer the
-                              dedicated bucket/prefix/endpoint/region fields above.
-                            </Text>
                           </GridItem>
                         </Grid>
                       </Stack>
@@ -975,9 +1043,6 @@ function ResticRepositorySettings({
                         placeholder='AWS_SESSION_TOKEN, NO_PROXY="host1,host2"'
                         onSave={(value) => handleSettingChange('backup-restic-additional-env', value)}
                       />
-                      <Text className={styles.helperText}>
-                        Optional env vars to pass to restic (comma or space separated KEY or KEY=VALUE). Quote values with commas.
-                      </Text>
                     </GridItem>
                   </Grid>
                 </Stack>
@@ -1052,6 +1117,49 @@ function ResticRepositorySettings({
           )
         })}
       </Stack>
+
+      <ConfirmModal
+        isOpen={isChecklistModalOpen}
+        closeModal={onCloseChecklistModal}
+        title="Initialize Restic Repository"
+        body={
+          <VStack align='start' spacing={3}>
+            <Text>
+              The {isAws ? 'S3/MinIO' : isSftp ? 'SFTP' : 'local'} repository is not yet initialized:
+            </Text>
+            <Text
+              fontWeight='bold'
+              fontSize='sm'
+              fontFamily='monospace'
+              bg='gray.100'
+              p={2}
+              borderRadius='md'
+              wordBreak='break-all'
+            >
+              {isAws ? awsRepoPath : config?.backupResticLocalRepository}
+            </Text>
+            <Divider />
+            <Checkbox
+              isChecked={checklistConfirmedTarget}
+              onChange={(e) => setChecklistConfirmedTarget(e.target.checked)}
+            >
+              <Text fontSize='sm'>I confirmed this is the intended repository target.</Text>
+            </Checkbox>
+            <Checkbox
+              isChecked={checklistConfirmedNew}
+              onChange={(e) => setChecklistConfirmedNew(e.target.checked)}
+            >
+              <Text fontSize='sm'>I understand this will create a new restic repository here.</Text>
+            </Checkbox>
+          </VStack>
+        }
+        onConfirmClick={handleChecklistConfirmInit}
+        confirmButtonText="Initialize"
+        confirmButtonProps={{
+          isDisabled: !isChecklistReady,
+          colorScheme: 'blue'
+        }}
+      />
 
       <ConfirmModal
         isOpen={isInitModalOpen}

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -448,6 +448,29 @@ export const resticInitRepo = createGuardedAsyncThunk(
         { allowEmptyPrefix },
         baseURL
       )
+      if (!status || status < 200 || status >= 300) {
+        const msg = (data && typeof data === 'object' && data.message)
+          ? data.message
+          : (typeof data === 'string' && data) ? data : 'Initialize repository request failed'
+        return thunkAPI.rejectWithValue({ errorMessage: msg, errorStatus: status || 500 })
+      }
+      return { data, status }
+    } catch (error) {
+      return handleError(error, thunkAPI)
+    }
+  }
+)
+
+export const resticCheckConfig = createGuardedAsyncThunk(
+  'cluster/resticCheckConfig',
+  async ({ clusterName }, thunkAPI) => {
+    try {
+      const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+      const { data, status } = await clusterService.resticCheckConfig(clusterName, baseURL)
+      if (!status || status < 200 || status >= 300) {
+        const msg = (data && typeof data === 'object' && data.message) ? data.message : 'Check repository request failed'
+        return thunkAPI.rejectWithValue({ errorMessage: msg, errorStatus: status || 500 })
+      }
       return { data, status }
     } catch (error) {
       return handleError(error, thunkAPI)

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -34,6 +34,7 @@ export const clusterService = {
   resticMountToggle,
   getResticMountStatus,
   resticInitRepo,
+  resticCheckConfig,
 
   // Security / workload remediation APIs
   fixSecState,
@@ -931,6 +932,10 @@ function resticInitRepo(clusterName, force, options, baseURL) {
     ? { allow_empty_prefix: true }
     : undefined
   return getApi(baseURL).post(endpoint, payload)
+}
+
+function resticCheckConfig(clusterName, baseURL) {
+  return getApi(baseURL).post(`clusters/${clusterName}/restic/check-config`)
 }
 
 function fixSecState(clusterName, errKey, baseURL, tag) {

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -47,6 +47,18 @@ const (
 	MoveLast  MoveType = "last"
 )
 
+// initPolicy controls whether automatic repository initialization may be attempted.
+type initPolicy int
+
+const (
+	// initPolicyPassive classifies repo state only; never attempts auto-init.
+	initPolicyPassive initPolicy = iota
+	// initPolicyBoot allows one auto-init attempt during manager startup.
+	initPolicyBoot
+	// initPolicyPreBackup allows an auto-init retry immediately before backup.
+	initPolicyPreBackup
+)
+
 func GetTaskName(taskType TaskType) string {
 	switch taskType {
 	case InitTask:
@@ -371,6 +383,7 @@ type ResticManager struct {
 	stopCh               chan struct{} // Stop channel to signal the goroutine to stop
 	CanFetch             bool
 	CanInitRepo          bool
+	AutoInit             bool
 	NeedPurgeNow         bool
 	PurgeNowOption       ResticPurgeOption
 	isPaused             bool
@@ -403,9 +416,15 @@ type ResticManager struct {
 	currentTask          *ResticTaskState
 	currentTaskMutex     *sync.Mutex
 	// Error backoff state to prevent log flooding
-	lastInitError    error     // Last init error encountered
-	initErrorCount   int       // Number of consecutive init errors
-	initBackoffUntil time.Time // Don't retry init until this time
+	lastInitError    error             // Last init error encountered
+	initErrorCount   int               // Number of consecutive init errors
+	initBackoffUntil time.Time         // Don't retry init until this time
+	bootInitDone     bool              // prevents repeated auto-init on subsequent FetchRepo calls
+	repoState        ManualCheckStatus // Most recently classified repository state
+	// s3existenceProber is a test seam; nil in production.
+	// When set, checkS3RepoFiles calls it instead of creating a real S3 client.
+	// It receives bucket, configKey, dataPrefix and returns existence + error for each.
+	s3existenceProber func(bucket, configKey, dataPrefix string) (configExists bool, configErr error, dataExists bool, dataErr error)
 }
 
 // NewResticRepo initializes the repository manager
@@ -576,6 +595,76 @@ func (repo *ResticManager) FetchAndClearError(task TaskType) error {
 	}
 
 	delete(repo.TaskErrors, task)
+	return errs
+}
+
+// GetInitIssue returns the current init error without consuming it.
+// It first checks TaskErrors[InitTask], then falls back to lastInitError (which
+// persists through backoff periods even after TaskErrors is consumed).
+// Returns (error, true) when an issue is present, (nil, false) otherwise.
+func (repo *ResticManager) GetInitIssue() (error, bool) {
+	repo.errorMutex.Lock()
+	defer repo.errorMutex.Unlock()
+	if err, exists := repo.TaskErrors[InitTask]; exists && err != nil {
+		return err, true
+	}
+	if repo.lastInitError != nil {
+		return repo.lastInitError, true
+	}
+	return nil, false
+}
+
+// GetRepoState returns the most recently classified repository state.
+// Returns empty string when the state has not yet been determined.
+func (repo *ResticManager) GetRepoState() ManualCheckStatus {
+	repo.errorMutex.Lock()
+	defer repo.errorMutex.Unlock()
+	return repo.repoState
+}
+
+func (repo *ResticManager) setRepoState(state ManualCheckStatus) {
+	repo.errorMutex.Lock()
+	defer repo.errorMutex.Unlock()
+	repo.repoState = state
+}
+
+// ClearRepoState discards the cached repository state so that the next
+// classification attempt (boot, pre-backup, or manual check) starts fresh.
+// Call this whenever repo-targeting config changes to prevent a stale
+// initialization_required state from suppressing passive fetches indefinitely.
+func (repo *ResticManager) ClearRepoState() {
+	repo.errorMutex.Lock()
+	defer repo.errorMutex.Unlock()
+	repo.repoState = ""
+}
+
+// FetchAndClearErrorsExcept returns and clears all TaskErrors except those for
+// the given task types. Excluded tasks are left in the map untouched.
+func (repo *ResticManager) FetchAndClearErrorsExcept(excludedTasks ...TaskType) map[TaskType]error {
+	repo.errorMutex.Lock()
+	defer repo.errorMutex.Unlock()
+
+	if len(repo.TaskErrors) == 0 {
+		return nil
+	}
+
+	excluded := make(map[TaskType]struct{}, len(excludedTasks))
+	for _, t := range excludedTasks {
+		excluded[t] = struct{}{}
+	}
+
+	errs := make(map[TaskType]error)
+	for k, v := range repo.TaskErrors {
+		if _, skip := excluded[k]; !skip {
+			errs[k] = v
+		}
+	}
+	for k := range errs {
+		delete(repo.TaskErrors, k)
+	}
+	if len(errs) == 0 {
+		return nil
+	}
 	return errs
 }
 
@@ -2978,22 +3067,21 @@ func (repo *ResticManager) resolveS3RepoSpec(repopath string) (bucket, prefix, e
 	return bucket, prefix, endpoint, nil
 }
 
-// checkS3RepoFiles verifies S3 repository structure and initializes if needed
+// checkS3RepoFiles verifies S3 repository structure without attempting auto-init.
 func (repo *ResticManager) checkS3RepoFiles(bucket, prefix, endpoint string) error {
-	// Create S3 client
-	client, err := s3helper.NewClient(repo.AwsAccessKeyID, repo.AwsSecretAccessKey, "", repo.AwsRegion, endpoint)
-	if err != nil {
-		repo.CanInitRepo = false
-		err = fmt.Errorf("failed to create S3 client: %w", err)
-		repo.SetError(InitTask, err)
-		repo.setInitErrorBackoff(err)
-		return err
-	}
+	return repo.checkS3RepoFilesWithPolicy(bucket, prefix, endpoint, initPolicyPassive)
+}
 
-	// Build config object key
+// checkS3RepoFilesWithPolicy verifies S3 repository structure.
+// When policy is not passive and AutoInit is true, it may attempt initialization.
+func (repo *ResticManager) checkS3RepoFilesWithPolicy(bucket, prefix, endpoint string, policy initPolicy) error {
 	configKey := "config"
 	if prefix != "" {
 		configKey = prefix + "/config"
+	}
+	dataPrefix := "data/"
+	if prefix != "" {
+		dataPrefix = prefix + "/data/"
 	}
 
 	endpointDisplay := endpoint
@@ -3003,31 +3091,56 @@ func (repo *ResticManager) checkS3RepoFiles(bucket, prefix, endpoint string) err
 	repo.Printf(logrus.DebugLevel, "Checking S3 repository: endpoint=%s bucket=%s prefix=%s",
 		endpointDisplay, bucket, prefix)
 
-	// Check if config exists
-	configExists, err := s3helper.CheckObjectExists(client, bucket, configKey)
-	if err != nil {
-		repo.CanInitRepo = false
-		repo.SetError(InitTask, err)
-		repo.setInitErrorBackoff(err)
-		return err
+	// Probe existence: use test seam if set, otherwise use real S3 client.
+	var configExists bool
+	var getDataExists func() (bool, error)
+
+	if repo.s3existenceProber != nil {
+		ce, ceErr, de, deErr := repo.s3existenceProber(bucket, configKey, dataPrefix)
+		if ceErr != nil {
+			repo.CanInitRepo = false
+			repo.SetError(InitTask, ceErr)
+			repo.setInitErrorBackoff(ceErr)
+			repo.setRepoState(ManualCheckStatusError)
+			return ceErr
+		}
+		configExists = ce
+		getDataExists = func() (bool, error) { return de, deErr }
+	} else {
+		client, err := s3helper.NewClient(repo.AwsAccessKeyID, repo.AwsSecretAccessKey, "", repo.AwsRegion, endpoint)
+		if err != nil {
+			repo.CanInitRepo = false
+			err = fmt.Errorf("failed to create S3 client: %w", err)
+			repo.SetError(InitTask, err)
+			repo.setInitErrorBackoff(err)
+			repo.setRepoState(ManualCheckStatusError)
+			return err
+		}
+		var checkErr error
+		configExists, checkErr = s3helper.CheckObjectExists(client, bucket, configKey)
+		if checkErr != nil {
+			repo.CanInitRepo = false
+			repo.SetError(InitTask, checkErr)
+			repo.setInitErrorBackoff(checkErr)
+			repo.setRepoState(ManualCheckStatusError)
+			return checkErr
+		}
+		getDataExists = func() (bool, error) {
+			return s3helper.ListPrefixHasRealObjects(client, bucket, dataPrefix)
+		}
 	}
 
 	if !configExists {
 		// Config missing - check for data directory
 		errstr := "repo config is missing"
 
-		dataPrefix := "data/"
-		if prefix != "" {
-			dataPrefix = prefix + "/data/"
-		}
-
-		dataExists, err := s3helper.ListPrefixHasRealObjects(client, bucket, dataPrefix)
+		dataExists, err := getDataExists()
 		if err != nil {
-			// Error checking data
 			repo.CanInitRepo = false
 			err = fmt.Errorf("%s and failed to check repo data: %w", errstr, err)
 			repo.SetError(InitTask, err)
 			repo.setInitErrorBackoff(err)
+			repo.setRepoState(ManualCheckStatusError)
 			return err
 		}
 
@@ -3038,21 +3151,27 @@ func (repo *ResticManager) checkS3RepoFiles(bucket, prefix, endpoint string) err
 			err = errors.New(errstr)
 			repo.SetError(InitTask, err)
 			repo.setInitErrorBackoff(err)
+			repo.setRepoState(ManualCheckStatusError)
 			return err
 		}
 
-		// No config, no data - return error to require explicit init
+		// No config, no data - fresh repository
 		repo.CanInitRepo = true
-		err = errors.New(errstr)
+		if policy != initPolicyPassive && repo.AutoInit {
+			return repo.InitRepoWithOptions(ResticInitOption{})
+		}
+		repo.setRepoState(ManualCheckStatusInitRequired)
+		err = errors.New("repository initialization required: " + errstr)
 		repo.SetError(InitTask, err)
 		repo.setInitErrorBackoff(err)
 		return err
 	}
 
-	// Config exists or was just initialized
+	// Config exists
 	repo.CanInitRepo = true
 	delete(repo.TaskErrors, InitTask)
 	repo.clearInitErrorBackoff()
+	repo.setRepoState(ManualCheckStatusOK)
 
 	return nil
 }
@@ -3137,10 +3256,21 @@ func (repo *ResticManager) shouldSkipInitDueToBackoff() bool {
 	return false
 }
 
+// CheckRepoFiles validates repository state without attempting auto-init.
+// It is safe to call from periodic/background paths.
 func (repo *ResticManager) CheckRepoFiles() error {
-	// Check if we're in backoff period due to repeated init failures
-	if repo.shouldSkipInitDueToBackoff() {
-		// Return cached error without retrying or logging
+	return repo.checkRepoFilesWithPolicy(initPolicyPassive)
+}
+
+// checkRepoFilesWithPolicy validates repository state and optionally attempts
+// automatic initialization depending on policy:
+//   - initPolicyPassive: classify state only; respects backoff; never inits
+//   - initPolicyBoot: may init once at startup; bypasses backoff
+//   - initPolicyPreBackup: may init before backup; bypasses backoff
+func (repo *ResticManager) checkRepoFilesWithPolicy(policy initPolicy) error {
+	// Passive mode respects backoff to avoid log flooding from periodic checks.
+	// Boot and pre-backup policies bypass backoff so they can retry.
+	if policy == initPolicyPassive && repo.shouldSkipInitDueToBackoff() {
 		repo.errorMutex.Lock()
 		cachedErr := repo.lastInitError
 		repo.errorMutex.Unlock()
@@ -3160,37 +3290,38 @@ func (repo *ResticManager) CheckRepoFiles() error {
 			repo.setInitErrorBackoff(err)
 			return err
 		}
-		client, err := s3helper.NewClient(repo.AwsAccessKeyID, repo.AwsSecretAccessKey, "", repo.AwsRegion, endpoint)
-		if err != nil {
-			repo.CanInitRepo = false
-			err = fmt.Errorf("failed to create S3 client: %w", err)
-			repo.SetError(InitTask, err)
-			repo.setInitErrorBackoff(err)
-			return err
+		if policy != initPolicyPassive {
+			client, err := s3helper.NewClient(repo.AwsAccessKeyID, repo.AwsSecretAccessKey, "", repo.AwsRegion, endpoint)
+			if err != nil {
+				repo.CanInitRepo = false
+				err = fmt.Errorf("failed to create S3 client: %w", err)
+				repo.SetError(InitTask, err)
+				repo.setInitErrorBackoff(err)
+				return err
+			}
+			if err := s3helper.EnsurePrefixMarker(client, bucket, prefix); err != nil {
+				repo.CanInitRepo = false
+				err = fmt.Errorf("failed to create S3 prefix marker: %w", err)
+				repo.SetError(InitTask, err)
+				repo.setInitErrorBackoff(err)
+				return err
+			}
 		}
-		if err := s3helper.EnsurePrefixMarker(client, bucket, prefix); err != nil {
-			repo.CanInitRepo = false
-			err = fmt.Errorf("failed to create S3 prefix marker: %w", err)
-			repo.SetError(InitTask, err)
-			repo.setInitErrorBackoff(err)
-			return err
-		}
-		return repo.checkS3RepoFiles(bucket, prefix, endpoint)
+		return repo.checkS3RepoFilesWithPolicy(bucket, prefix, endpoint, policy)
 	}
 
 	if config.IsSftpResticRepository(repopath) {
 		// Repo lives on a remote host via SSH/SFTP; skip local filesystem
 		// existence checks and let actual restic commands surface
 		// init-required errors naturally.
+		// Do not clear prior init failure state — a passive SFTP check cannot
+		// confirm the repository is healthy.
 		repo.CanInitRepo = true
-		delete(repo.TaskErrors, InitTask)
-		repo.clearInitErrorBackoff()
 		return nil
 	}
 
-	// Existing local filesystem logic
+	// Local filesystem check
 	if _, err := os.Stat(filepath.Join(repopath, "config")); os.IsNotExist(err) {
-		// Check the repo data
 		errstr := "repo config is missing"
 		_, err := os.Stat(filepath.Join(repopath, "data"))
 		if err == nil {
@@ -3198,31 +3329,314 @@ func (repo *ResticManager) CheckRepoFiles() error {
 			repo.CanInitRepo = false
 			err = errors.New(errstr)
 			repo.SetError(InitTask, err)
+			repo.setRepoState(ManualCheckStatusError)
 			return err
-		} else if err != nil && !os.IsNotExist(err) { // Not a not-exist error (i.e., other error)
+		} else if err != nil && !os.IsNotExist(err) {
 			errstr += " and failed to check repo data: " + err.Error()
 			repo.CanInitRepo = false
 			err = errors.New(errstr)
 			repo.SetError(InitTask, err)
-			return err
-		} else { // Repo data does not exist (explicit init required, but possible)
-			repo.CanInitRepo = true
-			err = errors.New(errstr)
-			repo.SetError(InitTask, err)
+			repo.setRepoState(ManualCheckStatusError)
 			return err
 		}
+		// Fresh repo: no config, no data.
+		repo.CanInitRepo = true
+		if policy != initPolicyPassive && repo.AutoInit {
+			return repo.InitRepoWithOptions(ResticInitOption{})
+		}
+		repo.setRepoState(ManualCheckStatusInitRequired)
+		err = errors.New("repository initialization required: " + errstr)
+		repo.SetError(InitTask, err)
+		return err
 	} else if err != nil {
 		repo.CanInitRepo = false
 		err = fmt.Errorf("failed to check repo config: %w", err)
 		repo.SetError(InitTask, err)
+		repo.setRepoState(ManualCheckStatusError)
 		return err
 	}
 
 	repo.CanInitRepo = true
-	delete(repo.TaskErrors, InitTask) // Clear any previous init errors
+	delete(repo.TaskErrors, InitTask)
 	repo.clearInitErrorBackoff()
+	repo.setRepoState(ManualCheckStatusOK)
 
 	return nil
+}
+
+// ManualCheckStatus indicates the outcome of a manual repository validation.
+type ManualCheckStatus string
+
+const (
+	ManualCheckStatusOK           ManualCheckStatus = "ok"
+	ManualCheckStatusInitRequired ManualCheckStatus = "initialization_required"
+	ManualCheckStatusError        ManualCheckStatus = "error"
+)
+
+// ManualCheckResult holds the outcome of a manual repository configuration check.
+type ManualCheckResult struct {
+	Status      ManualCheckStatus `json:"status"`
+	Message     string            `json:"message"`
+	CanInit     bool              `json:"can_init"`
+	FetchQueued bool              `json:"fetch_queued"`
+	RepoPath    string            `json:"repo_path,omitempty"`
+}
+
+// isResticInitRequiredError returns true when restic stderr indicates the repository
+// is not yet initialized (as opposed to a credential or network failure).
+func isResticInitRequiredError(stderr string) bool {
+	lower := strings.ToLower(stderr)
+	return strings.Contains(lower, "repository does not exist") ||
+		strings.Contains(lower, "is there a repository") ||
+		strings.Contains(lower, "please initialize the repository")
+}
+
+// validateRepoAccessReadOnly runs a lightweight read-only restic snapshots command to
+// confirm live repository access. Returns initRequired=true when stderr signals the
+// repository is not initialized, or a non-nil accessErr on any other failure.
+func (repo *ResticManager) validateRepoAccessReadOnly() (initRequired bool, accessErr error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	_, stderr, runErr := repo.RunCommandWithContext(ctx, []string{"snapshots", "--no-lock", "--json"}, logrus.DebugLevel, false)
+	if runErr != nil {
+		stderrStr := strings.TrimSpace(string(stderr))
+		if isResticInitRequiredError(stderrStr) {
+			return true, nil
+		}
+		if stderrStr != "" {
+			return false, errors.New(stderrStr)
+		}
+		return false, runErr
+	}
+	return false, nil
+}
+
+// validateLocalRepoManual classifies a local filesystem repository state read-only and
+// confirms access with a restic command when the config file is present.
+func (repo *ResticManager) validateLocalRepoManual(repoPath string) ManualCheckResult {
+	_, configErr := os.Stat(filepath.Join(repoPath, "config"))
+	if os.IsNotExist(configErr) {
+		_, dataErr := os.Stat(filepath.Join(repoPath, "data"))
+		if dataErr == nil {
+			return ManualCheckResult{
+				Status:  ManualCheckStatusError,
+				Message: "repository config is missing but data directory exists (corrupt repository)",
+				CanInit: false,
+			}
+		} else if os.IsNotExist(dataErr) {
+			return ManualCheckResult{
+				Status:  ManualCheckStatusInitRequired,
+				Message: "repository is not yet initialized",
+				CanInit: true,
+			}
+		}
+		return ManualCheckResult{
+			Status:  ManualCheckStatusError,
+			Message: fmt.Sprintf("failed to check repository data directory: %v", dataErr),
+			CanInit: false,
+		}
+	} else if configErr != nil {
+		return ManualCheckResult{
+			Status:  ManualCheckStatusError,
+			Message: fmt.Sprintf("failed to check repository config: %v", configErr),
+			CanInit: false,
+		}
+	}
+
+	initRequired, err := repo.validateRepoAccessReadOnly()
+	if initRequired {
+		return ManualCheckResult{
+			Status:  ManualCheckStatusInitRequired,
+			Message: "repository is not yet initialized",
+			CanInit: true,
+		}
+	}
+	if err != nil {
+		return ManualCheckResult{
+			Status:  ManualCheckStatusError,
+			Message: err.Error(),
+			CanInit: false,
+		}
+	}
+	return ManualCheckResult{
+		Status:  ManualCheckStatusOK,
+		Message: "repository configuration verified",
+		CanInit: true,
+	}
+}
+
+// validateS3RepoManual classifies an S3 repository state using read-only probes only
+// (no EnsurePrefixMarker writes) and confirms access with a restic command when the
+// config object is present.
+func (repo *ResticManager) validateS3RepoManual(repoPath string) ManualCheckResult {
+	bucket, prefix, endpoint, err := repo.resolveS3RepoSpec(repoPath)
+	if err != nil {
+		return ManualCheckResult{
+			Status:  ManualCheckStatusError,
+			Message: fmt.Sprintf("failed to parse S3 repository URL: %v", err),
+		}
+	}
+
+	configKey := "config"
+	if prefix != "" {
+		configKey = prefix + "/config"
+	}
+	dataPrefix := "data/"
+	if prefix != "" {
+		dataPrefix = prefix + "/data/"
+	}
+
+	var configExists bool
+	var dataExists bool
+
+	if repo.s3existenceProber != nil {
+		ce, ceErr, de, deErr := repo.s3existenceProber(bucket, configKey, dataPrefix)
+		if ceErr != nil {
+			return ManualCheckResult{
+				Status:  ManualCheckStatusError,
+				Message: fmt.Sprintf("failed to probe S3 config key: %v", ceErr),
+				CanInit: false,
+			}
+		}
+		if deErr != nil {
+			return ManualCheckResult{
+				Status:  ManualCheckStatusError,
+				Message: fmt.Sprintf("failed to probe S3 data prefix: %v", deErr),
+				CanInit: false,
+			}
+		}
+		configExists = ce
+		dataExists = de
+	} else {
+		client, clientErr := s3helper.NewClient(repo.AwsAccessKeyID, repo.AwsSecretAccessKey, "", repo.AwsRegion, endpoint)
+		if clientErr != nil {
+			return ManualCheckResult{
+				Status:  ManualCheckStatusError,
+				Message: fmt.Sprintf("failed to create S3 client: %v", clientErr),
+				CanInit: false,
+			}
+		}
+		configExists, err = s3helper.CheckObjectExists(client, bucket, configKey)
+		if err != nil {
+			return ManualCheckResult{
+				Status:  ManualCheckStatusError,
+				Message: fmt.Sprintf("failed to check S3 config key: %v", err),
+				CanInit: false,
+			}
+		}
+		if !configExists {
+			dataExists, err = s3helper.ListPrefixHasRealObjects(client, bucket, dataPrefix)
+			if err != nil {
+				return ManualCheckResult{
+					Status:  ManualCheckStatusError,
+					Message: fmt.Sprintf("failed to check S3 data prefix: %v", err),
+					CanInit: false,
+				}
+			}
+		}
+	}
+
+	if !configExists {
+		if dataExists {
+			return ManualCheckResult{
+				Status:  ManualCheckStatusError,
+				Message: "S3 repository config is missing but data objects exist (corrupt repository)",
+				CanInit: false,
+			}
+		}
+		return ManualCheckResult{
+			Status:  ManualCheckStatusInitRequired,
+			Message: "S3 repository is not yet initialized",
+			CanInit: true,
+		}
+	}
+
+	initRequired, err := repo.validateRepoAccessReadOnly()
+	if initRequired {
+		return ManualCheckResult{
+			Status:  ManualCheckStatusInitRequired,
+			Message: "S3 repository is not yet initialized",
+			CanInit: true,
+		}
+	}
+	if err != nil {
+		return ManualCheckResult{
+			Status:  ManualCheckStatusError,
+			Message: err.Error(),
+			CanInit: false,
+		}
+	}
+	return ManualCheckResult{
+		Status:  ManualCheckStatusOK,
+		Message: "S3 repository configuration verified",
+		CanInit: true,
+	}
+}
+
+// ValidateRepoConfigManual performs a read-only manual check of the current repository
+// configuration. It never attempts auto-initialization and never alters auto-init
+// policy state or error backoff state. It updates repoState so that the general
+// fetch suppression guard reflects the latest manual classification.
+func (repo *ResticManager) ValidateRepoConfigManual() ManualCheckResult {
+	result := repo.classifyRepoManual()
+	repo.setRepoState(result.Status)
+	return result
+}
+
+// classifyRepoManual performs the read-only classification logic for ValidateRepoConfigManual.
+func (repo *ResticManager) classifyRepoManual() ManualCheckResult {
+	repoPath := repo.GetRepoPath()
+	if strings.TrimSpace(repoPath) == "" {
+		return ManualCheckResult{
+			Status:  ManualCheckStatusError,
+			Message: "repository path is not configured",
+			CanInit: false,
+		}
+	}
+	if strings.TrimSpace(repo.BinaryPath) == "" {
+		return ManualCheckResult{
+			Status:  ManualCheckStatusError,
+			Message: "restic binary path is not configured",
+			CanInit: false,
+		}
+	}
+
+	if config.IsS3ResticRepository(repoPath) || repo.AwsBucket != "" {
+		result := repo.validateS3RepoManual(repoPath)
+		result.RepoPath = repoPath
+		return result
+	}
+
+	if config.IsSftpResticRepository(repoPath) {
+		initRequired, err := repo.validateRepoAccessReadOnly()
+		if initRequired {
+			return ManualCheckResult{
+				Status:   ManualCheckStatusInitRequired,
+				Message:  "SFTP repository is not yet initialized",
+				CanInit:  true,
+				RepoPath: repoPath,
+			}
+		}
+		if err != nil {
+			return ManualCheckResult{
+				Status:   ManualCheckStatusError,
+				Message:  err.Error(),
+				CanInit:  false,
+				RepoPath: repoPath,
+			}
+		}
+		return ManualCheckResult{
+			Status:   ManualCheckStatusOK,
+			Message:  "SFTP repository configuration verified",
+			CanInit:  true,
+			RepoPath: repoPath,
+		}
+	}
+
+	result := repo.validateLocalRepoManual(repoPath)
+	result.RepoPath = repoPath
+	return result
 }
 
 // RunCommand executes a command within the context of a Restic repository, capturing stdout and stderr.
@@ -3459,6 +3873,7 @@ func (repo *ResticManager) InitRepoWithOptions(opt ResticInitOption) error {
 	}
 
 	// Only add fetch task on successful initialization
+	delete(repo.TaskErrors, InitTask)
 	repo.AddFetchTask()
 	repo.clearInitErrorBackoff()
 
@@ -3512,7 +3927,9 @@ func (repo *ResticManager) fetchRepoSnapshots() error {
 	return nil // Success
 }
 
-// FetchRepo performs the fetch for snapshots and stats
+// FetchRepo performs the fetch for snapshots and stats.
+// The first call uses the boot auto-init policy (one-shot); subsequent calls
+// are passive and will not retry initialization automatically.
 func (repo *ResticManager) FetchRepo() error {
 	// Check if the repo is able to fetch and initialized
 	if !repo.GetCanFetch() {
@@ -3522,8 +3939,20 @@ func (repo *ResticManager) FetchRepo() error {
 	repo.SetCanFetch(false)
 	defer repo.SetCanFetch(true)
 
-	// Check if the repo is initialized
-	if err := repo.CheckRepoFiles(); err != nil {
+	// Determine policy: boot-time init is allowed once per manager lifetime.
+	repo.errorMutex.Lock()
+	bootDone := repo.bootInitDone
+	if !bootDone {
+		repo.bootInitDone = true
+	}
+	repo.errorMutex.Unlock()
+
+	policy := initPolicyPassive
+	if !bootDone {
+		policy = initPolicyBoot
+	}
+
+	if err := repo.checkRepoFilesWithPolicy(policy); err != nil {
 		return err
 	}
 
@@ -3846,6 +4275,13 @@ func (repo *ResticManager) BackupWithOptions(opt ResticBackupOption) (string, er
 
 	repo.SetCanFetch(false)
 	defer repo.SetCanFetch(true)
+
+	// Ensure the repository is ready before backup; retry init if fresh and
+	// auto-init is enabled. This bypasses passive backoff so a real backup
+	// attempt can recover from a failed boot init.
+	if err := repo.checkRepoFilesWithPolicy(initPolicyPreBackup); err != nil {
+		return "", err
+	}
 
 	// Prepare the arguments for the "backup" command
 	args := []string{"backup", "--json"}

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -3329,6 +3329,7 @@ func (repo *ResticManager) checkRepoFilesWithPolicy(policy initPolicy) error {
 			repo.CanInitRepo = false
 			err = errors.New(errstr)
 			repo.SetError(InitTask, err)
+			repo.setInitErrorBackoff(err)
 			repo.setRepoState(ManualCheckStatusError)
 			return err
 		} else if err != nil && !os.IsNotExist(err) {
@@ -3336,6 +3337,7 @@ func (repo *ResticManager) checkRepoFilesWithPolicy(policy initPolicy) error {
 			repo.CanInitRepo = false
 			err = errors.New(errstr)
 			repo.SetError(InitTask, err)
+			repo.setInitErrorBackoff(err)
 			repo.setRepoState(ManualCheckStatusError)
 			return err
 		}

--- a/utils/backupmgr/restic_test.go
+++ b/utils/backupmgr/restic_test.go
@@ -582,6 +582,9 @@ func TestCheckRepoFilesAutoInitCorrupt(t *testing.T) {
 	if _, statErr := os.Stat(filepath.Join(repoDir, "config")); !os.IsNotExist(statErr) {
 		t.Fatal("repo must not have been initialized for corrupt state")
 	}
+	if !repo.shouldSkipInitDueToBackoff() {
+		t.Fatal("expected backoff to be active after corrupt local repo detection")
+	}
 }
 
 func TestCheckS3RepoFilesAutoInitDisabled(t *testing.T) {

--- a/utils/backupmgr/restic_test.go
+++ b/utils/backupmgr/restic_test.go
@@ -406,22 +406,30 @@ func TestCheckRepoFiles(t *testing.T) {
 	})
 
 	// Fresh repo dir: no config, no data - explicit init required but still possible
-	if err := repo.CheckRepoFiles(); err == nil {
+	freshErr := repo.CheckRepoFiles()
+	if freshErr == nil {
 		t.Fatalf("expected error when repo is not yet initialized")
 	}
 	if !repo.CanInitRepo {
 		t.Fatalf("expected CanInitRepo true for a fresh, uninitialized repo")
+	}
+	if !strings.Contains(freshErr.Error(), "initialization required") {
+		t.Fatalf("expected fresh-repo error to contain 'initialization required', got %q", freshErr.Error())
 	}
 
 	// Data exists without config: corrupted repo, cannot be auto/explicitly initialized
 	if err := os.MkdirAll(filepath.Join(repoDir, "data"), 0755); err != nil {
 		t.Fatalf("mkdir data: %v", err)
 	}
-	if err := repo.CheckRepoFiles(); err == nil {
+	corruptErr := repo.CheckRepoFiles()
+	if corruptErr == nil {
 		t.Fatalf("expected error when config missing but data exists")
 	}
 	if repo.CanInitRepo {
 		t.Fatalf("expected CanInitRepo false when data exists without config")
+	}
+	if strings.Contains(corruptErr.Error(), "initialization required") {
+		t.Fatalf("corrupt-repo error must not contain 'initialization required', got %q", corruptErr.Error())
 	}
 }
 
@@ -432,10 +440,11 @@ func TestCheckRepoFilesSftp(t *testing.T) {
 		"RESTIC_REPOSITORY=sftp:backup@10.0.0.1:/srv/restic-repo",
 	})
 
-	// Simulate state left over from a prior failed init attempt, so we can
-	// verify the sftp branch clears it rather than just leaving CanInitRepo
-	// at its zero-value default of true. The backoff deadline is set in the
-	// past so it doesn't short-circuit this call to CheckRepoFiles.
+	// Simulate state left over from a prior failed init attempt. The backoff
+	// deadline is set in the past so it does not short-circuit the call to
+	// CheckRepoFiles. After the call we verify that CanInitRepo is true but
+	// the prior failure state is preserved — a passive SFTP check cannot
+	// confirm the repository is healthy, so it must not erase a real failure.
 	repo.CanInitRepo = false
 	repo.SetError(InitTask, errors.New("previous init failure"))
 	repo.errorMutex.Lock()
@@ -450,11 +459,240 @@ func TestCheckRepoFilesSftp(t *testing.T) {
 	if !repo.CanInitRepo {
 		t.Fatalf("expected CanInitRepo true for sftp repository")
 	}
-	if _, ok := repo.TaskErrors[InitTask]; ok {
-		t.Fatalf("expected InitTask error to be cleared for sftp repository")
+	if _, ok := repo.TaskErrors[InitTask]; !ok {
+		t.Fatalf("expected InitTask error to be retained for sftp repository")
 	}
-	if repo.shouldSkipInitDueToBackoff() {
-		t.Fatalf("expected init backoff to be cleared for sftp repository")
+	repo.errorMutex.Lock()
+	lastErr := repo.lastInitError
+	repo.errorMutex.Unlock()
+	if lastErr == nil {
+		t.Fatalf("expected init error backoff state to be retained for sftp repository")
+	}
+}
+
+func TestCheckS3RepoFilesFreshRepo(t *testing.T) {
+	repo := newPausedRepo(t)
+	// Wire the test seam: no config, no data (fresh bucket).
+	repo.s3existenceProber = func(bucket, configKey, dataPrefix string) (bool, error, bool, error) {
+		return false, nil, false, nil
+	}
+
+	err := repo.checkS3RepoFiles("test-bucket", "", "")
+	if err == nil {
+		t.Fatalf("expected error for fresh S3 repo")
+	}
+	if !repo.CanInitRepo {
+		t.Fatalf("expected CanInitRepo true for fresh S3 repo")
+	}
+	if !strings.Contains(err.Error(), "initialization required") {
+		t.Fatalf("expected 'initialization required' in error, got %q", err.Error())
+	}
+}
+
+func TestCheckS3RepoFilesCorruptRepo(t *testing.T) {
+	repo := newPausedRepo(t)
+	// Wire the test seam: no config but data exists (corrupt bucket).
+	repo.s3existenceProber = func(bucket, configKey, dataPrefix string) (bool, error, bool, error) {
+		return false, nil, true, nil
+	}
+
+	err := repo.checkS3RepoFiles("test-bucket", "", "")
+	if err == nil {
+		t.Fatalf("expected error for corrupt S3 repo")
+	}
+	if repo.CanInitRepo {
+		t.Fatalf("expected CanInitRepo false for corrupt S3 repo")
+	}
+	if strings.Contains(err.Error(), "initialization required") {
+		t.Fatalf("corrupt S3 repo error must not contain 'initialization required', got %q", err.Error())
+	}
+}
+
+func TestCheckRepoFilesAutoInitDisabled(t *testing.T) {
+	repo := newPausedRepo(t)
+	repoDir, _, _ := getTestingDirs(t)
+	resetSharedDirs(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=" + repoDir,
+	})
+	repo.AutoInit = false
+
+	err := repo.CheckRepoFiles()
+	if err == nil {
+		t.Fatal("expected error for fresh repo with auto-init disabled")
+	}
+	if !strings.Contains(err.Error(), "initialization required") {
+		t.Fatalf("expected 'initialization required', got %q", err.Error())
+	}
+	if !repo.CanInitRepo {
+		t.Fatal("expected CanInitRepo true for fresh repo")
+	}
+	if _, statErr := os.Stat(filepath.Join(repoDir, "config")); !os.IsNotExist(statErr) {
+		t.Fatal("repo must not have been initialized when auto-init is disabled")
+	}
+}
+
+func TestCheckRepoFilesAutoInitEnabled(t *testing.T) {
+	// CheckRepoFiles is a passive path; it must not auto-init even when AutoInit=true.
+	repo := newPausedRepo(t)
+	repoDir, _, _ := getTestingDirs(t)
+	resetSharedDirs(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=" + repoDir,
+	})
+	repo.AutoInit = true
+
+	err := repo.CheckRepoFiles()
+	if err == nil {
+		t.Fatal("passive CheckRepoFiles must return an error for a fresh repo even when AutoInit=true")
+	}
+	if !strings.Contains(err.Error(), "initialization required") {
+		t.Fatalf("expected 'initialization required', got %q", err.Error())
+	}
+	if !repo.CanInitRepo {
+		t.Fatal("expected CanInitRepo true for fresh repo")
+	}
+	if _, statErr := os.Stat(filepath.Join(repoDir, "config")); !os.IsNotExist(statErr) {
+		t.Fatal("CheckRepoFiles must not auto-init the repo")
+	}
+}
+
+func TestCheckRepoFilesAutoInitCorrupt(t *testing.T) {
+	repo := newPausedRepo(t)
+	repoDir, _, _ := getTestingDirs(t)
+	resetSharedDirs(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=" + repoDir,
+	})
+	repo.AutoInit = true
+	if err := os.MkdirAll(filepath.Join(repoDir, "data"), 0755); err != nil {
+		t.Fatalf("mkdir data: %v", err)
+	}
+
+	err := repo.CheckRepoFiles()
+	if err == nil {
+		t.Fatal("expected error for corrupt repo")
+	}
+	if repo.CanInitRepo {
+		t.Fatal("expected CanInitRepo false for corrupt repo")
+	}
+	if _, statErr := os.Stat(filepath.Join(repoDir, "config")); !os.IsNotExist(statErr) {
+		t.Fatal("repo must not have been initialized for corrupt state")
+	}
+}
+
+func TestCheckS3RepoFilesAutoInitDisabled(t *testing.T) {
+	repo := newPausedRepo(t)
+	repo.s3existenceProber = func(bucket, configKey, dataPrefix string) (bool, error, bool, error) {
+		return false, nil, false, nil
+	}
+	repo.AutoInit = false
+
+	err := repo.checkS3RepoFiles("test-bucket", "", "")
+	if err == nil {
+		t.Fatal("expected error for fresh S3 repo with auto-init disabled")
+	}
+	if !strings.Contains(err.Error(), "initialization required") {
+		t.Fatalf("expected 'initialization required', got %q", err.Error())
+	}
+	if !repo.CanInitRepo {
+		t.Fatal("expected CanInitRepo true for fresh S3 repo")
+	}
+}
+
+func TestCheckS3RepoFilesAutoInitEnabled(t *testing.T) {
+	// checkS3RepoFiles is a passive path; it must not auto-init even when AutoInit=true.
+	repo := newPausedRepo(t)
+	repo.s3existenceProber = func(bucket, configKey, dataPrefix string) (bool, error, bool, error) {
+		return false, nil, false, nil
+	}
+	repo.AutoInit = true
+
+	err := repo.checkS3RepoFiles("test-bucket", "", "")
+	if err == nil {
+		t.Fatal("passive checkS3RepoFiles must return an error for a fresh repo even when AutoInit=true")
+	}
+	if !strings.Contains(err.Error(), "initialization required") {
+		t.Fatalf("expected 'initialization required', got %q", err.Error())
+	}
+	if !repo.CanInitRepo {
+		t.Fatal("expected CanInitRepo true for fresh S3 repo")
+	}
+}
+
+func TestCheckS3RepoFilesAutoInitCorrupt(t *testing.T) {
+	repo := newPausedRepo(t)
+	repo.s3existenceProber = func(bucket, configKey, dataPrefix string) (bool, error, bool, error) {
+		return false, nil, true, nil // no config, data exists → corrupt
+	}
+	repo.AutoInit = true
+
+	err := repo.checkS3RepoFiles("test-bucket", "", "")
+	if err == nil {
+		t.Fatal("expected error for corrupt S3 repo")
+	}
+	if repo.CanInitRepo {
+		t.Fatal("expected CanInitRepo false for corrupt S3 repo")
+	}
+	if strings.Contains(err.Error(), "initialization required") {
+		t.Fatalf("corrupt S3 error must not contain 'initialization required', got %q", err.Error())
+	}
+}
+
+func TestCheckRepoFilesSftpAutoInitIgnored(t *testing.T) {
+	repo := newPausedRepo(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=sftp:backup@10.0.0.1:/srv/restic-repo",
+	})
+	repo.AutoInit = true
+
+	if err := repo.CheckRepoFiles(); err != nil {
+		t.Fatalf("expected no error for sftp repo, got %v", err)
+	}
+	if !repo.CanInitRepo {
+		t.Fatal("expected CanInitRepo true for sftp repo")
+	}
+	// AutoInit must have no effect on SFTP: no init attempt means no task error.
+	if _, attempted := repo.TaskErrors[InitTask]; attempted {
+		t.Fatal("expected no InitTask error for sftp repo: auto-init must not have been attempted")
+	}
+}
+
+func TestCheckRepoFilesAutoInitFailure(t *testing.T) {
+	// Boot-policy auto-init with a broken binary must fail, set backoff, and
+	// leave CanInitRepo=false so passive callers know init is pending.
+	repo := newPausedRepo(t)
+	repoDir, _, _ := getTestingDirs(t)
+	resetSharedDirs(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=" + repoDir,
+	})
+	repo.AutoInit = true
+	repo.BinaryPath = "/nonexistent/restic"
+
+	err := repo.checkRepoFilesWithPolicy(initPolicyBoot)
+	if err == nil {
+		t.Fatal("expected error when boot auto-init fails")
+	}
+	if repo.CanInitRepo {
+		t.Fatal("expected CanInitRepo false after failed boot auto-init")
+	}
+	if _, hasErr := repo.TaskErrors[InitTask]; !hasErr {
+		t.Fatal("expected InitTask error to be set after failed boot auto-init")
+	}
+	repo.errorMutex.Lock()
+	count := repo.initErrorCount
+	repo.errorMutex.Unlock()
+	if count == 0 {
+		t.Fatal("expected initErrorCount > 0 after failed boot auto-init")
+	}
+	if !repo.shouldSkipInitDueToBackoff() {
+		t.Fatal("expected backoff to be active after failed boot auto-init")
 	}
 }
 
@@ -2106,5 +2344,590 @@ func TestInitErrorBackoffPreventsFlooding(t *testing.T) {
 	if repo.initErrorCount != originalCount {
 		t.Errorf("initErrorCount changed during backoff: was %d, now %d",
 			originalCount, repo.initErrorCount)
+	}
+}
+
+func TestGetInitIssue(t *testing.T) {
+	repo := NewResticRepo("", nil, config.ConstLogModRestic)
+
+	// No error set: GetInitIssue should return false.
+	if _, ok := repo.GetInitIssue(); ok {
+		t.Fatal("expected no issue when neither TaskErrors nor lastInitError is set")
+	}
+
+	// TaskErrors[InitTask] set: should return that error.
+	taskErr := errors.New("task init error")
+	repo.SetError(InitTask, taskErr)
+	got, ok := repo.GetInitIssue()
+	if !ok {
+		t.Fatal("expected issue when TaskErrors[InitTask] is set")
+	}
+	if got != taskErr {
+		t.Fatalf("GetInitIssue returned %v, want %v", got, taskErr)
+	}
+
+	// After consuming TaskErrors[InitTask] via setInitErrorBackoff (which sets lastInitError),
+	// GetInitIssue should fall back to lastInitError.
+	backoffErr := errors.New("backoff init error")
+	repo.setInitErrorBackoff(backoffErr)
+	// Manually clear TaskErrors[InitTask] to simulate it having been consumed.
+	repo.errorMutex.Lock()
+	delete(repo.TaskErrors, InitTask)
+	repo.errorMutex.Unlock()
+
+	got, ok = repo.GetInitIssue()
+	if !ok {
+		t.Fatal("expected issue when lastInitError is set after TaskErrors consumed")
+	}
+	if got != backoffErr {
+		t.Fatalf("GetInitIssue returned %v, want %v", got, backoffErr)
+	}
+
+	// After ClearInitErrorBackoffManual, both are cleared.
+	repo.ClearInitErrorBackoffManual()
+	if _, ok := repo.GetInitIssue(); ok {
+		t.Fatal("expected no issue after ClearInitErrorBackoffManual")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Boot / pre-backup auto-init policy tests
+// ---------------------------------------------------------------------------
+
+// TestBootAutoInitRunsOnce verifies that the first FetchRepo call auto-inits a
+// fresh local repo when AutoInit is enabled, and that a second FetchRepo call
+// does not re-attempt init (passive policy).
+func TestBootAutoInitRunsOnce(t *testing.T) {
+	repoDir := t.TempDir()
+	cacheDir := t.TempDir()
+
+	repo := newPausedRepo(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=" + repoDir,
+		"RESTIC_CACHE_DIR=" + cacheDir,
+	})
+	repo.AutoInit = true
+
+	// First FetchRepo → boot policy → should auto-init and succeed.
+	if err := repo.FetchRepo(); err != nil {
+		t.Fatalf("first FetchRepo (boot) failed: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(repoDir, "config")); statErr != nil {
+		t.Fatalf("expected repo to be initialized after boot FetchRepo: %v", statErr)
+	}
+	if _, hasErr := repo.TaskErrors[InitTask]; hasErr {
+		t.Fatal("expected InitTask error cleared after successful boot auto-init")
+	}
+
+	// bootInitDone must now be true so subsequent FetchRepo calls are passive.
+	repo.errorMutex.Lock()
+	done := repo.bootInitDone
+	repo.errorMutex.Unlock()
+	if !done {
+		t.Fatal("expected bootInitDone=true after first FetchRepo")
+	}
+
+	// Second FetchRepo → passive policy → must succeed (repo is initialized).
+	if err := repo.FetchRepo(); err != nil {
+		t.Fatalf("second FetchRepo (passive) failed: %v", err)
+	}
+}
+
+// TestBootAutoInitDoesNotRepeatOnPassiveFetch verifies that after a failed boot
+// auto-init the subsequent passive FetchRepo calls do not retry init.
+func TestBootAutoInitDoesNotRepeatOnPassiveFetch(t *testing.T) {
+	repoDir := t.TempDir()
+	cacheDir := t.TempDir()
+
+	repo := newPausedRepo(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=" + repoDir,
+		"RESTIC_CACHE_DIR=" + cacheDir,
+	})
+	repo.AutoInit = true
+	repo.BinaryPath = "/nonexistent/restic"
+
+	// First FetchRepo → boot policy → init fails (broken binary).
+	bootErr := repo.FetchRepo()
+	if bootErr == nil {
+		t.Fatal("expected error from boot FetchRepo with broken binary")
+	}
+
+	repo.errorMutex.Lock()
+	countAfterBoot := repo.initErrorCount
+	repo.errorMutex.Unlock()
+	if countAfterBoot == 0 {
+		t.Fatal("expected initErrorCount > 0 after failed boot init")
+	}
+
+	// Expire the backoff so the second call would reach classification.
+	repo.errorMutex.Lock()
+	repo.initBackoffUntil = time.Now().Add(-time.Second)
+	repo.errorMutex.Unlock()
+
+	// Second FetchRepo → passive policy → must NOT attempt init (backoff expired
+	// but passive policy never inits), just report init-required.
+	_ = repo.FetchRepo()
+
+	// initErrorCount must not have increased via another init attempt.
+	repo.errorMutex.Lock()
+	countAfterPassive := repo.initErrorCount
+	repo.errorMutex.Unlock()
+	if countAfterPassive > countAfterBoot {
+		t.Fatalf("passive FetchRepo must not retry init: count was %d, now %d",
+			countAfterBoot, countAfterPassive)
+	}
+}
+
+// TestPreBackupAutoInitSuccess verifies that BackupWithOptions auto-inits a
+// fresh repo before attempting backup when AutoInit is enabled.
+func TestPreBackupAutoInitSuccess(t *testing.T) {
+	repoDir := t.TempDir()
+	cacheDir := t.TempDir()
+	dataDir := t.TempDir()
+
+	repo := newPausedRepo(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=" + repoDir,
+		"RESTIC_CACHE_DIR=" + cacheDir,
+	})
+	repo.AutoInit = true
+
+	// Mark boot as done so the FetchRepo inside the worker won't use boot policy.
+	repo.errorMutex.Lock()
+	repo.bootInitDone = true
+	repo.errorMutex.Unlock()
+
+	// Repo is fresh; backup should auto-init then succeed.
+	if err := os.WriteFile(filepath.Join(dataDir, "file.txt"), []byte("payload"), 0644); err != nil {
+		t.Fatalf("write data file: %v", err)
+	}
+	snapshotID, err := repo.BackupWithOptions(ResticBackupOption{
+		DirPath: dataDir,
+		Tags:    []string{"pre-backup-test"},
+	})
+	if err != nil {
+		t.Fatalf("BackupWithOptions failed after pre-backup auto-init: %v", err)
+	}
+	if snapshotID == "" {
+		t.Fatal("expected non-empty snapshot ID after successful backup")
+	}
+	if _, statErr := os.Stat(filepath.Join(repoDir, "config")); statErr != nil {
+		t.Fatalf("expected repo to be initialized after pre-backup auto-init: %v", statErr)
+	}
+}
+
+// TestPreBackupAutoInitFailure verifies that BackupWithOptions returns the real
+// init failure when pre-backup auto-init cannot succeed, and preserves backoff.
+func TestPreBackupAutoInitFailure(t *testing.T) {
+	repoDir := t.TempDir()
+	cacheDir := t.TempDir()
+	dataDir := t.TempDir()
+
+	repo := newPausedRepo(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=" + repoDir,
+		"RESTIC_CACHE_DIR=" + cacheDir,
+	})
+	repo.AutoInit = true
+	repo.BinaryPath = "/nonexistent/restic"
+
+	if err := os.WriteFile(filepath.Join(dataDir, "file.txt"), []byte("payload"), 0644); err != nil {
+		t.Fatalf("write data file: %v", err)
+	}
+	_, err := repo.BackupWithOptions(ResticBackupOption{
+		DirPath: dataDir,
+		Tags:    []string{"pre-backup-test"},
+	})
+	if err == nil {
+		t.Fatal("expected error when pre-backup auto-init fails")
+	}
+	if _, hasErr := repo.TaskErrors[InitTask]; !hasErr {
+		t.Fatal("expected InitTask error preserved after failed pre-backup init")
+	}
+	repo.errorMutex.Lock()
+	count := repo.initErrorCount
+	repo.errorMutex.Unlock()
+	if count == 0 {
+		t.Fatal("expected backoff state set after failed pre-backup init")
+	}
+}
+
+// TestPreBackupAutoInitBypassesPassiveBackoff verifies that BackupWithOptions
+// can retry init even when passive callers are in the backoff period.
+func TestPreBackupAutoInitBypassesPassiveBackoff(t *testing.T) {
+	repoDir := t.TempDir()
+	cacheDir := t.TempDir()
+	dataDir := t.TempDir()
+
+	repo := newPausedRepo(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=" + repoDir,
+		"RESTIC_CACHE_DIR=" + cacheDir,
+	})
+	repo.AutoInit = true
+
+	// Simulate a prior failed init with active backoff.
+	repo.errorMutex.Lock()
+	repo.lastInitError = errors.New("previous init failure")
+	repo.initErrorCount = 3
+	repo.initBackoffUntil = time.Now().Add(30 * time.Minute) // long backoff
+	repo.bootInitDone = true
+	repo.errorMutex.Unlock()
+	repo.SetError(InitTask, errors.New("previous init failure"))
+
+	// Passive CheckRepoFiles should respect backoff.
+	if err := repo.CheckRepoFiles(); err == nil {
+		t.Fatal("expected passive CheckRepoFiles to return backoff error")
+	}
+
+	// BackupWithOptions must bypass backoff and retry init.
+	if err := os.WriteFile(filepath.Join(dataDir, "file.txt"), []byte("payload"), 0644); err != nil {
+		t.Fatalf("write data file: %v", err)
+	}
+	snapshotID, err := repo.BackupWithOptions(ResticBackupOption{
+		DirPath: dataDir,
+		Tags:    []string{"bypass-backoff-test"},
+	})
+	if err != nil {
+		t.Fatalf("BackupWithOptions should bypass passive backoff and succeed: %v", err)
+	}
+	if snapshotID == "" {
+		t.Fatal("expected non-empty snapshot ID")
+	}
+}
+
+// TestPassiveFetchDoesNotAutoInit verifies that FetchRepo after boot init is
+// done never triggers auto-init on subsequent calls.
+func TestPassiveFetchDoesNotAutoInit(t *testing.T) {
+	repoDir := t.TempDir()
+	cacheDir := t.TempDir()
+
+	repo := newPausedRepo(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=" + repoDir,
+		"RESTIC_CACHE_DIR=" + cacheDir,
+	})
+	repo.AutoInit = true
+
+	// Mark boot done; repo remains uninitialized.
+	repo.errorMutex.Lock()
+	repo.bootInitDone = true
+	repo.errorMutex.Unlock()
+
+	// FetchRepo after boot done → passive → must not init.
+	fetchErr := repo.FetchRepo()
+	if fetchErr == nil {
+		t.Fatal("expected passive FetchRepo to return error for uninitialized repo")
+	}
+	if _, statErr := os.Stat(filepath.Join(repoDir, "config")); !os.IsNotExist(statErr) {
+		t.Fatal("passive FetchRepo must not auto-init the repo")
+	}
+}
+
+// TestSftpNotAutoInitedAtBootOrPreBackup verifies that SFTP repos are never
+// auto-initialized regardless of policy.
+func TestSftpNotAutoInitedAtBootOrPreBackup(t *testing.T) {
+	repo := newPausedRepo(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=sftp:backup@10.0.0.1:/srv/restic-repo",
+	})
+	repo.AutoInit = true
+
+	for _, policy := range []initPolicy{initPolicyBoot, initPolicyPreBackup, initPolicyPassive} {
+		// None of these should attempt init for SFTP; the call should return nil.
+		if err := repo.checkRepoFilesWithPolicy(policy); err != nil {
+			t.Fatalf("policy=%d: expected no error for SFTP repo, got %v", policy, err)
+		}
+		if !repo.CanInitRepo {
+			t.Fatalf("policy=%d: expected CanInitRepo true for SFTP repo", policy)
+		}
+		if _, hasErr := repo.TaskErrors[InitTask]; hasErr {
+			t.Fatalf("policy=%d: expected no InitTask error for SFTP repo", policy)
+		}
+	}
+}
+
+// TestS3BootAutoInitRunsOnce verifies that the boot policy auto-inits a fresh
+// S3 repo and that the passive wrapper does not.
+func TestS3BootAutoInitRunsOnce(t *testing.T) {
+	// Boot policy should auto-init.
+	repoDir := t.TempDir()
+	repo := newPausedRepo(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		// Point RESTIC_REPOSITORY at a local dir so restic init works without a
+		// real S3 endpoint. The s3existenceProber simulates fresh-S3 state.
+		"RESTIC_REPOSITORY=" + repoDir,
+	})
+	repo.s3existenceProber = func(bucket, configKey, dataPrefix string) (bool, error, bool, error) {
+		return false, nil, false, nil // fresh bucket
+	}
+	repo.AutoInit = true
+
+	if err := repo.checkS3RepoFilesWithPolicy("test-bucket", "", "", initPolicyBoot); err != nil {
+		t.Fatalf("boot policy: expected no error after S3 auto-init, got %v", err)
+	}
+	if !repo.CanInitRepo {
+		t.Fatal("boot policy: expected CanInitRepo true after S3 auto-init")
+	}
+	if _, statErr := os.Stat(filepath.Join(repoDir, "config")); statErr != nil {
+		t.Fatalf("boot policy: expected repo config after S3 auto-init: %v", statErr)
+	}
+
+	// Passive wrapper (checkS3RepoFiles) must not init.
+	repoDir2 := t.TempDir()
+	repo2 := newPausedRepo(t)
+	repo2.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=" + repoDir2,
+	})
+	repo2.s3existenceProber = func(bucket, configKey, dataPrefix string) (bool, error, bool, error) {
+		return false, nil, false, nil
+	}
+	repo2.AutoInit = true
+
+	err := repo2.checkS3RepoFiles("test-bucket", "", "")
+	if err == nil {
+		t.Fatal("passive checkS3RepoFiles must not auto-init even when AutoInit=true")
+	}
+	if !strings.Contains(err.Error(), "initialization required") {
+		t.Fatalf("expected 'initialization required', got %q", err.Error())
+	}
+}
+
+// --- ValidateRepoConfigManual tests ---
+
+func TestValidateRepoConfigManualMissingPath(t *testing.T) {
+	repo := newPausedRepo(t)
+	// No RESTIC_REPOSITORY set, GetRepoPath returns ""
+	result := repo.ValidateRepoConfigManual()
+	if result.Status != ManualCheckStatusError {
+		t.Fatalf("expected error with missing repo path, got %s: %s", result.Status, result.Message)
+	}
+}
+
+func TestValidateRepoConfigManualFreshLocal(t *testing.T) {
+	repo := newPausedRepo(t)
+	repoDir, cacheDir, _ := getTestingDirs(t)
+	resetSharedDirs(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=" + repoDir,
+		"RESTIC_CACHE_DIR=" + cacheDir,
+	})
+
+	result := repo.ValidateRepoConfigManual()
+	if result.Status != ManualCheckStatusInitRequired {
+		t.Fatalf("expected initialization_required for fresh repo, got %s: %s", result.Status, result.Message)
+	}
+	if !result.CanInit {
+		t.Fatalf("expected CanInit true for fresh repo")
+	}
+	if result.FetchQueued {
+		t.Fatalf("expected FetchQueued false for init-required result")
+	}
+}
+
+func TestValidateRepoConfigManualCorruptLocal(t *testing.T) {
+	repo := newPausedRepo(t)
+	repoDir, cacheDir, _ := getTestingDirs(t)
+	resetSharedDirs(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=" + repoDir,
+		"RESTIC_CACHE_DIR=" + cacheDir,
+	})
+	// Create data dir without config file to simulate corruption.
+	if err := os.MkdirAll(filepath.Join(repoDir, "data"), 0755); err != nil {
+		t.Fatalf("mkdir data: %v", err)
+	}
+
+	result := repo.ValidateRepoConfigManual()
+	if result.Status != ManualCheckStatusError {
+		t.Fatalf("expected error for corrupt repo, got %s: %s", result.Status, result.Message)
+	}
+	if result.CanInit {
+		t.Fatalf("expected CanInit false for corrupt repo")
+	}
+}
+
+func TestValidateRepoConfigManualValidLocal(t *testing.T) {
+	repo, repoDir, cacheDir, _ := newResticRepo(t, false)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=" + repoDir,
+		"RESTIC_CACHE_DIR=" + cacheDir,
+	})
+
+	result := repo.ValidateRepoConfigManual()
+	if result.Status != ManualCheckStatusOK {
+		t.Fatalf("expected ok for valid repo, got %s: %s", result.Status, result.Message)
+	}
+	if result.RepoPath != repoDir {
+		t.Fatalf("expected repo path %s, got %s", repoDir, result.RepoPath)
+	}
+}
+
+func TestValidateRepoConfigManualFreshS3(t *testing.T) {
+	repo := newPausedRepo(t)
+	repo.s3existenceProber = func(bucket, configKey, dataPrefix string) (bool, error, bool, error) {
+		return false, nil, false, nil // no config, no data
+	}
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=s3:https://minio.example.com/mybucket/myprefix",
+	})
+
+	result := repo.ValidateRepoConfigManual()
+	if result.Status != ManualCheckStatusInitRequired {
+		t.Fatalf("expected initialization_required for fresh S3 repo, got %s: %s", result.Status, result.Message)
+	}
+	if !result.CanInit {
+		t.Fatalf("expected CanInit true for fresh S3 repo")
+	}
+}
+
+func TestValidateRepoConfigManualCorruptS3(t *testing.T) {
+	repo := newPausedRepo(t)
+	repo.s3existenceProber = func(bucket, configKey, dataPrefix string) (bool, error, bool, error) {
+		return false, nil, true, nil // no config, data exists → corrupt
+	}
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=s3:https://minio.example.com/mybucket/myprefix",
+	})
+
+	result := repo.ValidateRepoConfigManual()
+	if result.Status != ManualCheckStatusError {
+		t.Fatalf("expected error for corrupt S3 repo, got %s: %s", result.Status, result.Message)
+	}
+	if result.CanInit {
+		t.Fatalf("expected CanInit false for corrupt S3 repo")
+	}
+}
+
+func TestValidateRepoConfigManualS3ProbeError(t *testing.T) {
+	repo := newPausedRepo(t)
+	repo.s3existenceProber = func(bucket, configKey, dataPrefix string) (bool, error, bool, error) {
+		return false, errors.New("connection refused"), false, nil
+	}
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=s3:https://minio.example.com/mybucket/myprefix",
+	})
+
+	result := repo.ValidateRepoConfigManual()
+	if result.Status != ManualCheckStatusError {
+		t.Fatalf("expected error on S3 probe failure, got %s: %s", result.Status, result.Message)
+	}
+}
+
+func TestValidateRepoConfigManualDoesNotAutoInit(t *testing.T) {
+	repo := newPausedRepo(t)
+	repoDir, cacheDir, _ := getTestingDirs(t)
+	resetSharedDirs(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=" + repoDir,
+		"RESTIC_CACHE_DIR=" + cacheDir,
+	})
+	repo.AutoInit = true // must be ignored by manual check
+
+	result := repo.ValidateRepoConfigManual()
+	// Fresh repo: must return init_required, never ok (no auto-init)
+	if result.Status != ManualCheckStatusInitRequired {
+		t.Fatalf("expected initialization_required; auto-init must not run during manual check, got %s: %s", result.Status, result.Message)
+	}
+	// Confirm repo was not actually initialized
+	if _, err := os.Stat(filepath.Join(repoDir, "config")); err == nil {
+		t.Fatal("repository was initialized during manual check but should not have been")
+	}
+}
+
+// --- ValidateRepoConfigManual sets repoState ---
+
+func TestValidateRepoConfigManualSetsStateInitRequired(t *testing.T) {
+	repo := newPausedRepo(t)
+	repoDir, cacheDir, _ := getTestingDirs(t)
+	resetSharedDirs(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=" + repoDir,
+		"RESTIC_CACHE_DIR=" + cacheDir,
+	})
+
+	result := repo.ValidateRepoConfigManual()
+	if result.Status != ManualCheckStatusInitRequired {
+		t.Fatalf("expected initialization_required, got %s", result.Status)
+	}
+	if got := repo.GetRepoState(); got != ManualCheckStatusInitRequired {
+		t.Fatalf("GetRepoState() = %s after init-required check, want initialization_required", got)
+	}
+}
+
+func TestValidateRepoConfigManualSetsStateOK(t *testing.T) {
+	repo, repoDir, cacheDir, _ := newResticRepo(t, false)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=" + repoDir,
+		"RESTIC_CACHE_DIR=" + cacheDir,
+	})
+
+	result := repo.ValidateRepoConfigManual()
+	if result.Status != ManualCheckStatusOK {
+		t.Fatalf("expected ok, got %s: %s", result.Status, result.Message)
+	}
+	if got := repo.GetRepoState(); got != ManualCheckStatusOK {
+		t.Fatalf("GetRepoState() = %s after ok check, want ok", got)
+	}
+}
+
+func TestValidateRepoConfigManualSetsStateError(t *testing.T) {
+	repo := newPausedRepo(t)
+	repoDir, cacheDir, _ := getTestingDirs(t)
+	resetSharedDirs(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=" + repoDir,
+		"RESTIC_CACHE_DIR=" + cacheDir,
+	})
+	// Corrupt repo: data dir present but no config file.
+	if err := os.MkdirAll(filepath.Join(repoDir, "data"), 0755); err != nil {
+		t.Fatalf("mkdir data: %v", err)
+	}
+
+	result := repo.ValidateRepoConfigManual()
+	if result.Status != ManualCheckStatusError {
+		t.Fatalf("expected error for corrupt repo, got %s", result.Status)
+	}
+	if got := repo.GetRepoState(); got != ManualCheckStatusError {
+		t.Fatalf("GetRepoState() = %s after error check, want error", got)
+	}
+}
+
+func TestValidateRepoConfigManualFreshS3SetsState(t *testing.T) {
+	repo := newPausedRepo(t)
+	repo.s3existenceProber = func(bucket, configKey, dataPrefix string) (bool, error, bool, error) {
+		return false, nil, false, nil // no config, no data → fresh
+	}
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=s3:https://minio.example.com/mybucket/myprefix",
+	})
+
+	result := repo.ValidateRepoConfigManual()
+	if result.Status != ManualCheckStatusInitRequired {
+		t.Fatalf("expected initialization_required for fresh S3 repo, got %s", result.Status)
+	}
+	if got := repo.GetRepoState(); got != ManualCheckStatusInitRequired {
+		t.Fatalf("GetRepoState() = %s after S3 init-required check, want initialization_required", got)
 	}
 }


### PR DESCRIPTION
## Summary
- add manual restic repository config checking and clearer init state handling
- scope auto-init behavior so boot and pre-backup paths can recover fresh repos without passive retries
- add dashboard repo check/init UX for local, SFTP, and S3 repository settings

## Testing
- git diff --cached --check
- go test -run "^$" ./cluster ./server ./config
- go test -run "^$" ./utils/backupmgr
- go test -run "^(TestCheckRepoFiles|TestCheckRepoFilesSftp|TestCheckS3RepoFilesFreshRepo|TestCheckS3RepoFilesCorruptRepo|TestGetInitIssue|TestValidateRepoConfigManualMissingPath|TestValidateRepoConfigManualFreshLocal|TestValidateRepoConfigManualCorruptLocal)$" ./utils/backupmgr