### PR TITLE
Fix arbitrator MySQL backend heartbeat and stats queries

### DIFF
--- a/arbitrator/arbitrator.go
+++ b/arbitrator/arbitrator.go
@@ -468,7 +468,11 @@ func handlerStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rows, err := db.Queryx("SELECT cluster, uid, status, date, hosts, failed FROM heartbeat ORDER BY cluster, uid")
+	statsQuery := "SELECT cluster, uid, status, date, hosts, failed FROM heartbeat ORDER BY cluster, uid"
+	if db.DriverName() == "mysql" {
+		statsQuery = "SELECT cluster, uid, status, date, hosts, failed FROM replication_manager_schema.heartbeat ORDER BY cluster, uid"
+	}
+	rows, err := db.Queryx(statsQuery)
 	if err != nil {
 		w.WriteHeader(500)
 		fmt.Fprint(w, "Query error")

--- a/utils/dbhelper/arbitration.go
+++ b/utils/dbhelper/arbitration.go
@@ -4,8 +4,42 @@
 
 package dbhelper
 
-import "github.com/jmoiron/sqlx"
-import log "github.com/sirupsen/logrus"
+import (
+	"github.com/jmoiron/sqlx"
+	log "github.com/sirupsen/logrus"
+)
+
+// heartbeatTable returns the schema-qualified heartbeat table name for the given driver.
+func heartbeatTable(db *sqlx.DB) string {
+	if db.DriverName() == "mysql" {
+		return "replication_manager_schema.heartbeat"
+	}
+	return "heartbeat"
+}
+
+// nowExpr returns the SQL current-timestamp expression for the given driver.
+func nowExpr(db *sqlx.DB) string {
+	if db.DriverName() == "mysql" {
+		return "NOW()"
+	}
+	return "DATETIME('now')"
+}
+
+// tenSecondsAgoExpr returns the SQL expression for ten seconds ago for the given driver.
+func tenSecondsAgoExpr(db *sqlx.DB) string {
+	if db.DriverName() == "mysql" {
+		return "DATE_SUB(NOW(), INTERVAL 10 SECOND)"
+	}
+	return "DATETIME('now', '-10 seconds')"
+}
+
+// upsertVerb returns the SQL upsert keyword for the given driver.
+func upsertVerb(db *sqlx.DB) string {
+	if db.DriverName() == "mysql" {
+		return "REPLACE"
+	}
+	return "INSERT OR REPLACE"
+}
 
 func SetHeartbeatTable(db *sqlx.DB) error {
 
@@ -52,30 +86,18 @@ func SetHeartbeatTable(db *sqlx.DB) error {
 
 func WriteHeartbeat(db *sqlx.DB, uuid string, secret string, cluster string, master string, uid int, hosts int, failed int) error {
 
-	var stmt string
-	if db.DriverName() == "mysql" {
-		stmt = "REPLACE INTO replication_manager_schema.heartbeat (secret,uuid,uid,master,date,cluster,hosts,failed) VALUES(?,?,?,?,NOW(),?,?,?)"
-	} else {
-		stmt = "INSERT OR REPLACE INTO heartbeat (secret,uuid,uid,master,date,cluster,hosts,failed) VALUES(?,?,?,?,DATETIME('now'),?,?,?)"
-	}
+	tbl := heartbeatTable(db)
+	stmt := upsertVerb(db) + " INTO " + tbl + " (secret,uuid,uid,master,date,cluster,hosts,failed) VALUES(?,?,?,?," + nowExpr(db) + ",?,?,?)"
 	_, err := db.Exec(stmt, secret, uuid, uid, master, cluster, hosts, failed)
 	if err != nil {
 		return err
 	}
 
 	var count int
-	if db.DriverName() == "mysql" {
-		stmt = "SELECT count(distinct master) FROM replication_manager_schema.heartbeat WHERE cluster=? AND secret=? AND date > DATE_SUB(NOW(), INTERVAL 10 SECOND)"
-	} else {
-		stmt = "SELECT count(distinct master) FROM heartbeat WHERE cluster=? AND secret=? AND date > DATETIME('now', '-10 seconds')"
-	}
+	stmt = "SELECT count(distinct master) FROM " + tbl + " WHERE cluster=? AND secret=? AND date > " + tenSecondsAgoExpr(db)
 	err = db.QueryRowx(stmt, cluster, secret).Scan(&count)
 	if err == nil && count == 1 {
-		if db.DriverName() == "mysql" {
-			stmt = "UPDATE replication_manager_schema.heartbeat set status='U' WHERE status='E' AND cluster=? AND secret=?"
-		} else {
-			stmt = "UPDATE heartbeat set status='U' WHERE status='E' AND cluster=? AND secret=?"
-		}
+		stmt = "UPDATE " + tbl + " set status='U' WHERE status='E' AND cluster=? AND secret=?"
 		_, err = db.Exec(stmt, cluster, secret)
 		if err != nil {
 			return err
@@ -89,12 +111,7 @@ func WriteHeartbeat(db *sqlx.DB, uuid string, secret string, cluster string, mas
 
 func ForgetArbitration(db *sqlx.DB, secret string) error {
 
-	var stmt string
-	if db.DriverName() == "mysql" {
-		stmt = "DELETE FROM replication_manager_schema.heartbeat WHERE secret=?"
-	} else {
-		stmt = "DELETE FROM heartbeat WHERE secret=?"
-	}
+	stmt := "DELETE FROM " + heartbeatTable(db) + " WHERE secret=?"
 	_, err := db.Exec(stmt, secret)
 	if err != nil {
 		return err
@@ -111,34 +128,21 @@ func RequestArbitration(db *sqlx.DB, uuid string, secret string, cluster string,
 		log.Error("(dbhelper.RequestArbitration) Error opening transaction: ", err)
 		return false
 	}
+	tbl := heartbeatTable(db)
 	// count the number of replication manager Elected that is not me for this cluster
-	var stmt string
-	if db.DriverName() == "mysql" {
-		stmt = "SELECT count(*) FROM replication_manager_schema.heartbeat WHERE cluster=? AND secret=? AND status='E' and uid<>?"
-	} else {
-		stmt = "SELECT count(*) FROM heartbeat WHERE cluster=? AND secret=? AND status='E' and uid<>?"
-	}
+	stmt := "SELECT count(*) FROM " + tbl + " WHERE cluster=? AND secret=? AND status='E' and uid<>?"
 	err = tx.QueryRowx(stmt, cluster, secret, uid).Scan(&count)
 	// If none i can consider myself the elected replication-manager
 	if err == nil && count == 0 {
 		log.Info("No elected managers found for this cluster")
 		// A non elected replication-manager may see more nodes than me than in this case lose the election
-		if db.DriverName() == "mysql" {
-			stmt = "SELECT count(*) FROM replication_manager_schema.heartbeat WHERE cluster=? AND secret=? AND status = 'U' and uid <> ?  and failed < ?"
-		} else {
-			stmt = "SELECT count(*) FROM heartbeat WHERE cluster=? AND secret=? AND status = 'U' and uid <> ?  and failed < ?"
-		}
+		stmt = "SELECT count(*) FROM " + tbl + " WHERE cluster=? AND secret=? AND status = 'U' and uid <> ?  and failed < ?"
 		err = tx.QueryRowx(stmt, cluster, secret, uid, failed).Scan(&count)
 		if err == nil && count == 0 {
 			log.Info("Node won election")
 			// stmt = "INSERT INTO heartbeat(secret,uuid,uid,master,date,arbitration_date,cluster, hosts, failed ) VALUES('" + secret + "','" + uuid + "'," + uid + ",'" + master + "', DATETIME('now'), DATETIME('now'),'" + cluster + "'," + hosts + "," + failed + ") ON DUPLICATE KEY UPDATE arbitration_date=DATETIME('now'),date=DATETIME('now'),master='" + master + "',status='E', uuid='" + uuid + "',hosts=" + hosts + ",failed=" + failed
-			if db.DriverName() == "mysql" {
-				stmt = `REPLACE INTO replication_manager_schema.heartbeat (secret,uuid,uid,master,date,arbitration_date,cluster,hosts,failed,status)
-      VALUES(?,?,?,?,NOW(),NOW(),?,?,?,'E')`
-			} else {
-				stmt = `INSERT OR REPLACE INTO heartbeat (secret,uuid,uid,master,date,arbitration_date,cluster,hosts,failed,status)
-      VALUES(?,?,?,?,DATETIME('now'),DATETIME('now'),?,?,?,'E')`
-			}
+			now := nowExpr(db)
+			stmt = upsertVerb(db) + " INTO " + tbl + " (secret,uuid,uid,master,date,arbitration_date,cluster,hosts,failed,status) VALUES(?,?,?,?," + now + "," + now + ",?,?,?,'E')"
 			_, err = tx.Exec(stmt, secret, uuid, uid, master, cluster, hosts, failed)
 			if err != nil {
 				log.Error("(dbhelper.RequestArbitration) Error executing transaction: ", err)
@@ -163,12 +167,7 @@ func RequestArbitration(db *sqlx.DB, uuid string, secret string, cluster string,
 func GetArbitrationMaster(db *sqlx.DB, secret string, cluster string) string {
 	var master string
 	// count the number of replication manager Elected that is not me for this cluster
-	var stmt string
-	if db.DriverName() == "mysql" {
-		stmt = "SELECT master FROM replication_manager_schema.heartbeat WHERE cluster=? AND secret=?  AND status IN ('E')"
-	} else {
-		stmt = "SELECT master FROM heartbeat WHERE cluster=? AND secret=?  AND status IN ('E')"
-	}
+	stmt := "SELECT master FROM " + heartbeatTable(db) + " WHERE cluster=? AND secret=?  AND status IN ('E')"
 	err := db.QueryRowx(stmt, cluster, secret).Scan(&master)
 	if err == nil {
 		return master
@@ -177,6 +176,9 @@ func GetArbitrationMaster(db *sqlx.DB, secret string, cluster string) string {
 }
 
 // SetStatusActiveHeartbeat arbitrator can set or remove election flag "E"
+// NOTE: this function omits cluster from the INSERT, but the MySQL table's PRIMARY KEY
+// is (secret, cluster, uid), so it cannot be made MySQL-safe without adding cluster to
+// the signature. It is currently unused by the active arbitrator flow.
 func SetStatusActiveHeartbeat(db *sqlx.DB, uuid string, status string, master string, secret string, uid int) error {
 
 	//stmt := "INSERT INTO heartbeat(secret,uid,master,date ) VALUES('" + secret + "','" + uid + "', DATETIME('now')) ON DUPLICATE KEY UPDATE uuid='" + uuid + "', date=DATETIME('now'),master='" + master + "', status='" + status + "' "

--- a/utils/dbhelper/arbitration.go
+++ b/utils/dbhelper/arbitration.go
@@ -52,18 +52,30 @@ func SetHeartbeatTable(db *sqlx.DB) error {
 
 func WriteHeartbeat(db *sqlx.DB, uuid string, secret string, cluster string, master string, uid int, hosts int, failed int) error {
 
-	// stmt := "INSERT INTO heartbeat(secret,uuid,uid,master,date,cluster,hosts,failed) VALUES('" + secret + "','" + uuid + "'," + uid + ",'" + master + "', DATETIME('now'),'" + cluster + "'," + hosts + "," + failed
-	stmt := "INSERT OR REPLACE INTO heartbeat (secret,uuid,uid,master,date,cluster,hosts,failed) VALUES(?,?,?,?,DATETIME('now'),?,?,?)"
+	var stmt string
+	if db.DriverName() == "mysql" {
+		stmt = "REPLACE INTO replication_manager_schema.heartbeat (secret,uuid,uid,master,date,cluster,hosts,failed) VALUES(?,?,?,?,NOW(),?,?,?)"
+	} else {
+		stmt = "INSERT OR REPLACE INTO heartbeat (secret,uuid,uid,master,date,cluster,hosts,failed) VALUES(?,?,?,?,DATETIME('now'),?,?,?)"
+	}
 	_, err := db.Exec(stmt, secret, uuid, uid, master, cluster, hosts, failed)
 	if err != nil {
 		return err
 	}
 
 	var count int
-	stmt = "SELECT count(distinct master) FROM heartbeat WHERE cluster=? AND secret=? AND date > DATETIME('now', '-10 seconds')"
+	if db.DriverName() == "mysql" {
+		stmt = "SELECT count(distinct master) FROM replication_manager_schema.heartbeat WHERE cluster=? AND secret=? AND date > DATE_SUB(NOW(), INTERVAL 10 SECOND)"
+	} else {
+		stmt = "SELECT count(distinct master) FROM heartbeat WHERE cluster=? AND secret=? AND date > DATETIME('now', '-10 seconds')"
+	}
 	err = db.QueryRowx(stmt, cluster, secret).Scan(&count)
 	if err == nil && count == 1 {
-		stmt = "UPDATE heartbeat set status='U' WHERE status='E' AND cluster=? AND secret=?"
+		if db.DriverName() == "mysql" {
+			stmt = "UPDATE replication_manager_schema.heartbeat set status='U' WHERE status='E' AND cluster=? AND secret=?"
+		} else {
+			stmt = "UPDATE heartbeat set status='U' WHERE status='E' AND cluster=? AND secret=?"
+		}
 		_, err = db.Exec(stmt, cluster, secret)
 		if err != nil {
 			return err
@@ -77,7 +89,12 @@ func WriteHeartbeat(db *sqlx.DB, uuid string, secret string, cluster string, mas
 
 func ForgetArbitration(db *sqlx.DB, secret string) error {
 
-	stmt := "DELETE FROM heartbeat WHERE secret=?"
+	var stmt string
+	if db.DriverName() == "mysql" {
+		stmt = "DELETE FROM replication_manager_schema.heartbeat WHERE secret=?"
+	} else {
+		stmt = "DELETE FROM heartbeat WHERE secret=?"
+	}
 	_, err := db.Exec(stmt, secret)
 	if err != nil {
 		return err
@@ -95,20 +112,34 @@ func RequestArbitration(db *sqlx.DB, uuid string, secret string, cluster string,
 		return false
 	}
 	// count the number of replication manager Elected that is not me for this cluster
-	stmt := "SELECT count(*) FROM heartbeat WHERE cluster=? AND secret=? AND status='E' and uid<>?"
+	var stmt string
+	if db.DriverName() == "mysql" {
+		stmt = "SELECT count(*) FROM replication_manager_schema.heartbeat WHERE cluster=? AND secret=? AND status='E' and uid<>?"
+	} else {
+		stmt = "SELECT count(*) FROM heartbeat WHERE cluster=? AND secret=? AND status='E' and uid<>?"
+	}
 	err = tx.QueryRowx(stmt, cluster, secret, uid).Scan(&count)
 	// If none i can consider myself the elected replication-manager
 	if err == nil && count == 0 {
 		log.Info("No elected managers found for this cluster")
 		// A non elected replication-manager may see more nodes than me than in this case lose the election
-		stmt = "SELECT count(*) FROM heartbeat WHERE cluster=? AND secret=? AND status = 'U' and uid <> ?  and failed < ?"
+		if db.DriverName() == "mysql" {
+			stmt = "SELECT count(*) FROM replication_manager_schema.heartbeat WHERE cluster=? AND secret=? AND status = 'U' and uid <> ?  and failed < ?"
+		} else {
+			stmt = "SELECT count(*) FROM heartbeat WHERE cluster=? AND secret=? AND status = 'U' and uid <> ?  and failed < ?"
+		}
 		err = tx.QueryRowx(stmt, cluster, secret, uid, failed).Scan(&count)
 		if err == nil && count == 0 {
 			log.Info("Node won election")
 			// stmt = "INSERT INTO heartbeat(secret,uuid,uid,master,date,arbitration_date,cluster, hosts, failed ) VALUES('" + secret + "','" + uuid + "'," + uid + ",'" + master + "', DATETIME('now'), DATETIME('now'),'" + cluster + "'," + hosts + "," + failed + ") ON DUPLICATE KEY UPDATE arbitration_date=DATETIME('now'),date=DATETIME('now'),master='" + master + "',status='E', uuid='" + uuid + "',hosts=" + hosts + ",failed=" + failed
-			stmt = `INSERT OR REPLACE INTO heartbeat (secret,uuid,uid,master,date,arbitration_date,cluster,hosts,failed,status)
+			if db.DriverName() == "mysql" {
+				stmt = `REPLACE INTO replication_manager_schema.heartbeat (secret,uuid,uid,master,date,arbitration_date,cluster,hosts,failed,status)
+      VALUES(?,?,?,?,NOW(),NOW(),?,?,?,'E')`
+			} else {
+				stmt = `INSERT OR REPLACE INTO heartbeat (secret,uuid,uid,master,date,arbitration_date,cluster,hosts,failed,status)
       VALUES(?,?,?,?,DATETIME('now'),DATETIME('now'),?,?,?,'E')`
-			_, err = tx.Exec(stmt, secret, uuid, uid, master, cluster, hosts, failed, secret, cluster, uid)
+			}
+			_, err = tx.Exec(stmt, secret, uuid, uid, master, cluster, hosts, failed)
 			if err != nil {
 				log.Error("(dbhelper.RequestArbitration) Error executing transaction: ", err)
 				tx.Rollback()
@@ -132,7 +163,12 @@ func RequestArbitration(db *sqlx.DB, uuid string, secret string, cluster string,
 func GetArbitrationMaster(db *sqlx.DB, secret string, cluster string) string {
 	var master string
 	// count the number of replication manager Elected that is not me for this cluster
-	stmt := "SELECT master FROM heartbeat WHERE cluster=? AND secret=?  AND status IN ('E')"
+	var stmt string
+	if db.DriverName() == "mysql" {
+		stmt = "SELECT master FROM replication_manager_schema.heartbeat WHERE cluster=? AND secret=?  AND status IN ('E')"
+	} else {
+		stmt = "SELECT master FROM heartbeat WHERE cluster=? AND secret=?  AND status IN ('E')"
+	}
 	err := db.QueryRowx(stmt, cluster, secret).Scan(&master)
 	if err == nil {
 		return master

--- a/utils/dbhelper/arbitration_test.go
+++ b/utils/dbhelper/arbitration_test.go
@@ -1,0 +1,198 @@
+package dbhelper
+
+import (
+	"regexp"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	_ "modernc.org/sqlite"
+)
+
+// mockDB returns a *sqlx.DB whose DriverName() is the supplied string, backed by sqlmock.
+func mockDB(t *testing.T, driver string) (*sqlx.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	raw, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { raw.Close() })
+	return sqlx.NewDb(raw, driver), mock
+}
+
+// newSQLiteArbitrationDB opens an in-memory SQLite DB and creates the heartbeat table.
+func newSQLiteArbitrationDB(t *testing.T) *sqlx.DB {
+	t.Helper()
+	db, err := sqlx.Connect("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sqlite connect: %v", err)
+	}
+	// Mirror the production arbitrator connection limits (arbitrator.go ~212-215).
+	// SQLite in-memory databases are per-connection; a second connection sees an empty DB.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	t.Cleanup(func() { db.Close() })
+	if err := SetHeartbeatTable(db); err != nil {
+		t.Fatalf("SetHeartbeatTable: %v", err)
+	}
+	return db
+}
+
+// ---- dialect helper unit tests ----
+
+func TestHeartbeatTable(t *testing.T) {
+	mysqlDB, _ := mockDB(t, "mysql")
+	sqliteDB, _ := mockDB(t, "sqlite")
+	if got := heartbeatTable(mysqlDB); got != "replication_manager_schema.heartbeat" {
+		t.Errorf("mysql: got %q, want replication_manager_schema.heartbeat", got)
+	}
+	if got := heartbeatTable(sqliteDB); got != "heartbeat" {
+		t.Errorf("sqlite: got %q, want heartbeat", got)
+	}
+}
+
+func TestNowExpr(t *testing.T) {
+	mysqlDB, _ := mockDB(t, "mysql")
+	sqliteDB, _ := mockDB(t, "sqlite")
+	if got := nowExpr(mysqlDB); got != "NOW()" {
+		t.Errorf("mysql: got %q, want NOW()", got)
+	}
+	if got := nowExpr(sqliteDB); got != "DATETIME('now')" {
+		t.Errorf("sqlite: got %q, want DATETIME('now')", got)
+	}
+}
+
+func TestTenSecondsAgoExpr(t *testing.T) {
+	mysqlDB, _ := mockDB(t, "mysql")
+	sqliteDB, _ := mockDB(t, "sqlite")
+	if got := tenSecondsAgoExpr(mysqlDB); got != "DATE_SUB(NOW(), INTERVAL 10 SECOND)" {
+		t.Errorf("mysql: got %q", got)
+	}
+	if got := tenSecondsAgoExpr(sqliteDB); got != "DATETIME('now', '-10 seconds')" {
+		t.Errorf("sqlite: got %q", got)
+	}
+}
+
+func TestUpsertVerb(t *testing.T) {
+	mysqlDB, _ := mockDB(t, "mysql")
+	sqliteDB, _ := mockDB(t, "sqlite")
+	if got := upsertVerb(mysqlDB); got != "REPLACE" {
+		t.Errorf("mysql: got %q, want REPLACE", got)
+	}
+	if got := upsertVerb(sqliteDB); got != "INSERT OR REPLACE" {
+		t.Errorf("sqlite: got %q, want INSERT OR REPLACE", got)
+	}
+}
+
+// ---- SQLite in-memory integration tests ----
+
+func TestWriteHeartbeat_SQLite(t *testing.T) {
+	db := newSQLiteArbitrationDB(t)
+	if err := WriteHeartbeat(db, "uuid1", "secret1", "cluster1", "master1", 1, 2, 0); err != nil {
+		t.Fatalf("WriteHeartbeat: %v", err)
+	}
+}
+
+func TestRequestArbitration_Winner_SQLite(t *testing.T) {
+	db := newSQLiteArbitrationDB(t)
+	// Empty table: no elected managers, no competing unelected managers → wins.
+	if !RequestArbitration(db, "uuid1", "secret1", "cluster1", "master1", 1, 2, 0) {
+		t.Fatal("expected RequestArbitration to return true on empty table")
+	}
+}
+
+func TestGetArbitrationMaster_SQLite(t *testing.T) {
+	db := newSQLiteArbitrationDB(t)
+	RequestArbitration(db, "uuid1", "secret1", "cluster1", "master1", 1, 2, 0)
+	got := GetArbitrationMaster(db, "secret1", "cluster1")
+	if got != "master1" {
+		t.Errorf("GetArbitrationMaster: got %q, want master1", got)
+	}
+}
+
+func TestForgetArbitration_SQLite(t *testing.T) {
+	db := newSQLiteArbitrationDB(t)
+	RequestArbitration(db, "uuid1", "secret1", "cluster1", "master1", 1, 2, 0)
+	if err := ForgetArbitration(db, "secret1"); err != nil {
+		t.Fatalf("ForgetArbitration: %v", err)
+	}
+	if got := GetArbitrationMaster(db, "secret1", "cluster1"); got != "" {
+		t.Errorf("expected empty master after ForgetArbitration, got %q", got)
+	}
+}
+
+// ---- MySQL SQL dialect mock tests ----
+
+func TestForgetArbitration_MySQL_SQL(t *testing.T) {
+	db, mock := mockDB(t, "mysql")
+	mock.ExpectExec(regexp.QuoteMeta(
+		"DELETE FROM replication_manager_schema.heartbeat WHERE secret=?",
+	)).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := ForgetArbitration(db, "secret1"); err != nil {
+		t.Fatalf("ForgetArbitration: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestGetArbitrationMaster_MySQL_SQL(t *testing.T) {
+	db, mock := mockDB(t, "mysql")
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"SELECT master FROM replication_manager_schema.heartbeat WHERE cluster=? AND secret=?  AND status IN ('E')",
+	)).WillReturnRows(sqlmock.NewRows([]string{"master"}).AddRow("master1"))
+
+	if got := GetArbitrationMaster(db, "secret1", "cluster1"); got != "master1" {
+		t.Errorf("got %q, want master1", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestRequestArbitration_Winner_MySQL_SQL(t *testing.T) {
+	db, mock := mockDB(t, "mysql")
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"SELECT count(*) FROM replication_manager_schema.heartbeat WHERE cluster=? AND secret=? AND status='E' and uid<>?",
+	)).WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"SELECT count(*) FROM replication_manager_schema.heartbeat WHERE cluster=? AND secret=? AND status = 'U' and uid <> ?  and failed < ?",
+	)).WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectExec(regexp.QuoteMeta(
+		"REPLACE INTO replication_manager_schema.heartbeat (secret,uuid,uid,master,date,arbitration_date,cluster,hosts,failed,status) VALUES(?,?,?,?,NOW(),NOW(),?,?,?,'E')",
+	)).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	if !RequestArbitration(db, "uuid1", "secret1", "cluster1", "master1", 1, 2, 0) {
+		t.Fatal("expected RequestArbitration to return true")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestWriteHeartbeat_MySQL_SQL(t *testing.T) {
+	db, mock := mockDB(t, "mysql")
+
+	mock.ExpectExec(regexp.QuoteMeta(
+		"REPLACE INTO replication_manager_schema.heartbeat (secret,uuid,uid,master,date,cluster,hosts,failed) VALUES(?,?,?,?,NOW(),?,?,?)",
+	)).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"SELECT count(distinct master) FROM replication_manager_schema.heartbeat WHERE cluster=? AND secret=? AND date > DATE_SUB(NOW(), INTERVAL 10 SECOND)",
+	)).WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	mock.ExpectExec(regexp.QuoteMeta(
+		"UPDATE replication_manager_schema.heartbeat set status='U' WHERE status='E' AND cluster=? AND secret=?",
+	)).WillReturnResult(sqlmock.NewResult(0, 0))
+
+	if err := WriteHeartbeat(db, "uuid1", "secret1", "cluster1", "master1", 1, 2, 0); err != nil {
+		t.Fatalf("WriteHeartbeat: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}


### PR DESCRIPTION
This PR fixes the arbitrator code paths that currently emit SQLite-only SQL or query an unqualified heartbeat table, causing failures when the arbitrator backend is MySQL/MariaDB.

Changes:
- utils/dbhelper/arbitration.go
  - WriteHeartbeat(): use MySQL-compatible REPLACE / NOW() / DATE_SUB(...) and qualify the table as replication_manager_schema.heartbeat.
  - RequestArbitration(): same dialect fix for the winner write path, and correct the argument list passed to Exec.
  - GetArbitrationMaster(), ForgetArbitration(): qualify the heartbeat table for MySQL.
  - SQLite code paths remain unchanged.

- arbitrator/arbitrator.go
  - handlerStats(): use replication_manager_schema.heartbeat for MySQL while keeping the SQLite query unchanged.

The arbitrator MySQL connection is opened without a default database, and SetHeartbeatTable() creates the table under replication_manager_schema, so explicit schema qualification is required for MySQL.

Backward compatibility is preserved: SQLite behavior is unchanged.