### PR TITLE
feat: add opt-in docker config bootstrap

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,5 +39,9 @@ RUN apt-get update && apt-get -y install mydumper ca-certificates restic mariadb
   && curl -LO https://github.com/sysown/proxysql/releases/download/v$PROXYSQL_VERSION/proxysql_$PROXYSQL_VERSION-debian12_amd64.deb && dpkg -i proxysql_$PROXYSQL_VERSION-debian12_amd64.deb \
   && curl -LO https://github.com/mydumper/mydumper/releases/download/v$MYDUMPER_VERSION/mydumper_$MYDUMPER_VERSION.bookworm_amd64.deb && dpkg -i mydumper_$MYDUMPER_VERSION.bookworm_amd64.deb \
   && rm -f *.deb && rm -rf /var/lib/mysql/*
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY --from=builder /go/src/github.com/signal18/replication-manager/etc/local/config.toml.docker /usr/share/replication-manager/config.toml.default
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["replication-manager", "monitor", "--http-server"]
 EXPOSE 10001

--- a/docker/Dockerfile.pro
+++ b/docker/Dockerfile.pro
@@ -42,5 +42,9 @@ RUN apt-get update && apt-get -y install mydumper ca-certificates restic mariadb
   && curl -LO https://github.com/sysown/proxysql/releases/download/v$PROXYSQL_VERSION/proxysql_$PROXYSQL_VERSION-debian12_amd64.deb && dpkg -i proxysql_$PROXYSQL_VERSION-debian12_amd64.deb \
   && curl -LO https://github.com/mydumper/mydumper/releases/download/v$MYDUMPER_VERSION/mydumper_$MYDUMPER_VERSION.bookworm_amd64.deb && dpkg -i mydumper_$MYDUMPER_VERSION.bookworm_amd64.deb \
   && rm -f *.deb && rm -rf /var/lib/mysql/*
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY --from=builder /go/src/github.com/signal18/replication-manager/etc/local/config.toml.docker /usr/share/replication-manager/config.toml.default
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["replication-manager", "monitor", "--http-server"]
 EXPOSE 10001

--- a/docker/Dockerfile.pro_rootless
+++ b/docker/Dockerfile.pro_rootless
@@ -43,9 +43,13 @@ RUN apt-get update && apt-get -y install mydumper ca-certificates restic mariadb
   && curl -LO https://github.com/sysown/proxysql/releases/download/v$PROXYSQL_VERSION/proxysql_$PROXYSQL_VERSION-debian12_amd64.deb && dpkg -i proxysql_$PROXYSQL_VERSION-debian12_amd64.deb \
   && curl -LO https://github.com/mydumper/mydumper/releases/download/v$MYDUMPER_VERSION/mydumper_$MYDUMPER_VERSION.bookworm_amd64.deb && dpkg -i mydumper_$MYDUMPER_VERSION.bookworm_amd64.deb \
   && rm -f *.deb && rm -rf /var/lib/mysql/*
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY --from=builder /go/src/github.com/signal18/replication-manager/etc/local/config.toml.docker /usr/share/replication-manager/config.toml.default
 RUN groupadd -g 10001 repman \
   && useradd -r -u 10001 -g repman -d /var/lib/replication-manager -s /usr/sbin/nologin repman \
-  && chown -R repman:repman /etc/replication-manager /etc/replication-manager/cluster.d /var/lib/replication-manager
+  && chown -R repman:repman /etc/replication-manager /etc/replication-manager/cluster.d /var/lib/replication-manager \
+  && chmod +x /usr/local/bin/docker-entrypoint.sh
 USER repman
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["replication-manager", "monitor", "--http-server"]
 EXPOSE 10001

--- a/docker/Dockerfile.rootless
+++ b/docker/Dockerfile.rootless
@@ -40,9 +40,13 @@ RUN apt-get update && apt-get -y install mydumper ca-certificates restic mariadb
   && curl -LO https://github.com/sysown/proxysql/releases/download/v$PROXYSQL_VERSION/proxysql_$PROXYSQL_VERSION-debian12_amd64.deb && dpkg -i proxysql_$PROXYSQL_VERSION-debian12_amd64.deb \
   && curl -LO https://github.com/mydumper/mydumper/releases/download/v$MYDUMPER_VERSION/mydumper_$MYDUMPER_VERSION.bookworm_amd64.deb && dpkg -i mydumper_$MYDUMPER_VERSION.bookworm_amd64.deb \
   && rm -f *.deb && rm -rf /var/lib/mysql/*
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY --from=builder /go/src/github.com/signal18/replication-manager/etc/local/config.toml.docker /usr/share/replication-manager/config.toml.default
 RUN groupadd -g 10001 repman \
   && useradd -r -u 10001 -g repman -d /var/lib/replication-manager -s /usr/sbin/nologin repman \
-  && chown -R repman:repman /etc/replication-manager /etc/replication-manager/cluster.d /var/lib/replication-manager
+  && chown -R repman:repman /etc/replication-manager /etc/replication-manager/cluster.d /var/lib/replication-manager \
+  && chmod +x /usr/local/bin/docker-entrypoint.sh
 USER repman
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["replication-manager", "monitor", "--http-server"]
 EXPOSE 10001

--- a/docker/Dockerfile.slim
+++ b/docker/Dockerfile.slim
@@ -35,5 +35,9 @@ COPY --from=builder /go/src/github.com/signal18/replication-manager/build/binari
 COPY --from=builder /go/src/github.com/signal18/replication-manager/build/binaries/replication-manager-cli /usr/bin/replication-manager-cli
 
 RUN curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --mariadb-server-version="mariadb-$MARIADB_VERSION" --skip-maxscale
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY --from=builder /go/src/github.com/signal18/replication-manager/etc/local/config.toml.docker /usr/share/replication-manager/config.toml.default
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["replication-manager", "monitor", "--http-server"]
 EXPOSE 10001

--- a/docker/Dockerfile.slim_rootless
+++ b/docker/Dockerfile.slim_rootless
@@ -35,9 +35,13 @@ COPY --from=builder /go/src/github.com/signal18/replication-manager/build/binari
 COPY --from=builder /go/src/github.com/signal18/replication-manager/build/binaries/replication-manager-cli /usr/bin/replication-manager-cli
 
 RUN curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --mariadb-server-version="mariadb-$MARIADB_VERSION" --skip-maxscale
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY --from=builder /go/src/github.com/signal18/replication-manager/etc/local/config.toml.docker /usr/share/replication-manager/config.toml.default
 RUN groupadd -g 10001 repman \
   && useradd -r -u 10001 -g repman -d /var/lib/replication-manager -s /usr/sbin/nologin repman \
-  && chown -R repman:repman /etc/replication-manager /etc/replication-manager/cluster.d /var/lib/replication-manager
+  && chown -R repman:repman /etc/replication-manager /etc/replication-manager/cluster.d /var/lib/replication-manager \
+  && chmod +x /usr/local/bin/docker-entrypoint.sh
 USER repman
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["replication-manager", "monitor", "--http-server"]
 EXPOSE 10001

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,17 +14,16 @@ The main features are:
 
 #### Quick start
 
-The container runs with http-server enabled by default and exposed on port 10001. You can either mount a configuration file or use environment variables with `REPLICATION_MANAGER_*` prefixes and skip config reads.
+The container runs with http-server enabled by default and exposed on port 10001. You can mount your own configuration file, or layer cluster-specific settings on top of the bundled default config using `REPLICATION_MANAGER_*` environment variables (env vars take precedence over file values).
 
 Example usage, deploying a container with a config file in the working directory:
 ```
 docker run -d -p 10001:10001 -v $(pwd)/config.toml:/etc/replication-manager/config.toml --name repman signal18/replication-manager:latest
 ```
 
-Example usage, deploying with env-only config:
+Example usage, overriding cluster settings via environment variables on top of the bundled config:
 ```
 docker run -d -p 10001:10001 \
-  -e REPLICATION_MANAGER_DEFAULT_SKIP_CONFIG=true \
   -e REPLICATION_MANAGER_DEFAULT_HTTP_SERVER=true \
   -e REPLICATION_MANAGER_DEFAULT_HTTP_BIND_ADDRESS=0.0.0.0 \
   -e REPLICATION_MANAGER_DEFAULT_HTTP_PORT=10001 \
@@ -33,6 +32,42 @@ docker run -d -p 10001:10001 \
   -e REPLICATION_MANAGER_CLUSTER1_REPLICATION_CREDENTIAL=root:admin \
   --name repman signal18/replication-manager:2.0
 ```
+
+#### Auto-creating a missing config.toml (opt-in)
+
+By default the container behaves exactly as before. If you mount a directory over `/etc/replication-manager` and that directory is **empty**, you can ask the container to seed a working default `config.toml` by setting:
+
+```
+REPLICATION_MANAGER_CREATE_MISSING_CONFIG=true
+```
+
+Example:
+```
+docker run -d -p 10001:10001 \
+  -e REPLICATION_MANAGER_CREATE_MISSING_CONFIG=true \
+  -v /my/empty/config-dir:/etc/replication-manager \
+  --name repman signal18/replication-manager:latest
+```
+
+**Guardrails — the feature only acts when ALL of the following are true:**
+1. `REPLICATION_MANAGER_CREATE_MISSING_CONFIG=true` is set explicitly.
+2. `/etc/replication-manager/config.toml` does not already exist.
+3. The bundled fallback template exists in the image (`/usr/share/replication-manager/config.toml.default`).
+4. `/etc/replication-manager/` is writable at container start time.
+
+If any condition is false, the container starts normally with no file operations performed. **Existing configs are never overwritten or modified** — this includes regular files, directories, symlinks, and broken symlinks at the config path. Conditions 1 and 2 are silent no-ops (normal operation); conditions 3 and 4 log a message to stderr before continuing.
+
+The seeded template is the Docker-specific default (`etc/local/config.toml.docker`), which pre-fills binary paths for the tools bundled in the image so the container starts without additional configuration.
+
+**Rootless images (`*-rootless` tags):** the entrypoint runs as UID 10001 (`repman`). For auto-create to succeed, the mounted directory must be writable by that user:
+```
+sudo chown 10001:10001 /my/empty/config-dir
+docker run -d -p 10001:10001 \
+  -e REPLICATION_MANAGER_CREATE_MISSING_CONFIG=true \
+  -v /my/empty/config-dir:/etc/replication-manager \
+  --name repman signal18/replication-manager:latest-rootless
+```
+If the directory is not writable, auto-create is skipped with a log message and the container starts normally.
 
 The container also includes the replication-manager client. You can run commands non-interactively such as:
 ```

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# Fast path: feature is off by default — exec immediately with no side effects.
+if [ "${REPLICATION_MANAGER_CREATE_MISSING_CONFIG:-}" != "true" ]; then
+    exec "$@"
+fi
+
+CONFIG_FILE="/etc/replication-manager/config.toml"
+TEMPLATE_FILE="/usr/share/replication-manager/config.toml.default"
+
+# Any existing filesystem entry at the config path (file, dir, symlink, broken symlink) — nothing to do.
+if [ -e "$CONFIG_FILE" ] || [ -L "$CONFIG_FILE" ]; then
+    exec "$@"
+fi
+
+# Template not packaged in this image — log and proceed.
+if [ ! -f "$TEMPLATE_FILE" ]; then
+    echo "[entrypoint] REPLICATION_MANAGER_CREATE_MISSING_CONFIG=true but $TEMPLATE_FILE not found; skipping auto-create" >&2
+    exec "$@"
+fi
+
+# Target directory not writable (e.g. read-only mount) — log and proceed.
+CONFIG_DIR=$(dirname "$CONFIG_FILE")
+if [ ! -w "$CONFIG_DIR" ]; then
+    echo "[entrypoint] REPLICATION_MANAGER_CREATE_MISSING_CONFIG=true but $CONFIG_DIR is not writable; skipping auto-create" >&2
+    exec "$@"
+fi
+
+# All conditions met — create the config from the default template.
+if cp "$TEMPLATE_FILE" "$CONFIG_FILE"; then
+    echo "[entrypoint] created $CONFIG_FILE from default template" >&2
+else
+    echo "[entrypoint] REPLICATION_MANAGER_CREATE_MISSING_CONFIG=true but copy failed; continuing without auto-create" >&2
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary
- add a Docker entrypoint that can optionally seed /etc/replication-manager/config.toml when it is missing
- keep current container behavior unchanged unless REPLICATION_MANAGER_CREATE_MISSING_CONFIG=true is set
- wire the entrypoint into the main Docker image variants and document the guardrails, including rootless behavior

## Details
- the seeded config uses the existing Docker-specific default template at /usr/share/replication-manager/config.toml.default
- existing config paths are left untouched, including files, directories, symlinks, and broken symlinks
- when the feature cannot run because the template is missing or the directory is not writable, the container logs and continues normal startup

## Validation
- reviewed branch diff and guardrails
- no automated tests run
