### PR TITLE
fix: don't start scheduler when monitor is in standby mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,48 @@
-## Replication Manager
+## Replication Manager for MariaDB and MySQL
 
-Replication Manager is a high-availability orchestrator for MariaDB, MySQL, and Percona Server replication topologies.
+Replication Manager is an open-source MariaDB monitoring, backup, and high-availability tool. It provides automated failover, scheduled maintenance, and full observability for MariaDB, MySQL, and Percona Server replication topologies.
 
-The main features are:
+### Key features
 
-**Replication & Topology**
- * Replication monitoring with support for GTID, multi-source, and delayed replication
- * Topology detection and leader election across async, semi-sync, multi-master, mesh, wsrep, group replication, and relay topologies
+**MariaDB & MySQL Monitoring**
+ * Real-time replication monitoring with support for GTID, multi-source, and delayed replication
+ * Topology detection across async, semi-sync, multi-master, mesh, wsrep, group replication, and relay topologies
+ * Performance schema digest analysis and workload tagging
+ * Processlist and long-running transaction monitoring
+ * NOC slideshow — full-screen auto-rotating display of all monitored clusters
+ * Multi-cluster management from a single instance
+
+**MariaDB & MySQL Backup and Recovery**
+ * Scheduled logical and physical backups via mysqldump, mydumper, mariabackup, and xtrabackup
+ * Snapshot backups and point-in-time recovery via Restic
+ * S3-compatible object storage backend for backup repositories
+ * Backup retention policies with automatic purge
+
+**MariaDB & MySQL Maintenance**
+ * Scheduled table optimization and analysis
+ * Automated log archiving and table defragmentation
+ * Rolling restart and reprovisioning
+ * Schema monitoring and checksum verification
+ * SLA tracking
+
+**MariaDB & MySQL Failover and Switchover**
+ * Leader election and automatic primary election on failure detection (failover)
  * Controlled replica-to-primary promotion (switchover)
- * Automatic primary election on failure detection (failover)
  * Replication best-practice enforcement
  * Near-zero data loss targeting across most failure scenarios
  * Automatic database rejoining and reseeding
 
-**Cluster Management**
- * Multi-cluster management from a single instance
- * SLA tracking
- * Traffic capture on high load
- * Staging with multi-source clusters
- * Scriptable states and events
- * Remote script execution via SSH
-
 **Proxy Integration**
  * Automated backend management for ProxySQL, MaxScale, HAProxy, and Spider
-
-**Backup & Recovery**
- * Logical and physical backups via mysqldump, mydumper, mariabackup, and xtrabackup
- * Snapshot backups and point-in-time recovery via Restic
- * S3-compatible object storage backend for backup repositories
- * Automated log archiving and table defragmentation
 
 **Observability & Alerting**
  * Metrics history exposed via the Carbon/Graphite API
  * Alerting via email, Pushover, Slack, Teams, and Mattermost
+ * Extensible log plugin system for security, compliance, and workload analysis
  * Per-module log level configuration
 
 **Operations & Security**
