### PR TITLE
feat(apps): add credit-based app sizing and usage UI

### DIFF
--- a/cluster/app.go
+++ b/cluster/app.go
@@ -77,7 +77,6 @@ func (cluster *Cluster) newAppList() error {
 	}
 	pending := make([]pendingApp, 0, len(cluster.Conf.Apps))
 	news3providers := make([]string, 0)
-	cluster.Conf.Cloud18ApplicationCreditsUsed = 0
 
 	for k, appcnf := range cluster.Conf.Apps {
 		if appcnf.AppHost == "" {
@@ -116,6 +115,22 @@ func (cluster *Cluster) newAppList() error {
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlInfo, "Loaded %d apps", len(cluster.Apps))
 
 	cluster.LoadAllAppTemplateMD5Provisioned()
+
+	// Backfill ProvAppCreditUsed for apps that are provisioned but whose saved
+	// value is zero — this covers apps created before credit persistence was added.
+	// We only save when the value actually changes so restarts after backfill are
+	// no-ops.
+	for _, app := range cluster.Apps {
+		if app.HasProvisionCookie() && app.AppConfig.ProvAppCreditUsed == 0 && app.AppConfig.ProvAppCreditPlanned > 0 {
+			app.AppConfig.ProvAppCreditUsed = app.AppConfig.ProvAppCreditPlanned
+			if _, err := cluster.SaveApp(app, ""); err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlErr,
+					"Failed to persist backfilled credit usage for %s: %s", app.Name, err)
+			}
+		}
+	}
+
+	cluster.recomputeAppCredits()
 
 	return nil
 }

--- a/cluster/app_set.go
+++ b/cluster/app_set.go
@@ -128,6 +128,50 @@ func (app *App) SetCluster(c *Cluster) {
 	app.ClusterGroup = c
 }
 
