### PR TITLE
fix(app): improve deployment path mappings

### DIFF
--- a/cluster/path_mapping_compat_test.go
+++ b/cluster/path_mapping_compat_test.go
@@ -851,3 +851,117 @@ func TestValidateAppVolumeSizes_AllowsValidSizes(t *testing.T) {
 		}
 	}
 }
+
+// TestGetOpenSVCDeploymentPathMapping_MultiPathSameVolumeSubpaths verifies that
+// two direct path mappings referencing the same volume row but different
+// SourcePath subpaths both render as distinct OpenSVC volume_mounts entries:
+// vol-a/data:/docker/data and vol-a/config:/docker/config.
+func TestGetOpenSVCDeploymentPathMapping_MultiPathSameVolumeSubpaths(t *testing.T) {
+	deployment := config.NewDeploymentConfig()
+	deployment.Storages.Volumes = config.Volumes{
+		{Name: "vol-a", PoolName: "data", VolumeDir: "data"},
+	}
+	deployment.Paths = config.PathMaps{
+		{
+			Name:       "data-path",
+			DockerPath: "/docker/data",
+			SourceType: config.SourceVolume,
+			SourceName: "vol-a",
+			SourcePath: "data",
+			VolumeName: "vol-a",
+		},
+		{
+			Name:       "config-path",
+			DockerPath: "/docker/config",
+			SourceType: config.SourceVolume,
+			SourceName: "vol-a",
+			SourcePath: "config",
+			VolumeName: "vol-a",
+		},
+	}
+
+	if errs := deployment.ResolvePaths(); len(errs) > 0 {
+		t.Fatalf("expected deployment paths to resolve, got %v", errs)
+	}
+
+	cl := &Cluster{Name: "test", Conf: &config.Config{}}
+	app := &App{Name: "myapp", AppConfig: &config.AppConfig{Deployment: deployment}}
+
+	got := cl.GetOpenSVCDeploymentPathMapping(app)
+	tokens := strings.Fields(got)
+	if len(tokens) != 2 {
+		t.Fatalf("expected 2 mount mappings, got %d: %q", len(tokens), got)
+	}
+
+	expected := map[string]bool{
+		"vol-a/data:/docker/data":     false,
+		"vol-a/config:/docker/config": false,
+	}
+	for _, token := range tokens {
+		if _, ok := expected[token]; ok {
+			expected[token] = true
+		}
+	}
+	for token, found := range expected {
+		if !found {
+			t.Fatalf("expected mount mapping %q in output %q", token, got)
+		}
+	}
+}
+
+// TestGetOpenSVCDeploymentPathMapping_RootAndSubdirOnSameVolume verifies that a
+// root mapping (SourcePath ".") and a subdir mapping (SourcePath "config") on
+// the same volume row render as distinct entries: vol-a:/docker/root and
+// vol-a/config:/docker/config.
+func TestGetOpenSVCDeploymentPathMapping_RootAndSubdirOnSameVolume(t *testing.T) {
+	deployment := config.NewDeploymentConfig()
+	deployment.Storages.Volumes = config.Volumes{
+		{Name: "vol-a", PoolName: "data", VolumeDir: "data"},
+	}
+	deployment.Paths = config.PathMaps{
+		{
+			Name:       "root-path",
+			DockerPath: "/docker/root",
+			SourceType: config.SourceVolume,
+			SourceName: "vol-a",
+			SourcePath: ".",
+			VolumeName: "vol-a",
+		},
+		{
+			Name:       "config-path",
+			DockerPath: "/docker/config",
+			SourceType: config.SourceVolume,
+			SourceName: "vol-a",
+			SourcePath: "config",
+			VolumeName: "vol-a",
+		},
+	}
+
+	if errs := deployment.ResolvePaths(); len(errs) > 0 {
+		t.Fatalf("expected deployment paths to resolve, got %v", errs)
+	}
+
+	cl := &Cluster{Name: "test", Conf: &config.Config{}}
+	app := &App{Name: "myapp", AppConfig: &config.AppConfig{Deployment: deployment}}
+
+	got := cl.GetOpenSVCDeploymentPathMapping(app)
+	tokens := strings.Fields(got)
+	if len(tokens) != 2 {
+		t.Fatalf("expected 2 mount mappings, got %d: %q", len(tokens), got)
+	}
+
+	expected := map[string]bool{
+		"vol-a:/docker/root":          false,
+		"vol-a/config:/docker/config": false,
+	}
+	for _, token := range tokens {
+		if _, ok := expected[token]; ok {
+			expected[token] = true
+		}
+	}
+	for token, found := range expected {
+		if !found {
+			t.Fatalf("expected mount mapping %q in output %q", token, got)
+		}
+	}
+}

