### PR TITLE
fix(app): custom route FQDNs, hardened health checks, and dashboard polish

### DIFF
--- a/cluster/app_chk.go
+++ b/cluster/app_chk.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,10 +17,64 @@ import (
 	"github.com/signal18/replication-manager/utils/state"
 )
 
+// canonicalExpectStatus returns a sorted, deduplicated representation of a
+// (post-Normalize) expect-status string so that "200,204" and "204,200"
+// produce the same key.  Falls back to the raw string on parse failure
+// (defensive; valid configs always parse after Normalize).
+func canonicalExpectStatus(s string) string {
+	codes, err := config.ParseExpectStatus(s)
+	if err != nil || len(codes) == 0 {
+		return s
+	}
+	sort.Ints(codes)
+	parts := make([]string, len(codes))
+	for i, c := range codes {
+		parts[i] = strconv.Itoa(c)
+	}
+	return strings.Join(parts, ",")
+}
+
+// buildLocalCheckKey returns a deduplication key for a route's local
+// reachability probe.  Routes with identical keys exercise the same local
+// network path and share a single check result.
+//
+//	tcp:        local-host + destination-port
+//	http/https: local-host + destination-port + monitor contract
+//	            (path, expected status, auth type/user/secret ref)
+//
+// http and https routes collapse to the same "http" local class because TLS
+// terminates at the HAProxy gateway; the backend always speaks plain HTTP
+// regardless of the external scheme.
+func buildLocalCheckKey(appHost string, route config.Route) string {
+	port := route.DestinationPort
+	if port == "" {
+		port = route.Port
+	}
+	switch route.Protocol {
+	case "tcp":
+		return "local|tcp|" + appHost + "|" + port
+	case "http", "https":
+		// Defaults match what RouteMonitor.Normalize() would produce for a zero-value
+		// monitor, ensuring nil and explicit-default monitors share the same key.
+		monPath, expectStatus, authType, authUser, authSecretVar := "/", "200", "", "", ""
+		if route.Monitor != nil {
+			m := *route.Monitor
+			m.Normalize()
+			monPath = m.Path
+			expectStatus = canonicalExpectStatus(m.ExpectStatus)
+			authType = m.AuthType
+			authUser = m.AuthUser
+			authSecretVar = m.AuthSecretVar
+		}
+		return strings.Join([]string{"local", "http", appHost, port, monPath, expectStatus, authType, authUser, authSecretVar}, "|")
+	default:
+		return "local|unsupported|" + route.Protocol + "|" + appHost + "|" + port
+	}
+}
+
 func (app *App) GetMonitoringStatus() string {
 	cluster := app.ClusterGroup
 	routes := app.GetAppConfig().Deployment.Routes
-	var primaryStatus = stateAppRunning
 	appErrKeys := []string{ErrAppConnectFailed, ErrAppUnexpectedStatus, ErrAppTCPConnectFailed, ErrAppUnsupportedProto, ErrAppGatewayConflict}
 	errStates := make(map[string]state.State)
 
@@ -81,6 +137,36 @@ func (app *App) GetMonitoringStatus() string {
 		return stateFailed
 	}
 
+	// Run each unique local endpoint check exactly once.
+	type localResult struct {
+		err    error
+		status int    // HTTP status code; 0 for TCP
+		errKey string // error key for debounce reporting on HTTP failure
+	}
+	appHost := app.GetHost()
+	localCache := make(map[string]*localResult)
+	for _, route := range routes {
+		lKey := buildLocalCheckKey(appHost, route)
+		if _, seen := localCache[lKey]; seen {
+			continue
+		}
+		switch route.Protocol {
+		case "https", "http":
+			status, _, err := app.GetAppLocalHTTPStatus(route, false)
+			res := &localResult{err: err, status: status, errKey: ErrAppConnectFailed}
+			if err != nil && strings.HasPrefix(err.Error(), "unexpected status code") {
+				res.errKey = ErrAppUnexpectedStatus
+			}
+			localCache[lKey] = res
+		case "tcp":
+			err := app.GetAppLocalTCPStatus(route)
+			localCache[lKey] = &localResult{err: err, errKey: ErrAppTCPConnectFailed}
+		default:
+			localCache[lKey] = &localResult{err: fmt.Errorf("unsupported protocol: %s", route.Protocol)}
+		}
+	}
+
+	// Evaluate each route using cached local results; also run external checks.
 	routeStatuses := make([]config.RouteStatus, 0, len(routes))
 	for _, route := range routes {
 		routeKey := routeEndpoint(route)
@@ -88,18 +174,17 @@ func (app *App) GetMonitoringStatus() string {
 		routeNorm := route
 		routeNorm.Normalize()
 		routeLabel := " on route " + routeNorm.Label()
+		lKey := buildLocalCheckKey(appHost, route)
+
 		switch route.Protocol {
 		case "https", "http":
-			localStatus, _, localErr := app.GetAppLocalHTTPStatus(route, false)
-			if localErr != nil {
-				errKey := ErrAppConnectFailed
-				errDesc := fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), localErr)
-				if strings.HasPrefix(localErr.Error(), "unexpected status code") {
-					errKey = ErrAppUnexpectedStatus
-					errDesc = fmt.Sprintf(config.ClusterError[ErrAppUnexpectedStatus], app.GetId(), localStatus)
+			localRes := localCache[lKey]
+			if localRes.err != nil {
+				errDesc := fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), localRes.err)
+				if localRes.errKey == ErrAppUnexpectedStatus {
+					errDesc = fmt.Sprintf(config.ClusterError[ErrAppUnexpectedStatus], app.GetId(), localRes.status)
 				}
-				debouncedRecordAppErr(routeKey, []state.State{{ErrType: "WARN", ErrKey: errKey, ErrDesc: errDesc + routeLabel, ServerUrl: app.Host}}, localErr)
-				primaryStatus = stateFailed
+				debouncedRecordAppErr(routeKey, []state.State{{ErrType: "WARN", ErrKey: localRes.errKey, ErrDesc: errDesc + routeLabel, ServerUrl: app.Host}}, localRes.err)
 				routeStatus.Status = stateFailed
 			} else {
 				extStatus, _, extErr := app.GetAppHTTPStatus(route, false)
@@ -113,21 +198,19 @@ func (app *App) GetMonitoringStatus() string {
 						errDesc = fmt.Sprintf(config.ClusterError[ErrAppUnexpectedStatus], app.GetId(), extStatus)
 					}
 					debouncedRecordAppErr(routeKey, []state.State{{ErrType: "WARN", ErrKey: errKey, ErrDesc: errDesc + routeLabel, ServerUrl: app.Host}}, extErr)
-					primaryStatus = stateAppWarning
 					routeStatus.Status = stateAppWarning
 				}
 			}
 		case "tcp":
-			if localErr := app.GetAppLocalTCPStatus(route); localErr != nil {
+			localRes := localCache[lKey]
+			if localRes.err != nil {
 				// Temporary compatibility: emit APPERR003 (canonical) and APPERR001 together.
 				debouncedRecordAppErr(routeKey, []state.State{
-					{ErrType: "WARN", ErrKey: ErrAppTCPConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppTCPConnectFailed], app.GetId(), localErr) + routeLabel, ServerUrl: app.Host},
-					{ErrType: "WARN", ErrKey: ErrAppConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), localErr) + routeLabel, ServerUrl: app.Host},
-				}, localErr)
-				primaryStatus = stateFailed
+					{ErrType: "WARN", ErrKey: ErrAppTCPConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppTCPConnectFailed], app.GetId(), localRes.err) + routeLabel, ServerUrl: app.Host},
+					{ErrType: "WARN", ErrKey: ErrAppConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), localRes.err) + routeLabel, ServerUrl: app.Host},
+				}, localRes.err)
 				routeStatus.Status = stateFailed
 			} else if extErr := app.GetAppTCPStatus(route); extErr != nil {
-				primaryStatus = stateAppWarning
 				routeStatus.Status = stateAppWarning
 			} else {
 				markSuccessfulRouteCheck(routeKey)
@@ -137,10 +220,39 @@ func (app *App) GetMonitoringStatus() string {
 			errStates[ErrAppUnsupportedProto] = state.State{ErrType: "WARN", ErrKey: ErrAppUnsupportedProto, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppUnsupportedProto], route.Protocol, app.GetId()) + routeLabel, ServerUrl: app.Host}
 			app.ResetAppErrConsecutiveCnt(routeKey)
 			routeStatus.Status = stateFailed
-			primaryStatus = stateFailed
 		}
 
 		routeStatuses = append(routeStatuses, routeStatus)
+	}
+
+	// Aggregate app status:
+	//   Failed     – all deduped local endpoints are down (vacuously true when no local checks exist)
+	//   AppWarning – at least one local endpoint succeeds but some route has an issue
+	//   Running    – all checks pass
+	allLocalFailed := true
+	for _, res := range localCache {
+		if res.err == nil {
+			allLocalFailed = false
+			break
+		}
+	}
+
+	var primaryStatus string
+	if allLocalFailed {
+		primaryStatus = stateFailed
+	} else {
+		anyNotRunning := false
+		for _, rs := range routeStatuses {
+			if rs.Status != stateAppRunning {
+				anyNotRunning = true
+				break
+			}
+		}
+		if anyNotRunning {
+			primaryStatus = stateAppWarning
+		} else {
+			primaryStatus = stateAppRunning
+		}
 	}
 
 	for _, key := range appErrKeys {

--- a/cluster/app_chk.go
+++ b/cluster/app_chk.go
@@ -229,6 +229,10 @@ func (app *App) GetMonitoringStatus() string {
 	//   Failed     – all deduped local endpoints are down (vacuously true when no local checks exist)
 	//   AppWarning – at least one local endpoint succeeds but some route has an issue
 	//   Running    – all checks pass
+	//
+	// Note: route.Primary is intentionally not used here. A primary route can be
+	// locally down while a secondary route's local check keeps the app at
+	// AppWarning; Failed is only reached when every unique local backend fails.
 	allLocalFailed := true
 	for _, res := range localCache {
 		if res.err == nil {

--- a/cluster/app_chk.go
+++ b/cluster/app_chk.go
@@ -89,110 +89,55 @@ func (app *App) GetMonitoringStatus() string {
 		routeNorm.Normalize()
 		routeLabel := " on route " + routeNorm.Label()
 		switch route.Protocol {
-		case "https":
-			httpStatus, _, err := app.GetAppHTTPStatus(route, false)
-			if err == nil {
-				markSuccessfulRouteCheck(routeKey)
-			} else {
-				routeStatus.Status = stateAppWarning
-				// Don't set primaryStatus yet — defer until local check outcome is known.
-
+		case "https", "http":
+			localStatus, _, localErr := app.GetAppLocalHTTPStatus(route, false)
+			if localErr != nil {
 				errKey := ErrAppConnectFailed
-				errDesc := fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), err)
-				if strings.HasPrefix(err.Error(), "unexpected status code") {
+				errDesc := fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), localErr)
+				if strings.HasPrefix(localErr.Error(), "unexpected status code") {
 					errKey = ErrAppUnexpectedStatus
-					errDesc = fmt.Sprintf(config.ClusterError[ErrAppUnexpectedStatus], app.GetId(), httpStatus)
+					errDesc = fmt.Sprintf(config.ClusterError[ErrAppUnexpectedStatus], app.GetId(), localStatus)
 				}
-
-				httpStatus, _, err := app.GetAppLocalHTTPStatus(route, false)
-				if err != nil {
-					if strings.HasPrefix(err.Error(), "unexpected status code") {
-						errKey = ErrAppUnexpectedStatus
-						errDesc = fmt.Sprintf(config.ClusterError[ErrAppUnexpectedStatus], app.GetId(), httpStatus)
-					} else {
-						errKey = ErrAppConnectFailed
-						errDesc = fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), err)
-					}
-
-					debouncedRecordAppErr(routeKey, []state.State{{ErrType: "WARN", ErrKey: errKey, ErrDesc: errDesc + routeLabel, ServerUrl: app.Host}}, err)
-
-					if route.Primary {
-						primaryStatus = stateFailed
-					} else {
-						primaryStatus = stateAppWarning
-					}
-					routeStatus.Status = stateFailed
-				} else {
-					markSuccessfulRouteCheck(routeKey)
-				}
-			}
-		case "http":
-			httpStatus, _, err := app.GetAppHTTPStatus(route, false)
-			if err == nil {
-				markSuccessfulRouteCheck(routeKey)
+				debouncedRecordAppErr(routeKey, []state.State{{ErrType: "WARN", ErrKey: errKey, ErrDesc: errDesc + routeLabel, ServerUrl: app.Host}}, localErr)
+				primaryStatus = stateFailed
+				routeStatus.Status = stateFailed
 			} else {
-				routeStatus.Status = stateAppWarning
-				// Don't set primaryStatus yet — defer until local check outcome is known.
-				errKey := ErrAppConnectFailed
-				errDesc := fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), err)
-				if strings.HasPrefix(err.Error(), "unexpected status code") {
-					errKey = ErrAppUnexpectedStatus
-					errDesc = fmt.Sprintf(config.ClusterError[ErrAppUnexpectedStatus], app.GetId(), httpStatus)
-				}
-				httpStatus, _, err = app.GetAppLocalHTTPStatus(route, false)
-				if err != nil {
-					if strings.HasPrefix(err.Error(), "unexpected status code") {
-						errKey = ErrAppUnexpectedStatus
-						errDesc = fmt.Sprintf(config.ClusterError[ErrAppUnexpectedStatus], app.GetId(), httpStatus)
-					} else {
-						errKey = ErrAppConnectFailed
-						errDesc = fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), err)
-					}
-					debouncedRecordAppErr(routeKey, []state.State{{ErrType: "WARN", ErrKey: errKey, ErrDesc: errDesc + routeLabel, ServerUrl: app.Host}}, err)
-					if route.Primary {
-						primaryStatus = stateFailed
-					} else {
-						primaryStatus = stateAppWarning
-					}
-					routeStatus.Status = stateFailed
-				} else {
+				extStatus, _, extErr := app.GetAppHTTPStatus(route, false)
+				if extErr == nil {
 					markSuccessfulRouteCheck(routeKey)
+				} else {
+					errKey := ErrAppConnectFailed
+					errDesc := fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), extErr)
+					if strings.HasPrefix(extErr.Error(), "unexpected status code") {
+						errKey = ErrAppUnexpectedStatus
+						errDesc = fmt.Sprintf(config.ClusterError[ErrAppUnexpectedStatus], app.GetId(), extStatus)
+					}
+					debouncedRecordAppErr(routeKey, []state.State{{ErrType: "WARN", ErrKey: errKey, ErrDesc: errDesc + routeLabel, ServerUrl: app.Host}}, extErr)
+					primaryStatus = stateAppWarning
+					routeStatus.Status = stateAppWarning
 				}
 			}
 		case "tcp":
-			err := app.GetAppTCPStatus(route)
-			if err == nil {
-				markSuccessfulRouteCheck(routeKey)
-			} else {
-				routeStatus.Status = stateAppWarning
+			if localErr := app.GetAppLocalTCPStatus(route); localErr != nil {
+				// Temporary compatibility: emit APPERR003 (canonical) and APPERR001 together.
+				debouncedRecordAppErr(routeKey, []state.State{
+					{ErrType: "WARN", ErrKey: ErrAppTCPConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppTCPConnectFailed], app.GetId(), localErr) + routeLabel, ServerUrl: app.Host},
+					{ErrType: "WARN", ErrKey: ErrAppConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), localErr) + routeLabel, ServerUrl: app.Host},
+				}, localErr)
+				primaryStatus = stateFailed
+				routeStatus.Status = stateFailed
+			} else if extErr := app.GetAppTCPStatus(route); extErr != nil {
 				primaryStatus = stateAppWarning
-
-				if err := app.GetAppLocalTCPStatus(route); err != nil {
-					// Temporary compatibility: emit APPERR003 (canonical) and APPERR001 together.
-					debouncedRecordAppErr(routeKey, []state.State{
-						{ErrType: "WARN", ErrKey: ErrAppTCPConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppTCPConnectFailed], app.GetId(), err) + routeLabel, ServerUrl: app.Host},
-						{ErrType: "WARN", ErrKey: ErrAppConnectFailed, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppConnectFailed], app.GetId(), err) + routeLabel, ServerUrl: app.Host},
-					}, err)
-
-					routeStatus.Status = stateFailed
-					if route.Primary {
-						primaryStatus = stateFailed
-					}
-				} else {
-					markSuccessfulRouteCheck(routeKey)
-				}
+				routeStatus.Status = stateAppWarning
+			} else {
+				markSuccessfulRouteCheck(routeKey)
 			}
 		default:
 			// Keep APPERR004 argument order aligned with config.ClusterError format string.
 			errStates[ErrAppUnsupportedProto] = state.State{ErrType: "WARN", ErrKey: ErrAppUnsupportedProto, ErrDesc: fmt.Sprintf(config.ClusterError[ErrAppUnsupportedProto], route.Protocol, app.GetId()) + routeLabel, ServerUrl: app.Host}
 			app.ResetAppErrConsecutiveCnt(routeKey)
 			routeStatus.Status = stateFailed
-
-			if route.Primary {
-				primaryStatus = stateFailed
-			} else {
-				primaryStatus = stateAppWarning
-			}
+			primaryStatus = stateFailed
 		}
 
 		routeStatuses = append(routeStatuses, routeStatus)