+// effectiveSizingMode returns the sizing mode that governs this app.
+// Resolution order: app mode → cluster mode → legacy (empty string).
+func (app *App) effectiveSizingMode() string {
+	if app.AppConfig.ProvAppSizingMode != "" {
+		return app.AppConfig.ProvAppSizingMode
+	}
+	if app.ClusterGroup.Conf.ProvAppSizingMode != "" {
+		return app.ClusterGroup.Conf.ProvAppSizingMode
+	}
+	return ""
+}
+
+// preservedLegacyInUnitPolicy reports whether the effective unit policy is coming
+// from the cluster while this app itself has not been explicitly stamped as a
+// unit-managed app. In that case, the app's stored CPU/memory/disk values are
+// treated as preserved legacy values until the first unit-mode write.
+func (app *App) preservedLegacyInUnitPolicy() bool {
+	return app.effectiveSizingMode() == config.AppSizingModeUnit && app.AppConfig.ProvAppSizingMode != config.AppSizingModeUnit
+}
+
+func (app *App) deriveUnitFromStoredResources() int {
+	cores, _ := strconv.Atoi(app.AppConfig.ProvAppCpuCores)
+	memMB, _ := config.ParseUnitMeasurementToInt("M", app.AppConfig.ProvAppMem, false)
+	diskGB, _ := config.ParseUnitMeasurementToInt("G", app.AppConfig.ProvAppDisk, false)
+	unitFromCores, unitFromMem, unitFromDisk := 1, 1, 1
+	if cores > config.AppUnitCpuCores {
+		unitFromCores = (cores + config.AppUnitCpuCores - 1) / config.AppUnitCpuCores
+	}
+	if memMB > config.AppUnitMemMB {
+		unitFromMem = (memMB + config.AppUnitMemMB - 1) / config.AppUnitMemMB
+	}
+	if diskGB > config.AppUnitDiskGB {
+		unitFromDisk = (diskGB + config.AppUnitDiskGB - 1) / config.AppUnitDiskGB
+	}
+	appUnit := unitFromCores
+	if unitFromMem > appUnit {
+		appUnit = unitFromMem
+	}
+	if unitFromDisk > appUnit {
+		appUnit = unitFromDisk
+	}
+	return appUnit
+}
+
 func (app *App) SetSetting(key, value string) error {
 	switch key {
 	case "prov-app-docker-img":
@@ -135,7 +179,30 @@ func (app *App) SetSetting(key, value string) error {
 	case "prov-app-docker-cmd":
 		app.AppConfig.ProvAppDockerCmd = value
 	case "prov-app-agents":
-		app.AppConfig.ProvAppAgents = value
+		if app.effectiveSizingMode() == config.AppSizingModeUnit {
+			// Unit mode only: preserve App Unit per agent, recalculate total credits.
+			// Save previous agents so we can roll back if credit recalculation fails.
+			oldCount := len(app.GetAppAgents())
+			oldUnit := 1
+			if app.preservedLegacyInUnitPolicy() {
+				oldUnit = app.deriveUnitFromStoredResources()
+			} else if oldCount > 0 && app.AppConfig.ProvAppCreditPlanned > 0 {
+				oldUnit = app.AppConfig.ProvAppCreditPlanned / oldCount
+			}
+			prevAgents := app.AppConfig.ProvAppAgents
+			app.AppConfig.ProvAppAgents = value
+			newCount := len(app.GetAppAgents())
+			if newCount == 0 {
+				newCount = 1
+			}
+			if err := app.SetAppProvisionByCredit(oldUnit * newCount); err != nil {
+				app.AppConfig.ProvAppAgents = prevAgents
+				return fmt.Errorf("agent change rejected: %w", err)
+			}
+		} else {
+			// Legacy ("") and Manual: just update agents, no credit recalculation
+			app.AppConfig.ProvAppAgents = value
+		}
 	case "prov-app-template":
 		app.AppConfig.ProvAppTemplate = value
 	case "app-port":
@@ -147,6 +214,10 @@ func (app *App) SetSetting(key, value string) error {
 	case "app-db-schema":
 		app.AppConfig.AppDbSchema = value
 	case "prov-app-credit-planned":
+		effectiveMode := app.effectiveSizingMode()
+		if effectiveMode == config.AppSizingModeManual {
+			return errors.New("prov-app-credit-planned cannot be set in manual mode; use CPU/memory/disk controls instead")
+		}
 		creditPlanSize, err := strconv.Atoi(value)
 		if err != nil {
 			return errors.New("invalid credit planned value: " + value)
@@ -154,15 +225,136 @@ func (app *App) SetSetting(key, value string) error {
 		if creditPlanSize < 1 {
 			return errors.New("credit planned must be greater than or equal to 1")
 		}
-		if err := app.SetAppProvisionByCredit(creditPlanSize); err != nil {
-			return err
+		if effectiveMode == "" {
+			if err := app.SetAppProvisionByLegacyCredit(creditPlanSize); err != nil {
+				return err
+			}
+		} else {
+			if err := app.SetAppProvisionByCredit(creditPlanSize); err != nil {
+				return err
+			}
+		}
+	case "prov-app-sizing-mode":
+		if value == "" {
+			prevAppMode := app.AppConfig.ProvAppSizingMode
+			oldMode := app.effectiveSizingMode()
+			app.AppConfig.ProvAppSizingMode = ""
+			newMode := app.effectiveSizingMode()
+			if newMode == oldMode {
+				return nil
+			}
+			if newMode == config.AppSizingModeUnit {
+				numAgents := len(app.GetAppAgents())
+				if numAgents == 0 {
+					app.AppConfig.ProvAppSizingMode = prevAppMode
+					return errors.New("cannot inherit unit mode: no agents configured")
+				}
+				appUnit := app.deriveUnitFromStoredResources()
+				creditPlanSize := appUnit * numAgents
+				app.AppConfig.ProvAppCreditPlanned = creditPlanSize
+				app.AppConfig.ProvAppCpuCores = strconv.Itoa(appUnit * config.AppUnitCpuCores)
+				app.AppConfig.ProvAppMem = strconv.Itoa(appUnit * config.AppUnitMemMB)
+				app.AppConfig.ProvAppDisk = strconv.Itoa(appUnit * config.AppUnitDiskGB)
+				app.SetReprovCookie()
+				app.ClusterGroup.recomputeAppCredits()
+			}
+			return nil
+		}
+		if value != config.AppSizingModeUnit && value != config.AppSizingModeManual {
+			return errors.New("prov-app-sizing-mode must be 'unit' or 'manual'")
+		}
+		prevAppMode := app.AppConfig.ProvAppSizingMode
+		oldMode := app.effectiveSizingMode()
+		app.AppConfig.ProvAppSizingMode = value
+		// When switching any non-unit mode (legacy "" or manual) → unit:
+		// derive best-fit units from current resources and force-apply resource formula.
+		// We do not call SetAppProvisionByCredit here because its early-exit on matching
+		// credit count would leave resources at old values if the derived credit count
+		// happens to equal the stored planned credits.
+		if value == config.AppSizingModeUnit && oldMode != config.AppSizingModeUnit {
+			numAgents := len(app.GetAppAgents())
+			if numAgents == 0 {
+				app.AppConfig.ProvAppSizingMode = prevAppMode
+				return errors.New("cannot switch to unit mode: no agents configured")
+			}
+			var cores int
+			if app.AppConfig.ProvAppCpuCores != "" {
+				var parseErr error
+				cores, parseErr = strconv.Atoi(app.AppConfig.ProvAppCpuCores)
+				if parseErr != nil {
+					app.AppConfig.ProvAppSizingMode = prevAppMode
+					return fmt.Errorf("cannot switch to unit mode: unparseable cpu-cores %q: %w", app.AppConfig.ProvAppCpuCores, parseErr)
+				}
+			}
+			var memMB int
+			if app.AppConfig.ProvAppMem != "" {
+				var parseErr error
+				memMB, parseErr = config.ParseUnitMeasurementToInt("M", app.AppConfig.ProvAppMem, false)
+				if parseErr != nil {
+					app.AppConfig.ProvAppSizingMode = prevAppMode
+					return fmt.Errorf("cannot switch to unit mode: unparseable memory %q: %w", app.AppConfig.ProvAppMem, parseErr)
+				}
+			}
+			var diskGB int
+			if app.AppConfig.ProvAppDisk != "" {
+				var parseErr error
+				diskGB, parseErr = config.ParseUnitMeasurementToInt("G", app.AppConfig.ProvAppDisk, false)
+				if parseErr != nil {
+					app.AppConfig.ProvAppSizingMode = prevAppMode
+					return fmt.Errorf("cannot switch to unit mode: unparseable disk %q: %w", app.AppConfig.ProvAppDisk, parseErr)
+				}
+			}
+			unitFromCores, unitFromMem, unitFromDisk := 1, 1, 1
+			if cores > config.AppUnitCpuCores {
+				unitFromCores = (cores + config.AppUnitCpuCores - 1) / config.AppUnitCpuCores
+			}
+			if memMB > config.AppUnitMemMB {
+				unitFromMem = (memMB + config.AppUnitMemMB - 1) / config.AppUnitMemMB
+			}
+			if diskGB > config.AppUnitDiskGB {
+				unitFromDisk = (diskGB + config.AppUnitDiskGB - 1) / config.AppUnitDiskGB
+			}
+			appUnit := unitFromCores
+			if unitFromMem > appUnit {
+				appUnit = unitFromMem
+			}
+			if unitFromDisk > appUnit {
+				appUnit = unitFromDisk
+			}
+			creditPlanSize := appUnit * numAgents
+			app.AppConfig.ProvAppCreditPlanned = creditPlanSize
+			app.AppConfig.ProvAppCpuCores = strconv.Itoa(appUnit * config.AppUnitCpuCores)
+			app.AppConfig.ProvAppMem = strconv.Itoa(appUnit * config.AppUnitMemMB)
+			app.AppConfig.ProvAppDisk = strconv.Itoa(appUnit * config.AppUnitDiskGB)
+			app.SetReprovCookie()
 		}
 	case "prov-app-ha-topology":
 		app.AppConfig.ProvAppHATopology = value
+	case "prov-app-cpu-cores":
+		app.AppConfig.ProvAppCpuCores = value
+		if app.effectiveSizingMode() == config.AppSizingModeManual {
+			app.SetReprovCookie()
+		}
+	case "prov-app-memory":
+		app.AppConfig.ProvAppMem = value
+		if app.effectiveSizingMode() == config.AppSizingModeManual {
+			app.SetReprovCookie()
+		}
+	case "prov-app-disk-size":
+		app.AppConfig.ProvAppDisk = value
+		if app.effectiveSizingMode() == config.AppSizingModeManual {
+			app.SetReprovCookie()
+		}
+	case "prov-app-disk-iops":
+		app.AppConfig.ProvAppDiskIops = value
+		if app.effectiveSizingMode() == config.AppSizingModeManual {
+			app.SetReprovCookie()
+		}
 	default:
 		return errors.New("unknown setting: " + key)
 	}
 
+	app.ClusterGroup.recomputeAppCredits()
 	return nil
 }
 
@@ -220,21 +412,52 @@ func (app *App) UpdateVariable(vIndex int, field, newValue string) error {
 func (app *App) SetAppProvisionByCredit(creditPlanSize int) error {
 
 	if creditPlanSize == app.AppConfig.ProvAppCreditPlanned {
-		// No change in credit planned, nothing to do
 		return nil
 	}
 
-	num_agents := len(app.GetAppAgents())
+	numAgents := len(app.GetAppAgents())
 
-	if num_agents == 0 {
+	if numAgents == 0 {
 		return errors.New("no agents available for flex provisioning")
 	}
-	if creditPlanSize%num_agents != 0 {
+	if creditPlanSize%numAgents != 0 {
+		return fmt.Errorf("credit planned (%d) must be a multiple of the number of agents (%d)", creditPlanSize, numAgents)
+	}
+
+	app.AppConfig.ProvAppCreditPlanned = creditPlanSize
+
+	// Unit mode only: apply the App Unit resource formula and trigger reprovision.
+	// Legacy and manual modes are dispatched to their own helpers before this function
+	// is called, so reaching here in a non-unit mode is a no-op.
+	if app.effectiveSizingMode() == config.AppSizingModeUnit {
+		unitsPerAgent := creditPlanSize / numAgents
+		app.AppConfig.ProvAppCpuCores = strconv.Itoa(unitsPerAgent * config.AppUnitCpuCores)
+		app.AppConfig.ProvAppMem = strconv.Itoa(unitsPerAgent * config.AppUnitMemMB)
+		app.AppConfig.ProvAppDisk = strconv.Itoa(unitsPerAgent * config.AppUnitDiskGB)
+		app.SetReprovCookie()
+	}
+
+	return nil
+}
+
+// SetAppProvisionByLegacyCredit is the exact origin/develop SetAppProvisionByCredit
+// logic preserved for legacy-mode apps (ProvAppSizingMode == ""). It uses only the
+// app-level cluster defaults (ProvAppCpuCores / ProvAppMem / ProvAppDisk) with no
+// fallback to the DB-level Prov* fields, matching pre-split behavior exactly.
+func (app *App) SetAppProvisionByLegacyCredit(creditPlanSize int) error {
+	if creditPlanSize == app.AppConfig.ProvAppCreditPlanned {
+		return nil
+	}
+
+	numAgents := len(app.GetAppAgents())
+	if numAgents == 0 {
+		return errors.New("no agents available for flex provisioning")
+	}
+	if creditPlanSize%numAgents != 0 {
 		return errors.New("credit planned must be a multiple of the number of agents for flex provisioning")
 	}
 
-	// For flex provisioning, we divide the credit planned by the number of agents
-	provCredit := creditPlanSize / num_agents
+	provCredit := creditPlanSize / numAgents
 
 	baseCore, err := config.ParseUnitMeasurementToInt("0", app.ClusterGroup.Conf.ProvAppCpuCores, true)
 	if err != nil {
@@ -249,16 +472,10 @@ func (app *App) SetAppProvisionByCredit(creditPlanSize int) error {
 		return err
 	}
 
-	oldCredit := app.AppConfig.ProvAppCreditPlanned
 	app.AppConfig.ProvAppCreditPlanned = creditPlanSize
 	app.AppConfig.ProvAppCpuCores = strconv.Itoa(provCredit * baseCore)
 	app.AppConfig.ProvAppMem = strconv.Itoa(provCredit * baseMemory)
 	app.AppConfig.ProvAppDisk = strconv.Itoa(provCredit * baseDisk)
-
-	// only reduce available credits if the credit planned is greater than the old credit, else do nothing and will update the used credits when application is re-provisioned
-	if creditPlanSize >= oldCredit {
-		app.ClusterGroup.Conf.Cloud18ApplicationCreditsUsed = app.ClusterGroup.Conf.Cloud18ApplicationCreditsUsed + (creditPlanSize - oldCredit)
-	}
 
 	app.SetReprovCookie()
 
@@ -266,7 +483,6 @@ func (app *App) SetAppProvisionByCredit(creditPlanSize int) error {
 }
 
 func (app *App) ApplyPlannedCredits() {
-	// If the planned credits are not equal to the used credits, we need to update the used credits (usually happens when the app is re-provisioned with lower credits)
 	if app.AppConfig.ProvAppCreditPlanned != app.AppConfig.ProvAppCreditUsed {
 		app.AppConfig.ProvAppCreditUsed = app.AppConfig.ProvAppCreditPlanned
 	}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1385,6 +1385,57 @@ type ClusterState struct {
 	IsProvisioned bool      `json:"isProvisioned"`
 }
 
+// recomputeAppCredits recomputes Cloud18ApplicationCreditsUsed and
+// Cloud18ApplicationCreditsPlanned from the current per-app values.
+// Must be called without the cluster lock held.
+func (cluster *Cluster) recomputeAppCredits() {
+	cluster.Lock()
+	used := 0
+	planned := 0
+	for _, app := range cluster.Apps {
+		used += app.AppConfig.ProvAppCreditUsed
+		planned += app.AppConfig.ProvAppCreditPlanned
+	}
+	cluster.Unlock()
+	cluster.Conf.Cloud18ApplicationCreditsUsed = used
+	cluster.Conf.Cloud18ApplicationCreditsPlanned = planned
+}
+
+// ClearAppProvisionedCredits zeros the used credits for app, removes its provision
+// cookie, refreshes cluster totals, and persists the cleared state so restart
+// rebuilds stay correct. Call this after a successful unprovision.
+func (cluster *Cluster) ClearAppProvisionedCredits(app *App) {
+	if app == nil {
+		return
+	}
+	app.AppConfig.ProvAppCreditUsed = 0
+	app.DelProvisionCookie()
+	// Mark explicitly unprovisioned so the status-cycle backfill in IsAppProvisioned
+	// does not re-credit the app if it still briefly appears running.
+	app.SetUnprovisionCookie()
+	cluster.recomputeAppCredits()
+	if _, err := cluster.SaveApp(app, ""); err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlErr, "Failed to persist credit clear for %s: %s", app.Name, err)
+	}
+}
+
+// StartBillingCycle is called when a new sponsorship cycle is accepted.
+// It recomputes totals from apps and, if current usage is below the cap,
+// lowers the cap to match usage (including zero), then persists the new cap.
+// Failures are logged but never propagated — sponsorship is already committed
+// by the time this runs, so a persist failure must not misreport the outcome.
+func (cluster *Cluster) StartBillingCycle() {
+	cluster.recomputeAppCredits()
+	used := cluster.Conf.Cloud18ApplicationCreditsUsed
+	cap := cluster.Conf.Cloud18ApplicationCredits
+	if cap > 0 && used < cap {
+		cluster.Conf.Cloud18ApplicationCredits = used
+		if _, err := cluster.SaveConfigFile(); err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Failed to persist billing cycle cap: %s", err)
+		}
+	}
+}
+
 type ClusterSLAState struct {
 	SLA        state.Sla   `json:"sla"`
 	SLAHistory []state.Sla `json:"slaHistory"`
@@ -2822,13 +2873,11 @@ func (c *Cluster) AddApp(app *App) error {
 	c.bumpAppListVersion()
 	c.Unlock()
 
+	c.recomputeAppCredits()
 	if app.AppConfig.ProvAppCreditPlanned > app.AppConfig.ProvAppCreditUsed {
-		c.Conf.Cloud18ApplicationCreditsUsed += app.AppConfig.ProvAppCreditPlanned
 		if app.HasProvisionCookie() {
 			app.SetReprovCookie()
 		}
-	} else {
-		c.Conf.Cloud18ApplicationCreditsUsed += app.AppConfig.ProvAppCreditUsed
 	}
 	return nil
 }

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -19,8 +19,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"os/user"
+	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
@@ -78,117 +78,117 @@ type ClusterResponse struct {
 }
 
 type Cluster struct {
-	OsUser                        *user.User                 `json:"-"`
-	Name                          string                     `json:"name" groups:"apps,web"`
-	Tenant                        string                     `json:"tenant" groups:"web"`
-	WorkingDir                    string                     `json:"workingDir" groups:"web"`
-	Servers                       serverList                 `json:"servers" groups:"apps"`
-	LogSlaveServers               []string                   `json:"logSlaveServers" groups:"web" ` //To store slave with log-slave-updates
-	ServerIdList                  []string                   `json:"dbServers" groups:"web"`
-	Crashes                       crashList                  `json:"dbServersCrashes" groups:"web"` //This will be purged on all db node up
-	FailoverHistory               crashList                  `json:"failoverHistory" groups:"web"`  //This will be used for PITR
-	Apps                          appList                    `json:"apps" groups:"apps" `
-	AppIdList                     []string                   `json:"appServers" groups:"web"`
-	Proxies                       proxyList                  `json:"proxies" groups:"apps"`
-	ProxyIdList                   []string                   `json:"proxyServers" groups:"web"`
-	FailoverCtr                   int                        `json:"failoverCounter" groups:"web"`
-	FailoverTs                    int64                      `json:"failoverLastTime" groups:"web"`
-	Status                        string                     `json:"activePassiveStatus" groups:"web"`
-	IsSplitBrain                  bool                       `json:"isSplitBrain" groups:"web"`
-	IsSplitBrainBck               bool                       `json:"-"`
-	IsFailedArbitrator            bool                       `json:"isFailedArbitrator" groups:"web"`
-	IsLostMajority                bool                       `json:"isLostMajority" groups:"web"`
-	IsDown                        bool                       `json:"isDown" groups:"web"`
-	IsClusterDown                 bool                       `json:"isClusterDown" groups:"web"`
-	IsMasterDown                  bool                       `json:"isMasterDown" groups:"web"`
-	IsAllDbUp                     bool                       `json:"isAllDbUp" groups:"web"`
-	IsFailable                    bool                       `json:"isFailable" groups:"web"`
-	IsPostgres                    bool                       `json:"isPostgres" groups:"web"`
-	IsProvision                   bool                       `json:"isProvision" groups:"web"`
-	IsNeedProxiesRestart          bool                       `json:"isNeedProxiesRestart" groups:"web"`
-	IsNeedProxiesReprov           bool                       `json:"isNeedProxiesReprov" groups:"web"`
-	IsNeedProxiesConfigChange     bool                       `json:"isNeedProxiesConfigChange" groups:"web"`
-	IsNeedDatabasesRestart        bool                       `json:"isNeedDatabasesRestart" groups:"web"`
-	IsNeedDatabasesRollingRestart bool                       `json:"isNeedDatabasesRollingRestart" groups:"web"`
-	IsNeedDatabasesRollingReprov  bool                       `json:"isNeedDatabasesRollingReprov" groups:"web"`
-	IsNeedDatabasesReprov         bool                       `json:"isNeedDatabasesReprov" groups:"web"`
-	IsNeedDatabasesConfigChange   bool                       `json:"isNeedDatabasesConfigChange" groups:"web"`
-	IsNeedAppsReprov              bool                       `json:"isNeedAppsReprov" groups:"web"`
-	IsGettingSlowLog              bool                       `json:"isGettingSlowLog" groups:"web"`
-	IsValidBackup                 bool                       `json:"isValidBackup" groups:"web"`
-	IsNotMonitoring               bool                       `json:"isNotMonitoring" groups:"web"`
-	HaveSSHKeyChecked             bool                       `json:"-"`
-	IsCapturing                   bool                       `json:"isCapturing" groups:"web"`
-	IsGitPull                     bool                       `json:"isGitPull" groups:"web"`
-	IsGitPush                     bool                       `json:"isGitPush" groups:"web"`
-	IsSavingConfig                bool                       `json:"-"`
-	IsNeedGitPush                 bool                       `json:"-"`
-	IsExportPush                  bool                       `json:"isExportPush" groups:"web"`
-	IsAlertDisable                bool                       `json:"isAlertDisable" groups:"web"`
-	IsIntervention                bool                       `json:"isIntervention" groups:"web"`
-	InterventionCurrent           *InterventionEntry         `json:"interventionCurrent,omitempty" groups:"web"`
-	InterventionHistory           []InterventionEntry        `json:"interventionHistory" groups:"web"`
-	InterventionSuppressedAlerts  int                        `json:"interventionSuppressedAlerts" groups:"web"`
-	InterventionPending           *InterventionEntry         `json:"interventionPending,omitempty" groups:"web"`
-	IsRefreshStaging              bool                       `json:"isRefreshStaging" groups:"web"`
-	IsNeedStagingChange           bool                       `json:"isNeedStagingChange" groups:"web"`
-	IsConfigPathChange            bool                       `json:"isConfigPathChange" groups:"web"`
-	IsResticQueuePaused           bool                       `json:"isResticQueuePaused" groups:"web"`
-	BackupSlotsInUse              int                        `json:"backupSlotsInUse" groups:"web"`
-	BackupSlotsTotal              int                        `json:"backupSlotsTotal" groups:"web"`
-	SchemaMonitorRequested        int32                      `json:"-"`
-	Conf                          *config.Config             `json:"config" groups:"apps"`
-	Confs                         *config.ConfVersion        `json:"-"`
-	CleanAll                      bool                       `json:"cleanReplication" groups:"web"` //used in testing
-	Topology                      string                     `json:"topology" groups:"web"`
-	Uptime                        string                     `json:"uptime" groups:"web"`
-	UptimeFailable                string                     `json:"uptimeFailable" groups:"web"`
-	UptimeSemiSync                string                     `json:"uptimeSemisync" groups:"web"`
-	MonitorSpin                   string                     `json:"monitorSpin" groups:"web"`
-	WorkLoad                      config.WorkLoad            `json:"workLoad" groups:"web"`
-	DockerRepos                   []config.DockerRepo        `json:"-"`
-	Logrus                        *log.Logger                `json:"-"`
-	LogPushover                   *log.Logger                `json:"-"`
-	Log                           s18log.HttpLog             `json:"-" groups:"web"`
-	LogTask                       s18log.HttpLog             `json:"-" groups:"web"`
-	LogSecurity                   s18log.HttpLog             `json:"-" groups:"web"`
-	LogWorkload                   s18log.HttpLog             `json:"-" groups:"web"`
-	LogDDL                        s18log.HttpLog             `json:"-" groups:"web"`
-	LogVariableChange             s18log.HttpLog             `json:"-" groups:"web"`
-	LogSlack                      *slackman.SlackManager     `json:"-"`
-	JobResults                    *config.TasksMap           `json:"jobResults" groups:"web"`
-	FalsePositiveChecks           map[string]bool            `json:"falsePositiveChecks" groups:"web"`
-	Grants                        map[string]string          `json:"-"`
-	Roles                         map[string]string          `json:"-"`
-	tlog                          *s18log.TermLog            `json:"-"`
-	htlog                         *s18log.HttpLog            `json:"-"`
-	SQLGeneralLog                 s18log.HttpLog             `json:"sqlGeneralLog" groups:"web"`
-	SQLErrorLog                   s18log.HttpLog             `json:"sqlErrorLog" groups:"web"`
-	MonitorType                   map[string]string          `json:"monitorType" groups:"web"`
-	TopologyType                  map[string]string          `json:"topologyType" groups:"web"`
-	FSType                        map[string]bool            `json:"fsType" groups:"web"`
-	DiskType                      map[string]string          `json:"diskType" groups:"web"`
-	VMType                        map[string]bool            `json:"vmType" groups:"web"`
-	AppS3Providers                []string                   `json:"appS3Providers" groups:"web"`
-	GatewayConflicts              map[string]string          `json:"gatewayConflicts" groups:"web"`
+	OsUser                        *user.User             `json:"-"`
+	Name                          string                 `json:"name" groups:"apps,web"`
+	Tenant                        string                 `json:"tenant" groups:"web"`
+	WorkingDir                    string                 `json:"workingDir" groups:"web"`
+	Servers                       serverList             `json:"servers" groups:"apps"`
+	LogSlaveServers               []string               `json:"logSlaveServers" groups:"web" ` //To store slave with log-slave-updates
+	ServerIdList                  []string               `json:"dbServers" groups:"web"`
+	Crashes                       crashList              `json:"dbServersCrashes" groups:"web"` //This will be purged on all db node up
+	FailoverHistory               crashList              `json:"failoverHistory" groups:"web"`  //This will be used for PITR
+	Apps                          appList                `json:"apps" groups:"apps" `
+	AppIdList                     []string               `json:"appServers" groups:"web"`
+	Proxies                       proxyList              `json:"proxies" groups:"apps"`
+	ProxyIdList                   []string               `json:"proxyServers" groups:"web"`
+	FailoverCtr                   int                    `json:"failoverCounter" groups:"web"`
+	FailoverTs                    int64                  `json:"failoverLastTime" groups:"web"`
+	Status                        string                 `json:"activePassiveStatus" groups:"web"`
+	IsSplitBrain                  bool                   `json:"isSplitBrain" groups:"web"`
+	IsSplitBrainBck               bool                   `json:"-"`
+	IsFailedArbitrator            bool                   `json:"isFailedArbitrator" groups:"web"`
+	IsLostMajority                bool                   `json:"isLostMajority" groups:"web"`
+	IsDown                        bool                   `json:"isDown" groups:"web"`
+	IsClusterDown                 bool                   `json:"isClusterDown" groups:"web"`
+	IsMasterDown                  bool                   `json:"isMasterDown" groups:"web"`
+	IsAllDbUp                     bool                   `json:"isAllDbUp" groups:"web"`
+	IsFailable                    bool                   `json:"isFailable" groups:"web"`
+	IsPostgres                    bool                   `json:"isPostgres" groups:"web"`
+	IsProvision                   bool                   `json:"isProvision" groups:"web"`
+	IsNeedProxiesRestart          bool                   `json:"isNeedProxiesRestart" groups:"web"`
+	IsNeedProxiesReprov           bool                   `json:"isNeedProxiesReprov" groups:"web"`
+	IsNeedProxiesConfigChange     bool                   `json:"isNeedProxiesConfigChange" groups:"web"`
+	IsNeedDatabasesRestart        bool                   `json:"isNeedDatabasesRestart" groups:"web"`
+	IsNeedDatabasesRollingRestart bool                   `json:"isNeedDatabasesRollingRestart" groups:"web"`
+	IsNeedDatabasesRollingReprov  bool                   `json:"isNeedDatabasesRollingReprov" groups:"web"`
+	IsNeedDatabasesReprov         bool                   `json:"isNeedDatabasesReprov" groups:"web"`
+	IsNeedDatabasesConfigChange   bool                   `json:"isNeedDatabasesConfigChange" groups:"web"`
+	IsNeedAppsReprov              bool                   `json:"isNeedAppsReprov" groups:"web"`
+	IsGettingSlowLog              bool                   `json:"isGettingSlowLog" groups:"web"`
+	IsValidBackup                 bool                   `json:"isValidBackup" groups:"web"`
+	IsNotMonitoring               bool                   `json:"isNotMonitoring" groups:"web"`
+	HaveSSHKeyChecked             bool                   `json:"-"`
+	IsCapturing                   bool                   `json:"isCapturing" groups:"web"`
+	IsGitPull                     bool                   `json:"isGitPull" groups:"web"`
+	IsGitPush                     bool                   `json:"isGitPush" groups:"web"`
+	IsSavingConfig                bool                   `json:"-"`
+	IsNeedGitPush                 bool                   `json:"-"`
+	IsExportPush                  bool                   `json:"isExportPush" groups:"web"`
+	IsAlertDisable                bool                   `json:"isAlertDisable" groups:"web"`
+	IsIntervention                bool                   `json:"isIntervention" groups:"web"`
+	InterventionCurrent           *InterventionEntry     `json:"interventionCurrent,omitempty" groups:"web"`
+	InterventionHistory           []InterventionEntry    `json:"interventionHistory" groups:"web"`
+	InterventionSuppressedAlerts  int                    `json:"interventionSuppressedAlerts" groups:"web"`
+	InterventionPending           *InterventionEntry     `json:"interventionPending,omitempty" groups:"web"`
+	IsRefreshStaging              bool                   `json:"isRefreshStaging" groups:"web"`
+	IsNeedStagingChange           bool                   `json:"isNeedStagingChange" groups:"web"`
+	IsConfigPathChange            bool                   `json:"isConfigPathChange" groups:"web"`
+	IsResticQueuePaused           bool                   `json:"isResticQueuePaused" groups:"web"`
+	BackupSlotsInUse              int                    `json:"backupSlotsInUse" groups:"web"`
+	BackupSlotsTotal              int                    `json:"backupSlotsTotal" groups:"web"`
+	SchemaMonitorRequested        int32                  `json:"-"`
+	Conf                          *config.Config         `json:"config" groups:"apps"`
+	Confs                         *config.ConfVersion    `json:"-"`
+	CleanAll                      bool                   `json:"cleanReplication" groups:"web"` //used in testing
+	Topology                      string                 `json:"topology" groups:"web"`
+	Uptime                        string                 `json:"uptime" groups:"web"`
+	UptimeFailable                string                 `json:"uptimeFailable" groups:"web"`
+	UptimeSemiSync                string                 `json:"uptimeSemisync" groups:"web"`
+	MonitorSpin                   string                 `json:"monitorSpin" groups:"web"`
+	WorkLoad                      config.WorkLoad        `json:"workLoad" groups:"web"`
+	DockerRepos                   []config.DockerRepo    `json:"-"`
+	Logrus                        *log.Logger            `json:"-"`
+	LogPushover                   *log.Logger            `json:"-"`
+	Log                           s18log.HttpLog         `json:"-" groups:"web"`
+	LogTask                       s18log.HttpLog         `json:"-" groups:"web"`
+	LogSecurity                   s18log.HttpLog         `json:"-" groups:"web"`
+	LogWorkload                   s18log.HttpLog         `json:"-" groups:"web"`
+	LogDDL                        s18log.HttpLog         `json:"-" groups:"web"`
+	LogVariableChange             s18log.HttpLog         `json:"-" groups:"web"`
+	LogSlack                      *slackman.SlackManager `json:"-"`
+	JobResults                    *config.TasksMap       `json:"jobResults" groups:"web"`
+	FalsePositiveChecks           map[string]bool        `json:"falsePositiveChecks" groups:"web"`
+	Grants                        map[string]string      `json:"-"`
+	Roles                         map[string]string      `json:"-"`
+	tlog                          *s18log.TermLog        `json:"-"`
+	htlog                         *s18log.HttpLog        `json:"-"`
+	SQLGeneralLog                 s18log.HttpLog         `json:"sqlGeneralLog" groups:"web"`
+	SQLErrorLog                   s18log.HttpLog         `json:"sqlErrorLog" groups:"web"`
+	MonitorType                   map[string]string      `json:"monitorType" groups:"web"`
+	TopologyType                  map[string]string      `json:"topologyType" groups:"web"`
+	FSType                        map[string]bool        `json:"fsType" groups:"web"`
+	DiskType                      map[string]string      `json:"diskType" groups:"web"`
+	VMType                        map[string]bool        `json:"vmType" groups:"web"`
+	AppS3Providers                []string               `json:"appS3Providers" groups:"web"`
+	GatewayConflicts              map[string]string      `json:"gatewayConflicts" groups:"web"`
 	// s3Providers groups S3 provider state and locking primitives in one place.
 	// Use the accessor methods (Add/Remove/Update/GetS3ProvidersSnapshot) and
 	// CRUD transaction lock helpers instead of direct field mutation.
-	s3Providers                   s3ProviderState
-	Agents                        []Agent                    `json:"agents" groups:"web"`
-	AgentMaxFreq                  map[string]int64           `json:"-"`
-	hostList                      []string                   `json:"-"`
-	proxyList                     []string                   `json:"-"`
-	clusterList                   map[string]*Cluster        `json:"-"`
-	clusterOrder                  []string                   `json:"-"` // ClusterList order; index = ownership priority
-	deprecatedKeys                map[string]map[string]bool `json:"-"`
-	slaves                        serverList                 `json:"slaves" groups:"apps"`
-	master                        *ServerMonitor             `json:"master" groups:"apps"`
-	oldMaster                     *ServerMonitor             `json:"oldmaster" groups:"web"`
-	vmaster                       *ServerMonitor             `json:"vmaster" `
-	StagingServer                 *ServerMonitor             `json:"-" groups:"web"`
-	mxs                           *maxscale.MaxScale         `json:"-"`
-	CheckSumConfig                map[string]hash.Hash       `json:"-"`
+	s3Providers    s3ProviderState
+	Agents         []Agent                    `json:"agents" groups:"web"`
+	AgentMaxFreq   map[string]int64           `json:"-"`
+	hostList       []string                   `json:"-"`
+	proxyList      []string                   `json:"-"`
+	clusterList    map[string]*Cluster        `json:"-"`
+	clusterOrder   []string                   `json:"-"` // ClusterList order; index = ownership priority
+	deprecatedKeys map[string]map[string]bool `json:"-"`
+	slaves         serverList                 `json:"slaves" groups:"apps"`
+	master         *ServerMonitor             `json:"master" groups:"apps"`
+	oldMaster      *ServerMonitor             `json:"oldmaster" groups:"web"`
+	vmaster        *ServerMonitor             `json:"vmaster" `
+	StagingServer  *ServerMonitor             `json:"-" groups:"web"`
+	mxs            *maxscale.MaxScale         `json:"-"`
+	CheckSumConfig map[string]hash.Hash       `json:"-"`
 	//dbUser                        string                      `json:"-"`
 	//oldDbUser string `json:"-"`
 	//dbPass                        string                      `json:"-"`
@@ -197,38 +197,38 @@ type Cluster struct {
 	//rplPass                   string                      `json:"-"`
 	//proxysqlUser              string                      `json:"-"`
 	//proxysqlPass              string                      `json:"-"`
-	StateMachine                        *state.StateMachine         `json:"stateMachine" groups:"web"`
-	SecurityStateMachine                *state.StateMachine         `json:"securityStateMachine" groups:"web"`
+	StateMachine         *state.StateMachine `json:"stateMachine" groups:"web"`
+	SecurityStateMachine *state.StateMachine `json:"securityStateMachine" groups:"web"`
 	// WorkloadStateMachine tracks workload/performance findings from Graphite spike-detection
 	// plugins (WORKLOAD severity). Kept separate from the HA StateMachine so performance
 	// noise does not obscure operational cluster health or trigger false failover gates.
-	WorkloadStateMachine                *state.StateMachine         `json:"workloadStateMachine" groups:"web"`
+	WorkloadStateMachine *state.StateMachine `json:"workloadStateMachine" groups:"web"`
 	// SecurityStates is a snapshot of all open security findings from the current monitoring
 	// tick, serialised into the cluster JSON for the dashboard (SecurityStateMachine.CurState
 	// has json:"-" so it cannot be read directly). Updated by CheckLogPlugins.
-	SecurityStates                      []state.State               `json:"securityStates" groups:"web"`
+	SecurityStates []state.State `json:"securityStates" groups:"web"`
 	// SecurityRemediations is the current remediation plan for all open security findings.
 	// Populated alongside SecurityStates in CheckLogPlugins so the dashboard gets
 	// AutoFixable flags, fix tags, and risk levels without a separate API call.
 	// This is the authoritative source — the UI must not duplicate autoFixable logic.
-	SecurityRemediations                RemediationPlan             `json:"securityRemediations" groups:"web"`
+	SecurityRemediations RemediationPlan `json:"securityRemediations" groups:"web"`
 	// WorkloadRemediations is the current remediation plan for actionable workload advisories.
 	// Populated alongside WorkloadStates in CheckLogPlugins.
-	WorkloadRemediations                RemediationPlan             `json:"workloadRemediations" groups:"web"`
+	WorkloadRemediations RemediationPlan `json:"workloadRemediations" groups:"web"`
 	// WorkloadStates is a snapshot of all open workload findings from the current monitoring
 	// tick. Updated by CheckLogPlugins after all servers have been evaluated.
-	WorkloadStates                      []state.State               `json:"workloadStates" groups:"web"`
-	SecurityScore                       SecurityScore               `json:"securityScore" groups:"web"`
+	WorkloadStates []state.State `json:"workloadStates" groups:"web"`
+	SecurityScore  SecurityScore `json:"securityScore" groups:"web"`
 	// Set by dbjob SSH scripts scanning my.cnf/.my.cnf on DB servers
-	SecurityClearPwdConfig              bool                        `json:"securityClearPwdConfig"`
+	SecurityClearPwdConfig bool `json:"securityClearPwdConfig"`
 	// Set by dbjob SSH scripts scanning .bash_history/.mysql_history on DB servers
-	SecurityClearPwdHistory             bool                        `json:"securityClearPwdHistory"`
+	SecurityClearPwdHistory bool `json:"securityClearPwdHistory"`
 	// SecurityLogrus is a dedicated logrus.Logger that writes to security.log.
 	// Set by the server on cluster init. Nil when no log-file is configured.
-	SecurityLogrus                      *log.Logger                 `json:"-"`
+	SecurityLogrus *log.Logger `json:"-"`
 	// WorkloadLogrus is a dedicated logrus.Logger that writes to workload.log.
 	// Set by the server on cluster init. Nil when no log-file is configured.
-	WorkloadLogrus                      *log.Logger                 `json:"-"`
+	WorkloadLogrus *log.Logger `json:"-"`
 	// MaintenanceLogrus is a dedicated logrus.Logger that writes to maintenance.log.
 	// Receives ConstLogModMaintenance events: backup, SST, task execution, purge, etc.
 	// Set by the server on cluster init. Nil when no log-file is configured.
@@ -317,14 +317,14 @@ type Cluster struct {
 	SlavesConnected        int
 	clog                   *clog.Logger `json:"-"`
 	*ClusterGraphite
-	VersionsMap           *config.VersionsMap
-	SessionManager        *tty.SessionManager `json:"-"`
-	SysBenchTpcMResults   []SysBenchTpcResultPerMinute
-	SysbenchHistory       SysbenchLog                  `json:"sysbenchHistory"  groups:"web"`
-	OpenSVCStats          atomic.Value `json:"-"`
-	OrchestratorVersion   string       `json:"-"`
-	orchestratorVersionMu sync.RWMutex `json:"-"`
-	lastOrchestratorProbe time.Time    `json:"-"`
+	VersionsMap            *config.VersionsMap
+	SessionManager         *tty.SessionManager `json:"-"`
+	SysBenchTpcMResults    []SysBenchTpcResultPerMinute
+	SysbenchHistory        SysbenchLog        `json:"sysbenchHistory"  groups:"web"`
+	OpenSVCStats           atomic.Value       `json:"-"`
+	OrchestratorVersion    string             `json:"-"`
+	orchestratorVersionMu  sync.RWMutex       `json:"-"`
+	lastOrchestratorProbe  time.Time          `json:"-"`
 	opensvcPoolInfoCache   []opensvc.PoolInfo `json:"-"`
 	opensvcPoolInfoCacheAt time.Time          `json:"-"`
 	opensvcPoolInfoCacheMu sync.RWMutex       `json:"-"`
@@ -692,9 +692,12 @@ func (cluster *Cluster) InitFromConf() {
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Could not set proxy list %s", err)
 	}
+	persistRebasedAppCreditCap := false
 	err = cluster.newAppList()
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Could not set app list %s", err)
+	} else if cluster.rebaseAppCreditCap() {
+		persistRebasedAppCreditCap = true
 	}
 	//Loading configuration compliances
 	err = cluster.Configurator.Init(*cluster.Conf, cluster.Logrus)
@@ -716,6 +719,12 @@ func (cluster *Cluster) InitFromConf() {
 	cluster.RefreshToolVersions()
 	cluster.initResticLocalDir()
 	cluster.StartResticManager()
+	if persistRebasedAppCreditCap {
+		if _, saveErr := cluster.SaveConfigFile(); saveErr != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
+				"Failed to reconcile credit cap at startup: %s", saveErr)
+		}
+	}
 
 	cluster.Conf.TopologyTarget = cluster.GetTopologyFromConf()
 }
@@ -1298,50 +1307,88 @@ func (s *SecurityScore) ApplyCheck(tag string, pass bool) {
 
 func (s *SecurityScore) getCheck(tag string) bool {
 	switch tag {
-	case "HasSSL":              return s.HasSSL
-	case "HasZeroSSL":         return s.HasZeroSSL
-	case "HasTableEncryption": return s.HasTableEncryption
-	case "HasBinlogEncryption":return s.HasBinlogEncryption
-	case "HasTmpEncryption":   return s.HasTmpEncryption
-	case "HasBackupEncryption":return s.HasBackupEncryption
-	case "HasAuditPlugins":    return s.HasAuditPlugins
-	case "NoEmptyPassword":    return s.NoEmptyPassword
-	case "HasPrepareStatement":return s.HasPrepareStatement
-	case "HasStrongPwd":       return s.HasStrongPwd
-	case "HasProxies":         return s.HasProxies
-	case "HasParsecPlugins":   return s.HasParsecPlugins
-	case "HasPasswordRotation":return s.HasPasswordRotation
-	case "NoWeakAuthPlugin":   return s.NoWeakAuthPlugin
-	case "NoHostnameGrants":   return s.NoHostnameGrants
-	case "NoClearPwdConfigs":  return s.NoClearPwdConfigs
-	case "NoClearPwdHistory":  return s.NoClearPwdHistory
-	case "NoClearPwdBinlogs":  return s.NoClearPwdBinlogs
-	case "HasLastLTS":         return s.HasLastLTS
+	case "HasSSL":
+		return s.HasSSL
+	case "HasZeroSSL":
+		return s.HasZeroSSL
+	case "HasTableEncryption":
+		return s.HasTableEncryption
+	case "HasBinlogEncryption":
+		return s.HasBinlogEncryption
+	case "HasTmpEncryption":
+		return s.HasTmpEncryption
+	case "HasBackupEncryption":
+		return s.HasBackupEncryption
+	case "HasAuditPlugins":
+		return s.HasAuditPlugins
+	case "NoEmptyPassword":
+		return s.NoEmptyPassword
+	case "HasPrepareStatement":
+		return s.HasPrepareStatement
+	case "HasStrongPwd":
+		return s.HasStrongPwd
+	case "HasProxies":
+		return s.HasProxies
+	case "HasParsecPlugins":
+		return s.HasParsecPlugins
+	case "HasPasswordRotation":
+		return s.HasPasswordRotation
+	case "NoWeakAuthPlugin":
+		return s.NoWeakAuthPlugin
+	case "NoHostnameGrants":
+		return s.NoHostnameGrants
+	case "NoClearPwdConfigs":
+		return s.NoClearPwdConfigs
+	case "NoClearPwdHistory":
+		return s.NoClearPwdHistory
+	case "NoClearPwdBinlogs":
+		return s.NoClearPwdBinlogs
+	case "HasLastLTS":
+		return s.HasLastLTS
 	}
 	return false
 }
 
 func (s *SecurityScore) setCheck(tag string, pass bool) {
 	switch tag {
-	case "HasSSL":              s.HasSSL = pass
-	case "HasZeroSSL":         s.HasZeroSSL = pass
-	case "HasTableEncryption": s.HasTableEncryption = pass
-	case "HasBinlogEncryption":s.HasBinlogEncryption = pass
-	case "HasTmpEncryption":   s.HasTmpEncryption = pass
-	case "HasBackupEncryption":s.HasBackupEncryption = pass
-	case "HasAuditPlugins":    s.HasAuditPlugins = pass
-	case "NoEmptyPassword":    s.NoEmptyPassword = pass
-	case "HasPrepareStatement":s.HasPrepareStatement = pass
-	case "HasStrongPwd":       s.HasStrongPwd = pass
-	case "HasProxies":         s.HasProxies = pass
-	case "HasParsecPlugins":   s.HasParsecPlugins = pass
-	case "HasPasswordRotation":s.HasPasswordRotation = pass
-	case "NoWeakAuthPlugin":   s.NoWeakAuthPlugin = pass
-	case "NoHostnameGrants":   s.NoHostnameGrants = pass
-	case "NoClearPwdConfigs":  s.NoClearPwdConfigs = pass
-	case "NoClearPwdHistory":  s.NoClearPwdHistory = pass
-	case "NoClearPwdBinlogs":  s.NoClearPwdBinlogs = pass
-	case "HasLastLTS":         s.HasLastLTS = pass
+	case "HasSSL":
+		s.HasSSL = pass
+	case "HasZeroSSL":
+		s.HasZeroSSL = pass
+	case "HasTableEncryption":
+		s.HasTableEncryption = pass
+	case "HasBinlogEncryption":
+		s.HasBinlogEncryption = pass
+	case "HasTmpEncryption":
+		s.HasTmpEncryption = pass
+	case "HasBackupEncryption":
+		s.HasBackupEncryption = pass
+	case "HasAuditPlugins":
+		s.HasAuditPlugins = pass
+	case "NoEmptyPassword":
+		s.NoEmptyPassword = pass
+	case "HasPrepareStatement":
+		s.HasPrepareStatement = pass
+	case "HasStrongPwd":
+		s.HasStrongPwd = pass
+	case "HasProxies":
+		s.HasProxies = pass
+	case "HasParsecPlugins":
+		s.HasParsecPlugins = pass
+	case "HasPasswordRotation":
+		s.HasPasswordRotation = pass
+	case "NoWeakAuthPlugin":
+		s.NoWeakAuthPlugin = pass
+	case "NoHostnameGrants":
+		s.NoHostnameGrants = pass
+	case "NoClearPwdConfigs":
+		s.NoClearPwdConfigs = pass
+	case "NoClearPwdHistory":
+		s.NoClearPwdHistory = pass
+	case "NoClearPwdBinlogs":
+		s.NoClearPwdBinlogs = pass
+	case "HasLastLTS":
+		s.HasLastLTS = pass
 	}
 }
 
@@ -1362,11 +1409,16 @@ func (s *SecurityScore) Compute() {
 	}
 	s.Score = passed * 100 / len(checks)
 	switch {
-	case s.Score >= 90: s.Grade = "A"
-	case s.Score >= 75: s.Grade = "B"
-	case s.Score >= 60: s.Grade = "C"
-	case s.Score >= 40: s.Grade = "D"
-	default:            s.Grade = "F"
+	case s.Score >= 90:
+		s.Grade = "A"
+	case s.Score >= 75:
+		s.Grade = "B"
+	case s.Score >= 60:
+		s.Grade = "C"
+	case s.Score >= 40:
+		s.Grade = "D"
+	default:
+		s.Grade = "F"
 	}
 }
 
@@ -1379,10 +1431,10 @@ type ClusterState struct {
 	RepmgrOS      string    `json:"repmgrOS"`
 	// Peer health fields — consumed by the BO to build peer.json with health data,
 	// removing the need for direct peer-to-peer HTTP polling.
-	IsDown        bool      `json:"isDown"`
-	IsMasterDown  bool      `json:"isMasterDown"`
-	IsFailable    bool      `json:"isFailable"`
-	IsProvisioned bool      `json:"isProvisioned"`
+	IsDown        bool `json:"isDown"`
+	IsMasterDown  bool `json:"isMasterDown"`
+	IsFailable    bool `json:"isFailable"`
+	IsProvisioned bool `json:"isProvisioned"`
 }
 
 // recomputeAppCredits recomputes Cloud18ApplicationCreditsUsed and
@@ -1399,6 +1451,16 @@ func (cluster *Cluster) recomputeAppCredits() {
 	cluster.Unlock()
 	cluster.Conf.Cloud18ApplicationCreditsUsed = used
 	cluster.Conf.Cloud18ApplicationCreditsPlanned = planned
+}
+
+// rebaseAppCreditCap raises Cloud18ApplicationCredits to the current used total
+// when actual provisioned usage has outgrown the persisted cap.
+func (cluster *Cluster) rebaseAppCreditCap() bool {
+	if cluster.Conf.Cloud18ApplicationCreditsUsed <= cluster.Conf.Cloud18ApplicationCredits {
+		return false
+	}
+	cluster.Conf.Cloud18ApplicationCredits = cluster.Conf.Cloud18ApplicationCreditsUsed
+	return true
 }
 
 // ClearAppProvisionedCredits zeros the used credits for app, removes its provision

--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -27,17 +27,22 @@ func getAppTemplateRepoLock(key string) *sync.Mutex {
 }
 
 func (cluster *Cluster) NewAppConfig(apphost, port string) *config.AppConfig {
-	return &config.AppConfig{
+	agents := cluster.GetAppAgents(nil)
+	appcnf := &config.AppConfig{
 		AppHost:           apphost,
 		AppPort:           port,
 		ProvAppDiskType:   "volume",
-		ProvAppMem:        cluster.GetAppMemory(nil),
-		ProvAppCpuCores:   cluster.GetAppCores(nil),
-		ProvAppDisk:       cluster.GetAppDisk(nil),
-		ProvAppAgents:     cluster.GetAppAgents(nil),
+		ProvAppAgents:     agents,
 		ProvAppHATopology: cluster.GetAppHATopology(nil),
 		Deployment:        config.NewDeploymentConfig(),
 	}
+	// Populate resource fields from cluster defaults so the stored TOML is explicit
+	// and the UI never shows zero resources. Sizing mode stays empty (legacy) — the
+	// operator must explicitly switch to "unit" or "manual" to enable managed sizing.
+	cluster.GetAppMemory(appcnf)
+	cluster.GetAppCores(appcnf)
+	cluster.GetAppDisk(appcnf)
+	return appcnf
 }
 
 func (cluster *Cluster) appendConfAppIfAbsent(appcnf *config.AppConfig) bool {
@@ -980,6 +985,7 @@ func (cluster *Cluster) AddSeededApp(srv, port, dockerImg, template string) erro
 			}
 		}
 	}
+	cluster.recomputeAppCredits()
 	appAdded = false
 	return nil
 }
@@ -1088,6 +1094,19 @@ func (cluster *Cluster) GetAppCores(appcnf *config.AppConfig) string {
 	}
 
 	return cores
+}
+
+func (cluster *Cluster) GetAppDiskIops(appcnf *config.AppConfig) string {
+	if appcnf != nil && appcnf.ProvAppDiskIops != "" {
+		return appcnf.ProvAppDiskIops
+	}
+
+	iops := cluster.Conf.ProvIops
+	if iops != "" && appcnf != nil {
+		appcnf.ProvAppDiskIops = iops
+	}
+
+	return iops
 }
 
 func (cluster *Cluster) GetAppHATopology(appcnf *config.AppConfig) string {

--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -537,6 +537,16 @@ func (cluster *Cluster) LoadAppConfig(dirname, appname string) error {
 			}
 			return fmt.Errorf("invalid deployment path mapping in app config %q", filename)
 		}
+		// Normalize volume sizes. Invalid sizes are preserved as-is and logged as
+		// warnings so that apps with stale persisted configs remain loadable.
+		// OpenSVC provisioning is blocked at the provision entrypoints before any
+		// remote state is written — see validateAppVolumeSizes in prov_opensvc_app.go.
+		if sizeErrs := appcnf.Deployment.NormalizeVolumeSizes(); len(sizeErrs) > 0 {
+			for _, sizeErr := range sizeErrs {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModConfigLoad, config.LvlWarn,
+					"App config %q has invalid volume size (provisioning blocked until fixed): %v", filename, sizeErr)
+			}
+		}
 		// Normalize routes eagerly so in-memory state always has canonical
 		// mode/sourcePort/destPort values, regardless of how old the TOML is.
 		appcnf.Deployment.NormalizeRoutes()

--- a/cluster/cluster_app_template_migration_test.go
+++ b/cluster/cluster_app_template_migration_test.go
@@ -942,3 +942,102 @@ func TestRefreshTemplateContent_RepoSyncFailureWithoutCacheReturnsError(t *testi
 		t.Fatalf("expected repo-related error, got: %v", err)
 	}
 }
+
+// TestLoadAppConfig_InvalidVolumeSizeIsWarningNotFatal verifies that a persisted
+// invalid volume size does not prevent the app config from loading. The raw
+// invalid value must be preserved so the operator can identify and fix it.
+func TestLoadAppConfig_InvalidVolumeSizeIsWarningNotFatal(t *testing.T) {
+	workingDir := t.TempDir()
+	appsDir := filepath.Join(workingDir, "apps")
+	if err := os.MkdirAll(appsDir, 0o755); err != nil {
+		t.Fatalf("mkdir apps dir failed: %v", err)
+	}
+
+	const invalidSizeContent = `
+app-host = "badsize-app"
+app-port = "8080"
+prov-app-memory = "128M"
+prov-app-disk-size = "1G"
+
+[deployment.storages]
+[[deployment.storages.volumes]]
+name = "badsize-app-data"
+poolname = "data"
+volumedir = "data"
+size = "badvalue"
+`
+	if err := os.WriteFile(filepath.Join(appsDir, "badsize-app.toml"), []byte(invalidSizeContent), 0o644); err != nil {
+		t.Fatalf("write app file failed: %v", err)
+	}
+
+	cluster := &Cluster{
+		Name:       "test-cluster",
+		WorkingDir: workingDir,
+		crcTable:   crc64.MakeTable(crc64.ECMA),
+		Conf: &config.Config{
+			WorkingDir:     workingDir,
+			Apps:           make([]*config.AppConfig, 0),
+			DefaultFlagMap: map[string]interface{}{"prov-app-memory": "128M", "prov-app-disk-size": "1G"},
+		},
+	}
+
+	if err := cluster.LoadAppConfig(appsDir, "badsize-app"); err != nil {
+		t.Fatalf("LoadAppConfig must succeed for invalid volume size, got error: %v", err)
+	}
+
+	if len(cluster.Conf.Apps) != 1 {
+		t.Fatalf("expected 1 app loaded, got %d", len(cluster.Conf.Apps))
+	}
+	app := cluster.Conf.Apps[0]
+	if app.Deployment == nil || len(app.Deployment.Storages.Volumes) == 0 {
+		t.Fatal("expected deployment volumes to be present")
+	}
+	if got := app.Deployment.Storages.Volumes[0].Size; got != "badvalue" {
+		t.Fatalf("expected raw invalid size %q preserved, got %q", "badvalue", got)
+	}
+}
+
+// TestLoadAppConfigs_InvalidVolumeSizeLoadsAppButAggregateIsClean verifies that
+// LoadAppConfigs does not return an aggregate error for an app whose only problem
+// is an invalid volume size — the app is loaded with a warning so it remains
+// accessible while the operator fixes the TOML.
+func TestLoadAppConfigs_InvalidVolumeSizeLoadsAppAndNoError(t *testing.T) {
+	workingDir := t.TempDir()
+	appsDir := filepath.Join(workingDir, "apps")
+	if err := os.MkdirAll(appsDir, 0o755); err != nil {
+		t.Fatalf("mkdir apps dir failed: %v", err)
+	}
+
+	const content = `
+app-host = "badsize2"
+app-port = "9090"
+
+[deployment.storages]
+[[deployment.storages.volumes]]
+name = "badsize2-data"
+poolname = "data"
+volumedir = "data"
+size = "notanumber"
+`
+	if err := os.WriteFile(filepath.Join(appsDir, "badsize2.toml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write app file failed: %v", err)
+	}
+
+	cluster := &Cluster{
+		Name:       "test-cluster",
+		WorkingDir: workingDir,
+		crcTable:   crc64.MakeTable(crc64.ECMA),
+		Conf: &config.Config{
+			WorkingDir:     workingDir,
+			Apps:           make([]*config.AppConfig, 0),
+			DefaultFlagMap: map[string]interface{}{},
+		},
+	}
+
+	if err := cluster.LoadAppConfigs(); err != nil {
+		t.Fatalf("LoadAppConfigs must not return error for invalid-size-only app, got: %v", err)
+	}
+	if len(cluster.Conf.Apps) != 1 {
+		t.Fatalf("expected 1 app loaded, got %d", len(cluster.Conf.Apps))
+	}
+}

--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -1216,8 +1216,8 @@ func (cluster *Cluster) CheckDefaultUser(i bool) {
 }
 
 func (cluster *Cluster) CheckAvailableCredit() {
-	if cluster.Conf.Cloud18ApplicationCreditsUsed > cluster.Conf.Cloud18ApplicationCredits {
-		cluster.SetState("CREDIT01", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(config.ClusterError["CREDIT01"], cluster.Conf.Cloud18ApplicationCredits, cluster.Conf.Cloud18ApplicationCreditsUsed), ErrFrom: "CLUSTER"})
+	if cluster.Conf.Cloud18ApplicationCreditsPlanned > cluster.Conf.Cloud18ApplicationCredits {
+		cluster.SetState("CREDIT01", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(config.ClusterError["CREDIT01"], cluster.Conf.Cloud18ApplicationCredits, cluster.Conf.Cloud18ApplicationCreditsPlanned), ErrFrom: "CLUSTER"})
 	}
 }
 

--- a/cluster/cluster_del.go
+++ b/cluster/cluster_del.go
@@ -204,6 +204,7 @@ func (cluster *Cluster) RemoveAppMonitor(host string, port string) error {
 		}
 		cluster.Unlock()
 		cluster.StateMachine.RemoveFailoverState()
+		cluster.recomputeAppCredits()
 	} else {
 		return fmt.Errorf("App with address %s:%s not found in cluster", host, port)
 	}

--- a/cluster/cluster_has.go
+++ b/cluster/cluster_has.go
@@ -125,16 +125,27 @@ func (cluster *Cluster) IsProvisioned() bool {
 }
 
 func (cluster *Cluster) IsAppProvisioned() bool {
-	if cluster.Conf.AppHosts == "" {
+	if len(cluster.Apps) == 0 {
 		return true
 	}
 
 	for _, app := range cluster.Apps {
 		if !app.HasProvisionCookie() {
-			if app.IsRunning() {
+			if app.IsRunning() && !app.HasUnprovisionCookie() {
+				// App is running without a provision cookie — recover state from a restart.
+				// Skip entirely when the unprovision cookie is present: the app was explicitly
+				// unprovisioned and may just be in a brief shutdown transition.
 				app.SetProvisionCookie()
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Can App Connect creating cookie state:%s", app.GetState())
-			} else {
+				if app.AppConfig.ProvAppCreditUsed == 0 && app.AppConfig.ProvAppCreditPlanned > 0 {
+					app.AppConfig.ProvAppCreditUsed = app.AppConfig.ProvAppCreditPlanned
+					if _, err := cluster.SaveApp(app, ""); err != nil {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlErr,
+							"Failed to persist backfilled credit usage for %s: %s", app.Name, err)
+					}
+					cluster.recomputeAppCredits()
+				}
+			} else if !app.IsRunning() {
 				return false
 			}
 		}

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -41,6 +41,7 @@ func (cluster *Cluster) SetStatus() {
 	cluster.IsCapturing = cluster.IsInCaptureMode()
 	cluster.MonitorSpin = fmt.Sprintf("%d ", cluster.GetStateMachine().GetHeartbeats())
 	cluster.IsProvision = cluster.IsProvisioned()
+	cluster.IsAppProvisioned()
 	cluster.IsNeedProxiesRestart = cluster.HasRequestProxiesRestart()
 	cluster.IsNeedProxiesReprov = cluster.HasRequestProxiesReprov()
 	cluster.IsNeedDatabasesConfigChange = cluster.HasRequestDBConfigChange()

--- a/cluster/path_mapping_compat_test.go
+++ b/cluster/path_mapping_compat_test.go
@@ -722,3 +722,132 @@ func TestPathMapsSort_UsesLevelThenPath(t *testing.T) {
 		t.Fatalf("expected level-1 paths sorted by dockerpath, got %q then %q", paths[1].Name, paths[2].Name)
 	}
 }
+
+// TestOpenSVCAppVolumeSection_UsesEnvSizeWhenNoOverride confirms that a volume
+// with a blank Size emits "{env.size}" so provisioning falls back to the
+// app-wide disk size.
+func TestOpenSVCAppVolumeSection_UsesEnvSizeWhenNoOverride(t *testing.T) {
+	vol := &config.Volume{Name: "myapp-data", PoolName: "data", VolumeDir: "data", Size: ""}
+	section := openSVCAppVolumeSection(vol, map[string][]string{}, false)
+	if section["size"] != "{env.size}" {
+		t.Fatalf("expected size={env.size} for blank override, got %q", section["size"])
+	}
+}
+
+// TestOpenSVCAppVolumeSection_UsesOverrideSizeWhenSet confirms that a volume
+// with a non-blank Size emits the override value with a "g" suffix, matching
+// the format used by cluster.GetAppDisk.
+func TestOpenSVCAppVolumeSection_UsesOverrideSizeWhenSet(t *testing.T) {
+	vol := &config.Volume{Name: "myapp-data", PoolName: "data", VolumeDir: "data", Size: "10"}
+	section := openSVCAppVolumeSection(vol, map[string][]string{}, false)
+	if section["size"] != "10g" {
+		t.Fatalf("expected size=10g for override=10, got %q", section["size"])
+	}
+}
+
+// TestOpenSVCAppVolumeSection_SharedVolume confirms that the size override
+// is independent of the shared flag.
+func TestOpenSVCAppVolumeSection_SharedVolume(t *testing.T) {
+	vol := &config.Volume{Name: "shared-data", PoolName: "shared", VolumeDir: "data", Size: "20"}
+	section := openSVCAppVolumeSection(vol, map[string][]string{}, true)
+	if section["size"] != "20g" {
+		t.Fatalf("expected size=20g for shared override=20, got %q", section["size"])
+	}
+	if section["shared"] != "true" {
+		t.Fatalf("expected shared=true, got %q", section["shared"])
+	}
+}
+
+// TestOpenSVCAppVolumeSection_SizeRendering documents the rendering contract of
+// the low-level helper: blank → {env.size}, valid normalized → <n>g, raw
+// invalid → <invalid>g.  This shows why provision-only validation must live
+// upstream (in validateAppVolumeSizes) rather than here, so preview/MD5
+// paths are not affected.
+func TestOpenSVCAppVolumeSection_SizeRendering(t *testing.T) {
+	cases := []struct {
+		size string
+		want string
+	}{
+		{"", "{env.size}"},
+		{"10", "10g"},
+		{"badvalue", "badvalueg"},
+	}
+	for _, tc := range cases {
+		vol := &config.Volume{Name: "vol", PoolName: "data", VolumeDir: "data", Size: tc.size}
+		section := openSVCAppVolumeSection(vol, map[string][]string{}, false)
+		if section["size"] != tc.want {
+			t.Errorf("openSVCAppVolumeSection size=%q: got %q, want %q", tc.size, section["size"], tc.want)
+		}
+	}
+}
+
+// TestValidateAppVolumeSizes_RejectsInvalidSize verifies that the provision-only
+// validator returns an error for an invalid persisted size, including the app
+// name, volume name, and raw value in the message.
+func TestValidateAppVolumeSizes_RejectsInvalidSize(t *testing.T) {
+	app := &App{
+		AppConfig: &config.AppConfig{
+			AppHost: "myapp",
+			Deployment: func() *config.Deployment {
+				d := config.NewDeploymentConfig()
+				d.Storages.Volumes = config.Volumes{
+					{Name: "myapp-data", PoolName: "data", VolumeDir: "data", Size: "badvalue"},
+				}
+				return d
+			}(),
+		},
+	}
+
+	err := validateAppVolumeSizes(app)
+	if err == nil {
+		t.Fatal("validateAppVolumeSizes: expected error for invalid size, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"myapp", "myapp-data", "badvalue"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q: %s", want, msg)
+		}
+	}
+}
+
+// TestValidateAppVolumeSizes_AllowsBlankSize verifies that a volume with no
+// size override is accepted (blank means inherit the app-wide default).
+func TestValidateAppVolumeSizes_AllowsBlankSize(t *testing.T) {
+	app := &App{
+		AppConfig: &config.AppConfig{
+			AppHost: "myapp",
+			Deployment: func() *config.Deployment {
+				d := config.NewDeploymentConfig()
+				d.Storages.Volumes = config.Volumes{
+					{Name: "myapp-data", PoolName: "data", VolumeDir: "data", Size: ""},
+				}
+				return d
+			}(),
+		},
+	}
+	if err := validateAppVolumeSizes(app); err != nil {
+		t.Fatalf("validateAppVolumeSizes: unexpected error for blank size: %v", err)
+	}
+}
+
+// TestValidateAppVolumeSizes_AllowsValidSizes verifies that correctly formatted
+// size strings ("10", "10G", "2T") are accepted by the provision validator.
+func TestValidateAppVolumeSizes_AllowsValidSizes(t *testing.T) {
+	for _, size := range []string{"10", "10G", "2T"} {
+		app := &App{
+			AppConfig: &config.AppConfig{
+				AppHost: "myapp",
+				Deployment: func() *config.Deployment {
+					d := config.NewDeploymentConfig()
+					d.Storages.Volumes = config.Volumes{
+						{Name: "myapp-data", PoolName: "data", VolumeDir: "data", Size: size},
+					}
+					return d
+				}(),
+			},
+		}
+		if err := validateAppVolumeSizes(app); err != nil {
+			t.Errorf("validateAppVolumeSizes: unexpected error for size=%q: %v", size, err)
+		}
+	}
+}

--- a/cluster/prov.go
+++ b/cluster/prov.go
@@ -254,8 +254,7 @@ func (cluster *Cluster) InitAppService(app *App) error {
 			// Rebase cap upward if actual provisioned usage now exceeds it.
 			// No cap > 0 guard: StartBillingCycle may have legitimately zeroed the cap,
 			// and a fresh provision must still be able to raise it.
-			if cluster.Conf.Cloud18ApplicationCreditsUsed > cluster.Conf.Cloud18ApplicationCredits {
-				cluster.Conf.Cloud18ApplicationCredits = cluster.Conf.Cloud18ApplicationCreditsUsed
+			if cluster.rebaseAppCreditCap() {
 				if _, saveErr := cluster.SaveConfigFile(); saveErr != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlErr, "Failed to persist rebased credit cap for %s: %s", app.Name, saveErr)
 				}

--- a/cluster/prov.go
+++ b/cluster/prov.go
@@ -235,10 +235,6 @@ func (cluster *Cluster) InitProxyService(prx DatabaseProxy) error {
 }
 
 func (cluster *Cluster) InitAppService(app *App) error {
-	if app != nil {
-		app.ApplyPlannedCredits()
-	}
-
 	switch cluster.GetOrchestrator() {
 	case config.ConstOrchestratorOpenSVC:
 		go cluster.OpenSVCProvisionAppService(app)
@@ -249,6 +245,23 @@ func (cluster *Cluster) InitAppService(app *App) error {
 	err := <-cluster.errorChan
 	cluster.StateMachine.RemoveFailoverState()
 	if err == nil {
+		if app != nil {
+			app.ApplyPlannedCredits()
+			cluster.recomputeAppCredits()
+			if _, saveErr := cluster.SaveApp(app, ""); saveErr != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlErr, "Failed to persist credit usage for %s: %s", app.Name, saveErr)
+			}
+			// Rebase cap upward if actual provisioned usage now exceeds it.
+			// No cap > 0 guard: StartBillingCycle may have legitimately zeroed the cap,
+			// and a fresh provision must still be able to raise it.
+			if cluster.Conf.Cloud18ApplicationCreditsUsed > cluster.Conf.Cloud18ApplicationCredits {
+				cluster.Conf.Cloud18ApplicationCredits = cluster.Conf.Cloud18ApplicationCreditsUsed
+				if _, saveErr := cluster.SaveConfigFile(); saveErr != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlErr, "Failed to persist rebased credit cap for %s: %s", app.Name, saveErr)
+				}
+			}
+		}
+		app.DelUnprovisionCookie()
 		app.SetProvisionCookie()
 	} else {
 		return err

--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -259,7 +259,31 @@ func (cluster *Cluster) OpenSVCClearAppInstanceState(app *App, node string) erro
 	return nil
 }
 
+// validateAppVolumeSizes checks that every non-blank volume Size in the app's
+// deployment is a valid size string.  It validates without mutating or logging
+// so it is safe to call from any provision entrypoint.  Returns the first
+// invalid entry as an error that names the app, volume, and raw size.
+func validateAppVolumeSizes(app *App) error {
+	if app.AppConfig == nil || app.AppConfig.Deployment == nil {
+		return nil
+	}
+	appcnf := app.AppConfig
+	for _, vol := range appcnf.Deployment.Storages.Volumes {
+		if vol.Size == "" {
+			continue
+		}
+		if _, err := config.NormalizeVolumeSize(vol.Size); err != nil {
+			return fmt.Errorf("app %q volume %q has invalid persisted size %q: fix the TOML and reload before provisioning", appcnf.AppHost, vol.Name, vol.Size)
+		}
+	}
+	return nil
+}
+
 func (cluster *Cluster) OpenSVCProvisionAppV3(app *App, svc opensvc.Collector, agent opensvc.Host) error {
+	if err := validateAppVolumeSizes(app); err != nil {
+		return err
+	}
+
 	err := cluster.OpenSVCCreateAppVariableMaps(agent.Node_name, app)
 	if err != nil {
 		return err
@@ -324,6 +348,12 @@ func (cluster *Cluster) OpenSVCProvisionAppService(app *App) error {
 		}
 		cluster.errorChan <- nil
 		return nil
+	}
+
+	if err := validateAppVolumeSizes(app); err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not provision app: %s", err)
+		cluster.errorChan <- err
+		return err
 	}
 
 	err = cluster.OpenSVCCreateAppVariableMaps(agent.Node_name, app)
@@ -531,7 +561,11 @@ func openSVCAppVolumeSection(vol *config.Volume, pathmap map[string][]string, sh
 	svcvol := make(map[string]string)
 	svcvol["name"] = vol.Name
 	svcvol["pool"] = vol.PoolName
-	svcvol["size"] = "{env.size}"
+	if vol.Size != "" {
+		svcvol["size"] = vol.Size + "g"
+	} else {
+		svcvol["size"] = "{env.size}"
+	}
 	if shared {
 		svcvol["shared"] = "true"
 	}

--- a/config/app_template_canonical_test.go
+++ b/config/app_template_canonical_test.go
@@ -1022,3 +1022,66 @@ func TestAppConfigVersionFromRaw(t *testing.T) {
 		t.Fatalf("expected 0 for non-numeric marker, got %d", v)
 	}
 }
+
+// TestCanonicalizeV1Merge_SizeFirstRowWins confirms that when V1 same-pool
+// duplicates are merged, the first row's size value is kept and later rows'
+// conflicting size values are dropped.
+func TestCanonicalizeV1Merge_SizeFirstRowWins(t *testing.T) {
+	content := []byte(`
+[deployment.storages]
+[[deployment.storages.volumes]]
+name = "row1"
+poolname = "data"
+volumedir = "etc"
+size = "10"
+
+[[deployment.storages.volumes]]
+name = "row2"
+poolname = "data"
+volumedir = "log"
+size = "20"
+`)
+
+	out, _, err := CanonicalizeAppVolumesTOML(content, "myapp")
+	if err != nil {
+		t.Fatalf("CanonicalizeAppVolumesTOML error: %v", err)
+	}
+
+	// The merged row should keep first-row size "10".
+	if !strings.Contains(string(out), `size = "10"`) {
+		t.Fatalf("expected merged row to keep first-row size=10, got:\n%s", out)
+	}
+	// The second row's size "20" must not survive.
+	if strings.Count(string(out), "size") > 1 {
+		t.Fatalf("expected only one size entry in merged output, got:\n%s", out)
+	}
+}
+
+// TestCanonicalizeV1Merge_BlankSizeKept confirms that a blank size on the
+// first row is preserved (blank = inherit app default) and not overwritten
+// by a non-blank size from a later row.
+func TestCanonicalizeV1Merge_BlankSizeKept(t *testing.T) {
+	content := []byte(`
+[deployment.storages]
+[[deployment.storages.volumes]]
+name = "row1"
+poolname = "data"
+volumedir = "etc"
+
+[[deployment.storages.volumes]]
+name = "row2"
+poolname = "data"
+volumedir = "log"
+size = "20"
+`)
+
+	out, _, err := CanonicalizeAppVolumesTOML(content, "myapp")
+	if err != nil {
+		t.Fatalf("CanonicalizeAppVolumesTOML error: %v", err)
+	}
+
+	// No size entry from the second row should appear.
+	if strings.Contains(string(out), `size = "20"`) {
+		t.Fatalf("expected second-row size to be dropped from merged output, got:\n%s", out)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -687,6 +687,7 @@ type Config struct {
 	ProvAppCpuCores                           string                       `mapstructure:"prov-app-cpu-cores" toml:"prov-app-cpu-cores" json:"provAppCpuCores" groups:"apps"`
 	ProvAppAgents                             string                       `mapstructure:"prov-app-agents" toml:"prov-app-agents" json:"provAppAgents" groups:"apps"`
 	ProvAppHATopology                         string                       `mapstructure:"prov-app-ha-topology" toml:"prov-app-ha-topology" json:"provAppHaTopology" groups:"apps"`
+	ProvAppSizingMode                         string                       `mapstructure:"prov-app-sizing-mode" toml:"prov-app-sizing-mode" json:"provAppSizingMode" groups:"apps"`
 	ProvAppTemplateRepo                       string                       `mapstructure:"prov-app-template-repo" toml:"prov-app-template-repo" json:"provAppTemplateRepo" groups:"apps"`
 	ProvAppTemplateRepoBranch                 string                       `mapstructure:"prov-app-template-repo-branch" toml:"prov-app-template-repo-branch" json:"provAppTemplateRepoBranch" groups:"apps"`
 	ProvAppTemplateRepoUser                   string                       `mapstructure:"prov-app-template-repo-user" toml:"prov-app-template-repo-user" json:"provAppTemplateRepoUser" groups:"apps"`
@@ -962,7 +963,8 @@ type Config struct {
 	Cloud18AlertSlackUser                  string                 `mapstructure:"cloud18-alert-slack-user"  toml:"cloud18-alert-slack-user" json:"cloud18AlertSlackUser"`
 	Cloud18HealthRefreshInterval           int                    `mapstructure:"cloud18-health-refresh-interval"  toml:"cloud18-health-refresh-interval" json:"cloud18HealthRefreshInterval"`
 	Cloud18ApplicationCredits              int                    `mapstructure:"cloud18-application-credits" toml:"Cloud18-application-credits" json:"cloud18ApplicationCredits"`
-	Cloud18ApplicationCreditsUsed          int                    `mapstructure:"cloud18-application-credits-used" toml:"Cloud18-application-credits-used" json:"cloud18ApplicationCreditsUsed"`
+	Cloud18ApplicationCreditsUsed          int                    `mapstructure:"-" toml:"-" json:"cloud18ApplicationCreditsUsed"`
+	Cloud18ApplicationCreditsPlanned       int                    `mapstructure:"-" toml:"-" json:"cloud18ApplicationCreditsPlanned"`
 	Cloud18ApplicationCreditsPrice         int                    `mapstructure:"cloud18-application-credits-price" toml:"Cloud18-application-credits-price" json:"cloud18ApplicationCreditsPrice"`
 	ProvRegister                           bool                   `mapstructure:"opensvc-register" toml:"opensvc-register" json:"opensvcRegister"`
 	ProvAdminUser                          string                 `mapstructure:"opensvc-admin-user" toml:"opensvc-admin-user" json:"opensvcAdminUser"`
@@ -1009,6 +1011,7 @@ type AppConfig struct {
 	ProvAppMem            string `measurement:"M,bytes,required" mapstructure:"prov-app-memory" toml:"prov-app-memory" json:"provAppMemory"`
 	ProvAppCpuCores       string `mapstructure:"prov-app-cpu-cores" toml:"prov-app-cpu-cores" json:"provAppCpuCores"`
 	ProvAppDisk           string `measurement:"G,bytes,required" mapstructure:"prov-app-disk-size" toml:"prov-app-disk-size" json:"provAppDiskSize"`
+	ProvAppDiskIops       string `mapstructure:"prov-app-disk-iops" toml:"prov-app-disk-iops" json:"provAppDiskIops"`
 	ProvAppDiskType       string `mapstructure:"prov-app-disk-type" toml:"prov-app-disk-type" json:"provAppDiskType"`
 	ProvAppDockerImg      string `mapstructure:"prov-app-docker-img" toml:"prov-app-docker-img" json:"provAppDockerImg"`
 	ProvAppDockerCmd      string `mapstructure:"prov-app-docker-cmd" toml:"prov-app-docker-cmd" json:"provAppDockerCmd"`
@@ -1021,6 +1024,7 @@ type AppConfig struct {
 	ProvAppAgentsFailover string `mapstructure:"prov-app-agents-failover" toml:"prov-app-agents-failover" json:"provAppAgentsFailover"`
 	ProvAppCreditUsed     int    `mapstructure:"prov-app-credit-used" toml:"prov-app-credit-used" json:"provAppCreditUsed"`
 	ProvAppCreditPlanned  int    `mapstructure:"prov-app-credit-planned" toml:"prov-app-credit-planned" json:"provAppCreditPlanned"`
+	ProvAppSizingMode     string `mapstructure:"prov-app-sizing-mode" toml:"prov-app-sizing-mode" json:"provAppSizingMode"`
 	AppHost               string `mapstructure:"app-host" toml:"app-host" json:"appHost"`
 	AppHostsIPV6          string `mapstructure:"app-hosts-ipv6" toml:"app-hosts-ipv6" json:"appHostsIpv6"`
 	AppPort               string `mapstructure:"app-port" toml:"app-port" json:"appPort"`
@@ -1218,6 +1222,19 @@ const (
 	ConstResticS3ModeAuto   string = "auto"
 	ConstResticS3ModeNew    string = "new"
 	ConstResticS3ModeLegacy string = "legacy"
+)
+
+// App sizing modes: unit = credit-based/App Unit sizing; manual = direct resource editing.
+const (
+	AppSizingModeUnit   = "unit"
+	AppSizingModeManual = "manual"
+)
+
+// Fixed resource quantities that define one App Unit.
+const (
+	AppUnitCpuCores = 1    // 1 core per App Unit
+	AppUnitMemMB    = 4096 // 4 GB per App Unit (in MB)
+	AppUnitDiskGB   = 10   // 10 GB per App Unit
 )
 const (
 	ConstProxyMaxscale    string = "maxscale"

--- a/config/deployment.go
+++ b/config/deployment.go
@@ -91,6 +91,13 @@ func (d *Deployment) InsertVolume(v *Volume, appConfigVersion int) error {
 
 	// Normalize before validating so duplicate/empty tokens don't slip in.
 	v.VolumeDir = NormalizeVolumeDirs(v.VolumeDir)
+	if v.Size != "" {
+		normalized, err := NormalizeVolumeSize(v.Size)
+		if err != nil {
+			return fmt.Errorf("invalid volume size: %w", err)
+		}
+		v.Size = normalized
+	}
 
 	if err := v.Validate(); err != nil {
 		return err
@@ -1334,6 +1341,47 @@ type Volume struct {
 	Name      string `mapstructure:"name" toml:"name" json:"name" groups:"apps"`
 	PoolName  string `mapstructure:"poolname" toml:"poolname" json:"poolname" groups:"apps"`
 	VolumeDir string `mapstructure:"volumedir" toml:"volumedir" json:"volumedir" options:"etc|log|var|data" groups:"apps"`
+	Size      string `mapstructure:"size" toml:"size" json:"size" groups:"apps"`
+}
+
+// NormalizeVolumeSize normalizes a per-volume size override using the same
+// measurement convention as the app-wide disk size (base unit: G, 1024-based).
+// An empty input is returned as-is — empty means inherit the app-wide default.
+func NormalizeVolumeSize(size string) (string, error) {
+	if size == "" {
+		return "", nil
+	}
+	mtag, err := GetTagDetails("G,bytes")
+	if err != nil {
+		return size, err
+	}
+	return ParseUnitMeasurement(mtag, size, false)
+}
+
+// NormalizeVolumeSizes normalizes the Size field on every saved volume row,
+// applying the same G-based measurement convention used by NormalizeVolumeSize.
+// Rows with blank Size are left untouched. Rows with an invalid Size value are
+// left as-is and an error is returned for each offending row; the caller should
+// treat any returned errors as fatal so provisioning never runs against a
+// malformed size. Call this after loading a deployment from TOML, alongside
+// NormalizeRoutes.
+func (d *Deployment) NormalizeVolumeSizes() []error {
+	d.Mutex.Lock()
+	defer d.Mutex.Unlock()
+
+	var errs []error
+	for _, v := range d.Storages.Volumes {
+		if v.Size == "" {
+			continue
+		}
+		normalized, err := NormalizeVolumeSize(v.Size)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("volume %q: invalid size %q: %w", v.Name, v.Size, err))
+			continue
+		}
+		v.Size = normalized
+	}
+	return errs
 }
 
 // AppMountVolumeDir is the directory token used to select (or seed) the app

--- a/config/deployment_test.go
+++ b/config/deployment_test.go
@@ -300,3 +300,116 @@ func TestVolumes_GroupByPool_SupportsLegacyDuplicateRows(t *testing.T) {
 		t.Fatalf("grouped[docs] = %v, want docs-volume=docs", grouped["docs"])
 	}
 }
+
+func TestNormalizeVolumeSize(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"empty inherits default", "", "", false},
+		{"G unit stays G-based", "10G", "10", false},
+		{"T unit converts to G", "2T", "2048", false},
+		{"raw number passthrough", "20", "20", false},
+		{"invalid string", "badvalue", "", true},
+		{"M unit below G rejected", "500M", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NormalizeVolumeSize(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("NormalizeVolumeSize(%q) expected error, got %q", tc.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeVolumeSize(%q) unexpected error: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Fatalf("NormalizeVolumeSize(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeployment_InsertVolume_NormalizesSize(t *testing.T) {
+	d := NewDeploymentConfig()
+	d.Storages = *NewStorageMapping()
+
+	err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "data", VolumeDir: "data", Size: "10G"}, 0)
+	if err != nil {
+		t.Fatalf("InsertVolume() error = %v", err)
+	}
+
+	got, err := d.GetVolumeByName("data-volume")
+	if err != nil {
+		t.Fatalf("GetVolumeByName() error = %v", err)
+	}
+	if got.Size != "10" {
+		t.Fatalf("Size = %q, want %q", got.Size, "10")
+	}
+}
+
+func TestDeployment_InsertVolume_BlankSizeInheritsDefault(t *testing.T) {
+	d := NewDeploymentConfig()
+	d.Storages = *NewStorageMapping()
+
+	err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "data", VolumeDir: "data", Size: ""}, 0)
+	if err != nil {
+		t.Fatalf("InsertVolume() error = %v", err)
+	}
+
+	got, _ := d.GetVolumeByName("data-volume")
+	if got.Size != "" {
+		t.Fatalf("expected blank Size to remain blank, got %q", got.Size)
+	}
+}
+
+func TestDeployment_InsertVolume_RejectsInvalidSize(t *testing.T) {
+	d := NewDeploymentConfig()
+	d.Storages = *NewStorageMapping()
+
+	err := d.InsertVolume(&Volume{Name: "data-volume", PoolName: "data", VolumeDir: "data", Size: "invalid"}, 0)
+	if err == nil {
+		t.Fatal("InsertVolume() expected error for invalid size, got nil")
+	}
+}
+
+func TestDeployment_NormalizeVolumeSizes_LoadPath(t *testing.T) {
+	cases := []struct {
+		name      string
+		rawSize   string
+		wantSize  string
+		wantError bool
+	}{
+		{"G unit normalized", "10G", "10", false},
+		{"T unit converted to G", "2T", "2048", false},
+		{"already normalized number", "20", "20", false},
+		{"blank preserved", "", "", false},
+		// Invalid size must NOT be cleared — the raw value is left intact so
+		// the operator can identify and fix it. An error is returned so the
+		// caller can block provisioning.
+		{"invalid returns error and preserves raw value", "badvalue", "badvalue", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewDeploymentConfig()
+			d.Storages = *NewStorageMapping()
+			d.Storages.Volumes = Volumes{
+				{Name: "vol", PoolName: "data", VolumeDir: "data", Size: tc.rawSize},
+			}
+			errs := d.NormalizeVolumeSizes()
+			if d.Storages.Volumes[0].Size != tc.wantSize {
+				t.Fatalf("NormalizeVolumeSizes() Size = %q, want %q", d.Storages.Volumes[0].Size, tc.wantSize)
+			}
+			if tc.wantError && len(errs) == 0 {
+				t.Fatal("NormalizeVolumeSizes() expected an error for invalid size, got none")
+			}
+			if !tc.wantError && len(errs) > 0 {
+				t.Fatalf("NormalizeVolumeSizes() unexpected errors: %v", errs)
+			}
+		})
+	}
+}

--- a/config/error.go
+++ b/config/error.go
@@ -16,7 +16,7 @@ var ClusterError = map[string]string{
 	"APPERR003": "Error connecting to application %s via TCP. Err: %s",
 	"APPERR004": "Unsupported protocol %s for application %s",
 	"APPERR005": "Gateway route conflict for application %s: %s — gateway routes blocked, fix route config to resolve",
-	"CREDIT01":  "Cluster has exceeded available credits. Credits: (%d), Total Usage: (%d). Additional charge may apply.",
+	"CREDIT01":  "Credit cap (%d) exceeded by planned allocation (%d). Over-subscription is allowed; cap auto-rebases to actual usage on successful provision.",
 	"CREDIT02":  "Application %s has negative planned credit (%d). Please check the configuration.",
 	"CREDIT03":  "Application %s has negative used credit (%d). Please check the configuration.",
 	"CREDIT04":  "Application %s has planned credit (%d) not equal to used credit (%d). Please provision the application again to implement the changes.",

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -1038,6 +1038,7 @@ func (repman *ReplicationManager) handlerMuxAppUnprovision(w http.ResponseWriter
 				http.Error(w, fmt.Sprintf("Can not unprovision app service: %s", err), http.StatusInternalServerError)
 				return
 			}
+			mycluster.ClearAppProvisionedCredits(node)
 		} else {
 			http.Error(w, "Server Not Found", http.StatusInternalServerError)
 			return
@@ -3663,6 +3664,7 @@ func applyTemplateOwnedProjection(dst, src *config.AppConfig, templateName strin
 	dst.ProvAppMem = src.ProvAppMem
 	dst.ProvAppCpuCores = src.ProvAppCpuCores
 	dst.ProvAppDisk = src.ProvAppDisk
+	dst.ProvAppDiskIops = src.ProvAppDiskIops
 	dst.ProvAppDiskType = src.ProvAppDiskType
 	dst.ProvAppRouteAddr = src.ProvAppRouteAddr
 	dst.ProvAppRoutePort = src.ProvAppRoutePort
@@ -3670,6 +3672,8 @@ func applyTemplateOwnedProjection(dst, src *config.AppConfig, templateName strin
 	dst.ProvAppAgents = src.ProvAppAgents
 	dst.ProvAppHATopology = src.ProvAppHATopology
 	dst.ProvAppAgentsFailover = src.ProvAppAgentsFailover
+	// ProvAppSizingMode is intentionally not projected: it is app-owned (how the
+	// operator wants to manage resources), not a property the template should dictate.
 }
 
 func buildTemplateProjectionImpact(current, projected *config.AppConfig, templateName string) []appTemplateFieldChange {
@@ -3702,6 +3706,7 @@ func buildTemplateProjectionImpact(current, projected *config.AppConfig, templat
 	appendIfChanged("ProvAppMem", current.ProvAppMem, projected.ProvAppMem)
 	appendIfChanged("ProvAppCpuCores", current.ProvAppCpuCores, projected.ProvAppCpuCores)
 	appendIfChanged("ProvAppDisk", current.ProvAppDisk, projected.ProvAppDisk)
+	appendIfChanged("ProvAppDiskIops", current.ProvAppDiskIops, projected.ProvAppDiskIops)
 	appendIfChanged("ProvAppDiskType", current.ProvAppDiskType, projected.ProvAppDiskType)
 	appendIfChanged("ProvAppRouteAddr", current.ProvAppRouteAddr, projected.ProvAppRouteAddr)
 	appendIfChanged("ProvAppRoutePort", current.ProvAppRoutePort, projected.ProvAppRoutePort)

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -2632,6 +2632,14 @@ func (repman *ReplicationManager) handlerMuxModifyStorageField(w http.ResponseWr
 
 					deployment.ResolveVolumePaths(vol.Name)
 
+				case "size":
+					normalized, err := config.NormalizeVolumeSize(newValue)
+					if err != nil {
+						http.Error(w, "Invalid size: "+err.Error(), http.StatusBadRequest)
+						return
+					}
+					vol.Size = normalized
+
 				default:
 					http.Error(w, "Invalid key for volumes", http.StatusInternalServerError)
 					return

--- a/server/api_app_volume_v2_test.go
+++ b/server/api_app_volume_v2_test.go
@@ -211,3 +211,94 @@ func TestModifyVolumePoolname_AllowsMoveOntoUsedPoolWhenV2(t *testing.T) {
 		t.Fatalf("expected second row name unchanged, got %q", volumes[1].Name)
 	}
 }
+
+// newModifyVolumeSizeRequest builds a POST request equivalent to
+// /api/clusters/{cluster}/apps/{app}/storages/volumes/index/{index}/size/modify.
+func newModifyVolumeSizeRequest(t *testing.T, repman *ReplicationManager, cl *cluster.Cluster, index int, newSize string) *http.Request {
+	t.Helper()
+	tok := issueVolumeTestJWT(t, repman)
+	body, _ := json.Marshal(map[string]string{"value": newSize})
+	url := fmt.Sprintf("/api/clusters/%s/apps/%s/storages/volumes/index/%d/size/modify", cl.Name, volumeTestAppId, index)
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req = setMuxVars(req, map[string]string{
+		"clusterName": cl.Name,
+		"appName":     volumeTestAppId,
+		"field":       "volumes",
+		"index":       fmt.Sprintf("%d", index),
+		"key":         "size",
+	})
+	return req
+}
+
+// TestAddStorageVolume_WithSize verifies that adding a volume row with an
+// explicit size stores the normalized value (G as base unit).
+func TestAddStorageVolume_WithSize(t *testing.T) {
+	repman, cl, app := newVolumeTestSetup(t, config.AppConfigVersionV2)
+	req := newAddVolumeRequest(t, repman, cl, config.Volume{Name: "myapp-docs", PoolName: "docs", VolumeDir: "docs", Size: "10G"})
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddStorage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	volumes := app.AppConfig.Deployment.Storages.Volumes
+	if len(volumes) != 2 {
+		t.Fatalf("expected 2 volume rows, got %d", len(volumes))
+	}
+	if volumes[1].Size != "10" {
+		t.Fatalf("expected normalized size=10 (G base), got %q", volumes[1].Size)
+	}
+}
+
+// TestModifyVolumeSize sets a size override on an existing volume row and
+// verifies the normalized value is stored.
+func TestModifyVolumeSize(t *testing.T) {
+	repman, cl, app := newVolumeTestSetup(t, 0)
+	req := newModifyVolumeSizeRequest(t, repman, cl, 0, "20G")
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxModifyStorageField(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for size modify, got %d: %s", w.Code, w.Body.String())
+	}
+	if app.AppConfig.Deployment.Storages.Volumes[0].Size != "20" {
+		t.Fatalf("expected size=20, got %q", app.AppConfig.Deployment.Storages.Volumes[0].Size)
+	}
+}
+
+// TestModifyVolumeSize_ClearToBlank verifies that clearing a size override
+// back to blank (empty string) is accepted and persisted as "".
+func TestModifyVolumeSize_ClearToBlank(t *testing.T) {
+	repman, cl, app := newVolumeTestSetup(t, 0)
+	app.AppConfig.Deployment.Storages.Volumes[0].Size = "10"
+
+	req := newModifyVolumeSizeRequest(t, repman, cl, 0, "")
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxModifyStorageField(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for clear-to-blank, got %d: %s", w.Code, w.Body.String())
+	}
+	if app.AppConfig.Deployment.Storages.Volumes[0].Size != "" {
+		t.Fatalf("expected size cleared to blank, got %q", app.AppConfig.Deployment.Storages.Volumes[0].Size)
+	}
+}
+
+// TestModifyVolumeSize_RejectsInvalidFormat verifies that an invalid size
+// string is rejected with a 400.
+func TestModifyVolumeSize_RejectsInvalidFormat(t *testing.T) {
+	repman, cl, _ := newVolumeTestSetup(t, 0)
+	req := newModifyVolumeSizeRequest(t, repman, cl, 0, "badvalue")
+
+	w := httptest.NewRecorder()
+	repman.handlerMuxModifyStorageField(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid size, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -4739,6 +4739,14 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 			return err
 		}
 		mycluster.Conf.ProvAppTemplateRepoTimeout = parsedTimeout
+	case "prov-app-sizing-mode":
+		trimmed := strings.TrimSpace(strings.ToLower(value))
+		switch trimmed {
+		case "", config.AppSizingModeUnit, config.AppSizingModeManual:
+			mycluster.Conf.ProvAppSizingMode = trimmed
+		default:
+			return fmt.Errorf("prov-app-sizing-mode must be empty, 'unit', or 'manual'")
+		}
 	default:
 		// Check if this is a plugin-config key: "plugin-config-<pluginname>-<key>"
 		// e.g. "plugin-config-errorlog-timeframe-hours"      → PluginConfig["errorlog"]["timeframe-hours"]

--- a/server/server.go
+++ b/server/server.go
@@ -1257,6 +1257,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.ProvAppCpuCores, "prov-app-cpu-cores", "1", "Cpu cores. When cloud18 credit system is used, this is the base for 1 credit")
 	flags.StringVar(&conf.ProvAppMem, "prov-app-memory", "1G", "App container memory, value with unit e.g. 256M, 1G. Base for 1 credit in cloud18")
 	flags.StringVar(&conf.ProvAppHATopology, "prov-app-ha-topology", "failover", "High availability mode for application. [failover|flex]")
+	flags.StringVar(&conf.ProvAppSizingMode, "prov-app-sizing-mode", "", "Cluster-level app sizing policy: 'unit' (App Unit credit-based) or 'manual' (direct resource edit). Empty means legacy mode.")
 	flags.StringVar(&conf.ProvAppTemplateRepo, "prov-app-template-repo", "https://github.com/signal18/cloud18-templates", "Git repository for application templates (cluster-scoped)")
 	flags.StringVar(&conf.ProvAppTemplateRepoBranch, "prov-app-template-repo-branch", "main", "Git repository branch for application templates (cluster-scoped)")
 	flags.StringVar(&conf.ProvAppTemplateRepoUser, "prov-app-template-repo-user", "", "Git repository user for application templates (cluster-scoped)")
@@ -2815,6 +2816,7 @@ func (repman *ReplicationManager) Run() error {
 		repman.ProduceGitSupervisionStates()
 		if counter%60 == 0 {
 			repman.ProduceCloud18ConnectivityStates()
+			repman.RefreshCreditsFromCRM()
 		}
 		repman.ProcessAlertStateLifecycle()
 

--- a/server/server_cloud.go
+++ b/server/server_cloud.go
@@ -107,6 +107,10 @@ func (repman *ReplicationManager) AcceptSubscription(userform cluster.UserForm, 
 	cl.LoadAPIUsers()
 	cl.SaveAcls()
 	cl.Save()
+	// Sponsorship is already committed above; treat cap-persist failure as a
+	// warning only — returning an error here would misreport success as failure
+	// and risk double-accept on retry.
+	cl.StartBillingCycle()
 
 	return nil
 }

--- a/server/server_state.go
+++ b/server/server_state.go
@@ -412,6 +412,11 @@ func (repman *ReplicationManager) ProduceCloud18ConnectivityStates() {
 	}
 }
 
+// RefreshCreditsFromCRM is retained for future use; credit usage is now computed
+// from per-app ProvAppCreditUsed totals and is no longer sourced from CRM.
+func (repman *ReplicationManager) RefreshCreditsFromCRM() {
+}
+
 // probeHTTPReachability performs a HEAD request to url and returns an error if
 // the host is unreachable or returns a 5xx server error.  4xx responses are
 // treated as reachable (the endpoint exists; access control is expected).

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Overview/AppCredit/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Overview/AppCredit/index.jsx
@@ -9,7 +9,7 @@ function AppCredit({ config, appConfig }) {
     const clusterCredits = config?.cloud18ApplicationCredits ?? 0
     const clusterCreditsUsed = config?.cloud18ApplicationCreditsUsed ?? 0
     const clusterCreditsPlanned = config?.cloud18ApplicationCreditsPlanned ?? 0
-    const clusterCreditsUnallocated = hasCreditsSet ? clusterCredits - clusterCreditsPlanned : 0
+    const clusterCreditsUnallocated = hasCreditsSet ? Math.max(0, clusterCredits - clusterCreditsPlanned) : 0
     const appCreditsUsed = appConfig?.provAppCreditUsed ?? 0
     const provAppCreditPlanned = appConfig?.provAppCreditPlanned || 0
     const provAppAgents = appConfig?.provAppAgents || ''

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Overview/AppCredit/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Overview/AppCredit/index.jsx
@@ -1,147 +1,74 @@
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import styles from '../styles.module.scss'
-import { Flex, Text, VStack } from '@chakra-ui/react'
-import { useDispatch } from 'react-redux'
-import Gauge from '../../../../../components/Gauge'
-import { convertSize } from '../../../../../utility/common'
-import { setAppSetting } from '../../../../../redux/settingsSlice'
+import { Text, VStack } from '@chakra-ui/react'
 import TableType2 from '../../../../../components/TableType2'
-import ConfirmModal from '../../../../../components/Modals/ConfirmModal'
-import NumberInput from '../../../../../components/NumberInput'
-import { showErrorToast } from '../../../../../redux/toastSlice'
 import PropTypes from 'prop-types'
 
-function AppCredit({ clusterName, appId, config, appConfig, user }) {
-    const dispatch = useDispatch()
-    const [confirmState, setConfirmState] = useState({
-        isOpen: false,
-        title: '',
-        body: '',
-        handler: null
-    })
-    const { isOpen, title, body, handler } = confirmState
+function AppCredit({ config, appConfig }) {
+    const hasCreditsSet = config?.cloud18ApplicationCredits != null
+    const clusterCredits = config?.cloud18ApplicationCredits ?? 0
+    const clusterCreditsUsed = config?.cloud18ApplicationCreditsUsed ?? 0
+    const clusterCreditsPlanned = config?.cloud18ApplicationCreditsPlanned ?? 0
+    const clusterCreditsUnallocated = hasCreditsSet ? clusterCredits - clusterCreditsPlanned : 0
+    const provAppCreditPlanned = appConfig?.provAppCreditPlanned || 0
+    const provAppAgents = appConfig?.provAppAgents || ''
+    const appSizingMode = appConfig?.provAppSizingMode ?? ''
+    const clusterSizingMode = config?.provAppSizingMode || ''
+    const isUnitMode = (appSizingMode || clusterSizingMode) === 'unit'
 
-    const creditStep = useMemo(() => {
-        return appConfig?.provAppAgents?.split(",").filter(agent => agent.trim() !== '').length || 0
-    }, [appConfig?.provAppAgents])
+    const agentCount = useMemo(() => {
+        if (!provAppAgents) return 1
+        const list = typeof provAppAgents === 'string'
+            ? provAppAgents.split(',').filter(a => a.trim())
+            : (Array.isArray(provAppAgents) ? provAppAgents.filter(Boolean) : [])
+        return list.length || 1
+    }, [provAppAgents])
 
-    const closeConfirmModal = () => {
-        setConfirmState({
-            isOpen: false,
-            title: '',
-            body: '',
-            handler: null
-        })
-    }
+    const creditIsValid = isUnitMode && agentCount > 0 && provAppCreditPlanned > 0
+        ? provAppCreditPlanned % agentCount === 0
+        : true
+    const appUnitPerAgent = creditIsValid && agentCount > 0 && provAppCreditPlanned > 0
+        ? provAppCreditPlanned / agentCount
+        : 0
 
-    const allowEdit = user?.grants['app-config-flag'] !== false
-    const clusterCredits = config?.cloud18ApplicationCredits || 0
-    const clusterCreditsUsed = config?.cloud18ApplicationCreditsUsed || 0
-    const clusterCreditsAvailable = clusterCredits - clusterCreditsUsed
-    const provAppMemory = convertSize(appConfig?.provAppMemory, "M", "M")
-    const provAppDiskSize = convertSize(appConfig?.provAppDiskSize, "G", "G")
-    const provAppCpuCores = appConfig?.provAppCpuCores || 0
-    const appCredits = appConfig?.provAppCreditPlanned || 0
+    const dataObject = useMemo(() => {
+        const rows = [
+            {
+                key: "Cloud18 Credit Usage",
+                value: hasCreditsSet
+                    ? (<Text>{clusterCreditsUsed} / {clusterCredits}</Text>)
+                    : (<Text>{'Not set'}</Text>),
+            },
+            {
+                key: "Unallocated Credits",
+                value: hasCreditsSet
+                    ? (<Text>{clusterCreditsUnallocated} / {clusterCredits}</Text>)
+                    : (<Text>{'Not set'}</Text>),
+            },
+        ]
 
-    const dataObject = useMemo(() => [
-        {
-            key: "Cloud18 Credits Available",
-            value: clusterCredits ? (<Text>{clusterCreditsAvailable} / {clusterCredits}</Text>) : (<Text>{'Not set'}</Text>),
-        },
-        {
-            key: 'Resources',
-            value: (
-                <Flex className={styles.resources}>
-                    <Gauge
-                        isDisabled={true}
-                        minValue={256}
-                        maxValue={256 * 1024}
-                        value={provAppMemory}
-                        text={'Memory'}
-                        width={220}
-                        height={150}
-                        hideMinMax={false}
-                        appendTextToValue='MB'
-                        textOverlayClassName={styles.textOverlay}
-                    />
-                    <Gauge
-                        isDisabled={true}
-                        minValue={1}
-                        maxValue={10000}
-                        value={provAppDiskSize}
-                        text={'Disk size'}
-                        width={220}
-                        height={150}
-                        hideMinMax={false}
-                        appendTextToValue='GB'
-                        textOverlayClassName={styles.textOverlay}
-                    />
-                    <Gauge
-                        isDisabled={true}
-                        minValue={1}
-                        maxValue={256}
-                        value={provAppCpuCores}
-                        text={'Cores'}
-                        width={220}
-                        height={150}
-                        hideMinMax={false}
-                        textOverlayClassName={styles.textOverlay}
-                    />
-                </Flex>
-            )
-        },
-        {
-            key: 'Credits',
-            value: (
-                <Flex className={styles.resources}>
-                    { creditStep ? (<NumberInput
-                        isDisabled={!allowEdit}
-                        minValue={creditStep}
-                        maxValue={10000}
-                        step={creditStep}
-                        value={appCredits}
-                        showConfirmModal={true}
-                        confirmTitle={`Confirm change for 'prov-app-credit-planned'`}
-                        confirmBody={`Are you sure you want to change the 'prov-app-credit-planned' value?`}
-                        showEditButton={true}
-                        onConfirmValidator={(value) => {
-                            if (value % creditStep !== 0) {
-                                dispatch(showErrorToast(`Value must be a multiple of ${creditStep}`))
-                                return false
-                            }
-                            return true
-                        }}
-                        onConfirm={(value) => {
-                            dispatch(
-                                setAppSetting({
-                                    clusterName: clusterName,
-                                    appId: appId,
-                                    setting: 'prov-app-credit-planned',
-                                    value: value
-                                })
-                            )
-                        }}
-                    />) : (
-                        <Text>No Agents Available</Text>
-                    )}
-                </Flex>
-            )
+        if (isUnitMode && provAppCreditPlanned > 0) {
+            rows.push({
+                key: 'App Units',
+                value: creditIsValid ? (
+                    <Text>
+                        {appUnitPerAgent} App Unit/node × {agentCount} node{agentCount !== 1 ? 's' : ''} = {provAppCreditPlanned} total credits
+                    </Text>
+                ) : (
+                    <Text color='red.500'>
+                        Invalid: {provAppCreditPlanned} credit{provAppCreditPlanned !== 1 ? 's' : ''} / {agentCount} agent{agentCount !== 1 ? 's' : ''} — not evenly divisible
+                    </Text>
+                ),
+            })
         }
-    ], [clusterCreditsAvailable, clusterCredits, provAppMemory, provAppDiskSize, provAppCpuCores, appCredits, creditStep, allowEdit, clusterName, appId, dispatch])
+
+        return rows
+    }, [hasCreditsSet, clusterCreditsUsed, clusterCredits, clusterCreditsUnallocated,
+        isUnitMode, provAppCreditPlanned, appUnitPerAgent, agentCount, creditIsValid])
+
     return (
         <VStack>
-            <TableType2 key={creditStep} dataArray={dataObject} className={styles.table} />
-            <ConfirmModal
-                isOpen={isOpen}
-                closeModal={closeConfirmModal}
-                title={title}
-                body={body}
-                onConfirmClick={() => {
-                    console.log('onConfirmClick clicked', handler)
-                    handler()
-                    closeConfirmModal()
-                }}
-            />
+            <TableType2 dataArray={dataObject} className={styles.table} />
         </VStack>
     )
 }
@@ -149,20 +76,15 @@ function AppCredit({ clusterName, appId, config, appConfig, user }) {
 export default AppCredit
 
 AppCredit.propTypes = {
-  clusterName: PropTypes.string.isRequired,
-  appId: PropTypes.string.isRequired,
   config: PropTypes.shape({
     cloud18ApplicationCredits: PropTypes.number,
-    cloud18ApplicationCreditsUsed: PropTypes.number
+    cloud18ApplicationCreditsUsed: PropTypes.number,
+    cloud18ApplicationCreditsPlanned: PropTypes.number,
+    provAppSizingMode: PropTypes.string,
   }),
   appConfig: PropTypes.shape({
-    provAppAgents: PropTypes.string,
-    provAppMemory: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    provAppDiskSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    provAppCpuCores: PropTypes.number,
-    provAppCreditPlanned: PropTypes.number
+    provAppCreditPlanned: PropTypes.number,
+    provAppAgents: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
+    provAppSizingMode: PropTypes.string,
   }),
-  user: PropTypes.shape({
-    grants: PropTypes.object
-  })
 }

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Overview/AppCredit/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Overview/AppCredit/index.jsx
@@ -10,6 +10,7 @@ function AppCredit({ config, appConfig }) {
     const clusterCreditsUsed = config?.cloud18ApplicationCreditsUsed ?? 0
     const clusterCreditsPlanned = config?.cloud18ApplicationCreditsPlanned ?? 0
     const clusterCreditsUnallocated = hasCreditsSet ? clusterCredits - clusterCreditsPlanned : 0
+    const appCreditsUsed = appConfig?.provAppCreditUsed ?? 0
     const provAppCreditPlanned = appConfig?.provAppCreditPlanned || 0
     const provAppAgents = appConfig?.provAppAgents || ''
     const appSizingMode = appConfig?.provAppSizingMode ?? ''
@@ -34,7 +35,11 @@ function AppCredit({ config, appConfig }) {
     const dataObject = useMemo(() => {
         const rows = [
             {
-                key: "Cloud18 Credit Usage",
+                key: 'App Credit Usage',
+                value: (<Text>{appCreditsUsed} / {provAppCreditPlanned}</Text>),
+            },
+            {
+                key: 'Cluster Credit Usage',
                 value: hasCreditsSet
                     ? (<Text>{clusterCreditsUsed} / {clusterCredits}</Text>)
                     : (<Text>{'Not set'}</Text>),
@@ -63,8 +68,8 @@ function AppCredit({ config, appConfig }) {
         }
 
         return rows
-    }, [hasCreditsSet, clusterCreditsUsed, clusterCredits, clusterCreditsUnallocated,
-        isUnitMode, provAppCreditPlanned, appUnitPerAgent, agentCount, creditIsValid])
+    }, [hasCreditsSet, appCreditsUsed, provAppCreditPlanned, clusterCreditsUsed, clusterCredits,
+        clusterCreditsUnallocated, isUnitMode, appUnitPerAgent, agentCount, creditIsValid])
 
     return (
         <VStack>
@@ -83,6 +88,7 @@ AppCredit.propTypes = {
     provAppSizingMode: PropTypes.string,
   }),
   appConfig: PropTypes.shape({
+    provAppCreditUsed: PropTypes.number,
     provAppCreditPlanned: PropTypes.number,
     provAppAgents: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
     provAppSizingMode: PropTypes.string,

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Overview/GeneralSection.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Overview/GeneralSection.jsx
@@ -140,7 +140,7 @@ const GeneralSection = ({ clusterName, appId, appName, appHost, config, appConfi
   const appUnitValue = (appUnitIsValid && creditStep > 0 && provAppCreditPlanned > 0)
     ? (isLegacyAppInUnitCluster ? derivedUnitFromResources : provAppCreditPlanned / creditStep)
     : (isLegacyAppInUnitCluster ? derivedUnitFromResources : 0)
-  const maxAppUnit = clusterCreditsAvailable > 0 ? Math.floor(clusterCreditsAvailable / creditStep) : 256
+  const maxAppUnit = 256
 
   const sliderDisplayValue = useMemo(() => {
     if (isUnitMode && !isLegacyAppInUnitCluster && appUnitIsValid && creditStep > 0 && provAppCreditPlanned > 0) {
@@ -363,11 +363,13 @@ const GeneralSection = ({ clusterName, appId, appName, appHost, config, appConfi
             onChange={(unit) => {
               const credits = unit * creditStep
               const needsModeSwitch = provAppSizingMode !== 'unit'
+              const exceedsPool = clusterCredits > 0 && clusterCreditsAvailable > 0 && credits > clusterCreditsAvailable
+              const poolWarning = exceedsPool ? ` — ⚠ exceeds available pool (${Math.floor(clusterCreditsAvailable / creditStep)} App Unit free)` : ''
               setAppUnitConfirmState({
                 isOpen: true,
                 title: needsModeSwitch
-                  ? `Switch to App Unit: ${unit} App Unit — ${formatAppUnit(unit)} × ${creditStep} agent(s) = ${credits} credits`
-                  : `Confirm App Unit change to ${unit} — ${formatAppUnit(unit)} × ${creditStep} agent(s) = ${credits} credits`,
+                  ? `Switch to App Unit: ${unit} App Unit — ${formatAppUnit(unit)} × ${creditStep} agent(s) = ${credits} credits${poolWarning}`
+                  : `Confirm App Unit change to ${unit} — ${formatAppUnit(unit)} × ${creditStep} agent(s) = ${credits} credits${poolWarning}`,
                 handler: () => {
                   const saveCredits = () => dispatch(setAppSetting({ clusterName, appId, setting: 'prov-app-credit-planned', value: credits }))
                   if (needsModeSwitch) {
@@ -475,6 +477,7 @@ const GeneralSection = ({ clusterName, appId, appName, appHost, config, appConfi
     substitution, user,
     sliderDisplayValue, appUnitValue, appUnitIsValid, maxAppUnit, creditStep, formatAppUnit, clusterName, appId, dispatch,
     provAppCreditPlanned, provAppCpuCores, provAppMemory, provAppDiskSize,
+    clusterCreditsAvailable, clusterCredits,
   ])
 
   return (

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Overview/GeneralSection.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Overview/GeneralSection.jsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Text } from '@chakra-ui/react'
+import { Box, Flex, Slider, SliderFilledTrack, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import TextForm from '../../../../components/TextForm';
 import styles from './styles.module.scss';
 import { useDispatch } from 'react-redux';
@@ -14,6 +14,60 @@ import VariableInputArea from '../../../../components/VariableTree/VariableInput
 import PropTypes from 'prop-types';
 import CopyTextModal from '../../../../components/Modals/CopyTextModal';
 import ConfirmModal from '../../../../components/Modals/ConfirmModal';
+import { convertSize } from '../../../../utility/common';
+import Gauge from '../../../../components/Gauge';
+
+function AppUnitSlider({ value, min, max, step, isDisabled, formatFn, onChange }) {
+  const [draft, setDraft] = useState(null)
+  const [showTooltip, setShowTooltip] = useState(false)
+  const current = draft !== null ? draft : value
+  const safeMin = min > 0 ? min : 1
+  const safeMax = max > safeMin ? max : safeMin + 256
+
+  return (
+    <Box w='100%'>
+      <Flex justify='space-between' mb={1}>
+        <Text fontSize='sm' fontWeight='bold' color='var(--text-color)'>App Unit</Text>
+        <Text fontSize='sm' fontWeight='semibold' color='var(--text-color)'>{formatFn(current)}</Text>
+      </Flex>
+      <Slider
+        min={safeMin}
+        max={safeMax}
+        step={step > 0 ? step : 1}
+        value={Math.max(current, safeMin)}
+        isDisabled={isDisabled}
+        onChange={(v) => setDraft(v)}
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+        onChangeEnd={(v) => {
+          setDraft(null)
+          if (v !== value && onChange) onChange(v)
+        }}
+      >
+        <SliderTrack h='8px' borderRadius='full' bg='gray.200'>
+          <SliderFilledTrack bg='teal.400' />
+        </SliderTrack>
+        <Tooltip label={formatFn(current)} placement='top' isOpen={showTooltip || draft !== null} hasArrow>
+          <SliderThumb boxSize={5} bg='teal.500' />
+        </Tooltip>
+      </Slider>
+      <Flex justify='space-between' mt={1}>
+        <Text fontSize='9px' color='gray.500'>{safeMin} App Unit</Text>
+        <Text fontSize='9px' color='gray.500'>{safeMax} App Unit</Text>
+      </Flex>
+    </Box>
+  )
+}
+
+AppUnitSlider.propTypes = {
+  value: PropTypes.number,
+  min: PropTypes.number,
+  max: PropTypes.number,
+  step: PropTypes.number,
+  isDisabled: PropTypes.bool,
+  formatFn: PropTypes.func,
+  onChange: PropTypes.func,
+}
 
 const GeneralSection = ({ clusterName, appId, appName, appHost, config, appConfig, dockerTemplates, substitution, user }) => {
 
@@ -30,13 +84,84 @@ const GeneralSection = ({ clusterName, appId, appName, appHost, config, appConfi
     const templateList = Array.isArray(dockerTemplates) ? dockerTemplates : []
     return [{ name: 'Select Template', value: '' }, ...templateList.map(item => ({ name: item, value: item }))]
   }, [dockerTemplates])
-  const { provAppDockerImg = '', provAppDockerCmd = '', provAppTemplate = '', provAppAgents = '', provAppHaTopology = '' } = appConfig;
+  const {
+    provAppDockerImg = '', provAppDockerCmd = '', provAppTemplate = '',
+    provAppAgents = '', provAppHaTopology = '', provAppCreditPlanned = 0,
+    provAppSizingMode: appSizingMode = '', provAppCpuCores = '', provAppMemory = '', provAppDiskSize = ''
+  } = appConfig;
+
+  // Effective mode resolution mirrors backend logic:
+  // 1) app override when cluster allows it
+  // 2) cluster mode when set
+  // 3) existing app-stamped mode when cluster mode is unset
+  // 4) legacy when neither is set
+  const clusterSizingMode = config?.provAppSizingMode || ''
+  const provAppSizingMode = appSizingMode || clusterSizingMode
+  const isUnitMode = provAppSizingMode === 'unit'
+  const isManualMode = provAppSizingMode === 'manual'
+  // Effective mode is empty: neither cluster nor app has set a sizing policy.
+  const isLegacyMode = !isUnitMode && !isManualMode
+  // Cluster policy says "unit" but this app itself is not explicitly unit-managed yet.
+  // Preserve raw stored values on read; the first unit-based write normalizes them.
+  const isLegacyAppInUnitCluster = isUnitMode && appSizingMode !== 'unit'
+
+  const baseCore = 1
+  const baseMem = 4096
+  const baseDisk = 10
+
+  // Derive unit from raw stored resources (used for legacy apps that haven't been normalised yet).
+  const derivedUnitFromResources = useMemo(() => {
+    const cores = parseInt(provAppCpuCores) || 0
+    const memMB = parseFloat(convertSize(provAppMemory, 'M', 'M')) || 0
+    const diskGB = parseFloat(convertSize(provAppDiskSize, 'G', 'G')) || 0
+    if (!cores && !memMB && !diskGB) return 1
+    return Math.max(1, Math.ceil(Math.max(
+      cores ? cores / baseCore : 0,
+      memMB ? memMB / baseMem : 0,
+      diskGB ? diskGB / baseDisk : 0
+    )))
+  }, [provAppCpuCores, provAppMemory, provAppDiskSize])
+
+  const creditStep = useMemo(() => {
+    const raw = provAppAgents
+    const list = typeof raw === 'string' ? raw.split(',').filter((a) => a.trim()) : (Array.isArray(raw) ? raw.filter(Boolean) : [])
+    return list.length || 1
+  }, [provAppAgents])
+
+  const clusterCredits = config?.cloud18ApplicationCredits || 0
+  const clusterCreditsUsed = config?.cloud18ApplicationCreditsUsed || 0
+  const clusterCreditsAvailable = clusterCredits > 0 ? clusterCredits - clusterCreditsUsed + provAppCreditPlanned : 0
+
+  const appUnitIsValid = isLegacyAppInUnitCluster
+    ? true
+    : isUnitMode && creditStep > 0 && provAppCreditPlanned > 0
+    ? provAppCreditPlanned % creditStep === 0
+    : true
+  const appUnitValue = (appUnitIsValid && creditStep > 0 && provAppCreditPlanned > 0)
+    ? (isLegacyAppInUnitCluster ? derivedUnitFromResources : provAppCreditPlanned / creditStep)
+    : (isLegacyAppInUnitCluster ? derivedUnitFromResources : 0)
+  const maxAppUnit = clusterCreditsAvailable > 0 ? Math.floor(clusterCreditsAvailable / creditStep) : 256
+
+  const sliderDisplayValue = useMemo(() => {
+    if (isUnitMode && !isLegacyAppInUnitCluster && appUnitIsValid && creditStep > 0 && provAppCreditPlanned > 0) {
+      return provAppCreditPlanned / creditStep
+    }
+    return derivedUnitFromResources || 1
+  }, [isUnitMode, isLegacyAppInUnitCluster, appUnitIsValid, creditStep, provAppCreditPlanned, derivedUnitFromResources])
+
+  const formatAppUnit = useCallback((unit) => {
+    const mem = unit * baseMem
+    const memLabel = mem >= 1024 ? `${mem / 1024}GB` : `${mem}MB`
+    return `${unit} App Unit — ${unit * baseCore} cores, ${memLabel} mem, ${unit * baseDisk}GB disk per agent`
+  }, [])
+
   const agentList = useMemo(() => {
     const raw = config?.provAppAgents || config?.provDbAgents
     if (Array.isArray(raw)) return raw
     if (typeof raw === 'string' && raw.trim()) return raw.split(',').map((s) => s.trim()).filter(Boolean)
     return []
   }, [config?.provAppAgents, config?.provDbAgents])
+
   const onSaveDockerImage = useCallback((value) => dispatch(setAppSetting({ clusterName: clusterName, appId: appId, setting: 'prov-app-docker-img', value: value })), [clusterName, appId, dispatch])
   const onSaveDockerCmd = useCallback((value) => dispatch(setAppSetting({ clusterName: clusterName, appId: appId, setting: 'prov-app-docker-cmd', value: value })), [clusterName, appId, dispatch])
   const onSaveAppAsTemplate = useCallback(() => dispatch(saveAppAsTemplate({ clusterName: clusterName, appId: appId, template: appName })), [clusterName, appId, appName, dispatch])
@@ -70,7 +195,15 @@ const GeneralSection = ({ clusterName, appId, appName, appHost, config, appConfi
     dispatch(resetAppFromTemplate({ clusterName, appId, template: resetImpactTemplate, forceRefresh: resetImpactForceRefresh }))
     setIsResetImpactModalOpen(false)
   }, [clusterName, appId, resetImpactTemplate, resetImpactForceRefresh, dispatch])
-  const onAgentsChange = useCallback((value) => dispatch(setAppSetting({ clusterName, appId, setting: 'prov-app-agents', value: value.toString() })), [clusterName, appId, dispatch])
+
+  const onAgentsChange = useCallback((value) => {
+    const newList = Array.isArray(value)
+      ? value.filter(Boolean)
+      : (typeof value === 'string' ? value.split(',').filter(a => a.trim()) : [])
+    // Always dispatch agent update; backend handles credit recalculation for unit mode
+    dispatch(setAppSetting({ clusterName, appId, setting: 'prov-app-agents', value: newList.join(',') }))
+  }, [clusterName, appId, dispatch])
+
   const onHATopologyChange = useCallback((value) => { dispatch(setAppSetting({ clusterName: clusterName, appId: appId, setting: 'prov-app-ha-topology', value: value })) }, [clusterName, appId, dispatch])
   const onPreviewTemplate = useCallback(() => {
     if (!provAppTemplate) {
@@ -85,8 +218,11 @@ const GeneralSection = ({ clusterName, appId, appName, appHost, config, appConfi
       })
   }, [clusterName, provAppTemplate, dispatch])
 
+  const [appUnitConfirmState, setAppUnitConfirmState] = useState({ isOpen: false, title: '', handler: null })
+  const closeAppUnitConfirm = useCallback(() => setAppUnitConfirmState({ isOpen: false, title: '', handler: null }), [])
+
   const dataObject = useMemo(() => {
-    return [
+    const rows = [
       {
         key: 'App Name',
         value: (<Text>{appName}</Text>)
@@ -167,7 +303,7 @@ const GeneralSection = ({ clusterName, appId, appName, appHost, config, appConfi
             aria-label="Save App As Template"
             tooltip="Save App As Template"
             onClick={onSaveAppAsTemplate}
-            isDisabled={!user?.grants['app-deployment']}
+            isDisabled={user?.grants['app-deployment'] == false}
             confirmTitle="Save App As Template"
           />
         )
@@ -180,7 +316,9 @@ const GeneralSection = ({ clusterName, appId, appName, appHost, config, appConfi
             values={provAppAgents}
             confirm={true}
             splitConfirm={true}
-            confirmTitle={`Confirm change 'prov-app-agents' to: `}
+            confirmTitle={isUnitMode && !isLegacyAppInUnitCluster
+              ? `Confirm agent change — App Unit stays at ${appUnitValue || 1} per agent, planned credits will be updated`
+              : `Confirm agent change`}
             onChange={onAgentsChange}
             parentStyles={styles}
           />
@@ -200,8 +338,145 @@ const GeneralSection = ({ clusterName, appId, appName, appHost, config, appConfi
         )
       },
     ]
-  }, [appName, appHost, provAppDockerImg, onSaveDockerImage, provAppDockerCmd, onSaveDockerCmd, onSaveAppAsTemplate, templateOptions, provAppTemplate, onPreviewTemplate, onResetAppFromTemplate, onRefreshAndResetAppFromTemplate, agentList, onAgentsChange, provAppAgents, onHATopologyChange, provAppHaTopology, haTopologyOptions, substitution, user])
-  
+
+    rows.push({
+      key: 'Resources',
+      value: (
+        <Flex direction='column' gap={4} w='100%'>
+          {isUnitMode && isLegacyAppInUnitCluster && (
+            <Text fontSize='xs' color='orange.500'>
+              Legacy resource values preserved. The next App Unit edit will normalize this app (derived: {derivedUnitFromResources} App Unit).
+            </Text>
+          )}
+          {isUnitMode && !appUnitIsValid && (
+            <Text fontSize='sm' color='red.500'>
+              Inconsistent state: {provAppCreditPlanned} credit{provAppCreditPlanned !== 1 ? 's' : ''} cannot be evenly distributed across {creditStep} agent{creditStep !== 1 ? 's' : ''}. Update agents or credits to resolve.
+            </Text>
+          )}
+          <AppUnitSlider
+            isDisabled={user?.grants['app-config'] == false}
+            value={sliderDisplayValue}
+            min={1}
+            max={maxAppUnit}
+            step={1}
+            formatFn={formatAppUnit}
+            onChange={(unit) => {
+              const credits = unit * creditStep
+              const needsModeSwitch = provAppSizingMode !== 'unit'
+              setAppUnitConfirmState({
+                isOpen: true,
+                title: needsModeSwitch
+                  ? `Switch to App Unit: ${unit} App Unit — ${formatAppUnit(unit)} × ${creditStep} agent(s) = ${credits} credits`
+                  : `Confirm App Unit change to ${unit} — ${formatAppUnit(unit)} × ${creditStep} agent(s) = ${credits} credits`,
+                handler: () => {
+                  const saveCredits = () => dispatch(setAppSetting({ clusterName, appId, setting: 'prov-app-credit-planned', value: credits }))
+                  if (needsModeSwitch) {
+                    dispatch(setAppSetting({ clusterName, appId, setting: 'prov-app-sizing-mode', value: 'unit' })).unwrap().then(saveCredits)
+                  } else {
+                    saveCredits()
+                  }
+                }
+              })
+            }}
+          />
+          <Flex className={styles.resources} flexWrap='wrap'>
+            <Gauge
+              isDisabled={user?.grants['app-config'] == false}
+              minValue={256}
+              maxValue={262144}
+              value={parseFloat(convertSize(provAppMemory, 'M', 'M')) || 0}
+              text={'Memory'}
+              width={150}
+              height={105}
+              hideMinMax={false}
+              showStep={true}
+              step={256}
+              appendTextToValue='MB'
+              handleStepChange={(value) => {
+                const needsModeSwitch = provAppSizingMode !== 'manual'
+                const memLabel = value >= 1024 ? `${value / 1024}GB` : `${value}MB`
+                setAppUnitConfirmState({
+                  isOpen: true,
+                  title: needsModeSwitch ? `Switch to Manual — set memory to ${memLabel}` : `Confirm memory change to ${memLabel}`,
+                  handler: () => {
+                    const save = () => dispatch(setAppSetting({ clusterName, appId, setting: 'prov-app-memory', value: String(value) }))
+                    if (needsModeSwitch) {
+                      dispatch(setAppSetting({ clusterName, appId, setting: 'prov-app-sizing-mode', value: 'manual' })).unwrap().then(save)
+                    } else { save() }
+                  }
+                })
+              }}
+            />
+            <Gauge
+              isDisabled={user?.grants['app-config'] == false}
+              minValue={1}
+              maxValue={10000}
+              value={parseFloat(convertSize(provAppDiskSize, 'G', 'G')) || 0}
+              text={'Disk size'}
+              width={150}
+              height={105}
+              hideMinMax={false}
+              showStep={true}
+              step={10}
+              appendTextToValue='GB'
+              handleStepChange={(value) => {
+                const needsModeSwitch = provAppSizingMode !== 'manual'
+                setAppUnitConfirmState({
+                  isOpen: true,
+                  title: needsModeSwitch ? `Switch to Manual — set disk to ${value}GB` : `Confirm disk size change to ${value}GB`,
+                  handler: () => {
+                    const save = () => dispatch(setAppSetting({ clusterName, appId, setting: 'prov-app-disk-size', value: String(value) }))
+                    if (needsModeSwitch) {
+                      dispatch(setAppSetting({ clusterName, appId, setting: 'prov-app-sizing-mode', value: 'manual' })).unwrap().then(save)
+                    } else { save() }
+                  }
+                })
+              }}
+            />
+            <Gauge
+              isDisabled={user?.grants['app-config'] == false}
+              minValue={1}
+              maxValue={256}
+              value={parseInt(provAppCpuCores) || 0}
+              text={'Cores'}
+              width={150}
+              height={105}
+              hideMinMax={false}
+              showStep={true}
+              step={1}
+              handleStepChange={(value) => {
+                const needsModeSwitch = provAppSizingMode !== 'manual'
+                setAppUnitConfirmState({
+                  isOpen: true,
+                  title: needsModeSwitch ? `Switch to Manual — set cores to ${value}` : `Confirm CPU cores change to ${value}`,
+                  handler: () => {
+                    const save = () => dispatch(setAppSetting({ clusterName, appId, setting: 'prov-app-cpu-cores', value: String(value) }))
+                    if (needsModeSwitch) {
+                      dispatch(setAppSetting({ clusterName, appId, setting: 'prov-app-sizing-mode', value: 'manual' })).unwrap().then(save)
+                    } else { save() }
+                  }
+                })
+              }}
+            />
+          </Flex>
+        </Flex>
+      )
+    })
+
+    return rows
+  }, [
+    appName, appHost, provAppDockerImg, onSaveDockerImage, provAppDockerCmd, onSaveDockerCmd,
+    onSaveAppAsTemplate, templateOptions, provAppTemplate, onPreviewTemplate,
+    onResetAppFromTemplate, onRefreshAndResetAppFromTemplate,
+    agentList, onAgentsChange, provAppAgents, onHATopologyChange, provAppHaTopology, haTopologyOptions,
+    isUnitMode, isManualMode, isLegacyMode,
+    appSizingMode, clusterSizingMode, provAppSizingMode,
+    isLegacyAppInUnitCluster, derivedUnitFromResources,
+    substitution, user,
+    sliderDisplayValue, appUnitValue, appUnitIsValid, maxAppUnit, creditStep, formatAppUnit, clusterName, appId, dispatch,
+    provAppCreditPlanned, provAppCpuCores, provAppMemory, provAppDiskSize,
+  ])
+
   return (
     <Flex direction="column" className={`${styles.tableSectionWrapper}`} w={"100%"} gap="8px">
       <TableType2 dataArray={dataObject} className={styles.table} />
@@ -211,6 +486,15 @@ const GeneralSection = ({ clusterName, appId, appName, appHost, config, appConfi
         title={templatePreviewTitle}
         text={templatePreviewContent}
         showPrettyJsonCheckbox={false}
+      />
+      <ConfirmModal
+        isOpen={appUnitConfirmState.isOpen}
+        closeModal={closeAppUnitConfirm}
+        title={appUnitConfirmState.title}
+        onConfirmClick={() => {
+          appUnitConfirmState.handler?.()
+          closeAppUnitConfirm()
+        }}
       />
       <ConfirmModal
         isOpen={isResetImpactModalOpen}
@@ -253,14 +537,25 @@ GeneralSection.propTypes = {
   appHost: PropTypes.string,
   config: PropTypes.shape({
     provAppAgents: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
-    provDbAgents: PropTypes.oneOfType([PropTypes.array, PropTypes.string])
+    provDbAgents: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
+    provAppCpuCores: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    provAppMemory: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    provAppDiskSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    provAppSizingMode: PropTypes.string,
+    cloud18ApplicationCredits: PropTypes.number,
+    cloud18ApplicationCreditsUsed: PropTypes.number,
   }),
   appConfig: PropTypes.shape({
     provAppDockerImg: PropTypes.string,
     provAppDockerCmd: PropTypes.string,
     provAppTemplate: PropTypes.string,
     provAppAgents: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
-    provAppHaTopology: PropTypes.string
+    provAppHaTopology: PropTypes.string,
+    provAppCreditPlanned: PropTypes.number,
+    provAppSizingMode: PropTypes.string,
+    provAppCpuCores: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    provAppMemory: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    provAppDiskSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   }).isRequired,
   dockerTemplates: PropTypes.arrayOf(PropTypes.string),
   substitution: PropTypes.array,

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Overview/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Overview/index.jsx
@@ -124,7 +124,7 @@ const Overview = ({ clusterName, config, appId, appName, appHost, appConfig, use
                     />
                     <AccordionComponent
                         heading={'Infra Resources'}
-                        body={<AppCredit clusterName={clusterName} appId={appId} config={config} appConfig={appConfig} user={user} />}
+                        body={<AppCredit config={config} appConfig={appConfig} />}
                     />
                     <AccordionComponent
                         heading={'DNS Routes'}

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/Volume.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/Volume.jsx
@@ -11,7 +11,7 @@ import { HiTrash } from "react-icons/hi";
 import { getVolumeDirTokens } from "./volumeDirUtils";
 
 
-const defaultVol = { name: "", poolname: "", volumedir: "" };
+const defaultVol = { name: "", poolname: "", volumedir: "", size: "" };
 
 // AppConfigVersionV2 mirrors config.AppConfigVersionV2 (config/app_template_canonical.go):
 // the app-config-version marker at/above which intentional multiple volume
@@ -125,6 +125,9 @@ const VolumeSection = ({
             columnHelper.accessor((row) => getVolumeDirTokens(row.volumedir).join(', '), {
                 header: 'Volume Dir'
             }),
+            columnHelper.accessor((row) => row.size ? row.size + 'G' : '(app default)', {
+                header: 'Size'
+            }),
             columnHelper.display({
                 id: 'actions',
                 cell: ({ row }) => (
@@ -215,6 +218,11 @@ const VolumeRowForm = React.memo(({ fieldName, volume, index, poolOptions = [], 
                     <TextForm placeholder="Volume Dir" confirmTitle="Change Volume Dir" value={vol.volumedir} onSave={(value) => onChange(fieldName, index, "volumedir", value)} />
                     {availableDirs.length > 1 && (<Text mb={1} fontSize="sm" color="gray.500">Directories: {availableDirs.join(', ')}</Text>)}
                 </Flex>
+                <Flex direction="column" flex="1">
+                    <Text mb={1}>Size:</Text>
+                    <TextForm placeholder="Size (e.g. 10G, 2T)" confirmTitle="Change Volume Size" value={vol.size ? vol.size + 'G' : ''} onSave={(value) => onChange(fieldName, index, "size", value)} />
+                    <Text mb={1} fontSize="sm" color="gray.500">Blank inherits app default. Accepts units (e.g. 10G, 2T); saved value is normalized to GB.</Text>
+                </Flex>
             </Flex>
         </Flex>
     )
@@ -265,6 +273,11 @@ const VolumeNewForm = React.memo(({ saveCaption = "Save Volume", onSave = () => 
                     <Text mb={1}>Volume Dir:</Text>
                     <Input placeholder="Volume Dir" value={vol.volumedir} onChange={(e) => handleArrayChange("volumedir", e.target.value)} />
                     {availableDirs.length > 1 && (<Text mb={1} fontSize="sm" color="gray.500">Directories: {availableDirs.join(', ')}</Text>)}
+                </Flex>
+                <Flex direction="column" flex="1">
+                    <Text mb={1}>Size:</Text>
+                    <Input placeholder="Size (e.g. 10G, blank = app default)" value={vol.size} onChange={(e) => handleArrayChange("size", e.target.value)} />
+                    <Text mb={1} fontSize="sm" color="gray.500">Blank inherits app default. Accepts units (e.g. 10G, 2T); saved value is normalized to GB.</Text>
                 </Flex>
                 <Flex direction="column" flex="1">
                     <HStack spacing={2} mt={4}>

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/Volume.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/Volume.jsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useState } from "react";
-import { VStack, Input, HStack, Heading, Flex, Box, Text } from "@chakra-ui/react";
+import React, { useMemo, useState, useEffect } from "react";
+import { VStack, Input, HStack, Heading, Flex, Box, Text, ButtonGroup, Button } from "@chakra-ui/react";
 import styles from "./styles.module.scss";
 import TextForm from "../../../../components/TextForm";
 import { createColumnHelper } from "@tanstack/react-table";
@@ -12,6 +12,101 @@ import { getVolumeDirTokens } from "./volumeDirUtils";
 
 
 const defaultVol = { name: "", poolname: "", volumedir: "", size: "" };
+
+// Parse a stored size value (plain GB number or "10G"/"2T" string) into { num, unit }.
+const parseSizeValue = (v) => {
+    if (!v) return { num: '', unit: 'G' };
+    const s = String(v).trim().toUpperCase();
+    const m = s.match(/^(\d+(?:\.\d+)?)\s*([GT]?)$/);
+    if (!m) return { num: String(v), unit: 'G' };
+    return { num: m[1], unit: m[2] || 'G' };
+};
+
+// Shared size input: number field + GB/TB toggle.
+// Pass onSave (row edit, shows Apply/Reset) or onChange (new form, immediate).
+const SizeField = React.memo(({ value = '', onSave, onChange }) => {
+    const { num: initNum, unit: initUnit } = parseSizeValue(value);
+    const [num, setNum] = useState(initNum);
+    const [unit, setUnit] = useState(initUnit);
+    const [pending, setPending] = useState(false);
+
+    useEffect(() => {
+        if (!pending) {
+            const { num: n, unit: u } = parseSizeValue(value);
+            setNum(n);
+            setUnit(u);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [value]);
+
+    const combined = num ? `${num}${unit}` : '';
+
+    const handleNum = (e) => {
+        const v = e.target.value;
+        setNum(v);
+        if (onChange) onChange(v ? `${v}${unit}` : '');
+        if (onSave) setPending(true);
+    };
+
+    const handleUnit = (u) => {
+        setUnit(u);
+        if (onChange) onChange(num ? `${num}${u}` : '');
+        if (onSave) setPending(true);
+    };
+
+    const handleApply = () => {
+        if (onSave) {
+            onSave(combined);
+            setPending(false);
+        }
+    };
+
+    const handleReset = () => {
+        const { num: n, unit: u } = parseSizeValue(value);
+        setNum(n);
+        setUnit(u);
+        setPending(false);
+    };
+
+    return (
+        <Flex direction="column" gap={1}>
+            <HStack spacing={2} align="center">
+                <Input
+                    type="number"
+                    min={0}
+                    step={1}
+                    placeholder="blank = app default"
+                    value={num}
+                    onChange={handleNum}
+                    maxW="180px"
+                />
+                <ButtonGroup isAttached variant="outline">
+                    <Button
+                        onClick={() => handleUnit('G')}
+                        variant={unit === 'G' ? 'solid' : 'outline'}
+                        colorScheme={unit === 'G' ? 'blue' : 'gray'}
+                    >
+                        GB
+                    </Button>
+                    <Button
+                        onClick={() => handleUnit('T')}
+                        variant={unit === 'T' ? 'solid' : 'outline'}
+                        colorScheme={unit === 'T' ? 'blue' : 'gray'}
+                    >
+                        TB
+                    </Button>
+                </ButtonGroup>
+                {onSave && pending && (
+                    <>
+                        <RMButton onClick={handleApply}>Apply</RMButton>
+                        <RMButton onClick={handleReset}>Reset</RMButton>
+                    </>
+                )}
+            </HStack>
+            <Text fontSize="sm" color="gray.500">Blank inherits app default; saved value is normalized to GB.</Text>
+        </Flex>
+    );
+});
 
 // AppConfigVersionV2 mirrors config.AppConfigVersionV2 (config/app_template_canonical.go):
 // the app-config-version marker at/above which intentional multiple volume
@@ -220,8 +315,7 @@ const VolumeRowForm = React.memo(({ fieldName, volume, index, poolOptions = [], 
                 </Flex>
                 <Flex direction="column" flex="1">
                     <Text mb={1}>Size:</Text>
-                    <TextForm placeholder="Size (e.g. 10G, 2T)" confirmTitle="Change Volume Size" value={vol.size ? vol.size + 'G' : ''} onSave={(value) => onChange(fieldName, index, "size", value)} />
-                    <Text mb={1} fontSize="sm" color="gray.500">Blank inherits app default. Accepts units (e.g. 10G, 2T); saved value is normalized to GB.</Text>
+                    <SizeField value={vol.size} onSave={(value) => onChange(fieldName, index, "size", value)} />
                 </Flex>
             </Flex>
         </Flex>
@@ -276,8 +370,7 @@ const VolumeNewForm = React.memo(({ saveCaption = "Save Volume", onSave = () => 
                 </Flex>
                 <Flex direction="column" flex="1">
                     <Text mb={1}>Size:</Text>
-                    <Input placeholder="Size (e.g. 10G, blank = app default)" value={vol.size} onChange={(e) => handleArrayChange("size", e.target.value)} />
-                    <Text mb={1} fontSize="sm" color="gray.500">Blank inherits app default. Accepts units (e.g. 10G, 2T); saved value is normalized to GB.</Text>
+                    <SizeField value={vol.size} onChange={(value) => handleArrayChange("size", value)} />
                 </Flex>
                 <Flex direction="column" flex="1">
                     <HStack spacing={2} mt={4}>

--- a/share/dashboard_react/src/Pages/ClusterApp/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/index.jsx
@@ -78,28 +78,30 @@ function ClusterApp() {
       callServices()
       return
     }
-
     if (clusterApps?.length > 0 && appId) {
       const app = clusterApps.find((x) => x.id === appId)
       setSelectedApp(app)
     }
+  }, [appId, clusterApps])
+
+  useEffect(() => {
     if (clusterData?.apiUsers && loggedUser) {
-        const apiUser = clusterData?.apiUsers[loggedUser.User] || clusterData?.apiUsers[loggedUser.Email]
-        if (apiUser) {
-          const authorizedTabs = [
-            <>
-              <CustomIcon icon={HiArrowNarrowLeft} /> Dashboard
-            </>
-          ]
-          authorizedTabs.push('App Overview')
-          authorizedTabs.push('Storages')
-          authorizedTabs.push('Service OpenSVC')
-          authorizedTabs.push('Templates')
-          tabs.current = authorizedTabs
-          setUser(apiUser)
-        }
+      const apiUser = clusterData?.apiUsers[loggedUser.User] || clusterData?.apiUsers[loggedUser.Email]
+      if (apiUser) {
+        const authorizedTabs = [
+          <>
+            <CustomIcon icon={HiArrowNarrowLeft} /> Dashboard
+          </>
+        ]
+        authorizedTabs.push('App Overview')
+        authorizedTabs.push('Storages')
+        authorizedTabs.push('Service OpenSVC')
+        authorizedTabs.push('Templates')
+        tabs.current = authorizedTabs
+        setUser(apiUser)
+      }
     }
-  }, [appId, clusterApps, loggedUser])
+  }, [clusterData, loggedUser])
 
 
   const handleTabChange = (tabIndex) => {

--- a/share/dashboard_react/src/Pages/ClusterApp/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/index.jsx
@@ -74,11 +74,11 @@ function ClusterApp() {
 
 
   useEffect(() => {
-    if (clusterApps?.length === 0) {
+    if (!Array.isArray(clusterApps) || clusterApps.length === 0) {
       callServices()
       return
     }
-    if (clusterApps?.length > 0 && appId) {
+    if (appId) {
       const app = clusterApps.find((x) => x.id === appId)
       setSelectedApp(app)
     }
@@ -112,7 +112,7 @@ function ClusterApp() {
     }
   }
 
-  if (clusterApps?.length === 0 || !selectedApp) {
+  if (!Array.isArray(clusterApps) || clusterApps.length === 0 || !selectedApp) {
     return (
       <PageContainer>
         <Box className={styles.container}>

--- a/share/dashboard_react/src/components/Dropdown/index.jsx
+++ b/share/dashboard_react/src/components/Dropdown/index.jsx
@@ -26,6 +26,7 @@ function Dropdown({
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false)
 
   useEffect(() => {
+    if (isConfirmModalOpen) return
     if (options && selectedValue) {
       const option = options.find((opt) => opt.value == selectedValue || opt.name === selectedValue)
       if (option) {
@@ -33,7 +34,7 @@ function Dropdown({
         setPreviousOption(option)
       }
     }
-  }, [options, selectedValue])
+  }, [options, selectedValue, isConfirmModalOpen])
 
   const handleChange = (option) => {
     setSelectedOption(option)

--- a/share/dashboard_react/src/components/ServerStatus.jsx
+++ b/share/dashboard_react/src/components/ServerStatus.jsx
@@ -4,7 +4,7 @@ import TagPill from './TagPill'
 function ServerStatus({ state, isVirtualMaster, isBlinking = false }) {
   const [isVirtual, setIsVirtual] = useState('')
   const [colorScheme, setColorScheme] = useState('gray')
-  const [stateValue, setStateValue] = useState(state.toUpperCase())
+  const [stateValue, setStateValue] = useState(state ? state.toUpperCase() : '')
 
   useEffect(() => {
     if (state) {

--- a/share/dashboard_react/src/components/TextForm/index.jsx
+++ b/share/dashboard_react/src/components/TextForm/index.jsx
@@ -26,7 +26,7 @@ function TextForm({ onSave, id, type, label, value, loading, maxLength = 120, cl
   const [isTreeModalOpen, setIsTreeModalOpen] = useState(false)
 
   useEffect(() => {
-    if (value) {
+    if (value !== undefined && value !== null) {
       setCurrentValue(value)
       setPreviousValue(value)
     }

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -2778,8 +2778,9 @@ export const clusterSlice = createSlice({
         }
 
         if (typePrefix === 'cluster/getClusterApps') {
-          state.clusterApps = action.payload?.data
-          state.clusterAppStates = buildClusterStateSignature(action.payload?.data)
+          const appsData = action.payload?.data
+          state.clusterApps = Array.isArray(appsData) ? appsData : []
+          state.clusterAppStates = buildClusterStateSignature(state.clusterApps)
           return
         }
 

--- a/share/dashboard_react/src/redux/settingsSlice.js
+++ b/share/dashboard_react/src/redux/settingsSlice.js
@@ -84,7 +84,7 @@ export const setAppSetting = createAsyncThunk('settings/setAppSetting', async ({
   try {
     // showLoaderBanner(`${setting} `, thunkAPI)
     const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
-    const { data, status } = value !== "" ? await settingsService.setAppSetting(clusterName, appId, setting, value, baseURL) : await settingsService.clearAppSetting(clusterName, setting, baseURL)
+    const { data, status } = value !== "" ? await settingsService.setAppSetting(clusterName, appId, setting, value, baseURL) : await settingsService.clearAppSetting(clusterName, appId, setting, baseURL)
     if (status === 200) {
       showSuccessBanner(`${setting} changed successfully!`, status, thunkAPI)
       return { data, status }


### PR DESCRIPTION
## Summary
- add app sizing modes, credit tracking, and startup/provision credit reconciliation
- add app overview UI for per-app and cluster Cloud18 credit usage plus unit-based sizing controls
- add per-volume size overrides and related template/deployment compatibility handling
- harden cluster app loading for malformed app payloads and guard empty server status rendering

## Validation
- go test ./cluster
- npm run build

## Notes
- branch includes the related follow-up fixes for credit cap reconciliation and ClusterApp UI hardening