### PR TITLE
fix: harden arbitrator docker image and mysql backend

### DIFF
--- a/arbitrator/arbitrator.go
+++ b/arbitrator/arbitrator.go
@@ -155,7 +155,9 @@ func getArbitratorBackendStorageConnection() (*sqlx.DB, error) {
 			return nil, fmt.Errorf("arbitrator mysql backend requires db-servers-hosts")
 		}
 		host, port := misc.SplitHostPort(hosts[0])
-		user, pass := misc.SplitPair(RepMan.Confs["arbitrator"].User)
+		arbConf := RepMan.Confs["arbitrator"]
+		credential := arbConf.DecryptSecretValue("db-servers-credential", arbConf.User)
+		user, pass := misc.SplitPair(credential)
 		db, err = dbhelper.MySQLConnect(user, pass, dbhelper.GetAddress(host, port, ""), fmt.Sprintf("timeout=%ds", RepMan.Confs["arbitrator"].Timeout))
 	}
 	return db, err

--- a/arbitrator/arbitrator.go
+++ b/arbitrator/arbitrator.go
@@ -14,13 +14,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/jmoiron/sqlx"
-	"github.com/signal18/replication-manager/cluster"
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/server"
 	"github.com/signal18/replication-manager/utils/dbhelper"
+	"github.com/signal18/replication-manager/utils/misc"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	_ "modernc.org/sqlite"
@@ -92,7 +93,6 @@ type response struct {
 }
 
 var (
-	arbitratorCluster *cluster.Cluster
 	arbitratorDB      *sqlx.DB
 )
 
