### PR TITLE
Clean up OpenSVC app provisioning env

### DIFF
--- a/cluster/app_get.go
+++ b/cluster/app_get.go
@@ -21,7 +21,6 @@ import (
 
 	//jsoniter "github.com/json-iterator/go"
 	"github.com/signal18/replication-manager/config"
-	"github.com/signal18/replication-manager/opensvc"
 )
 
 func (cluster *Cluster) GetAppsSubstitutionJSon(app *App) (string, error) {
@@ -64,25 +63,7 @@ func (app *App) GetJanitorWeight() string {
 	return app.Weight
 }
 
-func (app *App) GetInitContainer(collector opensvc.Collector) string {
-	var vm string
-	if collector.ProvMicroSrv == "docker" {
-		vm = vm + `
-[container#0002]
-detach = false
-type = docker
-image = busybox
-netns = container#01
-start_timeout = 30s
-rm = true
-volume_mounts = /etc/localtime:/etc/localtime:ro {env.base_dir}/pod01:/data
-command = sh -c 'wget -qO- http://{env.mrm_api_addr}/api/clusters/{env.mrm_cluster_name}/servers/{env.ip_pod01}/{env.port_pod01}/config|tar xzvf - -C /data'
-optional=true
-
- `
-	}
-	return vm
-}
+// Remove unused method
 
 func (app *App) GetBindAddress() string {
 	if app.ClusterGroup.Conf.ProvOrchestrator == config.ConstOrchestratorSlapOS {

--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -645,8 +645,6 @@ func (cluster *Cluster) FoundAllAppAgents(app *App) ([]opensvc.Host, error) {
 }
 
 func (cluster *Cluster) OpenSVCGetAppEnvSection(app *App) map[string]string {
-	domain := cluster.GetDomain()
-
 	appcnf := app.AppConfig
 	svcenv := make(map[string]string)
 
@@ -655,19 +653,11 @@ func (cluster *Cluster) OpenSVCGetAppEnvSection(app *App) map[string]string {
 	svcenv["mrm_api_addr"] = cluster.Conf.MonitorAddress + ":" + cluster.Conf.HttpPort
 	svcenv["mrm_cluster_name"] = cluster.GetClusterName()
 
-	// App section
-	// FQDN: Fully Qualified Domain Name
-	fqdn := appcnf.AppHost
-	if !strings.Contains(appcnf.AppHost, domain) {
-		fqdn = fqdn + "." + domain
-	}
-
 	svcenv["nodes"] = strings.ReplaceAll(cluster.GetAppAgents(appcnf), ",", " ")
 	svcenv["size"] = cluster.GetAppDisk(appcnf) + "g"
 	svcenv["app_img"] = appcnf.ProvAppDockerImg
 	svcenv["app_host"] = appcnf.AppHost
 	svcenv["app_port"] = appcnf.AppPort
-	svcenv["fqdn"] = fqdn
 
 	svcenv["ip_pod01"] = app.GetHost()
 	svcenv["port_pod01"] = app.GetPort()

--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -656,15 +656,6 @@ func (cluster *Cluster) OpenSVCGetAppEnvSection(app *App) map[string]string {
 	svcenv["nodes"] = strings.ReplaceAll(cluster.GetAppAgents(appcnf), ",", " ")
 	svcenv["size"] = cluster.GetAppDisk(appcnf) + "g"
 	svcenv["app_img"] = appcnf.ProvAppDockerImg
-	svcenv["app_host"] = appcnf.AppHost
-	svcenv["app_port"] = appcnf.AppPort
-
-	svcenv["ip_pod01"] = app.GetHost()
-	svcenv["port_pod01"] = app.GetPort()
-	svcenv["port_telnet"] = app.GetPort()
-	svcenv["port_admin"] = app.GetPort()
-	svcenv["port_http"] = "80"
-	svcenv["user_admin"] = app.User
 
 	return svcenv
 }


### PR DESCRIPTION
## Summary
- remove invalid and unnecessary environment values from the OpenSVC app env section
- keep only the env keys still used by the current app template path
- remove the dead app init-container helper that depended on the old env contract

## What changed
### `cluster/prov_opensvc_app.go`
- simplify `OpenSVCGetAppEnvSection()` to emit only:
  - `base_dir`
  - `mrm_api_addr`
  - `mrm_cluster_name`
  - `nodes`
  - `size`
  - `app_img`
- remove unused app env keys:
  - `fqdn`
  - `app_host`
  - `app_port`
  - `ip_pod01`
  - `port_pod01`
  - `port_telnet`
  - `port_admin`
  - `port_http`
  - `user_admin`

### `cluster/app_get.go`
- delete the unused app `GetInitContainer(...)` helper
- remove its now-unneeded `opensvc` import

## Why
These values were either invalid for app provisioning or no longer used by the current OpenSVC app template flow. Removing them reduces config noise and keeps the app provisioning code aligned with the actual generated template.

## Testing
- Not run (not requested)

## Notes
- PR scope is the committed diff from `origin/develop..HEAD` only.