--- a/cluster/app_error_test.go
+++ b/cluster/app_error_test.go
@@ -213,10 +213,11 @@ func TestGetMonitoringStatusSuccessOnOneRouteDoesNotResetOtherRouteDebounce(t *t
 	normOK.Normalize()
 	okKey := config.BuildRouteStateKey(normOK)
 
+	// With one local endpoint up and one down the aggregate is AppWarning, not Failed.
 	for i := 1; i <= 2; i++ {
 		status := app.GetMonitoringStatus()
-		if status != stateFailed {
-			t.Fatalf("expected state %s on iteration %d, got %s", stateFailed, i, status)
+		if status != stateAppWarning {
+			t.Fatalf("expected state %s on iteration %d, got %s", stateAppWarning, i, status)
 		}
 		if _, ok := app.ErrState[ErrAppTCPConnectFailed]; ok {
 			t.Fatalf("did not expect %s before threshold, iteration %d", ErrAppTCPConnectFailed, i)
@@ -230,8 +231,8 @@ func TestGetMonitoringStatusSuccessOnOneRouteDoesNotResetOtherRouteDebounce(t *t
 	}
 
 	status := app.GetMonitoringStatus()
-	if status != stateFailed {
-		t.Fatalf("expected state %s on threshold iteration, got %s", stateFailed, status)
+	if status != stateAppWarning {
+		t.Fatalf("expected state %s on threshold iteration, got %s", stateAppWarning, status)
 	}
 	if _, ok := app.ErrState[ErrAppTCPConnectFailed]; !ok {
 		t.Fatalf("expected %s at threshold", ErrAppTCPConnectFailed)
@@ -299,5 +300,324 @@ func TestGetMonitoringStatusDefaultDebounceThresholdIsThree(t *testing.T) {
 	}
 	if _, ok := app.ErrState[ErrAppTCPConnectFailed]; !ok {
 		t.Fatalf("expected %s at default threshold", ErrAppTCPConnectFailed)
+	}
+}
+
+// --- Aggregation behaviour tests ---
+
+func TestGetMonitoringStatusTwoUniqueLocalsBothFail_IsFailed(t *testing.T) {
+	// Both unique local endpoints are unreachable → aggregate must be Failed.
+	routes := []config.Route{
+		{Protocol: "tcp", CName: "127.0.0.1", Port: "1", DestinationPort: "1", Primary: true},
+		{Protocol: "tcp", CName: "127.0.0.2", Port: "2", DestinationPort: "2", Primary: false},
+	}
+	app := newMonitoringTestApp(routes)
+
+	status := app.GetMonitoringStatus()
+	if status != stateFailed {
+		t.Fatalf("expected %s when all local endpoints fail, got %s", stateFailed, status)
+	}
+}
+
+func TestGetMonitoringStatusTwoUniquesOneLocalFails_IsAppWarning(t *testing.T) {
+	// One local endpoint is up, one is down → aggregate must be AppWarning.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer ln.Close()
+	openPort := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+
+	routes := []config.Route{
+		{Protocol: "tcp", CName: "127.0.0.1", Port: "1", DestinationPort: "1", Primary: true},
+		{Protocol: "tcp", CName: "127.0.0.1", Port: openPort, DestinationPort: openPort, Primary: false},
+	}
+	app := newMonitoringTestApp(routes)
+
+	status := app.GetMonitoringStatus()
+	if status != stateAppWarning {
+		t.Fatalf("expected %s for partial local outage, got %s", stateAppWarning, status)
+	}
+}
+
+func TestGetMonitoringStatusReverseOrderStillAppWarning(t *testing.T) {
+	// Same as above but with routes in the reverse order to verify the result is
+	// not sensitive to route ordering.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer ln.Close()
+	openPort := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+
+	routes := []config.Route{
+		{Protocol: "tcp", CName: "127.0.0.1", Port: openPort, DestinationPort: openPort, Primary: false},
+		{Protocol: "tcp", CName: "127.0.0.1", Port: "1", DestinationPort: "1", Primary: true},
+	}
+	app := newMonitoringTestApp(routes)
+
+	status := app.GetMonitoringStatus()
+	if status != stateAppWarning {
+		t.Fatalf("expected %s for partial local outage (reversed order), got %s", stateAppWarning, status)
+	}
+}
+
+func TestGetMonitoringStatusLocalSucceedsExternalFails_IsAppWarning(t *testing.T) {
+	// Local reachable, external unreachable → AppWarning.
+	// Use separate Port (external) and DestinationPort (local) on the same route.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer ln.Close()
+	localPort := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+
+	// Port="1" is the external target; DestinationPort=localPort is the local target.
+	route := config.Route{
+		Protocol:        "tcp",
+		CName:           "127.0.0.1",
+		Port:            "1",
+		DestinationPort: localPort,
+		Primary:         true,
+	}
+	app := newMonitoringTestApp([]config.Route{route})
+
+	status := app.GetMonitoringStatus()
+	if status != stateAppWarning {
+		t.Fatalf("expected %s when local ok but external fails, got %s", stateAppWarning, status)
+	}
+}
+
+func TestGetMonitoringStatusAllChecksPass_IsRunning(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer ln.Close()
+	port := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+
+	// Both local and external connect to the same open port.
+	route := config.Route{Protocol: "tcp", CName: "127.0.0.1", Port: port, DestinationPort: port, Primary: true}
+	app := newMonitoringTestApp([]config.Route{route})
+
+	status := app.GetMonitoringStatus()
+	if status != stateAppRunning {
+		t.Fatalf("expected %s when all checks pass, got %s", stateAppRunning, status)
+	}
+}
+
+func TestGetMonitoringStatusSharedLocalEndpointBothGetRouteStatus(t *testing.T) {
+	// Two routes that share the same local endpoint (same DestinationPort) must
+	// each appear in the RouteStatus slice even though the local check is run once.
+	routes := []config.Route{
+		{Protocol: "tcp", CName: "127.0.0.1", Port: "1", DestinationPort: "1", Primary: true},
+		{Protocol: "tcp", CName: "127.0.0.2", Port: "2", DestinationPort: "1", Primary: false},
+	}
+	app := newMonitoringTestApp(routes)
+
+	status := app.GetMonitoringStatus()
+	if status != stateFailed {
+		t.Fatalf("expected %s when shared local endpoint is down, got %s", stateFailed, status)
+	}
+
+	statuses := app.RouteStatus
+	if len(statuses) != 2 {
+		t.Fatalf("expected 2 route statuses, got %d", len(statuses))
+	}
+	for i, rs := range statuses {
+		if rs.Status != stateFailed {
+			t.Fatalf("route[%d]: expected status %s, got %s", i, stateFailed, rs.Status)
+		}
+	}
+}
+
+func TestGetMonitoringStatusRefreshPartialOutageIsAppWarning(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer ln.Close()
+	openPort := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+
+	routes := []config.Route{
+		{Protocol: "tcp", CName: "127.0.0.1", Port: "1", DestinationPort: "1", Primary: true},
+		{Protocol: "tcp", CName: "127.0.0.1", Port: openPort, DestinationPort: openPort, Primary: false},
+	}
+	app := newMonitoringTestApp(routes)
+
+	if err := app.Refresh(); err != nil {
+		t.Fatalf("Refresh returned error: %v", err)
+	}
+	if app.State != stateAppWarning {
+		t.Fatalf("expected app state %s after partial local outage, got %s", stateAppWarning, app.State)
+	}
+}
+
+// --- Local dedupe key policy tests ---
+// Policy: http and https collapse to the same "http" local backend class
+// (HAProxy terminates TLS; backend always speaks plain HTTP).
+// Two routes only get separate local probes when the backend contract differs.
+
+// TestBuildLocalCheckKeyHTTPAndHTTPSSameContractShareKey verifies that an http
+// and an https route pointing at the same backend destination with the same
+// monitor contract share a single local check key.
+func TestBuildLocalCheckKeyHTTPAndHTTPSSameContractShareKey(t *testing.T) {
+	httpsRoute := config.Route{Protocol: "https", Port: "443", DestinationPort: "8080"}
+	httpRoute := config.Route{Protocol: "http", Port: "80", DestinationPort: "8080"}
+
+	httpsKey := buildLocalCheckKey("127.0.0.1", httpsRoute)
+	httpKey := buildLocalCheckKey("127.0.0.1", httpRoute)
+
+	if httpsKey != httpKey {
+		t.Fatalf("expected http and https routes with identical backend contract to share a local check key; got http=%q https=%q", httpKey, httpsKey)
+	}
+}
+
+// TestBuildLocalCheckKeyDifferentMonitorPathNoDedupe verifies that routes with
+// the same backend port but different monitor paths get distinct local check keys.
+func TestBuildLocalCheckKeyDifferentMonitorPathNoDedupe(t *testing.T) {
+	route1 := config.Route{Protocol: "https", DestinationPort: "8080", Monitor: &config.RouteMonitor{Path: "/health"}}
+	route2 := config.Route{Protocol: "http", DestinationPort: "8080", Monitor: &config.RouteMonitor{Path: "/status"}}
+
+	key1 := buildLocalCheckKey("127.0.0.1", route1)
+	key2 := buildLocalCheckKey("127.0.0.1", route2)
+
+	if key1 == key2 {
+		t.Fatalf("expected different monitor paths to produce distinct local check keys; both got %q", key1)
+	}
+}
+
+// TestBuildLocalCheckKeyNilMonitorAndDefaultMonitorDedupe verifies that a nil
+// monitor and a zero-value monitor struct produce the same local check key,
+// preventing phantom duplicate probes from config variations.
+func TestBuildLocalCheckKeyNilMonitorAndDefaultMonitorDedupe(t *testing.T) {
+	routeNilMon := config.Route{Protocol: "https", DestinationPort: "8080"}
+	routeEmptyMon := config.Route{Protocol: "http", DestinationPort: "8080", Monitor: &config.RouteMonitor{}}
+
+	keyNil := buildLocalCheckKey("127.0.0.1", routeNilMon)
+	keyEmpty := buildLocalCheckKey("127.0.0.1", routeEmptyMon)
+
+	if keyNil != keyEmpty {
+		t.Fatalf("expected nil and zero-value monitor to produce the same local check key; got nil=%q empty=%q", keyNil, keyEmpty)
+	}
+}
+
+// TestBuildLocalCheckKeyNormalizesMonitorContract verifies that monitor fields
+// are normalized before keying so that semantically equivalent configs share
+// a key: explicit default ExpectStatus, path without leading slash, and
+// AuthType case variations must all produce the same key as their canonical forms.
+func TestBuildLocalCheckKeyNormalizesMonitorContract(t *testing.T) {
+	cases := []struct {
+		name string
+		r1   config.Route
+		r2   config.Route
+	}{
+		{
+			name: "explicit 200 ExpectStatus matches nil monitor default",
+			r1:   config.Route{Protocol: "https", DestinationPort: "8080"},
+			r2:   config.Route{Protocol: "http", DestinationPort: "8080", Monitor: &config.RouteMonitor{ExpectStatus: "200"}},
+		},
+		{
+			name: "monitor path without leading slash matches path with leading slash",
+			r1:   config.Route{Protocol: "https", DestinationPort: "8080", Monitor: &config.RouteMonitor{Path: "/health"}},
+			r2:   config.Route{Protocol: "http", DestinationPort: "8080", Monitor: &config.RouteMonitor{Path: "health"}},
+		},
+		{
+			name: "AuthType 'BASIC' matches 'basic'",
+			r1:   config.Route{Protocol: "https", DestinationPort: "8080", Monitor: &config.RouteMonitor{AuthType: "BASIC", AuthUser: "u", AuthSecretVar: "s"}},
+			r2:   config.Route{Protocol: "http", DestinationPort: "8080", Monitor: &config.RouteMonitor{AuthType: "basic", AuthUser: "u", AuthSecretVar: "s"}},
+		},
+		{
+			name: "expect-status list order does not affect key",
+			r1:   config.Route{Protocol: "https", DestinationPort: "8080", Monitor: &config.RouteMonitor{ExpectStatus: "200,204"}},
+			r2:   config.Route{Protocol: "http", DestinationPort: "8080", Monitor: &config.RouteMonitor{ExpectStatus: "204,200"}},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			k1 := buildLocalCheckKey("127.0.0.1", tc.r1)
+			k2 := buildLocalCheckKey("127.0.0.1", tc.r2)
+			if k1 != k2 {
+				t.Fatalf("expected same key for semantically equivalent monitor configs; got %q and %q", k1, k2)
+			}
+		})
+	}
+}
+
+// TestGetMonitoringStatusHTTPAndHTTPSSameBackendDeduped verifies the end-to-end
+// deduplication: an http and an https route pointing at the same unreachable
+// backend share a single local check, both receive Failed status, and the
+// aggregate is Failed (all deduped local backends are down).
+func TestGetMonitoringStatusHTTPAndHTTPSSameBackendDeduped(t *testing.T) {
+	// Port 1 is unreachable; both routes point at it as the local backend.
+	routes := []config.Route{
+		{Protocol: "https", CName: "127.0.0.1", Port: "443", DestinationPort: "1", Primary: true},
+		{Protocol: "http", CName: "127.0.0.1", Port: "80", DestinationPort: "1", Primary: false},
+	}
+	app := newMonitoringTestApp(routes)
+
+	status := app.GetMonitoringStatus()
+
+	// Single deduped local backend is down → all local backends failed → Failed.
+	if status != stateFailed {
+		t.Fatalf("expected %s when all deduped local backends are down, got %s", stateFailed, status)
+	}
+	if len(app.RouteStatus) != 2 {
+		t.Fatalf("expected 2 route statuses, got %d", len(app.RouteStatus))
+	}
+	for i, rs := range app.RouteStatus {
+		if rs.Status != stateFailed {
+			t.Errorf("route[%d]: expected %s, got %s", i, stateFailed, rs.Status)
+		}
+	}
+}
+
+// TestGetMonitoringStatusUnsupportedPlusHealthyRouteIsAppWarning verifies the
+// softer aggregate policy: an unsupported-protocol route combined with a
+// healthy route yields AppWarning, not Failed.
+func TestGetMonitoringStatusUnsupportedPlusHealthyRouteIsAppWarning(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer ln.Close()
+	port := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+
+	routes := []config.Route{
+		{Protocol: "bad", CName: "127.0.0.1", Port: port, Primary: false},
+		{Protocol: "tcp", CName: "127.0.0.1", Port: port, DestinationPort: port, Primary: true},
+	}
+	app := newMonitoringTestApp(routes)
+
+	status := app.GetMonitoringStatus()
+	if status != stateAppWarning {
+		t.Fatalf("expected %s for unsupported+healthy route pair, got %s", stateAppWarning, status)
+	}
+}
+
+func TestGetMonitoringStatusRefreshTotalOutageBecomesFailedAfterMaxFail(t *testing.T) {
+	routes := []config.Route{
+		{Protocol: "tcp", CName: "127.0.0.1", Port: "1", DestinationPort: "1", Primary: true},
+		{Protocol: "tcp", CName: "127.0.0.1", Port: "2", DestinationPort: "2", Primary: false},
+	}
+	app := newMonitoringTestApp(routes)
+	app.ClusterGroup.Conf.MaxFail = 1
+
+	// First Refresh: FailCount(0) < MaxFail(1) → Suspect.
+	if err := app.Refresh(); err != nil {
+		t.Fatalf("Refresh returned error: %v", err)
+	}
+	if app.State != stateSuspect {
+		t.Fatalf("expected %s on first total-outage refresh, got %s", stateSuspect, app.State)
+	}
+
+	// Second Refresh: FailCount(1) >= MaxFail(1) → Failed.
+	if err := app.Refresh(); err != nil {
+		t.Fatalf("Refresh returned error: %v", err)
+	}
+	if app.State != stateFailed {
+		t.Fatalf("expected %s after max-fail threshold, got %s", stateFailed, app.State)
 	}
 }

--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 	"sort"
@@ -340,11 +339,9 @@ func (cluster *Cluster) OpenSVCProvisionAppService(app *App) error {
 			cluster.errorChan <- err
 			return err
 		}
-		err = cluster.OpenSVCProvisionRoute(app)
-		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create app route:  %s ", err)
-			cluster.errorChan <- err
-			return err
+		if err = cluster.OpenSVCProvisionRoute(app); err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn,
+				"App %s service provisioned but route publication failed: %s — retry via update-routes when DNS and gateway are ready", app.GetId(), err)
 		}
 		cluster.errorChan <- nil
 		return nil
@@ -386,11 +383,9 @@ func (cluster *Cluster) OpenSVCProvisionAppService(app *App) error {
 		cluster.errorChan <- err
 		return err
 	}
-	err = cluster.OpenSVCProvisionRoute(app)
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not create app route:  %s ", err)
-		cluster.errorChan <- err
-		return err
+	if err = cluster.OpenSVCProvisionRoute(app); err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn,
+			"App %s service provisioned but route publication failed: %s — retry via update-routes when DNS and gateway are ready", app.GetId(), err)
 	}
 	cluster.errorChan <- nil
 	return nil
@@ -1073,6 +1068,46 @@ func buildRouteObjectName(route config.Route, opensvcDNS string) string {
 	return opensvcDNS + "_" + route.DestinationPort
 }
 
+// normalizeRouteCNAME lowercases a CNAME and trims surrounding whitespace and
+// any trailing dot, matching the canonical DNS wire format used in HAProxy rules.
+func normalizeRouteCNAME(cname string) string {
+	return strings.ToLower(strings.TrimRight(strings.TrimSpace(cname), "."))
+}
+
+// buildGroupedHostRouteFragment generates a single HAProxy config fragment for
+// all host routes sharing the same destination port.  Multiple CNAMEs produce
+// multiple use_backend rules in the shared 'frontend https' block.  All CNAMEs
+// are normalized before being emitted.
+func buildGroupedHostRouteFragment(routes []config.Route, opensvcDNS string, numBE int) (fragmentKey, haproxyfragment string, err error) {
+	if len(routes) == 0 {
+		return "", "", errors.New("buildGroupedHostRouteFragment: no routes provided")
+	}
+	destPort := routes[0].DestinationPort
+	backend := opensvcDNS + "_" + destPort
+	fragmentKey = "haproxy.cfg.d/" + backend
+
+	var frontendLines strings.Builder
+	for _, r := range routes {
+		cname := normalizeRouteCNAME(r.CName)
+		fmt.Fprintf(&frontendLines, "    use_backend %s if { hdr(host) -i %s }\n", backend, cname)
+	}
+
+	haproxyfragment = fmt.Sprintf(`
+frontend https
+%s
+backend %s
+    cookie SERVER insert indirect nocache dynamic
+    balance roundrobin
+    dynamic-cookie-key mysecretphrase
+    option http-server-close
+    timeout connect 10s
+    timeout server 5m
+    timeout tunnel 1h
+    server-template srv %d %s:%s resolvers cluster check init-addr none
+`, frontendLines.String(), backend, numBE, opensvcDNS, destPort)
+	return fragmentKey, haproxyfragment, nil
+}
+
 // buildRouteFragment generates the HAProxy config fragment and its gateway
 // fragment key for the given route.  It does not perform DNS provisioning.
 //
@@ -1264,23 +1299,47 @@ func (cluster *Cluster) OpenSVCProvisionRoute(app *App) error {
 
 	// Step 3: build the desired fragment set, provisioning DNS for host routes.
 	desired := make(map[string]string) // fragmentKey → haproxyfragment
+
+	// Group host routes by destination port so that multiple CNAMEs targeting
+	// the same port share one fragment with multiple use_backend rules instead
+	// of overwriting each other in the desired map.
+	hostRoutesByPort := make(map[string][]config.Route)
+	var hostPortOrder []string // preserve declaration order for deterministic output
 	for _, route := range app.AppConfig.Deployment.Routes {
-		if route.Mode == "host" {
+		if route.Mode == "host" || route.Mode == "" {
+			if _, seen := hostRoutesByPort[route.DestinationPort]; !seen {
+				hostPortOrder = append(hostPortOrder, route.DestinationPort)
+			}
+			hostRoutesByPort[route.DestinationPort] = append(hostRoutesByPort[route.DestinationPort], route)
+		}
+	}
+
+	for _, destPort := range hostPortOrder {
+		routes := hostRoutesByPort[destPort]
+		for _, route := range routes {
 			if err := cluster.provisionHostRouteDNS(route); err != nil {
 				return fmt.Errorf("DNS provisioning failed for route %s (app %s): %w", route.CName, app.Name, err)
 			}
 		}
-
-		if route.Mode == "host" || route.Mode == "" {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlWarn,
-				"app %s route %s: host-mode fragment adds a use_backend rule to the shared 'frontend https' block; ensure the gateway base config defines that frontend or the HAProxy reload will fail",
-				app.Name, route.CName)
-		}
-		key, frag, fragErr := buildRouteFragment(route, opensvcDNS, numBE)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlWarn,
+			"app %s host routes on port %s: fragment adds use_backend rules to the shared 'frontend https' block; ensure the gateway base config defines that frontend or the HAProxy reload will fail",
+			app.Name, destPort)
+		key, frag, fragErr := buildGroupedHostRouteFragment(routes, opensvcDNS, numBE)
 		if fragErr != nil {
-			return fmt.Errorf("cannot build route fragment for app %s: %w", app.Name, fragErr)
+			return fmt.Errorf("cannot build host route fragment for app %s port %s: %w", app.Name, destPort, fragErr)
 		}
 		desired[key] = frag
+	}
+
+	// Port routes are per-route (CName+port combo is already unique by validation).
+	for _, route := range app.AppConfig.Deployment.Routes {
+		if route.Mode == "port" {
+			key, frag, fragErr := buildRouteFragment(route, opensvcDNS, numBE)
+			if fragErr != nil {
+				return fmt.Errorf("cannot build route fragment for app %s: %w", app.Name, fragErr)
+			}
+			desired[key] = frag
+		}
 	}
 
 	// Step 4: list existing gateway fragments and delete stale or legacy ones.
@@ -1353,42 +1412,23 @@ func (cluster *Cluster) OpenSVCProvisionRoute(app *App) error {
 	return nil
 }
 
-// provisionHostRouteDNS handles managed/external DNS for host-mode routes.
-// Ownership is determined using the exact configured Cloud18 managed suffix
-// (see Cluster.Cloud18ManagedSuffix).
-//
-//   - managed CNAME that doesn't resolve yet → add via BashScriptProvDNS
-//   - managed CNAME that resolves to our gateway → skip (already correct)
-//   - any CNAME that resolves to a different target → hard-fail
-//   - any CNAME that doesn't resolve and is not managed → hard-fail
+// provisionHostRouteDNS calls cloud18-domain-add-script with the full
+// normalized FQDN.  The script is the authority on which domains it manages;
+// repman does not restrict by suffix.  If no script is configured DNS is
+// considered operator-managed and provisioning is skipped without error.
 func (cluster *Cluster) provisionHostRouteDNS(route config.Route) error {
-	result, err := net.LookupCNAME(route.CName)
-	if err != nil {
-		// CNAME doesn't resolve yet — check ownership before attempting to create.
-		shortLabel, managed := cluster.ManagedHostCNAME(route.CName)
-		if !managed {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
-				"CNAME %s does not resolve and is not under our managed suffix — fix DNS before provisioning", route.CName)
-			return fmt.Errorf("CNAME %s is not managed by this cluster — fix it before provisioning", route.CName)
-		}
-		if cluster.Conf.Cloud18DomainAddScript == "" {
-			return fmt.Errorf("CNAME %s requires DNS provisioning but cloud18-domain-add-script is not configured — configure it before provisioning", route.CName)
-		}
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
-			"Adding managed CNAME %s to gateway %s", route.CName, cluster.Conf.Cloud18GatewayDomainName)
-		if err := cluster.BashScriptProvDNS(shortLabel); err != nil {
-			return err
-		}
-	} else if !strings.EqualFold(strings.TrimRight(result, "."), strings.TrimRight(cluster.Conf.Cloud18GatewayDomainName, ".")) {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
-			"CNAME %s resolves to %s which is not gateway %s — fix DNS before provisioning",
-			route.CName, strings.TrimRight(result, "."), cluster.Conf.Cloud18GatewayDomainName)
-		return fmt.Errorf("CNAME %s points to %s, expected gateway %s", route.CName, strings.TrimRight(result, "."), cluster.Conf.Cloud18GatewayDomainName)
-	} else {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
-			"CNAME %s already resolves to gateway %s, skipping DNS add", route.CName, cluster.Conf.Cloud18GatewayDomainName)
+	cname := normalizeRouteCNAME(route.CName)
+	if cname == "" {
+		return fmt.Errorf("host route has an empty CNAME — set a valid hostname before provisioning")
 	}
-	return nil
+	if cluster.Conf.Cloud18DomainAddScript == "" {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+			"cloud18-domain-add-script not configured, skipping DNS provisioning for CNAME %s", cname)
+		return nil
+	}
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+		"Provisioning DNS for CNAME %s via add script", cname)
+	return cluster.BashScriptProvDNS(cname)
 }
 
 // managedCNAMEsFile returns the path of the per-app JSON file that records
@@ -1505,13 +1545,12 @@ func (cluster *Cluster) reconcileStaleManagedCNAMEs(
 	}
 
 	for _, fqdn := range staleCNAMEs {
-		shortLabel, managed := cluster.ManagedHostCNAME(fqdn)
-		if !managed {
+		if _, managed := cluster.ManagedHostCNAME(fqdn); !managed {
 			// The FQDN was recorded under a previous managed suffix (cluster
 			// rename, domain/subdomain/zone config change, etc.).  Log a warning
 			// and retain the entry rather than aborting the whole reconcile — a
-			// misconfigured drop-script call with an empty label would be worse
-			// than leaving the entry for manual cleanup.
+			// drop-script call for an unrecognised zone would be worse than
+			// leaving the entry for manual cleanup.
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
 				"Stale CNAME %s (app %s) does not match the current managed suffix — skipping drop; retaining in state for manual cleanup",
 				fqdn, app.Name)
@@ -1520,7 +1559,7 @@ func (cluster *Cluster) reconcileStaleManagedCNAMEs(
 		}
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
 			"Deleting stale managed DNS record %s (app %s)", fqdn, app.Name)
-		if err := cluster.BashScriptDeprovDNS(shortLabel); err != nil {
+		if err := cluster.BashScriptDeprovDNS(fqdn); err != nil {
 			return nil, fmt.Errorf("failed to delete stale managed DNS record %s (app %s): %w", fqdn, app.Name, err)
 		}
 	}

--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -340,7 +340,7 @@ func (cluster *Cluster) OpenSVCProvisionAppService(app *App) error {
 			return err
 		}
 		if err = cluster.OpenSVCProvisionRoute(app); err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn,
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr,
 				"App %s service provisioned but route publication failed: %s — retry via update-routes when DNS and gateway are ready", app.GetId(), err)
 		}
 		cluster.errorChan <- nil
@@ -384,7 +384,7 @@ func (cluster *Cluster) OpenSVCProvisionAppService(app *App) error {
 		return err
 	}
 	if err = cluster.OpenSVCProvisionRoute(app); err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn,
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr,
 			"App %s service provisioned but route publication failed: %s — retry via update-routes when DNS and gateway are ready", app.GetId(), err)
 	}
 	cluster.errorChan <- nil