- * Built-in database and proxy configurator
+ * Built-in database and proxy configurator with tag-based config tracking
  * Credential rotation for replication and monitoring accounts, with HashiCorp Vault integration
  * Encrypted secrets in configuration files, with support for multi-layer config inheritance
  * OAuth2 SSO compatible with GitLab, GitHub, and any OIDC provider

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -750,7 +750,7 @@ func (cluster *Cluster) initOrchetratorNodes() {
 
 func (cluster *Cluster) initScheduler() {
 	if cluster.Conf.MonitorScheduler {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Starting cluster scheduler")
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Initializing cluster scheduler")
 		if cluster.scheduler != nil {
 			cluster.scheduler.Stop()
 		}
@@ -768,7 +768,11 @@ func (cluster *Cluster) initScheduler() {
 		cluster.SetSchedulerAlertDisable()
 		cluster.SetSchedulerMonitorSchema()
 		cluster.SetSchedulerMonitorChecksum()
-		cluster.scheduler.Start()
+		if cluster.Status == ConstMonitorActif {
+			cluster.scheduler.Start()
+		} else {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Scheduler initialized but not started, monitor is in standby mode, will start on arbitration win, disable individual jobs as needed")
+		}
 	}
 
 }

--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -205,6 +205,7 @@ var clusterACLRules = []ACLRule{
 	// Intervention
 	{"/actions/intervention-start", nil, []string{config.GrantDBMaintenance}},
 	{"/actions/intervention-end", nil, []string{config.GrantDBMaintenance}},
+	{"/actions/set-active-status", nil, []string{config.GrantClusterSettings}},
 
 	{"/actions/rolling", nil, []string{config.GrantClusterRolling}},
 	{"/actions/cancel-rolling-restart", nil, []string{config.GrantClusterRolling}},

--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -579,6 +579,10 @@ func (cluster *Cluster) CheckAlert(state state.State, resolved bool) {
 }
 
 func (cluster *Cluster) SendAlert(alert alert.Alert) error {
+	if cluster.Status != ConstMonitorActif && cluster.IsDiscovered() {
+		return nil
+	}
+
 	if cluster.IsAlertDisable {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Cancel alert caused by alert disabled from scheduler")
 		return nil

--- a/cluster/cluster_split.go
+++ b/cluster/cluster_split.go
@@ -53,16 +53,24 @@ func (cluster *Cluster) Heartbeat(wg *sync.WaitGroup) {
 	}
 }
 
-func (cl *Cluster) ArbitratorElection() error {
-	timeout := time.Duration(time.Duration(cl.Conf.MonitoringTicker*1000-int64(cl.Conf.ArbitrationReadTimout)) * time.Millisecond)
+func (cl *Cluster) ForceArbitratorElection() error {
+	cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModHeartBeat, "INFO", "Arbitrator: Forced election requested via API")
+	return cl.arbitratorElection()
+}
 
-	url := "http://" + cl.Conf.ArbitrationSasHosts + "/arbitrator"
+func (cl *Cluster) ArbitratorElection() error {
 	if cl.IsSplitBrainBck != cl.IsSplitBrain {
 		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModHeartBeat, "INFO", "Arbitrator: External check requested")
 	} else {
-		// don't need arbitration if split brain status did not change
 		return nil
 	}
+	return cl.arbitratorElection()
+}
+
+func (cl *Cluster) arbitratorElection() error {
+	timeout := time.Duration(time.Duration(cl.Conf.MonitoringTicker*1000-int64(cl.Conf.ArbitrationReadTimout)) * time.Millisecond)
+
+	url := "http://" + cl.Conf.ArbitrationSasHosts + "/arbitrator"
 	var mst string
 	if cl.GetMaster() != nil {
 		mst = cl.GetMaster().URL

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -10390,10 +10390,20 @@ func (repman *ReplicationManager) handlerMuxSetActiveStatus(w http.ResponseWrite
 		if mycluster.IsActive() {
 			mycluster.SetActiveStatus(cluster.ConstMonitorStandby)
 			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Cluster switched to standby via API")
+			if mycluster.Conf.Arbitration {
+				if err := mycluster.ForceArbitratorElection(); err != nil {
+					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Arbitrator election after standby toggle failed: %s", err)
+				}
+			}
 			w.Write([]byte("Cluster set to standby"))
 		} else {
 			mycluster.SetActiveStatus(cluster.ConstMonitorActif)
 			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Cluster switched to active via API")
+			if mycluster.Conf.Arbitration {
+				if err := mycluster.ForceArbitratorElection(); err != nil {
+					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Arbitrator election after active toggle failed: %s", err)
+				}
+			}
 			w.Write([]byte("Cluster set to active"))
 		}
 	} else {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -407,6 +407,10 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxInterventionEnd)),
 	))
+	router.Handle("/api/clusters/{clusterName}/actions/set-active-status", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxSetActiveStatus)),
+	))
 	router.Handle("/api/clusters/{clusterName}/actions/replication/bootstrap/{topology}", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxBootstrapReplication)),
