### PR TITLE
fix(app): resolve template placeholders in app env variables on save

### DIFF
--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -1223,6 +1223,32 @@ func (cluster *Cluster) GetAppEncryptedVariableValue(app *App, key string) (stri
 	return cluster.Conf.GetEncryptedString(decrypted), nil
 }
 
+// ResolveEnvVariableValue resolves template placeholders in rawValue using the app's
+// substitution context. Returns the resolved value only when all placeholders are resolved;
+// returns rawValue unchanged if substitution data is unavailable or any placeholder is unresolvable.
+func (cluster *Cluster) ResolveEnvVariableValue(app *App, rawValue string) string {
+	if app == nil {
+		return rawValue
+	}
+	sub := app.AppClusterSubstitute
+	if sub == "" {
+		var err error
+		sub, err = cluster.GetAppsSubstitutionJSon(app)
+		if err != nil || sub == "" {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlWarn,
+				"App %s: substitution data unavailable for env variable resolution", app.Name)
+			return rawValue
+		}
+	}
+	resolved, err := cluster.ParseAppTemplate(rawValue, sub)
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlDbg,
+			"App %s: env variable has unresolvable placeholders, keeping raw value: %v", app.Name, err)
+		return rawValue
+	}
+	return resolved
+}
+
 func (cluster *Cluster) SetAppVariableValue(app *App, v config.VariableMapping) error {
 	if app == nil || app.AppConfig == nil || app.AppConfig.Deployment == nil {
 		return errors.New("app or app configuration is not initialized")
@@ -1230,6 +1256,8 @@ func (cluster *Cluster) SetAppVariableValue(app *App, v config.VariableMapping) 
 	newValue := v.Value
 	if v.Type == config.VariableTypeSecret {
 		newValue = cluster.Conf.GetEncryptedString(cluster.Conf.GetDecryptedPassword(v.Name, v.Value))
+	} else if v.Type == config.VariableTypeEnv {
+		newValue = cluster.ResolveEnvVariableValue(app, v.Value)
 	}
 
 	for i, variable := range app.AppConfig.Deployment.Variables {
@@ -1243,6 +1271,14 @@ func (cluster *Cluster) SetAppVariableValue(app *App, v config.VariableMapping) 
 	// If the variable does not exist, add it — preserve all fields from the input
 	newVar := v
 	newVar.Value = newValue
+	if v.Type == config.VariableTypeEnv && len(v.Conditional) > 0 {
+		resolvedCond := make(config.AVSlice, len(v.Conditional))
+		copy(resolvedCond, v.Conditional)
+		for i, c := range resolvedCond {
+			resolvedCond[i].Value = cluster.ResolveEnvVariableValue(app, c.Value)
+		}
+		newVar.Conditional = resolvedCond
+	}
 	app.AppConfig.Deployment.Variables = append(app.AppConfig.Deployment.Variables, newVar)
 	return nil
 }

--- a/cluster/cluster_app_variable_test.go
+++ b/cluster/cluster_app_variable_test.go
@@ -1,0 +1,214 @@
+package cluster
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+)
+
+// proxySub is a substitution JSON that provides one proxy host, enough to resolve
+// {{proxies.#.host}} to "192.168.1.10".
+const proxySub = `{"proxies":[{"host":"192.168.1.10"}]}`
+
+func newTestClusterForVarTest(t *testing.T) *Cluster {
+	t.Helper()
+	return &Cluster{
+		Name: "test-cluster",
+		Conf: &config.Config{},
+	}
+}
+
+func newTestAppWithSub(name, sub string) *App {
+	return &App{
+		Name:                 name,
+		Mutex:                &sync.Mutex{},
+		AppClusterSubstitute: sub,
+		AppConfig: &config.AppConfig{
+			Deployment: config.NewDeploymentConfig(),
+		},
+	}
+}
+
+// --- ResolveEnvVariableValue ---
+
+func TestResolveEnvVariableValue_FullyResolvable(t *testing.T) {
+	cl := newTestClusterForVarTest(t)
+	app := newTestAppWithSub("app1", proxySub)
+
+	got := cl.ResolveEnvVariableValue(app, "{{proxies.#.host}}")
+	if got != "192.168.1.10" {
+		t.Errorf("expected resolved host, got %q", got)
+	}
+}
+
+func TestResolveEnvVariableValue_UnresolvablePlaceholder_KeepsRaw(t *testing.T) {
+	cl := newTestClusterForVarTest(t)
+	app := newTestAppWithSub("app1", proxySub)
+
+	raw := "{{nonexistent.key}}"
+	got := cl.ResolveEnvVariableValue(app, raw)
+	if got != raw {
+		t.Errorf("expected raw value %q to be kept, got %q", raw, got)
+	}
+}
+
+func TestResolveEnvVariableValue_PartiallyResolvable_KeepsRaw(t *testing.T) {
+	cl := newTestClusterForVarTest(t)
+	app := newTestAppWithSub("app1", proxySub)
+
+	raw := "{{proxies.#.host}}-{{nonexistent.key}}"
+	got := cl.ResolveEnvVariableValue(app, raw)
+	if got != raw {
+		t.Errorf("expected raw value %q to be kept when partially unresolvable, got %q", raw, got)
+	}
+}
+
+func TestResolveEnvVariableValue_NoSubstitutionData_KeepsRaw(t *testing.T) {
+	cl := newTestClusterForVarTest(t)
+	// AppClusterSubstitute is empty; GetAppsSubstitutionJSon will fail on a minimal cluster
+	app := newTestAppWithSub("app1", "")
+	app.ClusterGroup = cl
+
+	raw := "{{proxies.#.host}}"
+	got := cl.ResolveEnvVariableValue(app, raw)
+	if got != raw {
+		t.Errorf("expected raw value %q to be kept when no sub data, got %q", raw, got)
+	}
+}
+
+func TestResolveEnvVariableValue_PlainString_Unchanged(t *testing.T) {
+	cl := newTestClusterForVarTest(t)
+	app := newTestAppWithSub("app1", proxySub)
+
+	got := cl.ResolveEnvVariableValue(app, "no-placeholders-here")
+	if got != "no-placeholders-here" {
+		t.Errorf("expected plain string unchanged, got %q", got)
+	}
+}
+
+// --- SetAppVariableValue ---
+
+func TestSetAppVariableValue_EnvAdd_ResolvesTemplate(t *testing.T) {
+	cl := newTestClusterForVarTest(t)
+	app := newTestAppWithSub("app1", proxySub)
+
+	v := config.VariableMapping{
+		Name:  "DB_HOST",
+		Value: "{{proxies.#.host}}",
+		Type:  config.VariableTypeEnv,
+	}
+	if err := cl.SetAppVariableValue(app, v); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := app.AppConfig.Deployment.Variables[0].Value
+	if got != "192.168.1.10" {
+		t.Errorf("expected resolved value, got %q", got)
+	}
+}
+
+func TestSetAppVariableValue_EnvAdd_UnresolvablePlaceholder_KeepsRaw(t *testing.T) {
+	cl := newTestClusterForVarTest(t)
+	app := newTestAppWithSub("app1", proxySub)
+
+	raw := "{{nonexistent.key}}"
+	v := config.VariableMapping{Name: "DB_HOST", Value: raw, Type: config.VariableTypeEnv}
+	if err := cl.SetAppVariableValue(app, v); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := app.AppConfig.Deployment.Variables[0].Value
+	if got != raw {
+		t.Errorf("expected raw value %q kept for unresolvable placeholder, got %q", raw, got)
+	}
+}
+
+func TestSetAppVariableValue_EnvAdd_ConditionalResolved(t *testing.T) {
+	cl := newTestClusterForVarTest(t)
+	app := newTestAppWithSub("app1", proxySub)
+
+	v := config.VariableMapping{
+		Name:  "DB_HOST",
+		Value: "{{proxies.#.host}}",
+		Type:  config.VariableTypeEnv,
+		Conditional: config.AVSlice{
+			{Agent: "agent1", Value: "{{proxies.#.host}}"},
+		},
+	}
+	if err := cl.SetAppVariableValue(app, v); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	variable := app.AppConfig.Deployment.Variables[0]
+	if variable.Value != "192.168.1.10" {
+		t.Errorf("expected resolved main value, got %q", variable.Value)
+	}
+	if len(variable.Conditional) != 1 {
+		t.Fatalf("expected one conditional, got %d", len(variable.Conditional))
+	}
+	if variable.Conditional[0].Value != "192.168.1.10" {
+		t.Errorf("expected resolved conditional value, got %q", variable.Conditional[0].Value)
+	}
+}
+
+func TestSetAppVariableValue_EnvAdd_ConditionalUnresolvable_KeepsRaw(t *testing.T) {
+	cl := newTestClusterForVarTest(t)
+	app := newTestAppWithSub("app1", proxySub)
+
+	raw := "{{bad.key}}"
+	v := config.VariableMapping{
+		Name:  "DB_HOST",
+		Value: "static",
+		Type:  config.VariableTypeEnv,
+		Conditional: config.AVSlice{
+			{Agent: "agent1", Value: raw},
+		},
+	}
+	if err := cl.SetAppVariableValue(app, v); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := app.AppConfig.Deployment.Variables[0].Conditional[0].Value
+	if got != raw {
+		t.Errorf("expected raw conditional value %q kept, got %q", raw, got)
+	}
+}
+
+func TestSetAppVariableValue_SecretAdd_NotResolved(t *testing.T) {
+	cl := newTestClusterForVarTest(t)
+	app := newTestAppWithSub("app1", proxySub)
+
+	raw := "{{proxies.#.host}}"
+	v := config.VariableMapping{Name: "MY_SECRET", Value: raw, Type: config.VariableTypeSecret}
+	if err := cl.SetAppVariableValue(app, v); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := app.AppConfig.Deployment.Variables[0].Value
+	// Secrets go through encryption only; the placeholder must NOT be template-expanded.
+	if got == "192.168.1.10" {
+		t.Errorf("secret value must not be template-resolved, but got resolved value %q", got)
+	}
+}
+
+func TestSetAppVariableValue_EnvAdd_DoesNotMutateInputConditional(t *testing.T) {
+	cl := newTestClusterForVarTest(t)
+	app := newTestAppWithSub("app1", proxySub)
+
+	origCond := config.AVSlice{{Agent: "a1", Value: "{{proxies.#.host}}"}}
+	v := config.VariableMapping{
+		Name:        "DB_HOST",
+		Value:       "{{proxies.#.host}}",
+		Type:        config.VariableTypeEnv,
+		Conditional: origCond,
+	}
+	if err := cl.SetAppVariableValue(app, v); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The caller's original slice must not be mutated.
+	if origCond[0].Value != "{{proxies.#.host}}" {
+		t.Errorf("input conditional slice was mutated: got %q", origCond[0].Value)
+	}
+}

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -1541,6 +1541,9 @@ func (repman *ReplicationManager) handlerMuxModifyDeploymentField(w http.Respons
 					node.Unlock()
 					row.Name = newValue
 				case "value":
+					if row.Type == config.VariableTypeEnv {
+						newValue = mycluster.ResolveEnvVariableValue(node, newValue)
+					}
 					if row.Value == newValue {
 						http.Error(w, "Variable value unchanged", http.StatusBadRequest)
 						return
@@ -1561,19 +1564,13 @@ func (repman *ReplicationManager) handlerMuxModifyDeploymentField(w http.Respons
 					row.Type = newValue
 				case "conditional":
 					old := row.Conditional
-					// addFunc := func(new config.AgentVariable) config.AgentVariable {
-					// 	// new.Value, _ = node.ClusterGroup.ParseAppTemplate(new.Value, node.AppClusterSubstitute)
-					// 	return new
-					// }
-					// updateFunc := func(old, new config.AgentVariable) config.AgentVariable {
-					// 	// new.Value, _ = node.ClusterGroup.ParseAppTemplate(new.Value, node.AppClusterSubstitute)
-					// 	return new
-					// }
-
 					if row.Type == config.VariableTypeSecret {
 						for i, v := range condValue {
-							// Decrypt the value if it's a secret
 							condValue[i].Value = mycluster.Conf.GetEncryptedString(mycluster.Conf.GetDecryptedPassword(row.Name+"@"+v.Agent, v.Value))
+						}
+					} else if row.Type == config.VariableTypeEnv {
+						for i, c := range condValue {
+							condValue[i].Value = mycluster.ResolveEnvVariableValue(node, c.Value)
 						}
 					}
 


### PR DESCRIPTION
Add ResolveEnvVariableValue helper that expands {{...}} placeholders in app deployment env variables when they are saved. Unresolvable or partial templates fall back to the raw value so existing behavior is preserved.

Apply the helper to:
- adding a new env variable
- editing an env variable value
- editing env variable conditional values

Secrets are intentionally left unchanged and still go through encryption.

Includes focused tests for full/partial resolution, missing substitution data, conditional values, and secret non-expansion.