--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -1153,22 +1153,8 @@ backend %s
     server-template srv %d %s:%s resolvers cluster check init-addr none
 `, frontend, route.CName, route.SourcePort, backend, backend, numBE, opensvcDNS, route.DestinationPort)
 		}
-	default: // host
-		backend := routeName
-		haproxyfragment = fmt.Sprintf(`
-frontend https
-    use_backend %s if { hdr(host) -i %s }
-
-backend %s
-    cookie SERVER insert indirect nocache dynamic
-    balance roundrobin
-    dynamic-cookie-key mysecretphrase
-    option http-server-close
-    timeout connect 10s
-    timeout server 5m
-    timeout tunnel 1h
-    server-template srv %d %s:%s resolvers cluster check init-addr none
-`, backend, route.CName, backend, numBE, opensvcDNS, route.DestinationPort)
+	default:
+		return "", "", fmt.Errorf("buildRouteFragment: unsupported mode %q — host routes must use buildGroupedHostRouteFragment", route.Mode)
 	}
 	return fragmentKey, haproxyfragment, nil
 }

--- a/cluster/prov_opensvc_app.go
+++ b/cluster/prov_opensvc_app.go
@@ -1408,8 +1408,10 @@ func (cluster *Cluster) provisionHostRouteDNS(route config.Route) error {
 		return fmt.Errorf("host route has an empty CNAME — set a valid hostname before provisioning")
 	}
 	if cluster.Conf.Cloud18DomainAddScript == "" {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
-			"cloud18-domain-add-script not configured, skipping DNS provisioning for CNAME %s", cname)
+		if _, managed := cluster.ManagedHostCNAME(cname); !managed {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+				"cloud18-domain-add-script not configured and CNAME %s is not in the managed suffix %s; DNS is operator-managed and collision prevention is the operator's responsibility", cname, cluster.Cloud18ManagedSuffix())
+		}
 		return nil
 	}
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,

--- a/cluster/prov_opensvc_app_dns_test.go
+++ b/cluster/prov_opensvc_app_dns_test.go
@@ -1,9 +1,11 @@
 package cluster
 
 import (
+	"fmt"
 	"hash/crc64"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -17,11 +19,11 @@ func newDNSTestCluster(t *testing.T, clusterName, dropScript string) *Cluster {
 	return &Cluster{
 		Name: clusterName,
 		Conf: &config.Config{
-			WorkingDir:              t.TempDir(),
-			Cloud18Domain:           "signal18",
-			Cloud18SubDomain:        "dev2",
+			WorkingDir:               t.TempDir(),
+			Cloud18Domain:            "signal18",
+			Cloud18SubDomain:         "dev2",
 			Cloud18GatewayDomainName: "cloud18.io",
-			Cloud18DomainDropScript: dropScript,
+			Cloud18DomainDropScript:  dropScript,
 		},
 		crcTable: crc64.MakeTable(crc64.ISO),
 	}
@@ -140,6 +142,35 @@ func TestReconcileStaleManagedCNAMEs_DropScriptConfigured_DeletesStale(t *testin
 	}
 }
 
+// The drop script must receive the full FQDN as $3, not a short label.
+func TestReconcileStaleManagedCNAMEs_DropScriptReceivesFullFQDN(t *testing.T) {
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "drop.sh")
+	argsFile := filepath.Join(scriptDir, "args.txt")
+	if err := os.WriteFile(scriptPath, []byte(fmt.Sprintf("#!/bin/sh\necho \"$3\" > %s\nexit 0\n", argsFile)), 0o755); err != nil {
+		t.Fatalf("write drop script: %v", err)
+	}
+
+	cl := newDNSTestCluster(t, "c1", scriptPath)
+	app := newDNSTestApp(t)
+
+	staleFQDN := managedFQDN("stale", "c1")
+	old := map[string]struct{}{staleFQDN: {}}
+	new_ := map[string]struct{}{}
+
+	if _, err := cl.reconcileStaleManagedCNAMEs(app, old, new_); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read args file: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != staleFQDN {
+		t.Fatalf("drop script received %q as $3, want full FQDN %q", strings.TrimSpace(string(got)), staleFQDN)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // stale CNAME from a previous managed suffix — should warn and retain
 // ---------------------------------------------------------------------------
@@ -166,5 +197,94 @@ func TestReconcileStaleManagedCNAMEs_StaleUnderOldSuffix_WarnsAndRetains(t *test
 	// Entry must be retained in persisted for manual cleanup, not silently dropped.
 	if _, ok := persisted[externalFQDN]; !ok {
 		t.Fatalf("expected stale CNAME %q to be retained in persisted set for manual cleanup, got %v", externalFQDN, persisted)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// provisionHostRouteDNS tests
+// ---------------------------------------------------------------------------
+
+// newProvDNSCluster creates a minimal cluster for provisionHostRouteDNS tests
+// without a managed suffix (unmanaged CNAME behavior).
+func newProvDNSCluster(t *testing.T, addScript, gatewayDomain string) *Cluster {
+	t.Helper()
+	return &Cluster{
+		Name: "testcluster",
+		Conf: &config.Config{
+			Cloud18DomainAddScript:   addScript,
+			Cloud18GatewayDomainName: gatewayDomain,
+		},
+		crcTable: crc64.MakeTable(crc64.ISO),
+	}
+}
+
+func TestProvisionHostRouteDNS_EmptyCNAME_Fails(t *testing.T) {
+	cl := newProvDNSCluster(t, "some-script", "cloud18.io")
+	route := config.Route{Mode: "host", CName: "  "}
+	if err := cl.provisionHostRouteDNS(route); err == nil {
+		t.Fatal("expected error for empty CNAME after normalization")
+	}
+}
+
+// No add-script configured means operator manages DNS manually — any CNAME
+// must be accepted without error.
+func TestProvisionHostRouteDNS_NoAddScript_Skips(t *testing.T) {
+	cl := newProvDNSCluster(t, "", "cloud18.io")
+	for _, cname := range []string{"app.example.com", "api.myproduct.io", "console.company.net"} {
+		route := config.Route{Mode: "host", CName: cname}
+		if err := cl.provisionHostRouteDNS(route); err != nil {
+			t.Fatalf("expected nil for %q when no add-script configured, got: %v", cname, err)
+		}
+	}
+}
+
+// The full normalized FQDN must be passed to the add script regardless of domain.
+func TestProvisionHostRouteDNS_PassesFullFQDNToScript(t *testing.T) {
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "add.sh")
+	argsFile := filepath.Join(scriptDir, "args.txt")
+	if err := os.WriteFile(scriptPath, []byte(fmt.Sprintf("#!/bin/sh\necho \"$3\" > %s\nexit 0\n", argsFile)), 0o755); err != nil {
+		t.Fatalf("write add script: %v", err)
+	}
+
+	cl := newProvDNSCluster(t, scriptPath, "cloud18.io")
+	// Mixed-case with trailing dot — normalization must apply before script invocation.
+	route := config.Route{Mode: "host", CName: "App.Example.COM."}
+
+	if err := cl.provisionHostRouteDNS(route); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read args file: %v", err)
+	}
+	if want := "app.example.com"; strings.TrimSpace(string(got)) != want {
+		t.Fatalf("script received %q, want %q", strings.TrimSpace(string(got)), want)
+	}
+}
+
+// Trailing dot must be stripped before script invocation, for any domain.
+func TestProvisionHostRouteDNS_TrailingDotCNAME_Normalized(t *testing.T) {
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "add.sh")
+	argsFile := filepath.Join(scriptDir, "args.txt")
+	if err := os.WriteFile(scriptPath, []byte(fmt.Sprintf("#!/bin/sh\necho \"$3\" > %s\nexit 0\n", argsFile)), 0o755); err != nil {
+		t.Fatalf("write add script: %v", err)
+	}
+
+	cl := newProvDNSCluster(t, scriptPath, "cloud18.io")
+	route := config.Route{Mode: "host", CName: "custom.domain.io."}
+
+	if err := cl.provisionHostRouteDNS(route); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read args file: %v", err)
+	}
+	if want := "custom.domain.io"; strings.TrimSpace(string(got)) != want {
+		t.Fatalf("trailing dot not stripped: got %q, want %q", strings.TrimSpace(string(got)), want)
 	}
 }

--- a/cluster/prov_opensvc_app_route_test.go
+++ b/cluster/prov_opensvc_app_route_test.go
@@ -7,34 +7,16 @@ import (
 	"github.com/signal18/replication-manager/config"
 )
 
-func TestBuildRouteFragment_HostRouteUsesOriginDevelopNames(t *testing.T) {
+func TestBuildRouteFragment_HostRouteReturnsErrorNotSingleRoute(t *testing.T) {
 	route := config.Route{
 		Mode:            "host",
 		Protocol:        "https",
 		CName:           "console.example.com",
 		DestinationPort: "9001",
 	}
-
-	key, fragment, err := buildRouteFragment(route, "minio.crm.svc.cluster.local", 2)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	want := "haproxy.cfg.d/minio.crm.svc.cluster.local_9001"
-	if key != want {
-		t.Fatalf("unexpected fragment key: got %q want %q", key, want)
-	}
-	if !strings.Contains(fragment, "use_backend minio.crm.svc.cluster.local_9001 if { hdr(host) -i console.example.com }") {
-		t.Fatalf("host fragment lost origin/develop backend naming: %s", fragment)
-	}
-	if !strings.Contains(fragment, "backend minio.crm.svc.cluster.local_9001") {
-		t.Fatalf("host backend name mismatch: %s", fragment)
-	}
-	if !strings.Contains(fragment, "timeout tunnel 1h") {
-		t.Fatalf("host fragment missing websocket timeout tunnel: %s", fragment)
-	}
-	if strings.Contains(fragment, "be_") || strings.Contains(fragment, "repman_") {
-		t.Fatalf("host fragment still contains tokenized naming: %s", fragment)
+	_, _, err := buildRouteFragment(route, "minio.crm.svc.cluster.local", 2)
+	if err == nil {
+		t.Fatal("expected error for host-mode route, got nil")
 	}
 }
 
@@ -98,20 +80,15 @@ func TestBuildRouteFragment_PortRoutesDifferentCNamesHaveDifferentKeys(t *testin
 	}
 }
 
-func TestBuildRouteFragment_HostRouteEmitsLegacyCookieKey(t *testing.T) {
+func TestBuildRouteFragment_HostRouteReturnsError(t *testing.T) {
 	route := config.Route{
 		Mode:            "host",
-		Protocol:        "https",
 		CName:           "app.example.com",
 		DestinationPort: "8080",
 	}
-
-	_, fragment, err := buildRouteFragment(route, "app.cluster.svc.local", 2)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(fragment, "dynamic-cookie-key mysecretphrase") {
-		t.Fatalf("host-route fragment must preserve legacy dynamic-cookie-key; got:\n%s", fragment)
+	_, _, err := buildRouteFragment(route, "app.cluster.svc.local", 2)
+	if err == nil {
+		t.Fatal("expected error for host-mode route, got nil")
 	}
 }
 

--- a/cluster/prov_opensvc_app_route_test.go
+++ b/cluster/prov_opensvc_app_route_test.go
@@ -114,3 +114,105 @@ func TestBuildRouteFragment_HostRouteEmitsLegacyCookieKey(t *testing.T) {
 		t.Fatalf("host-route fragment must preserve legacy dynamic-cookie-key; got:\n%s", fragment)
 	}
 }
+
+func TestNormalizeRouteCNAME(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"app.example.com", "app.example.com"},
+		{"App.Example.COM.", "app.example.com"},
+		{"  WWW.EXAMPLE.COM.  ", "www.example.com"},
+		{"UPPER.", "upper"},
+		{"", ""},
+		{"   ", ""},
+	}
+	for _, tt := range tests {
+		got := normalizeRouteCNAME(tt.input)
+		if got != tt.want {
+			t.Errorf("normalizeRouteCNAME(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestBuildGroupedHostRouteFragment_SingleRoute(t *testing.T) {
+	routes := []config.Route{
+		{Mode: "host", CName: "app.example.com", DestinationPort: "8080"},
+	}
+	key, frag, err := buildGroupedHostRouteFragment(routes, "app.cluster.svc.local", 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "haproxy.cfg.d/app.cluster.svc.local_8080" {
+		t.Fatalf("unexpected fragment key: got %q", key)
+	}
+	if !strings.Contains(frag, "use_backend app.cluster.svc.local_8080 if { hdr(host) -i app.example.com }") {
+		t.Fatalf("missing use_backend rule in fragment:\n%s", frag)
+	}
+	if !strings.Contains(frag, "backend app.cluster.svc.local_8080") {
+		t.Fatalf("missing backend section in fragment:\n%s", frag)
+	}
+	if !strings.Contains(frag, "dynamic-cookie-key mysecretphrase") {
+		t.Fatalf("missing dynamic-cookie-key in fragment:\n%s", frag)
+	}
+	if !strings.Contains(frag, "timeout tunnel 1h") {
+		t.Fatalf("missing timeout tunnel in fragment:\n%s", frag)
+	}
+}
+
+func TestBuildGroupedHostRouteFragment_MultipleHostsSamePort(t *testing.T) {
+	routes := []config.Route{
+		{Mode: "host", CName: "app.example.com", DestinationPort: "8080"},
+		{Mode: "host", CName: "www.example.com", DestinationPort: "8080"},
+	}
+	key, frag, err := buildGroupedHostRouteFragment(routes, "app.cluster.svc.local", 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "haproxy.cfg.d/app.cluster.svc.local_8080" {
+		t.Fatalf("unexpected fragment key: got %q", key)
+	}
+	if !strings.Contains(frag, "use_backend app.cluster.svc.local_8080 if { hdr(host) -i app.example.com }") {
+		t.Fatalf("missing first use_backend rule:\n%s", frag)
+	}
+	if !strings.Contains(frag, "use_backend app.cluster.svc.local_8080 if { hdr(host) -i www.example.com }") {
+		t.Fatalf("missing second use_backend rule:\n%s", frag)
+	}
+	// Exactly one backend section (not counting use_backend lines).
+	backendSections := 0
+	for _, line := range strings.Split(frag, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "backend ") {
+			backendSections++
+		}
+	}
+	if backendSections != 1 {
+		t.Fatalf("expected 1 backend section, found %d in:\n%s", backendSections, frag)
+	}
+}
+
+func TestBuildGroupedHostRouteFragment_NormalizesHostnames(t *testing.T) {
+	routes := []config.Route{
+		{Mode: "host", CName: "APP.EXAMPLE.COM.", DestinationPort: "9000"},
+		{Mode: "host", CName: "WWW.EXAMPLE.COM. ", DestinationPort: "9000"},
+	}
+	_, frag, err := buildGroupedHostRouteFragment(routes, "svc.ns.svc.local", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(frag, "{ hdr(host) -i app.example.com }") {
+		t.Fatalf("first CNAME not normalized to lowercase:\n%s", frag)
+	}
+	if !strings.Contains(frag, "{ hdr(host) -i www.example.com }") {
+		t.Fatalf("second CNAME not normalized to lowercase:\n%s", frag)
+	}
+	if strings.Contains(frag, "APP.EXAMPLE.COM") || strings.Contains(frag, "WWW.EXAMPLE.COM") {
+		t.Fatalf("mixed-case hostname leaked into fragment:\n%s", frag)
+	}
+}
+
+func TestBuildGroupedHostRouteFragment_EmptyRoutes_Errors(t *testing.T) {
+	_, _, err := buildGroupedHostRouteFragment(nil, "svc.ns.svc.local", 1)
+	if err == nil {
+		t.Fatal("expected error for empty routes slice")
+	}
+}

--- a/share/dashboard_react/src/App.jsx
+++ b/share/dashboard_react/src/App.jsx
@@ -36,7 +36,7 @@ function SessionGuard() {
     if (localStorage.getItem('user_token') && sessionStatus === 'unknown') {
       dispatch(whoami())
     }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [pathname, sessionStatus, dispatch])
 
   useEffect(() => {
     const handle401 = () => dispatch(logout())

--- a/share/dashboard_react/src/App.jsx
+++ b/share/dashboard_react/src/App.jsx
@@ -1,6 +1,8 @@
-import { Suspense } from 'react'
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
+import { Suspense, useEffect } from 'react'
+import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-router-dom'
+import { useDispatch, useSelector } from 'react-redux'
 import PropTypes from 'prop-types'
+import { Spinner, Center } from '@chakra-ui/react'
 import './App.css'
 import ToastManager from './components/ToastManager'
 import SSOUpgradePoller from './components/SSOUpgradePoller'
@@ -13,10 +15,52 @@ import Slideshow from './Pages/Slideshow'
 import ClusterDB from './Pages/ClusterDB'
 import TerminalComponent from './Pages/Terminal'
 import ClusterApp from './Pages/ClusterApp'
+import { whoami, logout } from './redux/authSlice'
+
+const UNAVAILABLE_RETRY_MS = 15_000
+
+// Dispatches the initial whoami on mount (if a token exists) and listens for
+// server-side 401 events emitted by apiHelper so we can update Redux state
+// without a full page reload. Also retries whoami when the server is unavailable.
+function SessionGuard() {
+  const dispatch = useDispatch()
+  const sessionStatus = useSelector((state) => state.auth.sessionStatus)
+  const unavailableRetryCount = useSelector((state) => state.auth.unavailableRetryCount)
+  const { pathname } = useLocation()
+
+  useEffect(() => {
+    // /dashboard runs its own viewer-token polling loop (Login dashboard=true).
+    // Running whoami there can race with a freshly fetched dashboard token and
+    // clear it if the previous token was stale, breaking the slideshow recovery path.
+    if (pathname === '/dashboard') return
+    if (localStorage.getItem('user_token') && sessionStatus === 'unknown') {
+      dispatch(whoami())
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    const handle401 = () => dispatch(logout())
+    window.addEventListener('repman:auth401', handle401)
+    return () => window.removeEventListener('repman:auth401', handle401)
+  }, [dispatch])
+
+  // When the server was unreachable, retry whoami after a delay so the session
+  // can recover once the backend comes back. Each failed attempt increments
+  // unavailableRetryCount, which re-triggers this effect to schedule the next try.
+  useEffect(() => {
+    if (sessionStatus !== 'unavailable') return
+    if (!localStorage.getItem('user_token')) return
+    const timer = setTimeout(() => dispatch(whoami()), UNAVAILABLE_RETRY_MS)
+    return () => clearTimeout(timer)
+  }, [sessionStatus, unavailableRetryCount, dispatch])
+
+  return null
+}
 
 function App() {
   return (
     <BrowserRouter>
+      <SessionGuard />
       <ToastManager />
       <SSOUpgradePoller />
       <Routes>
@@ -115,15 +159,39 @@ function App() {
 }
 
 const PrivateRoute = ({ children }) => {
-  const isLoggedIn = localStorage.getItem('user_token') !== null
-  return isLoggedIn ? <Suspense fallback={<div>Loading...</div>}>{children}</Suspense> : <Navigate to='/login' />
+  const sessionStatus = useSelector((state) => state.auth.sessionStatus)
+  const hasToken = localStorage.getItem('user_token') !== null
+
+  // No token at all — go to login immediately, no point waiting for whoami.
+  if (!hasToken && sessionStatus === 'unknown') return <Navigate to='/login' />
+
+  // Token exists but whoami hasn't resolved yet — hold here while SessionGuard validates.
+  if (sessionStatus === 'unknown') {
+    return <Center h='100vh'><Spinner size='xl' /></Center>
+  }
+
+  if (sessionStatus === 'unauthenticated') return <Navigate to='/login' />
+
+  // 'authenticated' or 'unavailable': keep user in app while server restarts,
+  // but if the token disappeared out-of-band, redirect immediately rather than
+  // waiting for the next API call to discover it.
+  if (!hasToken) return <Navigate to='/login' />
+
+  return <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
 }
 
 // Slideshow uses the dashboard token — on auth failure redirect back to /dashboard
 // (not /login) so the viewer token is re-fetched automatically.
 const SlideshowRoute = ({ children }) => {
-  const isLoggedIn = localStorage.getItem('user_token') !== null
-  return isLoggedIn ? <Suspense fallback={<div>Loading...</div>}>{children}</Suspense> : <Navigate to='/dashboard' />
+  const sessionStatus = useSelector((state) => state.auth.sessionStatus)
+  const hasToken = localStorage.getItem('user_token') !== null
+
+  if (!hasToken && sessionStatus === 'unknown') return <Navigate to='/dashboard' />
+  if (sessionStatus === 'unknown') return <Center h='100vh'><Spinner size='xl' /></Center>
+  if (sessionStatus === 'unauthenticated') return <Navigate to='/dashboard' />
+  if (!hasToken) return <Navigate to='/dashboard' />
+
+  return <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
 }
 
 PrivateRoute.propTypes = {

--- a/share/dashboard_react/src/Pages/ClusterApp/components/ClusterAppTabContent/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/ClusterAppTabContent/index.jsx
@@ -16,6 +16,8 @@ function ClusterAppTabContent({ appId, tab, clusterName, user, selectedApp, conf
   const appName = selectedApp?.name
   const appHost = selectedApp?.host
 
+  const appRouteStatus = selectedApp?.routeStatus
+
   const overviewComponent = useMemo(() => {
     return (
       <Overview
@@ -26,9 +28,10 @@ function ClusterAppTabContent({ appId, tab, clusterName, user, selectedApp, conf
         appConfig={appConfig}
         config={config}
         user={user}
+        routeStatus={appRouteStatus}
       />
     )
-  }, [clusterName, appId, appName, appHost, appConfig, config, user])
+  }, [clusterName, appId, appName, appHost, appConfig, config, user, appRouteStatus])
 
   const storagesComponent = useMemo(() => {
     return (

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Overview/Routes.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Overview/Routes.jsx
@@ -1,16 +1,16 @@
 import {
   VStack, HStack, Text, Heading, Input, Select, Flex, Tooltip, Box,
-  Table, Thead, Tbody, Tr, Th, Td, Badge,
+  Table, Thead, Tbody, Tr, Th, Td, Badge, Divider, SimpleGrid,
 } from '@chakra-ui/react'
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { HiTrash, HiInformationCircle, HiChevronDown, HiChevronRight } from 'react-icons/hi'
+import { TbEdit } from 'react-icons/tb'
 import PropTypes from 'prop-types'
-import TextForm from '../../../../components/TextForm';
 import RMIconButton from '../../../../components/RMIconButton';
 import RMButton from '../../../../components/RMButton';
+import { useTheme } from '../../../../ThemeProvider';
 import styles from './styles.module.scss';
 import { uniqueId } from 'lodash';
-import Dropdown from '../../../../components/Dropdown';
 
 const modeOptions = [
   { value: 'host', name: 'Host' },
@@ -112,6 +112,31 @@ function normalizeNewRouteMonitorDraft(draft) {
   };
 }
 
+function routeToEditDraft(route) {
+  const mode = effectiveMode(route);
+  return {
+    mode,
+    cname: route.cname || '',
+    port: mode === 'host' ? (route.destPort || route.port || '') : '',
+    sourcePort: mode === 'port' ? (route.sourcePort || '') : '',
+    destPort: mode === 'port' ? (route.destPort || route.port || '') : '',
+    protocol: route.protocol || defaultProtocolForMode(mode),
+    monitorPath: route.monitor?.path || '',
+    monitorAuthType: route.monitor?.authType || 'none',
+    monitorAuthUser: route.monitor?.authUser || '',
+    monitorAuthSecretVar: route.monitor?.authSecretVar || '',
+    monitorExpectStatus: route.monitor?.expectStatus || '',
+  };
+}
+
+async function resolveRequest(request) {
+  if (!request) return request;
+  if (typeof request.unwrap === 'function') {
+    return request.unwrap();
+  }
+  return request;
+}
+
 function routeKey(route) {
   const mode = effectiveMode(route);
   const cname = route.cname?.toLowerCase() || '';
@@ -129,11 +154,121 @@ function matchRouteStatus(route, routeStatuses) {
   return null;
 }
 
-function StatusBadge({ status }) {
-  if (!status) return <Badge colorScheme="gray" fontSize="2xs" px={1}>—</Badge>;
-  if (status === 'AppRunning') return <Badge colorScheme="green" fontSize="2xs" px={1}>Running</Badge>;
-  if (status === 'AppWarning') return <Badge colorScheme="yellow" fontSize="2xs" px={1}>Warning</Badge>;
-  return <Badge colorScheme="red" fontSize="2xs" px={1}>Failed</Badge>;
+function modeMeta(route) {
+  const isHost = effectiveMode(route) === 'host';
+  return {
+    isHost,
+    label: isHost ? 'Host route' : 'Port route',
+    badgeScheme: isHost ? 'purple' : 'teal',
+  };
+}
+
+function protocolColorScheme(protocol) {
+  if (protocol === 'https') return 'green';
+  if (protocol === 'http') return 'orange';
+  return 'gray';
+}
+
+function routeEntryLabel(route) {
+  const mode = effectiveMode(route);
+  if (mode === 'port') {
+    const cname = route.cname || 'listener';
+    return `${cname}:${route.sourcePort || '—'}`;
+  }
+  return route.cname || '—';
+}
+
+function routeEntryHint(route) {
+  return effectiveMode(route) === 'host'
+    ? 'Public hostname on the shared gateway'
+    : 'Listener CNAME and source port on the shared gateway';
+}
+
+function routeBackendLabel(route) {
+  const backendPort = route.destPort || route.port;
+  return backendPort ? `:${backendPort}` : '—';
+}
+
+function monitorCredentialSummary(monitor) {
+  return {
+    user: monitor?.authUser ? 'Username configured' : 'No username',
+    secret: monitor?.authSecretVar ? 'Secret configured' : 'No secret variable',
+  };
+}
+
+function actionButtonStyle(kind, theme) {
+  const common = {
+    minWidth: '34px',
+    width: '34px',
+    height: '34px',
+    padding: '4px',
+    borderRadius: '8px',
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    boxShadow: 'none',
+  };
+
+  if (theme !== 'dark') return undefined;
+
+  if (kind === 'edit') {
+    return {
+      ...common,
+      backgroundColor: 'rgba(44, 82, 130, 0.16)',
+      borderColor: 'rgba(66, 153, 225, 0.45)',
+    };
+  }
+
+  if (kind === 'delete') {
+    return {
+      ...common,
+      backgroundColor: 'rgba(229, 62, 62, 0.14)',
+      borderColor: 'rgba(252, 129, 129, 0.45)',
+    };
+  }
+
+  return {
+    ...common,
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
+    borderColor: 'rgba(219, 232, 246, 0.22)',
+  };
+}
+
+function MetricCard({ label, value, accent }) {
+  return (
+    <Box
+      borderWidth="1px"
+      borderColor="var(--quaternary-color)"
+      borderRadius="lg"
+      px={3}
+      py={2}
+      bg="var(--secondary-gray-color)"
+    >
+      <HStack justify="space-between" align="baseline" spacing={3}>
+        <Text fontSize="xs" textTransform="uppercase" letterSpacing="widest" color="var(--darkgray-color)">{label}</Text>
+        <Text fontSize="lg" fontWeight="semibold" color={accent || 'var(--text-color)'}>
+          {value}
+        </Text>
+      </HStack>
+    </Box>
+  );
+}
+
+MetricCard.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  accent: PropTypes.string,
+}
+
+function StatusBadge({ status, variant = 'subtle' }) {
+  if (!status) return <Badge colorScheme="gray" variant={variant} fontSize="2xs" px={1}>—</Badge>;
+  if (status === 'AppRunning') return <Badge colorScheme="green" variant={variant} fontSize="2xs" px={1}>Running</Badge>;
+  if (status === 'AppWarning') return <Badge colorScheme="yellow" variant={variant} fontSize="2xs" px={1}>Warning</Badge>;
+  return <Badge colorScheme="red" variant={variant} fontSize="2xs" px={1}>Failed</Badge>;
+}
+
+StatusBadge.propTypes = {
+  status: PropTypes.string,
+  variant: PropTypes.string,
 }
 
 function MonitoringSummary({ route }) {
@@ -145,6 +280,20 @@ function MonitoringSummary({ route }) {
   if (m.authType && m.authType !== 'none') parts.push(m.authType.charAt(0).toUpperCase() + m.authType.slice(1));
   if (!parts.length) return <Text fontSize="xs" color="gray.400">—</Text>;
   return <Text fontSize="xs" color="gray.600" whiteSpace="nowrap">{parts.join(' · ')}</Text>;
+}
+
+MonitoringSummary.propTypes = {
+  route: PropTypes.shape({
+    mode: PropTypes.string,
+    protocol: PropTypes.string,
+    monitor: PropTypes.shape({
+      path: PropTypes.string,
+      authType: PropTypes.string,
+      authUser: PropTypes.string,
+      authSecretVar: PropTypes.string,
+      expectStatus: PropTypes.string,
+    }),
+  }).isRequired,
 }
 
 const Routes = React.memo(function Routes({
@@ -162,7 +311,29 @@ const Routes = React.memo(function Routes({
 
   const [formData, setFormData] = useState([]);
   const [expandedMonitorKeys, setExpandedMonitorKeys] = useState(new Set());
+  const [editingIndex, setEditingIndex] = useState(null);
+  const [editDraft, setEditDraft] = useState(null);
+  const { theme } = useTheme();
   const secretVarOpts = secretVariableOptions(variables);
+  const panelBg = 'var(--secondary-gray-color)';
+  const subtleBg = 'var(--tertiary-color)';
+  const borderColor = 'var(--quaternary-color)';
+  const mutedColor = 'var(--darkgray-color)';
+  const headingColor = 'var(--text-color)';
+  const insetBg = 'var(--body-bg-color)';
+  const accentColor = 'var(--secondary-color)';
+  const badgeVariant = theme === 'dark' ? 'solid' : 'subtle';
+  const actionVariant = theme === 'dark' ? 'ghost' : undefined;
+  const neutralActionColorScheme = theme === 'dark' ? 'blue' : undefined;
+  const neutralActionIconFill = undefined;
+  const expandActionColorScheme = theme === 'dark' ? 'whiteAlpha' : undefined;
+
+  const routeMetrics = useMemo(() => {
+    const host = rows.filter((route) => effectiveMode(route) === 'host').length;
+    const port = rows.length - host;
+    const monitored = rows.filter((route) => hasMonitorConfig(route)).length;
+    return { total: rows.length, host, port, monitored };
+  }, [rows]);
 
   const toggleMonitorRow = (key) => {
     setExpandedMonitorKeys(prev => {
@@ -191,6 +362,25 @@ const Routes = React.memo(function Routes({
     }));
   };
 
+  const handleEditDraftChange = (key, value) => {
+    setEditDraft((prev) => {
+      if (!prev) return prev;
+      const updated = { ...prev, [key]: value };
+      if (key === 'mode') {
+        updated.protocol = defaultProtocolForMode(value);
+        if (value === 'host') {
+          updated.port = prev.destPort || prev.port || '';
+          updated.destPort = '';
+          updated.sourcePort = '';
+        } else {
+          updated.destPort = prev.port || prev.destPort || '';
+          updated.port = '';
+        }
+      }
+      return updated;
+    });
+  };
+
   const handleAddItem = () => {
     setFormData(prevState => [...prevState, {
       id: uniqueId(),
@@ -217,6 +407,57 @@ const Routes = React.memo(function Routes({
     });
   };
 
+  const handleStartEdit = (index, route) => {
+    setEditingIndex(index);
+    setEditDraft(routeToEditDraft(route));
+    onPauseAutoReload();
+  };
+
+  const handleCancelEdit = () => {
+    setEditingIndex(null);
+    setEditDraft(null);
+    onResumeAutoReload();
+  };
+
+  const handleSaveEdit = async () => {
+    if (editingIndex == null || !editDraft) return;
+
+    const normalized = normalizeNewRouteMonitorDraft(editDraft);
+    const requests = [];
+
+    requests.push(onRowArrayChange(fieldName, editingIndex, 'mode', normalized.mode));
+    requests.push(onRowArrayChange(fieldName, editingIndex, 'cname', normalized.cname || ''));
+    requests.push(onRowArrayChange(fieldName, editingIndex, 'protocol', normalized.protocol || defaultProtocolForMode(normalized.mode)));
+
+    if (normalized.mode === 'host') {
+      requests.push(onRowArrayChange(fieldName, editingIndex, 'port', normalized.port || ''));
+    } else {
+      requests.push(onRowArrayChange(fieldName, editingIndex, 'sourcePort', normalized.sourcePort || ''));
+      requests.push(onRowArrayChange(fieldName, editingIndex, 'destPort', normalized.destPort || normalized.port || ''));
+    }
+
+    if (normalized.monitor) {
+      requests.push(onRowArrayChange(fieldName, editingIndex, 'monitor.path', normalized.monitor.path || ''));
+      requests.push(onRowArrayChange(fieldName, editingIndex, 'monitor.auth-type', normalized.monitor.authType || ''));
+      requests.push(onRowArrayChange(fieldName, editingIndex, 'monitor.auth-user', normalized.monitor.authUser || ''));
+      requests.push(onRowArrayChange(fieldName, editingIndex, 'monitor.auth-secret-var', normalized.monitor.authSecretVar || ''));
+      requests.push(onRowArrayChange(fieldName, editingIndex, 'monitor.expect-status', normalized.monitor.expectStatus || ''));
+    } else {
+      requests.push(onRowArrayChange(fieldName, editingIndex, 'monitor.clear', 'true'));
+    }
+
+    try {
+      for (const request of requests) {
+        await resolveRequest(request);
+      }
+      setEditingIndex(null);
+      setEditDraft(null);
+      onResumeAutoReload();
+    } catch (error) {
+      // keep the editor open so the user can correct invalid values
+    }
+  };
+
   const handleSaveAdd = () => {
     if (formData.length > 0) {
       const normalized = formData.map(normalizeNewRouteMonitorDraft);
@@ -235,209 +476,429 @@ const Routes = React.memo(function Routes({
   return (
     <Flex direction="column" className={`${styles.sectionWrapper}`}>
       <VStack spacing={3} align="stretch">
-        <Heading as="h3" size="md">Domain Gateway</Heading>
-        <Text fontWeight={"bold"}>{gateway}</Text>
+        <Box borderWidth="1px" borderColor={borderColor} borderRadius="xl" bg={panelBg} p={3}>
+          <SimpleGrid columns={{ base: 1, lg: 4 }} spacing={3} alignItems="stretch">
+            <Box gridColumn={{ base: 'span 1', lg: 'span 2' }}>
+              <VStack spacing={2} align="stretch" h="100%" justify="center">
+                <HStack spacing={2} align="center" flexWrap="wrap">
+                  <Heading as="h3" size="sm">Domain Gateway</Heading>
+                  <Badge colorScheme={gateway ? 'green' : 'gray'} variant={badgeVariant} borderRadius="full" px={2}>
+                    {gateway ? 'Configured' : 'Missing'}
+                  </Badge>
+                </HStack>
+                <Text fontSize="sm" color={mutedColor}>
+                  Every published route below is exposed through this shared gateway entrypoint.
+                </Text>
+              </VStack>
+            </Box>
+            <Box
+              gridColumn={{ base: 'span 1', lg: 'span 2' }}
+              borderWidth="1px"
+              borderColor={borderColor}
+              borderRadius="lg"
+              bg={panelBg}
+              borderLeftWidth="4px"
+              borderLeftColor={accentColor}
+              px={4}
+              py={3}
+            >
+              <HStack justify="space-between" align="center" spacing={3} flexWrap="wrap">
+                <Box>
+                  <Text fontSize="xs" textTransform="uppercase" letterSpacing="widest" color="var(--darkgray-color)">Gateway domain</Text>
+                  <Text fontWeight="bold" fontFamily="mono" fontSize="sm" color={headingColor}>{gateway || 'Not configured'}</Text>
+                </Box>
+                {!gateway && (
+                  <Text fontSize="xs" color={mutedColor}>Set the gateway domain to expose public hostnames.</Text>
+                )}
+              </HStack>
+            </Box>
+          </SimpleGrid>
+        </Box>
       </VStack>
 
       <VStack spacing={3} align="stretch">
-        <HStack spacing={2} align="center">
-          <Heading as="h3" size="md">Route mappings</Heading>
-          <Tooltip
-            label={COMMON_SETUPS_TOOLTIP}
-            placement="right"
-            hasArrow
-            bg="gray.800"
-            color="gray.100"
-            fontSize="xs"
-            fontFamily="mono"
-            whiteSpace="pre"
-            px={3}
-            py={2}
-            borderRadius="md"
-            maxW="420px"
-          >
-            <span><HiInformationCircle size={16} style={{ cursor: 'pointer', color: 'gray' }} /></span>
-          </Tooltip>
-        </HStack>
+        <Box borderWidth="1px" borderColor={borderColor} borderRadius="xl" bg={panelBg} p={3}>
+          <VStack spacing={3} align="stretch">
+            <SimpleGrid columns={{ base: 1, xl: 5 }} spacing={3} alignItems="start">
+              <Box gridColumn={{ base: 'span 1', xl: 'span 2' }}>
+                <VStack align="stretch" spacing={2}>
+                  <HStack spacing={2} align="center" flexWrap="wrap">
+                    <Heading as="h3" size="sm">Route mappings</Heading>
+                    <Badge colorScheme="blue" variant={badgeVariant} borderRadius="full" px={2}>{routeMetrics.total}</Badge>
+                    <Tooltip
+                      label={COMMON_SETUPS_TOOLTIP}
+                      placement="right"
+                      hasArrow
+                      bg="gray.800"
+                      color="gray.100"
+                      fontSize="xs"
+                      fontFamily="mono"
+                      whiteSpace="pre"
+                      px={3}
+                      py={2}
+                      borderRadius="md"
+                      maxW="420px"
+                    >
+                      <span><HiInformationCircle size={16} style={{ cursor: 'pointer', color: 'gray' }} /></span>
+                    </Tooltip>
+                  </HStack>
+                  <Text fontSize="sm" color={mutedColor}>
+                    Publish app endpoints and attach health checks from one compact view.
+                  </Text>
+                  {formData.length === 0 && (
+                    <HStack pt={1}>
+                      <RMButton onClick={handleAddItem}>Add Route</RMButton>
+                    </HStack>
+                  )}
+                </VStack>
+              </Box>
 
-        {rows?.length > 0 ? (
-          <Box overflowX="auto">
-            <Table size="sm" variant="simple">
-              <Thead>
-                <Tr>
-                  <Th px={2} fontSize="xs">Status</Th>
-                  <Th px={2} fontSize="xs">Mode</Th>
-                  <Th px={2} fontSize="xs">Hostname / Listener</Th>
-                  <Th px={2} fontSize="xs">Src Port</Th>
-                  <Th px={2} fontSize="xs">Backend</Th>
-                  <Th px={2} fontSize="xs">Protocol</Th>
-                  <Th px={2} fontSize="xs">Monitoring</Th>
-                  <Th px={2}></Th>
-                </Tr>
-              </Thead>
-              <Tbody>
-                {rows.map((p, index) => {
-                  const mode = effectiveMode(p);
-                  const isHost = mode === 'host';
-                  const protocolOpts = isHost ? hostProtocolOptions : portProtocolOptions;
-                  const rowKey = `row_${index}`;
-                  const availableModeOptions = !isHost && !p.cname
-                    ? modeOptions.filter(o => o.value !== 'host')
-                    : modeOptions;
-                  const modeHelp = isHost
-                    ? 'Clients connect using this hostname over HTTPS via the shared gateway frontend.'
-                    : 'Clients connect to the listener endpoint (cname:sourcePort). Wildcard binds are not allowed.';
-                  const monitorCapable = isHTTPMonitorCapable(p);
-                  const authType = p.monitor?.authType || 'none';
-                  const savedSecretVarOpts = [{ value: '__none__', name: '— none —' }, ...secretVarOpts];
-                  const matched = matchRouteStatus(p, routeStatus);
-                  const rKey = routeKey(p);
-                  const monitorExpanded = expandedMonitorKeys.has(rKey);
+              <SimpleGrid gridColumn={{ base: 'span 1', xl: 'span 3' }} columns={{ base: 1, sm: 2, lg: 4 }} spacing={3}>
+              <MetricCard label="Total routes" value={routeMetrics.total} />
+              <MetricCard label="Host routes" value={routeMetrics.host} accent="purple.500" />
+              <MetricCard label="Port routes" value={routeMetrics.port} accent="teal.500" />
+              <MetricCard label="Health checks" value={routeMetrics.monitored} accent="blue.500" />
+            </SimpleGrid>
+            </SimpleGrid>
 
-                  return (
-                    <React.Fragment key={rowKey}>
+            {rows?.length > 0 ? (
+              <Box borderWidth="1px" borderColor={borderColor} borderRadius="xl" overflow="hidden">
+                <Box overflowX="auto">
+                  <Table size="sm" variant="simple">
+                    <Thead bg={subtleBg}>
                       <Tr>
-                        <Td px={2} py={1}>
-                          <StatusBadge status={matched?.status} />
-                        </Td>
-                        <Td px={2} py={1}>
-                          <Tooltip label={modeHelp} placement="top" hasArrow>
-                            <span>
-                              <Dropdown
-                                confirmTitle={"Route mode changed — protocol will be reset"}
-                                name={`${rowKey}.mode`}
-                                selectedValue={mode}
-                                onChange={(value) => onRowArrayChange(fieldName, index, "mode", value)}
-                                options={availableModeOptions}
-                              />
-                            </span>
-                          </Tooltip>
-                        </Td>
-                        <Td px={2} py={1}>
-                          <TextForm
-                            confirmTitle={isHost ? "Public hostname changed" : "Listener CNAME changed"}
-                            name={`${rowKey}.cname`}
-                            placeholder={isHost ? "Public hostname" : "Listener CNAME"}
-                            value={p.cname}
-                            onSave={(value) => onRowArrayChange(fieldName, index, "cname", value)}
-                          />
-                        </Td>
-                        <Td px={2} py={1}>
-                          {!isHost && (
-                            <TextForm
-                              confirmTitle={"Source port changed"}
-                              pattern='^[0-9]{1,5}$'
-                              name={`${rowKey}.sourcePort`}
-                              placeholder="Src port"
-                              value={p.sourcePort}
-                              onSave={(value) => onRowArrayChange(fieldName, index, "sourceport", sanitizePort(value))}
-                            />
-                          )}
-                        </Td>
-                        <Td px={2} py={1}>
-                          <TextForm
-                            confirmTitle={"Backend port changed"}
-                            pattern='^[0-9]{1,5}$'
-                            name={`${rowKey}.port`}
-                            placeholder="Port"
-                            value={isHost ? (p.destPort || p.port) : (p.destPort || p.port)}
-                            onSave={(value) => onRowArrayChange(fieldName, index, isHost ? "port" : "destport", sanitizePort(value))}
-                          />
-                        </Td>
-                        <Td px={2} py={1}>
-                          <Dropdown
-                            confirmTitle={"Protocol changed"}
-                            name={`${rowKey}.protocol`}
-                            selectedValue={p.protocol}
-                            onChange={(value) => onRowArrayChange(fieldName, index, "protocol", value)}
-                            options={protocolOpts}
-                          />
-                        </Td>
-                        <Td px={2} py={1}>
-                          <HStack spacing={1}>
-                            <MonitoringSummary route={p} />
-                            {monitorCapable && (
-                              <RMIconButton
-                                size="xs"
-                                icon={monitorExpanded ? HiChevronDown : HiChevronRight}
-                                aria-label={monitorExpanded ? "Collapse monitoring" : "Edit monitoring"}
-                                onClick={() => toggleMonitorRow(rKey)}
-                              />
-                            )}
-                          </HStack>
-                        </Td>
-                        <Td px={2} py={1}>
-                          <RMIconButton icon={HiTrash} aria-label="Delete Route" onClick={() => onRowDropIndex(fieldName, index)} />
-                        </Td>
+                        <Th px={3} fontSize="xs">Status</Th>
+                        <Th px={3} fontSize="xs">Public entrypoint</Th>
+                        <Th px={3} fontSize="xs">Backend</Th>
+                        <Th px={3} fontSize="xs">Access</Th>
+                        <Th px={3} fontSize="xs">Monitoring</Th>
                       </Tr>
-                      {monitorExpanded && monitorCapable && (
-                        <Tr>
-                          <Td colSpan={8} px={3} py={2} bg="gray.50">
-                            <HStack spacing={2} flexWrap="wrap" align="flex-start">
-                              <Text fontSize="xs" color="gray.500" fontWeight="semibold" minW="60px" pt={1}>Monitor</Text>
-                              <TextForm
-                                confirmTitle="Monitor path changed"
-                                name={`${rowKey}.monitor.path`}
-                                placeholder="/ (default)"
-                                value={p.monitor?.path || ''}
-                                onSave={(value) => onRowArrayChange(fieldName, index, 'monitor.path', value)}
-                              />
-                              <Dropdown
-                                confirmTitle="Monitor auth type changed"
-                                name={`${rowKey}.monitor.auth-type`}
-                                selectedValue={authType}
-                                onChange={(value) => onRowArrayChange(fieldName, index, 'monitor.auth-type', value)}
-                                options={authTypeOptions}
-                              />
-                              {authType === 'basic' && (
-                                <TextForm
-                                  confirmTitle="Monitor auth user changed"
-                                  name={`${rowKey}.monitor.auth-user`}
-                                  placeholder="Username"
-                                  value={p.monitor?.authUser || ''}
-                                  onSave={(value) => onRowArrayChange(fieldName, index, 'monitor.auth-user', value)}
-                                />
-                              )}
-                              {(authType === 'basic' || authType === 'bearer') && (
-                                <Dropdown
-                                  confirmTitle="Monitor secret variable changed"
-                                  name={`${rowKey}.monitor.auth-secret-var`}
-                                  selectedValue={p.monitor?.authSecretVar || '__none__'}
-                                  onChange={(value) => onRowArrayChange(fieldName, index, 'monitor.auth-secret-var', value === '__none__' ? '' : value)}
-                                  options={savedSecretVarOpts}
-                                  placeholder="Secret var"
-                                />
-                              )}
-                              <TextForm
-                                confirmTitle="Expected status codes changed"
-                                name={`${rowKey}.monitor.expect-status`}
-                                placeholder="200"
-                                value={p.monitor?.expectStatus || ''}
-                                onSave={(value) => onRowArrayChange(fieldName, index, 'monitor.expect-status', value)}
-                              />
-                              {hasMonitorConfig(p) && (
-                                <RMButton size="xs" variant="outline" onClick={() => onRowArrayChange(fieldName, index, 'monitor.clear', 'true')}>
-                                  Clear
-                                </RMButton>
-                              )}
-                            </HStack>
-                          </Td>
-                        </Tr>
-                      )}
-                    </React.Fragment>
-                  );
-                })}
-              </Tbody>
-            </Table>
-          </Box>
-        ) : (
-          <Text fontSize="sm" color="gray.500">No saved route mappings</Text>
-        )}
+                    </Thead>
+                    <Tbody>
+                      {rows.map((p, index) => {
+                        const { label: modeLabel, badgeScheme } = modeMeta(p);
+                        const rowKey = `row_${index}`;
+                        const monitorCapable = isHTTPMonitorCapable(p);
+                        const matched = matchRouteStatus(p, routeStatus);
+                        const rKey = routeKey(p);
+                        const monitorExpanded = expandedMonitorKeys.has(rKey);
+                        const isEditing = editingIndex === index;
+                        const credentialSummary = monitorCredentialSummary(p.monitor);
+                        const proto = (p.protocol || '').toUpperCase();
+
+                        return (
+                          <React.Fragment key={rowKey}>
+                            <Tr>
+                              <Td px={3} py={2} verticalAlign="top">
+                                <VStack align="flex-start" spacing={2}>
+                                  <StatusBadge status={matched?.status} variant={badgeVariant} />
+                                  <Badge colorScheme={badgeScheme} variant={badgeVariant} fontSize="2xs" px={2} borderRadius="full">
+                                    {modeLabel}
+                                  </Badge>
+                                </VStack>
+                              </Td>
+                              <Td px={3} py={2} verticalAlign="top">
+                                <VStack align="flex-start" spacing={1}>
+                                  <Text fontSize="sm" fontWeight="semibold" fontFamily="mono" color={headingColor}>
+                                    {routeEntryLabel(p)}
+                                  </Text>
+                                  <Text fontSize="xs" color={mutedColor}>{routeEntryHint(p)}</Text>
+                                </VStack>
+                              </Td>
+                              <Td px={3} py={2} verticalAlign="top">
+                                <VStack align="flex-start" spacing={1}>
+                                  <Text fontSize="sm" fontWeight="semibold" fontFamily="mono" color={headingColor}>
+                                    {routeBackendLabel(p)}
+                                  </Text>
+                                  <Text fontSize="xs" color={mutedColor}>Application backend port</Text>
+                                </VStack>
+                              </Td>
+                              <Td px={3} py={2} verticalAlign="top">
+                                <VStack align="flex-start" spacing={2}>
+                                  <Badge colorScheme={protocolColorScheme(p.protocol)} variant={badgeVariant} fontSize="2xs" px={2} borderRadius="full">
+                                    {proto || '—'}
+                                  </Badge>
+                                  <Text fontSize="xs" color={mutedColor}>
+                                    {monitorCapable ? 'Supports HTTP monitoring' : 'Transport-only route'}
+                                  </Text>
+                                </VStack>
+                              </Td>
+                              <Td px={3} py={2} verticalAlign="top">
+                                <HStack spacing={2} align="flex-start" justify="space-between">
+                                  <VStack align="flex-start" spacing={1}>
+                                    <MonitoringSummary route={p} />
+                                    {!monitorCapable && (
+                                      <Text fontSize="xs" color={mutedColor}>Monitoring details are only available for HTTPS or HTTP routes.</Text>
+                                    )}
+                                  </VStack>
+                                  <HStack spacing={1} px={1} py={1} borderRadius="lg">
+                                    <RMIconButton
+                                      size="sm"
+                                      iconFontsize="1rem"
+                                      variant={actionVariant}
+                                      colorScheme={neutralActionColorScheme}
+                                      iconFillColor={neutralActionIconFill}
+                                      style={actionButtonStyle('edit', theme)}
+                                      icon={TbEdit}
+                                      aria-label="Edit route"
+                                      tooltip="Edit route"
+                                      onClick={() => handleStartEdit(index, p)}
+                                    />
+                                    <RMIconButton
+                                      size="sm"
+                                      iconFontsize="1rem"
+                                      variant={actionVariant}
+                                      colorScheme={theme === 'dark' ? 'red' : undefined}
+                                      style={actionButtonStyle('delete', theme)}
+                                      icon={HiTrash}
+                                      aria-label="Delete route"
+                                      tooltip="Delete route"
+                                      onClick={() => onRowDropIndex(fieldName, index)}
+                                    />
+                                    {monitorCapable && (
+                                      <RMIconButton
+                                        size="sm"
+                                        iconFontsize="1rem"
+                                        variant={actionVariant}
+                                        colorScheme={expandActionColorScheme}
+                                        iconFillColor={neutralActionIconFill}
+                                        style={actionButtonStyle('expand', theme)}
+                                        icon={monitorExpanded ? HiChevronDown : HiChevronRight}
+                                        aria-label={monitorExpanded ? 'Collapse monitoring' : 'View monitoring'}
+                                        tooltip={monitorExpanded ? 'Hide monitoring details' : 'Show monitoring details'}
+                                        onClick={() => toggleMonitorRow(rKey)}
+                                      />
+                                    )}
+                                  </HStack>
+                                </HStack>
+                              </Td>
+                            </Tr>
+                            {monitorExpanded && monitorCapable && (
+                              <Tr>
+                                <Td colSpan={5} px={3} py={2} bg={panelBg}>
+                                  <SimpleGrid columns={{ base: 1, md: 2, xl: 4 }} spacing={3}>
+                                    <Box bg={insetBg} borderWidth="1px" borderColor={borderColor} borderRadius="lg" px={3} py={2}>
+                                      <Text fontSize="xs" color="gray.500" fontWeight="semibold">Monitor path</Text>
+                                      <Text fontSize="sm" fontFamily="mono" color={headingColor}>{p.monitor?.path || '/'}</Text>
+                                    </Box>
+                                    <Box bg={insetBg} borderWidth="1px" borderColor={borderColor} borderRadius="lg" px={3} py={2}>
+                                      <Text fontSize="xs" color="gray.500" fontWeight="semibold">Authentication</Text>
+                                      {p.monitor?.authType && p.monitor.authType !== 'none' ? (
+                                        <Badge colorScheme="blue" variant={badgeVariant} fontSize="2xs" px={2} borderRadius="full" textTransform="capitalize">
+                                          {p.monitor.authType}
+                                        </Badge>
+                                      ) : (
+                                        <Text fontSize="sm" color={mutedColor}>None</Text>
+                                      )}
+                                    </Box>
+                                    <Box bg={insetBg} borderWidth="1px" borderColor={borderColor} borderRadius="lg" px={3} py={2}>
+                                      <Text fontSize="xs" color="gray.500" fontWeight="semibold">Auth details</Text>
+                                      <Text fontSize="sm" color={mutedColor}>
+                                        {credentialSummary.user}
+                                      </Text>
+                                      <Text fontSize="sm" color={mutedColor}>
+                                        {credentialSummary.secret}
+                                      </Text>
+                                    </Box>
+                                    <Box bg={insetBg} borderWidth="1px" borderColor={borderColor} borderRadius="lg" px={3} py={2}>
+                                      <Text fontSize="xs" color="gray.500" fontWeight="semibold">Expected status</Text>
+                                      <Text fontSize="sm" fontFamily="mono" color={headingColor}>{p.monitor?.expectStatus || 'Default'}</Text>
+                                    </Box>
+                                  </SimpleGrid>
+                                </Td>
+                              </Tr>
+                            )}
+                            {isEditing && editDraft && (
+                              <Tr>
+                                <Td colSpan={5} px={4} py={4} bg={panelBg} borderTopWidth="1px" borderTopColor={borderColor}>
+                                  <Box borderWidth="1px" borderColor={borderColor} borderRadius="xl" bg={insetBg} px={3} py={3}>
+                                    <VStack align="stretch" spacing={4}>
+                                      <HStack justify="space-between" align="center" flexWrap="wrap">
+                                        <Box>
+                                          <Text fontSize="sm" fontWeight="semibold">Edit route</Text>
+                                          <Text fontSize="xs" color={mutedColor}>Update the published entrypoint and monitoring settings.</Text>
+                                        </Box>
+                                        <Badge colorScheme="blue" variant={badgeVariant} borderRadius="full" px={2}>Editing saved route</Badge>
+                                      </HStack>
+
+                                      <SimpleGrid columns={{ base: 1, md: editDraft.mode === 'host' ? 4 : 5 }} spacing={3}>
+                                        <Box>
+                                          <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>Mode</Text>
+                                          <Select
+                                            value={editDraft.mode}
+                                          onChange={(e) => handleEditDraftChange('mode', e.target.value)}
+                                        >
+                                          {modeOptions.map(opt => (
+                                            <option key={opt.value} value={opt.value}>{opt.name}</option>
+                                          ))}
+                                        </Select>
+                                      </Box>
+                                      <Box>
+                                        <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>
+                                          {editDraft.mode === 'host' ? 'Public hostname' : 'Listener CNAME'}
+                                        </Text>
+                                        <Input
+                                          value={editDraft.cname}
+                                          onChange={(e) => handleEditDraftChange('cname', e.target.value)}
+                                        />
+                                      </Box>
+                                      {editDraft.mode === 'port' && (
+                                        <Box>
+                                          <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>Source port</Text>
+                                          <Input
+                                            pattern='^[0-9]{1,5}$'
+                                            value={editDraft.sourcePort}
+                                            onChange={(e) => handleEditDraftChange('sourcePort', sanitizePort(e.target.value))}
+                                          />
+                                        </Box>
+                                      )}
+                                      <Box>
+                                        <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>
+                                          {editDraft.mode === 'host' ? 'Backend port' : 'Destination port'}
+                                        </Text>
+                                        <Input
+                                          pattern='^[0-9]{1,5}$'
+                                          value={editDraft.mode === 'host' ? editDraft.port : editDraft.destPort}
+                                          onChange={(e) => handleEditDraftChange(editDraft.mode === 'host' ? 'port' : 'destPort', sanitizePort(e.target.value))}
+                                        />
+                                      </Box>
+                                      <Box>
+                                        <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>Protocol</Text>
+                                        <Select
+                                          value={editDraft.protocol}
+                                          onChange={(e) => handleEditDraftChange('protocol', e.target.value)}
+                                        >
+                                          {(editDraft.mode === 'host' ? hostProtocolOptions : portProtocolOptions).map(opt => (
+                                            <option key={opt.value} value={opt.value}>{opt.name}</option>
+                                          ))}
+                                        </Select>
+                                        </Box>
+                                      </SimpleGrid>
+
+                                      <Box borderWidth="1px" borderColor={borderColor} borderRadius="lg" bg={panelBg} px={4} py={3}>
+                                        <Text fontSize="xs" textTransform="uppercase" letterSpacing="widest" color="gray.500" mb={1}>Preview</Text>
+                                        <Text fontSize="sm" fontFamily="mono" color={headingColor}>{newRoutePreview(editDraft)}</Text>
+                                      </Box>
+
+                                      {(editDraft.mode === 'host' ? editDraft.protocol === 'https' : editDraft.protocol === 'http') ? (
+                                        <Box borderWidth="1px" borderColor={borderColor} borderRadius="lg" bg={panelBg} px={3} py={3}>
+                                          <Text fontSize="sm" fontWeight="semibold" mb={2}>Monitoring</Text>
+                                          <SimpleGrid columns={{ base: 1, md: 2, xl: 4 }} spacing={3}>
+                                            <Box>
+                                            <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>Path</Text>
+                                            <Input
+                                              value={editDraft.monitorPath}
+                                              size="sm"
+                                              placeholder="/ (default)"
+                                              onChange={(e) => handleEditDraftChange('monitorPath', e.target.value)}
+                                            />
+                                          </Box>
+                                            <Box>
+                                            <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>Auth type</Text>
+                                            <Select
+                                              value={editDraft.monitorAuthType}
+                                              size="sm"
+                                              onChange={(e) => handleEditDraftChange('monitorAuthType', e.target.value)}
+                                            >
+                                              {authTypeOptions.map(opt => (
+                                                <option key={opt.value} value={opt.value}>{opt.name}</option>
+                                              ))}
+                                            </Select>
+                                            </Box>
+                                            {editDraft.monitorAuthType === 'basic' && (
+                                              <Box>
+                                              <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>Username</Text>
+                                              <Input
+                                                value={editDraft.monitorAuthUser}
+                                                size="sm"
+                                                placeholder="Username"
+                                                onChange={(e) => handleEditDraftChange('monitorAuthUser', e.target.value)}
+                                              />
+                                              </Box>
+                                            )}
+                                            {(editDraft.monitorAuthType === 'basic' || editDraft.monitorAuthType === 'bearer') && (
+                                              <Box>
+                                              <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>Secret variable</Text>
+                                              {secretVarOpts.length > 0 ? (
+                                                <Select
+                                                  value={editDraft.monitorAuthSecretVar}
+                                                  size="sm"
+                                                  onChange={(e) => handleEditDraftChange('monitorAuthSecretVar', e.target.value)}
+                                                >
+                                                  <option value="">— secret var —</option>
+                                                  {secretVarOpts.map(opt => (
+                                                    <option key={opt.value} value={opt.value}>{opt.name}</option>
+                                                  ))}
+                                                </Select>
+                                              ) : (
+                                                <Input
+                                                  value={editDraft.monitorAuthSecretVar}
+                                                  size="sm"
+                                                  placeholder="Secret variable name"
+                                                  onChange={(e) => handleEditDraftChange('monitorAuthSecretVar', e.target.value)}
+                                                />
+                                              )}
+                                              </Box>
+                                            )}
+                                            <Box>
+                                            <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>Expected status</Text>
+                                            <Input
+                                              value={editDraft.monitorExpectStatus}
+                                              size="sm"
+                                              placeholder="200"
+                                              onChange={(e) => handleEditDraftChange('monitorExpectStatus', e.target.value)}
+                                            />
+                                            </Box>
+                                          </SimpleGrid>
+                                        </Box>
+                                      ) : (
+                                        <Text fontSize="sm" color={mutedColor}>
+                                          Monitoring can only be configured for HTTPS host routes or HTTP port routes.
+                                        </Text>
+                                      )}
+
+                                      <HStack flexWrap="wrap">
+                                        <RMButton onClick={handleSaveEdit}>Save Changes</RMButton>
+                                        <RMButton onClick={handleCancelEdit}>Cancel</RMButton>
+                                      </HStack>
+                                    </VStack>
+                                  </Box>
+                                </Td>
+                              </Tr>
+                            )}
+                          </React.Fragment>
+                        );
+                      })}
+                    </Tbody>
+                  </Table>
+                </Box>
+              </Box>
+            ) : (
+              <Box borderWidth="1px" borderStyle="dashed" borderColor={borderColor} borderRadius="xl" p={6} bg={subtleBg}>
+                <VStack spacing={2} align="flex-start">
+                  <Heading as="h4" size="xs">No route mappings yet</Heading>
+                  <Text fontSize="sm" color={mutedColor}>
+                    Add a host or port route to publish this app through the shared gateway.
+                  </Text>
+                </VStack>
+              </Box>
+            )}
+          </VStack>
+        </Box>
       </VStack>
 
       {formData.length > 0 && (
         <VStack spacing={3} align="stretch">
-          <Heading as="h3" size="md">New Route</Heading>
+          <Box borderWidth="1px" borderColor={borderColor} borderRadius="xl" bg={panelBg} p={3}>
+            <VStack spacing={3} align="stretch">
+              <HStack justify="space-between" align="center" flexWrap="wrap">
+                <Box>
+                  <Heading as="h3" size="sm">New Route</Heading>
+                  <Text fontSize="sm" color={mutedColor}>Draft one or more routes before saving them to the deployment.</Text>
+                </Box>
+                <Badge colorScheme="blue" variant={badgeVariant} borderRadius="full" px={2}>{formData.length} draft{formData.length > 1 ? 's' : ''}</Badge>
+              </HStack>
+
           {formData.map((p, index) => {
             const isHost = p.mode === 'host';
             const protocolOpts = isHost ? hostProtocolOptions : portProtocolOptions;
@@ -447,157 +908,219 @@ const Routes = React.memo(function Routes({
             const newMonitorCapable = isHost ? p.protocol === 'https' : p.protocol === 'http';
             const newMonitorAuthType = p.monitorAuthType || 'none';
             return (
-              <VStack key={`new_${p.id}`} align="stretch" spacing={1}>
-                <HStack align="center">
-                  <Tooltip label={modeHelp} placement="top" hasArrow>
-                    <Select
-                      value={p.mode}
-                      onChange={(e) => handleArrayChange(index, 'mode', e.target.value)}
-                      maxW="110px"
-                    >
-                      {modeOptions.map(opt => (
-                        <option key={opt.value} value={opt.value}>{opt.name}</option>
-                      ))}
-                    </Select>
-                  </Tooltip>
-                  {isHost ? (
-                    <>
+              <Box key={`new_${p.id}`} borderWidth="1px" borderColor={borderColor} borderRadius="xl" bg={subtleBg} p={3}>
+                <VStack align="stretch" spacing={4}>
+                  <HStack justify="space-between" align="flex-start" flexWrap="wrap">
+                    <Box>
+                      <HStack spacing={2} mb={1}>
+                        <Badge colorScheme={isHost ? 'purple' : 'teal'} variant={badgeVariant} borderRadius="full" px={2}>
+                          {isHost ? 'Host route' : 'Port route'}
+                        </Badge>
+                        <Badge colorScheme={protocolColorScheme(p.protocol)} variant={badgeVariant} borderRadius="full" px={2}>
+                          {(p.protocol || '').toUpperCase() || '—'}
+                        </Badge>
+                      </HStack>
+                      <Text fontSize="sm" color={mutedColor}>{modeHelp}</Text>
+                    </Box>
+                    <RMIconButton
+                      size="sm"
+                      iconFontsize="1rem"
+                      icon={HiTrash}
+                      variant={actionVariant}
+                      colorScheme={theme === 'dark' ? 'red' : undefined}
+                      style={actionButtonStyle('delete', theme)}
+                      aria-label="Delete Route"
+                      tooltip="Remove draft route"
+                      onClick={() => handleRemoveItem(index)}
+                    />
+                  </HStack>
+
+                  <SimpleGrid columns={{ base: 1, md: isHost ? 3 : 4 }} spacing={3}>
+                    <Box>
+                      <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>Mode</Text>
+                      <Tooltip label={modeHelp} placement="top" hasArrow>
+                        <Select
+                          value={p.mode}
+                          onChange={(e) => handleArrayChange(index, 'mode', e.target.value)}
+                        >
+                          {modeOptions.map(opt => (
+                            <option key={opt.value} value={opt.value}>{opt.name}</option>
+                          ))}
+                        </Select>
+                      </Tooltip>
+                    </Box>
+
+                    <Box>
+                      <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>
+                        {isHost ? 'Public hostname' : 'Listener CNAME'}
+                      </Text>
                       <Input
                         name={`new_${p.id}.cname`}
-                        placeholder="Public hostname"
+                        placeholder={isHost ? 'api.example.com' : 'db.gw.example.com'}
                         value={p.cname}
                         onChange={(e) => handleArrayChange(index, 'cname', e.target.value)}
                       />
+                    </Box>
+
+                    {!isHost && (
+                      <Box>
+                        <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>Source port</Text>
+                        <Input
+                          name={`new_${p.id}.sourcePort`}
+                          pattern='^[0-9]{1,5}$'
+                          placeholder="9000"
+                          value={p.sourcePort}
+                          onChange={(e) => handleArrayChange(index, 'sourcePort', sanitizePort(e.target.value))}
+                        />
+                      </Box>
+                    )}
+
+                    <Box>
+                      <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>
+                        {isHost ? 'Backend port' : 'Destination port'}
+                      </Text>
                       <Input
-                        name={`new_${p.id}.port`}
+                        name={isHost ? `new_${p.id}.port` : `new_${p.id}.destPort`}
                         pattern='^[0-9]{1,5}$'
-                        placeholder="Backend port"
-                        value={p.port}
-                        onChange={(e) => handleArrayChange(index, 'port', sanitizePort(e.target.value))}
+                        placeholder={isHost ? '8080' : '3306'}
+                        value={isHost ? p.port : p.destPort}
+                        onChange={(e) => handleArrayChange(index, isHost ? 'port' : 'destPort', sanitizePort(e.target.value))}
                       />
-                    </>
-                  ) : (
-                    <>
-                      <Input
-                        name={`new_${p.id}.cname`}
-                        placeholder="Listener CNAME"
-                        value={p.cname}
-                        onChange={(e) => handleArrayChange(index, 'cname', e.target.value)}
-                      />
-                      <Input
-                        name={`new_${p.id}.sourcePort`}
-                        pattern='^[0-9]{1,5}$'
-                        placeholder="Source port"
-                        value={p.sourcePort}
-                        onChange={(e) => handleArrayChange(index, 'sourcePort', sanitizePort(e.target.value))}
-                      />
-                      <Input
-                        name={`new_${p.id}.destPort`}
-                        pattern='^[0-9]{1,5}$'
-                        placeholder="Dest port"
-                        value={p.destPort}
-                        onChange={(e) => handleArrayChange(index, 'destPort', sanitizePort(e.target.value))}
-                      />
-                    </>
-                  )}
-                  <Select
-                    value={p.protocol}
-                    onChange={(e) => handleArrayChange(index, 'protocol', e.target.value)}
-                    maxW="100px"
-                  >
-                    {protocolOpts.map(opt => (
-                      <option key={opt.value} value={opt.value}>{opt.name}</option>
-                    ))}
-                  </Select>
-                  <RMIconButton icon={HiTrash} aria-label="Delete Route" onClick={() => handleRemoveItem(index)} />
-                </HStack>
-                <Text fontSize="xs" color="gray.500" pl={1} fontFamily="mono">{newRoutePreview(p)}</Text>
-                {newMonitorCapable && (
-                  <Box pl={1} pt={1} borderLeft="2px solid" borderColor="gray.200">
-                    <HStack spacing={2} flexWrap="wrap" align="flex-start">
-                      <Text fontSize="xs" color="gray.400" fontWeight="semibold" minW="75px" pt={1}>Monitoring</Text>
-                      <Input
-                        name={`new_${p.id}.monitor.path`}
-                        placeholder="/ (default)"
-                        value={p.monitorPath}
-                        size="sm"
-                        maxW="160px"
-                        onChange={(e) => handleArrayChange(index, 'monitorPath', e.target.value)}
-                      />
+                    </Box>
+
+                    <Box>
+                      <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>Protocol</Text>
                       <Select
-                        value={p.monitorAuthType}
-                        size="sm"
-                        maxW="110px"
-                        onChange={(e) => handleArrayChange(index, 'monitorAuthType', e.target.value)}
+                        value={p.protocol}
+                        onChange={(e) => handleArrayChange(index, 'protocol', e.target.value)}
                       >
-                        {authTypeOptions.map(opt => (
+                        {protocolOpts.map(opt => (
                           <option key={opt.value} value={opt.value}>{opt.name}</option>
                         ))}
                       </Select>
-                      {newMonitorAuthType === 'basic' && (
-                        <Input
-                          name={`new_${p.id}.monitor.auth-user`}
-                          placeholder="Username"
-                          value={p.monitorAuthUser}
-                          size="sm"
-                          maxW="140px"
-                          onChange={(e) => handleArrayChange(index, 'monitorAuthUser', e.target.value)}
-                        />
+                    </Box>
+                  </SimpleGrid>
+
+                  <Box borderWidth="1px" borderColor={borderColor} borderRadius="lg" bg={panelBg} px={4} py={3}>
+                    <Text fontSize="xs" textTransform="uppercase" letterSpacing="widest" color="gray.500" mb={1}>Preview</Text>
+                    <Text fontSize="sm" fontFamily="mono" color={headingColor}>{newRoutePreview(p)}</Text>
+                  </Box>
+
+                  <Divider />
+
+                  <Box>
+                    <HStack justify="space-between" align="center" flexWrap="wrap" mb={3}>
+                      <Box>
+                        <Text fontSize="sm" fontWeight="semibold">Monitoring</Text>
+                        <Text fontSize="xs" color={mutedColor}>Optional health check settings for HTTP-capable routes.</Text>
+                      </Box>
+                      {!newMonitorCapable && (
+                        <Badge colorScheme="gray" variant={badgeVariant} borderRadius="full" px={2}>Unavailable for this protocol</Badge>
                       )}
-                      {(newMonitorAuthType === 'basic' || newMonitorAuthType === 'bearer') && (
-                        secretVarOpts.length > 0 ? (
-                          <Select
-                            value={p.monitorAuthSecretVar}
-                            size="sm"
-                            maxW="180px"
-                            onChange={(e) => handleArrayChange(index, 'monitorAuthSecretVar', e.target.value)}
-                          >
-                            <option value="">— secret var —</option>
-                            {secretVarOpts.map(opt => (
-                              <option key={opt.value} value={opt.value}>{opt.name}</option>
-                            ))}
-                          </Select>
-                        ) : (
-                          <Input
-                            name={`new_${p.id}.monitor.auth-secret-var`}
-                            placeholder="Secret variable name"
-                            value={p.monitorAuthSecretVar}
-                            size="sm"
-                            maxW="180px"
-                            onChange={(e) => handleArrayChange(index, 'monitorAuthSecretVar', e.target.value)}
-                          />
-                        )
-                      )}
-                      <Input
-                        name={`new_${p.id}.monitor.expect-status`}
-                        placeholder="200"
-                        value={p.monitorExpectStatus}
-                        size="sm"
-                        maxW="120px"
-                        onChange={(e) => handleArrayChange(index, 'monitorExpectStatus', e.target.value)}
-                      />
                     </HStack>
-                    {(newMonitorAuthType === 'basic' || newMonitorAuthType === 'bearer') && secretVarOpts.length === 0 && (
-                      <Text fontSize="xs" color="gray.400" pl={1} mt={1}>
-                        Create the secret first in ENV Variables, then reference it here.
+
+                    {newMonitorCapable ? (
+                      <Box borderLeft="2px solid" borderColor={borderColor} pl={3}>
+                        <SimpleGrid columns={{ base: 1, md: 2, xl: 4 }} spacing={3}>
+                          <Box>
+                            <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>Path</Text>
+                            <Input
+                              name={`new_${p.id}.monitor.path`}
+                              placeholder="/ (default)"
+                              value={p.monitorPath}
+                              size="sm"
+                              onChange={(e) => handleArrayChange(index, 'monitorPath', e.target.value)}
+                            />
+                          </Box>
+                          <Box>
+                            <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>Auth type</Text>
+                            <Select
+                              value={p.monitorAuthType}
+                              size="sm"
+                              onChange={(e) => handleArrayChange(index, 'monitorAuthType', e.target.value)}
+                            >
+                              {authTypeOptions.map(opt => (
+                                <option key={opt.value} value={opt.value}>{opt.name}</option>
+                              ))}
+                            </Select>
+                          </Box>
+                          {newMonitorAuthType === 'basic' && (
+                            <Box>
+                              <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>Username</Text>
+                              <Input
+                                name={`new_${p.id}.monitor.auth-user`}
+                                placeholder="Username"
+                                value={p.monitorAuthUser}
+                                size="sm"
+                                onChange={(e) => handleArrayChange(index, 'monitorAuthUser', e.target.value)}
+                              />
+                            </Box>
+                          )}
+                          {(newMonitorAuthType === 'basic' || newMonitorAuthType === 'bearer') && (
+                            <Box>
+                              <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>Secret variable</Text>
+                              {secretVarOpts.length > 0 ? (
+                                <Select
+                                  value={p.monitorAuthSecretVar}
+                                  size="sm"
+                                  onChange={(e) => handleArrayChange(index, 'monitorAuthSecretVar', e.target.value)}
+                                >
+                                  <option value="">— secret var —</option>
+                                  {secretVarOpts.map(opt => (
+                                    <option key={opt.value} value={opt.value}>{opt.name}</option>
+                                  ))}
+                                </Select>
+                              ) : (
+                                <Input
+                                  name={`new_${p.id}.monitor.auth-secret-var`}
+                                  placeholder="Secret variable name"
+                                  value={p.monitorAuthSecretVar}
+                                  size="sm"
+                                  onChange={(e) => handleArrayChange(index, 'monitorAuthSecretVar', e.target.value)}
+                                />
+                              )}
+                            </Box>
+                          )}
+                          <Box>
+                            <Text fontSize="xs" color="gray.500" fontWeight="semibold" mb={1}>Expected status</Text>
+                            <Input
+                              name={`new_${p.id}.monitor.expect-status`}
+                              placeholder="200"
+                              value={p.monitorExpectStatus}
+                              size="sm"
+                              onChange={(e) => handleArrayChange(index, 'monitorExpectStatus', e.target.value)}
+                            />
+                          </Box>
+                        </SimpleGrid>
+                        {(newMonitorAuthType === 'basic' || newMonitorAuthType === 'bearer') && secretVarOpts.length === 0 && (
+                          <Text fontSize="xs" color={mutedColor} mt={2}>
+                            Create the secret first in ENV Variables, then reference it here.
+                          </Text>
+                        )}
+                      </Box>
+                    ) : (
+                      <Text fontSize="sm" color={mutedColor}>
+                        Switch the route to HTTPS or HTTP to configure path-based health checks.
                       </Text>
                     )}
                   </Box>
-                )}
-              </VStack>
+                </VStack>
+              </Box>
             );
           })}
+            </VStack>
+          </Box>
         </VStack>
       )}
 
-      <VStack spacing={3} align="stretch">
-        <HStack>
-          {formData?.length > 0 && (
-            <RMButton onClick={handleSaveAdd}>Save Route</RMButton>
-          )}
-          <RMButton onClick={handleAddItem}>Add Route</RMButton>
-        </HStack>
-      </VStack>
+      {formData?.length > 0 && (
+        <VStack spacing={3} align="stretch">
+          <HStack flexWrap="wrap">
+            <RMButton onClick={handleSaveAdd}>Save Route{formData.length > 1 ? 's' : ''}</RMButton>
+            <RMButton onClick={handleAddItem}>Add Route</RMButton>
+          </HStack>
+        </VStack>
+      )}
     </Flex>
   );
 })

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Overview/Routes.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Overview/Routes.jsx
@@ -1,6 +1,9 @@
-import { VStack, HStack, Text, Heading, Input, Select, Flex, Tooltip, Code, Box } from '@chakra-ui/react'
+import {
+  VStack, HStack, Text, Heading, Input, Select, Flex, Tooltip, Box,
+  Table, Thead, Tbody, Tr, Th, Td, Badge,
+} from '@chakra-ui/react'
 import React, { useState } from 'react'
-import { HiTrash, HiInformationCircle } from 'react-icons/hi'
+import { HiTrash, HiInformationCircle, HiChevronDown, HiChevronRight } from 'react-icons/hi'
 import PropTypes from 'prop-types'
 import TextForm from '../../../../components/TextForm';
 import RMIconButton from '../../../../components/RMIconButton';
@@ -59,20 +62,6 @@ function defaultProtocolForMode(mode) {
   return mode === 'port' ? 'tcp' : 'https';
 }
 
-function routePreview(p) {
-  const mode = effectiveMode(p);
-  const backendPort = p.destPort || p.port;
-  if (mode === 'host') {
-    const proto = p.protocol || 'https';
-    const host = p.cname || '(public hostname)';
-    return `${proto}://${host}  →  backend :${backendPort || '?'}`;
-  }
-  const listener = p.cname
-    ? `${p.cname}:${p.sourcePort || '?'}`
-    : `(listener cname):${p.sourcePort || '?'}`;
-  return `${listener}  →  backend :${backendPort || '?'}`;
-}
-
 function newRoutePreview(p) {
   const backendPort = p.mode === 'host' ? (p.port || '?') : (p.destPort || '?');
   if (p.mode === 'host') {
@@ -123,10 +112,46 @@ function normalizeNewRouteMonitorDraft(draft) {
   };
 }
 
+function routeKey(route) {
+  const mode = effectiveMode(route);
+  const cname = route.cname?.toLowerCase() || '';
+  const proto = route.protocol || '';
+  if (mode === 'port') return `port:${cname}:${route.sourcePort || ''}:${route.destPort || route.port || ''}:${proto}`;
+  return `host:${cname}:${route.destPort || route.port || ''}:${proto}`;
+}
+
+function matchRouteStatus(route, routeStatuses) {
+  if (!routeStatuses?.length) return null;
+  const key = routeKey(route);
+  for (const rs of routeStatuses) {
+    if (routeKey(rs) === key) return rs;
+  }
+  return null;
+}
+
+function StatusBadge({ status }) {
+  if (!status) return <Badge colorScheme="gray" fontSize="2xs" px={1}>—</Badge>;
+  if (status === 'AppRunning') return <Badge colorScheme="green" fontSize="2xs" px={1}>Running</Badge>;
+  if (status === 'AppWarning') return <Badge colorScheme="yellow" fontSize="2xs" px={1}>Warning</Badge>;
+  return <Badge colorScheme="red" fontSize="2xs" px={1}>Failed</Badge>;
+}
+
+function MonitoringSummary({ route }) {
+  const m = route.monitor;
+  if (!isHTTPMonitorCapable(route) || !m) return <Text fontSize="xs" color="gray.400">—</Text>;
+  const parts = [];
+  if (m.path) parts.push(m.path);
+  if (m.expectStatus) parts.push(m.expectStatus);
+  if (m.authType && m.authType !== 'none') parts.push(m.authType.charAt(0).toUpperCase() + m.authType.slice(1));
+  if (!parts.length) return <Text fontSize="xs" color="gray.400">—</Text>;
+  return <Text fontSize="xs" color="gray.600" whiteSpace="nowrap">{parts.join(' · ')}</Text>;
+}
+
 const Routes = React.memo(function Routes({
   gateway = "",
   rows = [],
   variables = [],
+  routeStatus = [],
   fieldName = 'routes',
   onRowArrayChange,
   onRowDropIndex,
@@ -136,7 +161,16 @@ const Routes = React.memo(function Routes({
 }) {
 
   const [formData, setFormData] = useState([]);
+  const [expandedMonitorKeys, setExpandedMonitorKeys] = useState(new Set());
   const secretVarOpts = secretVariableOptions(variables);
+
+  const toggleMonitorRow = (key) => {
+    setExpandedMonitorKeys(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  };
 
   const handleArrayChange = (index, key, value) => {
     setFormData(prevState => prevState.map((item, i) => {
@@ -148,11 +182,9 @@ const Routes = React.memo(function Routes({
           updated.port = item.destPort || item.port || '';
           updated.destPort = '';
           updated.sourcePort = '';
-          // cname is kept — host routes use it as the public hostname
         } else {
           updated.destPort = item.port || item.destPort || '';
           updated.port = '';
-          // cname is kept — port routes require it as the listener CNAME
         }
       }
       return updated;
@@ -227,155 +259,180 @@ const Routes = React.memo(function Routes({
             <span><HiInformationCircle size={16} style={{ cursor: 'pointer', color: 'gray' }} /></span>
           </Tooltip>
         </HStack>
-        <Text fontSize="sm" color="gray.600">
-          Each row exposes one public entrypoint.{' '}
-          <strong>Host</strong> routes by hostname (HTTPS) via the shared gateway frontend.{' '}
-          <strong>Port</strong> routes by listener hostname + port (TCP or HTTP) — the gateway binds the
-          resolved listener address; wildcard binds are not allowed.{' '}
-          You can mix both in the same app.
-        </Text>
 
-        {rows?.length > 0
-          ? rows.map((p, index) => {
-            const mode = effectiveMode(p);
-            const isHost = mode === 'host';
-            const protocolOpts = isHost ? hostProtocolOptions : portProtocolOptions;
-            const rowKey = `row_${index}`;
-            const availableModeOptions = !isHost && !p.cname
-              ? modeOptions.filter(o => o.value !== 'host')
-              : modeOptions;
-            const modeHelp = isHost
-              ? 'Clients connect using this hostname over HTTPS via the shared gateway frontend. Traffic is forwarded to the backend port.'
-              : 'Clients connect to the listener endpoint (cname:sourcePort). The gateway resolves the listener CNAME to a local bind address — wildcard binds are not allowed.';
-            const monitorCapable = isHTTPMonitorCapable(p);
-            const authType = p.monitor?.authType || 'none';
-            const savedSecretVarOpts = [{ value: '__none__', name: '— none —' }, ...secretVarOpts];
-            return (
-              <VStack key={rowKey} align="stretch" spacing={1}>
-                <HStack align="center">
-                  <Tooltip label={modeHelp} placement="top" hasArrow>
-                    <span>
-                      <Dropdown
-                        confirmTitle={"Route mode changed — protocol will be reset to the new mode's default"}
-                        name={`${rowKey}.mode`}
-                        selectedValue={mode}
-                        onChange={(value) => onRowArrayChange(fieldName, index, "mode", value)}
-                        options={availableModeOptions}
-                      />
-                    </span>
-                  </Tooltip>
-                  {isHost ? (
-                    <>
-                      <TextForm
-                        confirmTitle={"Public hostname changed"}
-                        name={`${rowKey}.cname`}
-                        placeholder="Public hostname"
-                        value={p.cname}
-                        onSave={(value) => onRowArrayChange(fieldName, index, "cname", value)}
-                      />
-                      <TextForm
-                        confirmTitle={"Backend port changed"}
-                        pattern='^[0-9]{1,5}$'
-                        name={`${rowKey}.port`}
-                        placeholder="Backend port"
-                        value={p.destPort || p.port}
-                        onSave={(value) => onRowArrayChange(fieldName, index, "port", sanitizePort(value))}
-                      />
-                    </>
-                  ) : (
-                    <>
-                      <TextForm
-                        confirmTitle={"Listener CNAME changed — gateway will re-resolve the bind address on next reconcile"}
-                        name={`${rowKey}.cname`}
-                        placeholder="Listener CNAME"
-                        value={p.cname}
-                        onSave={(value) => onRowArrayChange(fieldName, index, "cname", value)}
-                      />
-                      <TextForm
-                        confirmTitle={"Source port changed"}
-                        pattern='^[0-9]{1,5}$'
-                        name={`${rowKey}.sourcePort`}
-                        placeholder="Source port"
-                        value={p.sourcePort}
-                        onSave={(value) => onRowArrayChange(fieldName, index, "sourceport", sanitizePort(value))}
-                      />
-                      <TextForm
-                        confirmTitle={"Destination port changed"}
-                        pattern='^[0-9]{1,5}$'
-                        name={`${rowKey}.destPort`}
-                        placeholder="Dest port"
-                        value={p.destPort || p.port}
-                        onSave={(value) => onRowArrayChange(fieldName, index, "destport", sanitizePort(value))}
-                      />
-                    </>
-                  )}
-                  <Dropdown
-                    confirmTitle={"Protocol changed"}
-                    name={`${rowKey}.protocol`}
-                    selectedValue={p.protocol}
-                    onChange={(value) => onRowArrayChange(fieldName, index, "protocol", value)}
-                    options={protocolOpts}
-                  />
-                  <RMIconButton icon={HiTrash} aria-label="Delete Route" onClick={() => onRowDropIndex(fieldName, index)} />
-                </HStack>
-                <Code fontSize="xs" color="gray.500" bg="transparent" pl={1}>{routePreview(p)}</Code>
-                {monitorCapable && (
-                  <Box pl={1} pt={1} borderLeft="2px solid" borderColor="gray.200">
-                    <HStack spacing={2} flexWrap="wrap" align="flex-start">
-                      <Text fontSize="xs" color="gray.400" fontWeight="semibold" minW="75px" pt={1}>Monitoring</Text>
-                      <TextForm
-                        confirmTitle="Monitor path changed"
-                        name={`${rowKey}.monitor.path`}
-                        placeholder="/ (default)"
-                        value={p.monitor?.path || ''}
-                        onSave={(value) => onRowArrayChange(fieldName, index, 'monitor.path', value)}
-                      />
-                      <Dropdown
-                        confirmTitle="Monitor auth type changed"
-                        name={`${rowKey}.monitor.auth-type`}
-                        selectedValue={authType}
-                        onChange={(value) => onRowArrayChange(fieldName, index, 'monitor.auth-type', value)}
-                        options={authTypeOptions}
-                      />
-                      {authType === 'basic' && (
-                        <TextForm
-                          confirmTitle="Monitor auth user changed"
-                          name={`${rowKey}.monitor.auth-user`}
-                          placeholder="Username"
-                          value={p.monitor?.authUser || ''}
-                          onSave={(value) => onRowArrayChange(fieldName, index, 'monitor.auth-user', value)}
-                        />
+        {rows?.length > 0 ? (
+          <Box overflowX="auto">
+            <Table size="sm" variant="simple">
+              <Thead>
+                <Tr>
+                  <Th px={2} fontSize="xs">Status</Th>
+                  <Th px={2} fontSize="xs">Mode</Th>
+                  <Th px={2} fontSize="xs">Hostname / Listener</Th>
+                  <Th px={2} fontSize="xs">Src Port</Th>
+                  <Th px={2} fontSize="xs">Backend</Th>
+                  <Th px={2} fontSize="xs">Protocol</Th>
+                  <Th px={2} fontSize="xs">Monitoring</Th>
+                  <Th px={2}></Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {rows.map((p, index) => {
+                  const mode = effectiveMode(p);
+                  const isHost = mode === 'host';
+                  const protocolOpts = isHost ? hostProtocolOptions : portProtocolOptions;
+                  const rowKey = `row_${index}`;
+                  const availableModeOptions = !isHost && !p.cname
+                    ? modeOptions.filter(o => o.value !== 'host')
+                    : modeOptions;
+                  const modeHelp = isHost
+                    ? 'Clients connect using this hostname over HTTPS via the shared gateway frontend.'
+                    : 'Clients connect to the listener endpoint (cname:sourcePort). Wildcard binds are not allowed.';
+                  const monitorCapable = isHTTPMonitorCapable(p);
+                  const authType = p.monitor?.authType || 'none';
+                  const savedSecretVarOpts = [{ value: '__none__', name: '— none —' }, ...secretVarOpts];
+                  const matched = matchRouteStatus(p, routeStatus);
+                  const rKey = routeKey(p);
+                  const monitorExpanded = expandedMonitorKeys.has(rKey);
+
+                  return (
+                    <React.Fragment key={rowKey}>
+                      <Tr>
+                        <Td px={2} py={1}>
+                          <StatusBadge status={matched?.status} />
+                        </Td>
+                        <Td px={2} py={1}>
+                          <Tooltip label={modeHelp} placement="top" hasArrow>
+                            <span>
+                              <Dropdown
+                                confirmTitle={"Route mode changed — protocol will be reset"}
+                                name={`${rowKey}.mode`}
+                                selectedValue={mode}
+                                onChange={(value) => onRowArrayChange(fieldName, index, "mode", value)}
+                                options={availableModeOptions}
+                              />
+                            </span>
+                          </Tooltip>
+                        </Td>
+                        <Td px={2} py={1}>
+                          <TextForm
+                            confirmTitle={isHost ? "Public hostname changed" : "Listener CNAME changed"}
+                            name={`${rowKey}.cname`}
+                            placeholder={isHost ? "Public hostname" : "Listener CNAME"}
+                            value={p.cname}
+                            onSave={(value) => onRowArrayChange(fieldName, index, "cname", value)}
+                          />
+                        </Td>
+                        <Td px={2} py={1}>
+                          {!isHost && (
+                            <TextForm
+                              confirmTitle={"Source port changed"}
+                              pattern='^[0-9]{1,5}$'
+                              name={`${rowKey}.sourcePort`}
+                              placeholder="Src port"
+                              value={p.sourcePort}
+                              onSave={(value) => onRowArrayChange(fieldName, index, "sourceport", sanitizePort(value))}
+                            />
+                          )}
+                        </Td>
+                        <Td px={2} py={1}>
+                          <TextForm
+                            confirmTitle={"Backend port changed"}
+                            pattern='^[0-9]{1,5}$'
+                            name={`${rowKey}.port`}
+                            placeholder="Port"
+                            value={isHost ? (p.destPort || p.port) : (p.destPort || p.port)}
+                            onSave={(value) => onRowArrayChange(fieldName, index, isHost ? "port" : "destport", sanitizePort(value))}
+                          />
+                        </Td>
+                        <Td px={2} py={1}>
+                          <Dropdown
+                            confirmTitle={"Protocol changed"}
+                            name={`${rowKey}.protocol`}
+                            selectedValue={p.protocol}
+                            onChange={(value) => onRowArrayChange(fieldName, index, "protocol", value)}
+                            options={protocolOpts}
+                          />
+                        </Td>
+                        <Td px={2} py={1}>
+                          <HStack spacing={1}>
+                            <MonitoringSummary route={p} />
+                            {monitorCapable && (
+                              <RMIconButton
+                                size="xs"
+                                icon={monitorExpanded ? HiChevronDown : HiChevronRight}
+                                aria-label={monitorExpanded ? "Collapse monitoring" : "Edit monitoring"}
+                                onClick={() => toggleMonitorRow(rKey)}
+                              />
+                            )}
+                          </HStack>
+                        </Td>
+                        <Td px={2} py={1}>
+                          <RMIconButton icon={HiTrash} aria-label="Delete Route" onClick={() => onRowDropIndex(fieldName, index)} />
+                        </Td>
+                      </Tr>
+                      {monitorExpanded && monitorCapable && (
+                        <Tr>
+                          <Td colSpan={8} px={3} py={2} bg="gray.50">
+                            <HStack spacing={2} flexWrap="wrap" align="flex-start">
+                              <Text fontSize="xs" color="gray.500" fontWeight="semibold" minW="60px" pt={1}>Monitor</Text>
+                              <TextForm
+                                confirmTitle="Monitor path changed"
+                                name={`${rowKey}.monitor.path`}
+                                placeholder="/ (default)"
+                                value={p.monitor?.path || ''}
+                                onSave={(value) => onRowArrayChange(fieldName, index, 'monitor.path', value)}
+                              />
+                              <Dropdown
+                                confirmTitle="Monitor auth type changed"
+                                name={`${rowKey}.monitor.auth-type`}
+                                selectedValue={authType}
+                                onChange={(value) => onRowArrayChange(fieldName, index, 'monitor.auth-type', value)}
+                                options={authTypeOptions}
+                              />
+                              {authType === 'basic' && (
+                                <TextForm
+                                  confirmTitle="Monitor auth user changed"
+                                  name={`${rowKey}.monitor.auth-user`}
+                                  placeholder="Username"
+                                  value={p.monitor?.authUser || ''}
+                                  onSave={(value) => onRowArrayChange(fieldName, index, 'monitor.auth-user', value)}
+                                />
+                              )}
+                              {(authType === 'basic' || authType === 'bearer') && (
+                                <Dropdown
+                                  confirmTitle="Monitor secret variable changed"
+                                  name={`${rowKey}.monitor.auth-secret-var`}
+                                  selectedValue={p.monitor?.authSecretVar || '__none__'}
+                                  onChange={(value) => onRowArrayChange(fieldName, index, 'monitor.auth-secret-var', value === '__none__' ? '' : value)}
+                                  options={savedSecretVarOpts}
+                                  placeholder="Secret var"
+                                />
+                              )}
+                              <TextForm
+                                confirmTitle="Expected status codes changed"
+                                name={`${rowKey}.monitor.expect-status`}
+                                placeholder="200"
+                                value={p.monitor?.expectStatus || ''}
+                                onSave={(value) => onRowArrayChange(fieldName, index, 'monitor.expect-status', value)}
+                              />
+                              {hasMonitorConfig(p) && (
+                                <RMButton size="xs" variant="outline" onClick={() => onRowArrayChange(fieldName, index, 'monitor.clear', 'true')}>
+                                  Clear
+                                </RMButton>
+                              )}
+                            </HStack>
+                          </Td>
+                        </Tr>
                       )}
-                      {(authType === 'basic' || authType === 'bearer') && (
-                        <Dropdown
-                          confirmTitle="Monitor secret variable changed"
-                          name={`${rowKey}.monitor.auth-secret-var`}
-                          selectedValue={p.monitor?.authSecretVar || '__none__'}
-                          onChange={(value) => onRowArrayChange(fieldName, index, 'monitor.auth-secret-var', value === '__none__' ? '' : value)}
-                          options={savedSecretVarOpts}
-                          placeholder="Secret var"
-                        />
-                      )}
-                      <TextForm
-                        confirmTitle="Expected status codes changed"
-                        name={`${rowKey}.monitor.expect-status`}
-                        placeholder="200"
-                        value={p.monitor?.expectStatus || ''}
-                        onSave={(value) => onRowArrayChange(fieldName, index, 'monitor.expect-status', value)}
-                      />
-                      {hasMonitorConfig(p) && (
-                        <RMButton size="xs" variant="outline" onClick={() => onRowArrayChange(fieldName, index, 'monitor.clear', 'true')}>
-                          Clear Monitoring
-                        </RMButton>
-                      )}
-                    </HStack>
-                  </Box>
-                )}
-              </VStack>
-            );
-          })
-          : <Text>No saved route mappings</Text>
-        }
+                    </React.Fragment>
+                  );
+                })}
+              </Tbody>
+            </Table>
+          </Box>
+        ) : (
+          <Text fontSize="sm" color="gray.500">No saved route mappings</Text>
+        )}
       </VStack>
 
       {formData.length > 0 && (
@@ -454,7 +511,7 @@ const Routes = React.memo(function Routes({
                   </Select>
                   <RMIconButton icon={HiTrash} aria-label="Delete Route" onClick={() => handleRemoveItem(index)} />
                 </HStack>
-                <Code fontSize="xs" color="gray.500" bg="transparent" pl={1}>{newRoutePreview(p)}</Code>
+                <Text fontSize="xs" color="gray.500" pl={1} fontFamily="mono">{newRoutePreview(p)}</Text>
                 {newMonitorCapable && (
                   <Box pl={1} pt={1} borderLeft="2px solid" borderColor="gray.200">
                     <HStack spacing={2} flexWrap="wrap" align="flex-start">
@@ -549,6 +606,7 @@ Routes.propTypes = {
   gateway: PropTypes.string,
   rows: PropTypes.array,
   variables: PropTypes.array,
+  routeStatus: PropTypes.array,
   fieldName: PropTypes.string,
   onRowArrayChange: PropTypes.func,
   onRowDropIndex: PropTypes.func,

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Overview/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Overview/index.jsx
@@ -13,7 +13,7 @@ import PathSection from "./Paths";
 import Variables from "./Variables";
 import PropTypes from "prop-types";
 
-const Overview = ({ clusterName, config, appId, appName, appHost, appConfig, user }) => {
+const Overview = ({ clusterName, config, appId, appName, appHost, appConfig, user, routeStatus }) => {
     const dispatch = useDispatch();
     const deployment = useSelector((state) => state.cluster?.app?.deployment);
     const substitution = useSelector((state) => state.cluster?.app?.substitution);
@@ -113,8 +113,8 @@ const Overview = ({ clusterName, config, appId, appName, appHost, appConfig, use
     const gateway = useMemo(() => config?.cloud18GatewayDomainName || '', [config]);
 
     const routeComponent = useMemo(() => {
-        return <Routes rows={routes} variables={variables} fieldName={'routes'} user={user} gateway={gateway} {...actionProps} />
-    }, [routes, variables, actionProps, user, gateway]);
+        return <Routes rows={routes} variables={variables} fieldName={'routes'} user={user} gateway={gateway} routeStatus={routeStatus} {...actionProps} />
+    }, [routes, variables, actionProps, user, gateway, routeStatus]);
 
     const pathComponent = useMemo(() => {
         return <PathSection
@@ -202,6 +202,7 @@ Overview.propTypes = {
     user: PropTypes.shape({
         grants: PropTypes.object,
     }),
+    routeStatus: PropTypes.array,
 };
 
 export default Overview;

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Overview/styles.module.scss
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Overview/styles.module.scss
@@ -134,8 +134,8 @@
 .sectionWrapper {
     display: flex;
     flex-direction: column;
-    padding: 16px;
-    gap: 16px;
+    padding: 12px;
+    gap: 12px;
     width: 100%;
 }
 

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppGrid/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppGrid/index.jsx
@@ -1,5 +1,5 @@
 import { Flex, SimpleGrid, Spacer, VStack } from '@chakra-ui/react'
-import React from 'react'
+import PropTypes from 'prop-types'
 import AppMenu from '../AppMenu'
 import { HiTable } from 'react-icons/hi'
 import TableType2 from '../../../../../components/TableType2'
@@ -29,7 +29,7 @@ function AppGrid({ apps = [], clusterName, showTableView, user, isDesktop, orche
             },
             {
               key: 'Routes',
-              value: <RouteSummary routeStatuses={rowData.routeStatus} configuredRouteCount={rowData.config?.deployment?.routes?.length ?? null} />
+              value: <RouteSummary routeStatuses={rowData.routeStatus} configuredRouteCount={rowData.config?.deployment?.routes?.length ?? null} showIdentity />
             }
           ]
           return (
@@ -66,3 +66,12 @@ function AppGrid({ apps = [], clusterName, showTableView, user, isDesktop, orche
 }
 
 export default AppGrid
+
+AppGrid.propTypes = {
+  apps: PropTypes.array,
+  clusterName: PropTypes.string,
+  showTableView: PropTypes.func,
+  user: PropTypes.object,
+  isDesktop: PropTypes.bool,
+  orchestrator: PropTypes.string,
+}

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppGrid/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppGrid/index.jsx
@@ -1,15 +1,13 @@
-import { Flex, SimpleGrid, Spacer, VStack, Text, Box } from '@chakra-ui/react'
+import { Flex, SimpleGrid, Spacer, VStack } from '@chakra-ui/react'
 import React from 'react'
 import AppMenu from '../AppMenu'
 import { HiTable } from 'react-icons/hi'
 import TableType2 from '../../../../../components/TableType2'
-import AccordionComponent from '../../../../../components/AccordionComponent'
 import AppStatus from '../AppStatus'
-import ServerStatus from '../../../../../components/ServerStatus'
-import TagPill from '../../../../../components/TagPill'
 import RMIconButton from '../../../../../components/RMIconButton'
 import styles from './styles.module.scss'
 import ServerName from '../../../../../components/ServerName'
+import RouteSummary from '../RouteSummary'
 
 function AppGrid({ apps = [], clusterName, showTableView, user, isDesktop, orchestrator }) {
   return (
@@ -28,6 +26,10 @@ function AppGrid({ apps = [], clusterName, showTableView, user, isDesktop, orche
             {
               key: 'Version',
               value: rowData.version
+            },
+            {
+              key: 'Routes',
+              value: <RouteSummary routeStatuses={rowData.routeStatus} configuredRouteCount={rowData.config?.deployment?.routes?.length ?? null} />
             }
           ]
           return (

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppTable/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppTable/index.jsx
@@ -1,31 +1,17 @@
 import { useMemo } from 'react'
 import { DataTable } from '../../../../../components/DataTable'
 import { createColumnHelper } from '@tanstack/react-table'
-import { Box, VStack } from '@chakra-ui/react'
+import { Box } from '@chakra-ui/react'
 import AppMenu from '../AppMenu'
 import styles from './styles.module.scss'
 import { Link } from 'react-router-dom'
 import ServerName from '../../../../../components/ServerName'
-import TagPill from '../../../../../components/TagPill'
 import ServerStatus from '../../../../../components/ServerStatus'
 import RMIconButton from '../../../../../components/RMIconButton'
 import { HiViewGrid } from 'react-icons/hi'
+import RouteSummary from '../RouteSummary'
 
 const columnHelper = createColumnHelper()
-
-function routePillText(route) {
-  const mode = route.mode || (route.protocol === 'tcp' ? 'port' : 'host')
-  if (mode === 'port') {
-    const prefix = route.name ? `${route.name} ` : ''
-    const cname = route.cname || ''
-    const sourcePort = route.sourcePort || ''
-    if (cname && sourcePort) return `${prefix}${cname}:${sourcePort}`
-    if (cname) return `${prefix}${cname}`
-    if (sourcePort) return `${prefix}:${sourcePort}`
-    return route.name || 'port route'
-  }
-  return route.cname || ''
-}
 
 function AppTable({ apps = [], isDesktop, clusterName, user, orchestrator, showGridView }) {
   const columns = useMemo(
@@ -61,11 +47,7 @@ function AppTable({ apps = [], isDesktop, clusterName, user, orchestrator, showG
         cell: (info) => info.getValue(),
         header: 'Docker Image'
       }),
-      columnHelper.accessor((row) => (<VStack>
-        {row.routeStatus?.filter((route) => route.primary).map((route, idx) => (
-          <TagPill key={idx} colorScheme="blue" text={routePillText(route)} />
-        ))}
-      </VStack>), {
+      columnHelper.accessor((row) => (<RouteSummary routeStatuses={row.routeStatus} configuredRouteCount={row.config?.deployment?.routes?.length ?? null} showIdentity />), {
         cell: (info) => info.getValue(),
         header: 'Routes'
       }),

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppTable/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppTable/index.jsx
@@ -2,11 +2,12 @@ import { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { DataTable } from '../../../../../components/DataTable'
 import { createColumnHelper } from '@tanstack/react-table'
-import { Box, Text, Tooltip } from '@chakra-ui/react'
+import { Box, Tooltip } from '@chakra-ui/react'
 import AppMenu from '../AppMenu'
 import styles from './styles.module.scss'
 import { Link } from 'react-router-dom'
 import ServerStatus from '../../../../../components/ServerStatus'
+import ServerName from '../../../../../components/ServerName'
 import RMIconButton from '../../../../../components/RMIconButton'
 import { HiViewGrid } from 'react-icons/hi'
 import RouteSummary from '../RouteSummary'
@@ -41,16 +42,15 @@ function AppTable({ apps = [], isDesktop, clusterName, user, orchestrator, showG
             <Tooltip label={name} placement="top" hasArrow openDelay={400}>
               <Link to={`/clusters/${clusterName}/apps/${row.original?.id}`} className={styles.appLink}>
                 <Box className={styles.appCell}>
-                  <Text className={styles.appName}>
-                    {name}
-                  </Text>
+                  <ServerName name={name} />
                 </Box>
               </Link>
             </Tooltip>
           );
         },
         header: 'Apps',
-        minWidth: '280px'
+        width: 280,
+        textAlign: 'left'
       }),
       columnHelper.accessor((row) => row.state, {
         cell: ({ row }) => <ServerStatus state={row.original.state} />,
@@ -63,14 +63,15 @@ function AppTable({ apps = [], isDesktop, clusterName, user, orchestrator, showG
           if (!val) return null;
           return (
             <Tooltip label={val} placement="top" hasArrow openDelay={400}>
-              <Text fontSize="xs" color="gray.600" whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis" maxW="200px">
+              <Box className={styles.dockerCell}>
                 {val}
-              </Text>
+              </Box>
             </Tooltip>
           );
         },
         header: 'Docker Image',
-        minWidth: '220px'
+        width: 240,
+        textAlign: 'left'
       }),
       columnHelper.accessor((row) => row.routeStatus, {
         cell: ({ row }) => (
@@ -81,7 +82,7 @@ function AppTable({ apps = [], isDesktop, clusterName, user, orchestrator, showG
           />
         ),
         header: 'Routes',
-        minWidth: '190px'
+        width: 160
       }),
     ],
     [clusterName, isDesktop, orchestrator, user, showGridView]

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppTable/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppTable/index.jsx
@@ -1,11 +1,11 @@
 import { useMemo } from 'react'
+import PropTypes from 'prop-types'
 import { DataTable } from '../../../../../components/DataTable'
 import { createColumnHelper } from '@tanstack/react-table'
-import { Box } from '@chakra-ui/react'
+import { Box, Text, Tooltip } from '@chakra-ui/react'
 import AppMenu from '../AppMenu'
 import styles from './styles.module.scss'
 import { Link } from 'react-router-dom'
-import ServerName from '../../../../../components/ServerName'
 import ServerStatus from '../../../../../components/ServerStatus'
 import RMIconButton from '../../../../../components/RMIconButton'
 import { HiViewGrid } from 'react-icons/hi'
@@ -33,23 +33,55 @@ function AppTable({ apps = [], isDesktop, clusterName, user, orchestrator, showG
           width: '40px'
         }
       ),
-      columnHelper.accessor((row) => (<Link to={`/clusters/${clusterName}/apps/${row?.id}`}>
-        <ServerName name={`${row.host}`} />
-      </Link>), {
-        cell: (info) => info.getValue(),
-        header: 'Apps'
+      columnHelper.accessor((row) => row.host, {
+        cell: ({ row }) => {
+          const name = row.original.host || row.original.name || row.original.id || '';
+
+          return (
+            <Tooltip label={name} placement="top" hasArrow openDelay={400}>
+              <Link to={`/clusters/${clusterName}/apps/${row.original?.id}`} className={styles.appLink}>
+                <Box className={styles.appCell}>
+                  <Text className={styles.appName}>
+                    {name}
+                  </Text>
+                </Box>
+              </Link>
+            </Tooltip>
+          );
+        },
+        header: 'Apps',
+        minWidth: '280px'
       }),
-      columnHelper.accessor((row) => (<ServerStatus state={row.state} />), {
-        cell: (info) => info.getValue(),
-        header: 'Status'
+      columnHelper.accessor((row) => row.state, {
+        cell: ({ row }) => <ServerStatus state={row.original.state} />,
+        header: 'Status',
+        width: '100px'
       }),
       columnHelper.accessor((row) => row.config?.provAppDockerImg, {
-        cell: (info) => info.getValue(),
-        header: 'Docker Image'
+        cell: (info) => {
+          const val = info.getValue() || '';
+          if (!val) return null;
+          return (
+            <Tooltip label={val} placement="top" hasArrow openDelay={400}>
+              <Text fontSize="xs" color="gray.600" whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis" maxW="200px">
+                {val}
+              </Text>
+            </Tooltip>
+          );
+        },
+        header: 'Docker Image',
+        minWidth: '220px'
       }),
-      columnHelper.accessor((row) => (<RouteSummary routeStatuses={row.routeStatus} configuredRouteCount={row.config?.deployment?.routes?.length ?? null} showIdentity />), {
-        cell: (info) => info.getValue(),
-        header: 'Routes'
+      columnHelper.accessor((row) => row.routeStatus, {
+        cell: ({ row }) => (
+          <RouteSummary
+            routeStatuses={row.original.routeStatus}
+            configuredRouteCount={row.original.config?.deployment?.routes?.length ?? null}
+            compact
+          />
+        ),
+        header: 'Routes',
+        minWidth: '190px'
       }),
     ],
     [clusterName, isDesktop, orchestrator, user, showGridView]
@@ -63,3 +95,12 @@ function AppTable({ apps = [], isDesktop, clusterName, user, orchestrator, showG
 }
 
 export default AppTable
+
+AppTable.propTypes = {
+  apps: PropTypes.array,
+  isDesktop: PropTypes.bool,
+  clusterName: PropTypes.string,
+  user: PropTypes.object,
+  orchestrator: PropTypes.string,
+  showGridView: PropTypes.func,
+}

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppTable/styles.module.scss
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppTable/styles.module.scss
@@ -11,9 +11,8 @@
   min-width: 0;
 }
 
-.appName {
-  font-size: rem(14);
-  font-weight: 600;
+.dockerCell {
+  font-size: rem(13);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppTable/styles.module.scss
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/AppTable/styles.module.scss
@@ -1,3 +1,20 @@
 .tableContainer {
   width: 100%;
 }
+
+.appLink {
+  display: block;
+  width: 100%;
+}
+
+.appCell {
+  min-width: 0;
+}
+
+.appName {
+  font-size: rem(14);
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/RouteSummary.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/RouteSummary.jsx
@@ -1,0 +1,65 @@
+import { HStack, VStack, Text, Badge } from '@chakra-ui/react'
+
+function routeStatusSummary(routeStatuses) {
+  if (!routeStatuses?.length) return { total: 0, up: 0, warn: 0, down: 0, primaryRoute: null };
+  let up = 0, warn = 0, down = 0, primaryRoute = null;
+  for (const rs of routeStatuses) {
+    if (rs.primary && !primaryRoute) primaryRoute = rs;
+    if (rs.status === 'AppRunning') up++;
+    else if (rs.status === 'AppWarning') warn++;
+    else down++;
+  }
+  return { total: routeStatuses.length, up, warn, down, primaryRoute };
+}
+
+function primaryRouteLabel(route) {
+  if (!route) return '';
+  const mode = route.mode || (route.protocol === 'tcp' ? 'port' : 'host');
+  if (mode === 'port') {
+    const cname = route.cname || '';
+    const sourcePort = route.sourcePort || '';
+    if (cname && sourcePort) return `${cname}:${sourcePort}`;
+    return cname || (sourcePort ? `:${sourcePort}` : 'port route');
+  }
+  return route.cname || '';
+}
+
+function RouteSummary({ routeStatuses, configuredRouteCount = null, showIdentity = false }) {
+  // Caller explicitly confirmed no routes are configured — no need to wait for monitoring.
+  if (configuredRouteCount === 0) {
+    return <Text fontSize="xs" color="gray.400">No routes</Text>;
+  }
+
+  // Runtime status hasn't arrived yet; routes may or may not be configured.
+  if (routeStatuses == null) {
+    return <Text fontSize="xs" color="gray.400">—</Text>;
+  }
+
+  const { total, up, warn, down, primaryRoute } = routeStatusSummary(routeStatuses);
+
+  if (total === 0) {
+    // Configured routes exist but runtime status is empty → still pending.
+    // Without config knowledge, fall back to "No routes".
+    return configuredRouteCount > 0
+      ? <Text fontSize="xs" color="gray.400">—</Text>
+      : <Text fontSize="xs" color="gray.400">No routes</Text>;
+  }
+
+  return (
+    <VStack spacing={0} align="start">
+      <HStack spacing={1} flexWrap="nowrap">
+        <Text fontSize="xs" color="gray.600" whiteSpace="nowrap">{total} {total === 1 ? 'route' : 'routes'}</Text>
+        {up > 0 && <Badge colorScheme="green" fontSize="2xs" px={1}>{up} up</Badge>}
+        {warn > 0 && <Badge colorScheme="yellow" fontSize="2xs" px={1}>{warn} warn</Badge>}
+        {down > 0 && <Badge colorScheme="red" fontSize="2xs" px={1}>{down} down</Badge>}
+      </HStack>
+      {showIdentity && primaryRoute && (
+        <Text fontSize="2xs" color="gray.400" whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis" maxW="180px">
+          {primaryRouteLabel(primaryRoute)}
+        </Text>
+      )}
+    </VStack>
+  );
+}
+
+export default RouteSummary

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/RouteSummary.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/RouteSummary.jsx
@@ -54,9 +54,9 @@ function getRouteBadgeProps(theme, kind) {
   }
 }
 
-function RouteStateBadges({ up, warn, down, theme }) {
+function RouteStateBadges({ up, warn, down, theme, compact }) {
   return (
-    <HStack spacing={1} flexWrap="nowrap" align="center">
+    <HStack spacing={1} flexWrap="nowrap" align="center" justify={compact ? 'center' : 'flex-start'} width={compact ? '100%' : 'auto'}>
       {up > 0 && <Badge fontSize="2xs" px={1.5} {...getRouteBadgeProps(theme, 'green')}>{up} up</Badge>}
       {warn > 0 && <Badge fontSize="2xs" px={1.5} {...getRouteBadgeProps(theme, 'yellow')}>{warn} warn</Badge>}
       {down > 0 && <Badge fontSize="2xs" px={1.5} {...getRouteBadgeProps(theme, 'red')}>{down} down</Badge>}
@@ -100,7 +100,7 @@ function RouteSummary({ routeStatuses, configuredRouteCount = null, showIdentity
   );
 
   if (compact) {
-    return <RouteStateBadges up={up} warn={warn} down={down} theme={theme} />;
+    return <RouteStateBadges up={up} warn={warn} down={down} theme={theme} compact />;
   }
 
   return summary;
@@ -120,4 +120,5 @@ RouteStateBadges.propTypes = {
   warn: PropTypes.number.isRequired,
   down: PropTypes.number.isRequired,
   theme: PropTypes.string.isRequired,
+  compact: PropTypes.bool,
 }

--- a/share/dashboard_react/src/Pages/Dashboard/components/Apps/RouteSummary.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Apps/RouteSummary.jsx
@@ -1,4 +1,6 @@
 import { HStack, VStack, Text, Badge } from '@chakra-ui/react'
+import PropTypes from 'prop-types'
+import { useTheme } from '../../../../ThemeProvider'
 
 function routeStatusSummary(routeStatuses) {
   if (!routeStatuses?.length) return { total: 0, up: 0, warn: 0, down: 0, primaryRoute: null };
@@ -24,7 +26,47 @@ function primaryRouteLabel(route) {
   return route.cname || '';
 }
 
-function RouteSummary({ routeStatuses, configuredRouteCount = null, showIdentity = false }) {
+function getRouteBadgeProps(theme, kind) {
+  if (theme !== 'dark') {
+    return { colorScheme: kind }
+  }
+
+  if (kind === 'green') {
+    return {
+      bg: 'rgba(15, 23, 42, 0.36)',
+      color: '#d9fbe8',
+      border: '1px solid rgba(104, 211, 145, 0.45)',
+    }
+  }
+
+  if (kind === 'yellow') {
+    return {
+      bg: 'rgba(15, 23, 42, 0.36)',
+      color: '#fef3c7',
+      border: '1px solid rgba(246, 173, 85, 0.45)',
+    }
+  }
+
+  return {
+    bg: 'rgba(15, 23, 42, 0.36)',
+    color: '#fee2e2',
+    border: '1px solid rgba(252, 129, 129, 0.48)',
+  }
+}
+
+function RouteStateBadges({ up, warn, down, theme }) {
+  return (
+    <HStack spacing={1} flexWrap="nowrap" align="center">
+      {up > 0 && <Badge fontSize="2xs" px={1.5} {...getRouteBadgeProps(theme, 'green')}>{up} up</Badge>}
+      {warn > 0 && <Badge fontSize="2xs" px={1.5} {...getRouteBadgeProps(theme, 'yellow')}>{warn} warn</Badge>}
+      {down > 0 && <Badge fontSize="2xs" px={1.5} {...getRouteBadgeProps(theme, 'red')}>{down} down</Badge>}
+    </HStack>
+  )
+}
+
+function RouteSummary({ routeStatuses, configuredRouteCount = null, showIdentity = false, compact = false }) {
+  const { theme } = useTheme()
+
   // Caller explicitly confirmed no routes are configured — no need to wait for monitoring.
   if (configuredRouteCount === 0) {
     return <Text fontSize="xs" color="gray.400">No routes</Text>;
@@ -36,6 +78,7 @@ function RouteSummary({ routeStatuses, configuredRouteCount = null, showIdentity
   }
 
   const { total, up, warn, down, primaryRoute } = routeStatusSummary(routeStatuses);
+  const primaryLabel = primaryRouteLabel(primaryRoute);
 
   if (total === 0) {
     // Configured routes exist but runtime status is empty → still pending.
@@ -45,21 +88,36 @@ function RouteSummary({ routeStatuses, configuredRouteCount = null, showIdentity
       : <Text fontSize="xs" color="gray.400">No routes</Text>;
   }
 
-  return (
-    <VStack spacing={0} align="start">
-      <HStack spacing={1} flexWrap="nowrap">
-        <Text fontSize="xs" color="gray.600" whiteSpace="nowrap">{total} {total === 1 ? 'route' : 'routes'}</Text>
-        {up > 0 && <Badge colorScheme="green" fontSize="2xs" px={1}>{up} up</Badge>}
-        {warn > 0 && <Badge colorScheme="yellow" fontSize="2xs" px={1}>{warn} warn</Badge>}
-        {down > 0 && <Badge colorScheme="red" fontSize="2xs" px={1}>{down} down</Badge>}
-      </HStack>
-      {showIdentity && primaryRoute && (
-        <Text fontSize="2xs" color="gray.400" whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis" maxW="180px">
-          {primaryRouteLabel(primaryRoute)}
+  const summary = (
+    <VStack spacing={0.5} align="start" maxW="100%">
+      {(showIdentity || compact) && primaryLabel && (
+        <Text fontSize="xs" fontWeight="medium" color={theme === 'dark' ? 'gray.200' : 'gray.700'} whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis" maxW="180px">
+          {primaryLabel}
         </Text>
       )}
+      <RouteStateBadges up={up} warn={warn} down={down} theme={theme} />
     </VStack>
   );
+
+  if (compact) {
+    return <RouteStateBadges up={up} warn={warn} down={down} theme={theme} />;
+  }
+
+  return summary;
 }
 
 export default RouteSummary
+
+RouteSummary.propTypes = {
+  routeStatuses: PropTypes.array,
+  configuredRouteCount: PropTypes.number,
+  showIdentity: PropTypes.bool,
+  compact: PropTypes.bool,
+}
+
+RouteStateBadges.propTypes = {
+  up: PropTypes.number.isRequired,
+  warn: PropTypes.number.isRequired,
+  down: PropTypes.number.isRequired,
+  theme: PropTypes.string.isRequired,
+}

--- a/share/dashboard_react/src/Pages/Login/index.jsx
+++ b/share/dashboard_react/src/Pages/Login/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, Suspense } from 'react'
+import React, { useCallback, useEffect, useRef, useState, Suspense } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 import { login, logout, setUserData } from '../../redux/authSlice'
@@ -24,38 +24,55 @@ function Login({ dashboard = false }) {
   const navigate = useNavigate()
   const dispatch = useDispatch()
   const {
-    auth: { isLogged, loading, loadingGitLogin, user, error }
+    auth: { isLogged, loading, loadingGitLogin, user, error, sessionStatus }
   } = useSelector((state) => state)
 
-  useEffect(() => {
-    // In dashboard mode always fetch a fresh token so the viewer lands on
-    // /slideshow even when a stale token is already in localStorage.
-    if (!dashboard && isAuthorized()) {
-      navigate('/')
-      return
-    }
+  // Guards against concurrent autologin fetches. Reset to false on network failure
+  // so a later retry is allowed; stays true after a definitive success or server rejection.
+  const autologinCalledRef = useRef(false)
+  const [autologinRetryCount, setAutologinRetryCount] = useState(0)
 
-    if (!dashboard) {
-      // Normal login page: try autologin once, fall through to manual login form on failure.
-      fetch('/api/autologin')
-        .then((res) => (res.ok ? res.json() : null))
-        .then((data) => {
-          if (data && data.token) {
-            localStorage.setItem('user_token', data.token)
-            localStorage.setItem('username', data.username || 'admin')
-            dispatch(setUserData())
-            navigate('/')
-          } else {
-            dispatch(logout())
-            dispatch(clearClusters())
-            dispatch(clearCluster())
-          }
-        })
-        .catch(() => {
+  const doAutologin = useCallback(() => {
+    if (autologinCalledRef.current) return
+    autologinCalledRef.current = true
+    fetch('/api/autologin')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data && data.token) {
+          localStorage.setItem('user_token', data.token)
+          localStorage.setItem('username', data.username || 'admin')
+          dispatch(setUserData())
+          navigate('/')
+        } else {
+          // Server is up but autologin is not configured — no retry.
           dispatch(logout())
           dispatch(clearClusters())
           dispatch(clearCluster())
-        })
+        }
+      })
+      .catch(() => {
+        // Network failure — server not up yet.
+        // Keep the guard set until the timer fires: dispatch(logout()) below will
+        // flip sessionStatus to 'unauthenticated', which would immediately re-trigger
+        // the sessionStatus effect. The guard being true prevents that instant retry.
+        dispatch(logout())
+        dispatch(clearClusters())
+        dispatch(clearCluster())
+        setTimeout(() => {
+          autologinCalledRef.current = false  // allow next attempt only after the delay
+          setAutologinRetryCount((c) => c + 1)
+        }, 10_000)
+      })
+  }, [dispatch, navigate])
+
+  useEffect(() => {
+    if (!dashboard) {
+      // If a token exists, SessionGuard (App.jsx) is already validating it via whoami.
+      // doAutologin will be called reactively below if whoami clears the stale token.
+      if (isAuthorized()) return
+
+      // No token on mount: try autologin immediately.
+      doAutologin()
       return
     }
 
@@ -89,6 +106,16 @@ function Login({ dashboard = false }) {
       clearTimeout(retryTimer)
     }
   }, [])
+
+  // Fires when:
+  //  - sessionStatus changes to 'unauthenticated' (stale token cleared by SessionGuard), or
+  //  - autologinRetryCount increments (previous attempt hit a network failure during restart).
+  useEffect(() => {
+    if (dashboard) return
+    if (sessionStatus !== 'unauthenticated') return
+    if (isAuthorized()) return
+    doAutologin()
+  }, [sessionStatus, autologinRetryCount, doAutologin])
 
   useEffect(() => {
     if (!loading || !loadingGitLogin) {

--- a/share/dashboard_react/src/Pages/PageContainer/index.jsx
+++ b/share/dashboard_react/src/Pages/PageContainer/index.jsx
@@ -16,6 +16,7 @@ function PageContainer({ children }) {
   const [fullVersion, setFullVersion] = useState('')
 
   const isLogged = useSelector((state) => state.auth.isLogged)
+  const sessionStatus = useSelector((state) => state.auth.sessionStatus)
   const user = useSelector((state) => state.auth.user)
   const monitor = useSelector((state) => state.globalClusters.monitor)
   const { isMobile, isTablet, isDesktop } = useSelector((state) => state.common)
@@ -53,7 +54,8 @@ function PageContainer({ children }) {
   }, [currentBreakpoint, dispatch, isDesktop, isMobile, isTablet])
 
   useEffect(() => {
-    if (isAuthorized() && (user === null || user.User === undefined)) {
+    const isViewerRoute = location.pathname === '/dashboard' || location.pathname === '/slideshow'
+    if (!isViewerRoute && isAuthorized() && (user === null || user.User === undefined)) {
       dispatch(whoami({}))
     }
     handleResize() // Initial setup
@@ -66,12 +68,19 @@ function PageContainer({ children }) {
   }, [dispatch, handleResize, user])
 
   useEffect(() => {
-    const isPublicAuthPage = location.pathname === '/login' || location.pathname === '/signup'
-    if (!isLogged && user === null && !isAuthorized() && !isPublicAuthPage) {
-      // Slideshow auth goes through /dashboard (viewer token) not /login (regular autologin → /)
+    const isPublicAuthPage = location.pathname === '/login' || location.pathname === '/signup' || location.pathname === '/dashboard'
+    if (isPublicAuthPage) return
+    // Redirect on confirmed unauthenticated state (401 from whoami or apiHelper).
+    // Skip 'unknown' (still checking) and 'unavailable' (server restarting — keep user in app).
+    if (sessionStatus === 'unauthenticated') {
+      navigate(location.pathname === '/slideshow' ? '/dashboard' : '/login')
+      return
+    }
+    // Legacy fallback: no token and no logged-in state.
+    if (!isLogged && user === null && !isAuthorized()) {
       navigate(location.pathname === '/slideshow' ? '/dashboard' : '/login')
     }
-  }, [isLogged, location.pathname, navigate, user])
+  }, [isLogged, sessionStatus, location.pathname, navigate, user])
 
   return (
     <Box className={styles.container}>

--- a/share/dashboard_react/src/components/DataTable/styles.module.scss
+++ b/share/dashboard_react/src/components/DataTable/styles.module.scss
@@ -57,6 +57,19 @@
     background-color: var(--warning-tertiary-color);
   }
 }
+
+:global(.dark) {
+  .table {
+    .redBlinking {
+      background-color: rgba(229, 62, 62, 0.28);
+    }
+
+    .orangeBlinking {
+      background-color: rgba(221, 107, 32, 0.26);
+    }
+  }
+}
+
 .paginationContainer {
   gap: rem(8);
   align-items: center;

--- a/share/dashboard_react/src/redux/authSlice.js
+++ b/share/dashboard_react/src/redux/authSlice.js
@@ -34,18 +34,19 @@ export const peerLogin = createAsyncThunk('auth/peerLogin', async ({  password, 
 })
 
 export const whoami = createAsyncThunk('auth/whoami', async (_, thunkAPI) => {
+  const tokenAtDispatch = localStorage.getItem('user_token')
   try {
     const response = await authService.whoami(thunkAPI.getState().auth.baseURL)
     if (response.status == 200){
       return response
     } else {
-      return thunkAPI.rejectWithValue({ errorMessage: response.data || "Request failed", errorStatus: response.status || 500 })
+      return thunkAPI.rejectWithValue({ errorMessage: response.data || "Request failed", errorStatus: response.status || 500, tokenAtDispatch })
     }
   } catch (error) {
     const errorMessage = error.message || 'Request failed'
     const errorStatus = error.errorStatus || 500 // Default error status if not provided
     // Handle errors (including custom errorStatus)
-    return thunkAPI.rejectWithValue({ errorMessage, errorStatus }) // Pass the entire Error object to the rejected action
+    return thunkAPI.rejectWithValue({ errorMessage, errorStatus, tokenAtDispatch }) // Pass the entire Error object to the rejected action
   }
 }, 
 // Add a condition to prevent the action from being dispatched if the user is already fetching the info
@@ -73,17 +74,27 @@ export const authSlice = createSlice({
     // SSO async upgrade state. ssoUpgradeId is set when login returns an upgrade_id.
     // SSOUpgradePoller reads this and replaces user_token once the upgrade completes.
     ssoUpgradeId: null,
+    // sessionStatus tracks whoami validation result:
+    //   'unknown'         — not yet checked (initial / post-mount)
+    //   'authenticated'   — whoami confirmed valid session
+    //   'unauthenticated' — 401: session invalid, token cleared
+    //   'unavailable'     — 5xx/network: server unreachable, keep existing session
+    sessionStatus: 'unknown',
+    // Incremented each time whoami rejects with a non-401 error.
+    // SessionGuard watches this to schedule the next retry without recursive timers.
+    unavailableRetryCount: 0,
   },
   reducers: {
-    logout: (state, action) => {
+    logout: (state) => {
       clearLocalStorageByPrefix('user_token')
       localStorage.removeItem('username')
       sessionStorage.removeItem('meet_unavailable')
       state.user = null
       state.isLogged = false
       state.ssoUpgradeId = null
+      state.sessionStatus = 'unauthenticated'
     },
-    setUserData: (state, action) => {
+    setUserData: (state) => {
       const username = localStorage.getItem('username')
       state.isLogged = localStorage.getItem('user_token') ? true : false
       state.user = state.user ? {
@@ -92,6 +103,8 @@ export const authSlice = createSlice({
       } : {
         username: username
       }
+      // Token came directly from the server (autologin / dashboard-token), treat as authenticated.
+      if (state.isLogged) state.sessionStatus = 'authenticated'
     },
     setBaseURL: (state, action) => {
       state.baseURL = action.payload.baseURL
@@ -117,6 +130,7 @@ export const authSlice = createSlice({
       localStorage.setItem('username', arg.username)
       state.isLogged = true
       state.user = { username: arg.username }
+      state.sessionStatus = 'authenticated'
       if (action.type === 'login') {
         state.loading = false
       }
@@ -149,11 +163,33 @@ export const authSlice = createSlice({
       } 
       state.error = action?.payload?.errorMessage
     })
-    builder.addMatcher(isAnyOf(whoami.pending), (state, action) => {
+    builder.addMatcher(isAnyOf(whoami.pending), (state) => {
       state.isLoadingUserData = true
     })
     builder.addMatcher(isAnyOf(whoami.rejected), (state, action) => {
       state.isLoadingUserData = false
+      const status = action.payload?.errorStatus
+      if (status === 401) {
+        // If a newer token was stored after this whoami was dispatched, the 401
+        // came from a stale request and the fresh token should not be evicted.
+        const currentToken = localStorage.getItem('user_token')
+        const usedToken = action.payload?.tokenAtDispatch
+        if (usedToken && currentToken && usedToken !== currentToken) {
+          return
+        }
+        // Invalid session — clear credentials and force re-login.
+        clearLocalStorageByPrefix('user_token')
+        localStorage.removeItem('username')
+        state.user = null
+        state.isLogged = false
+        state.ssoUpgradeId = null
+        state.sessionStatus = 'unauthenticated'
+      } else {
+        // 5xx / network error during restart — server is temporarily unreachable.
+        // Keep existing credentials; let the app stay mounted and retry later.
+        state.sessionStatus = 'unavailable'
+        state.unavailableRetryCount += 1
+      }
     })
     builder.addMatcher(isAnyOf(whoami.fulfilled), (state, action) => {
       const { payload } = action
@@ -166,6 +202,8 @@ export const authSlice = createSlice({
       }
       state.isLogged = true
       state.isLoadingUserData = false
+      state.sessionStatus = 'authenticated'
+      state.unavailableRetryCount = 0
     })
   }
 })

--- a/share/dashboard_react/src/services/apiHelper.js
+++ b/share/dashboard_react/src/services/apiHelper.js
@@ -114,12 +114,20 @@ const performRequest = async (method, apiUrl, params, authValue, baseUrl = '') =
   try {
     const response = await fetch(url, options);
 
-    if (response.status === 401 && baseUrl === '') {
+    // Only invalidate the session when the request actually carried an auth token.
+    // Public 401s (login form, autologin, unauthenticated endpoints) must not
+    // clear a valid concurrent session.
+    if (response.status === 401 && baseUrl === '' && headers.Authorization) {
+      // If a newer token was stored between request dispatch and response arrival,
+      // this 401 came from a stale request — don't evict the fresh token.
+      const tokenUsed = headers.Authorization.slice('Bearer '.length)
+      const currentToken = localStorage.getItem('user_token')
+      if (tokenUsed && currentToken && tokenUsed !== currentToken) {
+        return handleResponse(response)
+      }
       clearLocalStorageByPrefix('user_token');
       localStorage.removeItem('username');
-      if (window.location.pathname !== '/login') {
-        window.location.reload();
-      }
+      window.dispatchEvent(new CustomEvent('repman:auth401'));
     }
 
     return handleResponse(response);


### PR DESCRIPTION
## Summary

This PR continues the OpenSVC application-routing work on the `app-fqdn` branch with a focused set of backend fixes and dashboard improvements.

### Backend changes

- **Custom app route FQDNs in OpenSVC** (`cluster/prov_opensvc_app.go`)
  - Allow app host routes to use any FQDN instead of blocking provisioning on route/DNS publication errors.
  - Group host-mode routes by destination port so multiple domains can share the same backend without fragment collisions.
  - Normalize DNS add/drop script calls to use full FQDNs, matching the production script contract.

- **Hardened app health aggregation** (`cluster/app_chk.go`)
  - Fail an app when its local route checks are down.
  - Deduplicate local route checks by backend endpoint and aggregate app status from the set of unique local paths.
  - Report `AppWarning` when at least one local backend path still works; only escalate to `Failed` when all deduplicated local backends are down.
  - Keep per-route failures visible while avoiding false whole-app failures.

### Dashboard / UI changes

- **Auth recovery** (`share/dashboard_react/src/App.jsx`, `Login`, `PageContainer`, `authSlice`, `apiHelper`)
  - Harden token/session recovery paths so the dashboard re-authenticates more reliably after expiry or recovery.

- **App and route presentation** (`AppTable`, `AppGrid`, `RouteSummary`, `ClusterApp` routes/overview)
  - Align `AppTable` typography and column layout with the existing Proxies/DBServers tables.
  - Show explicit per-state counts (up/warn/down) in the route summary.
  - Improve dark-theme contrast for badges and soften failed/warning row backgrounds.
  - Reduce vertical spacing and heading/gateway font sizes in the ClusterApp Routes overview.

### Tests

- Added/updated tests for CNAME normalization, grouped host fragments, DNS add/drop script arguments, local-check dedupe keys, unsupported-route warnings, and refresh/fail-count transitions.
  - `cluster/app_error_test.go`
  - `cluster/prov_opensvc_app_dns_test.go`
  - `cluster/prov_opensvc_app_route_test.go`

### Scope

- 10 commits, ~2.1k insertions / ~620 deletions across Go backend and React dashboard.
- Builds on top of the previously merged #1548 (`app-fqdn`).