--- a/config/deployment.go
+++ b/config/deployment.go
@@ -331,10 +331,13 @@ func (d *Deployment) InsertPath(p PathMapping) error {
 	d.Mutex.Lock()
 	defer d.Mutex.Unlock()
 
-	// Check if the path already exists
+	// Check for duplicate DockerPath and duplicate Name (name drives parent resolution)
 	for _, existingPath := range d.Paths {
 		if existingPath.DockerPath == p.DockerPath {
 			return fmt.Errorf("path mapping already exists for target path: %s", p.DockerPath)
+		}
+		if p.Name != "" && existingPath.Name == p.Name {
+			return fmt.Errorf("path mapping with name %q already exists", p.Name)
 		}
 	}
 

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"net/http"
 	"os"
@@ -1965,13 +1966,41 @@ func (repman *ReplicationManager) handlerMuxAddDeploymentFieldRow(w http.Respons
 		errors := make([]error, 0)
 		deployment := node.AppConfig.Deployment
 		for _, row := range body {
-			if row.DockerPath == "" || row.SourceName == "" || row.SourcePath == "" {
-				http.Error(w, "All fields (destPath, sourceName, sourcePath) must be provided for path", http.StatusInternalServerError)
+			if row.DockerPath == "" {
+				http.Error(w, "dockerpath is required for all path rows", http.StatusBadRequest)
+				return
+			}
+			// A path must have a direct source or a parent to be provisionable
+			if row.SourceType == "" && row.ParentName == "" {
+				http.Error(w, "path "+row.DockerPath+" must have either srctype or parentname", http.StatusBadRequest)
+				return
+			}
+			// Reject partial source state
+			if row.SourceType != "" && row.SourceName == "" {
+				http.Error(w, "srcname is required when srctype is provided for path "+row.DockerPath, http.StatusBadRequest)
+				return
+			}
+			if row.SourceName != "" && row.SourceType == "" {
+				http.Error(w, "srctype is required when srcname is provided for path "+row.DockerPath, http.StatusBadRequest)
+				return
+			}
+			// Direct-source rows require srcpath
+			if row.SourceType != "" && row.SourcePath == "" {
+				http.Error(w, "srcpath is required for direct-source path "+row.DockerPath, http.StatusBadRequest)
+				return
+			}
+			// Inherited child rows must not mix partial source data
+			if row.ParentName != "" && row.SourceType == "" && (row.SourceName != "" || row.SourcePath != "") {
+				http.Error(w, "inherited child path "+row.DockerPath+" cannot have source fields without srctype", http.StatusBadRequest)
 				return
 			}
 			if row.Name == "" {
-				// Generate a unique name for the path if not provided
-				row.Name = fmt.Sprintf("path-%s-%s", row.SourceType, row.SourceName)
+				// Hash the raw DockerPath so the fallback name is unique for any
+				// distinct DockerPath string, including formatting variants that
+				// sanitization would otherwise collapse to the same token.
+				h := fnv.New32a()
+				h.Write([]byte(row.DockerPath))
+				row.Name = fmt.Sprintf("path-%08x", h.Sum32())
 			}
 			err := deployment.InsertPath(row)
 			if err != nil {

--- a/server/api_app_path_mapping_test.go
+++ b/server/api_app_path_mapping_test.go
@@ -12,6 +12,135 @@ import (
 	"github.com/signal18/replication-manager/config"
 )
 
+// newAddPathRequest builds a POST request equivalent to
+// /api/clusters/{cluster}/apps/{app}/deployment/paths/add with the given
+// path rows as JSON body.
+func newAddPathRequest(t *testing.T, repman *ReplicationManager, cl *cluster.Cluster, rows []config.PathMapping) *http.Request {
+	t.Helper()
+	tok := issueVolumeTestJWT(t, repman)
+	body, _ := json.Marshal(rows)
+	url := fmt.Sprintf("/api/clusters/%s/apps/%s/deployment/paths/add", cl.Name, volumeTestAppId)
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req = setMuxVars(req, map[string]string{
+		"clusterName": cl.Name,
+		"appName":     volumeTestAppId,
+		"field":       "paths",
+	})
+	return req
+}
+
+// TestAddPath_DirectVolumeRow_V2 verifies that a direct-source volume path row
+// with srcname = volume row name and srcpath "." is accepted, and that the
+// backend resolves VolumeName to the volume row name.
+func TestAddPath_DirectVolumeRow_V2(t *testing.T) {
+	repman, cl, app := newPathMappingTestSetup(t)
+
+	req := newAddPathRequest(t, repman, cl, []config.PathMapping{
+		{Name: "web-root", DockerPath: "/var/www/html", SourceType: config.SourceVolume, SourceName: "vol-a", SourcePath: "."},
+	})
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddDeploymentFieldRow(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for direct V2 volume path, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(app.AppConfig.Deployment.Paths) != 1 {
+		t.Fatalf("expected 1 path, got %d", len(app.AppConfig.Deployment.Paths))
+	}
+	got := app.AppConfig.Deployment.Paths[0]
+	if got.VolumeName != "vol-a" {
+		t.Fatalf("expected VolumeName vol-a, got %q", got.VolumeName)
+	}
+	if got.SourcePath != "." {
+		t.Fatalf("expected SourcePath '.', got %q", got.SourcePath)
+	}
+}
+
+// TestAddPath_InheritedChildRow verifies that an inherited child path row
+// (parentname set, empty source fields) is accepted and resolves VolumeName
+// from the parent.
+func TestAddPath_InheritedChildRow(t *testing.T) {
+	repman, cl, app := newPathMappingTestSetup(t)
+	// seed the parent row directly so the child has a real parent to resolve
+	app.AppConfig.Deployment.Paths = config.PathMaps{
+		{Name: "web-root", DockerPath: "/var/www/html", SourceType: config.SourceVolume, SourceName: "vol-a", SourcePath: ".", VolumeName: "vol-a"},
+	}
+	if errs := app.AppConfig.Deployment.ResolvePaths(); len(errs) > 0 {
+		t.Fatalf("initial ResolvePaths: %v", errs)
+	}
+
+	req := newAddPathRequest(t, repman, cl, []config.PathMapping{
+		{Name: "assets", DockerPath: "/var/www/html/assets", ParentName: "web-root"},
+	})
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddDeploymentFieldRow(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for inherited child path, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(app.AppConfig.Deployment.Paths) != 2 {
+		t.Fatalf("expected 2 paths, got %d", len(app.AppConfig.Deployment.Paths))
+	}
+	child := app.AppConfig.Deployment.Paths[1]
+	if child.SourceType != "" || child.SourceName != "" || child.SourcePath != "" {
+		t.Fatalf("expected inherited child source fields empty, got srctype=%q srcname=%q srcpath=%q",
+			child.SourceType, child.SourceName, child.SourcePath)
+	}
+	if child.VolumeName != "vol-a" {
+		t.Fatalf("expected child VolumeName vol-a (inherited from parent), got %q", child.VolumeName)
+	}
+}
+
+// TestAddPath_RejectsMissingDockerPath verifies that a path row without
+// dockerpath is rejected.
+func TestAddPath_RejectsMissingDockerPath(t *testing.T) {
+	repman, cl, _ := newPathMappingTestSetup(t)
+
+	req := newAddPathRequest(t, repman, cl, []config.PathMapping{
+		{Name: "bad", SourceType: config.SourceVolume, SourceName: "vol-a", SourcePath: "."},
+	})
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddDeploymentFieldRow(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Fatal("expected error for missing dockerpath, got 200")
+	}
+}
+
+// TestAddPath_RejectsPartialSource_SrcTypeWithoutSrcName verifies that srctype
+// without srcname is rejected.
+func TestAddPath_RejectsPartialSource_SrcTypeWithoutSrcName(t *testing.T) {
+	repman, cl, _ := newPathMappingTestSetup(t)
+
+	req := newAddPathRequest(t, repman, cl, []config.PathMapping{
+		{Name: "partial", DockerPath: "/var/www/html", SourceType: config.SourceVolume, SourcePath: "."},
+	})
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddDeploymentFieldRow(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Fatal("expected error for srctype without srcname, got 200")
+	}
+}
+
+// TestAddPath_RejectsDirectSourceWithoutSrcPath verifies that a direct-source
+// row without srcpath is rejected.
+func TestAddPath_RejectsDirectSourceWithoutSrcPath(t *testing.T) {
+	repman, cl, _ := newPathMappingTestSetup(t)
+
+	req := newAddPathRequest(t, repman, cl, []config.PathMapping{
+		{Name: "no-srcpath", DockerPath: "/var/www/html", SourceType: config.SourceVolume, SourceName: "vol-a"},
+	})
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddDeploymentFieldRow(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Fatal("expected error for direct-source row without srcpath, got 200")
+	}
+}
+
 func newPathMappingTestSetup(t *testing.T) (*ReplicationManager, *cluster.Cluster, *cluster.App) {
 	t.Helper()
 
@@ -230,5 +359,187 @@ func TestModifyVolumeName_PreservesInheritedChildSourceFields(t *testing.T) {
 	}
 	if child.VolumeName != "vol-renamed" {
 		t.Fatalf("expected child inherited volumename vol-renamed, got %q", child.VolumeName)
+	}
+}
+
+// TestAddPath_MultiPathSameVolumeRow verifies that two direct path rows
+// referencing the same volume row but with different srcpath subpaths are both
+// accepted by the add-path API, and that each row resolves VolumeName to the
+// shared volume row name while preserving its own distinct SourcePath.
+func TestAddPath_MultiPathSameVolumeRow(t *testing.T) {
+	repman, cl, app := newPathMappingTestSetup(t)
+
+	// Add the first path: vol-a mapped at subdir "data"
+	req := newAddPathRequest(t, repman, cl, []config.PathMapping{
+		{Name: "data-path", DockerPath: "/docker/data", SourceType: config.SourceVolume, SourceName: "vol-a", SourcePath: "data"},
+	})
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddDeploymentFieldRow(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for first path on vol-a, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Add the second path: same vol-a, different subdir "config"
+	req = newAddPathRequest(t, repman, cl, []config.PathMapping{
+		{Name: "config-path", DockerPath: "/docker/config", SourceType: config.SourceVolume, SourceName: "vol-a", SourcePath: "config"},
+	})
+	w = httptest.NewRecorder()
+	repman.handlerMuxAddDeploymentFieldRow(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for second path on vol-a, got %d: %s", w.Code, w.Body.String())
+	}
+
+	paths := app.AppConfig.Deployment.Paths
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 paths, got %d", len(paths))
+	}
+
+	// Both rows must resolve to the same VolumeName but keep distinct SourcePaths
+	if paths[0].VolumeName != "vol-a" || paths[1].VolumeName != "vol-a" {
+		t.Fatalf("expected both paths to resolve VolumeName vol-a, got %q and %q", paths[0].VolumeName, paths[1].VolumeName)
+	}
+	sourcePaths := map[string]bool{paths[0].SourcePath: true, paths[1].SourcePath: true}
+	if !sourcePaths["data"] || !sourcePaths["config"] {
+		t.Fatalf("expected SourcePaths {data, config}, got %q and %q", paths[0].SourcePath, paths[1].SourcePath)
+	}
+}
+
+// TestAddPath_RootAndSubdirOnSameVolumeRow verifies that a root mapping
+// (srcpath ".") and a subdir mapping (srcpath "config") on the same volume
+// row can coexist and are both accepted by the add-path API.
+func TestAddPath_RootAndSubdirOnSameVolumeRow(t *testing.T) {
+	repman, cl, app := newPathMappingTestSetup(t)
+
+	req := newAddPathRequest(t, repman, cl, []config.PathMapping{
+		{Name: "root-path", DockerPath: "/docker/root", SourceType: config.SourceVolume, SourceName: "vol-a", SourcePath: "."},
+	})
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddDeploymentFieldRow(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for root path on vol-a, got %d: %s", w.Code, w.Body.String())
+	}
+
+	req = newAddPathRequest(t, repman, cl, []config.PathMapping{
+		{Name: "config-path", DockerPath: "/docker/config", SourceType: config.SourceVolume, SourceName: "vol-a", SourcePath: "config"},
+	})
+	w = httptest.NewRecorder()
+	repman.handlerMuxAddDeploymentFieldRow(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for subdir path on vol-a, got %d: %s", w.Code, w.Body.String())
+	}
+
+	paths := app.AppConfig.Deployment.Paths
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 paths, got %d", len(paths))
+	}
+	sourcePaths := map[string]bool{paths[0].SourcePath: true, paths[1].SourcePath: true}
+	if !sourcePaths["."] || !sourcePaths["config"] {
+		t.Fatalf("expected SourcePaths {., config}, got %q and %q", paths[0].SourcePath, paths[1].SourcePath)
+	}
+}
+
+// TestAddPath_RejectsBareRootRow verifies that a path row with no srctype and
+// no parentname is rejected by the add-path API — such a row cannot be
+// provisioned by OpenSVC since it has no source and no inherited volume.
+func TestAddPath_RejectsBareRootRow(t *testing.T) {
+	repman, cl, _ := newPathMappingTestSetup(t)
+
+	req := newAddPathRequest(t, repman, cl, []config.PathMapping{
+		{Name: "bare", DockerPath: "/docker/bare"},
+	})
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddDeploymentFieldRow(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Fatal("expected error for bare root row (no srctype, no parentname), got 200")
+	}
+}
+
+// TestAddPath_UnnamedRowsFallbackNamesAreUnique verifies that when two unnamed
+// path rows targeting different dockerpaths are added to the same volume row,
+// both succeed and their server-generated fallback names are distinct.
+func TestAddPath_UnnamedRowsFallbackNamesAreUnique(t *testing.T) {
+	repman, cl, app := newPathMappingTestSetup(t)
+
+	req := newAddPathRequest(t, repman, cl, []config.PathMapping{
+		{DockerPath: "/docker/data", SourceType: config.SourceVolume, SourceName: "vol-a", SourcePath: "data"},
+	})
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddDeploymentFieldRow(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for first unnamed row, got %d: %s", w.Code, w.Body.String())
+	}
+
+	req = newAddPathRequest(t, repman, cl, []config.PathMapping{
+		{DockerPath: "/docker/config", SourceType: config.SourceVolume, SourceName: "vol-a", SourcePath: "config"},
+	})
+	w = httptest.NewRecorder()
+	repman.handlerMuxAddDeploymentFieldRow(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for second unnamed row, got %d: %s", w.Code, w.Body.String())
+	}
+
+	paths := app.AppConfig.Deployment.Paths
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 paths, got %d", len(paths))
+	}
+	if paths[0].Name == "" || paths[1].Name == "" {
+		t.Fatalf("expected non-empty fallback names, got %q and %q", paths[0].Name, paths[1].Name)
+	}
+	if paths[0].Name == paths[1].Name {
+		t.Fatalf("expected distinct fallback names, both got %q", paths[0].Name)
+	}
+}
+
+// TestAddPath_UnnamedRowsSameSanitizedToken verifies that two unnamed path rows
+// whose dockerpaths differ only in leading/trailing slash formatting (which the
+// old sanitization-based fallback would have collapsed to the same name) both
+// succeed and receive distinct fallback names.
+func TestAddPath_UnnamedRowsSameSanitizedToken(t *testing.T) {
+	repman, cl, app := newPathMappingTestSetup(t)
+
+	// These two paths differ only in a trailing slash; old sanitizer collapses both
+	// to "docker-data", producing a name collision. The hash-based fallback must
+	// give each a distinct name.
+	for _, dp := range []string{"/docker/data", "docker/data/"} {
+		req := newAddPathRequest(t, repman, cl, []config.PathMapping{
+			{DockerPath: dp, SourceType: config.SourceVolume, SourceName: "vol-a", SourcePath: "data"},
+		})
+		w := httptest.NewRecorder()
+		repman.handlerMuxAddDeploymentFieldRow(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200 for dockerpath %q, got %d: %s", dp, w.Code, w.Body.String())
+		}
+	}
+
+	paths := app.AppConfig.Deployment.Paths
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 paths, got %d", len(paths))
+	}
+	if paths[0].Name == paths[1].Name {
+		t.Fatalf("expected distinct fallback names for formatting variants, both got %q", paths[0].Name)
+	}
+}
+
+// TestAddPath_DuplicateNameRejected verifies that InsertPath rejects a second
+// path row whose explicit name collides with an existing row's name, even when
+// the dockerpaths differ.
+func TestAddPath_DuplicateNameRejected(t *testing.T) {
+	repman, cl, app := newPathMappingTestSetup(t)
+	app.AppConfig.Deployment.Paths = config.PathMaps{
+		{Name: "web-root", DockerPath: "/var/www/html", SourceType: config.SourceVolume, SourceName: "vol-a", SourcePath: ".", VolumeName: "vol-a"},
+	}
+	if errs := app.AppConfig.Deployment.ResolvePaths(); len(errs) > 0 {
+		t.Fatalf("initial ResolvePaths: %v", errs)
+	}
+
+	req := newAddPathRequest(t, repman, cl, []config.PathMapping{
+		{Name: "web-root", DockerPath: "/var/www/assets", SourceType: config.SourceVolume, SourceName: "vol-a", SourcePath: "assets"},
+	})
+	w := httptest.NewRecorder()
+	repman.handlerMuxAddDeploymentFieldRow(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Fatal("expected error for duplicate path name, got 200")
 	}
 }

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Overview/Paths.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Overview/Paths.jsx
@@ -1,4 +1,4 @@
-import { VStack, HStack, Text, Heading, Input, Select, Flex, InputGroup, Box } from '@chakra-ui/react'
+import { VStack, HStack, Text, Heading, Input, Select, Flex, InputGroup, Box, Divider } from '@chakra-ui/react'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { HiFolder, HiTrash } from 'react-icons/hi'
 import { TbEdit, TbLinkPlus } from 'react-icons/tb'
@@ -17,7 +17,9 @@ import {
   composeSourcePath,
   getDisplaySubPath,
   getVolumeDirTokens,
+  normalizeSubPath,
 } from '../Storage/volumeDirUtils';
+import { VolumeNewForm } from '../Storage/Volume';
 
 const sourceTypes = [
   { value: '', name: 'Select Source', isChildOption: true },
@@ -33,7 +35,7 @@ const defaultPath = {
   parentpath: "",
   srctype: "",
   srcname: "",
-  srcpath: "/",
+  srcpath: ".",
   srcbasepath: "",
   subpath: "/",
 }
@@ -42,6 +44,8 @@ const nodeToValue = (node) => (node.type === "directory" && !node.path.endsWith(
 const nodeToString = (node) => node.name || node.path;
 
 const columnHelper = createColumnHelper()
+
+const AppConfigVersionV2 = 2;
 
 const PathSection = ({
   rows = [],
@@ -55,6 +59,10 @@ const PathSection = ({
   onSaveAdd,
   onPauseAutoReload = () => { },
   onResumeAutoReload = () => { },
+  opensvcPools = [],
+  appHaTopology,
+  appConfigVersion = 0,
+  onSaveVolume,
 }) => {
   const [newForm, setNewForm] = useState({ isVisible: false, parentRow: null, rowdata: null, index: null });
   const dispatch = useDispatch();
@@ -75,6 +83,38 @@ const PathSection = ({
   const s3Options = useMemo(() => {
     return [{ value: "", name: "Select S3" }, ...s3Rows.map(s3 => ({ ...s3, value: s3.name, name: s3.name }))];
   }, [s3Rows]);
+
+  const poolOptions = useMemo(() => {
+    if (!Array.isArray(opensvcPools) || opensvcPools.length === 0) return [];
+    const normalized = opensvcPools
+      .map((pool) => {
+        if (typeof pool === 'string') {
+          const value = pool.trim();
+          return value ? { value, name: value, shared: false } : null;
+        }
+        if (pool && typeof pool === 'object') {
+          const value = String(pool.value ?? pool.name ?? '').trim();
+          if (!value) return null;
+          const name = String(pool.name ?? value).trim() || value;
+          return { value, name, shared: Boolean(pool.shared) };
+        }
+        return null;
+      })
+      .filter(Boolean);
+    const dedup = new Map();
+    for (const option of normalized) {
+      if (!dedup.has(option.value)) dedup.set(option.value, option);
+      else if (option.shared) dedup.set(option.value, { ...dedup.get(option.value), shared: true });
+    }
+    let options = [...dedup.values()];
+    if (appHaTopology === 'failover') options = options.filter((o) => o.shared);
+    return options.sort((a, b) => a.name.localeCompare(b.name));
+  }, [opensvcPools, appHaTopology]);
+
+  const usedPoolNames = useMemo(() => {
+    if (appConfigVersion >= AppConfigVersionV2) return new Set();
+    return new Set((volumeRows || []).map((row) => row.poolname).filter(Boolean));
+  }, [volumeRows, appConfigVersion]);
 
   const resolvedRows = useMemo(() => rows.map((row) => {
     const { srctype, srcname, srcpath, parentname } = row;
@@ -194,9 +234,9 @@ const PathSection = ({
           </Heading>
           <Box className={styles.tableContainer}>
             {rowdata ? (
-              <PathRowForm fieldName={fieldName} path={rowdata} clusterName={clusterName} appId={appId} gitRows={gitRows} gitOptions={gitOptions} volumeOptions={volumeOptions} s3Options={s3Options} parentRow={parentRow} dockerImage={dockerImage} onChange={onRowArrayChange} index={index} onCancel={handleCancel} />
+              <PathRowForm fieldName={fieldName} path={rowdata} clusterName={clusterName} appId={appId} gitRows={gitRows} gitOptions={gitOptions} volumeOptions={volumeOptions} s3Options={s3Options} parentRow={parentRow} dockerImage={dockerImage} onChange={onRowArrayChange} index={index} onCancel={handleCancel} poolOptions={poolOptions} usedPoolNames={usedPoolNames} onSaveVolume={onSaveVolume} appConfigVersion={appConfigVersion} />
             ) : (
-              <PathNewForm clusterName={clusterName} appId={appId} gitOptions={gitOptions} volumeOptions={volumeOptions} s3Options={s3Options} parentRow={parentRow} onSave={handleSaveAdd} onCancel={handleCancel} />
+              <PathNewForm clusterName={clusterName} appId={appId} gitOptions={gitOptions} volumeOptions={volumeOptions} s3Options={s3Options} parentRow={parentRow} onSave={handleSaveAdd} onCancel={handleCancel} poolOptions={poolOptions} usedPoolNames={usedPoolNames} onSaveVolume={onSaveVolume} appConfigVersion={appConfigVersion} />
             )}
           </Box>
         </VStack>
@@ -217,12 +257,30 @@ export default React.memo(PathSection);
 
 const EMPTY_OBJECT = {};
 
-const PathRowForm = React.memo(({ fieldName, path, index, clusterName, appId, gitOptions, volumeOptions, s3Options, parentRow, onChange, onCancel = () => { } }) => {
+const PathRowForm = React.memo(({ fieldName, path, index, clusterName, appId, gitOptions, volumeOptions, s3Options, parentRow, onChange, onCancel = () => { }, poolOptions = [], usedPoolNames, onSaveVolume, appConfigVersion = 0 }) => {
   const dispatch = useDispatch();
   const p = path || defaultPath;
-  const { dockerpath, parentname, srctype, srcname, srcpath } = p;
+  const { dockerpath, parentname, srctype, srcname: propSrcname, srcpath } = p;
+  const [showVolumeCreate, setShowVolumeCreate] = useState(false);
+  const [localVolumes, setLocalVolumes] = useState([]);
+  // Tracks the srcname selected within this edit session (inline volume creation
+  // or manual dropdown change) so the Dropdown reflects the selection immediately,
+  // without waiting for the parent store update to flow back through the stale
+  // rowdata snapshot.
+  const [srcnameOverride, setSrcnameOverride] = useState(null);
+  const srcname = srcnameOverride !== null ? srcnameOverride : propSrcname;
 
-  const vol = useMemo(() => srctype === "volume" ? volumeOptions.find(opt => opt.name === srcname) : null, [srctype, srcname, volumeOptions]);
+  useEffect(() => { setSrcnameOverride(null); setLocalVolumes([]); }, [path]);
+
+  const effectiveVolumeOptions = useMemo(() => {
+    const existing = new Set(volumeOptions.map(v => v.name));
+    const extras = localVolumes
+      .filter(v => !existing.has(v.name))
+      .map(v => ({ ...v, value: v.name, name: v.name }));
+    return [...volumeOptions, ...extras];
+  }, [volumeOptions, localVolumes]);
+
+  const vol = useMemo(() => srctype === "volume" ? effectiveVolumeOptions.find(opt => opt.name === srcname) : null, [srctype, srcname, effectiveVolumeOptions]);
   const gc = useMemo(() => srctype === "git" ? gitOptions.find(opt => opt.value === srcname) : null, [srctype, srcname, gitOptions]);
   const s3 = useMemo(() => srctype === "s3" ? s3Options.find(opt => opt.value === srcname) : null, [srctype, srcname, s3Options]);
   const parent = useMemo(() => parentRow || { dockerpath: "", srcpath: "", srctype: "", srcname: "" }, [parentRow]);
@@ -281,6 +339,7 @@ const PathRowForm = React.memo(({ fieldName, path, index, clusterName, appId, gi
 
   const handleChangeSourceType = useCallback((newvalue) => {
     if (srctype != newvalue) {
+      setSrcnameOverride(null);
       onRowArrayChange(fieldName, index, "srctype", newvalue);
     }
   }, [srctype, fieldName, index, onRowArrayChange]);
@@ -303,12 +362,35 @@ const PathRowForm = React.memo(({ fieldName, path, index, clusterName, appId, gi
     }
   }, [gc, clusterName, appId, dispatch]);
 
+  // For V1 apps (one volume per pool), union parent-tracked used pools with any
+  // pool claimed by an inline-created volume in this session. This prevents the
+  // same pool from appearing selectable again before the async refresh lands.
+  // V2 apps allow multiple volumes per pool, so no extra filtering is needed.
+  const effectiveUsedPoolNames = useMemo(() => {
+    if (appConfigVersion >= AppConfigVersionV2) return usedPoolNames;
+    const localPoolNames = new Set(localVolumes.map((v) => v.poolname).filter(Boolean));
+    if (localPoolNames.size === 0) return usedPoolNames;
+    return new Set([...(usedPoolNames || []), ...localPoolNames]);
+  }, [appConfigVersion, usedPoolNames, localVolumes]);
+
+  const canCreateVolume = poolOptions.some((opt) => !effectiveUsedPoolNames?.has(opt.value));
+
+  const handleCreateVolume = useCallback((volData) => {
+    if (!onSaveVolume) return Promise.resolve();
+    return onSaveVolume('volumes', volData).then(() => {
+      setLocalVolumes(prev => [...prev, volData]);
+      setShowVolumeCreate(false);
+      setSrcnameOverride(volData.name);
+      onRowArrayChange(fieldName, index, "srcname", volData.name);
+    });
+  }, [onSaveVolume, onRowArrayChange, fieldName, index]);
+
   const srcDropdown = useMemo(() => {
     let srcOptions = [];
     let srcLabel = '';
     switch (srctype) {
       case 'volume':
-        srcOptions = volumeOptions;
+        srcOptions = effectiveVolumeOptions;
         srcLabel = 'Volume :';
         break;
       case 'git':
@@ -323,15 +405,46 @@ const PathRowForm = React.memo(({ fieldName, path, index, clusterName, appId, gi
         srcOptions = [];
         srcLabel = '';
     }
+    if (srctype === 'volume') {
+      return (
+        <Flex direction="column" flex="1">
+          <Text mb={1}>{srcLabel}</Text>
+          <HStack>
+            <Dropdown key={srctype} confirmTitle={"Source changed"} placeholder="Source" options={srcOptions} selectedValue={srcname} onChange={(value) => { setSrcnameOverride(value); onRowArrayChange(fieldName, index, "srcname", value); }} />
+            {onSaveVolume && canCreateVolume && (
+              <RMButton size="sm" onClick={() => setShowVolumeCreate((v) => !v)}>
+                {showVolumeCreate ? 'Cancel' : '+ New Volume'}
+              </RMButton>
+            )}
+          </HStack>
+          {srcbasepath && (<Text key={srcname} mb={1} fontSize="sm" color="gray.500">Basepath: {srcbasepath}</Text>)}
+          {availableDirs.length > 0 && (<Text key={`${srcname}-dirs`} mb={1} fontSize="sm" color="gray.500">Available directories: {availableDirs.join(', ')}</Text>)}
+          {onSaveVolume && poolOptions.length > 0 && !canCreateVolume && (
+            <Text fontSize="xs" color="gray.400">No eligible pools available for new volume</Text>
+          )}
+          {showVolumeCreate && (
+            <Box mt={2} p={3} borderWidth={1} borderRadius="md">
+              <Divider mb={2} />
+              <VolumeNewForm
+                poolOptions={poolOptions}
+                usedPoolNames={effectiveUsedPoolNames}
+                saveCaption="Create & Select Volume"
+                onSave={handleCreateVolume}
+                onCancel={() => setShowVolumeCreate(false)}
+              />
+            </Box>
+          )}
+        </Flex>
+      );
+    }
     return (
       <Flex direction="column" flex="1">
         <Text mb={1}>{srcLabel}</Text>
-        <Dropdown key={srctype} confirmTitle={"Source changed"} placeholder="Source" options={srcOptions} selectedValue={srcname} onChange={(value) => onRowArrayChange(fieldName, index, "srcname", value)} />
+        <Dropdown key={srctype} confirmTitle={"Source changed"} placeholder="Source" options={srcOptions} selectedValue={srcname} onChange={(value) => { setSrcnameOverride(value); onRowArrayChange(fieldName, index, "srcname", value); }} />
         {srcbasepath && (<Text key={srcname} mb={1} fontSize="sm" color="gray.500">Basepath: {srcbasepath}</Text>)}
-        {srctype === 'volume' && availableDirs.length > 0 && (<Text key={`${srcname}-dirs`} mb={1} fontSize="sm" color="gray.500">Available directories: {availableDirs.join(', ')}</Text>)}
       </Flex>
     );
-  }, [srctype, volumeOptions, gitOptions, s3Options, srcname, srcbasepath, availableDirs]);
+  }, [srctype, effectiveVolumeOptions, gitOptions, s3Options, srcname, srcbasepath, availableDirs, showVolumeCreate, canCreateVolume, poolOptions, effectiveUsedPoolNames, handleCreateVolume, onSaveVolume]);
 
   const handleOnTreeSelect = useCallback((subpaths) => {
     if (typeof subpaths === 'string') {
@@ -384,10 +497,12 @@ const PathRowForm = React.memo(({ fieldName, path, index, clusterName, appId, gi
   )
 })
 
-const PathNewForm = React.memo(({ clusterName, appId, parentRow, gitOptions, volumeOptions, s3Options, onSave = () => { }, onCancel = () => { } }) => {
+const PathNewForm = React.memo(({ clusterName, appId, parentRow, gitOptions, volumeOptions, s3Options, onSave = () => { }, onCancel = () => { }, poolOptions = [], usedPoolNames, onSaveVolume, appConfigVersion = 0 }) => {
   const dispatch = useDispatch();
 
   const [path, setPath] = useState(defaultPath);
+  const [showVolumeCreate, setShowVolumeCreate] = useState(false);
+  const [localVolumes, setLocalVolumes] = useState([]);
   const [browseState, setBrowseState] = useState({
     isOpen: false,
     selectedPath: '',
@@ -410,9 +525,17 @@ const PathNewForm = React.memo(({ clusterName, appId, parentRow, gitOptions, vol
   const { isOpen, selectedPath, selectedKey } = browseState;
   const defaultExpandedValues = useMemo(() => [selectedPath], [selectedPath]);
 
+  const effectiveVolumeOptions = useMemo(() => {
+    const existing = new Set(volumeOptions.map(v => v.name));
+    const extras = localVolumes
+      .filter(v => !existing.has(v.name))
+      .map(v => ({ ...v, value: v.name, name: v.name }));
+    return [...volumeOptions, ...extras];
+  }, [volumeOptions, localVolumes]);
+
   const vol = useMemo(
-    () => srctype === 'volume' ? volumeOptions.find(opt => opt.name === srcname) : null,
-    [srctype, srcname, volumeOptions]
+    () => srctype === 'volume' ? effectiveVolumeOptions.find(opt => opt.name === srcname) : null,
+    [srctype, srcname, effectiveVolumeOptions]
   );
   const gc = useMemo(
     () => srctype === 'git' ? gitOptions.find(opt => opt.value === srcname) : null,
@@ -428,12 +551,35 @@ const PathNewForm = React.memo(({ clusterName, appId, parentRow, gitOptions, vol
     [srctype, vol]
   );
 
+  const effectiveUsedPoolNames = useMemo(() => {
+    if (appConfigVersion >= AppConfigVersionV2) return usedPoolNames;
+    const localPoolNames = new Set(localVolumes.map((v) => v.poolname).filter(Boolean));
+    if (localPoolNames.size === 0) return usedPoolNames;
+    return new Set([...(usedPoolNames || []), ...localPoolNames]);
+  }, [appConfigVersion, usedPoolNames, localVolumes]);
+
+  const canCreateVolume = poolOptions.some((opt) => !effectiveUsedPoolNames?.has(opt.value));
+
+  const handleCreateVolume = useCallback((volData) => {
+    if (!onSaveVolume) return Promise.resolve();
+    return onSaveVolume('volumes', volData).then(() => {
+      setLocalVolumes(prev => [...prev, volData]);
+      setShowVolumeCreate(false);
+      setPath(prev => ({
+        ...prev,
+        srcname: volData.name,
+        srcbasepath: '',
+        srcpath: composeSourcePath('', prev.subpath || '/'),
+      }));
+    });
+  }, [onSaveVolume]);
+
   const srcDropdown = useMemo(() => {
     let srcOptions = [];
     let srcLabel = '';
     switch (srctype) {
       case 'volume':
-        srcOptions = volumeOptions;
+        srcOptions = effectiveVolumeOptions;
         srcLabel = 'Volume :';
         break;
       case 'git':
@@ -448,15 +594,46 @@ const PathNewForm = React.memo(({ clusterName, appId, parentRow, gitOptions, vol
         srcOptions = [];
         srcLabel = '';
     }
+    if (srctype === 'volume') {
+      return (
+        <Flex direction="column" flex="1">
+          <Text mb={1}>{srcLabel}</Text>
+          <HStack>
+            <Dropdown key={srctype} placeholder="Source" options={srcOptions} selectedValue={srcname} onChange={(option) => handleArrayChange("srcname", option.value)} />
+            {onSaveVolume && canCreateVolume && (
+              <RMButton size="sm" onClick={() => setShowVolumeCreate((v) => !v)}>
+                {showVolumeCreate ? 'Cancel' : '+ New Volume'}
+              </RMButton>
+            )}
+          </HStack>
+          {srcbasepath && (<Text key={srcname} mb={1} fontSize="sm" color="gray.500">Basepath: {srcbasepath}</Text>)}
+          {availableDirs.length > 0 && (<Text key={`${srcname}-dirs`} mb={1} fontSize="sm" color="gray.500">Available directories: {availableDirs.join(', ')}</Text>)}
+          {onSaveVolume && poolOptions.length > 0 && !canCreateVolume && (
+            <Text fontSize="xs" color="gray.400">No eligible pools available for new volume</Text>
+          )}
+          {showVolumeCreate && (
+            <Box mt={2} p={3} borderWidth={1} borderRadius="md">
+              <Divider mb={2} />
+              <VolumeNewForm
+                poolOptions={poolOptions}
+                usedPoolNames={effectiveUsedPoolNames}
+                saveCaption="Create & Select Volume"
+                onSave={handleCreateVolume}
+                onCancel={() => setShowVolumeCreate(false)}
+              />
+            </Box>
+          )}
+        </Flex>
+      );
+    }
     return (
       <Flex direction="column" flex="1">
         <Text mb={1}>{srcLabel}</Text>
         <Dropdown key={srctype} placeholder="Source" options={srcOptions} selectedValue={srcname} onChange={(option) => handleArrayChange("srcname", option.value)} />
         {srcbasepath && (<Text key={srcname} mb={1} fontSize="sm" color="gray.500">Basepath: {srcbasepath}</Text>)}
-        {srctype === 'volume' && availableDirs.length > 0 && (<Text key={`${srcname}-dirs`} mb={1} fontSize="sm" color="gray.500">Available directories: {availableDirs.join(', ')}</Text>)}
       </Flex>
     );
-  }, [srctype, volumeOptions, gitOptions, s3Options, srcname, srcbasepath, availableDirs]);
+  }, [srctype, effectiveVolumeOptions, gitOptions, s3Options, srcname, srcbasepath, availableDirs, showVolumeCreate, canCreateVolume, poolOptions, effectiveUsedPoolNames, handleCreateVolume, onSaveVolume]);
 
   const parent = useMemo(() => (parentRow || { name: "", dockerpath: "", srcpath: "", srctype: "", srcname: "" }), [parentRow]);
   const { name: parentname, dockerpath: parentpath, srctype: parentsrctype, srcname: parentsrcname, srcpath: parentsrcpath } = parent;
@@ -611,16 +788,47 @@ const PathNewForm = React.memo(({ clusterName, appId, parentRow, gitOptions, vol
     if (srctype === "git") return !!gc?.value;
     if (srctype === "s3") return !!s3?.value;
 
+    // No source type: only valid as an inherited child row
+    if (!srctype) return !!path.parentname;
+
     return true;
-  }, [dockerpath, subpath, srctype, vol, gc, s3]);
+  }, [dockerpath, subpath, srctype, vol, gc, s3, path.parentname]);
 
   const handleSaveAdd = useCallback(() => {
-    if (valid) {
-      onSave([path]);
-    } else {
+    if (!valid) {
       dispatch(showErrorToast({ message: "Invalid path configuration. Please check the inputs. make sure dockerpath is not root or containing parent relative paths (..)" }));
+      return;
     }
-  }, [onSave, valid, path]);
+
+    const rowName = `path-${hashMurmur(dockerpath)}`;
+
+    let payload;
+    if (srctype) {
+      // Direct-source row: canonical V2 shape
+      payload = {
+        name: rowName,
+        dockerpath,
+        srctype,
+        srcname,
+        srcpath: srcpath === "/" ? "." : srcpath,
+      };
+      if (path.parentname) {
+        payload.parentname = path.parentname;
+      }
+    } else {
+      // Inherited child row: no direct source, VolumeName resolved from parent
+      payload = {
+        name: rowName,
+        dockerpath,
+        parentname: path.parentname,
+        srctype: "",
+        srcname: "",
+        srcpath: "",
+      };
+    }
+
+    onSave([payload]);
+  }, [onSave, valid, path, dockerpath, srctype, srcname, srcpath, dispatch]);
 
   const handleCancel = useCallback(() => {
     setPath(defaultPath);

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Overview/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Overview/index.jsx
@@ -5,8 +5,8 @@ import styles from "./styles.module.scss";
 import AccordionComponent from "../../../../components/AccordionComponent";
 import GeneralSection from "./GeneralSection";
 import AppCredit from "./AppCredit";
-import { useCallback, useMemo, useState } from "react";
-import { deploymentFieldChange, deploymentFieldIndexAdd, deploymentFieldIndexDrop, pauseAutoReload, resolveTemplateVariables } from "../../../../redux/clusterSlice";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { deploymentFieldChange, deploymentFieldIndexAdd, deploymentFieldIndexDrop, pauseAutoReload, resolveTemplateVariables, storageFieldIndexAdd, getOpenSVCPools } from "../../../../redux/clusterSlice";
 import ConfirmModal from "../../../../components/Modals/ConfirmModal";
 import Routes from "./Routes";
 import PathSection from "./Paths";
@@ -18,7 +18,16 @@ const Overview = ({ clusterName, config, appId, appName, appHost, appConfig, use
     const deployment = useSelector((state) => state.cluster?.app?.deployment);
     const substitution = useSelector((state) => state.cluster?.app?.substitution);
     const dockerTemplates = useSelector((state) => state.globalClusters.monitor?.serviceTemplates);
+    const opensvcPools = useSelector((state) => state.cluster?.opensvcPools || []);
+    const isOpenSVCOrchestrator = useSelector(
+        (state) => state.cluster?.clusterData?.config?.provOrchestrator === "opensvc"
+    );
     
+    useEffect(() => {
+        if (!clusterName || !isOpenSVCOrchestrator) return;
+        dispatch(getOpenSVCPools({ clusterName }));
+    }, [clusterName, dispatch, isOpenSVCOrchestrator]);
+
     const [modalState, setModalState] = useState({
         isOpen: false,
         field: null,
@@ -56,6 +65,16 @@ const Overview = ({ clusterName, config, appId, appName, appHost, appConfig, use
         () => dispatch(pauseAutoReload({ isPaused: false })),
         [dispatch]
     )
+
+    const handleSaveVolume = useCallback(
+        (field, value) => dispatch(storageFieldIndexAdd({ clusterName, appId, field, value })).unwrap(),
+        [clusterName, appId, dispatch]
+    );
+
+    const effectiveOpenSVCPools = useMemo(
+        () => isOpenSVCOrchestrator ? opensvcPools : [],
+        [isOpenSVCOrchestrator, opensvcPools]
+    );
 
     const handleResolveVariables = useCallback(
         (rawValue) => {
@@ -98,8 +117,23 @@ const Overview = ({ clusterName, config, appId, appName, appHost, appConfig, use
     }, [routes, variables, actionProps, user, gateway]);
 
     const pathComponent = useMemo(() => {
-        return <PathSection storages={storages} rows={paths} fieldName={'paths'} clusterName={clusterName} appId={appId} dockerImage={dockerImage} gitCloneRows={gitClones} user={user} {...actionProps} />;
-    }, [paths, clusterName, appId, dockerImage, gitClones, actionProps, storages, user]);
+        return <PathSection
+            storages={storages}
+            rows={paths}
+            fieldName={'paths'}
+            clusterName={clusterName}
+            appId={appId}
+            dockerImage={dockerImage}
+            gitCloneRows={gitClones}
+            user={user}
+            opensvcPools={effectiveOpenSVCPools}
+            appHaTopology={appConfig?.provAppHaTopology}
+            appConfigVersion={appConfig?.appConfigVersion}
+            onSaveVolume={handleSaveVolume}
+            {...actionProps}
+        />;
+    }, [paths, clusterName, appId, dockerImage, gitClones, actionProps, storages, user,
+        effectiveOpenSVCPools, appConfig?.provAppHaTopology, appConfig?.appConfigVersion, handleSaveVolume]);
 
     const variableComponent = useMemo(() => {
         return <Variables substitution={substitution} rows={variables} agentList={agentList} fieldName={'variables'} user={user} onResolveVariable={handleResolveVariables} {...actionProps} />;
@@ -162,6 +196,8 @@ Overview.propTypes = {
     appConfig: PropTypes.shape({
         provAppDockerImg: PropTypes.string,
         provAppAgents: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.string]),
+        provAppHaTopology: PropTypes.string,
+        appConfigVersion: PropTypes.number,
     }).isRequired,
     user: PropTypes.shape({
         grants: PropTypes.object,

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Storage/Volume.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Storage/Volume.jsx
@@ -280,6 +280,7 @@ const VolumeSection = ({
 }
 
 export default React.memo(VolumeSection);
+export { VolumeNewForm };
 
 const VolumeRowForm = React.memo(({ fieldName, volume, index, poolOptions = [], usedPoolNames, onChange }) => {
     const vol = volume || defaultVol;
@@ -343,7 +344,9 @@ const VolumeNewForm = React.memo(({ saveCaption = "Save Volume", onSave = () => 
 
     const handleSaveAdd = () => {
         if (valid) {
-            onSave(vol)
+            Promise.resolve(onSave(vol)).catch(() => {
+                // Rejection already surfaced via toast/banner from the thunk
+            });
         }
     };
 


### PR DESCRIPTION
## Summary
- tighten backend validation and duplicate-name handling for deployment path mappings
- support direct and inherited path rows with unique generated fallback names
- update the app paths UI for inline volume creation and add regression coverage for multi-path volume mappings