### PR TITLE
feat: standby config sync and defense-in-depth guards

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1208,7 +1208,7 @@ func (cluster *Cluster) StateProcessing() {
 		cluster.StateMachine.ClearState()
 		cluster.WorkloadStateMachine.ClearState()
 		cluster.SecurityStateMachine.ClearState()
-		if cluster.StateMachine.GetHeartbeats()%60 == 0 {
+		if cluster.StateMachine.GetHeartbeats()%60 == 0 && cluster.IsActive() {
 			cluster.ConfigManager.SaveConfig(cluster, false)
 		}
 	}

--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -30,6 +30,9 @@ import (
 )
 
 func (cluster *Cluster) CheckFailed() {
+	if !cluster.IsActive() {
+		return
+	}
 	// Don't trigger a failover if a switchover is happening
 	if cluster.StateMachine.IsInFailover() {
 		cluster.SetState("ERR00001", state.State{ErrType: "WARNING", ErrDesc: clusterError["ERR00001"], ErrFrom: "CHECK"})

--- a/cluster/cluster_scheduler.go
+++ b/cluster/cluster_scheduler.go
@@ -8,6 +8,9 @@ import (
 
 func (cluster *Cluster) GetBackupLogicalFunction() func() {
 	return func() {
+		if !cluster.IsActive() {
+			return
+		}
 		mysrv := cluster.GetBackupServer()
 		if mysrv != nil {
 			mysrv.JobBackupLogical(context.Background())
@@ -19,6 +22,9 @@ func (cluster *Cluster) GetBackupLogicalFunction() func() {
 
 func (cluster *Cluster) GetBackupPhysicalFunction() func() {
 	return func() {
+		if !cluster.IsActive() {
+			return
+		}
 		mysrv := cluster.GetBackupServer()
 		if mysrv != nil {
 			mysrv.JobBackupPhysical()
@@ -30,36 +36,54 @@ func (cluster *Cluster) GetBackupPhysicalFunction() func() {
 
 func (cluster *Cluster) GetRotateLogsFunction() func() {
 	return func() {
+		if !cluster.IsActive() {
+			return
+		}
 		cluster.RotateLogs()
 	}
 }
 
 func (cluster *Cluster) GetBackupLogsFunction() func() {
 	return func() {
+		if !cluster.IsActive() {
+			return
+		}
 		cluster.BackupLogs()
 	}
 }
 
 func (cluster *Cluster) GetRollingOptimizeFunction() func() {
 	return func() {
+		if !cluster.IsActive() {
+			return
+		}
 		cluster.RollingOptimize()
 	}
 }
 
 func (cluster *Cluster) GetRollingRestartFunction() func() {
 	return func() {
+		if !cluster.IsActive() {
+			return
+		}
 		cluster.RollingRestart()
 	}
 }
 
 func (cluster *Cluster) GetRollingReprovFunction() func() {
 	return func() {
+		if !cluster.IsActive() {
+			return
+		}
 		cluster.RollingReprov()
 	}
 }
 
 func (cluster *Cluster) GetAnalyzeFunction() func() {
 	return func() {
+		if !cluster.IsActive() {
+			return
+		}
 		cluster.JobAnalyzeSQL(cluster.Conf.AnalyzeUsePersistent)
 	}
 }
@@ -72,6 +96,9 @@ func (cluster *Cluster) GetSlaRotateFunction() func() {
 
 func (cluster *Cluster) GetDbJobsSshFunction() func() {
 	return func() {
+		if !cluster.IsActive() {
+			return
+		}
 		for _, s := range cluster.Servers {
 			if s == nil {
 				continue
@@ -97,6 +124,9 @@ func (cluster *Cluster) GetMonitorSchemasFunction() func() {
 
 func (cluster *Cluster) GetMonitorChecksumFunction() func() {
 	return func() {
+		if !cluster.IsActive() {
+			return
+		}
 		go cluster.CheckAllTableChecksum()
 	}
 }

--- a/config/manager/manager.go
+++ b/config/manager/manager.go
@@ -618,6 +618,13 @@ func (cm *ConfigManager) GitPush(conf *config.Config, clusterList []string, wait
 	}
 }
 
+func (cm *ConfigManager) WithGitLock(fn func()) {
+	cm.gitMutex.Lock()
+	cm.configWg.Wait()
+	cm.gitMutex.Unlock()
+	fn()
+}
+
 // Pulls the latest changes from the git repository for .pull
 func (cm *ConfigManager) GitPullDir() {
 

--- a/server/server.go
+++ b/server/server.go
@@ -2788,10 +2788,14 @@ func (repman *ReplicationManager) Run() error {
 		time.Sleep(time.Second * time.Duration(repman.Conf.MonitoringTicker))
 
 		if counter%60 == 0 {
-			repman.ConfigManager.SaveConfig(repman, true)
+			if repman.HasActiveCluster() {
+				repman.ConfigManager.SaveConfig(repman, true)
 
-			if counter%int64(repman.Conf.GitMonitoringTicker) == 0 && repman.Conf.GitUrl != "" {
-				repman.ConfigManager.GitPush(repman.Conf, repman.ClusterList, true)
+				if counter%int64(repman.Conf.GitMonitoringTicker) == 0 && repman.Conf.GitUrl != "" {
+					repman.ConfigManager.GitPush(repman.Conf, repman.ClusterList, true)
+				}
+			} else if repman.Conf.GitUrl != "" {
+				repman.PullActiveConfig()
 			}
 
 			if repman.Conf.Cloud18 && repman.Conf.GitUrlPull != "" {
@@ -3278,30 +3282,29 @@ func (repman *ReplicationManager) Stop() {
 		time.Sleep(time.Second)
 	}
 
-	repman.ConfigManager.SaveConfig(repman, true)
+	if repman.HasActiveCluster() {
+		repman.ConfigManager.SaveConfig(repman, true)
 
-	if repman.Conf.GitUrl != "" {
-		isNeedPush := repman.IsNeedGitPush
-		for _, cl := range repman.Clusters {
-			if cl.IsNeedGitPush {
-				repman.Logrus.Infof("Cluster %s need Git Push", cl.Name)
-				// flag as changed for git push
-				isNeedPush = true
-
-				// Remove old need push flag
-				cl.IsNeedGitPush = false
+		if repman.Conf.GitUrl != "" {
+			isNeedPush := repman.IsNeedGitPush
+			for _, cl := range repman.Clusters {
+				if cl.IsNeedGitPush {
+					repman.Logrus.Infof("Cluster %s need Git Push", cl.Name)
+					isNeedPush = true
+					cl.IsNeedGitPush = false
+				}
 			}
-		}
 
-		if isNeedPush {
-			repman.IsNeedGitPush = false
-			repman.ConfigManager.GitPush(repman.Conf, repman.ClusterList, true)
+			if isNeedPush {
+				repman.IsNeedGitPush = false
+				repman.ConfigManager.GitPush(repman.Conf, repman.ClusterList, true)
+			}
 		}
 	}
 
 	repman.ConfigManager.Stop()
 
-	if !repman.IsExportPush {
+	if !repman.IsExportPush && repman.HasActiveCluster() {
 		repman.PushConfigToBackupDir()
 	}
 }

--- a/server/server_get.go
+++ b/server/server_get.go
@@ -10,6 +10,17 @@ import (
 	"github.com/signal18/replication-manager/cluster"
 )
 
+func (repman *ReplicationManager) HasActiveCluster() bool {
+	repman.Lock()
+	defer repman.Unlock()
+	for _, cl := range repman.Clusters {
+		if cl.IsActive() {
+			return true
+		}
+	}
+	return false
+}
+
 func (repman *ReplicationManager) getClusterByName(clname string) *cluster.Cluster {
 	var c *cluster.Cluster
 	repman.Lock()

--- a/server/server_git.go
+++ b/server/server_git.go
@@ -23,6 +23,7 @@ import (
 	"github.com/signal18/replication-manager/utils/githelper"
 	"github.com/signal18/replication-manager/utils/meethelper"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 func (repman *ReplicationManager) GetIsGitPush() bool {
@@ -1235,4 +1236,129 @@ func (repman *ReplicationManager) ShallowClone() error {
 	})
 
 	return err
+}
+
+// PullActiveConfig pulls config from the push repo (GitUrl) when all clusters
+// are on standby. If changes were pulled, it reloads standby cluster configs.
+func (repman *ReplicationManager) PullActiveConfig() {
+	path := repman.Conf.WorkingDir
+	tok := repman.Conf.GetDecryptedValue("git-acces-token")
+	user := repman.Conf.GitUsername
+	url := repman.Conf.GitUrl
+
+	auth := &git_https.BasicAuth{
+		Username: user,
+		Password: tok,
+	}
+
+	gitDir := filepath.Join(path, ".git")
+	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlInfo,
+			"Standby: initializing git repo from %s for config sync", url)
+		tmpDir, tmpErr := os.MkdirTemp(filepath.Join(path, ".tmp"), "repman-standby-clone-*")
+		if tmpErr != nil {
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlErr,
+				"Standby: cannot create temp dir for clone: %s", tmpErr)
+			return
+		}
+		defer os.RemoveAll(tmpDir)
+
+		_, cloneErr := git.PlainClone(tmpDir, false, &git.CloneOptions{
+			URL:          url,
+			Auth:         auth,
+			Depth:        1,
+			SingleBranch: true,
+		})
+		if cloneErr != nil {
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlErr,
+				"Standby: cannot clone config repo: %s", cloneErr)
+			return
+		}
+
+		if err := os.Rename(filepath.Join(tmpDir, ".git"), gitDir); err != nil {
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlErr,
+				"Standby: cannot move .git metadata: %s", err)
+			return
+		}
+	}
+
+	r, err := git.PlainOpen(path)
+	if err != nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlErr,
+			"Standby: cannot open git repo at %s: %s", path, err)
+		return
+	}
+
+	w, err := r.Worktree()
+	if err != nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlErr,
+			"Standby: cannot get worktree: %s", err)
+		return
+	}
+
+	err = w.Pull(&git.PullOptions{
+		RemoteName:   "origin",
+		Auth:         auth,
+		SingleBranch: true,
+		Force:        true,
+	})
+
+	if err == git.NoErrAlreadyUpToDate {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlDbg,
+			"Standby: config already up to date")
+		return
+	}
+	if err != nil && err != transport.ErrEmptyRemoteRepository {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlErr,
+			"Standby: git pull failed: %s", err)
+		return
+	}
+
+	repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlInfo,
+		"Standby: pulled config changes from active node, reloading")
+
+	repman.ReloadStandbyConfigsFromDisk()
+}
+
+// ReloadStandbyConfigsFromDisk re-reads config files from the working directory
+// for each standby cluster and reloads if the config changed.
+func (repman *ReplicationManager) ReloadStandbyConfigsFromDisk() {
+	for _, name := range repman.ClusterList {
+		cl := repman.getClusterByName(name)
+		if cl == nil || cl.IsActive() {
+			continue
+		}
+
+		configFile := filepath.Join(repman.Conf.WorkingDir, name, name+".toml")
+		if _, err := os.Stat(configFile); os.IsNotExist(err) {
+			continue
+		}
+
+		v := viper.New()
+		v.SetConfigType("toml")
+		v.SetConfigFile(configFile)
+		if err := v.ReadInConfig(); err != nil {
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModConfigLoad, config.LvlErr,
+				"Standby: cannot read saved config for %s: %s", name, err)
+			continue
+		}
+
+		sub := v.Sub("saved-" + name)
+		if sub == nil {
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModConfigLoad, config.LvlDbg,
+				"Standby: no saved section found in %s", configFile)
+			continue
+		}
+
+		newConf := *cl.Conf
+		if err := sub.Unmarshal(&newConf); err != nil {
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModConfigLoad, config.LvlErr,
+				"Standby: cannot unmarshal saved config for %s: %s", name, err)
+			continue
+		}
+
+		cl.ReloadConfig(newConf)
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModConfigLoad, config.LvlInfo,
+			"Standby: reloaded config for cluster %s from active node", name)
+	}
 }

--- a/server/server_git.go
+++ b/server/server_git.go
@@ -1240,7 +1240,20 @@ func (repman *ReplicationManager) ShallowClone() error {
 
 // PullActiveConfig pulls config from the push repo (GitUrl) when all clusters
 // are on standby. If changes were pulled, it reloads standby cluster configs.
+// It coordinates with ConfigManager's gitMutex to avoid racing with push operations.
 func (repman *ReplicationManager) PullActiveConfig() {
+	if repman.ConfigManager == nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlErr,
+			"Standby: ConfigManager not initialized, skipping config pull")
+		return
+	}
+
+	repman.ConfigManager.WithGitLock(func() {
+		repman.pullActiveConfigLocked()
+	})
+}
+
+func (repman *ReplicationManager) pullActiveConfigLocked() {
 	path := repman.Conf.WorkingDir
 	tok := repman.Conf.GetDecryptedValue("git-acces-token")
 	user := repman.Conf.GitUsername
@@ -1255,7 +1268,13 @@ func (repman *ReplicationManager) PullActiveConfig() {
 	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
 		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlInfo,
 			"Standby: initializing git repo from %s for config sync", url)
-		tmpDir, tmpErr := os.MkdirTemp(filepath.Join(path, ".tmp"), "repman-standby-clone-*")
+		tmpParent := filepath.Join(path, ".tmp")
+		if err := os.MkdirAll(tmpParent, 0755); err != nil {
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlErr,
+				"Standby: cannot create .tmp directory: %s", err)
+			return
+		}
+		tmpDir, tmpErr := os.MkdirTemp(tmpParent, "repman-standby-clone-*")
 		if tmpErr != nil {
 			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlErr,
 				"Standby: cannot create temp dir for clone: %s", tmpErr)


### PR DESCRIPTION
## Summary
- Active nodes push config to git, standby nodes pull from the same repo and reload cluster configs on change
- Standby nodes are blocked from executing any database-modifying operations (config save, git push, failover, scheduled jobs)
- Defense-in-depth: all scheduler action functions and `CheckFailed` now check `IsActive()` independently of the scheduler stop

## Changes

**Config sync (standby pulls from GitUrl):**
- New `PullActiveConfig()` pulls from the push repo when all clusters are standby
- New `ReloadStandbyConfigsFromDisk()` re-reads saved dynamic config and calls `ReloadConfig` for changed clusters
- Periodic pull runs every 60 server ticks (same cadence as active push)

**Push guards on standby:**
- Cluster-level `SaveConfig` (every 60 heartbeats) — skip when `!IsActive()`
- Server-level `SaveConfig`, `GitPush`, `PushConfigToBackupDir` — skip when `!HasActiveCluster()`
- Shutdown config push and git push — skip on standby

**Defense-in-depth guards:**
- `CheckFailed()` — skip entirely when standby (prevents automatic failover without arbitration)
- 10 scheduler actions guarded: backup logical/physical, backup logs, rotate logs, rolling optimize/restart/reprov, analyze, dbjobs SSH, table checksum

## Test plan
- [ ] Active node: verify config save and git push continue as before
- [ ] Standby node: verify no config save, no git push, no backup dir push
- [ ] Standby node: verify pull from GitUrl picks up active's config changes
- [ ] Standby node: verify `CheckFailed` does not trigger failover
- [ ] Standby node: verify scheduled backups/dbjobs/optimize do not execute
- [ ] Toggle active→standby: verify push stops, pull starts
- [ ] Toggle standby→active: verify pull stops, push resumes