### PR TITLE
fix(dbhelper): binlog heartbeat DDL so replicas create the table

### DIFF
--- a/utils/dbhelper/arbitration.go
+++ b/utils/dbhelper/arbitration.go
@@ -44,14 +44,8 @@ func upsertVerb(db *sqlx.DB) string {
 func SetHeartbeatTable(db *sqlx.DB) error {
 
 	if db.DriverName() == "mysql" {
-		stmt := "SET sql_log_bin=0"
+		stmt := "CREATE DATABASE IF NOT EXISTS replication_manager_schema"
 		_, err := db.Exec(stmt)
-		if err != nil {
-			return err
-		}
-
-		stmt = "CREATE DATABASE IF NOT EXISTS replication_manager_schema"
-		_, err = db.Exec(stmt)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Remove SET sql_log_bin=0 from SetHeartbeatTable's MySQL branch. The current heartbeat write path executes REPLACE/DELETE against replication_manager_schema.heartbeat on the arbitrator's MySQL backend, but the schema/table creation was hidden from replication because sql_log_bin was disabled for that session. As a result, slaves applying the row events failed with 'Table 'replication_manager_schema.heartbeat' doesn't exist'.

Allowing the CREATE DATABASE and CREATE TABLE to replicate keeps schema and data creation consistent across the backend topology. SQLite behavior is unchanged.