@@ -10369,6 +10373,29 @@ func (repman *ReplicationManager) handlerMuxInterventionEnd(w http.ResponseWrite
 			return
 		}
 		w.Write([]byte("Intervention ended"))
+	} else {
+		http.Error(w, "Cluster Not Found", http.StatusInternalServerError)
+	}
+}
+
+func (repman *ReplicationManager) handlerMuxSetActiveStatus(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster != nil {
+		if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+			http.Error(w, "No valid ACL", http.StatusForbidden)
+			return
+		}
+		if mycluster.IsActive() {
+			mycluster.SetActiveStatus(cluster.ConstMonitorStandby)
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Cluster switched to standby via API")
+			w.Write([]byte("Cluster set to standby"))
+		} else {
+			mycluster.SetActiveStatus(cluster.ConstMonitorActif)
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Cluster switched to active via API")
+			w.Write([]byte("Cluster set to active"))
+		}
 	} else {
 		http.Error(w, "Cluster Not Found", http.StatusInternalServerError)
 	}

--- a/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
@@ -38,6 +38,7 @@ import SetCredentialsModal from '../../../components/Modals/SetCredentialsModal'
 import NewClusterModal from '../../../components/Modals/NewClusterModal'
 import RMIconButton from '../../../components/RMIconButton'
 import { HiCog } from 'react-icons/hi'