@@ -101,7 +101,7 @@ func init() {
 	rootCmd.AddCommand(arbitratorCmd)
 	arbitratorCmd.Flags().StringVar(&conf.ArbitratorAddress, "arbitrator-bind-address", "0.0.0.0:10001", "Arbitrator API port")
 	arbitratorCmd.Flags().StringVar(&conf.ArbitratorDriver, "arbitrator-driver", "sqlite", "sqlite|mysql, use a local sqllite or use a mysql backend")
-
+	
 }
 
 var arbitratorCmd = &cobra.Command{
@@ -114,12 +114,6 @@ var arbitratorCmd = &cobra.Command{
 
 		if _, ok := RepMan.Confs["arbitrator"]; !ok {
 			log.Fatal("Could not find arbitrator configuration section")
-		}
-
-		if RepMan.Confs["arbitrator"].ArbitratorDriver == "mysql" {
-			arbitratorCluster = new(cluster.Cluster)
-			arbitratorCluster.InitAgent(RepMan.Confs["arbitrator"])
-			arbitratorCluster.SetLogStdout()
 		}
 
 		var err error
@@ -156,7 +150,13 @@ func getArbitratorBackendStorageConnection() (*sqlx.DB, error) {
 		db, err = dbhelper.SQLiteConnect(conf.WorkingDir)
 	}
 	if RepMan.Confs["arbitrator"].ArbitratorDriver == "mysql" {
-		db, err = dbhelper.MySQLConnect(arbitratorCluster.GetServers()[0].User, arbitratorCluster.GetServers()[0].Pass, arbitratorCluster.GetServers()[0].Host+":"+arbitratorCluster.GetServers()[0].Port, fmt.Sprintf("?timeout=%ds", RepMan.Confs["arbitrator"].Timeout))
+		hosts := strings.Split(RepMan.Confs["arbitrator"].Hosts, ",")
+		if len(hosts) == 0 || hosts[0] == "" {
+			return nil, fmt.Errorf("arbitrator mysql backend requires db-servers-hosts")
+		}
+		host, port := misc.SplitHostPort(hosts[0])
+		user, pass := misc.SplitPair(RepMan.Confs["arbitrator"].User)
+		db, err = dbhelper.MySQLConnect(user, pass, dbhelper.GetAddress(host, port, ""), fmt.Sprintf("timeout=%ds", RepMan.Confs["arbitrator"].Timeout))
 	}
 	return db, err
 }

--- a/arbitrator/arbitrator.go
+++ b/arbitrator/arbitrator.go
@@ -113,7 +113,7 @@ var arbitratorCmd = &cobra.Command{
 		RepMan.InitConfig(conf, false)
 
 		if _, ok := RepMan.Confs["arbitrator"]; !ok {
-			log.Fatal("Could not find arbitrator configuration section")
+			log.Fatal("Could not find [arbitrator] configuration section. Provide a config file with an [arbitrator] section or use the Docker env-backed entrypoint configuration.")
 		}
 
 		var err error
@@ -152,11 +152,14 @@ func getArbitratorBackendStorageConnection() (*sqlx.DB, error) {
 	if RepMan.Confs["arbitrator"].ArbitratorDriver == "mysql" {
 		hosts := strings.Split(RepMan.Confs["arbitrator"].Hosts, ",")
 		if len(hosts) == 0 || hosts[0] == "" {
-			return nil, fmt.Errorf("arbitrator mysql backend requires db-servers-hosts")
+			return nil, fmt.Errorf("arbitrator mysql backend requires [arbitrator].db-servers-hosts (example: \"127.0.0.1:3306\")")
 		}
 		host, port := misc.SplitHostPort(hosts[0])
 		arbConf := RepMan.Confs["arbitrator"]
 		credential := arbConf.DecryptSecretValue("db-servers-credential", arbConf.User)
+		if !strings.Contains(credential, ":") {
+			return nil, fmt.Errorf("arbitrator mysql backend requires [arbitrator].db-servers-credential in \"user:password\" format")
+		}
 		user, pass := misc.SplitPair(credential)
 		db, err = dbhelper.MySQLConnect(user, pass, dbhelper.GetAddress(host, port, ""), fmt.Sprintf("timeout=%ds", RepMan.Confs["arbitrator"].Timeout))
 	}

--- a/arbitrator/arbitrator_cmd.go
+++ b/arbitrator/arbitrator_cmd.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/signal18/replication-manager/server"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var withArbitration = "ON"
@@ -80,7 +79,5 @@ func initLogFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&conf.LogRotateMaxSize, "log-rotate-max-size", 5, "Log rotate max size")
 	cmd.Flags().IntVar(&conf.LogRotateMaxBackup, "log-rotate-max-backup", 7, "Log rotate max backup")
 	cmd.Flags().IntVar(&conf.LogRotateMaxAge, "log-rotate-max-age", 7, "Log rotate max age")
-
-	viper.BindPFlags(cmd.Flags())
 
 }

--- a/docker/Dockerfile.arb
+++ b/docker/Dockerfile.arb
@@ -1,33 +1,27 @@
-FROM golang:1.13-alpine as builder
-
-RUN apk --no-cache --update add make git
+FROM golang:1.25-bookworm AS builder
 
 RUN mkdir -p /go/src/github.com/signal18/replication-manager
 WORKDIR /go/src/github.com/signal18/replication-manager
 
 COPY . .
+RUN make arb
 
-RUN make osc cli
-
-
-FROM alpine:3
+FROM debian:bookworm-slim
 
 RUN mkdir -p \
         /etc/replication-manager \
         /etc/replication-manager/cluster.d \
-        /var/lib/replication-manager \
-        /var/lib/replication-manager/conf \
-        /var/lib/replication-manager/recover
-RUN addgroup -S repman \
-  && adduser -S -D -G repman -h /var/lib/replication-manager -s /sbin/nologin repman \
-  && chown -R repman:repman /etc/replication-manager /etc/replication-manager/cluster.d /var/lib/replication-manager
+        /var/lib/replication-manager
 
-RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+RUN apt-get update && apt-get -y install ca-certificates sqlite3 \
+    && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /go/src/github.com/signal18/replication-manager/etc/local/features/arbitrator/config.toml.sample.arbitrator /etc/replication-manager/config.toml
-COPY --from=builder /go/src/github.com/signal18/replication-manager/build/binaries/replication-manager-arb /usr/bin/replication-manager
+COPY docker/arb/arbitrator.toml /etc/replication-manager/config.toml
+COPY --from=builder /go/src/github.com/signal18/replication-manager/build/binaries/replication-manager-arb /usr/bin/replication-manager-arb
+COPY docker/arb/docker-entrypoint-arb.sh /usr/local/bin/docker-entrypoint-arb.sh
 
-RUN apk --no-cache --update add ca-certificates restic mariadb-client mariadb haproxy
+RUN chmod +x /usr/local/bin/docker-entrypoint-arb.sh
 
-CMD ["replication-manager-arb", "arbitrator" ]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint-arb.sh"]
+CMD ["replication-manager-arb", "--config", "/etc/replication-manager/config.toml", "arbitrator"]
 EXPOSE 10001

--- a/docker/arb/arbitrator.toml
+++ b/docker/arb/arbitrator.toml
@@ -1,6 +1,6 @@
 [arbitrator]
 title = "arbitrator"
-arbitrator-bind-address = "0.0.0.0:10001"
+arbitrator-bind-address = "0.0.0.0:8080"
 arbitrator-driver = "sqlite"
 
 [default]

--- a/docker/arb/arbitrator.toml
+++ b/docker/arb/arbitrator.toml
@@ -1,0 +1,7 @@
+[arbitrator]
+title = "arbitrator"
+arbitrator-bind-address = "0.0.0.0:10001"
+arbitrator-driver = "sqlite"
+
+[default]
+monitoring-datadir = "/var/lib/replication-manager"

--- a/docker/arb/docker-entrypoint-arb.sh
+++ b/docker/arb/docker-entrypoint-arb.sh
@@ -49,7 +49,7 @@ if [ "$HAS_ENV_CONFIG" = "1" ]; then
   MONITORING_DATADIR=$(first_nonempty MONITORING_DATADIR REPLICATION_MANAGER_DEFAULT_MONITORING_DATADIR || printf '/var/lib/replication-manager')
 
   if [ "$DRIVER" = "mysql" ] && { [ -z "$DB_HOSTS" ] || [ -z "$DB_CREDENTIAL" ]; }; then
-    echo "error: mysql arbitrator backend requires DB_SERVERS_HOSTS and DB_SERVERS_CREDENTIAL" >&2
+    echo "error: mysql arbitrator backend requires DB_SERVERS_HOSTS and DB_SERVERS_CREDENTIAL (or REPLICATION_MANAGER_ARBITRATOR_DB_SERVERS_HOSTS and REPLICATION_MANAGER_ARBITRATOR_DB_SERVERS_CREDENTIAL)" >&2
     exit 1
   fi
 

--- a/docker/arb/docker-entrypoint-arb.sh
+++ b/docker/arb/docker-entrypoint-arb.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+set -eu
+
+CONFIG_FILE="/etc/replication-manager/config.toml"
+
+first_nonempty() {
+  for var_name in "$@"; do
+    eval "var_value=\${$var_name-}"
+    if [ -n "$var_value" ]; then
+      printf '%s' "$var_value"
+      return 0
+    fi
+  done
+  return 1
+}
+
+escape_toml() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+HAS_ENV_CONFIG=0
+for env_name in \
+  ARBITRATOR_TITLE \
+  ARBITRATOR_BIND_ADDRESS \
+  ARBITRATOR_DRIVER \
+  DB_SERVERS_HOSTS \
+  DB_SERVERS_CREDENTIAL \
+  MONITORING_DATADIR \
+  REPLICATION_MANAGER_ARBITRATOR_TITLE \
+  REPLICATION_MANAGER_ARBITRATOR_ARBITRATOR_BIND_ADDRESS \
+  REPLICATION_MANAGER_ARBITRATOR_ARBITRATOR_DRIVER \
+  REPLICATION_MANAGER_ARBITRATOR_DB_SERVERS_HOSTS \
+  REPLICATION_MANAGER_ARBITRATOR_DB_SERVERS_CREDENTIAL \
+  REPLICATION_MANAGER_DEFAULT_MONITORING_DATADIR
+do
+  eval "env_value=\${$env_name-}"
+  if [ -n "$env_value" ]; then
+    HAS_ENV_CONFIG=1
+    break
+  fi
+done
+
+if [ "$HAS_ENV_CONFIG" = "1" ]; then
+  TITLE=$(first_nonempty ARBITRATOR_TITLE REPLICATION_MANAGER_ARBITRATOR_TITLE || printf 'arbitrator')
+  BIND_ADDRESS=$(first_nonempty ARBITRATOR_BIND_ADDRESS REPLICATION_MANAGER_ARBITRATOR_ARBITRATOR_BIND_ADDRESS || printf '0.0.0.0:8080')
+  DRIVER=$(first_nonempty ARBITRATOR_DRIVER REPLICATION_MANAGER_ARBITRATOR_ARBITRATOR_DRIVER || printf 'sqlite')
+  DB_HOSTS=$(first_nonempty DB_SERVERS_HOSTS REPLICATION_MANAGER_ARBITRATOR_DB_SERVERS_HOSTS || printf '')
+  DB_CREDENTIAL=$(first_nonempty DB_SERVERS_CREDENTIAL REPLICATION_MANAGER_ARBITRATOR_DB_SERVERS_CREDENTIAL || printf '')
+  MONITORING_DATADIR=$(first_nonempty MONITORING_DATADIR REPLICATION_MANAGER_DEFAULT_MONITORING_DATADIR || printf '/var/lib/replication-manager')
+
+  if [ "$DRIVER" = "mysql" ] && { [ -z "$DB_HOSTS" ] || [ -z "$DB_CREDENTIAL" ]; }; then
+    echo "error: mysql arbitrator backend requires DB_SERVERS_HOSTS and DB_SERVERS_CREDENTIAL" >&2
+    exit 1
+  fi
+
+  mkdir -p "$MONITORING_DATADIR"
+
+  {
+    printf '[arbitrator]\n'
+    printf 'title = "%s"\n' "$(escape_toml "$TITLE")"
+    printf 'arbitrator-bind-address = "%s"\n' "$(escape_toml "$BIND_ADDRESS")"
+    printf 'arbitrator-driver = "%s"\n' "$(escape_toml "$DRIVER")"
+    if [ -n "$DB_HOSTS" ]; then
+      printf 'db-servers-hosts = "%s"\n' "$(escape_toml "$DB_HOSTS")"
+    fi
+    if [ -n "$DB_CREDENTIAL" ]; then
+      printf 'db-servers-credential = "%s"\n' "$(escape_toml "$DB_CREDENTIAL")"
+    fi
+    printf '[default]\n'
+    printf 'monitoring-datadir = "%s"\n' "$(escape_toml "$MONITORING_DATADIR")"
+  } > "$CONFIG_FILE"
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary
- make the arbitrator Docker image build the arb binary explicitly and support env-backed config generation
- move arbitrator Docker support files under `docker/arb/` and keep the default bind port backward compatible
- simplify the mysql backend connection path, decrypt `db-servers-credential`, and improve arbitrator config error messages

## Testing
- go build -tags "arbitrator" -o /tmp/replication-manager-arb .
- docker build -f "docker/Dockerfile.arb" -t repman-arb-test .
- docker run --rm repman-arb-test
- docker run --rm -e ARBITRATOR_BIND_ADDRESS=0.0.0.0:10002 repman-arb-test
- docker build -f "docker/Dockerfile.dev" -t repman-dev-test .
- docker build -f "docker/Dockerfile.pro" -t repman-pro-test .