### PR TITLE
feat(restic): add repository copy and wipe workflows

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -299,6 +299,7 @@ type Cluster struct {
 	failLoadP12Cert                     bool                        `json:"-"`
 	Mailer                              *mailer.Mailer              `json:"-"`
 	ResticManager                       *backupmgr.ResticManager    `json:"-"`
+	resolvedS3Mode                      string                      // probe-resolved S3 mode during auto startup; "" if not yet probed
 	MessageChan                         chan sharedlog.Message      `json:"-"`
 	ErrorConfigs                        config.ErrorConfigs         `json:"-"` //To store error config
 	Partner                             *config.Partner             `json:"partner" groups:"web"`

--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -165,7 +165,9 @@ var clusterACLRules = []ACLRule{
 	{"/backups/stats", nil, []string{config.GrantClusterShowBackups}}, // read-only stats
 	{"/backups/", nil, []string{config.GrantDBBackup}},                // write sub-paths: delete, reconcile
 	{"/backups", nil, []string{config.GrantClusterShowBackups}},       // list (bare path, no slash)
-	{"/restic/purge", nil, []string{config.GrantDBBackup}},            // delete a snapshot
+	{"/restic/purge", nil, []string{config.GrantDBBackup}},                                        // delete a snapshot
+	{"/restic/wipe", nil, []string{config.GrantDBBackup}},                                         // destructive wipe
+	{"/restic/check-config", nil, []string{config.GrantClusterProcess, config.GrantDBBackup}},     // preview also required by wipe workflow
 	{"/restic/snapshots", nil, []string{config.GrantClusterShowBackups}},
 	{"/restic/stats", nil, []string{config.GrantClusterShowBackups}},
 

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -46,6 +46,65 @@ func ValidateResticSftpRepository(repoPath string) error {
 	return nil
 }
 
+// parseLegacyS3ResticRepo decomposes a legacy restic S3 repository URL of the form
+//
+//	s3:[scheme://host/]bucket[/prefix...]
+//
+// into its endpoint, bucket, and raw prefix components. The scheme (http/https) is
+// preserved in the returned endpoint. A bare hostname (containing a dot or colon) is
+// also returned as the endpoint. bucket-only and bucket/prefix forms produce an empty
+// endpoint. The returned prefix is the raw stored value without any cluster suffix;
+// callers that need append-cluster behaviour must pass it through buildResticS3RepoSpec.
+func parseLegacyS3ResticRepo(rawURL string) (endpoint, bucket, prefix string, err error) {
+	if !config.IsS3ResticRepository(rawURL) {
+		return "", "", "", fmt.Errorf("not an S3 repository URL: %q", rawURL)
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(rawURL, "s3:"))
+	if rest == "" {
+		return "", "", "", fmt.Errorf("S3 repository URL is empty after s3: prefix")
+	}
+
+	// Explicit scheme (https:// or http://).
+	if strings.HasPrefix(rest, "https://") || strings.HasPrefix(rest, "http://") {
+		schemeSep := strings.Index(rest, "://")
+		afterScheme := rest[schemeSep+3:] // "host/bucket[/prefix]"
+		slashIdx := strings.Index(afterScheme, "/")
+		if slashIdx < 0 {
+			return "", "", "", fmt.Errorf("S3 repository URL %q has a scheme and host but no bucket", rawURL)
+		}
+		endpoint = rest[:schemeSep+3+slashIdx] // "scheme://host"
+		rest = afterScheme[slashIdx+1:]         // "bucket[/prefix]"
+	} else {
+		// No scheme: first path segment is either a bare hostname (contains "." or ":")
+		// or the bucket name. This mirrors how restic itself distinguishes the two forms:
+		// "s3:s3.amazonaws.com/bucket" vs "s3:bucket/prefix".
+		slashIdx := strings.Index(rest, "/")
+		if slashIdx >= 0 {
+			first := rest[:slashIdx]
+			if strings.ContainsAny(first, ".:") {
+				endpoint = first
+				rest = rest[slashIdx+1:] // "bucket[/prefix]"
+			}
+			// else: no separating character → rest stays "bucket[/prefix]"
+		}
+		// no slash → rest is just "bucket"
+	}
+
+	// rest is now "bucket[/prefix...]"
+	slashIdx := strings.Index(rest, "/")
+	if slashIdx < 0 {
+		bucket = rest
+	} else {
+		bucket = rest[:slashIdx]
+		prefix = rest[slashIdx+1:]
+	}
+	bucket = strings.TrimSpace(bucket)
+	if bucket == "" {
+		return "", "", "", fmt.Errorf("could not extract bucket from S3 repository URL %q", rawURL)
+	}
+	return endpoint, bucket, prefix, nil
+}
+
 func buildResticS3RepoSpec(endpoint, bucket, prefix, clusterName string, appendCluster bool) (string, string) {
 	bucket = strings.TrimSpace(bucket)
 	prefix = strings.Trim(prefix, "/")
@@ -541,6 +600,109 @@ func (cluster *Cluster) CheckResticErrors() {
 	}
 }
 
+// resticResolveSavedCopySource resolves the cluster's currently stored configuration
+// for the given backend type into an effective ResticCopySourceOption. The resolved
+// option is frozen in memory before queueing so later config changes cannot alter
+// the already-queued task (Guardrail S6). Secrets are never exposed to the caller
+// beyond the returned struct (Guardrail S0/S3).
+//
+// requestedMode must be config.ConstBackupArchiveModeResticLocal or
+// config.ConstBackupArchiveModeResticAws. For Local/SFTP, the effective mode in the
+// returned option may be upgraded to restic-sftp when the resolved path matches
+// SFTP syntax. keyHint is passed through unchanged.
+func (cluster *Cluster) resticResolveSavedCopySource(requestedMode, keyHint string) (backupmgr.ResticCopySourceOption, error) {
+	password := cluster.Conf.GetDecryptedValue("backup-restic-password")
+	if password == "" {
+		return backupmgr.ResticCopySourceOption{}, fmt.Errorf("saved source config is incomplete: backup-restic-password is empty")
+	}
+
+	switch requestedMode {
+	case config.ConstBackupArchiveModeResticLocal:
+		localRepoPath, appendCluster := resolveResticRepoPolicy(cluster.Conf, cluster.Conf.BackupResticLocalRepository, cluster)
+		var repoPath string
+		if localRepoPath != "" {
+			repoPath = localRepoPath
+			if appendCluster && shouldAppendClusterNameLocal(repoPath, cluster.Name) {
+				repoPath = filepath.Join(repoPath, cluster.Name)
+			}
+		} else {
+			repoPath = filepath.Join(cluster.Conf.WorkingDir, config.ConstStreamingSubDir, "archive", cluster.Name)
+		}
+		if repoPath == "" {
+			return backupmgr.ResticCopySourceOption{}, fmt.Errorf("saved Local/SFTP source config is incomplete: effective repository path could not be resolved")
+		}
+		inferredMode := config.ConstBackupArchiveModeResticLocal
+		if config.IsSftpResticRepository(repoPath) {
+			inferredMode = config.ConstBackupArchiveModeResticSftp
+		}
+		return backupmgr.ResticCopySourceOption{
+			Mode:       inferredMode,
+			Repository: repoPath,
+			Password:   password,
+			KeyHint:    keyHint,
+		}, nil
+
+	case config.ConstBackupArchiveModeResticAws:
+		// Use the stored append flag directly instead of resolveResticRepoPolicy.
+		// resolveResticRepoPolicy gates on conf.BackupResticAws to decide whether to
+		// honour appendCluster=false, so it would corrupt saved S3 source prefix
+		// interpretation whenever the operator switches the destination away from AWS.
+		// shouldAppendClusterNameS3 inside buildResticS3RepoSpec still prevents
+		// double-appending, so passing the raw stored flag is safe.
+		appendCluster := cluster.Conf.BackupResticRepoAppendCluster
+
+		// Structured S3 config takes precedence (Guardrail S9). When bucket is absent,
+		// fall back to the legacy backup-restic-repository S3 URL if one is configured.
+		bucket := strings.TrimSpace(cluster.Conf.BackupResticAwsBucket)
+		var endpoint, rawPrefix, accessKeyID, accessSecret, region string
+
+		if bucket != "" {
+			endpoint = strings.TrimSpace(cluster.Conf.BackupResticAwsEndpoint)
+			rawPrefix = cluster.Conf.BackupResticAwsPrefix
+			accessKeyID = cluster.Conf.BackupResticAwsAccessKeyId
+			accessSecret = cluster.Conf.GetDecryptedValue("backup-restic-aws-access-secret")
+			region = strings.TrimSpace(cluster.Conf.BackupResticAwsRegion)
+		} else {
+			legacyURL := strings.TrimSpace(cluster.Conf.BackupResticRepository)
+			if !config.IsS3ResticRepository(legacyURL) {
+				return backupmgr.ResticCopySourceOption{}, fmt.Errorf(
+					"saved S3 source config is incomplete: neither backup-restic-aws-bucket nor a valid backup-restic-repository S3 URL is configured")
+			}
+			parsedEndpoint, parsedBucket, parsedPrefix, parseErr := parseLegacyS3ResticRepo(legacyURL)
+			if parseErr != nil {
+				return backupmgr.ResticCopySourceOption{}, fmt.Errorf(
+					"saved S3 source config is incomplete: neither backup-restic-aws-bucket nor a valid backup-restic-repository S3 URL is configured")
+			}
+			bucket = parsedBucket
+			endpoint = parsedEndpoint
+			rawPrefix = parsedPrefix
+			// Legacy URL carries no structured access keys; use whatever AWS credentials
+			// are stored (BackupResticAwsAccessKeyId/Secret), or ambient auth if empty.
+			accessKeyID = cluster.Conf.BackupResticAwsAccessKeyId
+			accessSecret = cluster.Conf.GetDecryptedValue("backup-restic-aws-access-secret")
+			region = strings.TrimSpace(cluster.Conf.BackupResticAwsRegion)
+		}
+
+		_, effectivePrefix := buildResticS3RepoSpec(endpoint, bucket, rawPrefix, cluster.Name, appendCluster)
+		return backupmgr.ResticCopySourceOption{
+			Mode:     config.ConstBackupArchiveModeResticAws,
+			Password: password,
+			KeyHint:  keyHint,
+			AWS: &backupmgr.ResticCopySourceAWSOption{
+				Endpoint:     endpoint,
+				Bucket:       bucket,
+				Prefix:       effectivePrefix,
+				AccessKeyID:  accessKeyID,
+				AccessSecret: accessSecret,
+				Region:       region,
+			},
+		}, nil
+
+	default:
+		return backupmgr.ResticCopySourceOption{}, fmt.Errorf("saved-source preset is not supported for mode %q: use restic-local or restic-aws", requestedMode)
+	}
+}
+
 // ResticCopyRepoWithOptions validates and enqueues a repository copy task.
 // Static validation (mode, repo string, password, S3 credential mismatch) is
 // performed before queueing. One destination-state case is also preflight-checked
@@ -554,6 +716,23 @@ func (cluster *Cluster) ResticCopyRepoWithOptions(opt backupmgr.ResticCopyOption
 
 	if cluster.ResticManager == nil {
 		cluster.StartResticManager()
+	}
+
+	// When use_saved_config=true, resolve the cluster's stored config for the
+	// requested backend type into a concrete source option before validation/queueing.
+	// Hybrid payloads that mix use_saved_config with inline manual fields are rejected
+	// to avoid ambiguous resolution (Guardrail S1/S3).
+	if opt.Source.UseSavedConfig {
+		src := opt.Source
+		hasInline := src.Repository != "" || src.Password != "" || src.AWS != nil
+		if hasInline {
+			return fmt.Errorf("saved-source payload is invalid: inline repository/password/aws fields are not allowed when use_saved_config=true")
+		}
+		resolved, err := cluster.resticResolveSavedCopySource(src.Mode, src.KeyHint)
+		if err != nil {
+			return err
+		}
+		opt.Source = resolved
 	}
 
 	if err := cluster.ResticManager.ValidateCopyOption(opt); err != nil {

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -130,6 +130,98 @@ func buildResticS3RepoSpec(endpoint, bucket, prefix, clusterName string, appendC
 	return repoPath, prefix
 }
 
+// resticS3Resolution is the output of resolveResticS3: the concrete S3
+// configuration that will be used for a given selector mode.
+type resticS3Resolution struct {
+	Mode         string // ConstResticS3ModeNew or ConstResticS3ModeLegacy (never "auto")
+	RepoPath     string // effective s3:... repository path
+	Endpoint     string
+	Bucket       string
+	Prefix       string // effective prefix after append-cluster logic
+	AccessKeyID  string
+	AccessSecret string
+	Region       string
+}
+
+// resolveResticS3 applies the backup-restic-s3-mode selector and returns a
+// fully-resolved S3 configuration.  auto is promoted to new or legacy based on
+// which fields are actually populated.  The returned Mode is always new or
+// legacy (never auto).
+//
+// The cluster parameter may be nil; when non-nil it is only used for the
+// resolveResticRepoPolicy call (append-cluster logging).
+func resolveResticS3(conf *config.Config, clusterName string, cluster *Cluster) (resticS3Resolution, error) {
+	_, appendCluster := resolveResticRepoPolicy(conf, conf.BackupResticLocalRepository, cluster)
+
+	mode := conf.BackupResticS3Mode
+	if mode == "" {
+		mode = config.ConstResticS3ModeAuto
+	}
+
+	if mode == config.ConstResticS3ModeAuto {
+		// If a probe-resolved mode was determined at startup, use it directly
+		// instead of falling back to presence-based heuristics.
+		if cluster != nil && cluster.resolvedS3Mode != "" {
+			mode = cluster.resolvedS3Mode
+		} else if strings.TrimSpace(conf.BackupResticAwsBucket) != "" {
+			mode = config.ConstResticS3ModeNew
+		} else if config.IsS3ResticRepository(strings.TrimSpace(conf.BackupResticRepository)) {
+			mode = config.ConstResticS3ModeLegacy
+		} else {
+			return resticS3Resolution{}, fmt.Errorf(
+				"S3 configuration error: neither backup-restic-aws-bucket nor a valid backup-restic-repository S3 URL is configured")
+		}
+	}
+
+	switch mode {
+	case config.ConstResticS3ModeNew:
+		bucket := strings.TrimSpace(conf.BackupResticAwsBucket)
+		if bucket == "" {
+			return resticS3Resolution{}, fmt.Errorf(
+				"backup-restic-s3-mode=new requires backup-restic-aws-bucket to be set")
+		}
+		endpoint := strings.TrimSpace(conf.BackupResticAwsEndpoint)
+		repoPath, effectivePrefix := buildResticS3RepoSpec(
+			endpoint, bucket, conf.BackupResticAwsPrefix, clusterName, appendCluster)
+		return resticS3Resolution{
+			Mode:         config.ConstResticS3ModeNew,
+			RepoPath:     repoPath,
+			Endpoint:     endpoint,
+			Bucket:       bucket,
+			Prefix:       effectivePrefix,
+			AccessKeyID:  conf.BackupResticAwsAccessKeyId,
+			AccessSecret: conf.GetDecryptedValue("backup-restic-aws-access-secret"),
+			Region:       strings.TrimSpace(conf.BackupResticAwsRegion),
+		}, nil
+
+	case config.ConstResticS3ModeLegacy:
+		legacyURL := strings.TrimSpace(conf.BackupResticRepository)
+		if !config.IsS3ResticRepository(legacyURL) {
+			return resticS3Resolution{}, fmt.Errorf(
+				"backup-restic-s3-mode=legacy requires backup-restic-repository to be a valid S3 URL")
+		}
+		parsedEndpoint, parsedBucket, parsedPrefix, parseErr := parseLegacyS3ResticRepo(legacyURL)
+		if parseErr != nil {
+			return resticS3Resolution{}, fmt.Errorf("backup-restic-s3-mode=legacy: %w", parseErr)
+		}
+		repoPath, effectivePrefix := buildResticS3RepoSpec(
+			parsedEndpoint, parsedBucket, parsedPrefix, clusterName, appendCluster)
+		return resticS3Resolution{
+			Mode:         config.ConstResticS3ModeLegacy,
+			RepoPath:     repoPath,
+			Endpoint:     parsedEndpoint,
+			Bucket:       parsedBucket,
+			Prefix:       effectivePrefix,
+			AccessKeyID:  conf.BackupResticAwsAccessKeyId,
+			AccessSecret: conf.GetDecryptedValue("backup-restic-aws-access-secret"),
+			Region:       strings.TrimSpace(conf.BackupResticAwsRegion),
+		}, nil
+
+	default:
+		return resticS3Resolution{}, fmt.Errorf("unknown backup-restic-s3-mode: %q", mode)
+	}
+}
+
 func shouldAppendClusterNameS3(bucket, prefix, clusterName string) bool {
 	if clusterName == "" {
 		return false
@@ -159,8 +251,9 @@ func (cluster *Cluster) ResticS3EffectivePrefixForInit() (string, bool) {
 	if !cluster.Conf.BackupResticAws {
 		return "", false
 	}
-	bucket := strings.TrimSpace(cluster.Conf.BackupResticAwsBucket)
-	if bucket == "" {
+	res, err := resolveResticS3(cluster.Conf, cluster.Name, cluster)
+	if err != nil || res.Mode != config.ConstResticS3ModeNew {
+		// For legacy mode the prefix is embedded in the URL; skip the init hint.
 		return "", false
 	}
 	_, appendCluster := resolveResticRepoPolicy(cluster.Conf, cluster.Conf.BackupResticLocalRepository, cluster)
@@ -168,20 +261,13 @@ func (cluster *Cluster) ResticS3EffectivePrefixForInit() (string, bool) {
 		return "", false
 	}
 	currentPrefix := strings.Trim(cluster.Conf.BackupResticAwsPrefix, "/")
-	if !shouldAppendClusterNameS3(bucket, currentPrefix, cluster.Name) {
+	if !shouldAppendClusterNameS3(res.Bucket, currentPrefix, cluster.Name) {
 		return "", false
 	}
-	_, effectivePrefix := buildResticS3RepoSpec(
-		cluster.Conf.BackupResticAwsEndpoint,
-		bucket,
-		currentPrefix,
-		cluster.Name,
-		appendCluster,
-	)
-	if effectivePrefix == "" || effectivePrefix == currentPrefix {
+	if res.Prefix == "" || res.Prefix == currentPrefix {
 		return "", false
 	}
-	return effectivePrefix, true
+	return res.Prefix, true
 }
 
 func isWithinParentPath(parent, child string) bool {
@@ -460,24 +546,25 @@ func (cluster *Cluster) ResticGetEnv() []string {
 	cacheDir := cluster.Conf.WorkingDir + "/" + cluster.Name + "/.cache/restic"
 	password := cluster.Conf.GetDecryptedValue("backup-restic-password")
 	repoPath := ""
-	// backup-restic-aws controls whether the repo path is remote; otherwise local repo is used.
-	localRepoPath, appendCluster := resolveResticRepoPolicy(cluster.Conf, cluster.Conf.BackupResticLocalRepository, cluster)
+	accessKeyID := ""
+	accessSecret := ""
+	region := ""
 	if cluster.Conf.BackupResticAws {
-		if strings.TrimSpace(cluster.Conf.BackupResticAwsBucket) != "" {
-			repoPath, _ = buildResticS3RepoSpec(
-				cluster.Conf.BackupResticAwsEndpoint,
-				cluster.Conf.BackupResticAwsBucket,
-				cluster.Conf.BackupResticAwsPrefix,
-				cluster.Name,
-				appendCluster,
-			)
+		res, err := resolveResticS3(cluster.Conf, cluster.Name, cluster)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
+				"Restic S3 resolution failed: %s", err)
 		} else {
-			repoPath = cluster.Conf.BackupResticRepository
-			if appendCluster {
-				repoPath = repoPath + "/" + cluster.Name
-			}
+			repoPath = res.RepoPath
+			accessKeyID = res.AccessKeyID
+			accessSecret = res.AccessSecret
+			region = res.Region
 		}
 	} else {
+		localRepoPath, appendCluster := resolveResticRepoPolicy(cluster.Conf, cluster.Conf.BackupResticLocalRepository, cluster)
+		accessKeyID = cluster.Conf.BackupResticAwsAccessKeyId
+		accessSecret = cluster.Conf.GetDecryptedValue("backup-restic-aws-access-secret")
+		region = cluster.Conf.BackupResticAwsRegion
 		if localRepoPath != "" {
 			repoPath = localRepoPath
 			if appendCluster && shouldAppendClusterNameLocal(repoPath, cluster.Name) {
@@ -502,9 +589,9 @@ func (cluster *Cluster) ResticGetEnv() []string {
 		repoPath,
 		password,
 		cacheDir,
-		cluster.Conf.BackupResticAwsAccessKeyId,
-		cluster.Conf.GetDecryptedValue("backup-restic-aws-access-secret"),
-		cluster.Conf.BackupResticAwsRegion,
+		accessKeyID,
+		accessSecret,
+		region,
 		cluster.Conf.BackupResticAdditionalEnv,
 	)
 }
@@ -521,22 +608,23 @@ func (cluster *Cluster) reloadResticEnvCore(clearBackoff bool) {
 	bucket := ""
 	prefix := ""
 	endpoint := ""
-	if cluster.Conf.BackupResticAws && strings.TrimSpace(cluster.Conf.BackupResticAwsBucket) != "" {
-		_, appendCluster := resolveResticRepoPolicy(cluster.Conf, cluster.Conf.BackupResticLocalRepository, cluster)
-		_, prefix = buildResticS3RepoSpec(
-			cluster.Conf.BackupResticAwsEndpoint,
-			cluster.Conf.BackupResticAwsBucket,
-			cluster.Conf.BackupResticAwsPrefix,
-			cluster.Name,
-			appendCluster,
-		)
-		bucket = strings.TrimSpace(cluster.Conf.BackupResticAwsBucket)
-		endpoint = strings.TrimSpace(cluster.Conf.BackupResticAwsEndpoint)
+	accessKeyID := ""
+	accessSecret := ""
+	region := ""
+	if cluster.Conf.BackupResticAws {
+		if res, err := resolveResticS3(cluster.Conf, cluster.Name, cluster); err == nil {
+			bucket = res.Bucket
+			prefix = res.Prefix
+			endpoint = res.Endpoint
+			accessKeyID = res.AccessKeyID
+			accessSecret = res.AccessSecret
+			region = res.Region
+		}
 	}
 	cluster.ResticManager.SetAwsConfig(
-		cluster.Conf.BackupResticAwsAccessKeyId,
-		cluster.Conf.GetDecryptedValue("backup-restic-aws-access-secret"),
-		cluster.Conf.BackupResticAwsRegion,
+		accessKeyID,
+		accessSecret,
+		region,
 		endpoint,
 		bucket,
 		prefix,
@@ -549,6 +637,10 @@ func (cluster *Cluster) reloadResticEnvCore(clearBackoff bool) {
 }
 
 func (cluster *Cluster) ReloadResticEnv() {
+	// Invalidate the boot-probe S3 mode cache so that any config change applied
+	// through the API is not silently overridden by a stale startup probe result.
+	// The startup path calls reloadResticEnvCore directly and is unaffected.
+	cluster.resolvedS3Mode = ""
 	cluster.reloadResticEnvCore(true)
 }
 
@@ -643,58 +735,30 @@ func (cluster *Cluster) resticResolveSavedCopySource(requestedMode, keyHint stri
 		}, nil
 
 	case config.ConstBackupArchiveModeResticAws:
-		// Use the stored append flag directly instead of resolveResticRepoPolicy.
-		// resolveResticRepoPolicy gates on conf.BackupResticAws to decide whether to
-		// honour appendCluster=false, so it would corrupt saved S3 source prefix
-		// interpretation whenever the operator switches the destination away from AWS.
-		// shouldAppendClusterNameS3 inside buildResticS3RepoSpec still prevents
-		// double-appending, so passing the raw stored flag is safe.
-		appendCluster := cluster.Conf.BackupResticRepoAppendCluster
-
-		// Structured S3 config takes precedence (Guardrail S9). When bucket is absent,
-		// fall back to the legacy backup-restic-repository S3 URL if one is configured.
-		bucket := strings.TrimSpace(cluster.Conf.BackupResticAwsBucket)
-		var endpoint, rawPrefix, accessKeyID, accessSecret, region string
-
-		if bucket != "" {
-			endpoint = strings.TrimSpace(cluster.Conf.BackupResticAwsEndpoint)
-			rawPrefix = cluster.Conf.BackupResticAwsPrefix
-			accessKeyID = cluster.Conf.BackupResticAwsAccessKeyId
-			accessSecret = cluster.Conf.GetDecryptedValue("backup-restic-aws-access-secret")
-			region = strings.TrimSpace(cluster.Conf.BackupResticAwsRegion)
-		} else {
-			legacyURL := strings.TrimSpace(cluster.Conf.BackupResticRepository)
-			if !config.IsS3ResticRepository(legacyURL) {
-				return backupmgr.ResticCopySourceOption{}, fmt.Errorf(
-					"saved S3 source config is incomplete: neither backup-restic-aws-bucket nor a valid backup-restic-repository S3 URL is configured")
-			}
-			parsedEndpoint, parsedBucket, parsedPrefix, parseErr := parseLegacyS3ResticRepo(legacyURL)
-			if parseErr != nil {
-				return backupmgr.ResticCopySourceOption{}, fmt.Errorf(
-					"saved S3 source config is incomplete: neither backup-restic-aws-bucket nor a valid backup-restic-repository S3 URL is configured")
-			}
-			bucket = parsedBucket
-			endpoint = parsedEndpoint
-			rawPrefix = parsedPrefix
-			// Legacy URL carries no structured access keys; use whatever AWS credentials
-			// are stored (BackupResticAwsAccessKeyId/Secret), or ambient auth if empty.
-			accessKeyID = cluster.Conf.BackupResticAwsAccessKeyId
-			accessSecret = cluster.Conf.GetDecryptedValue("backup-restic-aws-access-secret")
-			region = strings.TrimSpace(cluster.Conf.BackupResticAwsRegion)
+		// Use the shared S3 resolver so that copy/migration obeys the same
+		// backup-restic-s3-mode selector as the active destination (Guardrail M3).
+		// We resolve against the stored config directly rather than routing through
+		// resolveResticRepoPolicy's BackupResticAws gate, because the operator may
+		// have since switched the destination away from AWS while the saved-source
+		// preset still points at an S3 repository.  We temporarily override the aws
+		// flag to force S3 resolution.
+		confCopy := *cluster.Conf
+		confCopy.BackupResticAws = true
+		res, err := resolveResticS3(&confCopy, cluster.Name, cluster)
+		if err != nil {
+			return backupmgr.ResticCopySourceOption{}, fmt.Errorf("saved S3 source config is incomplete: %w", err)
 		}
-
-		_, effectivePrefix := buildResticS3RepoSpec(endpoint, bucket, rawPrefix, cluster.Name, appendCluster)
 		return backupmgr.ResticCopySourceOption{
 			Mode:     config.ConstBackupArchiveModeResticAws,
 			Password: password,
 			KeyHint:  keyHint,
 			AWS: &backupmgr.ResticCopySourceAWSOption{
-				Endpoint:     endpoint,
-				Bucket:       bucket,
-				Prefix:       effectivePrefix,
-				AccessKeyID:  accessKeyID,
-				AccessSecret: accessSecret,
-				Region:       region,
+				Endpoint:     res.Endpoint,
+				Bucket:       res.Bucket,
+				Prefix:       res.Prefix,
+				AccessKeyID:  res.AccessKeyID,
+				AccessSecret: res.AccessSecret,
+				Region:       res.Region,
 			},
 		}, nil
 
@@ -784,6 +848,51 @@ func (cluster *Cluster) ensureResticManagerBase() {
 	cluster.ReloadResticEnv()
 }
 
+// resolveResticS3AutoProbe probes new and legacy S3 candidates in order and
+// returns the first usable result.  "Usable" means the probe returned nil
+// (repo initialized) or an "initialization required" error (bucket reachable
+// but not yet initialized).  Called during StartResticManager when mode is auto
+// so the runtime applies the actually-working config instead of guessing from
+// field presence alone.
+func (cluster *Cluster) resolveResticS3AutoProbe() (resticS3Resolution, error) {
+	newConf := *cluster.Conf
+	newConf.BackupResticS3Mode = config.ConstResticS3ModeNew
+	newRes, newCandErr := resolveResticS3(&newConf, cluster.Name, nil)
+
+	if newCandErr == nil {
+		probeErr := cluster.ResticManager.ProbeS3Candidate(
+			newRes.Bucket, newRes.Prefix, newRes.Endpoint,
+			newRes.AccessKeyID, newRes.AccessSecret, newRes.Region)
+		if backupmgr.S3ProbeUsable(probeErr) {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlInfo,
+				"Restic S3 auto-probe: new config is usable (bucket=%s)", newRes.Bucket)
+			return newRes, nil
+		}
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlWarn,
+			"Restic S3 auto-probe: new config not reachable (%v); trying legacy", probeErr)
+	}
+
+	legacyConf := *cluster.Conf
+	legacyConf.BackupResticS3Mode = config.ConstResticS3ModeLegacy
+	legacyRes, legacyCandErr := resolveResticS3(&legacyConf, cluster.Name, nil)
+
+	if legacyCandErr == nil {
+		probeErr := cluster.ResticManager.ProbeS3Candidate(
+			legacyRes.Bucket, legacyRes.Prefix, legacyRes.Endpoint,
+			legacyRes.AccessKeyID, legacyRes.AccessSecret, legacyRes.Region)
+		if backupmgr.S3ProbeUsable(probeErr) {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlInfo,
+				"Restic S3 auto-probe: legacy config is usable (bucket=%s)", legacyRes.Bucket)
+			return legacyRes, nil
+		}
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlWarn,
+			"Restic S3 auto-probe: legacy config not reachable (%v)", probeErr)
+	}
+
+	return resticS3Resolution{}, fmt.Errorf(
+		"S3 auto-probe: no usable configuration found (new: %v; legacy: %v)", newCandErr, legacyCandErr)
+}
+
 func (cluster *Cluster) StartResticManager() error {
 	if !cluster.Conf.BackupRestic {
 		return nil
@@ -793,6 +902,31 @@ func (cluster *Cluster) StartResticManager() error {
 	if cluster.ResticManager.RecoverMountStateOnStartup() {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlInfo, "Recovered restic mount state on startup")
 	}
+
+	// For S3 auto mode, probe both candidates before committing to one so the
+	// runtime uses the config that actually works, not just whichever fields
+	// happen to be populated (Issue 2 fix).
+	if cluster.Conf.BackupResticAws && cluster.Conf.BackupResticS3Mode == config.ConstResticS3ModeAuto {
+		if res, err := cluster.resolveResticS3AutoProbe(); err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlWarn,
+				"Restic S3 auto-probe failed at startup: %s; falling back to presence-based resolution", err)
+		} else {
+			cluster.resolvedS3Mode = res.Mode
+			// Reload env so the manager immediately uses the probe-winning config.
+			cluster.reloadResticEnvCore(true)
+		}
+	}
+
+	// Register the boot-fetch success hook.  FetchRepo() fires it on the very
+	// first successful call — regardless of which task path called FetchRepo()
+	// (UnlockTask→FetchRepo or an explicit FetchTask).  The hook clears itself
+	// after the first invocation (Issue 1 fix).
+	if cluster.Conf.BackupResticAws {
+		cluster.ResticManager.OnBootFetchSuccess = func() {
+			cluster.promoteResticS3ModeOnBootSuccess()
+		}
+	}
+
 	cluster.ResticManager.AddUnlockTask() // Queue unlock first to avoid fetch-before-unlock race on startup.
 	go cluster.ResticFetchRepo()
 	return nil
@@ -800,6 +934,55 @@ func (cluster *Cluster) StartResticManager() error {
 
 func (cluster *Cluster) ResticInitRepo(force bool) error {
 	return cluster.ResticInitRepoWithOptions(backupmgr.ResticInitOption{Force: force})
+}
+
+// promoteResticS3ModeOnBootSuccess is called once when the startup fetch
+// succeeds.  It promotes backup-restic-s3-mode from "auto" to the concrete
+// mode determined during startup (either from the probe result stored in
+// resolvedS3Mode, or from the current resolver as a fallback) and persists
+// the change through ConfigManager (Guardrails M1, M2, M4).  The hook clears
+// itself so later passive fetches cannot retrigger it.
+func (cluster *Cluster) promoteResticS3ModeOnBootSuccess() {
+	// Clear the hook first so it cannot fire again.
+	if cluster.ResticManager != nil {
+		cluster.ResticManager.Mutex.Lock()
+		cluster.ResticManager.OnBootFetchSuccess = nil
+		cluster.ResticManager.Mutex.Unlock()
+	}
+
+	// Only promote when the selector is still "auto".
+	if cluster.Conf.BackupResticS3Mode != config.ConstResticS3ModeAuto {
+		return
+	}
+
+	// Only applies to S3 repositories (Guardrail M2).
+	if !cluster.Conf.BackupResticAws {
+		return
+	}
+
+	// Prefer the mode that was determined by the startup probe; fall back to
+	// the presence-based resolver only if no probe was run.
+	promoteTo := cluster.resolvedS3Mode
+	if promoteTo == "" {
+		res, err := resolveResticS3(cluster.Conf, cluster.Name, cluster)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlWarn,
+				"Restic S3 boot promotion skipped: could not resolve S3 mode: %s", err)
+			return
+		}
+		promoteTo = res.Mode
+	}
+
+	cluster.Conf.BackupResticS3Mode = promoteTo
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlInfo,
+		"Restic S3 mode promoted from auto to %q after successful startup fetch", promoteTo)
+
+	if cluster.ConfigManager != nil && cluster.Conf.ConfRewrite {
+		cluster.ConfigManager.SaveConfig(cluster, false)
+	} else {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlInfo,
+			"Restic S3 mode resolved to %q in memory; config rewrite is disabled, on-disk value remains auto", promoteTo)
+	}
 }
 
 func (cluster *Cluster) ResticInitRepoWithOptions(options backupmgr.ResticInitOption) error {

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -1002,6 +1002,30 @@ func (cluster *Cluster) ResticInitRepoWithOptions(options backupmgr.ResticInitOp
 	return err
 }
 
+// ResticWipeRepoWithOptions destroys the contents of the cluster's configured restic repository.
+// The repository is left empty and uninitialized; no automatic re-initialization is performed.
+func (cluster *Cluster) ResticWipeRepoWithOptions(opt backupmgr.ResticWipeOption) error {
+	if !cluster.Conf.BackupRestic {
+		return fmt.Errorf("restic backup is not enabled")
+	}
+	if cluster.ResticManager == nil {
+		return fmt.Errorf("restic manager is not initialized")
+	}
+	return cluster.ResticManager.WipeRepoWithOptions(opt)
+}
+
+// ResticWipePreview runs the non-destructive wipe preflight and returns a preview
+// describing the effective target and whether the current state permits a wipe.
+func (cluster *Cluster) ResticWipePreview() backupmgr.WipePreviewResult {
+	if cluster.ResticManager == nil {
+		return backupmgr.WipePreviewResult{
+			CanWipe: false,
+			Message: "restic manager is not initialized",
+		}
+	}
+	return cluster.ResticManager.ComputeWipePreview()
+}
+
 func (cluster *Cluster) AddPurgeTask(snapshotID string) error {
 	return cluster.ResticPurgeSnapshotWithOptions(snapshotID, true, false)
 }
@@ -1162,11 +1186,14 @@ func (cluster *Cluster) ResticFetchRepo() {
 	}
 }
 
-// ResticCheckConfigManual performs a read-only manual validation of the current restic
-// repository configuration. When cluster.ResticManager is nil it is created via
-// ensureResticManagerBase (no mount recovery, no unlock/fetch tasks, no auto-init).
-// Queues a fetch only when validation succeeds.
-func (cluster *Cluster) ResticCheckConfigManual() backupmgr.ManualCheckResult {
+// ResticCheckConfigManual performs a manual validation of the current restic repository
+// configuration. When cluster.ResticManager is nil it is created via ensureResticManagerBase
+// (no mount recovery, no unlock/fetch tasks, no auto-init).
+// When skipFetch is false and validation succeeds, a fetch task is queued.
+// The returned ManualCheckResult includes additive wipe-preview fields (Backend,
+// IsS3EmptyPrefix, CanWipe, WipeMessage) so the UI can render the wipe confirmation
+// modal from a single call to this endpoint.
+func (cluster *Cluster) ResticCheckConfigManual(skipFetch bool) backupmgr.ManualCheckResult {
 	if !cluster.Conf.BackupRestic {
 		return backupmgr.ManualCheckResult{
 			Status:  backupmgr.ManualCheckStatusError,
@@ -1184,7 +1211,19 @@ func (cluster *Cluster) ResticCheckConfigManual() backupmgr.ManualCheckResult {
 
 	result := cluster.ResticManager.ValidateRepoConfigManual()
 
-	if result.Status == backupmgr.ManualCheckStatusOK {
+	// Compute wipe preview BEFORE queuing a fetch: ComputeWipePreview rejects
+	// non-empty task queues, so computing it after ResticFetchRepo would make
+	// can_wipe=false on a healthy idle repo — a self-blocking race.
+	preview := cluster.ResticManager.ComputeWipePreview()
+	result.Backend = preview.Backend
+	result.IsS3EmptyPrefix = preview.IsS3EmptyPrefix
+	result.CanWipe = preview.CanWipe
+	result.WipeMessage = preview.Message
+	if result.RepoPath == "" {
+		result.RepoPath = preview.RepoPath
+	}
+
+	if result.Status == backupmgr.ManualCheckStatusOK && !skipFetch {
 		cluster.ResticFetchRepo()
 		result.FetchQueued = true
 		result.Message = "Repository configuration verified. Snapshot refresh queued."

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -532,10 +532,48 @@ func (cluster *Cluster) CheckResticErrors() {
 		case backupmgr.UnlockTask:
 			cluster.SetState("WARN0095", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0095"], err), ErrFrom: "BACKUP"})
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Restic unlock error: %s", err)
+		case backupmgr.CopyTask:
+			cluster.SetState("WARN0095", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0095"], err), ErrFrom: "BACKUP"})
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Restic repository copy error: %s", err)
 		default:
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Unknown restic task error: %s", err)
 		}
 	}
+}
+
+// ResticCopyRepoWithOptions validates and enqueues a repository copy task.
+// Static validation (mode, repo string, password, S3 credential mismatch) is
+// performed before queueing. One destination-state case is also preflight-checked
+// synchronously: init_destination+copy_chunker_params against an already-initialized
+// repo (G4). Other destination failures (e.g. corrupt/inaccessible repo) are still
+// detected asynchronously inside the worker.
+func (cluster *Cluster) ResticCopyRepoWithOptions(opt backupmgr.ResticCopyOption) error {
+	if !cluster.Conf.BackupRestic {
+		return fmt.Errorf("restic backup is not enabled")
+	}
+
+	if cluster.ResticManager == nil {
+		cluster.StartResticManager()
+	}
+
+	if err := cluster.ResticManager.ValidateCopyOption(opt); err != nil {
+		return err
+	}
+
+	// G4: applying copy_chunker_params to an already-initialized destination is an
+	// error that can be detected synchronously, so reject it here rather than letting
+	// it fail silently inside the worker after the HTTP handler has returned 200.
+	if opt.InitDestination && opt.CopyChunkerParams {
+		result := cluster.ResticManager.ValidateRepoConfigManual()
+		if result.Status == backupmgr.ManualCheckStatusOK {
+			return fmt.Errorf("destination repository is already initialized; copy_chunker_params cannot be applied to an existing repository")
+		}
+	}
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlInfo,
+		"Queuing restic repository copy from source mode %q", opt.Source.Mode)
+	cluster.ResticManager.AddCopyTask(opt)
+	return nil
 }
 
 func (cluster *Cluster) CheckResticConfigBackup() {

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -600,48 +600,45 @@ func (cluster *Cluster) ResticGetEnv() []string {
 // When clearBackoff is true, the init error backoff counter is also reset
 // (used when credentials/config may have changed). When false (manual check path),
 // the backoff state is preserved to avoid resetting throttling unintentionally.
-func (cluster *Cluster) reloadResticEnvCore(clearBackoff bool) {
+func (cluster *Cluster) reloadResticEnvCore(clearBackoff bool) error {
 	if cluster.ResticManager == nil {
-		return
+		return nil
+	}
+	var s3Res *resticS3Resolution
+	if cluster.Conf.BackupResticAws {
+		res, err := resolveResticS3(cluster.Conf, cluster.Name, cluster)
+		if err != nil {
+			return err // invalid S3 config — leave manager entirely unchanged
+		}
+		s3Res = &res
 	}
 	cluster.ResticManager.SetEnv(cluster.ResticGetEnv())
-	bucket := ""
-	prefix := ""
-	endpoint := ""
-	accessKeyID := ""
-	accessSecret := ""
-	region := ""
-	if cluster.Conf.BackupResticAws {
-		if res, err := resolveResticS3(cluster.Conf, cluster.Name, cluster); err == nil {
-			bucket = res.Bucket
-			prefix = res.Prefix
-			endpoint = res.Endpoint
-			accessKeyID = res.AccessKeyID
-			accessSecret = res.AccessSecret
-			region = res.Region
-		}
+	if s3Res != nil {
+		cluster.ResticManager.SetAwsConfig(
+			s3Res.AccessKeyID,
+			s3Res.AccessSecret,
+			s3Res.Region,
+			s3Res.Endpoint,
+			s3Res.Bucket,
+			s3Res.Prefix,
+		)
+	} else {
+		cluster.ResticManager.SetAwsConfig("", "", "", "", "", "")
 	}
-	cluster.ResticManager.SetAwsConfig(
-		accessKeyID,
-		accessSecret,
-		region,
-		endpoint,
-		bucket,
-		prefix,
-	)
 	if clearBackoff {
 		cluster.ResticManager.ClearInitErrorBackoffManual()
 	}
 	cluster.ResticManager.ClearRepoState()
 	cluster.ResticManager.AutoInit = cluster.Conf.BackupResticAutoInit
+	return nil
 }
 
-func (cluster *Cluster) ReloadResticEnv() {
+func (cluster *Cluster) ReloadResticEnv() error {
 	// Invalidate the boot-probe S3 mode cache so that any config change applied
 	// through the API is not silently overridden by a stale startup probe result.
 	// The startup path calls reloadResticEnvCore directly and is unaffected.
 	cluster.resolvedS3Mode = ""
-	cluster.reloadResticEnvCore(true)
+	return cluster.reloadResticEnvCore(true)
 }
 
 func (cluster *Cluster) CheckResticInstallation() {
@@ -815,7 +812,9 @@ func (cluster *Cluster) ResticCopyRepoWithOptions(opt backupmgr.ResticCopyOption
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlInfo,
 		"Queuing restic repository copy from source mode %q", opt.Source.Mode)
-	cluster.ResticManager.AddCopyTask(opt)
+	if err := cluster.ResticManager.AddCopyTask(opt); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -832,7 +831,7 @@ func (cluster *Cluster) CheckResticConfigBackup() {
 // ensureResticManagerBase creates a fresh ResticManager, applies configuration, assigns it
 // to cluster.ResticManager, and calls ReloadResticEnv. It has no startup side effects
 // (no mount recovery, no unlock/fetch queuing, no auto-init).
-func (cluster *Cluster) ensureResticManagerBase() {
+func (cluster *Cluster) ensureResticManagerBase() error {
 	resticManager := backupmgr.NewResticRepo(cluster.Conf.BackupResticBinaryPath, cluster.MessageChan, config.ConstLogModRestic)
 	if err := cluster.Conf.ValidateResticPermissions(); err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Invalid restic permission config: %s", err)
@@ -845,7 +844,7 @@ func (cluster *Cluster) ensureResticManagerBase() {
 	resticManager.MountRecoveryEnabled = cluster.Conf.BackupResticMountRecoveryEnabled
 	resticManager.AutoDetectAndDisableMount()
 	cluster.ResticManager = resticManager
-	cluster.ReloadResticEnv()
+	return cluster.ReloadResticEnv()
 }
 
 // resolveResticS3AutoProbe probes new and legacy S3 candidates in order and
@@ -898,7 +897,9 @@ func (cluster *Cluster) StartResticManager() error {
 		return nil
 	}
 
-	cluster.ensureResticManagerBase()
+	if err := cluster.ensureResticManagerBase(); err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlWarn, "Restic env reload failed at startup: %s", err)
+	}
 	if cluster.ResticManager.RecoverMountStateOnStartup() {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlInfo, "Recovered restic mount state on startup")
 	}
@@ -913,7 +914,10 @@ func (cluster *Cluster) StartResticManager() error {
 		} else {
 			cluster.resolvedS3Mode = res.Mode
 			// Reload env so the manager immediately uses the probe-winning config.
-			cluster.reloadResticEnvCore(true)
+			if err := cluster.reloadResticEnvCore(true); err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlWarn,
+					"Restic env reload failed after S3 auto-probe: %s", err)
+			}
 		}
 	}
 
@@ -1202,11 +1206,21 @@ func (cluster *Cluster) ResticCheckConfigManual(skipFetch bool) backupmgr.Manual
 	}
 
 	if cluster.ResticManager == nil {
-		cluster.ensureResticManagerBase()
+		if err := cluster.ensureResticManagerBase(); err != nil {
+			return backupmgr.ManualCheckResult{
+				Status:  backupmgr.ManualCheckStatusError,
+				Message: fmt.Sprintf("invalid restic configuration: %s", err),
+			}
+		}
 	} else {
 		// Refresh env config without clearing backoff: manual check is read-only
 		// and should not inadvertently reset init throttling state.
-		cluster.reloadResticEnvCore(false)
+		if err := cluster.reloadResticEnvCore(false); err != nil {
+			return backupmgr.ManualCheckResult{
+				Status:  backupmgr.ManualCheckStatusError,
+				Message: fmt.Sprintf("invalid restic configuration: %s", err),
+			}
+		}
 	}
 
 	result := cluster.ResticManager.ValidateRepoConfigManual()
@@ -2188,7 +2202,9 @@ func (cluster *Cluster) ChangeResticRepoPassword(newpass string) error {
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlInfo, "Changing restic password for cluster %s", cluster.Name)
 
-	cluster.ReloadResticEnv()
+	if err := cluster.ReloadResticEnv(); err != nil {
+		return fmt.Errorf("invalid restic configuration: %w", err)
+	}
 
 	keylist, err := cluster.ResticManager.GetRepoKeyList()
 	if err != nil {
@@ -2253,7 +2269,9 @@ func (cluster *Cluster) ChangeResticRepoPassword(newpass string) error {
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlInfo, "New restic password saved in configuration successfully. Removing old key from repository using new password.")
 
 	// Reload env with new password
-	cluster.ReloadResticEnv()
+	if err := cluster.ReloadResticEnv(); err != nil {
+		return fmt.Errorf("invalid restic configuration after password change: %w", err)
+	}
 
 	// Remove old key using new password
 	err = cluster.ResticManager.RemoveRepoKey(oldkeyid)

--- a/cluster/cluster_bck_test.go
+++ b/cluster/cluster_bck_test.go
@@ -1428,3 +1428,316 @@ func TestResticCopyRepoWithOptionsG4Preflight(t *testing.T) {
 	}
 	rm.Mutex.Unlock()
 }
+
+// --- saved-source resolution tests ---
+
+// newSavedSourceCluster builds a minimal cluster configured for saved-source tests.
+// password and awsSecret are stored in conf.Secrets so GetDecryptedValue returns them.
+func newSavedSourceCluster(t *testing.T, conf *config.Config, password, awsSecret string) *Cluster {
+	t.Helper()
+	if conf.Secrets == nil {
+		conf.Secrets = make(map[string]config.Secret)
+	}
+	conf.Secrets["backup-restic-password"] = config.Secret{Value: password}
+	conf.Secrets["backup-restic-aws-access-secret"] = config.Secret{Value: awsSecret}
+	rm := backupmgr.NewResticRepo("", nil, config.ConstLogModRestic)
+	rm.PauseWorker()
+	t.Cleanup(rm.ShutdownWorker)
+	return &Cluster{
+		Name:          "mycluster",
+		Conf:          conf,
+		ResticManager: rm,
+	}
+}
+
+// TestSavedS3SourceAppendClusterFalseNonAwsDest verifies that when the current
+// destination is NOT S3 (BackupResticAws=false) and BackupResticRepoAppendCluster=false,
+// the saved S3 preset does NOT append the cluster name to the prefix.
+// This is the core regression case: resolveResticRepoPolicy used to force
+// appendCluster=true when BackupResticAws was false, corrupting the saved S3 prefix.
+func TestSavedS3SourceAppendClusterFalseNonAwsDest(t *testing.T) {
+	cluster := newSavedSourceCluster(t, &config.Config{
+		BackupRestic:                true,
+		BackupResticAws:             false, // current destination is local, not S3
+		BackupResticRepoAppendCluster: false,
+		BackupResticAwsBucket:       "mybucket",
+		BackupResticAwsPrefix:       "myprefix",
+		BackupResticAwsEndpoint:     "https://s3.example.com",
+		BackupResticAwsRegion:       "us-east-1",
+		BackupResticAwsAccessKeyId:  "AKID",
+	}, "resticpass", "secretkey")
+
+	resolved, err := cluster.resticResolveSavedCopySource(config.ConstBackupArchiveModeResticAws, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved.AWS == nil {
+		t.Fatal("expected AWS config in resolved option, got nil")
+	}
+	// With appendCluster=false and cluster name not already in bucket/prefix,
+	// the effective prefix should be exactly the stored prefix with no cluster suffix.
+	if resolved.AWS.Prefix != "myprefix" {
+		t.Errorf("expected prefix %q, got %q (cluster name must not be appended when append=false)", "myprefix", resolved.AWS.Prefix)
+	}
+	if resolved.AWS.Bucket != "mybucket" {
+		t.Errorf("expected bucket %q, got %q", "mybucket", resolved.AWS.Bucket)
+	}
+	if resolved.Password != "resticpass" {
+		t.Errorf("expected password resolved from config, got %q", resolved.Password)
+	}
+}
+
+// TestSavedS3SourceAppendClusterTrueAddsClusterName verifies that when
+// BackupResticRepoAppendCluster=true and the cluster name is not yet in the prefix,
+// the saved S3 resolution appends it exactly once.
+func TestSavedS3SourceAppendClusterTrueAddsClusterName(t *testing.T) {
+	cluster := newSavedSourceCluster(t, &config.Config{
+		BackupRestic:                true,
+		BackupResticAws:             false, // current destination is local — should not affect S3 source
+		BackupResticRepoAppendCluster: true,
+		BackupResticAwsBucket:       "mybucket",
+		BackupResticAwsPrefix:       "backup",
+		BackupResticAwsEndpoint:     "",
+		BackupResticAwsRegion:       "eu-west-1",
+		BackupResticAwsAccessKeyId:  "AKID",
+	}, "pass", "secret")
+
+	resolved, err := cluster.resticResolveSavedCopySource(config.ConstBackupArchiveModeResticAws, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "backup/" + cluster.Name
+	if resolved.AWS.Prefix != want {
+		t.Errorf("expected prefix %q, got %q", want, resolved.AWS.Prefix)
+	}
+}
+
+// TestSavedS3SourceFreezeOnQueueTime verifies that after ResticCopyRepoWithOptions
+// resolves and queues a saved-source task, mutating the cluster config does not
+// change the copy option already stored in the queue.
+func TestSavedS3SourceFreezeOnQueueTime(t *testing.T) {
+	conf := &config.Config{
+		BackupRestic:                true,
+		BackupResticAws:             false,
+		BackupResticRepoAppendCluster: true,
+		BackupResticAwsBucket:       "original-bucket",
+		BackupResticAwsPrefix:       "pfx",
+		BackupResticAwsRegion:       "us-east-1",
+		BackupResticAwsAccessKeyId:  "AKID",
+	}
+	cluster := newSavedSourceCluster(t, conf, "original-pass", "original-secret")
+
+	opt := backupmgr.ResticCopyOption{
+		Source: backupmgr.ResticCopySourceOption{
+			Mode:           config.ConstBackupArchiveModeResticAws,
+			UseSavedConfig: true,
+		},
+	}
+	if err := cluster.ResticCopyRepoWithOptions(opt); err != nil {
+		t.Fatalf("unexpected error queueing saved-source task: %v", err)
+	}
+
+	// Mutate config after queueing.
+	conf.BackupResticAwsBucket = "changed-bucket"
+	conf.Secrets["backup-restic-password"] = config.Secret{Value: "changed-pass"}
+
+	// Read the queued task option.
+	cluster.ResticManager.Mutex.Lock()
+	var queued *backupmgr.ResticCopyOption
+	for _, task := range cluster.ResticManager.TaskQueue {
+		if task.Type == backupmgr.CopyTask {
+			queued = task.CopyOpt
+			break
+		}
+	}
+	cluster.ResticManager.Mutex.Unlock()
+
+	if queued == nil {
+		t.Fatal("no copy task in queue")
+	}
+	if queued.Source.AWS == nil {
+		t.Fatal("expected AWS config in queued task, got nil")
+	}
+	if queued.Source.AWS.Bucket != "original-bucket" {
+		t.Errorf("queued task bucket changed: got %q, want %q (config mutation must not affect frozen queue entry)", queued.Source.AWS.Bucket, "original-bucket")
+	}
+	if queued.Source.Password != "original-pass" {
+		t.Errorf("queued task password changed: got %q (config mutation must not affect frozen queue entry)", queued.Source.Password)
+	}
+}
+
+// TestSavedS3SourceRejectsHybridPayload verifies that a request combining
+// use_saved_config=true with inline manual fields is rejected.
+func TestSavedS3SourceRejectsHybridPayload(t *testing.T) {
+	cluster := newSavedSourceCluster(t, &config.Config{
+		BackupRestic:          true,
+		BackupResticAwsBucket: "mybucket",
+	}, "pass", "secret")
+
+	opt := backupmgr.ResticCopyOption{
+		Source: backupmgr.ResticCopySourceOption{
+			Mode:           config.ConstBackupArchiveModeResticAws,
+			UseSavedConfig: true,
+			Password:       "inline-password", // hybrid: inline field present
+		},
+	}
+	err := cluster.ResticCopyRepoWithOptions(opt)
+	if err == nil {
+		t.Fatal("expected error for hybrid saved-source payload, got nil")
+	}
+	if !strings.Contains(err.Error(), "use_saved_config") {
+		t.Errorf("expected error to mention use_saved_config, got: %v", err)
+	}
+}
+
+// TestSavedS3SourceRejectsWhenNeitherStructuredNorLegacy verifies that the saved S3
+// preset fails with a clear error when both backup-restic-aws-bucket and
+// backup-restic-repository (S3 URL) are absent or unusable.
+func TestSavedS3SourceRejectsWhenNeitherStructuredNorLegacy(t *testing.T) {
+	cluster := newSavedSourceCluster(t, &config.Config{
+		BackupRestic:            true,
+		BackupResticAwsBucket:   "",            // no structured bucket
+		BackupResticRepository:  "/local/path", // not an S3 URL
+	}, "pass", "secret")
+
+	opt := backupmgr.ResticCopyOption{
+		Source: backupmgr.ResticCopySourceOption{
+			Mode:           config.ConstBackupArchiveModeResticAws,
+			UseSavedConfig: true,
+		},
+	}
+	err := cluster.ResticCopyRepoWithOptions(opt)
+	if err == nil {
+		t.Fatal("expected error when neither structured nor legacy S3 config is present, got nil")
+	}
+	if !strings.Contains(err.Error(), "backup-restic-aws-bucket") || !strings.Contains(err.Error(), "backup-restic-repository") {
+		t.Errorf("expected error to mention both config fields, got: %v", err)
+	}
+}
+
+// TestSavedS3SourceLegacyFallbackResolvesSuccessfully verifies that the saved S3 preset
+// resolves from backup-restic-repository when backup-restic-aws-bucket is absent.
+func TestSavedS3SourceLegacyFallbackResolvesSuccessfully(t *testing.T) {
+	cases := []struct {
+		name           string
+		legacyURL      string
+		wantBucket     string
+		wantEndpoint   string
+		wantPrefixHint string // substring that must appear in resolved prefix (or empty for any)
+	}{
+		{
+			name:       "bucket only",
+			legacyURL:  "s3:mybucket",
+			wantBucket: "mybucket",
+		},
+		{
+			name:           "bucket with prefix",
+			legacyURL:      "s3:mybucket/myprefix",
+			wantBucket:     "mybucket",
+			wantPrefixHint: "myprefix",
+		},
+		{
+			name:         "hostname endpoint",
+			legacyURL:    "s3:s3.amazonaws.com/mybucket",
+			wantEndpoint: "s3.amazonaws.com",
+			wantBucket:   "mybucket",
+		},
+		{
+			name:           "hostname endpoint with prefix",
+			legacyURL:      "s3:s3.amazonaws.com/mybucket/pfx",
+			wantEndpoint:   "s3.amazonaws.com",
+			wantBucket:     "mybucket",
+			wantPrefixHint: "pfx",
+		},
+		{
+			name:         "https endpoint",
+			legacyURL:    "s3:https://minio.example.com/mybucket",
+			wantEndpoint: "https://minio.example.com",
+			wantBucket:   "mybucket",
+		},
+		{
+			name:           "https endpoint with prefix",
+			legacyURL:      "s3:https://minio.example.com/mybucket/pfx",
+			wantEndpoint:   "https://minio.example.com",
+			wantBucket:     "mybucket",
+			wantPrefixHint: "pfx",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := newSavedSourceCluster(t, &config.Config{
+				BackupRestic:                  true,
+				BackupResticAwsBucket:         "", // force legacy path
+				BackupResticRepository:        tc.legacyURL,
+				BackupResticRepoAppendCluster: false,
+			}, "resticpass", "awssecret")
+
+			resolved, err := cluster.resticResolveSavedCopySource(config.ConstBackupArchiveModeResticAws, "")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resolved.AWS == nil {
+				t.Fatal("expected AWS config, got nil")
+			}
+			if resolved.AWS.Bucket != tc.wantBucket {
+				t.Errorf("bucket: got %q, want %q", resolved.AWS.Bucket, tc.wantBucket)
+			}
+			if resolved.AWS.Endpoint != tc.wantEndpoint {
+				t.Errorf("endpoint: got %q, want %q", resolved.AWS.Endpoint, tc.wantEndpoint)
+			}
+			if tc.wantPrefixHint != "" && !strings.Contains(resolved.AWS.Prefix, tc.wantPrefixHint) {
+				t.Errorf("prefix %q does not contain expected hint %q", resolved.AWS.Prefix, tc.wantPrefixHint)
+			}
+			if resolved.Password != "resticpass" {
+				t.Errorf("password: got %q", resolved.Password)
+			}
+		})
+	}
+}
+
+// TestSavedS3SourceStructuredPrecedenceOverLegacy verifies that when both
+// backup-restic-aws-bucket and backup-restic-repository are configured, the
+// structured bucket config is used and the legacy URL is ignored.
+func TestSavedS3SourceStructuredPrecedenceOverLegacy(t *testing.T) {
+	cluster := newSavedSourceCluster(t, &config.Config{
+		BackupRestic:                  true,
+		BackupResticAwsBucket:         "structured-bucket",
+		BackupResticAwsPrefix:         "structured-prefix",
+		BackupResticRepository:        "s3:legacy-bucket/legacy-prefix",
+		BackupResticRepoAppendCluster: false,
+	}, "pass", "secret")
+
+	resolved, err := cluster.resticResolveSavedCopySource(config.ConstBackupArchiveModeResticAws, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved.AWS == nil {
+		t.Fatal("expected AWS config, got nil")
+	}
+	if resolved.AWS.Bucket != "structured-bucket" {
+		t.Errorf("expected structured bucket, got %q", resolved.AWS.Bucket)
+	}
+	if strings.Contains(resolved.AWS.Prefix, "legacy") {
+		t.Errorf("legacy prefix leaked into resolved config: %q", resolved.AWS.Prefix)
+	}
+}
+
+// TestSavedS3SourceRejectsUnsupportedMode verifies that use_saved_config=true with
+// mode restic-sftp is rejected (sftp is local-preset territory, not saved-S3).
+func TestSavedS3SourceRejectsUnsupportedMode(t *testing.T) {
+	cluster := newSavedSourceCluster(t, &config.Config{
+		BackupRestic: true,
+	}, "pass", "")
+
+	opt := backupmgr.ResticCopyOption{
+		Source: backupmgr.ResticCopySourceOption{
+			Mode:           config.ConstBackupArchiveModeResticSftp,
+			UseSavedConfig: true,
+		},
+	}
+	err := cluster.ResticCopyRepoWithOptions(opt)
+	if err == nil {
+		t.Fatal("expected error for unsupported mode with use_saved_config, got nil")
+	}
+}

--- a/cluster/cluster_bck_test.go
+++ b/cluster/cluster_bck_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -1239,4 +1240,191 @@ func TestCheckResticErrors_TransientErrorsCleared(t *testing.T) {
 			}
 		})
 	}
+}
+
+// --- ResticCopyRepoWithOptions unit tests ---
+
+func newCopyTestCluster(t *testing.T, resticEnabled bool) *Cluster {
+	t.Helper()
+	rm := backupmgr.NewResticRepo("", nil, config.ConstLogModRestic)
+	rm.PauseWorker()
+	t.Cleanup(rm.ShutdownWorker)
+	return &Cluster{
+		Name:          "test-cluster",
+		Conf:          &config.Config{BackupRestic: resticEnabled},
+		ResticManager: rm,
+	}
+}
+
+func TestResticCopyRepoWithOptionsResticDisabled(t *testing.T) {
+	cluster := newCopyTestCluster(t, false)
+	opt := backupmgr.ResticCopyOption{
+		Source: backupmgr.ResticCopySourceOption{
+			Mode:       config.ConstBackupArchiveModeResticLocal,
+			Repository: "/some/path",
+			Password:   "pass",
+		},
+	}
+	if err := cluster.ResticCopyRepoWithOptions(opt); err == nil {
+		t.Fatal("expected error when restic is disabled, got nil")
+	}
+}
+
+func TestResticCopyRepoWithOptionsInvalidMode(t *testing.T) {
+	cluster := newCopyTestCluster(t, true)
+	opt := backupmgr.ResticCopyOption{
+		Source: backupmgr.ResticCopySourceOption{
+			Mode:       "invalid-mode",
+			Repository: "/some/path",
+			Password:   "pass",
+		},
+	}
+	if err := cluster.ResticCopyRepoWithOptions(opt); err == nil {
+		t.Fatal("expected error for invalid source mode, got nil")
+	}
+}
+
+func TestResticCopyRepoWithOptionsMissingPassword(t *testing.T) {
+	cluster := newCopyTestCluster(t, true)
+	opt := backupmgr.ResticCopyOption{
+		Source: backupmgr.ResticCopySourceOption{
+			Mode:       config.ConstBackupArchiveModeResticLocal,
+			Repository: "/some/path",
+		},
+	}
+	if err := cluster.ResticCopyRepoWithOptions(opt); err == nil {
+		t.Fatal("expected error for missing source password, got nil")
+	}
+}
+
+func TestResticCopyRepoWithOptionsMalformedSFTP(t *testing.T) {
+	cluster := newCopyTestCluster(t, true)
+	opt := backupmgr.ResticCopyOption{
+		Source: backupmgr.ResticCopySourceOption{
+			Mode:       config.ConstBackupArchiveModeResticSftp,
+			Repository: "not-sftp-format",
+			Password:   "pass",
+		},
+	}
+	err := cluster.ResticCopyRepoWithOptions(opt)
+	if err == nil {
+		t.Fatal("expected error for malformed SFTP repo, got nil")
+	}
+	if !strings.Contains(err.Error(), "sftp:") {
+		t.Errorf("expected error to mention sftp format, got: %v", err)
+	}
+}
+
+func TestResticCopyRepoWithOptionsChunkerWithoutInit(t *testing.T) {
+	cluster := newCopyTestCluster(t, true)
+	opt := backupmgr.ResticCopyOption{
+		Source: backupmgr.ResticCopySourceOption{
+			Mode:       config.ConstBackupArchiveModeResticLocal,
+			Repository: "/some/path",
+			Password:   "pass",
+		},
+		CopyChunkerParams: true,
+		InitDestination:   false,
+	}
+	err := cluster.ResticCopyRepoWithOptions(opt)
+	if err == nil {
+		t.Fatal("expected error when copy_chunker_params=true without init_destination, got nil")
+	}
+	if !strings.Contains(err.Error(), "copy_chunker_params") {
+		t.Errorf("expected error to mention copy_chunker_params, got: %v", err)
+	}
+}
+
+func TestResticCopyRepoWithOptionsValidQueues(t *testing.T) {
+	cluster := newCopyTestCluster(t, true) // worker paused + shutdown registered
+	opt := backupmgr.ResticCopyOption{
+		Source: backupmgr.ResticCopySourceOption{
+			Mode:       config.ConstBackupArchiveModeResticLocal,
+			Repository: "/some/src",
+			Password:   "pass",
+		},
+	}
+	if err := cluster.ResticCopyRepoWithOptions(opt); err != nil {
+		t.Fatalf("unexpected error for valid options: %v", err)
+	}
+	cluster.ResticManager.Mutex.Lock()
+	qlen := len(cluster.ResticManager.TaskQueue)
+	var firstType backupmgr.TaskType
+	if qlen > 0 {
+		firstType = cluster.ResticManager.TaskQueue[0].Type
+	}
+	cluster.ResticManager.Mutex.Unlock()
+	if qlen == 0 {
+		t.Fatal("expected copy task to be queued, got empty queue")
+	}
+	if firstType != backupmgr.CopyTask {
+		t.Errorf("expected CopyTask type, got %v", firstType)
+	}
+}
+
+// TestResticCopyRepoWithOptionsG4Preflight verifies that copy_chunker_params=true
+// against an already-initialized destination is rejected synchronously (before
+// queueing), not silently inside the worker. Requires the restic binary.
+func TestResticCopyRepoWithOptionsG4Preflight(t *testing.T) {
+	resticPath, err := exec.LookPath("restic")
+	if err != nil {
+		t.Skip("restic binary not found, skipping integration test")
+	}
+
+	base := t.TempDir()
+	dstDir := filepath.Join(base, "dst")
+	cacheDir := filepath.Join(base, "cache")
+	if err := os.MkdirAll(dstDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	rm := backupmgr.NewResticRepo(resticPath, nil, config.ConstLogModRestic)
+	rm.SetEnv([]string{
+		"RESTIC_REPOSITORY=" + dstDir,
+		"RESTIC_PASSWORD=dstpass",
+		"RESTIC_CACHE_DIR=" + cacheDir,
+		"HOME=" + base,
+	})
+	defer rm.ShutdownWorker()
+	if err := rm.InitRepo(false); err != nil {
+		t.Fatalf("init dst repo: %v", err)
+	}
+	if err := rm.FetchRepo(); err != nil {
+		t.Fatalf("fetch dst repo: %v", err)
+	}
+
+	cluster := &Cluster{
+		Name:          "test-cluster",
+		Conf:          &config.Config{BackupRestic: true},
+		ResticManager: rm,
+	}
+	opt := backupmgr.ResticCopyOption{
+		Source: backupmgr.ResticCopySourceOption{
+			Mode:       config.ConstBackupArchiveModeResticLocal,
+			Repository: "/some/src",
+			Password:   "srcpass",
+		},
+		InitDestination:   true,
+		CopyChunkerParams: true,
+	}
+	copyErr := cluster.ResticCopyRepoWithOptions(opt)
+	if copyErr == nil {
+		t.Fatal("expected error for G4 preflight violation, got nil")
+	}
+	if !strings.Contains(copyErr.Error(), "already initialized") {
+		t.Errorf("expected 'already initialized' in error, got: %v", copyErr)
+	}
+	// Verify nothing was queued — the rejection happened before AddCopyTask.
+	rm.Mutex.Lock()
+	for _, task := range rm.TaskQueue {
+		if task.Type == backupmgr.CopyTask {
+			rm.Mutex.Unlock()
+			t.Error("copy task was queued despite preflight rejection")
+			return
+		}
+	}
+	rm.Mutex.Unlock()
 }

--- a/cluster/cluster_bck_test.go
+++ b/cluster/cluster_bck_test.go
@@ -1741,3 +1741,323 @@ func TestSavedS3SourceRejectsUnsupportedMode(t *testing.T) {
 		t.Fatal("expected error for unsupported mode with use_saved_config, got nil")
 	}
 }
+
+// ── backup-restic-s3-mode resolver tests ──────────────────────────────────────
+
+func newS3ModeCluster(conf *config.Config) *Cluster {
+	if conf.Secrets == nil {
+		conf.Secrets = make(map[string]config.Secret)
+		conf.Secrets["backup-restic-aws-access-secret"] = config.Secret{Value: "secret"}
+		conf.Secrets["backup-restic-password"] = config.Secret{Value: "pass"}
+	}
+	conf.BackupResticAws = true
+	return &Cluster{Name: "mycluster", Conf: conf}
+}
+
+func TestResolveResticS3_AutoResolvesToNew(t *testing.T) {
+	cluster := newS3ModeCluster(&config.Config{
+		BackupResticS3Mode:            config.ConstResticS3ModeAuto,
+		BackupResticAwsBucket:         "mybucket",
+		BackupResticAwsPrefix:         "myprefix",
+		BackupResticAwsEndpoint:       "https://s3.example.com",
+		BackupResticRepoAppendCluster: false,
+	})
+	res, err := resolveResticS3(cluster.Conf, cluster.Name, cluster)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Mode != config.ConstResticS3ModeNew {
+		t.Errorf("expected mode=new, got %q", res.Mode)
+	}
+	if res.Bucket != "mybucket" {
+		t.Errorf("expected bucket=mybucket, got %q", res.Bucket)
+	}
+	if res.Endpoint != "https://s3.example.com" {
+		t.Errorf("expected endpoint, got %q", res.Endpoint)
+	}
+}
+
+func TestResolveResticS3_AutoResolvesToLegacy(t *testing.T) {
+	cluster := newS3ModeCluster(&config.Config{
+		BackupResticS3Mode:            config.ConstResticS3ModeAuto,
+		BackupResticAwsBucket:         "", // no bucket → fall back
+		BackupResticRepository:        "s3:https://s3.example.com/legacybucket/prefix",
+		BackupResticRepoAppendCluster: false,
+	})
+	res, err := resolveResticS3(cluster.Conf, cluster.Name, cluster)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Mode != config.ConstResticS3ModeLegacy {
+		t.Errorf("expected mode=legacy, got %q", res.Mode)
+	}
+	if res.Bucket != "legacybucket" {
+		t.Errorf("expected bucket=legacybucket, got %q", res.Bucket)
+	}
+}
+
+func TestResolveResticS3_AutoFailsWhenNeitherConfigured(t *testing.T) {
+	cluster := newS3ModeCluster(&config.Config{
+		BackupResticS3Mode:     config.ConstResticS3ModeAuto,
+		BackupResticAwsBucket:  "",
+		BackupResticRepository: "", // not an S3 URL
+	})
+	_, err := resolveResticS3(cluster.Conf, cluster.Name, cluster)
+	if err == nil {
+		t.Fatal("expected error when neither bucket nor S3 URL is configured")
+	}
+}
+
+func TestResolveResticS3_NewIgnoresLegacyURL(t *testing.T) {
+	cluster := newS3ModeCluster(&config.Config{
+		BackupResticS3Mode:            config.ConstResticS3ModeNew,
+		BackupResticAwsBucket:         "newbucket",
+		BackupResticRepository:        "s3:legacy-bucket/prefix", // should be ignored
+		BackupResticRepoAppendCluster: false,
+	})
+	res, err := resolveResticS3(cluster.Conf, cluster.Name, cluster)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Mode != config.ConstResticS3ModeNew {
+		t.Errorf("expected mode=new, got %q", res.Mode)
+	}
+	if res.Bucket != "newbucket" {
+		t.Errorf("expected newbucket, got %q", res.Bucket)
+	}
+	if strings.Contains(res.RepoPath, "legacy") {
+		t.Errorf("legacy URL leaked into resolved path: %q", res.RepoPath)
+	}
+}
+
+func TestResolveResticS3_NewFailsWhenNoBucket(t *testing.T) {
+	cluster := newS3ModeCluster(&config.Config{
+		BackupResticS3Mode:     config.ConstResticS3ModeNew,
+		BackupResticAwsBucket:  "",
+		BackupResticRepository: "s3:legacy-bucket/prefix",
+	})
+	_, err := resolveResticS3(cluster.Conf, cluster.Name, cluster)
+	if err == nil {
+		t.Fatal("expected error for mode=new with no bucket")
+	}
+}
+
+func TestResolveResticS3_LegacyIgnoresNewFields(t *testing.T) {
+	cluster := newS3ModeCluster(&config.Config{
+		BackupResticS3Mode:            config.ConstResticS3ModeLegacy,
+		BackupResticAwsBucket:         "newbucket", // present but must be ignored
+		BackupResticRepository:        "s3:legacy-bucket/prefix",
+		BackupResticRepoAppendCluster: false,
+	})
+	res, err := resolveResticS3(cluster.Conf, cluster.Name, cluster)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Mode != config.ConstResticS3ModeLegacy {
+		t.Errorf("expected mode=legacy, got %q", res.Mode)
+	}
+	if res.Bucket != "legacy-bucket" {
+		t.Errorf("expected legacy-bucket, got %q", res.Bucket)
+	}
+	if strings.Contains(res.RepoPath, "newbucket") {
+		t.Errorf("new bucket leaked into resolved path: %q", res.RepoPath)
+	}
+}
+
+func TestResolveResticS3_LegacyFailsForNonS3URL(t *testing.T) {
+	cluster := newS3ModeCluster(&config.Config{
+		BackupResticS3Mode:     config.ConstResticS3ModeLegacy,
+		BackupResticRepository: "/local/path/to/repo",
+	})
+	_, err := resolveResticS3(cluster.Conf, cluster.Name, cluster)
+	if err == nil {
+		t.Fatal("expected error for mode=legacy with non-S3 repository URL")
+	}
+}
+
+func TestResolveResticS3_AppendCluster(t *testing.T) {
+	cluster := newS3ModeCluster(&config.Config{
+		BackupResticS3Mode:            config.ConstResticS3ModeNew,
+		BackupResticAwsBucket:         "mybucket",
+		BackupResticAwsPrefix:         "",
+		BackupResticRepoAppendCluster: true,
+	})
+	res, err := resolveResticS3(cluster.Conf, cluster.Name, cluster)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Prefix != "mycluster" {
+		t.Errorf("expected prefix=mycluster, got %q", res.Prefix)
+	}
+	if !strings.HasSuffix(res.RepoPath, "/mycluster") {
+		t.Errorf("expected repo path to end with /mycluster, got %q", res.RepoPath)
+	}
+}
+
+// ── boot promotion tests ──────────────────────────────────────────────────────
+
+func newBootCluster(conf *config.Config) (*Cluster, *backupmgr.ResticManager) {
+	if conf.Secrets == nil {
+		conf.Secrets = make(map[string]config.Secret)
+		conf.Secrets["backup-restic-aws-access-secret"] = config.Secret{Value: "secret"}
+		conf.Secrets["backup-restic-password"] = config.Secret{Value: "pass"}
+	}
+	rm := backupmgr.NewResticRepo("", nil, config.ConstLogModRestic)
+	rm.PauseWorker()
+	cluster := &Cluster{
+		Name:          "mycluster",
+		Conf:          conf,
+		ResticManager: rm,
+	}
+	return cluster, rm
+}
+
+func TestPromoteResticS3Mode_AutoToNew(t *testing.T) {
+	cluster, _ := newBootCluster(&config.Config{
+		BackupResticAws:               true,
+		BackupResticS3Mode:            config.ConstResticS3ModeAuto,
+		BackupResticAwsBucket:         "mybucket",
+		BackupResticRepoAppendCluster: false,
+	})
+	cluster.promoteResticS3ModeOnBootSuccess()
+	if cluster.Conf.BackupResticS3Mode != config.ConstResticS3ModeNew {
+		t.Errorf("expected mode=new after promotion, got %q", cluster.Conf.BackupResticS3Mode)
+	}
+}
+
+func TestPromoteResticS3Mode_AutoToLegacy(t *testing.T) {
+	cluster, _ := newBootCluster(&config.Config{
+		BackupResticAws:               true,
+		BackupResticS3Mode:            config.ConstResticS3ModeAuto,
+		BackupResticAwsBucket:         "",
+		BackupResticRepository:        "s3:legacy-bucket/prefix",
+		BackupResticRepoAppendCluster: false,
+	})
+	cluster.promoteResticS3ModeOnBootSuccess()
+	if cluster.Conf.BackupResticS3Mode != config.ConstResticS3ModeLegacy {
+		t.Errorf("expected mode=legacy after promotion, got %q", cluster.Conf.BackupResticS3Mode)
+	}
+}
+
+func TestPromoteResticS3Mode_AlreadyNewSkips(t *testing.T) {
+	cluster, _ := newBootCluster(&config.Config{
+		BackupResticAws:       true,
+		BackupResticS3Mode:    config.ConstResticS3ModeNew,
+		BackupResticAwsBucket: "mybucket",
+	})
+	cluster.promoteResticS3ModeOnBootSuccess()
+	// Should remain "new", not re-derive.
+	if cluster.Conf.BackupResticS3Mode != config.ConstResticS3ModeNew {
+		t.Errorf("expected mode=new unchanged, got %q", cluster.Conf.BackupResticS3Mode)
+	}
+}
+
+func TestPromoteResticS3Mode_NonS3Skips(t *testing.T) {
+	cluster, _ := newBootCluster(&config.Config{
+		BackupResticAws:    false, // not S3
+		BackupResticS3Mode: config.ConstResticS3ModeAuto,
+	})
+	cluster.promoteResticS3ModeOnBootSuccess()
+	// Should remain auto; not S3, so no promotion.
+	if cluster.Conf.BackupResticS3Mode != config.ConstResticS3ModeAuto {
+		t.Errorf("expected mode=auto unchanged for non-S3, got %q", cluster.Conf.BackupResticS3Mode)
+	}
+}
+
+func TestPromoteResticS3Mode_HookClearsItself(t *testing.T) {
+	cluster, rm := newBootCluster(&config.Config{
+		BackupResticAws:               true,
+		BackupResticS3Mode:            config.ConstResticS3ModeAuto,
+		BackupResticAwsBucket:         "mybucket",
+		BackupResticRepoAppendCluster: false,
+	})
+	rm.OnBootFetchSuccess = func() {
+		cluster.promoteResticS3ModeOnBootSuccess()
+	}
+	// Call twice to verify the hook clears itself after the first invocation.
+	cluster.promoteResticS3ModeOnBootSuccess()
+	cluster.Conf.BackupResticS3Mode = config.ConstResticS3ModeAuto // reset manually
+	cluster.promoteResticS3ModeOnBootSuccess()                      // second call should be no-op (hook already nil)
+	// The hook should have been cleared on the first call; the second should be a no-op.
+	if rm.OnBootFetchSuccess != nil {
+		t.Error("expected OnBootFetchSuccess to be nil after first invocation")
+	}
+}
+
+// ── config normalization tests ────────────────────────────────────────────────
+
+func TestNormalizeResticS3Mode_EmptyBecomesAuto(t *testing.T) {
+	conf := &config.Config{BackupResticS3Mode: ""}
+	conf.NormalizeResticS3Mode()
+	if conf.BackupResticS3Mode != config.ConstResticS3ModeAuto {
+		t.Errorf("expected auto, got %q", conf.BackupResticS3Mode)
+	}
+}
+
+func TestNormalizeResticS3Mode_InvalidBecomesAuto(t *testing.T) {
+	conf := &config.Config{BackupResticS3Mode: "invalid-value"}
+	conf.NormalizeResticS3Mode()
+	if conf.BackupResticS3Mode != config.ConstResticS3ModeAuto {
+		t.Errorf("expected auto, got %q", conf.BackupResticS3Mode)
+	}
+}
+
+func TestNormalizeResticS3Mode_ValidUnchanged(t *testing.T) {
+	for _, mode := range []string{"auto", "new", "legacy"} {
+		conf := &config.Config{BackupResticS3Mode: mode}
+		conf.NormalizeResticS3Mode()
+		if conf.BackupResticS3Mode != mode {
+			t.Errorf("mode %q changed to %q after normalization", mode, conf.BackupResticS3Mode)
+		}
+	}
+}
+
+// ── saved-source copy selector alignment test ─────────────────────────────────
+
+func TestSavedS3SourceObeysS3ModeNew(t *testing.T) {
+	cluster := newSavedSourceCluster(t, &config.Config{
+		BackupRestic:                  true,
+		BackupResticS3Mode:            config.ConstResticS3ModeNew,
+		BackupResticAwsBucket:         "newbucket",
+		BackupResticRepository:        "s3:legacy-bucket/prefix",
+		BackupResticRepoAppendCluster: false,
+	}, "pass", "secret")
+
+	resolved, err := cluster.resticResolveSavedCopySource(config.ConstBackupArchiveModeResticAws, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved.AWS == nil {
+		t.Fatal("expected AWS config, got nil")
+	}
+	if resolved.AWS.Bucket != "newbucket" {
+		t.Errorf("expected newbucket, got %q", resolved.AWS.Bucket)
+	}
+	if strings.Contains(resolved.AWS.Bucket, "legacy") {
+		t.Errorf("legacy bucket leaked into resolved config: %q", resolved.AWS.Bucket)
+	}
+}
+
+func TestSavedS3SourceObeysS3ModeLegacy(t *testing.T) {
+	cluster := newSavedSourceCluster(t, &config.Config{
+		BackupRestic:                  true,
+		BackupResticS3Mode:            config.ConstResticS3ModeLegacy,
+		BackupResticAwsBucket:         "newbucket", // present but must be ignored
+		BackupResticRepository:        "s3:legacy-bucket/legacy-prefix",
+		BackupResticRepoAppendCluster: false,
+	}, "pass", "secret")
+
+	resolved, err := cluster.resticResolveSavedCopySource(config.ConstBackupArchiveModeResticAws, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved.AWS == nil {
+		t.Fatal("expected AWS config, got nil")
+	}
+	if resolved.AWS.Bucket != "legacy-bucket" {
+		t.Errorf("expected legacy-bucket, got %q", resolved.AWS.Bucket)
+	}
+	if strings.Contains(resolved.AWS.Bucket, "new") {
+		t.Errorf("new bucket leaked into resolved config: %q", resolved.AWS.Bucket)
+	}
+}

--- a/cluster/cluster_tgl.go
+++ b/cluster/cluster_tgl.go
@@ -174,8 +174,7 @@ func (cluster *Cluster) SetBackupArchiveMode(mode string) error {
 		// list and stats until the next fetch against the new repository.
 		cluster.ResticManager.ClearSnapshotList()
 	}
-	cluster.ReloadResticEnv()
-	return nil
+	return cluster.ReloadResticEnv()
 }
 
 func (cluster *Cluster) SwitchBackupBinlogs() {

--- a/cluster/srv_job_restic_test.go
+++ b/cluster/srv_job_restic_test.go
@@ -287,7 +287,7 @@ func TestResticCheckConfigManualNoSideEffects(t *testing.T) {
 		t.Fatal("precondition: ResticManager should be nil before the call")
 	}
 
-	result := cl.ResticCheckConfigManual()
+	result := cl.ResticCheckConfigManual(false)
 
 	if result.Status != backupmgr.ManualCheckStatusInitRequired {
 		t.Fatalf("expected initialization_required, got %s: %s", result.Status, result.Message)
@@ -364,7 +364,7 @@ func TestResticCheckConfigManualSuppressesFetch(t *testing.T) {
 	}
 
 	// Manual check classifies the fresh repo and sets repoState = initialization_required.
-	result := cl.ResticCheckConfigManual()
+	result := cl.ResticCheckConfigManual(false)
 	if result.Status != backupmgr.ManualCheckStatusInitRequired {
 		t.Fatalf("precondition: expected initialization_required, got %s", result.Status)
 	}
@@ -420,7 +420,7 @@ func TestReloadResticEnvClearsRepoState(t *testing.T) {
 	}
 
 	// Step 1: manual check classifies the fresh repo as initialization_required.
-	result := cl.ResticCheckConfigManual()
+	result := cl.ResticCheckConfigManual(false)
 	if result.Status != backupmgr.ManualCheckStatusInitRequired {
 		t.Fatalf("precondition: expected initialization_required, got %s", result.Status)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -848,6 +848,7 @@ type Config struct {
 	BackupResticReseedTimeout              int                    `mapstructure:"backup-restic-reseed-timeout" toml:"backup-restic-reseed-timeout" json:"backupResticReseedTimeout"`
 	BackupResticAllowUnsafeMount           bool                   `mapstructure:"backup-restic-allow-unsafe-mount" toml:"backup-restic-allow-unsafe-mount" json:"backupResticAllowUnsafeMount"`
 	BackupResticAutoInit                   bool                   `mapstructure:"backup-restic-auto-init" toml:"backup-restic-auto-init" json:"backupResticAutoInit"`
+	BackupResticS3Mode                     string                 `mapstructure:"backup-restic-s3-mode" toml:"backup-restic-s3-mode" json:"backupResticS3Mode"`
 	BackupReconcileInterval                int                    `mapstructure:"backup-reconcile-interval" toml:"backup-reconcile-interval" json:"backupReconcileInterval"`
 	BackupReconcileAutoCleanup             bool                   `mapstructure:"backup-reconcile-auto-cleanup" toml:"backup-reconcile-auto-cleanup" json:"backupReconcileAutoCleanup"`
 	BackupStreaming                        bool                   `mapstructure:"backup-streaming" toml:"backup-streaming" json:"backupStreaming"`
@@ -1210,6 +1211,13 @@ const (
 	ConstBackupArchiveModeResticLocal string = "restic-local"
 	ConstBackupArchiveModeResticAws   string = "restic-aws"
 	ConstBackupArchiveModeResticSftp  string = "restic-sftp"
+)
+
+// Restic S3 mode selector: controls which S3 configuration fields are authoritative.
+const (
+	ConstResticS3ModeAuto   string = "auto"
+	ConstResticS3ModeNew    string = "new"
+	ConstResticS3ModeLegacy string = "legacy"
 )
 const (
 	ConstProxyMaxscale    string = "maxscale"
@@ -3534,6 +3542,26 @@ func (conf *Config) NormalizeBackupArchiveMode() {
 	}
 
 	conf.applyBackupArchiveModeFlags()
+	conf.NormalizeResticS3Mode()
+}
+
+// ValidateResticS3Mode reports an error when mode is not one of the allowed
+// backup-restic-s3-mode values: auto, new, legacy.
+func (conf *Config) ValidateResticS3Mode(mode string) error {
+	switch mode {
+	case ConstResticS3ModeAuto, ConstResticS3ModeNew, ConstResticS3ModeLegacy:
+		return nil
+	default:
+		return NewValidationError("backup-restic-s3-mode", mode, "expected one of: auto, new, legacy")
+	}
+}
+
+// NormalizeResticS3Mode maps an empty or invalid BackupResticS3Mode to "auto".
+// Called from NormalizeBackupArchiveMode so it runs once at cluster init time.
+func (conf *Config) NormalizeResticS3Mode() {
+	if conf.ValidateResticS3Mode(conf.BackupResticS3Mode) != nil {
+		conf.BackupResticS3Mode = ConstResticS3ModeAuto
+	}
 }
 
 func (conf *Config) ValidateResticPermissions() error {

--- a/config/restic_s3_mode_test.go
+++ b/config/restic_s3_mode_test.go
@@ -1,0 +1,65 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+
+package config
+
+import "testing"
+
+func TestValidateResticS3Mode(t *testing.T) {
+	conf := &Config{}
+	cases := []struct {
+		mode  string
+		valid bool
+	}{
+		{"auto", true},
+		{"new", true},
+		{"legacy", true},
+		{"", false},
+		{"AUTO", false},
+		{"invalid", false},
+		{"restic-aws", false},
+	}
+	for _, tc := range cases {
+		err := conf.ValidateResticS3Mode(tc.mode)
+		if tc.valid && err != nil {
+			t.Errorf("ValidateResticS3Mode(%q): unexpected error: %v", tc.mode, err)
+		}
+		if !tc.valid && err == nil {
+			t.Errorf("ValidateResticS3Mode(%q): expected error, got nil", tc.mode)
+		}
+	}
+}
+
+func TestNormalizeResticS3Mode(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"", "auto"},
+		{"invalid", "auto"},
+		{"AUTO", "auto"},
+		{"auto", "auto"},
+		{"new", "new"},
+		{"legacy", "legacy"},
+	}
+	for _, tc := range cases {
+		conf := &Config{BackupResticS3Mode: tc.input}
+		conf.NormalizeResticS3Mode()
+		if conf.BackupResticS3Mode != tc.want {
+			t.Errorf("NormalizeResticS3Mode(%q): got %q, want %q", tc.input, conf.BackupResticS3Mode, tc.want)
+		}
+	}
+}
+
+func TestNormalizeBackupArchiveMode_SetsS3ModeAuto(t *testing.T) {
+	conf := &Config{
+		BackupRestic:       true,
+		BackupResticAws:    true,
+		BackupResticS3Mode: "", // empty: should be normalized to auto
+	}
+	conf.NormalizeBackupArchiveMode()
+	if conf.BackupResticS3Mode != ConstResticS3ModeAuto {
+		t.Errorf("expected BackupResticS3Mode=auto after NormalizeBackupArchiveMode, got %q", conf.BackupResticS3Mode)
+	}
+}

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -251,6 +251,11 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxResticCopy)),
 	))
 
+	router.Handle("/api/clusters/{clusterName}/restic/wipe", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxResticWipeRepo)),
+	))
+
 	router.Handle("/api/clusters/{clusterName}/certificates", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterCertificates)),
@@ -8567,6 +8572,76 @@ func (repman *ReplicationManager) handlerMuxResticCopy(w http.ResponseWriter, r 
 	})
 }
 
+// handlerMuxResticWipeRepo executes a destructive wipe of the restic repository for a cluster.
+// This endpoint is execute-only: confirm=false (or omitted) returns HTTP 400. Use
+// POST /restic/check-config for the non-destructive preview that returns repo_path, backend,
+// is_s3_empty_prefix, can_wipe, and wipe_message.
+//
+// The handler enforces GrantDBBackup directly so that a generic /restic grant alone
+// cannot authorize this destructive operation — URL-based ACL fallback is intentionally bypassed.
+// @Summary Wipe Restic Repository
+// @Description Execute-only destructive repository wipe. Requires confirm=true and typed_target_confirm matching the server-computed repo_path. Use POST /restic/check-config to obtain the preview/target before calling this endpoint.
+// @Tags ClusterRestic
+// @Accept json
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Param body body backupmgr.ResticWipeOption true "Wipe payload (confirm=true, typed_target_confirm, allow_empty_prefix)"
+// @Success 200 {object} map[string]string "Repository wiped successfully"
+// @Failure 400 {object} map[string]string "Invalid payload, missing confirmation, or guardrail rejection"
+// @Failure 403 {string} string "No valid ACL or insufficient grant (db-backup required)"
+// @Failure 500 {string} string "No cluster"
+// @Router /api/clusters/{clusterName}/restic/wipe [post]
+func (repman *ReplicationManager) handlerMuxResticWipeRepo(w http.ResponseWriter, r *http.Request) {
+	repman.withResticCluster(w, r, true, func(mycluster *cluster.Cluster, vars map[string]string) {
+		// Enforce GrantDBBackup explicitly: URL-based ACL matching falls back to the
+		// generic /restic rule (GrantClusterProcess) via hierarchical pattern matching,
+		// which would allow users without backup permissions to wipe the repository.
+		username := repman.GetUserFromRequest(r)
+		if u, ok := mycluster.APIUsers[username]; !ok || !u.Grants[config.GrantDBBackup] {
+			http.Error(w, "No valid ACL", http.StatusForbidden)
+			return
+		}
+
+		var opt backupmgr.ResticWipeOption
+		if err := json.NewDecoder(r.Body).Decode(&opt); err != nil && err != io.EOF {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "invalid request body: " + err.Error()})
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if !opt.Confirm {
+			// Execute-only: reject preview mode. Use POST /restic/check-config instead.
+			repoPath := ""
+			if mycluster.ResticManager != nil {
+				repoPath = mycluster.ResticManager.GetRepoPath()
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"message":   "This endpoint is execute-only (confirm=true required). Use POST /restic/check-config for a non-destructive preview.",
+				"repo_path": repoPath,
+			})
+			return
+		}
+
+		// Execute mode: validate confirmation and wipe.
+		if err := mycluster.ResticWipeRepoWithOptions(opt); err != nil {
+			preview := mycluster.ResticWipePreview()
+			preview.CanWipe = false
+			preview.Message = err.Error()
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(preview)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"message": "Repository wiped successfully."})
+	})
+}
+
 // handlerMuxResticCheckConfig handles the HTTP request to manually validate the restic
 // repository configuration for a given cluster.
 // @Summary Check Restic Repository Config
@@ -8581,7 +8656,8 @@ func (repman *ReplicationManager) handlerMuxResticCopy(w http.ResponseWriter, r 
 // @Router /api/clusters/{clusterName}/restic/check-config [post]
 func (repman *ReplicationManager) handlerMuxResticCheckConfig(w http.ResponseWriter, r *http.Request) {
 	repman.withResticCluster(w, r, true, func(mycluster *cluster.Cluster, vars map[string]string) {
-		result := mycluster.ResticCheckConfigManual()
+		skipFetch := r.URL.Query().Get("skip_fetch") == "true"
+		result := mycluster.ResticCheckConfigManual(skipFetch)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(result)

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -3912,6 +3912,7 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		mycluster.ReloadResticEnv()
 	case "backup-restic-aws-access-key-id":
 		mycluster.Conf.BackupResticAwsAccessKeyId = value
+		mycluster.ReloadResticEnv()
 	case "backup-restic-aws-access-secret":
 		val, err := base64.StdEncoding.DecodeString(value)
 		if err != nil {
@@ -3922,6 +3923,7 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		new_secret.Value = mycluster.Conf.BackupResticAwsAccessSecret
 		new_secret.OldValue = mycluster.Conf.GetDecryptedValue("backup-restic-aws-access-secret")
 		mycluster.Conf.Secrets["backup-restic-aws-access-secret"] = new_secret
+		mycluster.ReloadResticEnv()
 	case "backup-restic-aws-region":
 		mycluster.Conf.BackupResticAwsRegion = value
 		mycluster.ReloadResticEnv()
@@ -3941,6 +3943,12 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 			return errors.New("unable to decode")
 		}
 		mycluster.Conf.BackupResticAwsPrefix = string(val)
+		mycluster.ReloadResticEnv()
+	case "backup-restic-s3-mode":
+		if err := mycluster.Conf.ValidateResticS3Mode(value); err != nil {
+			return fmt.Errorf("invalid backup-restic-s3-mode: %w", err)
+		}
+		mycluster.Conf.BackupResticS3Mode = value
 		mycluster.ReloadResticEnv()
 	case "backup-restic-additional-env":
 		if err := cluster.ValidateResticAdditionalEnvOverrides(value); err != nil {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -246,6 +246,11 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxResticRestoreConfig)),
 	))
 
+	router.Handle("/api/clusters/{clusterName}/restic/copy", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxResticCopy)),
+	))
+
 	router.Handle("/api/clusters/{clusterName}/certificates", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterCertificates)),
@@ -8519,6 +8524,38 @@ func (repman *ReplicationManager) handlerMuxResticInitRepo(w http.ResponseWriter
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("Restic repository initialized"))
+	})
+}
+
+// handlerMuxResticCopy handles the HTTP request to queue a repository copy task.
+// @Summary Copy Restic Repository
+// @Description Copies snapshots from a source repository into the cluster's configured Restic repository.
+// @Tags ClusterRestic
+// @Accept json
+// @Produce plain
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Param body body backupmgr.ResticCopyOption true "Copy options"
+// @Success 200 {string} string "Restic repository copy queued"
+// @Failure 400 {string} string "Invalid payload or guardrail rejection"
+// @Failure 403 {string} string "No valid ACL"
+// @Failure 500 {string} string "No cluster"
+// @Router /api/clusters/{clusterName}/restic/copy [post]
+func (repman *ReplicationManager) handlerMuxResticCopy(w http.ResponseWriter, r *http.Request) {
+	repman.withResticCluster(w, r, true, func(mycluster *cluster.Cluster, vars map[string]string) {
+		var opt backupmgr.ResticCopyOption
+		if err := json.NewDecoder(r.Body).Decode(&opt); err != nil && err != io.EOF {
+			http.Error(w, "Error decoding request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if err := mycluster.ResticCopyRepoWithOptions(opt); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Restic repository copy queued"))
 	})
 }
 

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -3907,17 +3907,23 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 			}
 		}
 		mycluster.Conf.BackupResticLocalRepository = repoPath