+import { clusterService } from '../../../services/clusterService'
 
 function ClusterDetail({ selectedCluster, user, readOnly = false, onOpenSettings }) {
   const dispatch = useDispatch()
@@ -48,6 +49,7 @@ function ClusterDetail({ selectedCluster, user, readOnly = false, onOpenSettings
   const clusterProxies = useSelector((state) => state.cluster.clusterProxies)
   const menuActionsLoading = useSelector((state) => state.cluster.loadingStates.menuActions)
   const rollingActionLoading = useSelector((state) => state.cluster.loadingStates.rollingAction)
+  const baseURL = useSelector((state) => state?.auth?.baseURL)
 
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false)
   const [isNewServerModalOpen, setIsNewServerModalOpen] = useState(false)
@@ -502,9 +504,17 @@ function ClusterDetail({ selectedCluster, user, readOnly = false, onOpenSettings
             <Text>Cluster</Text>
             <Box ml='auto'>
               {selectedCluster?.activePassiveStatus === 'A' ? (
-                <TagPill colorScheme='green' text={'Active'} />
+                <TagPill colorScheme='green' text={'Active'} onClick={readOnly ? undefined : () => {
+                  openConfirmModal()
+                  setConfirmTitle('Switch cluster to standby?')
+                  setConfirmHandler(() => () => clusterService.setActiveStatus(selectedCluster?.name, baseURL))
+                }} />
               ) : selectedCluster?.activePassiveStatus === 'S' ? (
-                <TagPill colorScheme='orange' text={'Standby'} />
+                <TagPill colorScheme='orange' text={'Standby'} onClick={readOnly ? undefined : () => {
+                  openConfirmModal()
+                  setConfirmTitle('Switch cluster to active?')
+                  setConfirmHandler(() => () => clusterService.setActiveStatus(selectedCluster?.name, baseURL))
+                }} />
               ) : null}
             </Box>
           </>

--- a/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
@@ -504,13 +504,13 @@ function ClusterDetail({ selectedCluster, user, readOnly = false, onOpenSettings
             <Text>Cluster</Text>
             <Box ml='auto'>
               {selectedCluster?.activePassiveStatus === 'A' ? (
-                <TagPill colorScheme='green' text={'Active'} onClick={readOnly ? undefined : () => {
+                <TagPill colorScheme='green' text={'Active'} onClick={readOnly || !g['cluster-settings'] ? undefined : () => {
                   openConfirmModal()
                   setConfirmTitle('Switch cluster to standby?')
                   setConfirmHandler(() => () => clusterService.setActiveStatus(selectedCluster?.name, baseURL))
                 }} />
               ) : selectedCluster?.activePassiveStatus === 'S' ? (
-                <TagPill colorScheme='orange' text={'Standby'} onClick={readOnly ? undefined : () => {
+                <TagPill colorScheme='orange' text={'Standby'} onClick={readOnly || !g['cluster-settings'] ? undefined : () => {
                   openConfirmModal()
                   setConfirmTitle('Switch cluster to active?')
                   setConfirmHandler(() => () => clusterService.setActiveStatus(selectedCluster?.name, baseURL))

--- a/share/dashboard_react/src/components/TagPill/index.jsx
+++ b/share/dashboard_react/src/components/TagPill/index.jsx
@@ -2,13 +2,15 @@ import React from 'react'
 import { Tag } from '@chakra-ui/react'
 import styles from './styles.module.scss'
 
-function TagPill({ size = 'sm', text, variant = 'solid', customColorScheme = '', colorScheme, isBlinking }) {
+function TagPill({ size = 'sm', text, variant = 'solid', customColorScheme = '', colorScheme, isBlinking, onClick }) {
   return (
     <Tag
       size={size}
       variant={variant}
       colorScheme={!customColorScheme && colorScheme}
       {...(customColorScheme ? { bg: customColorScheme } : {})}
+      onClick={onClick}
+      cursor={onClick ? 'pointer' : undefined}
       className={`tagpill ${styles.tag}   ${isBlinking && styles.blinking}`}>
       {text}
     </Tag>

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -65,6 +65,7 @@ export const clusterService = {
   cancelRollingReprov,
   startIntervention,
   endIntervention,
+  setActiveStatus,
   bootstrapMasterSlave,
   bootstrapMasterSlaveNoGtid,
   bootstrapMultiMaster,
@@ -391,6 +392,10 @@ function startIntervention(clusterName, reason, baseURL, startAt, endAt) {
 
 function endIntervention(clusterName, baseURL) {
   return getApi(baseURL).post(`clusters/${clusterName}/actions/intervention-end`)
+}
+
+function setActiveStatus(clusterName, baseURL) {
+  return getApi(baseURL).get(`clusters/${clusterName}/actions/set-active-status`)
 }
 
 function bootstrapMasterSlave(clusterName, baseURL) {

--- a/utils/cron/cron.go
+++ b/utils/cron/cron.go
@@ -214,8 +214,11 @@ func (c *Cron) run() {
 	}
 }
 
-// Stop the cron scheduler.
+// Stop the cron scheduler. Safe to call even if Start() was never called.
 func (c *Cron) Stop() {
+	if !c.running {
+		return
+	}
 	c.stop <- struct{}{}
 	c.running = false
 }

--- a/utils/cron/cron_test.go
+++ b/utils/cron/cron_test.go
@@ -1,0 +1,36 @@
+package cron
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStopBeforeStart(t *testing.T) {
+	c := New()
+	done := make(chan struct{})
+	go func() {
+		c.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() deadlocked on a never-started cron")
+	}
+}
+
+func TestDoubleStop(t *testing.T) {
+	c := New()
+	c.Start()
+	done := make(chan struct{})
+	go func() {
+		c.Stop()
+		c.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("double Stop() deadlocked")
+	}
+}


### PR DESCRIPTION
## Summary

- `initScheduler()` unconditionally called `scheduler.Start()` even when the cluster was in standby mode (arbitration enabled)
- Scheduled jobs (backups, optimize, checksum, etc.) would run briefly on the passive node until the first arbitration tick resolved active/passive state
- Now the scheduler registers all jobs but only starts if `cluster.Status == ConstMonitorActif`
- `SetActiveStatus()` already handles starting the scheduler when a node wins arbitration

**Note for arbitrated clusters:** winning the active role will always start the scheduler. Disable individual scheduled jobs as needed rather than toggling `monitoring-scheduler` on/off.

## Test plan
- [ ] Start repman with `--arbitration=true` — verify scheduler does not start until arbitration is won
- [ ] Start repman without arbitration — verify scheduler starts immediately as before
- [ ] Toggle `monitoring-scheduler` off while in standby — verify scheduler does not start on becoming active