-		mycluster.ReloadResticEnv()
+		if err := mycluster.ReloadResticEnv(); err != nil {
+			return err
+		}
 	case "backup-restic-repository":
 		val, err := base64.StdEncoding.DecodeString(value)
 		if err != nil {
 			return errors.New("unable to decode")
 		}
 		mycluster.Conf.BackupResticRepository = string(val)
-		mycluster.ReloadResticEnv()
+		if err := mycluster.ReloadResticEnv(); err != nil {
+			return err
+		}
 	case "backup-restic-aws-access-key-id":
 		mycluster.Conf.BackupResticAwsAccessKeyId = value
-		mycluster.ReloadResticEnv()
+		if err := mycluster.ReloadResticEnv(); err != nil {
+			return err
+		}
 	case "backup-restic-aws-access-secret":
 		val, err := base64.StdEncoding.DecodeString(value)
 		if err != nil {
@@ -3928,39 +3934,53 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		new_secret.Value = mycluster.Conf.BackupResticAwsAccessSecret
 		new_secret.OldValue = mycluster.Conf.GetDecryptedValue("backup-restic-aws-access-secret")
 		mycluster.Conf.Secrets["backup-restic-aws-access-secret"] = new_secret
-		mycluster.ReloadResticEnv()
+		if err := mycluster.ReloadResticEnv(); err != nil {
+			return err
+		}
 	case "backup-restic-aws-region":
 		mycluster.Conf.BackupResticAwsRegion = value
-		mycluster.ReloadResticEnv()
+		if err := mycluster.ReloadResticEnv(); err != nil {
+			return err
+		}
 	case "backup-restic-aws-endpoint":
 		val, err := base64.StdEncoding.DecodeString(value)
 		if err != nil {
 			return errors.New("unable to decode")
 		}
 		mycluster.Conf.BackupResticAwsEndpoint = string(val)
-		mycluster.ReloadResticEnv()
+		if err := mycluster.ReloadResticEnv(); err != nil {
+			return err
+		}
 	case "backup-restic-aws-bucket":
 		mycluster.Conf.BackupResticAwsBucket = value
-		mycluster.ReloadResticEnv()
+		if err := mycluster.ReloadResticEnv(); err != nil {
+			return err
+		}
 	case "backup-restic-aws-prefix":
 		val, err := base64.StdEncoding.DecodeString(value)
 		if err != nil {
 			return errors.New("unable to decode")
 		}
 		mycluster.Conf.BackupResticAwsPrefix = string(val)
-		mycluster.ReloadResticEnv()
+		if err := mycluster.ReloadResticEnv(); err != nil {
+			return err
+		}
 	case "backup-restic-s3-mode":
 		if err := mycluster.Conf.ValidateResticS3Mode(value); err != nil {
 			return fmt.Errorf("invalid backup-restic-s3-mode: %w", err)
 		}
 		mycluster.Conf.BackupResticS3Mode = value
-		mycluster.ReloadResticEnv()
+		if err := mycluster.ReloadResticEnv(); err != nil {
+			return err
+		}
 	case "backup-restic-additional-env":
 		if err := cluster.ValidateResticAdditionalEnvOverrides(value); err != nil {
 			return fmt.Errorf("invalid backup-restic-additional-env: %w", err)
 		}
 		mycluster.Conf.BackupResticAdditionalEnv = value
-		mycluster.ReloadResticEnv()
+		if err := mycluster.ReloadResticEnv(); err != nil {
+			return err
+		}
 	case "backup-restic-password":
 		val, err := base64.StdEncoding.DecodeString(value)
 		if err != nil {
@@ -8531,7 +8551,10 @@ func (repman *ReplicationManager) handlerMuxResticInitRepo(w http.ResponseWriter
 
 		if effectivePrefix, ok := mycluster.ResticS3EffectivePrefixForInit(); ok {
 			mycluster.Conf.BackupResticAwsPrefix = effectivePrefix
-			mycluster.ReloadResticEnv()
+			if err := mycluster.ReloadResticEnv(); err != nil {
+				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModRestic, config.LvlWarn,
+					"Restic env reload failed after init prefix update: %s", err)
+			}
 			mycluster.ConfigManager.SaveConfig(mycluster, false)
 		}
 

--- a/server/api_restic_test.go
+++ b/server/api_restic_test.go
@@ -1,0 +1,151 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/signal18/replication-manager/cluster"
+	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/backupmgr"
+)
+
+// newResticRepman builds a ReplicationManager with JWT keys initialised and the
+// named cluster registered. The cluster has restic enabled, a ResticManager with
+// a paused worker, and a test user with GrantClusterProcess.
+func newResticRepman(t *testing.T, clusterName string, resticEnabled bool) (*ReplicationManager, string) {
+	t.Helper()
+
+	rm := backupmgr.NewResticRepo("", nil, config.ConstLogModRestic)
+	rm.PauseWorker()
+	t.Cleanup(rm.ShutdownWorker)
+
+	const (
+		testUser = "restic-test-user"
+		testPass = "restic-test-pass"
+	)
+
+	cl := &cluster.Cluster{
+		Name: clusterName,
+		Conf: &config.Config{
+			BackupRestic: resticEnabled,
+		},
+		ResticManager: rm,
+	}
+	cl.APIUsers = map[string]cluster.APIUser{
+		testUser: {
+			User:     testUser,
+			Password: testPass,
+			Grants:   map[string]bool{config.GrantClusterProcess: true},
+		},
+	}
+
+	repman := &ReplicationManager{
+		Clusters: map[string]*cluster.Cluster{clusterName: cl},
+		Conf:     &config.Config{TokenTimeout: 1},
+	}
+	repman.initKeys()
+
+	tok, err := repman.issueJWT(map[string]interface{}{
+		"Name":     testUser,
+		"Password": testPass,
+	}, "")
+	if err != nil {
+		t.Fatalf("issueJWT: %v", err)
+	}
+	return repman, tok
+}
+
+// TestHandlerResticCopy_NoCluster verifies that a request for a non-existent
+// cluster returns 500 before any ACL or business-logic checks run.
+func TestHandlerResticCopy_NoCluster(t *testing.T) {
+	repman := newTestRepmanWithCluster(t, "other-cluster", newTestClusterForAPI(t))
+	req := httptest.NewRequest(http.MethodPost, "/api/clusters/missing/restic/copy",
+		strings.NewReader(`{}`))
+	req = setMuxVars(req, map[string]string{"clusterName": "missing"})
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxResticCopy(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for missing cluster, got %d", w.Code)
+	}
+}
+
+// TestHandlerResticCopy_NoACL verifies that a request for an existing cluster
+// without a valid JWT is rejected with 403.
+func TestHandlerResticCopy_NoACL(t *testing.T) {
+	cl := newTestClusterForAPI(t)
+	cl.Conf.BackupRestic = true
+	repman := newTestRepmanWithCluster(t, "test-cluster", cl)
+	req := httptest.NewRequest(http.MethodPost, "/api/clusters/test-cluster/restic/copy",
+		strings.NewReader(`{}`))
+	req = setMuxVars(req, map[string]string{"clusterName": "test-cluster"})
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxResticCopy(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 without JWT, got %d", w.Code)
+	}
+}
+
+// TestHandlerResticCopy_BadJSON verifies that a malformed JSON body returns 400.
+func TestHandlerResticCopy_BadJSON(t *testing.T) {
+	repman, tok := newResticRepman(t, "test-cluster", true)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/clusters/test-cluster/restic/copy",
+		strings.NewReader(`{not valid json`))
+	req = setMuxVars(req, map[string]string{"clusterName": "test-cluster"})
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tok))
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxResticCopy(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for bad JSON, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandlerResticCopy_InvalidMode verifies that a valid-JSON body with an
+// unrecognised source mode returns 400.
+func TestHandlerResticCopy_InvalidMode(t *testing.T) {
+	repman, tok := newResticRepman(t, "test-cluster", true)
+	body := `{"source":{"mode":"unsupported","repository":"/x","password":"p"}}`
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/clusters/test-cluster/restic/copy",
+		strings.NewReader(body))
+	req = setMuxVars(req, map[string]string{"clusterName": "test-cluster"})
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tok))
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxResticCopy(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid mode, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandlerResticCopy_ValidRequest verifies that a well-formed, authenticated
+// request returns 200 and queues the task.
+func TestHandlerResticCopy_ValidRequest(t *testing.T) {
+	repman, tok := newResticRepman(t, "test-cluster", true)
+	body := `{"source":{"mode":"restic-local","repository":"/src","password":"srcpass"}}`
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/clusters/test-cluster/restic/copy",
+		strings.NewReader(body))
+	req = setMuxVars(req, map[string]string{"clusterName": "test-cluster"})
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tok))
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxResticCopy(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for valid request, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "queued") {
+		t.Errorf("expected response body to mention 'queued', got: %s", w.Body.String())
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -907,6 +907,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.IntVar(&conf.BackupResticReseedTimeout, "backup-restic-reseed-timeout", 3600, "Timeout in seconds for restic reseed operations")
 	flags.BoolVar(&conf.BackupResticAllowUnsafeMount, "backup-restic-allow-unsafe-mount", false, "Allow using a restic mount created by another process (unsafe)")
 	flags.BoolVar(&conf.BackupResticAutoInit, "backup-restic-auto-init", false, "Automatically initialize fresh local and S3 restic repositories on first use. Does not apply to SFTP repositories.")
+	flags.StringVar(&conf.BackupResticS3Mode, "backup-restic-s3-mode", "auto", "Restic S3 source-of-truth selector: auto (prefer new fields, fall back to legacy URL), new (use bucket/prefix/endpoint fields only), legacy (use backup-restic-repository URL only)")
 	flags.BoolVar(&conf.BackupStreaming, "backup-streaming", false, "Backup streaming to cloud ")
 	flags.BoolVar(&conf.BackupStreamingDebug, "backup-streaming-debug", false, "Debug mode for streaming to cloud ")
 	flags.StringVar(&conf.BackupStreamingAwsAccessKeyId, "backup-streaming-aws-access-key-id", "admin", "Backup AWS key id")

--- a/share/dashboard_react/src/Pages/Maintenance/index.jsx
+++ b/share/dashboard_react/src/Pages/Maintenance/index.jsx
@@ -464,27 +464,43 @@ function Maintenance({ selectedCluster, user, section, onOpenBackupSettings, onO
       return []
     }
 
+    const isCopyTask = currentResticTask.task_type === 8
     const isBackupTask = currentResticTask.task_type === 2
+    const phase = currentResticTask.phase
+
     const percentDone = (() => {
-      if (!isBackupTask || typeof currentResticTask.percent_done !== 'number') {
-        return 'Running'
+      const hasPercent = typeof currentResticTask.percent_done === 'number'
+
+      if (phase === 'init_destination') {
+        return (
+          <HStack spacing={3} alignItems="center">
+            <Progress size="sm" flex="1" isIndeterminate />
+            <Box minWidth="3.5rem" textAlign="right">Preparing...</Box>
+          </HStack>
+        )
       }
 
-      const clamped = Math.min(Math.max(currentResticTask.percent_done, 0), 1)
-      const percentValue = Math.round(clamped * 100)
+      if ((isBackupTask || (isCopyTask && phase === 'copy')) && hasPercent) {
+        const clamped = Math.min(Math.max(currentResticTask.percent_done, 0), 1)
+        const percentValue = Math.round(clamped * 100)
+        return (
+          <HStack spacing={3} alignItems="center">
+            <Progress value={percentValue} size="sm" flex="1" />
+            <Box minWidth="3.5rem" textAlign="right">{percentValue}%</Box>
+          </HStack>
+        )
+      }
 
-      return (
-        <HStack spacing={3} alignItems="center">
-          <Progress value={percentValue} size="sm" flex="1" />
-          <Box minWidth="3.5rem" textAlign="right">{percentValue}%</Box>
-        </HStack>
-      )
+      return 'Running'
     })()
     const bytesValue = currentResticTask.total_bytes
       ? `${formatBytes(currentResticTask.bytes_done || 0)} / ${formatBytes(currentResticTask.total_bytes)}`
       : '-'
     const filesValue = currentResticTask.total_files
       ? `${currentResticTask.files_done || 0} / ${currentResticTask.total_files}`
+      : '-'
+    const packsValue = currentResticTask.total_packs
+      ? `${currentResticTask.packs_done || 0} / ${currentResticTask.total_packs}`
       : '-'
     const startedAt = currentResticTask.started_at ? formatDate(currentResticTask.started_at) : '-'
     const completedAt = currentResticTask.completed_at ? formatDate(currentResticTask.completed_at) : '-'
@@ -495,46 +511,23 @@ function Maintenance({ selectedCluster, user, section, onOpenBackupSettings, onO
         : '-'
 
     return [
-      {
-        key: 'Task ID',
-        value: currentResticTask.task_id || '-'
-      },
-      {
-        key: 'Task Type',
-        value: resticTaskType(currentResticTask.task_type)
-      },
-      {
-        key: 'Status',
-        value: currentResticTask.status || '-'
-      },
-      {
-        key: 'Progress',
-        value: percentDone
-      },
-      {
-        key: 'Bytes',
-        value: bytesValue
-      },
-      {
-        key: 'Files',
-        value: filesValue
-      },
-      {
-        key: 'Snapshot ID',
-        value: currentResticTask.snapshot_id || '-'
-      },
-      {
-        key: 'Duration',
-        value: duration
-      },
-      {
-        key: 'Started',
-        value: startedAt
-      },
-      {
-        key: 'Completed',
-        value: completedAt
-      }
+      { key: 'Task ID', value: currentResticTask.task_id || '-' },
+      { key: 'Task Type', value: resticTaskType(currentResticTask.task_type) },
+      { key: 'Status', value: currentResticTask.status || '-' },
+      ...(currentResticTask.phase ? [{ key: 'Phase', value: currentResticTask.phase }] : []),
+      { key: 'Progress', value: percentDone },
+      { key: 'Bytes', value: bytesValue },
+      ...(isCopyTask
+        ? [{ key: 'Packs', value: packsValue }]
+        : [{ key: 'Files', value: filesValue }]),
+      ...(isCopyTask && currentResticTask.total_snapshots > 0 ? [{
+        key: 'Snapshots',
+        value: `${currentResticTask.completed_snapshots || 0} / ${currentResticTask.total_snapshots}`
+      }] : []),
+      { key: 'Snapshot ID', value: currentResticTask.snapshot_id || '-' },
+      { key: 'Duration', value: duration },
+      { key: 'Started', value: startedAt },
+      { key: 'Completed', value: completedAt }
     ]
   }, [currentResticTask])
 

--- a/share/dashboard_react/src/Pages/Maintenance/index.jsx
+++ b/share/dashboard_react/src/Pages/Maintenance/index.jsx
@@ -93,6 +93,8 @@ const resticTaskType = (rtt) => {
       return "restore"
     case 7:
       return "check"
+    case 8:
+      return "copy"
     default:
       return "Unknown"
   }

--- a/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
@@ -1,5 +1,5 @@
-import { Box, Flex, Grid, GridItem, HStack, Stack, Text, VStack, Checkbox, Alert, AlertIcon, Divider, useDisclosure } from '@chakra-ui/react'
-import React, { useState, useEffect } from 'react'
+import { Box, Flex, FormControl, FormLabel, Grid, GridItem, HStack, Input, Select, Stack, Text, VStack, Checkbox, Alert, AlertIcon, Divider, useDisclosure } from '@chakra-ui/react'
+import React, { useState, useEffect, useRef } from 'react'
 import { HiChevronDown, HiChevronUp, HiQuestionMarkCircle, HiRefresh } from 'react-icons/hi'
 import RMIconButton from '../../components/RMIconButton'
 import RMButton from '../../components/RMButton'
@@ -8,7 +8,7 @@ import TextForm from '../../components/TextForm'
 import Dropdown from '../../components/Dropdown'
 import ConfirmModal from '../../components/Modals/ConfirmModal'
 import { setSetting, switchSetting } from '../../redux/settingsSlice'
-import { resticInitRepo, resticCheckConfig } from '../../redux/clusterSlice'
+import { resticInitRepo, resticCheckConfig, resticCopyRepo, getResticCurrentTask } from '../../redux/clusterSlice'
 import styles from './styles.module.scss'
 import tableStyles from '../../components/TableType2/styles.module.scss'
 
@@ -345,6 +345,29 @@ function ResticRepositorySettings({
   const [checklistConfirmedNew, setChecklistConfirmedNew] = useState(false)
   const isChecklistReady = checklistConfirmedTarget && checklistConfirmedNew
 
+  // Copy modal state
+  const { isOpen: isCopyModalOpen, onOpen: onOpenCopyModal, onClose: onCloseCopyModal } = useDisclosure()
+  const [copySourceMode, setCopySourceMode] = useState('restic-local')
+  const [copySourceRepo, setCopySourceRepo] = useState('')
+  const [copySourcePassword, setCopySourcePassword] = useState('')
+  const [copySourceKeyHint, setCopySourceKeyHint] = useState('')
+  const [copySourceAwsEndpoint, setCopySourceAwsEndpoint] = useState('')
+  const [copySourceAwsBucket, setCopySourceAwsBucket] = useState('')
+  const [copySourceAwsPrefix, setCopySourceAwsPrefix] = useState('')
+  const [copySourceAwsAccessKeyId, setCopySourceAwsAccessKeyId] = useState('')
+  const [copySourceAwsAccessSecret, setCopySourceAwsAccessSecret] = useState('')
+  const [copySourceAwsRegion, setCopySourceAwsRegion] = useState('')
+  const [copyInitDestination, setCopyInitDestination] = useState(false)
+  const [copyCopyChunkerParams, setCopyCopyChunkerParams] = useState(false)
+  const [copySnapshotIds, setCopySnapshotIds] = useState('')
+  const [copyFilterHost, setCopyFilterHost] = useState('')
+  const [copyFilterPath, setCopyFilterPath] = useState('')
+  const [copyFilterTag, setCopyFilterTag] = useState('')
+  const [copyError, setCopyError] = useState(null)
+  const [copySubmitting, setCopySubmitting] = useState(false)
+  const [showCopyAdvancedFilters, setShowCopyAdvancedFilters] = useState(false)
+  const copySubmitGenRef = useRef(0)
+
   const handleCheckRepo = async () => {
     setIsCheckLoading(true)
     setCheckResult(null)
@@ -371,6 +394,100 @@ function ResticRepositorySettings({
       setCheckResult({ status: 'ok', message: 'Repository initialized. Snapshot refresh queued.' })
     } catch (error) {
       setCheckResult({ status: 'error', message: error?.errorMessage || error?.message || String(error) })
+    }
+  }
+
+  const resetCopyForm = () => {
+    setCopySourceMode('restic-local')
+    setCopySourceRepo('')
+    setCopySourcePassword('')
+    setCopySourceKeyHint('')
+    setCopySourceAwsEndpoint('')
+    setCopySourceAwsBucket('')
+    setCopySourceAwsPrefix('')
+    setCopySourceAwsAccessKeyId('')
+    setCopySourceAwsAccessSecret('')
+    setCopySourceAwsRegion('')
+    setCopyInitDestination(false)
+    setCopyCopyChunkerParams(false)
+    setCopySnapshotIds('')
+    setCopyFilterHost('')
+    setCopyFilterPath('')
+    setCopyFilterTag('')
+    setCopyError(null)
+    setCopySubmitting(false)
+    setShowCopyAdvancedFilters(false)
+  }
+
+  const handleCloseCopyModal = () => {
+    copySubmitGenRef.current++
+    resetCopyForm()
+    onCloseCopyModal()
+  }
+
+  const validateCopyForm = () => {
+    if (!copySourcePassword.trim()) return 'Source password is required.'
+    if ((copySourceMode === 'restic-local' || copySourceMode === 'restic-sftp') && !copySourceRepo.trim()) {
+      return 'Source repository path is required.'
+    }
+    if (copySourceMode === 'restic-aws' && !copySourceAwsBucket.trim()) {
+      return 'Source S3 bucket is required.'
+    }
+    if (copyCopyChunkerParams && !copyInitDestination) {
+      return 'Copy chunker parameters requires init destination to be enabled.'
+    }
+    return null
+  }
+
+  const buildCopyPayload = () => {
+    const splitFilter = (text) => text.split(',').map((s) => s.trim()).filter(Boolean)
+    const snapshotIds = splitFilter(copySnapshotIds)
+    const host = snapshotIds.length > 0 ? [] : splitFilter(copyFilterHost)
+    const path = snapshotIds.length > 0 ? [] : splitFilter(copyFilterPath)
+    const tag = snapshotIds.length > 0 ? [] : splitFilter(copyFilterTag)
+    const source = { mode: copySourceMode, password: copySourcePassword }
+    if (copySourceKeyHint.trim()) source.key_hint = copySourceKeyHint.trim()
+    if (copySourceMode === 'restic-aws') {
+      source.aws = {
+        endpoint: copySourceAwsEndpoint.trim(),
+        bucket: copySourceAwsBucket.trim(),
+        prefix: copySourceAwsPrefix.trim(),
+        access_key_id: copySourceAwsAccessKeyId.trim(),
+        access_secret: copySourceAwsAccessSecret,
+        region: copySourceAwsRegion.trim()
+      }
+    } else {
+      source.repository = copySourceRepo.trim()
+    }
+    return {
+      source,
+      init_destination: copyInitDestination,
+      copy_chunker_params: copyCopyChunkerParams,
+      snapshot_ids: snapshotIds,
+      host,
+      path,
+      tag
+    }
+  }
+
+  const handleCopySubmit = async () => {
+    const err = validateCopyForm()
+    if (err) { setCopyError(err); return }
+    setCopyError(null)
+    const submitGen = ++copySubmitGenRef.current
+    setCopySubmitting(true)
+    try {
+      await dispatch(resticCopyRepo(clusterName, buildCopyPayload()))
+      if (copySubmitGenRef.current === submitGen) {
+        onCloseCopyModal()
+        resetCopyForm()
+        dispatch(getResticCurrentTask({ clusterName }))
+      }
+    } catch (error) {
+      if (copySubmitGenRef.current === submitGen) {
+        setCopyError(error?.errorMessage || error?.message || 'Copy request failed.')
+        setCopySubmitting(false)
+      }
     }
   }
 
@@ -611,6 +728,17 @@ function ResticRepositorySettings({
                             'Re-initialize Local Repository'
                           )}
                         </HStack>
+                        <HStack>
+                          <RMButton
+                            size='sm'
+                            colorScheme='orange'
+                            onClick={onOpenCopyModal}
+                            isDisabled={user?.grants['cluster-process'] === false}
+                            title='Migrate/copy snapshots from another repository into this one'
+                          >
+                            Migrate/copy snapshots
+                          </RMButton>
+                        </HStack>
                         {checkResult && checkResult.status !== 'initialization_required' && (
                           <Alert status={checkResult.status === 'ok' ? 'success' : 'error'} size='sm' borderRadius='md'>
                             <AlertIcon />
@@ -672,6 +800,17 @@ function ResticRepositorySettings({
                             'Re-initialize the SFTP Restic repository. This creates a new repository configuration at the configured sftp:user@host:/path. Force re-initialization is not supported for SFTP repositories - remove the remote repository path manually over SSH before re-initializing.',
                             'Re-initialize SFTP Repository'
                           )}
+                        </HStack>
+                        <HStack>
+                          <RMButton
+                            size='sm'
+                            colorScheme='orange'
+                            onClick={onOpenCopyModal}
+                            isDisabled={user?.grants['cluster-process'] === false}
+                            title='Migrate/copy snapshots from another repository into this one'
+                          >
+                            Migrate/copy snapshots
+                          </RMButton>
                         </HStack>
                         {checkResult && checkResult.status !== 'initialization_required' && (
                           <Alert status={checkResult.status === 'ok' ? 'success' : 'error'} size='sm' borderRadius='md'>
@@ -936,6 +1075,14 @@ function ResticRepositorySettings({
                           isDisabled={user?.grants['cluster-settings'] === false}
                         >
                           Initialize repository
+                        </RMButton>
+                        <RMButton
+                          size='sm'
+                          colorScheme='orange'
+                          onClick={onOpenCopyModal}
+                          isDisabled={user?.grants['cluster-process'] === false}
+                        >
+                          Migrate/copy snapshots
                         </RMButton>
                       </HStack>
                       {checkResult && checkResult.status !== 'initialization_required' && (
@@ -1234,10 +1381,196 @@ function ResticRepositorySettings({
         }
         onConfirmClick={handleConfirmInit}
         confirmButtonText="Initialize"
-        confirmButtonProps={{ 
+        confirmButtonProps={{
           isDisabled: isForceInitBlocked,
-          colorScheme: initForce ? 'red' : 'blue' 
+          colorScheme: initForce ? 'red' : 'blue'
         }}
+      />
+
+      <ConfirmModal
+        isOpen={isCopyModalOpen}
+        closeModal={handleCloseCopyModal}
+        title="Migrate / Copy Snapshots"
+        onConfirmClick={handleCopySubmit}
+        confirmButtonText="Queue copy"
+        confirmButtonProps={{ isLoading: copySubmitting, colorScheme: 'orange' }}
+        body={
+          <VStack align='start' spacing={4}>
+            <Box w='full'>
+              <Text fontSize='sm' fontWeight='semibold' mb={1}>Destination (read-only)</Text>
+              <Text
+                fontSize='sm'
+                fontFamily='monospace'
+                bg='gray.100'
+                p={2}
+                borderRadius='md'
+                wordBreak='break-all'
+                w='full'
+              >
+                {isAws ? (awsRepoPath || 's3:<bucket>/<prefix>') : (config?.backupResticLocalRepository || '(not configured)')}
+              </Text>
+              {!isAws && appendCluster && (
+                <Text fontSize='xs' color='gray.500' mt={1}>
+                  Effective path may include /{clusterName} suffix if not already present.
+                </Text>
+              )}
+              <Text fontSize='xs' color='gray.500' mt={1}>
+                Repository configuration will not be changed by this copy operation.
+              </Text>
+            </Box>
+
+            <Divider />
+
+            <FormControl>
+              <FormLabel fontSize='sm'>Source repository type</FormLabel>
+              <Select size='sm' value={copySourceMode} onChange={(e) => setCopySourceMode(e.target.value)}>
+                <option value='restic-local'>Local filesystem</option>
+                <option value='restic-sftp'>SFTP</option>
+                <option value='restic-aws'>S3 / Object storage</option>
+              </Select>
+            </FormControl>
+
+            {(copySourceMode === 'restic-local' || copySourceMode === 'restic-sftp') && (
+              <FormControl isRequired>
+                <FormLabel fontSize='sm'>
+                  {copySourceMode === 'restic-sftp' ? 'Source SFTP URI' : 'Source repository path'}
+                </FormLabel>
+                <Input
+                  size='sm'
+                  value={copySourceRepo}
+                  onChange={(e) => setCopySourceRepo(e.target.value)}
+                  placeholder={copySourceMode === 'restic-sftp' ? 'sftp:user@host:/path/to/repo' : '/path/to/source/repo'}
+                />
+                {copySourceMode === 'restic-sftp' && (
+                  <Text fontSize='xs' color='gray.500' mt={1}>
+                    SSH auth uses the running process&apos;s key-based SSH config. Password-based SSH is not supported.
+                  </Text>
+                )}
+              </FormControl>
+            )}
+
+            {copySourceMode === 'restic-aws' && (
+              <VStack spacing={3} w='full' align='start'>
+                <FormControl>
+                  <FormLabel fontSize='sm'>Source S3 endpoint</FormLabel>
+                  <Input size='sm' value={copySourceAwsEndpoint} onChange={(e) => setCopySourceAwsEndpoint(e.target.value)} placeholder='https://minio.example.com' />
+                </FormControl>
+                <FormControl isRequired>
+                  <FormLabel fontSize='sm'>Source S3 bucket</FormLabel>
+                  <Input size='sm' value={copySourceAwsBucket} onChange={(e) => setCopySourceAwsBucket(e.target.value)} placeholder='bucket-name' />
+                </FormControl>
+                <FormControl>
+                  <FormLabel fontSize='sm'>Source S3 prefix</FormLabel>
+                  <Input size='sm' value={copySourceAwsPrefix} onChange={(e) => setCopySourceAwsPrefix(e.target.value)} placeholder='optional/prefix' />
+                </FormControl>
+                <FormControl>
+                  <FormLabel fontSize='sm'>Source S3 access key ID</FormLabel>
+                  <Input size='sm' value={copySourceAwsAccessKeyId} onChange={(e) => setCopySourceAwsAccessKeyId(e.target.value)} />
+                </FormControl>
+                <FormControl>
+                  <FormLabel fontSize='sm'>Source S3 access secret</FormLabel>
+                  <Input size='sm' type='password' value={copySourceAwsAccessSecret} onChange={(e) => setCopySourceAwsAccessSecret(e.target.value)} />
+                </FormControl>
+                <FormControl>
+                  <FormLabel fontSize='sm'>Source S3 region</FormLabel>
+                  <Input size='sm' value={copySourceAwsRegion} onChange={(e) => setCopySourceAwsRegion(e.target.value)} placeholder='us-east-1' />
+                </FormControl>
+              </VStack>
+            )}
+
+            <FormControl isRequired>
+              <FormLabel fontSize='sm'>Source repository password</FormLabel>
+              <Input size='sm' type='password' value={copySourcePassword} onChange={(e) => setCopySourcePassword(e.target.value)} />
+            </FormControl>
+
+            <FormControl>
+              <FormLabel fontSize='sm'>
+                Source key hint{' '}
+                <Text as='span' fontSize='xs' color='gray.500'>(optional)</Text>
+              </FormLabel>
+              <Input size='sm' value={copySourceKeyHint} onChange={(e) => setCopySourceKeyHint(e.target.value)} placeholder='key ID hint for multi-key repos' />
+            </FormControl>
+
+            <Divider />
+
+            <Checkbox
+              isChecked={copyInitDestination}
+              onChange={(e) => {
+                setCopyInitDestination(e.target.checked)
+                if (!e.target.checked) setCopyCopyChunkerParams(false)
+              }}
+            >
+              <Text fontSize='sm'>Initialize destination before copy</Text>
+            </Checkbox>
+            <Checkbox
+              isChecked={copyCopyChunkerParams}
+              isDisabled={!copyInitDestination}
+              onChange={(e) => setCopyCopyChunkerParams(e.target.checked)}
+            >
+              <Text fontSize='sm'>
+                Copy chunker parameters{' '}
+                <Text as='span' fontSize='xs' color='gray.500'>(requires init destination)</Text>
+              </Text>
+            </Checkbox>
+
+            <HStack
+              as='button'
+              type='button'
+              spacing={1}
+              onClick={() => setShowCopyAdvancedFilters((prev) => !prev)}
+            >
+              <Text fontSize='sm' color='blue.500'>Advanced filters</Text>
+              <Box fontSize='sm'>{showCopyAdvancedFilters ? <HiChevronUp /> : <HiChevronDown />}</Box>
+            </HStack>
+
+            {showCopyAdvancedFilters && (
+              <VStack spacing={3} w='full' align='start'>
+                <FormControl>
+                  <FormLabel fontSize='sm'>
+                    Snapshot IDs{' '}
+                    <Text as='span' fontSize='xs' color='gray.500'>(comma-separated; overrides host/path/tag filters)</Text>
+                  </FormLabel>
+                  <Input size='sm' value={copySnapshotIds} onChange={(e) => setCopySnapshotIds(e.target.value)} placeholder='abc123, def456' />
+                </FormControl>
+                <FormControl>
+                  <FormLabel fontSize='sm'>
+                    Filter by host{' '}
+                    <Text as='span' fontSize='xs' color='gray.500'>(comma-separated)</Text>
+                  </FormLabel>
+                  <Input size='sm' value={copyFilterHost} onChange={(e) => setCopyFilterHost(e.target.value)} />
+                </FormControl>
+                <FormControl>
+                  <FormLabel fontSize='sm'>
+                    Filter by path{' '}
+                    <Text as='span' fontSize='xs' color='gray.500'>(comma-separated)</Text>
+                  </FormLabel>
+                  <Input size='sm' value={copyFilterPath} onChange={(e) => setCopyFilterPath(e.target.value)} />
+                </FormControl>
+                <FormControl>
+                  <FormLabel fontSize='sm'>
+                    Filter by tag{' '}
+                    <Text as='span' fontSize='xs' color='gray.500'>(comma-separated)</Text>
+                  </FormLabel>
+                  <Input size='sm' value={copyFilterTag} onChange={(e) => setCopyFilterTag(e.target.value)} />
+                </FormControl>
+              </VStack>
+            )}
+
+            <Alert status='info' size='sm' borderRadius='md'>
+              <AlertIcon />
+              <Text fontSize='xs'>
+                Snapshots will be copied into the destination repository above. The copy job will appear in the Restic task queue and may take time to complete.
+              </Text>
+            </Alert>
+
+            {copyError && (
+              <Alert status='error' size='sm' borderRadius='md'>
+                <AlertIcon />
+                <Text fontSize='sm'>{copyError}</Text>
+              </Alert>
+            )}
+          </VStack>
+        }
       />
     </VStack>
   )

--- a/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
@@ -1,6 +1,6 @@
-import { Box, Flex, FormControl, FormLabel, Grid, GridItem, HStack, Input, Select, Stack, Text, VStack, Checkbox, Alert, AlertIcon, Divider, useDisclosure } from '@chakra-ui/react'
+import { Box, Flex, FormControl, FormLabel, Grid, GridItem, HStack, Icon, Input, Select, Stack, Text, VStack, Checkbox, Alert, AlertIcon, Divider, useDisclosure } from '@chakra-ui/react'
 import React, { useState, useEffect, useRef } from 'react'
-import { HiChevronDown, HiChevronUp, HiQuestionMarkCircle, HiRefresh } from 'react-icons/hi'
+import { HiChevronDown, HiChevronUp, HiQuestionMarkCircle, HiRefresh, HiCheckCircle, HiDatabase, HiArrowCircleRight, HiShieldExclamation, HiTrash, HiLockClosed } from 'react-icons/hi'
 import RMIconButton from '../../components/RMIconButton'
 import RMButton from '../../components/RMButton'
 import RMSwitch from '../../components/RMSwitch'
@@ -1201,14 +1201,15 @@ function ResticRepositorySettings({
                     <Text className={styles.subsectionTitle}>Repository initialization</Text>
                   </Box>
                   <Box className={styles.repositoryActionsBox}>
-                    <Stack spacing={2}>
+                    <Stack spacing={3}>
                       <Text className={styles.helperText}>
-                        Initialize the effective S3 repository shown in <strong>Repository target</strong> above.
+                        Verify or initialize the effective repository shown in <strong>Repository target</strong> above. Use <em>Migrate/copy</em> to move snapshots to a new destination.
                       </Text>
-                      <HStack spacing={2}>
+                      <HStack spacing={2} flexWrap='wrap'>
                         <RMButton
                           size='sm'
                           colorScheme='green'
+                          leftIcon={<HiCheckCircle />}
                           onClick={handleCheckRepo}
                           isLoading={isCheckLoading}
                           isDisabled={user?.grants['cluster-settings'] === false}
@@ -1218,6 +1219,7 @@ function ResticRepositorySettings({
                         <RMButton
                           size='sm'
                           colorScheme='blue'
+                          leftIcon={<HiDatabase />}
                           onClick={handleResticInit}
                           isDisabled={user?.grants['cluster-settings'] === false}
                         >
@@ -1226,6 +1228,7 @@ function ResticRepositorySettings({
                         <RMButton
                           size='sm'
                           colorScheme='orange'
+                          leftIcon={<HiArrowCircleRight />}
                           onClick={onOpenCopyModal}
                           isDisabled={user?.grants['cluster-process'] === false}
                         >
@@ -1340,26 +1343,43 @@ function ResticRepositorySettings({
                     </GridItem>
                   </Grid>
 
-                  <Divider />
-
-                  <HStack spacing={2} justify='flex-start' flexWrap='wrap'>
-                    <RMButton
-                      size='sm'
-                      colorScheme='red'
-                      onClick={handleOpenWipeModal}
-                      isDisabled={user?.grants['db-backup'] === false}
-                      title='Wipe repository — deletes all repository contents and leaves it uninitialized'
-                    >
-                      Wipe repository
-                    </RMButton>
-                  </HStack>
-
-                  {wipeResult && (
-                    <Alert status={wipeResult.status === 'ok' ? 'warning' : 'error'} size='sm' borderRadius='md'>
-                      <AlertIcon />
-                      <Text fontSize='sm'>{wipeResult.message}</Text>
-                    </Alert>
-                  )}
+                  <Box
+                    borderWidth='1px'
+                    borderColor='red.300'
+                    borderRadius='md'
+                    bg='red.50'
+                    p={3}
+                    _dark={{ bg: 'red.900', borderColor: 'red.600' }}
+                  >
+                    <Stack spacing={2}>
+                      <HStack spacing={2}>
+                        <Icon as={HiShieldExclamation} color='red.500' boxSize={4} />
+                        <Text fontSize='xs' fontWeight='700' textTransform='uppercase' letterSpacing='wide' color='red.600' _dark={{ color: 'red.300' }}>
+                          Danger zone
+                        </Text>
+                      </HStack>
+                      <Text fontSize='sm' color='gray.700' _dark={{ color: 'gray.200' }}>
+                        Permanently deletes all repository contents and leaves it uninitialized. This cannot be undone.
+                      </Text>
+                      <Box>
+                        <RMButton
+                          size='sm'
+                          colorScheme='red'
+                          leftIcon={<HiTrash />}
+                          onClick={handleOpenWipeModal}
+                          isDisabled={user?.grants['db-backup'] === false}
+                        >
+                          Wipe repository
+                        </RMButton>
+                      </Box>
+                      {wipeResult && (
+                        <Alert status={wipeResult.status === 'ok' ? 'warning' : 'error'} size='sm' borderRadius='md'>
+                          <AlertIcon />
+                          <Text fontSize='sm'>{wipeResult.message}</Text>
+                        </Alert>
+                      )}
+                    </Stack>
+                  </Box>
                 </Stack>
               )}
             </Stack>
@@ -1784,42 +1804,40 @@ function ResticRepositorySettings({
         confirmButtonProps={{ isLoading: wipeSubmitting, isDisabled: isWipeSubmitBlocked, colorScheme: 'red' }}
         body={
           <VStack align='start' spacing={3}>
-            <Alert status='error' size='sm' borderRadius='md'>
-              <AlertIcon />
+            <Alert status='error' size='sm' borderRadius='md' variant='left-accent'>
+              <AlertIcon as={HiShieldExclamation} />
               <Text fontSize='sm'>
-                <strong>Destructive operation.</strong> This permanently deletes all repository contents.
-                The repository will be left empty and uninitialized. This cannot be undone.
+                <strong>Destructive — cannot be undone.</strong> All repository contents will be permanently deleted.
+                The repository will be left empty and uninitialized.
               </Text>
             </Alert>
 
-            <Box w='full'>
-              <Text fontSize='sm' fontWeight='semibold' mb={1}>
-                Backend: {
-                  wipeServerBackend === 'restic-aws' ? 'S3 / Object storage'
-                  : wipeServerBackend === 'restic-sftp' ? 'SFTP remote'
-                  : wipeServerBackend === 'restic-local' ? 'Local filesystem'
-                  : isAws ? 'S3 / Object storage' : isSftp ? 'SFTP remote' : 'Local filesystem'
-                }
-              </Text>
-              <Text fontSize='sm' mb={1}>Server-computed target:</Text>
-              {wipeTargetLoading ? (
-                <Text fontSize='sm' color='gray.500' fontFamily='monospace' p={2}>Loading…</Text>
-              ) : (
-                <Text
-                  fontSize='sm'
-                  fontFamily='monospace'
-                  bg='gray.100'
-                  p={2}
-                  borderRadius='md'
-                  wordBreak='break-all'
-                  w='full'
-                >
-                  {wipeDisplayTarget || '(not configured)'}
-                </Text>
-              )}
+            <Box w='full' borderWidth='1px' borderColor='gray.200' borderRadius='md' overflow='hidden' _dark={{ borderColor: 'gray.600' }}>
+              <Box px={3} py={1} bg='gray.100' borderBottomWidth='1px' borderColor='gray.200' _dark={{ bg: 'gray.700', borderColor: 'gray.600' }}>
+                <HStack spacing={2} justify='space-between'>
+                  <Text fontSize='xs' fontWeight='600' textTransform='uppercase' letterSpacing='wide' color='gray.500'>
+                    Target
+                  </Text>
+                  <Text fontSize='xs' color='gray.500'>
+                    {
+                      wipeServerBackend === 'restic-aws' ? 'S3 / Object storage'
+                      : wipeServerBackend === 'restic-sftp' ? 'SFTP remote'
+                      : wipeServerBackend === 'restic-local' ? 'Local filesystem'
+                      : isAws ? 'S3 / Object storage' : isSftp ? 'SFTP remote' : 'Local filesystem'
+                    }
+                  </Text>
+                </HStack>
+              </Box>
+              <Box px={3} py={2}>
+                {wipeTargetLoading ? (
+                  <Text fontSize='sm' color='gray.400' fontFamily='monospace'>Loading…</Text>
+                ) : (
+                  <Text fontSize='sm' fontFamily='monospace' wordBreak='break-all' color={wipeDisplayTarget ? 'inherit' : 'gray.400'}>
+                    {wipeDisplayTarget || '(not configured)'}
+                  </Text>
+                )}
+              </Box>
             </Box>
-
-            <Divider />
 
             {wipeCanWipe === false && wipeServerMessage && (
               <Alert status='warning' size='sm' borderRadius='md'>
@@ -1829,11 +1847,11 @@ function ResticRepositorySettings({
             )}
 
             {(wipeServerBackend === 'restic-sftp' || (!wipeServerBackend && isSftp)) && (
-              <Alert status='warning' size='sm' borderRadius='md'>
+              <Alert status='info' size='sm' borderRadius='md'>
                 <AlertIcon />
                 <Text fontSize='sm'>
                   SFTP wipe runs over SSH. The process must have key-based SSH access to the remote host.
-                  The remote repository root directory will be preserved; all contents inside it will be deleted.
+                  The remote repository root directory will be preserved; only its contents will be deleted.
                 </Text>
               </Alert>
             )}
@@ -1856,10 +1874,15 @@ function ResticRepositorySettings({
               </Checkbox>
             )}
 
+            <Divider />
+
             <Box w='full'>
-              <Text fontSize='sm' mb={1}>
-                Type the target path above to confirm:
-              </Text>
+              <HStack spacing={1} mb={1}>
+                <Icon as={HiLockClosed} color='gray.500' boxSize={3} />
+                <Text fontSize='sm' fontWeight='medium'>
+                  Type the target path to confirm:
+                </Text>
+              </HStack>
               <Input
                 size='sm'
                 value={wipeTypedConfirm}
@@ -1868,9 +1891,16 @@ function ResticRepositorySettings({
                 fontFamily='monospace'
                 isDisabled={wipeTargetLoading || wipeCanonicalTarget === null || wipeCanWipe === false}
                 borderColor={wipeTypedConfirm && !isWipeTypedMatch ? 'red.400' : undefined}
+                _focus={{ borderColor: wipeTypedConfirm && !isWipeTypedMatch ? 'red.400' : 'blue.400', boxShadow: 'none' }}
               />
               {wipeTypedConfirm && !isWipeTypedMatch && (
-                <Text fontSize='xs' color='red.500' mt={1}>Does not match the server-computed target path.</Text>
+                <Text fontSize='xs' color='red.500' mt={1}>Does not match the server-computed target.</Text>
+              )}
+              {wipeTypedConfirm && isWipeTypedMatch && (
+                <HStack spacing={1} mt={1}>
+                  <Icon as={HiCheckCircle} color='green.500' boxSize={3} />
+                  <Text fontSize='xs' color='green.600'>Target confirmed.</Text>
+                </HStack>
               )}
             </Box>
 

--- a/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
@@ -347,6 +347,8 @@ function ResticRepositorySettings({
 
   // Copy modal state
   const { isOpen: isCopyModalOpen, onOpen: onOpenCopyModal, onClose: onCloseCopyModal } = useDisclosure()
+  // copySourceStrategy: 'manual' | 'saved-local' | 'saved-s3'
+  const [copySourceStrategy, setCopySourceStrategy] = useState('manual')
   const [copySourceMode, setCopySourceMode] = useState('restic-local')
   const [copySourceRepo, setCopySourceRepo] = useState('')
   const [copySourcePassword, setCopySourcePassword] = useState('')
@@ -367,6 +369,9 @@ function ResticRepositorySettings({
   const [copySubmitting, setCopySubmitting] = useState(false)
   const [showCopyAdvancedFilters, setShowCopyAdvancedFilters] = useState(false)
   const copySubmitGenRef = useRef(0)
+  // savedS3Available: structured bucket config OR a legacy backup-restic-repository S3 URL
+  const savedS3LegacyAvailable = !awsBucket && legacyRepoPath.startsWith('s3:')
+  const savedS3Available = Boolean(awsBucket) || savedS3LegacyAvailable
 
   const handleCheckRepo = async () => {
     setIsCheckLoading(true)
@@ -398,6 +403,7 @@ function ResticRepositorySettings({
   }
 
   const resetCopyForm = () => {
+    setCopySourceStrategy('manual')
     setCopySourceMode('restic-local')
     setCopySourceRepo('')
     setCopySourcePassword('')
@@ -426,12 +432,14 @@ function ResticRepositorySettings({
   }
 
   const validateCopyForm = () => {
-    if (!copySourcePassword.trim()) return 'Source password is required.'
-    if ((copySourceMode === 'restic-local' || copySourceMode === 'restic-sftp') && !copySourceRepo.trim()) {
-      return 'Source repository path is required.'
-    }
-    if (copySourceMode === 'restic-aws' && !copySourceAwsBucket.trim()) {
-      return 'Source S3 bucket is required.'
+    if (copySourceStrategy === 'manual') {
+      if (!copySourcePassword.trim()) return 'Source password is required.'
+      if ((copySourceMode === 'restic-local' || copySourceMode === 'restic-sftp') && !copySourceRepo.trim()) {
+        return 'Source repository path is required.'
+      }
+      if (copySourceMode === 'restic-aws' && !copySourceAwsBucket.trim()) {
+        return 'Source S3 bucket is required.'
+      }
     }
     if (copyCopyChunkerParams && !copyInitDestination) {
       return 'Copy chunker parameters requires init destination to be enabled.'
@@ -445,19 +453,29 @@ function ResticRepositorySettings({
     const host = snapshotIds.length > 0 ? [] : splitFilter(copyFilterHost)
     const path = snapshotIds.length > 0 ? [] : splitFilter(copyFilterPath)
     const tag = snapshotIds.length > 0 ? [] : splitFilter(copyFilterTag)
-    const source = { mode: copySourceMode, password: copySourcePassword }
-    if (copySourceKeyHint.trim()) source.key_hint = copySourceKeyHint.trim()
-    if (copySourceMode === 'restic-aws') {
-      source.aws = {
-        endpoint: copySourceAwsEndpoint.trim(),
-        bucket: copySourceAwsBucket.trim(),
-        prefix: copySourceAwsPrefix.trim(),
-        access_key_id: copySourceAwsAccessKeyId.trim(),
-        access_secret: copySourceAwsAccessSecret,
-        region: copySourceAwsRegion.trim()
-      }
+
+    let source
+    if (copySourceStrategy === 'saved-local') {
+      source = { mode: 'restic-local', use_saved_config: true }
+      if (copySourceKeyHint.trim()) source.key_hint = copySourceKeyHint.trim()
+    } else if (copySourceStrategy === 'saved-s3') {
+      source = { mode: 'restic-aws', use_saved_config: true }
+      if (copySourceKeyHint.trim()) source.key_hint = copySourceKeyHint.trim()
     } else {
-      source.repository = copySourceRepo.trim()
+      source = { mode: copySourceMode, password: copySourcePassword }
+      if (copySourceKeyHint.trim()) source.key_hint = copySourceKeyHint.trim()
+      if (copySourceMode === 'restic-aws') {
+        source.aws = {
+          endpoint: copySourceAwsEndpoint.trim(),
+          bucket: copySourceAwsBucket.trim(),
+          prefix: copySourceAwsPrefix.trim(),
+          access_key_id: copySourceAwsAccessKeyId.trim(),
+          access_secret: copySourceAwsAccessSecret,
+          region: copySourceAwsRegion.trim()
+        }
+      } else {
+        source.repository = copySourceRepo.trim()
+      }
     }
     return {
       source,
@@ -1422,66 +1440,100 @@ function ResticRepositorySettings({
             <Divider />
 
             <FormControl>
-              <FormLabel fontSize='sm'>Source repository type</FormLabel>
-              <Select size='sm' value={copySourceMode} onChange={(e) => setCopySourceMode(e.target.value)}>
-                <option value='restic-local'>Local filesystem</option>
-                <option value='restic-sftp'>SFTP</option>
-                <option value='restic-aws'>S3 / Object storage</option>
+              <FormLabel fontSize='sm'>Source input</FormLabel>
+              <Select size='sm' value={copySourceStrategy} onChange={(e) => setCopySourceStrategy(e.target.value)}>
+                <option value='manual'>Manual entry</option>
+                <option value='saved-local'>Use saved Local/SFTP config</option>
+                <option value='saved-s3' disabled={!savedS3Available}>Use saved S3 config{!savedS3Available ? ' (no S3 config stored)' : ''}</option>
               </Select>
             </FormControl>
 
-            {(copySourceMode === 'restic-local' || copySourceMode === 'restic-sftp') && (
-              <FormControl isRequired>
-                <FormLabel fontSize='sm'>
-                  {copySourceMode === 'restic-sftp' ? 'Source SFTP URI' : 'Source repository path'}
-                </FormLabel>
-                <Input
-                  size='sm'
-                  value={copySourceRepo}
-                  onChange={(e) => setCopySourceRepo(e.target.value)}
-                  placeholder={copySourceMode === 'restic-sftp' ? 'sftp:user@host:/path/to/repo' : '/path/to/source/repo'}
-                />
-                {copySourceMode === 'restic-sftp' && (
-                  <Text fontSize='xs' color='gray.500' mt={1}>
-                    SSH auth uses the running process&apos;s key-based SSH config. Password-based SSH is not supported.
-                  </Text>
+            {copySourceStrategy === 'saved-local' && (
+              <Alert status='info' size='sm' borderRadius='md'>
+                <AlertIcon />
+                <Text fontSize='xs'>
+                  Source repository and password will be resolved from the cluster&apos;s current stored Local/SFTP configuration. No secrets are sent from this form.
+                </Text>
+              </Alert>
+            )}
+
+            {copySourceStrategy === 'saved-s3' && (
+              <Alert status='info' size='sm' borderRadius='md'>
+                <AlertIcon />
+                <Text fontSize='xs'>
+                  {awsBucket
+                    ? <>Source repository, credentials, and password will be resolved from the cluster&apos;s current stored S3 configuration (bucket: <strong>{awsBucket}</strong>). No secrets are sent from this form.</>
+                    : <>Source repository and password will be resolved from the stored S3 URL in <strong>backup-restic-repository</strong>. No secrets are sent from this form.</>
+                  }
+                </Text>
+              </Alert>
+            )}
+
+            {copySourceStrategy === 'manual' && (
+              <>
+                <FormControl>
+                  <FormLabel fontSize='sm'>Source repository type</FormLabel>
+                  <Select size='sm' value={copySourceMode} onChange={(e) => setCopySourceMode(e.target.value)}>
+                    <option value='restic-local'>Local filesystem</option>
+                    <option value='restic-sftp'>SFTP</option>
+                    <option value='restic-aws'>S3 / Object storage</option>
+                  </Select>
+                </FormControl>
+
+                {(copySourceMode === 'restic-local' || copySourceMode === 'restic-sftp') && (
+                  <FormControl isRequired>
+                    <FormLabel fontSize='sm'>
+                      {copySourceMode === 'restic-sftp' ? 'Source SFTP URI' : 'Source repository path'}
+                    </FormLabel>
+                    <Input
+                      size='sm'
+                      value={copySourceRepo}
+                      onChange={(e) => setCopySourceRepo(e.target.value)}
+                      placeholder={copySourceMode === 'restic-sftp' ? 'sftp:user@host:/path/to/repo' : '/path/to/source/repo'}
+                    />
+                    {copySourceMode === 'restic-sftp' && (
+                      <Text fontSize='xs' color='gray.500' mt={1}>
+                        SSH auth uses the running process&apos;s key-based SSH config. Password-based SSH is not supported.
+                      </Text>
+                    )}
+                  </FormControl>
                 )}
-              </FormControl>
-            )}
 
-            {copySourceMode === 'restic-aws' && (
-              <VStack spacing={3} w='full' align='start'>
-                <FormControl>
-                  <FormLabel fontSize='sm'>Source S3 endpoint</FormLabel>
-                  <Input size='sm' value={copySourceAwsEndpoint} onChange={(e) => setCopySourceAwsEndpoint(e.target.value)} placeholder='https://minio.example.com' />
-                </FormControl>
+                {copySourceMode === 'restic-aws' && (
+                  <VStack spacing={3} w='full' align='start'>
+                    <FormControl>
+                      <FormLabel fontSize='sm'>Source S3 endpoint</FormLabel>
+                      <Input size='sm' value={copySourceAwsEndpoint} onChange={(e) => setCopySourceAwsEndpoint(e.target.value)} placeholder='https://minio.example.com' />
+                    </FormControl>
+                    <FormControl isRequired>
+                      <FormLabel fontSize='sm'>Source S3 bucket</FormLabel>
+                      <Input size='sm' value={copySourceAwsBucket} onChange={(e) => setCopySourceAwsBucket(e.target.value)} placeholder='bucket-name' />
+                    </FormControl>
+                    <FormControl>
+                      <FormLabel fontSize='sm'>Source S3 prefix</FormLabel>
+                      <Input size='sm' value={copySourceAwsPrefix} onChange={(e) => setCopySourceAwsPrefix(e.target.value)} placeholder='optional/prefix' />
+                    </FormControl>
+                    <FormControl>
+                      <FormLabel fontSize='sm'>Source S3 access key ID</FormLabel>
+                      <Input size='sm' value={copySourceAwsAccessKeyId} onChange={(e) => setCopySourceAwsAccessKeyId(e.target.value)} />
+                    </FormControl>
+                    <FormControl>
+                      <FormLabel fontSize='sm'>Source S3 access secret</FormLabel>
+                      <Input size='sm' type='password' value={copySourceAwsAccessSecret} onChange={(e) => setCopySourceAwsAccessSecret(e.target.value)} />
+                    </FormControl>
+                    <FormControl>
+                      <FormLabel fontSize='sm'>Source S3 region</FormLabel>
+                      <Input size='sm' value={copySourceAwsRegion} onChange={(e) => setCopySourceAwsRegion(e.target.value)} placeholder='us-east-1' />
+                    </FormControl>
+                  </VStack>
+                )}
+
                 <FormControl isRequired>
-                  <FormLabel fontSize='sm'>Source S3 bucket</FormLabel>
-                  <Input size='sm' value={copySourceAwsBucket} onChange={(e) => setCopySourceAwsBucket(e.target.value)} placeholder='bucket-name' />
+                  <FormLabel fontSize='sm'>Source repository password</FormLabel>
+                  <Input size='sm' type='password' value={copySourcePassword} onChange={(e) => setCopySourcePassword(e.target.value)} />
                 </FormControl>
-                <FormControl>
-                  <FormLabel fontSize='sm'>Source S3 prefix</FormLabel>
-                  <Input size='sm' value={copySourceAwsPrefix} onChange={(e) => setCopySourceAwsPrefix(e.target.value)} placeholder='optional/prefix' />
-                </FormControl>
-                <FormControl>
-                  <FormLabel fontSize='sm'>Source S3 access key ID</FormLabel>
-                  <Input size='sm' value={copySourceAwsAccessKeyId} onChange={(e) => setCopySourceAwsAccessKeyId(e.target.value)} />
-                </FormControl>
-                <FormControl>
-                  <FormLabel fontSize='sm'>Source S3 access secret</FormLabel>
-                  <Input size='sm' type='password' value={copySourceAwsAccessSecret} onChange={(e) => setCopySourceAwsAccessSecret(e.target.value)} />
-                </FormControl>
-                <FormControl>
-                  <FormLabel fontSize='sm'>Source S3 region</FormLabel>
-                  <Input size='sm' value={copySourceAwsRegion} onChange={(e) => setCopySourceAwsRegion(e.target.value)} placeholder='us-east-1' />
-                </FormControl>
-              </VStack>
+              </>
             )}
-
-            <FormControl isRequired>
-              <FormLabel fontSize='sm'>Source repository password</FormLabel>
-              <Input size='sm' type='password' value={copySourcePassword} onChange={(e) => setCopySourcePassword(e.target.value)} />
-            </FormControl>
 
             <FormControl>
               <FormLabel fontSize='sm'>

--- a/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
@@ -8,7 +8,7 @@ import TextForm from '../../components/TextForm'
 import Dropdown from '../../components/Dropdown'
 import ConfirmModal from '../../components/Modals/ConfirmModal'
 import { setSetting, switchSetting } from '../../redux/settingsSlice'
-import { resticInitRepo, resticCheckConfig, resticCopyRepo, getResticCurrentTask } from '../../redux/clusterSlice'
+import { resticInitRepo, resticCheckConfig, resticCopyRepo, resticWipeRepo, getResticCurrentTask } from '../../redux/clusterSlice'
 import styles from './styles.module.scss'
 import tableStyles from '../../components/TableType2/styles.module.scss'
 
@@ -523,6 +523,83 @@ function ResticRepositorySettings({
         setCopyError(error?.errorMessage || error?.message || 'Copy request failed.')
         setCopySubmitting(false)
       }
+    }
+  }
+
+  // Wipe modal state
+  const { isOpen: isWipeModalOpen, onOpen: onOpenWipeModal, onClose: onCloseWipeModal } = useDisclosure()
+  const [wipeTypedConfirm, setWipeTypedConfirm] = useState('')
+  const [wipeAllowEmptyPrefix, setWipeAllowEmptyPrefix] = useState(false)
+  const [wipeSubmitting, setWipeSubmitting] = useState(false)
+  const [wipeTargetLoading, setWipeTargetLoading] = useState(false)
+  const [wipeError, setWipeError] = useState(null)
+  const [wipeResult, setWipeResult] = useState(null)
+  // Server-fetched preview fields; null means not yet loaded
+  const [wipeCanonicalTarget, setWipeCanonicalTarget] = useState(null)
+  const [wipeServerEmptyPrefix, setWipeServerEmptyPrefix] = useState(false)
+  const [wipeCanWipe, setWipeCanWipe] = useState(null)
+  const [wipeServerMessage, setWipeServerMessage] = useState(null)
+  const [wipeServerBackend, setWipeServerBackend] = useState(null)
+
+  const wipeDisplayTarget = wipeCanonicalTarget ?? ''
+  const isWipeTypedMatch = wipeTypedConfirm.trim() === wipeDisplayTarget && wipeDisplayTarget !== ''
+  const isWipeEmptyPrefixRisk = wipeServerEmptyPrefix
+  const isWipeSubmitBlocked = wipeTargetLoading || wipeCanonicalTarget === null || !isWipeTypedMatch || (isWipeEmptyPrefixRisk && !wipeAllowEmptyPrefix) || wipeSubmitting || wipeCanWipe === false
+
+  const handleOpenWipeModal = async () => {
+    setWipeTypedConfirm('')
+    setWipeAllowEmptyPrefix(false)
+    setWipeError(null)
+    setWipeResult(null)
+    setWipeCanonicalTarget(null)
+    setWipeServerEmptyPrefix(false)
+    setWipeCanWipe(null)
+    setWipeServerMessage(null)
+    setWipeServerBackend(null)
+    onOpenWipeModal()
+    setWipeTargetLoading(true)
+    try {
+      const result = await dispatch(resticCheckConfig({ clusterName, skipFetch: true })).unwrap()
+      setWipeCanonicalTarget(result?.data?.repo_path ?? '')
+      setWipeServerEmptyPrefix(Boolean(result?.data?.is_s3_empty_prefix))
+      setWipeCanWipe(result?.data?.can_wipe !== false)
+      setWipeServerMessage(result?.data?.wipe_message ?? null)
+      setWipeServerBackend(result?.data?.backend ?? null)
+    } catch (error) {
+      setWipeError('Failed to fetch wipe target from server: ' + (error?.errorMessage || error?.message || String(error)))
+      setWipeCanonicalTarget('')
+      setWipeCanWipe(false)
+    } finally {
+      setWipeTargetLoading(false)
+    }
+  }
+
+  const handleCloseWipeModal = () => {
+    setWipeTypedConfirm('')
+    setWipeAllowEmptyPrefix(false)
+    setWipeError(null)
+    setWipeCanonicalTarget(null)
+    setWipeCanWipe(null)
+    setWipeServerMessage(null)
+    setWipeServerBackend(null)
+    onCloseWipeModal()
+  }
+
+  const handleWipeSubmit = async () => {
+    setWipeSubmitting(true)
+    setWipeError(null)
+    try {
+      await dispatch(resticWipeRepo(clusterName, {
+        confirm: true,
+        typed_target_confirm: wipeTypedConfirm.trim(),
+        allow_empty_prefix: wipeAllowEmptyPrefix
+      }))
+      handleCloseWipeModal()
+      setWipeResult({ status: 'ok', message: 'Repository wiped. It must be re-initialized before use.' })
+    } catch (error) {
+      setWipeError(error?.errorMessage || error?.message || 'Wipe request failed.')
+    } finally {
+      setWipeSubmitting(false)
     }
   }
 
@@ -1262,6 +1339,27 @@ function ResticRepositorySettings({
                       />
                     </GridItem>
                   </Grid>
+
+                  <Divider />
+
+                  <HStack spacing={2} justify='flex-start' flexWrap='wrap'>
+                    <RMButton
+                      size='sm'
+                      colorScheme='red'
+                      onClick={handleOpenWipeModal}
+                      isDisabled={user?.grants['db-backup'] === false}
+                      title='Wipe repository — deletes all repository contents and leaves it uninitialized'
+                    >
+                      Wipe repository
+                    </RMButton>
+                  </HStack>
+
+                  {wipeResult && (
+                    <Alert status={wipeResult.status === 'ok' ? 'warning' : 'error'} size='sm' borderRadius='md'>
+                      <AlertIcon />
+                      <Text fontSize='sm'>{wipeResult.message}</Text>
+                    </Alert>
+                  )}
                 </Stack>
               )}
             </Stack>
@@ -1671,6 +1769,115 @@ function ResticRepositorySettings({
               <Alert status='error' size='sm' borderRadius='md'>
                 <AlertIcon />
                 <Text fontSize='sm'>{copyError}</Text>
+              </Alert>
+            )}
+          </VStack>
+        }
+      />
+
+      <ConfirmModal
+        isOpen={isWipeModalOpen}
+        closeModal={handleCloseWipeModal}
+        title="Wipe Restic Repository"
+        onConfirmClick={handleWipeSubmit}
+        confirmButtonText="Wipe repository"
+        confirmButtonProps={{ isLoading: wipeSubmitting, isDisabled: isWipeSubmitBlocked, colorScheme: 'red' }}
+        body={
+          <VStack align='start' spacing={3}>
+            <Alert status='error' size='sm' borderRadius='md'>
+              <AlertIcon />
+              <Text fontSize='sm'>
+                <strong>Destructive operation.</strong> This permanently deletes all repository contents.
+                The repository will be left empty and uninitialized. This cannot be undone.
+              </Text>
+            </Alert>
+
+            <Box w='full'>
+              <Text fontSize='sm' fontWeight='semibold' mb={1}>
+                Backend: {
+                  wipeServerBackend === 'restic-aws' ? 'S3 / Object storage'
+                  : wipeServerBackend === 'restic-sftp' ? 'SFTP remote'
+                  : wipeServerBackend === 'restic-local' ? 'Local filesystem'
+                  : isAws ? 'S3 / Object storage' : isSftp ? 'SFTP remote' : 'Local filesystem'
+                }
+              </Text>
+              <Text fontSize='sm' mb={1}>Server-computed target:</Text>
+              {wipeTargetLoading ? (
+                <Text fontSize='sm' color='gray.500' fontFamily='monospace' p={2}>Loading…</Text>
+              ) : (
+                <Text
+                  fontSize='sm'
+                  fontFamily='monospace'
+                  bg='gray.100'
+                  p={2}
+                  borderRadius='md'
+                  wordBreak='break-all'
+                  w='full'
+                >
+                  {wipeDisplayTarget || '(not configured)'}
+                </Text>
+              )}
+            </Box>
+
+            <Divider />
+
+            {wipeCanWipe === false && wipeServerMessage && (
+              <Alert status='warning' size='sm' borderRadius='md'>
+                <AlertIcon />
+                <Text fontSize='sm'>{wipeServerMessage}</Text>
+              </Alert>
+            )}
+
+            {(wipeServerBackend === 'restic-sftp' || (!wipeServerBackend && isSftp)) && (
+              <Alert status='warning' size='sm' borderRadius='md'>
+                <AlertIcon />
+                <Text fontSize='sm'>
+                  SFTP wipe runs over SSH. The process must have key-based SSH access to the remote host.
+                  The remote repository root directory will be preserved; all contents inside it will be deleted.
+                </Text>
+              </Alert>
+            )}
+
+            {isWipeEmptyPrefixRisk && (
+              <Alert status='error' size='sm' borderRadius='md'>
+                <AlertIcon />
+                <Text fontSize='sm'>
+                  <strong>Empty S3 prefix detected.</strong> Wiping will affect the entire bucket, not just a repository prefix.
+                </Text>
+              </Alert>
+            )}
+
+            {isWipeEmptyPrefixRisk && (
+              <Checkbox
+                isChecked={wipeAllowEmptyPrefix}
+                onChange={(e) => setWipeAllowEmptyPrefix(e.target.checked)}
+              >
+                <Text fontSize='sm'>I understand this will wipe the entire bucket.</Text>
+              </Checkbox>
+            )}
+
+            <Box w='full'>
+              <Text fontSize='sm' mb={1}>
+                Type the target path above to confirm:
+              </Text>
+              <Input
+                size='sm'
+                value={wipeTypedConfirm}
+                onChange={(e) => setWipeTypedConfirm(e.target.value)}
+                placeholder={wipeDisplayTarget || 'repository path'}
+                fontFamily='monospace'
+                isDisabled={wipeTargetLoading || wipeCanonicalTarget === null || wipeCanWipe === false}
+                borderColor={wipeTypedConfirm && !isWipeTypedMatch ? 'red.400' : undefined}
+              />
+              {wipeTypedConfirm && !isWipeTypedMatch && (
+                <Text fontSize='xs' color='red.500' mt={1}>Does not match the server-computed target path.</Text>
+              )}
+            </Box>
+
+            {wipeError && (
+              <Alert status='error' size='sm' borderRadius='md'>
+                <AlertIcon />
+                <Text fontSize='sm'>{wipeError}</Text>
               </Alert>
             )}
           </VStack>

--- a/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
@@ -97,6 +97,18 @@ Switching types does not erase the values stored for the other types, so you can
 
 Config: \`backup-archive-mode\``
 
+const ResticS3ModeHelp = `**S3 Source-of-Truth Selector**
+
+Controls which set of S3 configuration fields is used as the authoritative source for the Restic repository path and credentials.
+
+- **Auto** (default): at startup the server probes both the new (bucket/prefix/endpoint) config and the legacy repository URL, picks whichever is reachable first (new is tried first), and persists the winner as \`new\` or \`legacy\` in config. If neither is reachable, it falls back to presence-based selection and retries on the next restart. The UI preview for auto mode is approximate — it reflects field presence, not the actual runtime probe result.
+- **New**: uses only \`backup-restic-aws-bucket\`, \`backup-restic-aws-prefix\`, \`backup-restic-aws-endpoint\`, and related credential fields.
+- **Legacy**: uses only \`backup-restic-repository\` as the repository URL.
+
+This selector applies to the active destination, startup checks, init behavior, and saved-source copy/migration so all operations see the same S3 source of truth.
+
+Config: \`backup-restic-s3-mode\``
+
 const ResticBinaryPathHelp = `**Backup Restic Binary Path**
 
 Filesystem path to the \`restic\` executable used for all backup, restore, and maintenance operations on this cluster.
@@ -174,9 +186,11 @@ Combined with "Backup restic repo append cluster": if enabled and the last prefi
 
 Config: \`backup-restic-aws-prefix\``
 
-const ResticEffectiveS3RepoHelp = `**Effective S3 Repository**
+const ResticEffectiveS3RepoHelp = `**Effective S3 Repository (preview)**
 
 Read-only preview of the full \`s3:\` repository path that restic will use, built from the endpoint, bucket, and prefix above plus the append-cluster rule.
+
+**When mode is \`auto\`:** this preview is approximate — it resolves based on which fields are populated in the UI, not the actual runtime probe. At startup the server probes both new and legacy configs and uses whichever is reachable; the runtime path may differ from what is shown here. Set the mode to \`new\` or \`legacy\` explicitly for an authoritative preview.
 
 This field is computed - it cannot be edited directly.`
 
@@ -259,6 +273,7 @@ function ResticRepositorySettings({
   const archiveMode = config?.backupArchiveMode || 'none'
   const isAws = archiveMode === 'restic-aws'
   const isSftp = archiveMode === 'restic-sftp'
+  const s3Mode = config?.backupResticS3Mode || 'auto'
   const awsBucket = (config?.backupResticAwsBucket || '').trim()
   const awsPrefix = (config?.backupResticAwsPrefix || '').trim()
   const awsEndpoint = (config?.backupResticAwsEndpoint || '').trim()
@@ -276,8 +291,10 @@ function ResticRepositorySettings({
   const effectiveLegacyRepoPath = appendCluster && clusterName && legacyRepoPath && !legacyHasClusterSuffix
     ? `${legacyRepoPath}${clusterSuffix}`
     : legacyRepoPath
-  const awsRepoPath = awsBucket
-    ? `s3:${trimmedEndpoint ? `${trimmedEndpoint}/` : ''}${awsBucket}${effectivePrefix ? `/${effectivePrefix}` : ''}`
+  // Compute effective repo path aligned with the backend s3Mode selector.
+  const resolvedS3Mode = s3Mode === 'new' ? 'new' : (s3Mode === 'legacy' ? 'legacy' : (awsBucket ? 'new' : 'legacy'))
+  const awsRepoPath = resolvedS3Mode === 'new'
+    ? (awsBucket ? `s3:${trimmedEndpoint ? `${trimmedEndpoint}/` : ''}${awsBucket}${effectivePrefix ? `/${effectivePrefix}` : ''}` : '')
     : effectiveLegacyRepoPath
   const isAwsPrefixEmpty = isAws && awsBucket && !awsPrefix
   const isForceInitBlocked = initForce && ((isAwsPrefixEmpty && !confirmEmptyPrefix) || isSftp)
@@ -844,6 +861,36 @@ function ResticRepositorySettings({
 
               {archiveMode === 'restic-aws' && (
                 <Stack spacing={{ base: 2, md: 3 }}>
+                  {/* 0. S3 mode selector */}
+                  <Stack spacing={{ base: 1, md: 2 }}>
+                    <Grid
+                      className={styles.resticMountGrid}
+                      templateColumns={{ base: '1fr', md: 'minmax(160px, 0.7fr) minmax(240px, 1fr)' }}
+                      columnGap={3}
+                      rowGap={1}
+                      w='full'
+                    >
+                      <GridItem className={styles.rowLabel}>
+                        <HStack spacing={1} justify='space-between' width='full'>
+                          <Text>S3 source-of-truth mode</Text>
+                          {h(ResticS3ModeHelp, 'S3 Source-of-Truth Mode')}
+                        </HStack>
+                      </GridItem>
+                      <GridItem className={styles.valueCell}>
+                        <Select
+                          size='sm'
+                          value={s3Mode}
+                          isDisabled={user?.grants['cluster-settings'] === false}
+                          onChange={(e) => handleSettingChange('backup-restic-s3-mode', e.target.value)}
+                        >
+                          <option value='auto'>Auto (probe new then legacy at startup; persist winner)</option>
+                          <option value='new'>New (bucket / prefix / endpoint fields only)</option>
+                          <option value='legacy'>Legacy (backup-restic-repository URL only)</option>
+                        </Select>
+                      </GridItem>
+                    </Grid>
+                  </Stack>
+
                   {/* 1. Provider connection */}
                   <Box className={styles.subsectionHeader}>
                     <Text className={styles.subsectionTitle}>Provider connection</Text>
@@ -1047,7 +1094,12 @@ function ResticRepositorySettings({
                     >
                       <GridItem className={styles.rowLabel}>
                         <HStack spacing={1} justify='space-between' width='full'>
-                          <Text>Effective S3 repository</Text>
+                          <Text>
+                            Effective S3 repository
+                            {s3Mode === 'auto' && (
+                              <Text as='span' fontSize='xs' color='orange.500' ml={1}>(approximate — auto mode)</Text>
+                            )}
+                          </Text>
                           {h(ResticEffectiveS3RepoHelp, 'Effective S3 Repository')}
                         </HStack>
                       </GridItem>

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -478,6 +478,31 @@ export const resticCheckConfig = createGuardedAsyncThunk(
   }
 )
 
+// Plain thunk, not createAsyncThunk: payload with secrets stays only in the call-stack closure
+// and is never stored in any module-level structure or placed in Redux action metadata.
+// showSuccessBanner/showErrorBanner only use thunkAPI.dispatch, so { dispatch } suffices.
+export const resticCopyRepo = (clusterName, payload) => async (dispatch, getState) => {
+  const thunkAPI = { dispatch }
+  try {
+    const baseURL = getState()?.auth?.baseURL || ''
+    const { data, status } = await clusterService.resticCopyRepo(clusterName, payload, baseURL)
+    if (!status || status < 200 || status >= 300) {
+      const msg = (data && typeof data === 'object' && data.message)
+        ? data.message
+        : 'Restic repository copy failed!'
+      showErrorBanner('Restic repository copy failed!', msg, thunkAPI)
+      throw { errorMessage: msg, errorStatus: status || 500 }
+    }
+    showSuccessBanner('Restic repository copy queued!', status, thunkAPI)
+    return { data, status }
+  } catch (error) {
+    if (!error.errorMessage) {
+      showErrorBanner('Restic repository copy failed!', error, thunkAPI)
+    }
+    throw error
+  }
+}
+
 export const getJobs = createGuardedAsyncThunk('cluster/getJobs', async ({ clusterName }, thunkAPI) => {
   try {
     const baseURL = thunkAPI.getState()?.auth?.baseURL || ''

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -463,10 +463,10 @@ export const resticInitRepo = createGuardedAsyncThunk(
 
 export const resticCheckConfig = createGuardedAsyncThunk(
   'cluster/resticCheckConfig',
-  async ({ clusterName }, thunkAPI) => {
+  async ({ clusterName, skipFetch }, thunkAPI) => {
     try {
       const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
-      const { data, status } = await clusterService.resticCheckConfig(clusterName, baseURL)
+      const { data, status } = await clusterService.resticCheckConfig(clusterName, baseURL, skipFetch)
       if (!status || status < 200 || status >= 300) {
         const msg = (data && typeof data === 'object' && data.message) ? data.message : 'Check repository request failed'
         return thunkAPI.rejectWithValue({ errorMessage: msg, errorStatus: status || 500 })
@@ -498,6 +498,30 @@ export const resticCopyRepo = (clusterName, payload) => async (dispatch, getStat
   } catch (error) {
     if (!error.errorMessage) {
       showErrorBanner('Restic repository copy failed!', error, thunkAPI)
+    }
+    throw error
+  }
+}
+
+// Plain thunk — payload with confirmation text stays only in the call-stack closure
+// and is never stored in Redux action metadata.
+export const resticWipeRepo = (clusterName, payload) => async (dispatch, getState) => {
+  const thunkAPI = { dispatch }
+  try {
+    const baseURL = getState()?.auth?.baseURL || ''
+    const { data, status } = await clusterService.resticWipeRepo(clusterName, payload, baseURL)
+    if (!status || status < 200 || status >= 300) {
+      const msg = (data && typeof data === 'object' && data.message)
+        ? data.message
+        : (typeof data === 'string' && data) ? data : 'Restic repository wipe failed!'
+      showErrorBanner('Restic repository wipe failed!', msg, thunkAPI)
+      throw { errorMessage: msg, errorStatus: status || 500 }
+    }
+    showSuccessBanner('Restic repository wiped successfully!', status, thunkAPI)
+    return { data, status }
+  } catch (error) {
+    if (!error.errorMessage) {
+      showErrorBanner('Restic repository wipe failed!', error, thunkAPI)
     }
     throw error
   }

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -35,6 +35,7 @@ export const clusterService = {
   getResticMountStatus,
   resticInitRepo,
   resticCheckConfig,
+  resticCopyRepo,
 
   // Security / workload remediation APIs
   fixSecState,
@@ -936,6 +937,10 @@ function resticInitRepo(clusterName, force, options, baseURL) {
 
 function resticCheckConfig(clusterName, baseURL) {
   return getApi(baseURL).post(`clusters/${clusterName}/restic/check-config`)
+}
+
+function resticCopyRepo(clusterName, payload, baseURL) {
+  return getApi(baseURL).post(`clusters/${clusterName}/restic/copy`, payload)
 }
 
 function fixSecState(clusterName, errKey, baseURL, tag) {

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -36,6 +36,7 @@ export const clusterService = {
   resticInitRepo,
   resticCheckConfig,
   resticCopyRepo,
+  resticWipeRepo,
 
   // Security / workload remediation APIs
   fixSecState,
@@ -935,12 +936,17 @@ function resticInitRepo(clusterName, force, options, baseURL) {
   return getApi(baseURL).post(endpoint, payload)
 }
 
-function resticCheckConfig(clusterName, baseURL) {
-  return getApi(baseURL).post(`clusters/${clusterName}/restic/check-config`)
+function resticCheckConfig(clusterName, baseURL, skipFetch) {
+  const qs = skipFetch ? '?skip_fetch=true' : ''
+  return getApi(baseURL).post(`clusters/${clusterName}/restic/check-config${qs}`)
 }
 
 function resticCopyRepo(clusterName, payload, baseURL) {
   return getApi(baseURL).post(`clusters/${clusterName}/restic/copy`, payload)
+}
+
+function resticWipeRepo(clusterName, payload, baseURL) {
+  return getApi(baseURL).post(`clusters/${clusterName}/restic/wipe`, payload)
 }
 
 function fixSecState(clusterName, errKey, baseURL, tag) {

--- a/share/dashboard_react/src/styles/_global.scss
+++ b/share/dashboard_react/src/styles/_global.scss
@@ -15,7 +15,7 @@ p,
 label,
 span:not([data-status='success']):not([data-status='info']):not([data-status='error']):not([class*='tagpill']):not(
     [class*='alertCount']
-  ):not([class*='-radio__control']):not([class*='-checkbox__control']),
+  ):not([class*='-radio__control']):not([class*='-checkbox__control']):not([class*='chakra-button__icon']),
 input,
 th,
 td,

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -417,6 +417,7 @@ type ResticManager struct {
 	AllowUnsafeMount     bool                // If true, allow using mount created by other process
 	MountRecoveryEnabled bool                // If true, recover/cleanup stale mounts on startup
 	OnPurgeComplete      func(ResticPurgeOption)
+	OnBootFetchSuccess   func() // called once when the startup fetch task succeeds
 	currentTask          *ResticTaskState
 	currentTaskMutex     *sync.Mutex
 	// Error backoff state to prevent log flooding
@@ -3950,6 +3951,9 @@ func (repo *ResticManager) fetchRepoSnapshots() error {
 // FetchRepo performs the fetch for snapshots and stats.
 // The first call uses the boot auto-init policy (one-shot); subsequent calls
 // are passive and will not retry initialization automatically.
+// When the first (boot) fetch succeeds, OnBootFetchSuccess is called once in a
+// goroutine so the cluster layer can promote "auto" to the concrete S3 mode that
+// was actually used.
 func (repo *ResticManager) FetchRepo() error {
 	// Check if the repo is able to fetch and initialized
 	if !repo.GetCanFetch() {
@@ -3967,8 +3971,9 @@ func (repo *ResticManager) FetchRepo() error {
 	}
 	repo.errorMutex.Unlock()
 
+	wasBootFetch := !bootDone
 	policy := initPolicyPassive
-	if !bootDone {
+	if wasBootFetch {
 		policy = initPolicyBoot
 	}
 
@@ -3993,7 +3998,94 @@ func (repo *ResticManager) FetchRepo() error {
 		return fmt.Errorf("failed to fetch repo stat: %w", err)
 	}
 
-	return nil // Success
+	// Boot fetch succeeded: fire the one-shot callback regardless of which task
+	// path led here (UnlockTask→FetchRepo, an explicit FetchTask, etc.).
+	if wasBootFetch {
+		repo.Mutex.Lock()
+		cb := repo.OnBootFetchSuccess
+		repo.Mutex.Unlock()
+		if cb != nil {
+			go cb()
+		}
+	}
+
+	return nil
+}
+
+// S3ProbeUsable reports whether a ProbeS3Candidate result means the S3
+// configuration is usable.  A nil error means the repo is initialized and
+// accessible.  An "initialization required" error means the bucket is reachable
+// but contains no restic repository yet — still usable (auto-init can finish it).
+// Any other error means the config is not reachable.
+func S3ProbeUsable(err error) bool {
+	if err == nil {
+		return true
+	}
+	return strings.Contains(err.Error(), "initialization required")
+}
+
+// ProbeS3Candidate performs a read-only S3 existence check against the given
+// parameters without permanently altering manager state.  It saves all mutable
+// fields, temporarily applies the probe parameters, runs a passive S3 check,
+// then restores everything.
+//
+// Callers should check the returned error with S3ProbeUsable to determine
+// whether the config is usable.
+//
+// ProbeS3Candidate is safe to call before the worker is started.  It must NOT
+// be called while other goroutines are actively mutating the manager's S3 or
+// error-backoff state.
+func (repo *ResticManager) ProbeS3Candidate(bucket, prefix, endpoint, accessKeyID, secretKey, region string) error {
+	// Save unguarded mutable fields.
+	savedCanInit := repo.CanInitRepo
+	savedBucket := repo.AwsBucket
+	savedPrefix := repo.AwsPrefix
+	savedEndpoint := repo.AwsEndpoint
+	savedKeyID := repo.AwsAccessKeyID
+	savedSecret := repo.AwsSecretAccessKey
+	savedRegion := repo.AwsRegion
+
+	// Save errorMutex-guarded fields (repoState is also guarded by errorMutex,
+	// matching GetRepoState / setRepoState).
+	repo.errorMutex.Lock()
+	savedLastErr := repo.lastInitError
+	savedErrCount := repo.initErrorCount
+	savedBackoff := repo.initBackoffUntil
+	savedRepoState := repo.repoState
+	savedTaskErrors := make(map[TaskType]error, len(repo.TaskErrors))
+	for k, v := range repo.TaskErrors {
+		savedTaskErrors[k] = v
+	}
+	repo.errorMutex.Unlock()
+
+	// Apply probe parameters.
+	repo.AwsBucket = bucket
+	repo.AwsPrefix = prefix
+	repo.AwsEndpoint = endpoint
+	repo.AwsAccessKeyID = accessKeyID
+	repo.AwsSecretAccessKey = secretKey
+	repo.AwsRegion = region
+
+	probeErr := repo.checkS3RepoFilesWithPolicy(bucket, prefix, endpoint, initPolicyPassive)
+
+	// Restore all mutable state.
+	repo.CanInitRepo = savedCanInit
+	repo.AwsBucket = savedBucket
+	repo.AwsPrefix = savedPrefix
+	repo.AwsEndpoint = savedEndpoint
+	repo.AwsAccessKeyID = savedKeyID
+	repo.AwsSecretAccessKey = savedSecret
+	repo.AwsRegion = savedRegion
+
+	repo.errorMutex.Lock()
+	repo.lastInitError = savedLastErr
+	repo.initErrorCount = savedErrCount
+	repo.initBackoffUntil = savedBackoff
+	repo.repoState = savedRepoState
+	repo.TaskErrors = savedTaskErrors
+	repo.errorMutex.Unlock()
+
+	return probeErr
 }
 
 // GetKeepWithinTime returns the arguments to keep within

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -357,6 +357,12 @@ type ResticTaskState struct {
 	TotalBytesProcessed int64   `json:"total_bytes_processed,omitempty"`
 	TotalDuration       float64 `json:"total_duration,omitempty"`
 	SnapshotID          string  `json:"snapshot_id,omitempty"`
+
+	Phase              string `json:"phase,omitempty"`               // init_destination or copy
+	CompletedSnapshots int    `json:"completed_snapshots,omitempty"` // snapshots completed during copy
+	TotalSnapshots     int    `json:"total_snapshots,omitempty"`     // total snapshots to copy
+	PacksDone          int    `json:"packs_done,omitempty"`          // packs copied (copy task only)
+	TotalPacks         int    `json:"total_packs,omitempty"`         // total packs to copy (copy task only)
 }
 
 const resticTaskStateTTL = 60 * time.Second
@@ -4587,6 +4593,50 @@ func (repo *ResticManager) SetCurrentTaskRunning(task *ResticTask) {
 	repo.currentTaskMutex.Lock()
 	repo.currentTask = state
 	repo.currentTaskMutex.Unlock()
+}
+
+// UpdateCurrentTaskPhase sets the phase on the current task (e.g., "init_destination", "copy").
+// No-op when no task is running.
+func (repo *ResticManager) UpdateCurrentTaskPhase(phase string) {
+	repo.currentTaskMutex.Lock()
+	defer repo.currentTaskMutex.Unlock()
+	if repo.currentTask == nil {
+		return
+	}
+	now := time.Now().UTC()
+	repo.currentTask.Phase = phase
+	repo.currentTask.LastUpdate = &now
+}
+
+// UpdateCurrentTaskCopyLine parses a single line of restic copy output and updates
+// the current task state. It handles:
+//   - progress lines: "[0:00] 100.00%  2 / 2 packs copied"
+//   - snapshot saved lines: "snapshot X saved, copied from source snapshot Y"
+//   - snapshot skipped lines: "skipping snapshot X"
+func (repo *ResticManager) UpdateCurrentTaskCopyLine(line string) {
+	repo.currentTaskMutex.Lock()
+	defer repo.currentTaskMutex.Unlock()
+	if repo.currentTask == nil {
+		return
+	}
+	now := time.Now().UTC()
+	if m := copyProgressLineRegex.FindStringSubmatch(line); m != nil {
+		if pct, err := strconv.ParseFloat(m[1], 64); err == nil {
+			repo.currentTask.PercentDone = pct / 100.0
+		}
+		if done, err := strconv.Atoi(m[2]); err == nil {
+			repo.currentTask.PacksDone = done
+		}
+		if total, err := strconv.Atoi(m[3]); err == nil {
+			repo.currentTask.TotalPacks = total
+		}
+		repo.currentTask.LastUpdate = &now
+		return
+	}
+	if copySnapshotSavedRegex.MatchString(line) || copySnapshotSkippedRegex.MatchString(line) {
+		repo.currentTask.CompletedSnapshots++
+		repo.currentTask.LastUpdate = &now
+	}
 }
 
 func (repo *ResticManager) UpdateCurrentTaskFromJSON(line []byte) {

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -123,6 +123,27 @@ type ResticInitOption struct {
 	FromRepo          string `json:"from_repo,omitempty"`
 }
 
+// ResticWipeOption holds the parameters for a destructive wipe operation.
+// The caller must set Confirm=true and TypedTargetConfirm to the server-computed
+// canonical repository target exactly. For S3 repositories with an empty prefix,
+// AllowEmptyPrefix must also be set to true.
+type ResticWipeOption struct {
+	Confirm            bool   `json:"confirm"`
+	TypedTargetConfirm string `json:"typed_target_confirm"`
+	AllowEmptyPrefix   bool   `json:"allow_empty_prefix,omitempty"`
+}
+
+// WipePreviewResult is returned by ComputeWipePreview. The wipe preview is surfaced to
+// clients via POST /restic/check-config (which embeds these fields into ManualCheckResult).
+// The /restic/wipe endpoint is execute-only and does not return preview data.
+type WipePreviewResult struct {
+	RepoPath        string `json:"repo_path"`
+	Backend         string `json:"backend"`
+	IsS3EmptyPrefix bool   `json:"is_s3_empty_prefix"`
+	CanWipe         bool   `json:"can_wipe"`
+	Message         string `json:"message"`
+}
+
 // ResticFetchOption holds the configuration for fetch
 type ResticFetchOption struct {
 	SkipStats bool `json:"skip_stats,omitempty"`
@@ -398,6 +419,7 @@ type ResticManager struct {
 	PurgeNowOption       ResticPurgeOption
 	isPaused             bool
 	isPausedByDisk       bool
+	wipeActive           bool // set while a destructive wipe is in progress; blocks appendTask/prependTask
 	HasLocks             bool
 	taskID               int
 	CurrentID            int
@@ -436,6 +458,9 @@ type ResticManager struct {
 	// When set, checkS3RepoFiles calls it instead of creating a real S3 client.
 	// It receives bucket, configKey, dataPrefix and returns existence + error for each.
 	s3existenceProber func(bucket, configKey, dataPrefix string) (configExists bool, configErr error, dataExists bool, dataErr error)
+	// destructiveMu serializes destructive operations (wipe) so that preflight checks
+	// and deletion cannot race with each other.
+	destructiveMu sync.Mutex
 }
 
 // NewResticRepo initializes the repository manager
@@ -986,16 +1011,19 @@ func (repo *ResticManager) worker() {
 			continue
 		}
 
-		// Get the task from TaskQueue
+		// Get the task from TaskQueue and mark it running before releasing the
+		// mutex so that WipeRepoWithOptions cannot observe an empty queue while
+		// a task has already been dequeued but not yet started.
 		task := repo.TaskQueue[0]
 		repo.TaskQueue = repo.TaskQueue[1:]
+		if task != nil {
+			repo.SetCurrentTaskRunning(task)
+		}
 		repo.Mutex.Unlock()
 
 		if task == nil {
 			continue
 		}
-
-		repo.SetCurrentTaskRunning(task)
 
 		// Process the task
 		loglevel := logrus.InfoLevel
@@ -1120,6 +1148,14 @@ func (repo *ResticManager) appendTask(task *ResticTask) {
 	repo.Mutex.Lock()
 	defer repo.Mutex.Unlock()
 
+	if repo.wipeActive {
+		repo.Printf(logrus.WarnLevel, "Task %s dropped: a wipe is in progress", GetTaskName(task.Type))
+		if task.resultCh != nil {
+			task.resultCh <- ResticResult{TaskID: task.ID, TaskType: task.Type, Error: fmt.Errorf("task dropped: a repository wipe is in progress")}
+			close(task.resultCh)
+		}
+		return
+	}
 	repo.TaskQueue = append(repo.TaskQueue, task)
 
 	// Log the addition of the tasks with ID
@@ -1139,6 +1175,14 @@ func (repo *ResticManager) prependTask(task *ResticTask) {
 	repo.Mutex.Lock()
 	defer repo.Mutex.Unlock()
 
+	if repo.wipeActive {
+		repo.Printf(logrus.WarnLevel, "Task %s dropped: a wipe is in progress", GetTaskName(task.Type))
+		if task.resultCh != nil {
+			task.resultCh <- ResticResult{TaskID: task.ID, TaskType: task.Type, Error: fmt.Errorf("task dropped: a repository wipe is in progress")}
+			close(task.resultCh)
+		}
+		return
+	}
 	repo.TaskQueue = append([]*ResticTask{task}, repo.TaskQueue...)
 
 	if task.ID != 0 {
@@ -1158,6 +1202,10 @@ func (repo *ResticManager) AddFetchTask() {
 func (repo *ResticManager) AddPurgeTask(opt ResticPurgeOption, immediate bool) error {
 	if immediate {
 		repo.Mutex.Lock()
+		if repo.wipeActive {
+			repo.Mutex.Unlock()
+			return fmt.Errorf("cannot schedule immediate purge: a repository wipe is in progress")
+		}
 		if repo.NeedPurgeNow {
 			repo.Mutex.Unlock()
 			return errors.New("a purge-now task is already scheduled")
@@ -3395,12 +3443,19 @@ const (
 )
 
 // ManualCheckResult holds the outcome of a manual repository configuration check.
+// The wipe preview fields (Backend, IsS3EmptyPrefix, CanWipe, WipeMessage) are additive
+// and backward-compatible; existing consumers that only read status/message/can_init are unaffected.
 type ManualCheckResult struct {
 	Status      ManualCheckStatus `json:"status"`
 	Message     string            `json:"message"`
 	CanInit     bool              `json:"can_init"`
 	FetchQueued bool              `json:"fetch_queued"`
 	RepoPath    string            `json:"repo_path,omitempty"`
+	// Wipe preview fields populated by ResticCheckConfigManual
+	Backend         string `json:"backend,omitempty"`
+	IsS3EmptyPrefix bool   `json:"is_s3_empty_prefix,omitempty"`
+	CanWipe         bool   `json:"can_wipe"`
+	WipeMessage     string `json:"wipe_message,omitempty"`
 }
 
 // isResticInitRequiredError returns true when restic stderr indicates the repository
@@ -3802,6 +3857,335 @@ func (repo *ResticManager) RunCommandWithContext(ctx context.Context, args []str
 	}
 
 	return nil, stderrBuf.Bytes(), nil
+}
+
+// sftpWipeTarget holds the parsed components of an sftp:[user@]host:/absolute/path URI.
+type sftpWipeTarget struct {
+	UserHost string
+	Path     string
+}
+
+// parseSftpWipeTarget parses an SFTP repository URI for use in wipe operations.
+// Only absolute remote paths are accepted; relative paths are rejected.
+func parseSftpWipeTarget(repoPath string) (sftpWipeTarget, error) {
+	if !strings.HasPrefix(repoPath, "sftp:") {
+		return sftpWipeTarget{}, fmt.Errorf("not an SFTP repository path: %s", repoPath)
+	}
+	rest := strings.TrimPrefix(repoPath, "sftp:")
+	colonIdx := strings.Index(rest, ":")
+	if colonIdx < 0 {
+		return sftpWipeTarget{}, fmt.Errorf("malformed SFTP repository path (missing host:path separator): %s", repoPath)
+	}
+	userHost := rest[:colonIdx]
+	remotePath := rest[colonIdx+1:]
+	if userHost == "" {
+		return sftpWipeTarget{}, fmt.Errorf("malformed SFTP repository path (empty host): %s", repoPath)
+	}
+	switch remotePath {
+	case "", "/", ".", "..":
+		return sftpWipeTarget{}, fmt.Errorf("unsafe SFTP remote path for wipe: %q", remotePath)
+	}
+	if !strings.HasPrefix(remotePath, "/") {
+		return sftpWipeTarget{}, fmt.Errorf("wipe requires an absolute SFTP remote path (got %q); relative paths are not supported", remotePath)
+	}
+	return sftpWipeTarget{UserHost: userHost, Path: remotePath}, nil
+}
+
+// shellescape returns s enclosed in single quotes, safe as a POSIX shell argument.
+func shellescape(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// wipeLocalRepo removes all contents of repoPath while preserving the root directory.
+// Symlinks inside the root are removed as entries and are not followed.
+func (repo *ResticManager) wipeLocalRepo(repoPath string) error {
+	repoPath = strings.TrimSpace(repoPath)
+	if repoPath == "" {
+		return fmt.Errorf("local repository path is empty")
+	}
+	if !filepath.IsAbs(repoPath) {
+		return fmt.Errorf("local repository path must be absolute: %q", repoPath)
+	}
+	if repoPath == "/" {
+		return fmt.Errorf("refusing to wipe root filesystem path")
+	}
+	info, statErr := os.Lstat(repoPath)
+	if os.IsNotExist(statErr) {
+		repo.Printf(logrus.InfoLevel, "Local repository does not exist at %s; treating as already wiped", repoPath)
+		return nil
+	}
+	if statErr != nil {
+		return fmt.Errorf("failed to stat repository path %s: %w", repoPath, statErr)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to wipe: repository root %q is a symbolic link", repoPath)
+	}
+	entries, err := os.ReadDir(repoPath)
+	if err != nil {
+		return fmt.Errorf("failed to read repository directory %s: %w", repoPath, err)
+	}
+	for _, entry := range entries {
+		entryPath := filepath.Join(repoPath, entry.Name())
+		if err := os.RemoveAll(entryPath); err != nil {
+			return fmt.Errorf("failed to remove %s: %w", entry.Name(), err)
+		}
+	}
+	repo.Printf(logrus.InfoLevel, "Local repository wiped: %s", repoPath)
+	return nil
+}
+
+// wipeS3Repo deletes all objects under the configured S3 prefix.
+func (repo *ResticManager) wipeS3Repo(opt ResticWipeOption) error {
+	repopath := repo.GetRepoPath()
+	bucket, prefix, endpoint, err := repo.resolveS3RepoSpec(repopath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve S3 repository spec: %w", err)
+	}
+	if prefix == "" && !opt.AllowEmptyPrefix {
+		return fmt.Errorf("refusing to wipe S3 repository with empty prefix (entire bucket scope): set allow_empty_prefix=true to proceed")
+	}
+	client, clientErr := s3helper.NewClient(repo.AwsAccessKeyID, repo.AwsSecretAccessKey, "", repo.AwsRegion, endpoint)
+	if clientErr != nil {
+		return fmt.Errorf("failed to create S3 client: %w", clientErr)
+	}
+	deleteOptions := s3helper.DeletePrefixOptions{RequireNonEmptyPrefix: !opt.AllowEmptyPrefix}
+	if delErr := s3helper.DeletePrefixWithOptions(client, bucket, prefix, deleteOptions); delErr != nil {
+		return fmt.Errorf("failed to wipe S3 repository: %w", delErr)
+	}
+	repo.Printf(logrus.InfoLevel, "S3 repository wiped: bucket=%s prefix=%q", bucket, prefix)
+	return nil
+}
+
+// wipeSftpRepo connects via SSH and removes repository contents while preserving the root directory.
+func (repo *ResticManager) wipeSftpRepo(repoPath string) error {
+	target, err := parseSftpWipeTarget(repoPath)
+	if err != nil {
+		return err
+	}
+	quotedPath := shellescape(target.Path)
+	// If the remote directory does not exist, treat as already wiped (exit 0).
+	// Otherwise delete all contents while preserving the root directory.
+	remoteCmd := fmt.Sprintf("[ ! -d %s ] || find %s -mindepth 1 -delete", quotedPath, quotedPath)
+	timeout := repo.OperationTimeout
+	if timeout <= 0 {
+		timeout = 2 * time.Hour
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "ssh", "-o", "BatchMode=yes", target.UserHost, remoteCmd)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if runErr := cmd.Run(); runErr != nil {
+		stderrStr := strings.TrimSpace(stderr.String())
+		if stderrStr != "" {
+			return fmt.Errorf("SFTP wipe failed for %s:%s: %s", target.UserHost, target.Path, stderrStr)
+		}
+		return fmt.Errorf("SFTP wipe failed for %s:%s: %w", target.UserHost, target.Path, runErr)
+	}
+	repo.Printf(logrus.InfoLevel, "SFTP repository wiped: %s:%s", target.UserHost, target.Path)
+	return nil
+}
+
+// resetAfterWipe clears cached snapshot/stats/state so the repository appears uninitialized.
+func (repo *ResticManager) resetAfterWipe() {
+	repo.Mutex.Lock()
+	repo.Backups = make([]BackupSnapshot, 0)
+	repo.BackupMap = make(map[string]*BackupSnapshot)
+	repo.BackupStat = BackupStat{}
+	repo.Mutex.Unlock()
+
+	repo.errorMutex.Lock()
+	repo.lastInitError = nil
+	repo.initErrorCount = 0
+	repo.initBackoffUntil = time.Time{}
+	delete(repo.TaskErrors, InitTask)
+	delete(repo.TaskErrors, FetchTask)
+	// Keep bootInitDone=true so the next passive fetch does not trigger auto-init.
+	// Explicit manual InitRepo is required before the repository is usable again.
+	repo.bootInitDone = true
+	repo.errorMutex.Unlock()
+
+	repo.setRepoState(ManualCheckStatusInitRequired)
+	repo.CanInitRepo = true
+}
+
+// ComputeWipePreview runs the non-destructive wipe preflight under the destructive-
+// operation lock and returns a WipePreviewResult describing the effective target and
+// whether the current manager state permits a wipe. It never mutates the repository.
+func (repo *ResticManager) ComputeWipePreview() WipePreviewResult {
+	repo.destructiveMu.Lock()
+	defer repo.destructiveMu.Unlock()
+
+	repo.Mutex.Lock()
+	mountPath := repo.mountPath
+	isQueueNotEmpty := len(repo.TaskQueue) > 0
+	isImmediatePurgePending := repo.NeedPurgeNow
+	repo.currentTaskMutex.Lock()
+	isTaskRunning := repo.currentTask != nil && repo.currentTask.Status == "running"
+	repo.currentTaskMutex.Unlock()
+	repo.Mutex.Unlock()
+
+	canonicalTarget := repo.GetRepoPath()
+
+	backend := "restic-local"
+	if config.IsS3ResticRepository(canonicalTarget) || repo.AwsBucket != "" {
+		backend = "restic-aws"
+	} else if config.IsSftpResticRepository(canonicalTarget) {
+		backend = "restic-sftp"
+	}
+	isS3EmptyPrefix := repo.AwsBucket != "" && repo.AwsPrefix == ""
+
+	result := WipePreviewResult{
+		RepoPath: canonicalTarget,
+		Backend:         backend,
+		IsS3EmptyPrefix: isS3EmptyPrefix,
+		CanWipe:         true,
+		Message:         "Repository can be wiped. Type the target above to confirm.",
+	}
+
+	if canonicalTarget == "" {
+		result.CanWipe = false
+		result.Message = "Cannot wipe: restic repository path is not configured."
+		return result
+	}
+	if mountPath != "" {
+		result.CanWipe = false
+		result.Message = fmt.Sprintf("Cannot wipe: repository is currently mounted at %s.", mountPath)
+		return result
+	}
+	if isTaskRunning {
+		result.CanWipe = false
+		result.Message = "Cannot wipe: a restic task is currently running."
+		return result
+	}
+	if isQueueNotEmpty {
+		result.CanWipe = false
+		result.Message = "Cannot wipe: the restic task queue is not empty."
+		return result
+	}
+	if isImmediatePurgePending {
+		result.CanWipe = false
+		result.Message = "Cannot wipe: an immediate purge is pending."
+		return result
+	}
+
+	// Non-destructive backend-specific validation: run the same path checks that
+	// WipeRepoWithOptions enforces so can_wipe accurately predicts whether the
+	// operation would succeed (avoids "modal says OK, submit fails" user experience).
+	switch backend {
+	case "restic-sftp":
+		if _, err := parseSftpWipeTarget(canonicalTarget); err != nil {
+			result.CanWipe = false
+			result.Message = fmt.Sprintf("Cannot wipe: %v", err)
+			return result
+		}
+	case "restic-local":
+		if !filepath.IsAbs(canonicalTarget) {
+			result.CanWipe = false
+			result.Message = fmt.Sprintf("Cannot wipe: local repository path must be absolute: %q", canonicalTarget)
+			return result
+		}
+		if canonicalTarget == "/" {
+			result.CanWipe = false
+			result.Message = "Cannot wipe: refusing to wipe root filesystem path."
+			return result
+		}
+		if info, statErr := os.Lstat(canonicalTarget); statErr == nil && info.Mode()&os.ModeSymlink != 0 {
+			result.CanWipe = false
+			result.Message = fmt.Sprintf("Cannot wipe: repository root %q is a symbolic link.", canonicalTarget)
+			return result
+		}
+	}
+
+	return result
+}
+
+// WipeRepoWithOptions destroys the contents of the configured repository, leaving it empty
+// and uninitialized. It does not run restic init afterward.
+//
+// Safety guardrails:
+//   - Fails if a mount, running task, or queued task is active.
+//   - Requires Confirm=true and TypedTargetConfirm matching the server-computed canonical path.
+//   - For S3 with empty prefix, AllowEmptyPrefix must be true.
+//
+// The worker goroutine is paused for the duration of the wipe to prevent races.
+func (repo *ResticManager) WipeRepoWithOptions(opt ResticWipeOption) error {
+	// Only one destructive operation at a time.
+	repo.destructiveMu.Lock()
+	defer repo.destructiveMu.Unlock()
+
+	// Under the main mutex: run preflight and pause the worker atomically.
+	// currentTask is checked here too (under both locks) so that the check is
+	// atomic with task dequeue, which now also happens under repo.Mutex.
+	repo.Mutex.Lock()
+	isMountActive := repo.mountPath != ""
+	isQueueNotEmpty := len(repo.TaskQueue) > 0
+	isImmediatePurgePending := repo.NeedPurgeNow
+	repo.currentTaskMutex.Lock()
+	isTaskRunning := repo.currentTask != nil && repo.currentTask.Status == "running"
+	repo.currentTaskMutex.Unlock()
+	priorPaused := repo.isPaused
+	if !isMountActive && !isQueueNotEmpty && !isImmediatePurgePending && !isTaskRunning {
+		repo.isPaused = true
+		repo.wipeActive = true
+	}
+	repo.Mutex.Unlock()
+
+	// Restore paused flag and wipeActive on any exit path.
+	defer func() {
+		repo.Mutex.Lock()
+		repo.isPaused = priorPaused
+		repo.wipeActive = false
+		if !priorPaused {
+			repo.cond.Broadcast()
+		}
+		repo.Mutex.Unlock()
+	}()
+
+	if isMountActive {
+		return fmt.Errorf("cannot wipe: repository is currently mounted at %s", repo.mountPath)
+	}
+	if isQueueNotEmpty {
+		return fmt.Errorf("cannot wipe: the restic task queue is not empty")
+	}
+	if isImmediatePurgePending {
+		return fmt.Errorf("cannot wipe: an immediate purge is pending")
+	}
+	if isTaskRunning {
+		return fmt.Errorf("cannot wipe: a restic task is currently running")
+	}
+
+	// Canonical target is the runtime RESTIC_REPOSITORY value from the manager env.
+	canonicalTarget := repo.GetRepoPath()
+	if canonicalTarget == "" {
+		return fmt.Errorf("cannot wipe: restic repository path is not configured")
+	}
+
+	if !opt.Confirm {
+		return fmt.Errorf("wipe requires explicit confirmation: set confirm=true")
+	}
+	if strings.TrimSpace(opt.TypedTargetConfirm) != canonicalTarget {
+		return fmt.Errorf("typed confirmation does not match the canonical repository target (expected %q)", canonicalTarget)
+	}
+
+	repo.Printf(logrus.WarnLevel, "Wiping repository: %s", canonicalTarget)
+
+	var err error
+	if config.IsS3ResticRepository(canonicalTarget) || repo.AwsBucket != "" {
+		err = repo.wipeS3Repo(opt)
+	} else if config.IsSftpResticRepository(canonicalTarget) {
+		err = repo.wipeSftpRepo(canonicalTarget)
+	} else {
+		err = repo.wipeLocalRepo(canonicalTarget)
+	}
+	if err != nil {
+		repo.Printf(logrus.ErrorLevel, "Repository wipe failed: %v", err)
+		return err
+	}
+
+	repo.Printf(logrus.InfoLevel, "Repository wipe complete: %s", canonicalTarget)
+	repo.resetAfterWipe()
+	return nil
 }
 
 // InitRepo initializes the repository with backward-compatible signature

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -1167,6 +1167,26 @@ func (repo *ResticManager) appendTask(task *ResticTask) {
 	repo.cond.Signal()
 }
 
+// appendTaskChecked enqueues task under the same lock as the wipeActive check,
+// making the check-and-enqueue atomic. Returns an error if wipeActive is set.
+func (repo *ResticManager) appendTaskChecked(task *ResticTask) error {
+	if task == nil {
+		return nil
+	}
+	repo.Mutex.Lock()
+	defer repo.Mutex.Unlock()
+	if repo.wipeActive {
+		repo.Printf(logrus.WarnLevel, "Task %s dropped: a wipe is in progress", GetTaskName(task.Type))
+		return fmt.Errorf("task dropped: a repository wipe is in progress")
+	}
+	repo.TaskQueue = append(repo.TaskQueue, task)
+	if task.ID != 0 {
+		repo.Printf(logrus.InfoLevel, "Added %s task to the queue, ID: %d", GetTaskName(task.Type), task.ID)
+	}
+	repo.cond.Signal()
+	return nil
+}
+
 func (repo *ResticManager) prependTask(task *ResticTask) {
 	if task == nil {
 		return
@@ -3236,7 +3256,7 @@ func (repo *ResticManager) checkS3RepoFilesWithPolicy(bucket, prefix, endpoint s
 
 	// Config exists
 	repo.CanInitRepo = true
-	delete(repo.TaskErrors, InitTask)
+	repo.FetchAndClearError(InitTask)
 	repo.clearInitErrorBackoff()
 	repo.setRepoState(ManualCheckStatusOK)
 
@@ -3426,7 +3446,7 @@ func (repo *ResticManager) checkRepoFilesWithPolicy(policy initPolicy) error {
 	}
 
 	repo.CanInitRepo = true
-	delete(repo.TaskErrors, InitTask)
+	repo.FetchAndClearError(InitTask)
 	repo.clearInitErrorBackoff()
 	repo.setRepoState(ManualCheckStatusOK)
 
@@ -4402,7 +4422,7 @@ func (repo *ResticManager) InitRepoWithOptions(opt ResticInitOption) error {
 	}
 
 	// Only add fetch task on successful initialization
-	delete(repo.TaskErrors, InitTask)
+	repo.FetchAndClearError(InitTask)
 	repo.AddFetchTask()
 	repo.clearInitErrorBackoff()
 

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -4018,10 +4018,16 @@ func (repo *ResticManager) ComputeWipePreview() WipePreviewResult {
 
 	repo.Mutex.Lock()
 	mountPath := repo.mountPath
-	isQueueNotEmpty := len(repo.TaskQueue) > 0
 	isImmediatePurgePending := repo.NeedPurgeNow
+	hasNonFetchQueued := false
+	for _, t := range repo.TaskQueue {
+		if t != nil && t.Type != FetchTask {
+			hasNonFetchQueued = true
+			break
+		}
+	}
 	repo.currentTaskMutex.Lock()
-	isTaskRunning := repo.currentTask != nil && repo.currentTask.Status == "running"
+	isNonFetchRunning := repo.currentTask != nil && repo.currentTask.Status == "running" && repo.currentTask.TaskType != FetchTask
 	repo.currentTaskMutex.Unlock()
 	repo.Mutex.Unlock()
 
@@ -4036,7 +4042,7 @@ func (repo *ResticManager) ComputeWipePreview() WipePreviewResult {
 	isS3EmptyPrefix := repo.AwsBucket != "" && repo.AwsPrefix == ""
 
 	result := WipePreviewResult{
-		RepoPath: canonicalTarget,
+		RepoPath:        canonicalTarget,
 		Backend:         backend,
 		IsS3EmptyPrefix: isS3EmptyPrefix,
 		CanWipe:         true,
@@ -4053,12 +4059,12 @@ func (repo *ResticManager) ComputeWipePreview() WipePreviewResult {
 		result.Message = fmt.Sprintf("Cannot wipe: repository is currently mounted at %s.", mountPath)
 		return result
 	}
-	if isTaskRunning {
+	if isNonFetchRunning {
 		result.CanWipe = false
 		result.Message = "Cannot wipe: a restic task is currently running."
 		return result
 	}
-	if isQueueNotEmpty {
+	if hasNonFetchQueued {
 		result.CanWipe = false
 		result.Message = "Cannot wipe: the restic task queue is not empty."
 		return result
@@ -4103,8 +4109,12 @@ func (repo *ResticManager) ComputeWipePreview() WipePreviewResult {
 // WipeRepoWithOptions destroys the contents of the configured repository, leaving it empty
 // and uninitialized. It does not run restic init afterward.
 //
+// Task policy:
+//   - Queued FetchTasks are discarded; other queued tasks block the wipe.
+//   - A running FetchTask is waited on for up to 30s; any other running task blocks the wipe.
+//   - New tasks cannot be enqueued once wipeActive is set (appendTask/prependTask check the flag).
+//
 // Safety guardrails:
-//   - Fails if a mount, running task, or queued task is active.
 //   - Requires Confirm=true and TypedTargetConfirm matching the server-computed canonical path.
 //   - For S3 with empty prefix, AllowEmptyPrefix must be true.
 //
@@ -4114,22 +4124,75 @@ func (repo *ResticManager) WipeRepoWithOptions(opt ResticWipeOption) error {
 	repo.destructiveMu.Lock()
 	defer repo.destructiveMu.Unlock()
 
-	// Under the main mutex: run preflight and pause the worker atomically.
-	// currentTask is checked here too (under both locks) so that the check is
-	// atomic with task dequeue, which now also happens under repo.Mutex.
+	// Validate request fields before touching scheduler state: a bad request
+	// must not have any side effects on the task queue.
+	canonicalTarget := repo.GetRepoPath()
+	if canonicalTarget == "" {
+		return fmt.Errorf("cannot wipe: restic repository path is not configured")
+	}
+	if !opt.Confirm {
+		return fmt.Errorf("wipe requires explicit confirmation: set confirm=true")
+	}
+	if strings.TrimSpace(opt.TypedTargetConfirm) != canonicalTarget {
+		return fmt.Errorf("typed confirmation does not match the canonical repository target (expected %q)", canonicalTarget)
+	}
+
+	// Under the main mutex: run preflight, drop queued fetch tasks, and pause the
+	// worker atomically. FetchTasks are handled specially: queued ones are discarded
+	// immediately; a running FetchTask is waited on (up to 30s) after the mutex is
+	// released. All other running or queued tasks block the wipe.
 	repo.Mutex.Lock()
 	isMountActive := repo.mountPath != ""
-	isQueueNotEmpty := len(repo.TaskQueue) > 0
 	isImmediatePurgePending := repo.NeedPurgeNow
+
+	// Classify the running task (if any) while holding both mutexes so the check
+	// is atomic with task dequeue.
 	repo.currentTaskMutex.Lock()
-	isTaskRunning := repo.currentTask != nil && repo.currentTask.Status == "running"
+	isFetchRunning := repo.currentTask != nil && repo.currentTask.Status == "running" && repo.currentTask.TaskType == FetchTask
+	isNonFetchRunning := repo.currentTask != nil && repo.currentTask.Status == "running" && repo.currentTask.TaskType != FetchTask
 	repo.currentTaskMutex.Unlock()
+
+	// Scan the queue to detect non-fetch tasks (decision only; no removal yet).
+	hasNonFetchQueued := false
+	for _, t := range repo.TaskQueue {
+		if t != nil && t.Type != FetchTask {
+			hasNonFetchQueued = true
+			break
+		}
+	}
+
 	priorPaused := repo.isPaused
-	if !isMountActive && !isQueueNotEmpty && !isImmediatePurgePending && !isTaskRunning {
+	canProceed := !isMountActive && !isImmediatePurgePending && !isNonFetchRunning && !hasNonFetchQueued
+	// droppedFetches is only populated when removal actually happens, so the
+	// close/log loop below is correctly conditional on the wipe proceeding.
+	var droppedFetches []*ResticTask
+	if canProceed {
+		// Remove all queued FetchTasks before pausing so the worker cannot dequeue
+		// them after isPaused is cleared on wipe completion.
+		remaining := make([]*ResticTask, 0, len(repo.TaskQueue))
+		for _, t := range repo.TaskQueue {
+			if t != nil && t.Type == FetchTask {
+				droppedFetches = append(droppedFetches, t)
+			} else {
+				remaining = append(remaining, t)
+			}
+		}
+		repo.TaskQueue = remaining
+		// Pause the worker to prevent it from dequeuing tasks. wipeActive is set
+		// later, after any running fetch has finished, so tasks enqueued during
+		// the fetch-wait window are not silently dropped if the wipe ultimately fails.
 		repo.isPaused = true
-		repo.wipeActive = true
 	}
 	repo.Mutex.Unlock()
+
+	// Close channels only for tasks that were actually removed from the queue.
+	for _, t := range droppedFetches {
+		repo.Printf(logrus.WarnLevel, "Fetch task %d dropped: a repository wipe is in progress", t.ID)
+		if t.resultCh != nil {
+			t.resultCh <- ResticResult{TaskID: t.ID, TaskType: t.Type, Error: fmt.Errorf("task dropped: a repository wipe is in progress")}
+			close(t.resultCh)
+		}
+	}
 
 	// Restore paused flag and wipeActive on any exit path.
 	defer func() {
@@ -4145,27 +4208,88 @@ func (repo *ResticManager) WipeRepoWithOptions(opt ResticWipeOption) error {
 	if isMountActive {
 		return fmt.Errorf("cannot wipe: repository is currently mounted at %s", repo.mountPath)
 	}
-	if isQueueNotEmpty {
-		return fmt.Errorf("cannot wipe: the restic task queue is not empty")
-	}
 	if isImmediatePurgePending {
 		return fmt.Errorf("cannot wipe: an immediate purge is pending")
 	}
-	if isTaskRunning {
+	if hasNonFetchQueued {
+		return fmt.Errorf("cannot wipe: the restic task queue contains non-fetch tasks")
+	}
+	if isNonFetchRunning {
 		return fmt.Errorf("cannot wipe: a restic task is currently running")
 	}
 
-	// Canonical target is the runtime RESTIC_REPOSITORY value from the manager env.
-	canonicalTarget := repo.GetRepoPath()
-	if canonicalTarget == "" {
-		return fmt.Errorf("cannot wipe: restic repository path is not configured")
+	// A fetch task is running: wait up to 30s for it to finish.
+	// wipeActive is not yet set, so tasks submitted during the wait are enqueued
+	// normally and will execute after the wipe (or immediately if the wipe fails).
+	if isFetchRunning {
+		const fetchWaitTimeout = 30 * time.Second
+		deadline := time.Now().Add(fetchWaitTimeout)
+		for time.Now().Before(deadline) {
+			repo.currentTaskMutex.Lock()
+			done := repo.currentTask == nil || repo.currentTask.Status != "running"
+			repo.currentTaskMutex.Unlock()
+			if done {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		repo.currentTaskMutex.Lock()
+		stillRunning := repo.currentTask != nil && repo.currentTask.Status == "running"
+		repo.currentTaskMutex.Unlock()
+		if stillRunning {
+			return fmt.Errorf("cannot wipe: running fetch task did not complete within 30s")
+		}
 	}
 
-	if !opt.Confirm {
-		return fmt.Errorf("wipe requires explicit confirmation: set confirm=true")
+	// Fetch has finished (or was not running). Re-check under the mutex before
+	// committing: a non-fetch task, immediate purge, or a new running task may
+	// have arrived during the fetch-wait window (wipeActive was not set, so
+	// appendTask / prependTask accepted new work).
+	repo.Mutex.Lock()
+	postWaitNonFetchQueued := false
+	for _, t := range repo.TaskQueue {
+		if t != nil && t.Type != FetchTask {
+			postWaitNonFetchQueued = true
+			break
+		}
 	}
-	if strings.TrimSpace(opt.TypedTargetConfirm) != canonicalTarget {
-		return fmt.Errorf("typed confirmation does not match the canonical repository target (expected %q)", canonicalTarget)
+	postWaitPurgePending := repo.NeedPurgeNow
+	repo.currentTaskMutex.Lock()
+	postWaitNonFetchRunning := repo.currentTask != nil && repo.currentTask.Status == "running" && repo.currentTask.TaskType != FetchTask
+	repo.currentTaskMutex.Unlock()
+	// postWaitDroppedFetches is only populated when removal actually happens.
+	var postWaitDroppedFetches []*ResticTask
+	if !postWaitNonFetchQueued && !postWaitPurgePending && !postWaitNonFetchRunning {
+		remaining := make([]*ResticTask, 0, len(repo.TaskQueue))
+		for _, t := range repo.TaskQueue {
+			if t != nil && t.Type == FetchTask {
+				postWaitDroppedFetches = append(postWaitDroppedFetches, t)
+			} else {
+				remaining = append(remaining, t)
+			}
+		}
+		repo.TaskQueue = remaining
+		repo.wipeActive = true
+	}
+	repo.Mutex.Unlock()
+
+	// Close channels only for tasks that were actually removed from the queue.
+	for _, t := range postWaitDroppedFetches {
+		repo.Printf(logrus.WarnLevel, "Fetch task %d dropped: a repository wipe is in progress", t.ID)
+		if t.resultCh != nil {
+			t.resultCh <- ResticResult{TaskID: t.ID, TaskType: t.Type, Error: fmt.Errorf("task dropped: a repository wipe is in progress")}
+			close(t.resultCh)
+		}
+	}
+
+	if postWaitNonFetchQueued {
+		return fmt.Errorf("cannot wipe: a non-fetch task was queued during the fetch-wait window")
+	}
+	if postWaitPurgePending {
+		return fmt.Errorf("cannot wipe: an immediate purge became pending during the fetch-wait window")
+	}
+	if postWaitNonFetchRunning {
+		return fmt.Errorf("cannot wipe: a non-fetch task started running during the fetch-wait window")
 	}
 
 	repo.Printf(logrus.WarnLevel, "Wiping repository: %s", canonicalTarget)

--- a/utils/backupmgr/restic.go
+++ b/utils/backupmgr/restic.go
@@ -37,6 +37,7 @@ const (
 	ChangePassTask
 	RestoreTask
 	CheckTask
+	CopyTask
 )
 
 type MoveType string
@@ -77,6 +78,8 @@ func GetTaskName(taskType TaskType) string {
 		return "restore"
 	case CheckTask:
 		return "check"
+	case CopyTask:
+		return "copy"
 	default:
 		return "Unknown"
 	}
@@ -145,6 +148,7 @@ type ResticTask struct {
 	InitOpt       *ResticInitOption       `json:"init_opt,omitempty"`       // Options for InitTask
 	FetchOpt      *ResticFetchOption      `json:"fetch_opt,omitempty"`      // Options for FetchTask
 	CheckOpt      *ResticCheckOption      `json:"check_opt,omitempty"`      // Options for CheckTask
+	CopyOpt       *ResticCopyOption       `json:"-"`                        // Options for CopyTask — excluded from JSON to prevent credential leakage
 	resultCh      chan ResticResult
 }
 
@@ -1047,6 +1051,14 @@ func (repo *ResticManager) worker() {
 				// Update check timestamps on success
 				isFullCheck := opt.ReadData
 				repo.UpdateLastCheckTime(isFullCheck)
+			}
+			result = ResticResult{TaskID: task.ID, TaskType: task.Type, Error: err}
+		case CopyTask:
+			var err error
+			if task.CopyOpt != nil {
+				err = repo.CopyRepoWithOptions(*task.CopyOpt)
+			} else {
+				err = errors.New("CopyTask requires CopyOpt to be set")
 			}
 			result = ResticResult{TaskID: task.ID, TaskType: task.Type, Error: err}
 		default:
@@ -3894,8 +3906,14 @@ func (repo *ResticManager) fetchRepoStat() error {
 		return fmt.Errorf("failed to fetch repo: %v, stderr: %s", err, stderr)
 	}
 
+	// restic stats --json writes a progress line to stdout before the JSON object
+	// (e.g. "[0:00] 100% ..."). Skip everything before the first '{'.
+	jsonStart := bytes.IndexByte(stdout, '{')
+	if jsonStart < 0 {
+		return fmt.Errorf("no JSON object in stats output: %q", stdout)
+	}
 	var backupstat BackupStat
-	err = json.Unmarshal(stdout, &backupstat)
+	err = json.Unmarshal(stdout[jsonStart:], &backupstat)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal backup stat: %w", err)
 	}

--- a/utils/backupmgr/restic_copy.go
+++ b/utils/backupmgr/restic_copy.go
@@ -587,8 +587,9 @@ func (repo *ResticManager) CopyRepoWithOptions(opt ResticCopyOption) error {
 }
 
 // AddCopyTask enqueues a copy task with the given options.
-func (repo *ResticManager) AddCopyTask(opt ResticCopyOption) {
-	repo.appendTask(&ResticTask{
+// Returns an error if a wipe is active; the check and enqueue are atomic.
+func (repo *ResticManager) AddCopyTask(opt ResticCopyOption) error {
+	return repo.appendTaskChecked(&ResticTask{
 		ID:      repo.GenerateTaskID(),
 		Type:    CopyTask,
 		CopyOpt: &opt,

--- a/utils/backupmgr/restic_copy.go
+++ b/utils/backupmgr/restic_copy.go
@@ -34,11 +34,12 @@ type ResticCopySourceAWSOption struct {
 // request body, but the entire ResticCopyOption is tagged json:"-" on ResticTask to
 // prevent credential leakage through queue/current-task API responses.
 type ResticCopySourceOption struct {
-	Mode       string                     `json:"mode,omitempty"`
-	Repository string                     `json:"repository,omitempty"`
-	Password   string                     `json:"password,omitempty"`
-	KeyHint    string                     `json:"key_hint,omitempty"`
-	AWS        *ResticCopySourceAWSOption `json:"aws,omitempty"`
+	Mode            string                     `json:"mode,omitempty"`
+	Repository      string                     `json:"repository,omitempty"`
+	Password        string                     `json:"password,omitempty"`
+	KeyHint         string                     `json:"key_hint,omitempty"`
+	AWS             *ResticCopySourceAWSOption `json:"aws,omitempty"`
+	UseSavedConfig  bool                       `json:"use_saved_config,omitempty"`
 }
 
 // ResticCopyOption holds all parameters for a repository copy task.

--- a/utils/backupmgr/restic_copy.go
+++ b/utils/backupmgr/restic_copy.go
@@ -4,12 +4,14 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os/exec"
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/sirupsen/logrus"
@@ -18,6 +20,18 @@ import (
 // copySftpRepoRegex matches the restic sftp backend syntax: sftp:[user@]host:/path
 // Mirrors cluster.resticSftpRepoRegex — keep both in sync if the pattern changes.
 var copySftpRepoRegex = regexp.MustCompile(`^sftp:[^:@\s]+(@[^:@\s]+)?:.+$`)
+
+// copyProgressLineRegex matches restic copy text-mode progress lines, e.g.:
+// "[0:00] 100.00%  2 / 2 packs copied"
+var copyProgressLineRegex = regexp.MustCompile(`\[[\d:]+\]\s+([\d.]+)%\s+(\d+)\s*/\s*(\d+)\s+packs`)
+
+// copySnapshotSavedRegex matches "snapshot X saved, copied from source snapshot Y"
+var copySnapshotSavedRegex = regexp.MustCompile(`(?i)snapshot\s+\S+\s+saved`)
+
+// copySnapshotSkippedRegex matches restic's skip-snapshot lines.
+// Restic emits "skipping source snapshot X, was already copied to snapshot Y"
+// so the pattern must cover both "skipping snapshot" and "skipping source snapshot".
+var copySnapshotSkippedRegex = regexp.MustCompile(`(?i)skipping(?:\s+source)?\s+snapshot`)
 
 // ResticCopySourceAWSOption holds S3 credentials for the copy source repository.
 type ResticCopySourceAWSOption struct {
@@ -324,6 +338,137 @@ func (repo *ResticManager) runCommandWithExtraEnv(ctx context.Context, args []st
 	return nil, stderrBuf.Bytes(), nil
 }
 
+// buildSourcePrimaryEnv constructs an env overlay that sets RESTIC_REPOSITORY and
+// RESTIC_PASSWORD to the source repository values so that regular restic commands
+// (e.g. "snapshots") target the source repo directly.
+// This is distinct from buildCopySourceEnvOverlay which sets RESTIC_FROM_* variables
+// used by "restic copy" and "restic init --from-repo".
+func buildSourcePrimaryEnv(src ResticCopySourceOption, srcRepo string) ([]string, error) {
+	if src.Password == "" {
+		return nil, fmt.Errorf("source password is required")
+	}
+	env := []string{
+		"RESTIC_REPOSITORY=" + srcRepo,
+		"RESTIC_PASSWORD=" + src.Password,
+	}
+	if hint := strings.TrimSpace(src.KeyHint); hint != "" {
+		env = append(env, "RESTIC_KEY_HINT="+hint)
+	}
+	if src.Mode == config.ConstBackupArchiveModeResticAws && src.AWS != nil {
+		if src.AWS.AccessKeyID != "" {
+			env = append(env, "AWS_ACCESS_KEY_ID="+src.AWS.AccessKeyID)
+		}
+		if src.AWS.AccessSecret != "" {
+			env = append(env, "AWS_SECRET_ACCESS_KEY="+src.AWS.AccessSecret)
+		}
+		if src.AWS.Region != "" {
+			env = append(env, "AWS_DEFAULT_REGION="+src.AWS.Region)
+		}
+	}
+	return env, nil
+}
+
+// countSourceSnapshots returns the number of snapshots that will be processed
+// by a copy operation, without running restic copy itself.
+//   - For explicit snapshot IDs: returns len(snapshotIDs) immediately.
+//   - For filter-based selection: runs restic snapshots on the source repo and counts matches.
+//     Returns 0 without error when the count cannot be determined (so copy still proceeds).
+func (repo *ResticManager) countSourceSnapshots(ctx context.Context, opt ResticCopyOption, srcRepo string) int {
+	snapshotIDs := trimResticValues(opt.SnapshotIDs)
+	if len(snapshotIDs) > 0 {
+		return len(snapshotIDs)
+	}
+
+	// Build env that targets the source repo directly (RESTIC_REPOSITORY/RESTIC_PASSWORD).
+	srcPrimaryEnv, err := buildSourcePrimaryEnv(opt.Source, srcRepo)
+	if err != nil {
+		return 0
+	}
+
+	args := []string{"snapshots", "--json"}
+	args = appendResticArgs(args, "--host", opt.Host)
+	args = appendResticArgs(args, "--path", opt.Path)
+	args = appendResticArgs(args, "--tag", opt.Tag)
+
+	stdout, _, err := repo.runCommandWithExtraEnv(ctx, args, srcPrimaryEnv, logrus.DebugLevel, true)
+	if err != nil || len(stdout) == 0 {
+		return 0
+	}
+
+	var snapshots []struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(stdout, &snapshots); err != nil {
+		return 0
+	}
+	return len(snapshots)
+}
+
+// runCopyWithProgress runs "restic copy" with the given args and env, streaming
+// stdout line-by-line through UpdateCurrentTaskCopyLine so the current task
+// state reflects real-time copy progress.
+func (repo *ResticManager) runCopyWithProgress(ctx context.Context, args []string, extraEnv []string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, repo.BinaryPath, args...)
+	cmd.Env = mergeEnvByKey(repo.getEnvCopy(), extraEnv)
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get stdout pipe: %w", err)
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get stderr pipe: %w", err)
+	}
+
+	repo.Printf(logrus.InfoLevel, "Starting command: %s %v", repo.BinaryPath, redactArgs(args))
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("error starting command: %w", err)
+	}
+
+	var stderrBuf bytes.Buffer
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		scanner := bufio.NewScanner(stdoutPipe)
+		for scanner.Scan() {
+			line := scanner.Text()
+			repo.Print(logrus.DebugLevel, "[OUT] "+line)
+			repo.UpdateCurrentTaskCopyLine(line)
+		}
+		if err := scanner.Err(); err != nil {
+			repo.Printf(logrus.ErrorLevel, "[OUT] Error reading copy output: %v", err)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		scanner := bufio.NewScanner(stderrPipe)
+		for scanner.Scan() {
+			line := scanner.Text()
+			repo.Print(logrus.DebugLevel, "[ERR] "+line)
+			stderrBuf.WriteString(line + "\n")
+		}
+		if err := scanner.Err(); err != nil {
+			repo.Printf(logrus.ErrorLevel, "[ERR] Error reading copy stderr: %v", err)
+		}
+	}()
+
+	wg.Wait()
+
+	if err := cmd.Wait(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return stderrBuf.Bytes(), fmt.Errorf("command timeout: %w", ctx.Err())
+		}
+		return stderrBuf.Bytes(), fmt.Errorf("command execution failed: %w", err)
+	}
+
+	repo.Printf(logrus.InfoLevel, "Command completed successfully: %s %v", repo.BinaryPath, redactArgs(args))
+	return stderrBuf.Bytes(), nil
+}
+
 // CopyRepoWithOptions copies snapshots from a source repository into the destination
 // repository configured on this ResticManager. All guardrails are enforced here:
 //   - G1: S3→S3 with mismatched credentials is rejected before execution.
@@ -349,6 +494,8 @@ func (repo *ResticManager) CopyRepoWithOptions(opt ResticCopyOption) error {
 
 	// Classify destination state before any init attempt (G4).
 	if opt.InitDestination {
+		repo.UpdateCurrentTaskPhase("init_destination")
+
 		result := repo.ValidateRepoConfigManual()
 		switch result.Status {
 		case ManualCheckStatusOK:
@@ -386,7 +533,10 @@ func (repo *ResticManager) CopyRepoWithOptions(opt ResticCopyOption) error {
 	}
 
 	// Build copy command arguments.
-	args := []string{"copy"}
+	// --verbose ensures restic prints "skipping snapshot" lines for already-copied
+	// snapshots; without it those lines are suppressed and completed_snapshots
+	// would never advance for them on reruns.
+	args := []string{"copy", "--verbose"}
 	snapshotIDs := trimResticValues(opt.SnapshotIDs)
 	if len(snapshotIDs) > 0 {
 		// Explicit snapshot IDs take precedence; host/path/tag filters are ignored.
@@ -403,11 +553,25 @@ func (repo *ResticManager) CopyRepoWithOptions(opt ResticCopyOption) error {
 		return fmt.Errorf("failed to build source env: %w", err)
 	}
 
+	// Pre-flight: count source snapshots so the UI can show X/Y progress.
+	preflightCtx, preflightCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer preflightCancel()
+	total := repo.countSourceSnapshots(preflightCtx, opt, srcRepo)
+	if total > 0 {
+		repo.currentTaskMutex.Lock()
+		if repo.currentTask != nil {
+			repo.currentTask.TotalSnapshots = total
+		}
+		repo.currentTaskMutex.Unlock()
+	}
+
+	repo.UpdateCurrentTaskPhase("copy")
+
 	timeout := repo.GetOperationTimeout()
 	copyCtx, copyCancel := context.WithTimeout(context.Background(), timeout)
 	defer copyCancel()
 
-	_, stderr, err := repo.runCommandWithExtraEnv(copyCtx, args, srcEnv, logrus.InfoLevel, false)
+	stderr, err := repo.runCopyWithProgress(copyCtx, args, srcEnv)
 	if err != nil {
 		if copyCtx.Err() == context.DeadlineExceeded {
 			return fmt.Errorf("restic copy timeout after %v", timeout)

--- a/utils/backupmgr/restic_copy.go
+++ b/utils/backupmgr/restic_copy.go
@@ -1,0 +1,431 @@
+package backupmgr
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/signal18/replication-manager/config"
+	"github.com/sirupsen/logrus"
+)
+
+// copySftpRepoRegex matches the restic sftp backend syntax: sftp:[user@]host:/path
+// Mirrors cluster.resticSftpRepoRegex — keep both in sync if the pattern changes.
+var copySftpRepoRegex = regexp.MustCompile(`^sftp:[^:@\s]+(@[^:@\s]+)?:.+$`)
+
+// ResticCopySourceAWSOption holds S3 credentials for the copy source repository.
+type ResticCopySourceAWSOption struct {
+	Endpoint     string `json:"endpoint,omitempty"`
+	Bucket       string `json:"bucket,omitempty"`
+	Prefix       string `json:"prefix,omitempty"`
+	AccessKeyID  string `json:"access_key_id,omitempty"`
+	AccessSecret string `json:"access_secret,omitempty"`
+	Region       string `json:"region,omitempty"`
+}
+
+// ResticCopySourceOption describes the source repository for a copy operation.
+// Password is intentionally serializable so the HTTP handler can decode it from the
+// request body, but the entire ResticCopyOption is tagged json:"-" on ResticTask to
+// prevent credential leakage through queue/current-task API responses.
+type ResticCopySourceOption struct {
+	Mode       string                     `json:"mode,omitempty"`
+	Repository string                     `json:"repository,omitempty"`
+	Password   string                     `json:"password,omitempty"`
+	KeyHint    string                     `json:"key_hint,omitempty"`
+	AWS        *ResticCopySourceAWSOption `json:"aws,omitempty"`
+}
+
+// ResticCopyOption holds all parameters for a repository copy task.
+// When attached to ResticTask, this field is tagged json:"-" to prevent
+// secrets from appearing in task-queue API responses.
+type ResticCopyOption struct {
+	Source            ResticCopySourceOption `json:"source"`
+	InitDestination   bool                   `json:"init_destination,omitempty"`
+	CopyChunkerParams bool                   `json:"copy_chunker_params,omitempty"`
+	SnapshotIDs       []string               `json:"snapshot_ids,omitempty"`
+	Host              []string               `json:"host,omitempty"`
+	Path              []string               `json:"path,omitempty"`
+	Tag               []string               `json:"tag,omitempty"`
+}
+
+// validateCopySourceMode rejects unsupported source mode values.
+func validateCopySourceMode(mode string) error {
+	switch mode {
+	case config.ConstBackupArchiveModeResticLocal,
+		config.ConstBackupArchiveModeResticAws,
+		config.ConstBackupArchiveModeResticSftp:
+		return nil
+	case "":
+		return fmt.Errorf("source mode is required")
+	default:
+		return fmt.Errorf("unsupported source mode %q: must be restic-local, restic-aws, or restic-sftp", mode)
+	}
+}
+
+// buildCopySourceRepoString constructs the restic repository URL for the source.
+func buildCopySourceRepoString(src ResticCopySourceOption) (string, error) {
+	switch src.Mode {
+	case config.ConstBackupArchiveModeResticLocal:
+		repo := strings.TrimSpace(src.Repository)
+		if repo == "" {
+			return "", fmt.Errorf("source repository path is required for mode %q", src.Mode)
+		}
+		return repo, nil
+	case config.ConstBackupArchiveModeResticSftp:
+		repo := strings.TrimSpace(src.Repository)
+		if repo == "" {
+			return "", fmt.Errorf("source repository path is required for mode %q", src.Mode)
+		}
+		if !copySftpRepoRegex.MatchString(repo) {
+			return "", fmt.Errorf("source SFTP repository %q does not match expected format sftp:[user@]host:/path", repo)
+		}
+		return repo, nil
+	case config.ConstBackupArchiveModeResticAws:
+		if src.AWS == nil {
+			return "", fmt.Errorf("source AWS configuration is required for mode restic-aws")
+		}
+		bucket := strings.TrimSpace(src.AWS.Bucket)
+		if bucket == "" {
+			return "", fmt.Errorf("source AWS bucket is required")
+		}
+		prefix := strings.Trim(src.AWS.Prefix, "/")
+		endpoint := strings.TrimRight(strings.TrimSpace(src.AWS.Endpoint), "/")
+		var repoStr string
+		if endpoint != "" {
+			repoStr = "s3:" + endpoint + "/" + bucket
+		} else {
+			repoStr = "s3:" + bucket
+		}
+		if prefix != "" {
+			repoStr += "/" + prefix
+		}
+		return repoStr, nil
+	default:
+		return "", fmt.Errorf("unsupported source mode: %q", src.Mode)
+	}
+}
+
+// buildCopySourceEnvOverlay builds the command-scoped environment entries needed
+// to authenticate the source repository during copy or init.
+// Never logs passwords or secrets.
+//
+// AWS credential handling: for restic-aws source mode, AWS credentials
+// (access_key_id, access_secret, region) are optional only when the destination
+// is non-S3 (local or SFTP). In that case omitted fields fall through to
+// ambient AWS auth (IAM instance profile, ECS task role, AWS_* env vars).
+// When the destination is also S3, validateS3SourceVsDest enforces that source
+// and destination credentials match explicitly — ambient credentials that differ
+// from the destination config will be rejected before the command runs.
+func buildCopySourceEnvOverlay(src ResticCopySourceOption, fromRepo string) ([]string, error) {
+	if src.Password == "" {
+		return nil, fmt.Errorf("source password is required")
+	}
+	env := []string{
+		"RESTIC_FROM_REPOSITORY=" + fromRepo,
+		"RESTIC_FROM_PASSWORD=" + src.Password,
+	}
+	if hint := strings.TrimSpace(src.KeyHint); hint != "" {
+		env = append(env, "RESTIC_FROM_KEY_HINT="+hint)
+	}
+	if src.Mode == config.ConstBackupArchiveModeResticAws && src.AWS != nil {
+		// S3 source needs AWS credentials so restic can access the source repository.
+		// Per G1, these credentials match destination creds (or destination is non-S3).
+		if src.AWS.AccessKeyID != "" {
+			env = append(env, "AWS_ACCESS_KEY_ID="+src.AWS.AccessKeyID)
+		}
+		if src.AWS.AccessSecret != "" {
+			env = append(env, "AWS_SECRET_ACCESS_KEY="+src.AWS.AccessSecret)
+		}
+		if src.AWS.Region != "" {
+			env = append(env, "AWS_DEFAULT_REGION="+src.AWS.Region)
+		}
+	}
+	return env, nil
+}
+
+// validateS3SourceVsDest enforces G1: reject S3→S3 copy when effective AWS
+// credentials or connection settings differ between source and destination.
+func (repo *ResticManager) validateS3SourceVsDest(src ResticCopySourceOption) error {
+	if src.Mode != config.ConstBackupArchiveModeResticAws {
+		return nil
+	}
+	// Check whether destination uses S3.
+	destPath := repo.GetRepoPath()
+	if !config.IsS3ResticRepository(destPath) && strings.TrimSpace(repo.AwsBucket) == "" {
+		return nil // destination is not S3 — no credential conflict
+	}
+	// Destination is S3: enforce matching credentials.
+	srcAWS := src.AWS
+	if srcAWS == nil {
+		return fmt.Errorf("source AWS configuration is required for mode restic-aws")
+	}
+	if srcAWS.AccessKeyID != repo.AwsAccessKeyID {
+		return fmt.Errorf("S3 source and destination have different AWS access key IDs; mismatched credentials are not supported for S3-to-S3 copy")
+	}
+	if srcAWS.AccessSecret != repo.AwsSecretAccessKey {
+		return fmt.Errorf("S3 source and destination have different AWS access secrets; mismatched credentials are not supported for S3-to-S3 copy")
+	}
+	srcRegion := strings.TrimSpace(srcAWS.Region)
+	destRegion := strings.TrimSpace(repo.AwsRegion)
+	if srcRegion != destRegion {
+		return fmt.Errorf("S3 source region %q differs from destination region %q", srcRegion, destRegion)
+	}
+	srcEndpoint := strings.TrimRight(strings.TrimSpace(srcAWS.Endpoint), "/")
+	destEndpoint := strings.TrimRight(strings.TrimSpace(repo.AwsEndpoint), "/")
+	if srcEndpoint != destEndpoint {
+		return fmt.Errorf("S3 source endpoint %q differs from destination endpoint %q", srcEndpoint, destEndpoint)
+	}
+	return nil
+}
+
+// ValidateCopyOption performs all early-rejection checks that do not require
+// running a restic command. Call before adding a copy task to the queue.
+//
+// AWS credential handling: omitting source.aws fields for restic-aws mode is
+// only permitted when the destination is non-S3. For S3-to-S3 copy,
+// validateS3SourceVsDest requires source and destination credentials to match
+// explicitly; ambient credentials cannot be relied upon in that path.
+func (repo *ResticManager) ValidateCopyOption(opt ResticCopyOption) error {
+	if err := validateCopySourceMode(opt.Source.Mode); err != nil {
+		return err
+	}
+	if _, err := buildCopySourceRepoString(opt.Source); err != nil {
+		return err
+	}
+	if opt.Source.Password == "" {
+		return fmt.Errorf("source password is required")
+	}
+	if opt.CopyChunkerParams && !opt.InitDestination {
+		return fmt.Errorf("copy_chunker_params requires init_destination to be true")
+	}
+	if err := repo.validateS3SourceVsDest(opt.Source); err != nil {
+		return err
+	}
+	return nil
+}
+
+// envKey returns the key portion of a KEY=value environment string.
+func envKey(kv string) string {
+	idx := strings.IndexByte(kv, '=')
+	if idx < 0 {
+		return kv
+	}
+	return kv[:idx]
+}
+
+// mergeEnvByKey merges two env slices with deterministic precedence.
+// Entries in override replace same-key entries from base. Order is preserved;
+// override entries that introduce a new key are appended.
+func mergeEnvByKey(base []string, override []string) []string {
+	// Track the index of each key in the result slice.
+	indexByKey := make(map[string]int, len(base))
+	result := make([]string, 0, len(base)+len(override))
+
+	for _, kv := range base {
+		k := envKey(kv)
+		if idx, exists := indexByKey[k]; exists {
+			result[idx] = kv
+		} else {
+			indexByKey[k] = len(result)
+			result = append(result, kv)
+		}
+	}
+	for _, kv := range override {
+		k := envKey(kv)
+		if idx, exists := indexByKey[k]; exists {
+			result[idx] = kv
+		} else {
+			indexByKey[k] = len(result)
+			result = append(result, kv)
+		}
+	}
+	return result
+}
+
+// redactArgs returns a copy of args with the value following --from-repo replaced
+// by [redacted] to avoid logging source repository URIs (host/bucket/path metadata).
+func redactArgs(args []string) []string {
+	out := make([]string, len(args))
+	copy(out, args)
+	for i, a := range out {
+		if a == "--from-repo" && i+1 < len(out) {
+			out[i+1] = "[redacted]"
+		}
+	}
+	return out
+}
+
+// runCommandWithExtraEnv executes a restic command with a command-scoped env overlay.
+// The effective env is: os.Environ() + repo.Env + extraEnv, with later entries
+// overriding earlier ones when keys collide (G8 deterministic precedence).
+// Source credentials in extraEnv are never written to repo.Env (G3 per-command scope).
+func (repo *ResticManager) runCommandWithExtraEnv(ctx context.Context, args []string, extraEnv []string, loglevel logrus.Level, captureOutput bool) ([]byte, []byte, error) {
+	cmd := exec.CommandContext(ctx, repo.BinaryPath, args...)
+	cmd.Env = mergeEnvByKey(repo.getEnvCopy(), extraEnv)
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get stdout pipe: %w", err)
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get stderr pipe: %w", err)
+	}
+
+	repo.Printf(loglevel, "Starting command: %s %v", repo.BinaryPath, redactArgs(args))
+
+	if err := cmd.Start(); err != nil {
+		return nil, nil, fmt.Errorf("error starting command: %w", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	streamOutput := func(pipe io.ReadCloser, prefix string, buffer *bytes.Buffer, capture bool) {
+		defer wg.Done()
+		scanner := bufio.NewScanner(pipe)
+		for scanner.Scan() {
+			line := scanner.Text()
+			repo.Print(logrus.DebugLevel, prefix+line)
+			if capture {
+				buffer.WriteString(line + "\n")
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			repo.Printf(logrus.ErrorLevel, prefix+"Error reading output: %v", err)
+		}
+	}
+
+	go streamOutput(stdoutPipe, "[OUT] ", &stdoutBuf, captureOutput)
+	go streamOutput(stderrPipe, "[ERR] ", &stderrBuf, true)
+	wg.Wait()
+
+	if err := cmd.Wait(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return stdoutBuf.Bytes(), stderrBuf.Bytes(), fmt.Errorf("command timeout: %w", ctx.Err())
+		}
+		return stdoutBuf.Bytes(), stderrBuf.Bytes(), fmt.Errorf("command execution failed: %w", err)
+	}
+
+	repo.Printf(loglevel, "Command completed successfully: %s %v", repo.BinaryPath, redactArgs(args))
+
+	if captureOutput {
+		return stdoutBuf.Bytes(), stderrBuf.Bytes(), nil
+	}
+	return nil, stderrBuf.Bytes(), nil
+}
+
+// CopyRepoWithOptions copies snapshots from a source repository into the destination
+// repository configured on this ResticManager. All guardrails are enforced here:
+//   - G1: S3→S3 with mismatched credentials is rejected before execution.
+//   - G3: source credentials are command-scoped and never mutate repo.Env.
+//   - G4: destination state is classified before init is attempted.
+//   - G5: init_destination must be true when copy_chunker_params is true.
+//   - G6: only restic copy (and optional init) are called — never forget/prune/rewrite.
+func (repo *ResticManager) CopyRepoWithOptions(opt ResticCopyOption) error {
+	// Validate source and guardrail combinations.
+	if err := validateCopySourceMode(opt.Source.Mode); err != nil {
+		return err
+	}
+	if opt.CopyChunkerParams && !opt.InitDestination {
+		return fmt.Errorf("copy_chunker_params requires init_destination to be true")
+	}
+	srcRepo, err := buildCopySourceRepoString(opt.Source)
+	if err != nil {
+		return err
+	}
+	if err := repo.validateS3SourceVsDest(opt.Source); err != nil {
+		return err
+	}
+
+	// Classify destination state before any init attempt (G4).
+	if opt.InitDestination {
+		result := repo.ValidateRepoConfigManual()
+		switch result.Status {
+		case ManualCheckStatusOK:
+			if opt.CopyChunkerParams {
+				return fmt.Errorf("destination repository is already initialized; copy_chunker_params cannot be applied to an existing repository")
+			}
+			repo.Printf(logrus.InfoLevel, "Destination repository already initialized; skipping init")
+		case ManualCheckStatusInitRequired:
+			// --from-repo and --copy-chunker-params together (restic >= 0.14) let the
+			// destination inherit the source's chunker parameters for better dedup.
+			// Without CopyChunkerParams a plain init is sufficient and works on all
+			// restic versions.
+			var initArgs []string
+			var srcEnvForInit []string
+			if opt.CopyChunkerParams {
+				initArgs = []string{"init", "--from-repo", srcRepo, "--copy-chunker-params"}
+				var envErr error
+				srcEnvForInit, envErr = buildCopySourceEnvOverlay(opt.Source, srcRepo)
+				if envErr != nil {
+					return fmt.Errorf("failed to build source env for init: %w", envErr)
+				}
+			} else {
+				initArgs = []string{"init"}
+			}
+			initCtx, initCancel := context.WithTimeout(context.Background(), repo.GetOperationTimeout())
+			defer initCancel()
+			_, stderr, err := repo.runCommandWithExtraEnv(initCtx, initArgs, srcEnvForInit, logrus.InfoLevel, false)
+			if err != nil {
+				return fmt.Errorf("failed to initialize destination repository: %v, stderr: %s", err, stderr)
+			}
+			repo.Printf(logrus.InfoLevel, "Destination repository initialized from source")
+		default: // ManualCheckStatusError
+			return fmt.Errorf("destination repository is inaccessible or corrupt: %s", result.Message)
+		}
+	}
+
+	// Build copy command arguments.
+	args := []string{"copy"}
+	snapshotIDs := trimResticValues(opt.SnapshotIDs)
+	if len(snapshotIDs) > 0 {
+		// Explicit snapshot IDs take precedence; host/path/tag filters are ignored.
+		args = append(args, snapshotIDs...)
+	} else {
+		args = appendResticArgs(args, "--host", opt.Host)
+		args = appendResticArgs(args, "--path", opt.Path)
+		args = appendResticArgs(args, "--tag", opt.Tag)
+	}
+
+	// Build command-scoped source env overlay (G3: never mutates repo.Env).
+	srcEnv, err := buildCopySourceEnvOverlay(opt.Source, srcRepo)
+	if err != nil {
+		return fmt.Errorf("failed to build source env: %w", err)
+	}
+
+	timeout := repo.GetOperationTimeout()
+	copyCtx, copyCancel := context.WithTimeout(context.Background(), timeout)
+	defer copyCancel()
+
+	_, stderr, err := repo.runCommandWithExtraEnv(copyCtx, args, srcEnv, logrus.InfoLevel, false)
+	if err != nil {
+		if copyCtx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("restic copy timeout after %v", timeout)
+		}
+		return fmt.Errorf("restic copy failed: %v, stderr: %s", err, stderr)
+	}
+
+	// Refresh destination snapshots and stats after successful copy.
+	if err := repo.FetchRepo(); err != nil {
+		repo.Printf(logrus.WarnLevel, "post-copy snapshot refresh failed: %v", err)
+	}
+	return nil
+}
+
+// AddCopyTask enqueues a copy task with the given options.
+func (repo *ResticManager) AddCopyTask(opt ResticCopyOption) {
+	repo.appendTask(&ResticTask{
+		ID:      repo.GenerateTaskID(),
+		Type:    CopyTask,
+		CopyOpt: &opt,
+	})
+}

--- a/utils/backupmgr/restic_copy_test.go
+++ b/utils/backupmgr/restic_copy_test.go
@@ -1,0 +1,726 @@
+package backupmgr
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+)
+
+// --- validateCopySourceMode ---
+
+func TestValidateCopySourceMode(t *testing.T) {
+	valid := []string{
+		config.ConstBackupArchiveModeResticLocal,
+		config.ConstBackupArchiveModeResticAws,
+		config.ConstBackupArchiveModeResticSftp,
+	}
+	for _, m := range valid {
+		if err := validateCopySourceMode(m); err != nil {
+			t.Errorf("expected mode %q to be valid, got: %v", m, err)
+		}
+	}
+
+	if err := validateCopySourceMode(""); err == nil {
+		t.Error("expected error for empty mode, got nil")
+	}
+	if err := validateCopySourceMode("restic-unknown"); err == nil {
+		t.Error("expected error for unknown mode, got nil")
+	}
+}
+
+// --- buildCopySourceRepoString ---
+
+func TestBuildCopySourceRepoStringLocal(t *testing.T) {
+	src := ResticCopySourceOption{Mode: config.ConstBackupArchiveModeResticLocal, Repository: "/srv/backup"}
+	got, err := buildCopySourceRepoString(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/srv/backup" {
+		t.Errorf("expected /srv/backup, got %q", got)
+	}
+}
+
+func TestBuildCopySourceRepoStringLocalEmpty(t *testing.T) {
+	src := ResticCopySourceOption{Mode: config.ConstBackupArchiveModeResticLocal, Repository: ""}
+	_, err := buildCopySourceRepoString(src)
+	if err == nil {
+		t.Error("expected error for empty repository, got nil")
+	}
+}
+
+func TestBuildCopySourceRepoStringSFTP(t *testing.T) {
+	src := ResticCopySourceOption{Mode: config.ConstBackupArchiveModeResticSftp, Repository: "sftp:backup@10.0.0.1:/srv/repo"}
+	got, err := buildCopySourceRepoString(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "sftp:backup@10.0.0.1:/srv/repo" {
+		t.Errorf("unexpected value: %q", got)
+	}
+}
+
+func TestBuildCopySourceRepoStringSFTPNoUser(t *testing.T) {
+	src := ResticCopySourceOption{Mode: config.ConstBackupArchiveModeResticSftp, Repository: "sftp:10.0.0.1:/srv/repo"}
+	got, err := buildCopySourceRepoString(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "sftp:10.0.0.1:/srv/repo" {
+		t.Errorf("unexpected value: %q", got)
+	}
+}
+
+func TestBuildCopySourceRepoStringSFTPMalformed(t *testing.T) {
+	cases := []string{
+		"backup@10.0.0.1:/srv/repo", // missing sftp: prefix
+		"sftp:/srv/repo",            // missing host
+		"sftp:10.0.0.1",             // missing path
+		"sftp:",                     // empty
+	}
+	for _, repo := range cases {
+		src := ResticCopySourceOption{Mode: config.ConstBackupArchiveModeResticSftp, Repository: repo}
+		_, err := buildCopySourceRepoString(src)
+		if err == nil {
+			t.Errorf("expected error for malformed SFTP repo %q, got nil", repo)
+		}
+	}
+}
+
+func TestBuildCopySourceRepoStringS3WithEndpoint(t *testing.T) {
+	src := ResticCopySourceOption{
+		Mode: config.ConstBackupArchiveModeResticAws,
+		AWS: &ResticCopySourceAWSOption{
+			Endpoint: "https://minio.example.com",
+			Bucket:   "backups",
+			Prefix:   "cluster-a",
+		},
+	}
+	got, err := buildCopySourceRepoString(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "s3:https://minio.example.com/backups/cluster-a"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestBuildCopySourceRepoStringS3NoEndpoint(t *testing.T) {
+	src := ResticCopySourceOption{
+		Mode: config.ConstBackupArchiveModeResticAws,
+		AWS: &ResticCopySourceAWSOption{
+			Bucket: "my-bucket",
+			Prefix: "prefix",
+		},
+	}
+	got, err := buildCopySourceRepoString(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "s3:my-bucket/prefix"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestBuildCopySourceRepoStringS3NilAWS(t *testing.T) {
+	src := ResticCopySourceOption{Mode: config.ConstBackupArchiveModeResticAws}
+	_, err := buildCopySourceRepoString(src)
+	if err == nil {
+		t.Error("expected error for nil AWS config, got nil")
+	}
+}
+
+func TestBuildCopySourceRepoStringS3EmptyBucket(t *testing.T) {
+	src := ResticCopySourceOption{
+		Mode: config.ConstBackupArchiveModeResticAws,
+		AWS:  &ResticCopySourceAWSOption{Bucket: ""},
+	}
+	_, err := buildCopySourceRepoString(src)
+	if err == nil {
+		t.Error("expected error for empty bucket, got nil")
+	}
+}
+
+// --- buildCopySourceEnvOverlay ---
+
+func TestBuildCopySourceEnvOverlayLocal(t *testing.T) {
+	src := ResticCopySourceOption{
+		Mode:       config.ConstBackupArchiveModeResticLocal,
+		Repository: "/srv/backup",
+		Password:   "secret",
+	}
+	fromRepo := "/srv/backup"
+	env, err := buildCopySourceEnvOverlay(src, fromRepo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkEnvContains(t, env, "RESTIC_FROM_REPOSITORY=/srv/backup")
+	checkEnvContains(t, env, "RESTIC_FROM_PASSWORD=secret")
+	checkEnvAbsent(t, env, "RESTIC_FROM_KEY_HINT")
+	checkEnvAbsent(t, env, "AWS_ACCESS_KEY_ID")
+}
+
+func TestBuildCopySourceEnvOverlayWithKeyHint(t *testing.T) {
+	src := ResticCopySourceOption{
+		Mode:       config.ConstBackupArchiveModeResticLocal,
+		Repository: "/srv/backup",
+		Password:   "secret",
+		KeyHint:    "mykeyid",
+	}
+	env, err := buildCopySourceEnvOverlay(src, "/srv/backup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkEnvContains(t, env, "RESTIC_FROM_KEY_HINT=mykeyid")
+}
+
+func TestBuildCopySourceEnvOverlayS3(t *testing.T) {
+	src := ResticCopySourceOption{
+		Mode:     config.ConstBackupArchiveModeResticAws,
+		Password: "s3pass",
+		AWS: &ResticCopySourceAWSOption{
+			AccessKeyID:  "AKID",
+			AccessSecret: "SECRET",
+			Region:       "us-east-1",
+		},
+	}
+	env, err := buildCopySourceEnvOverlay(src, "s3:bucket/prefix")
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkEnvContains(t, env, "RESTIC_FROM_REPOSITORY=s3:bucket/prefix")
+	checkEnvContains(t, env, "RESTIC_FROM_PASSWORD=s3pass")
+	checkEnvContains(t, env, "AWS_ACCESS_KEY_ID=AKID")
+	checkEnvContains(t, env, "AWS_SECRET_ACCESS_KEY=SECRET")
+	checkEnvContains(t, env, "AWS_DEFAULT_REGION=us-east-1")
+}
+
+func TestBuildCopySourceEnvOverlayMissingPassword(t *testing.T) {
+	src := ResticCopySourceOption{Mode: config.ConstBackupArchiveModeResticLocal, Repository: "/tmp/r"}
+	_, err := buildCopySourceEnvOverlay(src, "/tmp/r")
+	if err == nil {
+		t.Error("expected error for missing password, got nil")
+	}
+}
+
+// --- mergeEnvByKey ---
+
+func TestMergeEnvByKeyDeduplicate(t *testing.T) {
+	base := []string{"FOO=base", "BAR=1"}
+	override := []string{"FOO=override", "BAZ=new"}
+	result := mergeEnvByKey(base, override)
+
+	m := envSliceToMap(result)
+	if m["FOO"] != "override" {
+		t.Errorf("FOO should be 'override', got %q", m["FOO"])
+	}
+	if m["BAR"] != "1" {
+		t.Errorf("BAR should be '1', got %q", m["BAR"])
+	}
+	if m["BAZ"] != "new" {
+		t.Errorf("BAZ should be 'new', got %q", m["BAZ"])
+	}
+
+	// Each key should appear exactly once.
+	counts := make(map[string]int)
+	for _, kv := range result {
+		counts[envKey(kv)]++
+	}
+	for k, count := range counts {
+		if count != 1 {
+			t.Errorf("key %q appears %d times, expected 1", k, count)
+		}
+	}
+}
+
+func TestMergeEnvByKeyOrderPreserved(t *testing.T) {
+	base := []string{"A=1", "B=2", "C=3"}
+	override := []string{"B=override"}
+	result := mergeEnvByKey(base, override)
+	if len(result) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(result))
+	}
+	// B should be updated in-place (position 1).
+	if result[1] != "B=override" {
+		t.Errorf("expected B at index 1 = 'B=override', got %q", result[1])
+	}
+}
+
+// --- validateS3SourceVsDest (G1 guardrail) ---
+
+func TestValidateS3SourceVsDestLocalSource(t *testing.T) {
+	repo := newRepoWithAwsConfig("AKID", "SECRET", "us-east-1", "", "bucket", "prefix")
+	src := ResticCopySourceOption{Mode: config.ConstBackupArchiveModeResticLocal}
+	if err := repo.validateS3SourceVsDest(src); err != nil {
+		t.Errorf("local source against S3 dest should be accepted, got: %v", err)
+	}
+}
+
+func TestValidateS3SourceVsDestS3NonS3Dest(t *testing.T) {
+	// Source is S3, destination is local (no AwsBucket, non-S3 repo path).
+	repo := newRepoWithAwsConfig("", "", "", "", "", "")
+	repo.Env = []string{"RESTIC_REPOSITORY=/local/path"}
+	src := ResticCopySourceOption{
+		Mode: config.ConstBackupArchiveModeResticAws,
+		AWS:  &ResticCopySourceAWSOption{AccessKeyID: "SRC_AKID", AccessSecret: "SRC_SECRET"},
+	}
+	if err := repo.validateS3SourceVsDest(src); err != nil {
+		t.Errorf("S3 source to local dest should be accepted, got: %v", err)
+	}
+}
+
+func TestValidateS3SourceVsDestS3MatchingCreds(t *testing.T) {
+	repo := newRepoWithAwsConfig("AKID", "SECRET", "us-east-1", "https://minio.example.com", "bucket", "prefix")
+	repo.Env = []string{"RESTIC_REPOSITORY=s3:https://minio.example.com/bucket/prefix"}
+	src := ResticCopySourceOption{
+		Mode: config.ConstBackupArchiveModeResticAws,
+		AWS: &ResticCopySourceAWSOption{
+			AccessKeyID:  "AKID",
+			AccessSecret: "SECRET",
+			Region:       "us-east-1",
+			Endpoint:     "https://minio.example.com",
+			Bucket:       "src-bucket",
+		},
+	}
+	if err := repo.validateS3SourceVsDest(src); err != nil {
+		t.Errorf("matching S3 creds should be accepted, got: %v", err)
+	}
+}
+
+func TestValidateS3SourceVsDestS3MismatchAccessKey(t *testing.T) {
+	repo := newRepoWithAwsConfig("DEST_AKID", "SECRET", "us-east-1", "", "bucket", "")
+	repo.Env = []string{"RESTIC_REPOSITORY=s3:bucket"}
+	src := ResticCopySourceOption{
+		Mode: config.ConstBackupArchiveModeResticAws,
+		AWS:  &ResticCopySourceAWSOption{AccessKeyID: "SRC_AKID", AccessSecret: "SECRET", Region: "us-east-1"},
+	}
+	if err := repo.validateS3SourceVsDest(src); err == nil {
+		t.Error("expected error for mismatched access key, got nil")
+	}
+}
+
+func TestValidateS3SourceVsDestS3MismatchRegion(t *testing.T) {
+	repo := newRepoWithAwsConfig("AKID", "SECRET", "us-east-1", "", "bucket", "")
+	repo.Env = []string{"RESTIC_REPOSITORY=s3:bucket"}
+	src := ResticCopySourceOption{
+		Mode: config.ConstBackupArchiveModeResticAws,
+		AWS:  &ResticCopySourceAWSOption{AccessKeyID: "AKID", AccessSecret: "SECRET", Region: "eu-west-1"},
+	}
+	if err := repo.validateS3SourceVsDest(src); err == nil {
+		t.Error("expected error for mismatched region, got nil")
+	}
+}
+
+func TestValidateS3SourceVsDestS3MismatchEndpoint(t *testing.T) {
+	repo := newRepoWithAwsConfig("AKID", "SECRET", "us-east-1", "https://minio1.example.com", "bucket", "")
+	repo.Env = []string{"RESTIC_REPOSITORY=s3:https://minio1.example.com/bucket"}
+	src := ResticCopySourceOption{
+		Mode: config.ConstBackupArchiveModeResticAws,
+		AWS:  &ResticCopySourceAWSOption{AccessKeyID: "AKID", AccessSecret: "SECRET", Region: "us-east-1", Endpoint: "https://minio2.example.com"},
+	}
+	if err := repo.validateS3SourceVsDest(src); err == nil {
+		t.Error("expected error for mismatched endpoint, got nil")
+	}
+}
+
+// --- ValidateCopyOption ---
+
+func TestValidateCopyOptionValid(t *testing.T) {
+	repo := newRepoWithAwsConfig("", "", "", "", "", "")
+	repo.Env = []string{"RESTIC_REPOSITORY=/local/dest"}
+	opt := ResticCopyOption{
+		Source: ResticCopySourceOption{
+			Mode:       config.ConstBackupArchiveModeResticLocal,
+			Repository: "/srv/src",
+			Password:   "pass",
+		},
+	}
+	if err := repo.ValidateCopyOption(opt); err != nil {
+		t.Errorf("expected valid option to pass, got: %v", err)
+	}
+}
+
+func TestValidateCopyOptionChunkerWithoutInit(t *testing.T) {
+	repo := newRepoWithAwsConfig("", "", "", "", "", "")
+	opt := ResticCopyOption{
+		Source: ResticCopySourceOption{
+			Mode:       config.ConstBackupArchiveModeResticLocal,
+			Repository: "/srv/src",
+			Password:   "pass",
+		},
+		CopyChunkerParams: true,
+		InitDestination:   false,
+	}
+	if err := repo.ValidateCopyOption(opt); err == nil {
+		t.Error("expected error for chunker_params without init_destination, got nil")
+	}
+}
+
+func TestValidateCopyOptionMissingPassword(t *testing.T) {
+	repo := newRepoWithAwsConfig("", "", "", "", "", "")
+	opt := ResticCopyOption{
+		Source: ResticCopySourceOption{
+			Mode:       config.ConstBackupArchiveModeResticLocal,
+			Repository: "/srv/src",
+		},
+	}
+	if err := repo.ValidateCopyOption(opt); err == nil {
+		t.Error("expected error for missing password, got nil")
+	}
+}
+
+// --- AddCopyTask queue behavior ---
+
+func TestAddCopyTaskQueued(t *testing.T) {
+	repo := newPausedRepo(t)
+	opt := ResticCopyOption{
+		Source: ResticCopySourceOption{
+			Mode:       config.ConstBackupArchiveModeResticLocal,
+			Repository: "/srv/src",
+			Password:   "pass",
+		},
+	}
+	repo.AddCopyTask(opt)
+
+	repo.Mutex.Lock()
+	qlen := len(repo.TaskQueue)
+	var taskType TaskType
+	if qlen > 0 {
+		taskType = repo.TaskQueue[0].Type
+	}
+	repo.Mutex.Unlock()
+
+	if qlen != 1 {
+		t.Fatalf("expected 1 task in queue, got %d", qlen)
+	}
+	if taskType != CopyTask {
+		t.Errorf("expected CopyTask (%d), got %d", CopyTask, taskType)
+	}
+}
+
+// --- Copy task JSON secrecy ---
+
+func TestCopyTaskNotExposedInJSON(t *testing.T) {
+	opt := ResticCopyOption{
+		Source: ResticCopySourceOption{
+			Mode:       config.ConstBackupArchiveModeResticLocal,
+			Repository: "/srv/src",
+			Password:   "topsecret",
+			KeyHint:    "hint",
+			AWS: &ResticCopySourceAWSOption{
+				AccessSecret: "aws-secret",
+			},
+		},
+	}
+	task := ResticTask{
+		ID:      1,
+		Type:    CopyTask,
+		CopyOpt: &opt,
+	}
+
+	data, err := json.Marshal(task)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := string(data)
+	if strings.Contains(s, "topsecret") {
+		t.Error("JSON must not contain source password")
+	}
+	if strings.Contains(s, "aws-secret") {
+		t.Error("JSON must not contain source AWS secret")
+	}
+	if strings.Contains(s, "copy_opt") || strings.Contains(s, "CopyOpt") {
+		t.Error("JSON must not contain copy_opt field")
+	}
+	// Task ID and type should still be visible.
+	if !strings.Contains(s, `"task_id":1`) {
+		t.Errorf("expected task_id in JSON, got: %s", s)
+	}
+}
+
+// --- GetTaskName ---
+
+func TestGetTaskNameCopy(t *testing.T) {
+	if name := GetTaskName(CopyTask); name != "copy" {
+		t.Errorf("expected 'copy', got %q", name)
+	}
+}
+
+// --- Integration: copy between two local repos (requires restic binary) ---
+
+// TestCopyRepoLocalToLocal tests copy with init_destination=true against an
+// uninitialized destination (plain init, no chunker params — works on all restic
+// versions). Re-running copy is idempotent (restic skips already-present snapshots).
+func TestCopyRepoLocalToLocal(t *testing.T) {
+	resticPath, err := findResticBinary()
+	if err != nil {
+		t.Skipf("restic binary not found, skipping integration test: %v", err)
+	}
+
+	base := t.TempDir()
+	srcDir := filepath.Join(base, "src-repo")
+	dstDir := filepath.Join(base, "dst-repo")
+	dataDir := filepath.Join(base, "data")
+	cacheDir := filepath.Join(base, "cache")
+	for _, d := range []string{srcDir, dstDir, dataDir, cacheDir} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dummyFile := filepath.Join(dataDir, "hello.txt")
+	if err := os.WriteFile(dummyFile, []byte("hello restic copy"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	srcPass := "srcpass"
+	dstPass := "dstpass"
+
+	// Init and populate source repo.
+	srcRepo := newLocalResticRepo(t, resticPath, srcDir, srcPass, cacheDir)
+	defer srcRepo.ShutdownWorker()
+	if err := srcRepo.InitRepo(false); err != nil {
+		t.Fatalf("init src repo: %v", err)
+	}
+	if _, err := srcRepo.BackupWithOptions(ResticBackupOption{DirPath: dataDir}); err != nil {
+		t.Fatalf("backup to src repo: %v", err)
+	}
+	if err := srcRepo.FetchRepo(); err != nil {
+		t.Fatalf("fetch src repo: %v", err)
+	}
+	if len(srcRepo.Backups) == 0 {
+		t.Fatal("expected at least one snapshot in source repo")
+	}
+
+	// Destination is uninitialized; init_destination=true triggers plain init
+	// (no --from-repo since CopyChunkerParams=false) — compatible with all restic versions.
+	dstRepo := newLocalResticRepo(t, resticPath, dstDir, dstPass, cacheDir)
+	defer dstRepo.ShutdownWorker()
+
+	opt := ResticCopyOption{
+		Source: ResticCopySourceOption{
+			Mode:       config.ConstBackupArchiveModeResticLocal,
+			Repository: srcDir,
+			Password:   srcPass,
+		},
+		InitDestination: true,
+	}
+
+	if err := dstRepo.CopyRepoWithOptions(opt); err != nil {
+		t.Fatalf("CopyRepoWithOptions: %v", err)
+	}
+	if len(dstRepo.Backups) == 0 {
+		t.Fatal("expected snapshots in destination repo after copy")
+	}
+
+	// Re-running copy should be idempotent.
+	snapshotsBefore := len(dstRepo.Backups)
+	if err := dstRepo.CopyRepoWithOptions(opt); err != nil {
+		t.Fatalf("second CopyRepoWithOptions: %v", err)
+	}
+	if len(dstRepo.Backups) != snapshotsBefore {
+		t.Errorf("expected %d snapshots after re-copy, got %d", snapshotsBefore, len(dstRepo.Backups))
+	}
+}
+
+// TestCopyRepoInitDestinationWithChunkerParams tests init_destination=true with
+// copy_chunker_params=true. This uses restic init --from-repo --copy-chunker-params
+// which requires restic >= 0.14 and is skipped on older versions.
+func TestCopyRepoInitDestinationWithChunkerParams(t *testing.T) {
+	resticPath, err := findResticBinary()
+	if err != nil {
+		t.Skipf("restic binary not found: %v", err)
+	}
+	if !resticSupportsFromRepo(resticPath) {
+		t.Skip("restic init --from-repo requires restic >= 0.14, skipping")
+	}
+
+	base := t.TempDir()
+	srcDir := filepath.Join(base, "src")
+	dstDir := filepath.Join(base, "dst")
+	dataDir := filepath.Join(base, "data")
+	cacheDir := filepath.Join(base, "cache")
+	for _, d := range []string{srcDir, dstDir, dataDir, cacheDir} {
+		os.MkdirAll(d, 0755)
+	}
+	os.WriteFile(filepath.Join(dataDir, "f.txt"), []byte("data"), 0644)
+
+	srcRepo := newLocalResticRepo(t, resticPath, srcDir, "srcpass", cacheDir)
+	defer srcRepo.ShutdownWorker()
+	if err := srcRepo.InitRepo(false); err != nil {
+		t.Fatalf("init src: %v", err)
+	}
+	if _, err := srcRepo.BackupWithOptions(ResticBackupOption{DirPath: dataDir}); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+	if err := srcRepo.FetchRepo(); err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+
+	dstRepo := newLocalResticRepo(t, resticPath, dstDir, "dstpass", cacheDir)
+	defer dstRepo.ShutdownWorker()
+
+	opt := ResticCopyOption{
+		Source: ResticCopySourceOption{
+			Mode:       config.ConstBackupArchiveModeResticLocal,
+			Repository: srcDir,
+			Password:   "srcpass",
+		},
+		InitDestination:   true,
+		CopyChunkerParams: true,
+	}
+	if err := dstRepo.CopyRepoWithOptions(opt); err != nil {
+		t.Fatalf("CopyRepoWithOptions with chunker params: %v", err)
+	}
+	if len(dstRepo.Backups) == 0 {
+		t.Fatal("expected snapshots after copy with chunker-params init")
+	}
+}
+
+// TestCopyRepoAlreadyInitializedWithChunkerParamsFails verifies G4: requesting
+// copy_chunker_params=true against an already-initialized destination is rejected.
+func TestCopyRepoAlreadyInitializedWithChunkerParamsFails(t *testing.T) {
+	resticPath, err := findResticBinary()
+	if err != nil {
+		t.Skipf("restic binary not found: %v", err)
+	}
+
+	base := t.TempDir()
+	srcDir := filepath.Join(base, "src")
+	dstDir := filepath.Join(base, "dst")
+	cacheDir := filepath.Join(base, "cache")
+	for _, d := range []string{srcDir, dstDir, cacheDir} {
+		os.MkdirAll(d, 0755)
+	}
+
+	srcRepo := newLocalResticRepo(t, resticPath, srcDir, "srcpass", cacheDir)
+	defer srcRepo.ShutdownWorker()
+	dstRepo := newLocalResticRepo(t, resticPath, dstDir, "dstpass", cacheDir)
+	defer dstRepo.ShutdownWorker()
+
+	if err := srcRepo.InitRepo(false); err != nil {
+		t.Fatalf("init src: %v", err)
+	}
+	if err := dstRepo.InitRepo(false); err != nil {
+		t.Fatalf("init dst: %v", err)
+	}
+	// Wait for worker to settle after init FetchTask.
+	dstRepo.FetchRepo()
+
+	opt := ResticCopyOption{
+		Source: ResticCopySourceOption{
+			Mode:       config.ConstBackupArchiveModeResticLocal,
+			Repository: srcDir,
+			Password:   "srcpass",
+		},
+		InitDestination:   true,
+		CopyChunkerParams: true,
+	}
+
+	copyErr := dstRepo.CopyRepoWithOptions(opt)
+	if copyErr == nil {
+		t.Error("expected error when applying copy_chunker_params to already-initialized repo, got nil")
+	}
+	if !strings.Contains(copyErr.Error(), "already initialized") {
+		t.Errorf("expected 'already initialized' in error, got: %v", copyErr)
+	}
+}
+
+// resticSupportsFromRepo probes whether the installed restic binary supports
+// the --from-repo flag on init (requires restic >= 0.14).
+func resticSupportsFromRepo(binaryPath string) bool {
+	out, err := exec.Command(binaryPath, "init", "--help").CombinedOutput()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(out), "--from-repo")
+}
+
+// --- helpers ---
+
+func newRepoWithAwsConfig(accessKeyID, secretAccessKey, region, endpoint, bucket, prefix string) *ResticManager {
+	mu := &sync.Mutex{}
+	repo := &ResticManager{
+		BinaryPath:         "restic",
+		Env:                []string{},
+		envMutex:           &sync.RWMutex{},
+		Mutex:              mu,
+		errorMutex:         &sync.Mutex{},
+		currentTaskMutex:   &sync.Mutex{},
+		mountRefMutex:      &sync.Mutex{},
+		mountUsers:         make(map[string]struct{}),
+		TaskErrors:         make(map[TaskType]error),
+		TaskQueue:          make([]*ResticTask, 0),
+		AwsAccessKeyID:     accessKeyID,
+		AwsSecretAccessKey: secretAccessKey,
+		AwsRegion:          region,
+		AwsEndpoint:        endpoint,
+		AwsBucket:          bucket,
+		AwsPrefix:          prefix,
+	}
+	repo.cond = sync.NewCond(mu)
+	return repo
+}
+
+func newLocalResticRepo(t *testing.T, binaryPath, repoPath, password, cacheDir string) *ResticManager {
+	t.Helper()
+	repo := NewResticRepo(binaryPath, testMsgChan, 0)
+	repo.SetEnv([]string{
+		"RESTIC_REPOSITORY=" + repoPath,
+		"RESTIC_PASSWORD=" + password,
+		"RESTIC_CACHE_DIR=" + cacheDir,
+	})
+	return repo
+}
+
+func checkEnvContains(t *testing.T, env []string, want string) {
+	t.Helper()
+	for _, e := range env {
+		if e == want {
+			return
+		}
+	}
+	t.Errorf("env does not contain %q; got: %v", want, env)
+}
+
+func checkEnvAbsent(t *testing.T, env []string, prefix string) {
+	t.Helper()
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix+"=") {
+			t.Errorf("env should not contain key %q, but found: %q", prefix, e)
+		}
+	}
+}
+
+func envSliceToMap(env []string) map[string]string {
+	m := make(map[string]string, len(env))
+	for _, kv := range env {
+		idx := strings.IndexByte(kv, '=')
+		if idx < 0 {
+			m[kv] = ""
+		} else {
+			m[kv[:idx]] = kv[idx+1:]
+		}
+	}
+	return m
+}
+
+func findResticBinary() (string, error) {
+	for _, candidate := range []string{"restic", "/usr/local/bin/restic", "/usr/bin/restic"} {
+		path, err := exec.LookPath(candidate)
+		if err == nil {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("restic binary not found")
+}

--- a/utils/backupmgr/restic_s3probe_test.go
+++ b/utils/backupmgr/restic_s3probe_test.go
@@ -1,0 +1,361 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+
+package backupmgr
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Issue 1: Boot-fetch callback fires in FetchRepo(), not via task tagging
+// ---------------------------------------------------------------------------
+
+// TestBootFetchCallbackFiredByFetchRepo verifies that OnBootFetchSuccess is
+// called on the very first successful FetchRepo() regardless of how FetchRepo()
+// was invoked (directly, via FetchTask, or via UnlockTask→FetchRepo).
+func TestBootFetchCallbackFiredByFetchRepo(t *testing.T) {
+	repo, _, _, _ := newResticRepo(t, false)
+
+	// Reset bootInitDone so this is treated as the first boot fetch.
+	repo.errorMutex.Lock()
+	repo.bootInitDone = false
+	repo.errorMutex.Unlock()
+
+	var fired atomic.Int32
+	repo.OnBootFetchSuccess = func() { fired.Add(1) }
+
+	if err := repo.FetchRepo(); err != nil {
+		t.Fatalf("FetchRepo() error: %v", err)
+	}
+
+	// Give the goroutine a moment to execute.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && fired.Load() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if fired.Load() != 1 {
+		t.Fatalf("OnBootFetchSuccess fired %d times, want 1", fired.Load())
+	}
+}
+
+// TestBootFetchCallbackNotFiredOnSubsequentFetch verifies that the callback
+// does NOT fire on any fetch after the first one.
+func TestBootFetchCallbackNotFiredOnSubsequentFetch(t *testing.T) {
+	repo, _, _, _ := newResticRepo(t, false)
+
+	var fired atomic.Int32
+
+	// First fetch: callback should fire.
+	repo.errorMutex.Lock()
+	repo.bootInitDone = false
+	repo.errorMutex.Unlock()
+	repo.OnBootFetchSuccess = func() { fired.Add(1) }
+	if err := repo.FetchRepo(); err != nil {
+		t.Fatalf("first FetchRepo(): %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	// Second fetch: callback must not fire again.
+	if err := repo.FetchRepo(); err != nil {
+		t.Fatalf("second FetchRepo(): %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	if fired.Load() != 1 {
+		t.Fatalf("OnBootFetchSuccess fired %d times, want exactly 1", fired.Load())
+	}
+}
+
+// TestBootFetchCallbackNotFiredOnFailedBoot verifies no callback when the boot
+// fetch itself returns an error (e.g. lock error or missing repo).
+func TestBootFetchCallbackNotFiredOnFailedBoot(t *testing.T) {
+	repo := newPausedRepo(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=/nonexistent/path/repo",
+	})
+
+	repo.errorMutex.Lock()
+	repo.bootInitDone = false
+	repo.errorMutex.Unlock()
+
+	var fired atomic.Int32
+	repo.OnBootFetchSuccess = func() { fired.Add(1) }
+
+	// FetchRepo will fail: repo does not exist.
+	_ = repo.FetchRepo()
+	time.Sleep(100 * time.Millisecond)
+
+	if fired.Load() != 0 {
+		t.Fatalf("OnBootFetchSuccess must not fire on failed boot fetch; fired %d times", fired.Load())
+	}
+}
+
+// TestUnlockTaskTriggersBoot ensures that FetchRepo called from inside the
+// worker's UnlockTask path (simulated by calling FetchRepo directly while
+// bootInitDone=false) still fires the callback.
+func TestUnlockTaskTriggersBoot(t *testing.T) {
+	repo, _, _, _ := newResticRepo(t, false)
+
+	repo.errorMutex.Lock()
+	repo.bootInitDone = false
+	repo.errorMutex.Unlock()
+
+	var fired atomic.Int32
+	repo.OnBootFetchSuccess = func() { fired.Add(1) }
+
+	// Simulate what UnlockTask does: it calls FetchRepo() as part of unlock.
+	if err := repo.FetchRepo(); err != nil {
+		t.Fatalf("FetchRepo(): %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && fired.Load() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if fired.Load() != 1 {
+		t.Fatalf("callback not fired after unlock-path boot fetch (fired=%d)", fired.Load())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Issue 2: ProbeS3Candidate — probe-based auto selection via s3existenceProber
+// ---------------------------------------------------------------------------
+
+// buildS3Repo returns a paused ResticManager configured with an S3 repo URL
+// and an s3existenceProber seam.  The seam maps bucket names to probe results.
+type s3BucketResult struct {
+	configExists bool
+	configErr    error
+	dataExists   bool
+	dataErr      error
+}
+
+func buildS3RepoWithSeam(t *testing.T, results map[string]s3BucketResult) *ResticManager {
+	t.Helper()
+	repo := newPausedRepo(t)
+	repo.SetEnv([]string{
+		"RESTIC_PASSWORD=testpassword",
+		"RESTIC_REPOSITORY=s3:https://minio.example.com/primary-bucket/prefix",
+	})
+	repo.s3existenceProber = func(bucket, configKey, dataPrefix string) (bool, error, bool, error) {
+		if r, ok := results[bucket]; ok {
+			return r.configExists, r.configErr, r.dataExists, r.dataErr
+		}
+		return false, fmt.Errorf("unexpected bucket %q in probe seam", bucket), false, nil
+	}
+	return repo
+}
+
+// TestProbeS3Candidate_Initialized verifies that ProbeS3Candidate returns nil
+// when S3 reports the config key exists (repo is initialized and accessible).
+func TestProbeS3Candidate_Initialized(t *testing.T) {
+	results := map[string]s3BucketResult{
+		"my-bucket": {configExists: true, dataExists: true},
+	}
+	repo := buildS3RepoWithSeam(t, results)
+
+	err := repo.ProbeS3Candidate("my-bucket", "prefix", "https://minio.example.com", "key", "secret", "us-east-1")
+	if err != nil {
+		t.Fatalf("ProbeS3Candidate() unexpected error for initialized bucket: %v", err)
+	}
+}
+
+// TestProbeS3Candidate_FreshBucket verifies that ProbeS3Candidate returns an
+// "initialization required" error for a reachable but uninitialised bucket.
+func TestProbeS3Candidate_FreshBucket(t *testing.T) {
+	results := map[string]s3BucketResult{
+		"fresh-bucket": {configExists: false, dataExists: false},
+	}
+	repo := buildS3RepoWithSeam(t, results)
+
+	err := repo.ProbeS3Candidate("fresh-bucket", "prefix", "https://minio.example.com", "key", "secret", "us-east-1")
+	if !S3ProbeUsable(err) {
+		t.Fatalf("ProbeS3Candidate() should be usable for fresh (uninitialised) bucket; got: %v", err)
+	}
+}
+
+// TestProbeS3Candidate_Inaccessible verifies that ProbeS3Candidate returns a
+// non-usable error when the bucket cannot be reached.
+func TestProbeS3Candidate_Inaccessible(t *testing.T) {
+	results := map[string]s3BucketResult{
+		"bad-bucket": {configErr: fmt.Errorf("connection refused")},
+	}
+	repo := buildS3RepoWithSeam(t, results)
+
+	err := repo.ProbeS3Candidate("bad-bucket", "prefix", "https://minio.example.com", "key", "secret", "us-east-1")
+	if S3ProbeUsable(err) {
+		t.Fatalf("ProbeS3Candidate() should be non-usable for inaccessible bucket; got nil (or usable error)")
+	}
+}
+
+// TestProbeS3Candidate_RestoresState verifies that manager state is not
+// permanently altered after a probe: CanInitRepo, AwsBucket, AwsRegion, and
+// error-backoff fields must all be restored.
+func TestProbeS3Candidate_RestoresState(t *testing.T) {
+	results := map[string]s3BucketResult{
+		"probe-bucket": {configErr: fmt.Errorf("network error")}, // triggers error state inside probe
+	}
+	repo := buildS3RepoWithSeam(t, results)
+
+	// Set known pre-probe state.
+	repo.CanInitRepo = true
+	repo.AwsBucket = "original-bucket"
+	repo.AwsRegion = "eu-west-1"
+	repo.errorMutex.Lock()
+	repo.initErrorCount = 7
+	repo.errorMutex.Unlock()
+
+	_ = repo.ProbeS3Candidate("probe-bucket", "prefix", "https://minio.example.com", "k", "s", "us-east-1")
+
+	if !repo.CanInitRepo {
+		t.Errorf("CanInitRepo was not restored after probe")
+	}
+	if repo.AwsBucket != "original-bucket" {
+		t.Errorf("AwsBucket not restored: got %q", repo.AwsBucket)
+	}
+	if repo.AwsRegion != "eu-west-1" {
+		t.Errorf("AwsRegion not restored: got %q", repo.AwsRegion)
+	}
+	repo.errorMutex.Lock()
+	count := repo.initErrorCount
+	repo.errorMutex.Unlock()
+	if count != 7 {
+		t.Errorf("initErrorCount not restored: got %d", count)
+	}
+}
+
+// TestS3ProbeUsable covers the helper function directly.
+func TestS3ProbeUsable(t *testing.T) {
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{nil, true},
+		{fmt.Errorf("repository needs initialization required"), true},
+		{fmt.Errorf("initialization required before backup"), true},
+		{fmt.Errorf("connection refused"), false},
+		{fmt.Errorf("access denied"), false},
+	}
+	for _, tc := range cases {
+		got := S3ProbeUsable(tc.err)
+		if got != tc.want {
+			t.Errorf("S3ProbeUsable(%v) = %v, want %v", tc.err, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auto mode: probe order — new wins, legacy fallback, both fail
+// ---------------------------------------------------------------------------
+
+// These tests simulate the cluster-layer auto-probe logic at the backupmgr
+// level by calling ProbeS3Candidate for two candidate configs in order and
+// checking which one is selected.
+
+// autoProbeWinner is a local helper that mirrors what resolveResticS3AutoProbe
+// does at the cluster layer: try new bucket first, fallback to legacy.
+func autoProbeWinner(repo *ResticManager, newBucket, legacyBucket string) (string, error) {
+	err := repo.ProbeS3Candidate(newBucket, "prefix", "endpoint", "key", "secret", "region")
+	if S3ProbeUsable(err) {
+		return newBucket, nil
+	}
+	err2 := repo.ProbeS3Candidate(legacyBucket, "prefix", "endpoint", "key", "secret", "region")
+	if S3ProbeUsable(err2) {
+		return legacyBucket, nil
+	}
+	return "", fmt.Errorf("both new (%v) and legacy (%v) probes failed", err, err2)
+}
+
+// TestAutoProbe_NewWins: new config is reachable, legacy is not → new wins.
+func TestAutoProbe_NewWins(t *testing.T) {
+	results := map[string]s3BucketResult{
+		"new-bucket":    {configExists: true},
+		"legacy-bucket": {configErr: fmt.Errorf("connection refused")},
+	}
+	repo := buildS3RepoWithSeam(t, results)
+
+	winner, err := autoProbeWinner(repo, "new-bucket", "legacy-bucket")
+	if err != nil {
+		t.Fatalf("autoProbeWinner error: %v", err)
+	}
+	if winner != "new-bucket" {
+		t.Errorf("expected new-bucket to win, got %q", winner)
+	}
+}
+
+// TestAutoProbe_LegacyFallback: new config fails, legacy is reachable → legacy wins.
+func TestAutoProbe_LegacyFallback(t *testing.T) {
+	results := map[string]s3BucketResult{
+		"new-bucket":    {configErr: fmt.Errorf("endpoint not reachable")},
+		"legacy-bucket": {configExists: true},
+	}
+	repo := buildS3RepoWithSeam(t, results)
+
+	winner, err := autoProbeWinner(repo, "new-bucket", "legacy-bucket")
+	if err != nil {
+		t.Fatalf("autoProbeWinner error: %v", err)
+	}
+	if winner != "legacy-bucket" {
+		t.Errorf("expected legacy-bucket fallback, got %q", winner)
+	}
+}
+
+// TestAutoProbe_BothFail: both configs are unreachable → error.
+func TestAutoProbe_BothFail(t *testing.T) {
+	results := map[string]s3BucketResult{
+		"new-bucket":    {configErr: fmt.Errorf("network error")},
+		"legacy-bucket": {configErr: fmt.Errorf("network error")},
+	}
+	repo := buildS3RepoWithSeam(t, results)
+
+	_, err := autoProbeWinner(repo, "new-bucket", "legacy-bucket")
+	if err == nil {
+		t.Fatal("expected error when both probes fail, got nil")
+	}
+}
+
+// TestAutoProbe_NewFreshBucketWins: new bucket is fresh (init required) — still usable.
+func TestAutoProbe_NewFreshBucketWins(t *testing.T) {
+	results := map[string]s3BucketResult{
+		"new-bucket":    {configExists: false, dataExists: false}, // fresh → init required
+		"legacy-bucket": {configErr: fmt.Errorf("not reachable")},
+	}
+	repo := buildS3RepoWithSeam(t, results)
+
+	winner, err := autoProbeWinner(repo, "new-bucket", "legacy-bucket")
+	if err != nil {
+		t.Fatalf("autoProbeWinner error: %v", err)
+	}
+	if winner != "new-bucket" {
+		t.Errorf("expected fresh new-bucket to win, got %q", winner)
+	}
+}
+
+// TestAutoProbe_StateRestoredBetweenProbes: manager state must be clean after
+// the first (failing) probe so the second probe sees a neutral starting state.
+func TestAutoProbe_StateRestoredBetweenProbes(t *testing.T) {
+	results := map[string]s3BucketResult{
+		"new-bucket":    {configErr: fmt.Errorf("unreachable")},
+		"legacy-bucket": {configExists: true},
+	}
+	repo := buildS3RepoWithSeam(t, results)
+	repo.CanInitRepo = true
+
+	winner, err := autoProbeWinner(repo, "new-bucket", "legacy-bucket")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if winner != "legacy-bucket" {
+		t.Errorf("expected legacy-bucket, got %q", winner)
+	}
+	// CanInitRepo must still be true — not clobbered by the failing first probe.
+	if !repo.CanInitRepo {
+		t.Error("CanInitRepo was corrupted by the failing first probe")
+	}
+}


### PR DESCRIPTION
## Summary
- add restic repository copy support, including saved source presets and copy progress tracking
- add repository wipe workflow updates and relax wipe fetch blocking
- extend restic settings and API support for S3 config mode selection and related UI polish

## Testing
- tested before commit