### PR TITLE
fix(arbitration): align active/standby election and split-brain protection with docs

### DIFF
--- a/arbitrator/arbitrator.go
+++ b/arbitrator/arbitrator.go
@@ -170,6 +170,12 @@ var rs = routes{
 		"/forget/",
 		handlerForget,
 	},
+	route{
+		"WinnerMaster",
+		"GET",
+		"/winner-master",
+		handlerWinnerMaster,
+	},
 }
 
 type response struct {
@@ -347,6 +353,53 @@ func handlerArbitrator(w http.ResponseWriter, r *http.Request) {
 	}
 
 }
+// handlerWinnerMaster is a read-only lookup endpoint used by losing repman instances
+// to perform loser-side split-brain master protection for non-authority clusters.
+//
+// Query params:
+//   secret           - arbitration secret
+//   authority_cluster - cluster key used for the repman-wide election
+//   cluster          - target cluster whose winner master is requested
+//
+// Response: {"winner_uuid":"...","master":"..."}
+// Returns 404 JSON if no elected row exists for the authority cluster.
+func handlerWinnerMaster(w http.ResponseWriter, r *http.Request) {
+	secret := r.URL.Query().Get("secret")
+	authCluster := r.URL.Query().Get("authority_cluster")
+	targetCluster := r.URL.Query().Get("cluster")
+
+	if secret == "" || authCluster == "" || targetCluster == "" {
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "secret, authority_cluster and cluster are required"})
+		return
+	}
+
+	db, err := getArbitratorDB()
+	if err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
+	winnerUUID := dbhelper.GetArbitrationWinnerUUID(db, secret, authCluster)
+	if winnerUUID == "" {
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "no elected winner for authority cluster"})
+		return
+	}
+
+	master := dbhelper.GetHeartbeatMasterForUUID(db, secret, targetCluster, winnerUUID)
+
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+	type winnerMasterResponse struct {
+		WinnerUUID string `json:"winner_uuid"`
+		Master     string `json:"master"`
+	}
+	json.NewEncoder(w).Encode(winnerMasterResponse{WinnerUUID: winnerUUID, Master: master})
+}
+
 func handlerHeartbeat(w http.ResponseWriter, r *http.Request) {
 	var h server.Heartbeat
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1048576))

--- a/arbitrator/arbitrator.go
+++ b/arbitrator/arbitrator.go
@@ -356,22 +356,24 @@ func handlerArbitrator(w http.ResponseWriter, r *http.Request) {
 // handlerWinnerMaster is a read-only lookup endpoint used by losing repman instances
 // to perform loser-side split-brain master protection for non-authority clusters.
 //
-// Query params:
-//   secret           - arbitration secret
-//   authority_cluster - cluster key used for the repman-wide election
-//   cluster          - target cluster whose winner master is requested
+// The arbitration secret is read from the X-Arbitration-Secret header (not a query
+// param) to avoid leaking it into server access logs.
 //
-// Response: {"winner_uuid":"...","master":"..."}
+// Query params:
+//   authority_cluster - cluster key used for the repman-wide election
+//   cluster           - target cluster whose winner master is requested
+//
+// Response: server.WinnerMasterResponse JSON {"winner_uuid":"...","master":"..."}
 // Returns 404 JSON if no elected row exists for the authority cluster.
 func handlerWinnerMaster(w http.ResponseWriter, r *http.Request) {
-	secret := r.URL.Query().Get("secret")
+	secret := r.Header.Get("X-Arbitration-Secret")
 	authCluster := r.URL.Query().Get("authority_cluster")
 	targetCluster := r.URL.Query().Get("cluster")
 
 	if secret == "" || authCluster == "" || targetCluster == "" {
 		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "secret, authority_cluster and cluster are required"})
+		json.NewEncoder(w).Encode(map[string]string{"error": "X-Arbitration-Secret header and authority_cluster, cluster query params are required"})
 		return
 	}
 
@@ -393,11 +395,7 @@ func handlerWinnerMaster(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusOK)
-	type winnerMasterResponse struct {
-		WinnerUUID string `json:"winner_uuid"`
-		Master     string `json:"master"`
-	}
-	json.NewEncoder(w).Encode(winnerMasterResponse{WinnerUUID: winnerUUID, Master: master})
+	json.NewEncoder(w).Encode(server.WinnerMasterResponse{WinnerUUID: winnerUUID, Master: master})
 }
 
 func handlerHeartbeat(w http.ResponseWriter, r *http.Request) {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -95,7 +95,6 @@ type Cluster struct {
 	FailoverTs                    int64                  `json:"failoverLastTime" groups:"web"`
 	Status                        string                 `json:"activePassiveStatus" groups:"web"`
 	IsSplitBrain                  bool                   `json:"isSplitBrain" groups:"web"`
-	IsSplitBrainBck               bool                   `json:"-"`
 	// RepmanArbitrationRequired gates cluster-side external arbitrator contact.
 	// Set from the repman-wide ArbitrationRequired flag; must not be written from
 	// cluster topology logic so it stays decoupled from IsSplitBrain.

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -96,6 +96,23 @@ type Cluster struct {
 	Status                        string                 `json:"activePassiveStatus" groups:"web"`
 	IsSplitBrain                  bool                   `json:"isSplitBrain" groups:"web"`
 	IsSplitBrainBck               bool                   `json:"-"`
+	// RepmanArbitrationRequired gates cluster-side external arbitrator contact.
+	// Set from the repman-wide ArbitrationRequired flag; must not be written from
+	// cluster topology logic so it stays decoupled from IsSplitBrain.
+	RepmanArbitrationRequired    bool `json:"-"`
+	RepmanArbitrationRequiredBck bool `json:"-"`
+	// IsAuthorityCluster is true for the single cluster that is permitted to
+	// contact the arbitrator and update repman-wide role.  Set once at startup
+	// from ImmutableClusterList[0]; never changes at runtime.
+	IsAuthorityCluster bool `json:"-"`
+	// RoleEstablished is propagated from ReplicationManager.RoleEstablished and
+	// is true after the authority cluster has completed its first arbitrator
+	// election (bootstrap).  Once true, automatic split-brain recovery is gated
+	// by IsEligibleForArbitration().
+	RoleEstablished bool `json:"-"`
+	// onArbitrationResult is called after an arbitrator election completes so the
+	// owning ReplicationManager can update its repman-wide role.
+	onArbitrationResult func(string)
 	IsFailedArbitrator            bool                   `json:"isFailedArbitrator" groups:"web"`
 	IsLostMajority                bool                   `json:"isLostMajority" groups:"web"`
 	IsDown                        bool                   `json:"isDown" groups:"web"`

--- a/cluster/cluster_has.go
+++ b/cluster/cluster_has.go
@@ -452,6 +452,12 @@ func (cluster *Cluster) IsActive() bool {
 	}
 }
 
+// SetArbitrationResultCallback registers a function called after each external
+// arbitrator election so the owning ReplicationManager can update its repman-wide role.
+func (cl *Cluster) SetArbitrationResultCallback(fn func(string)) {
+	cl.onArbitrationResult = fn
+}
+
 func (cluster *Cluster) IsVerbose() bool {
 	if cluster.Conf.Verbose {
 		return true

--- a/cluster/cluster_split.go
+++ b/cluster/cluster_split.go
@@ -114,17 +114,20 @@ func (cl *Cluster) ReconcileLostArbitrationMaster(authorityCluster string) {
 	}
 
 	timeout := time.Duration(time.Duration(cl.Conf.MonitoringTicker*1000-int64(cl.Conf.ArbitrationReadTimout)) * time.Millisecond)
+	if timeout <= 0 {
+		timeout = 2 * time.Second
+	}
 
 	// Build the read-only lookup URL.  We append query params to the arbitratorURL
 	// base so the Cloud18 uri parameter (if any) is preserved alongside our params.
+	// The secret is sent in X-Arbitration-Secret to avoid exposure in access logs.
 	base := cl.arbitratorURL("/winner-master")
 	sep := "&"
 	if !strings.Contains(base, "?") {
 		sep = "?"
 	}
 	reqURL := base + sep +
-		"secret=" + url.QueryEscape(cl.Conf.ArbitrationSasSecret) +
-		"&authority_cluster=" + url.QueryEscape(authorityCluster) +
+		"authority_cluster=" + url.QueryEscape(authorityCluster) +
 		"&cluster=" + url.QueryEscape(cl.GetName())
 
 	req, err := http.NewRequest("GET", reqURL, nil)
@@ -133,6 +136,7 @@ func (cl *Cluster) ReconcileLostArbitrationMaster(authorityCluster string) {
 			"LoserProtection: could not build arbitrator request for cluster %s: %s", cl.GetName(), err)
 		return
 	}
+	req.Header.Set("X-Arbitration-Secret", cl.Conf.ArbitrationSasSecret)
 
 	client := &http.Client{Timeout: timeout}
 	resp, err := client.Do(req)
@@ -150,6 +154,8 @@ func (cl *Cluster) ReconcileLostArbitrationMaster(authorityCluster string) {
 
 	body, _ := io.ReadAll(resp.Body)
 
+	// winnerMasterResponse mirrors server.WinnerMasterResponse; cluster cannot
+	// import server (circular dependency), so the type is redeclared locally.
 	type winnerMasterResponse struct {
 		WinnerUUID string `json:"winner_uuid"`
 		Master     string `json:"master"`
@@ -165,6 +171,10 @@ func (cl *Cluster) ReconcileLostArbitrationMaster(authorityCluster string) {
 		return
 	}
 	if r.Master != localMaster {
+		if cl.GetServerFromURL(r.Master) == nil {
+			cl.SetState("WARN0082", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0082"], fmt.Sprintf("LoserProtection: winner master %s not found in local server list for cluster %s — check host/IP canonicalization between repman peers", r.Master, cl.GetName())), ErrFrom: "ARB"})
+			return
+		}
 		cl.LostArbitration(r.Master)
 		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModHeartBeat, config.LvlInfo,
 			"LoserProtection: cluster %s local master %s differs from winner master %s, applied split-brain protection",
@@ -183,6 +193,9 @@ func (cl *Cluster) ArbitratorElection() error {
 
 func (cl *Cluster) arbitratorElection() error {
 	timeout := time.Duration(time.Duration(cl.Conf.MonitoringTicker*1000-int64(cl.Conf.ArbitrationReadTimout)) * time.Millisecond)
+	if timeout <= 0 {
+		timeout = 2 * time.Second
+	}
 
 	url := cl.arbitratorURL("/arbitrator")
 	var mst string

--- a/cluster/cluster_split.go
+++ b/cluster/cluster_split.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -47,31 +48,41 @@ func (cluster *Cluster) Heartbeat(wg *sync.WaitGroup) {
 
 	defer wg.Done()
 	if cluster.Conf.Arbitration {
-		if cluster.IsSplitBrain {
-			if !cluster.Conf.IsEligibleForArbitration() {
-				cluster.SetState("ERR00104", state.State{ErrType: "ERROR", ErrDesc: clusterError["ERR00104"], ErrFrom: "ARB"})
-				cluster.IsSplitBrainBck = cluster.IsSplitBrain
-				return
-			}
-			err := cluster.SetArbitratorReport()
-			if err != nil {
+		if cluster.RepmanArbitrationRequired {
+			// All clusters publish their current state to the arbitrator heartbeat table
+			// so the loser-side reconciliation can resolve master for any cluster key.
+			if err := cluster.SetArbitratorReport(); err != nil {
 				cluster.SetState("WARN0081", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0081"], err), ErrFrom: "ARB"})
 			}
-			if cluster.IsSplitBrainBck != cluster.IsSplitBrain {
+		}
+
+		if cluster.RepmanArbitrationRequired && cluster.IsAuthorityCluster {
+			// Only the authority cluster drives the repman-wide election.
+			// All other clusters have their role driven exclusively by syncClustersFromRepmanRole().
+			if !cluster.Conf.IsEligibleForArbitration() {
+				if cluster.RoleEstablished {
+					// automatic split-brain recovery is subscription-gated
+					cluster.SetState("ERR00104", state.State{ErrType: "ERROR", ErrDesc: clusterError["ERR00104"], ErrFrom: "ARB"})
+					cluster.RepmanArbitrationRequiredBck = cluster.RepmanArbitrationRequired
+					return
+				}
+				// bootstrap election is allowed for any plan
+			}
+			if cluster.RepmanArbitrationRequiredBck != cluster.RepmanArbitrationRequired {
 				time.Sleep(5 * time.Second)
 			}
 			i := 1
 			for i <= 3 {
 				i++
-				err = cluster.ArbitratorElection()
+				err := cluster.ArbitratorElection()
 				if err != nil {
 					cluster.SetState("WARN0082", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0082"], err), ErrFrom: "ARB"})
 				} else {
-					break //break the loop on success retry 3 times
+					break // break the loop on success, retry 3 times
 				}
 			}
 		}
-		cluster.IsSplitBrainBck = cluster.IsSplitBrain
+		cluster.RepmanArbitrationRequiredBck = cluster.RepmanArbitrationRequired
 	}
 }
 
@@ -80,8 +91,89 @@ func (cl *Cluster) ForceArbitratorElection() error {
 	return cl.arbitratorElection()
 }
 
+// ReconcileLostArbitrationMaster resolves the winning repman's last-known master for
+// this cluster by querying the arbitrator's /winner-master endpoint and runs split-brain
+// master protection if it differs from the local master.
+//
+// authorityCluster is the cluster key that held the repman-wide election.  The arbitrator
+// looks up the elected UUID from that key, then returns the master that UUID last reported
+// for this cluster — without triggering a new election.
+//
+// Must not modify repman.Status, cluster.Status, or RoleEstablished; it is strictly
+// read/repair.
+func (cl *Cluster) ReconcileLostArbitrationMaster(authorityCluster string) {
+	if !cl.Conf.Arbitration {
+		return
+	}
+	localMaster := ""
+	if cl.GetMaster() != nil {
+		localMaster = cl.GetMaster().URL
+	}
+	if localMaster == "" {
+		return
+	}
+
+	timeout := time.Duration(time.Duration(cl.Conf.MonitoringTicker*1000-int64(cl.Conf.ArbitrationReadTimout)) * time.Millisecond)
+
+	// Build the read-only lookup URL.  We append query params to the arbitratorURL
+	// base so the Cloud18 uri parameter (if any) is preserved alongside our params.
+	base := cl.arbitratorURL("/winner-master")
+	sep := "&"
+	if !strings.Contains(base, "?") {
+		sep = "?"
+	}
+	reqURL := base + sep +
+		"secret=" + url.QueryEscape(cl.Conf.ArbitrationSasSecret) +
+		"&authority_cluster=" + url.QueryEscape(authorityCluster) +
+		"&cluster=" + url.QueryEscape(cl.GetName())
+
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModHeartBeat, config.LvlErr,
+			"LoserProtection: could not build arbitrator request for cluster %s: %s", cl.GetName(), err)
+		return
+	}
+
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModHeartBeat, config.LvlWarn,
+			"LoserProtection: could not reach arbitrator for cluster %s: %s", cl.GetName(), err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		// No elected winner row for the authority cluster yet — skip protection.
+		return
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+
+	type winnerMasterResponse struct {
+		WinnerUUID string `json:"winner_uuid"`
+		Master     string `json:"master"`
+	}
+	var r winnerMasterResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModHeartBeat, config.LvlWarn,
+			"LoserProtection: arbitrator returned invalid JSON for cluster %s: %s", cl.GetName(), body)
+		return
+	}
+	if r.Master == "" {
+		// Winner hasn't reported a master for this cluster yet.
+		return
+	}
+	if r.Master != localMaster {
+		cl.LostArbitration(r.Master)
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModHeartBeat, config.LvlInfo,
+			"LoserProtection: cluster %s local master %s differs from winner master %s, applied split-brain protection",
+			cl.GetName(), localMaster, r.Master)
+	}
+}
+
 func (cl *Cluster) ArbitratorElection() error {
-	if cl.IsSplitBrainBck != cl.IsSplitBrain {
+	if cl.RepmanArbitrationRequiredBck != cl.RepmanArbitrationRequired {
 		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModHeartBeat, "INFO", "Arbitrator: External check requested")
 	} else {
 		return nil
@@ -131,6 +223,7 @@ func (cl *Cluster) arbitratorElection() error {
 	}
 
 	cl.IsFailedArbitrator = false
+	cl.RoleEstablished = true
 	if r.Arbitration == "winner" {
 		cl.SetActiveStatus(ConstMonitorActif)
 		cl.SetState("WARN0083", state.State{ErrType: "WARNING", ErrDesc: clusterError["WARN0083"], ErrFrom: "ARB"})
@@ -144,6 +237,10 @@ func (cl *Cluster) arbitratorElection() error {
 				cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModHeartBeat, "INFO", "Election Lost - Current master %s different from winner master %s, %s is split brain victim. ", mst, r.Master, mst)
 			}
 		}
+	}
+	// Notify the owning ReplicationManager so it can update its repman-wide role.
+	if cl.onArbitrationResult != nil {
+		cl.onArbitrationResult(cl.Status)
 	}
 	return nil
 }

--- a/cluster/cluster_split_test.go
+++ b/cluster/cluster_split_test.go
@@ -1,0 +1,171 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+
+package cluster
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/state"
+)
+
+// newTestClusterForSplit builds the minimal Cluster needed by ReconcileLostArbitrationMaster.
+func newTestClusterForSplit(t *testing.T, masterURL string) *Cluster {
+	t.Helper()
+	conf := &config.Config{
+		Arbitration:           true,
+		ArbitrationSasSecret:  "test-secret",
+		MonitoringTicker:      2,
+		ArbitrationReadTimout: 0,
+	}
+	cl := &Cluster{
+		Name:         "test-cluster",
+		Conf:         conf,
+		StateMachine: new(state.StateMachine),
+	}
+	cl.StateMachine.Init()
+
+	if masterURL != "" {
+		srv := &ServerMonitor{
+			Host: "127.0.0.1",
+			Port: "3306",
+			URL:  masterURL,
+		}
+		cl.master = srv
+		cl.Servers = []*ServerMonitor{srv}
+	}
+	return cl
+}
+
+// TestReconcileLostArbitrationMaster_404 verifies that a 404 from the arbitrator
+// (no winner elected yet) causes an early return without touching the cluster state.
+func TestReconcileLostArbitrationMaster_404(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/winner-master" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "no elected winner for authority cluster"})
+	}))
+	defer ts.Close()
+
+	cl := newTestClusterForSplit(t, "127.0.0.1:3306")
+	cl.Conf.ArbitrationSasHosts = ts.Listener.Addr().String()
+
+	cl.ReconcileLostArbitrationMaster("auth-cluster")
+
+	if cl.StateMachine.CurState.Search("WARN0082") {
+		t.Error("expected no WARN0082 on 404 path")
+	}
+}
+
+// TestReconcileLostArbitrationMaster_MasterMatches verifies that when the arbitrator
+// returns the same master URL as the local master, no state change occurs.
+func TestReconcileLostArbitrationMaster_MasterMatches(t *testing.T) {
+	const masterURL = "127.0.0.1:3306"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{
+			"winner_uuid": "uuid-winner",
+			"master":      masterURL,
+		})
+	}))
+	defer ts.Close()
+
+	cl := newTestClusterForSplit(t, masterURL)
+	cl.Conf.ArbitrationSasHosts = ts.Listener.Addr().String()
+
+	cl.ReconcileLostArbitrationMaster("auth-cluster")
+
+	if cl.StateMachine.CurState.Search("WARN0082") {
+		t.Error("expected no WARN0082 when masters match")
+	}
+}
+
+// TestReconcileLostArbitrationMaster_UnknownWinnerMaster verifies that when the
+// winner's master URL is not found in the local server list (host canonicalization
+// mismatch), WARN0082 is emitted instead of calling LostArbitration blindly.
+func TestReconcileLostArbitrationMaster_UnknownWinnerMaster(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		secret := r.Header.Get("X-Arbitration-Secret")
+		if secret != "test-secret" {
+			t.Errorf("expected X-Arbitration-Secret=test-secret, got %q", secret)
+		}
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{
+			"winner_uuid": "uuid-winner",
+			// Winner reports a different hostname than what the loser knows.
+			"master": "db-primary:3306",
+		})
+	}))
+	defer ts.Close()
+
+	// Local cluster knows the master as 127.0.0.1:3306, not db-primary:3306.
+	cl := newTestClusterForSplit(t, "127.0.0.1:3306")
+	cl.Conf.ArbitrationSasHosts = ts.Listener.Addr().String()
+
+	cl.ReconcileLostArbitrationMaster("auth-cluster")
+
+	if !cl.StateMachine.CurState.Search("WARN0082") {
+		t.Error("expected WARN0082 when winner master URL not found in local server list")
+	}
+}
+
+// TestReconcileLostArbitrationMaster_SecretInHeader verifies the secret is sent via
+// X-Arbitration-Secret header, not as a query parameter.
+func TestReconcileLostArbitrationMaster_SecretInHeader(t *testing.T) {
+	secretInQuery := false
+	secretInHeader := false
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("secret") != "" {
+			secretInQuery = true
+		}
+		if r.Header.Get("X-Arbitration-Secret") == "test-secret" {
+			secretInHeader = true
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	cl := newTestClusterForSplit(t, "127.0.0.1:3306")
+	cl.Conf.ArbitrationSasHosts = ts.Listener.Addr().String()
+
+	cl.ReconcileLostArbitrationMaster("auth-cluster")
+
+	if secretInQuery {
+		t.Error("secret must not appear in URL query string")
+	}
+	if !secretInHeader {
+		t.Error("secret must be sent in X-Arbitration-Secret header")
+	}
+}
+
+// TestReconcileLostArbitrationMaster_NoMaster verifies early return when the cluster
+// has no current master (e.g. during cluster startup or after all servers failed).
+func TestReconcileLostArbitrationMaster_NoMaster(t *testing.T) {
+	called := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	cl := newTestClusterForSplit(t, "") // no master
+	cl.Conf.ArbitrationSasHosts = ts.Listener.Addr().String()
+
+	cl.ReconcileLostArbitrationMaster("auth-cluster")
+
+	if called {
+		t.Error("expected no HTTP call when cluster has no master")
+	}
+}

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -10539,20 +10539,31 @@ func (repman *ReplicationManager) handlerMuxSetActiveStatus(w http.ResponseWrite
 			http.Error(w, "No valid ACL", http.StatusForbidden)
 			return
 		}
-		if mycluster.IsActive() {
-			mycluster.SetActiveStatus(cluster.ConstMonitorStandby)
-			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Cluster switched to standby via API")
-			if mycluster.Conf.Arbitration {
-				if err := mycluster.ForceArbitratorElection(); err != nil {
+		// Manual role toggle operates on the repman-wide role so all clusters
+		// remain consistent (documented: stop other instances first when
+		// arbitrator-assisted failover is unavailable).
+		//
+		// ForceArbitratorElection must always run on the authority cluster so the
+		// result propagates back through the registered onArbitrationResult callback
+		// and keeps repman.Status in sync with the arbitrator's decision.
+		authCluster := repman.getClusterByName(repman.authorityClusterName())
+		if authCluster == nil {
+			authCluster = mycluster
+		}
+		if repman.IsRepmanActive() {
+			repman.SetRepmanRoleStandby()
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "RepMan switched to standby via API")
+			if authCluster.Conf.Arbitration {
+				if err := authCluster.ForceArbitratorElection(); err != nil {
 					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Arbitrator election after standby toggle failed: %s", err)
 				}
 			}
 			w.Write([]byte("Cluster set to standby"))
 		} else {
-			mycluster.SetActiveStatus(cluster.ConstMonitorActif)
-			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Cluster switched to active via API")
-			if mycluster.Conf.Arbitration {
-				if err := mycluster.ForceArbitratorElection(); err != nil {
+			repman.SetRepmanRoleActive()
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "RepMan switched to active via API")
+			if authCluster.Conf.Arbitration {
+				if err := authCluster.ForceArbitratorElection(); err != nil {
 					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Arbitrator election after active toggle failed: %s", err)
 				}
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -287,6 +287,15 @@ type Heartbeat struct {
 	Failed  int    `json:"failed"`
 }
 
+// WinnerMasterResponse is the JSON payload returned by the arbitrator's
+// /winner-master endpoint and consumed by cluster.ReconcileLostArbitrationMaster.
+// The struct is defined here so that arbitrator/arbitrator.go can import it
+// without creating a circular dependency (cluster cannot import server).
+type WinnerMasterResponse struct {
+	WinnerUUID string `json:"winner_uuid"`
+	Master     string `json:"master"`
+}
+
 var confs = make(map[string]config.Config)
 
 var cfgGroup string
@@ -3315,9 +3324,10 @@ func (repman *ReplicationManager) Heartbeat() {
 	}
 
 	// Propagate repman-wide arbitration state to all cluster fields.
-	// Cluster.IsSplitBrain is intentionally NOT touched here.
+	// IsSplitBrain is kept as a JSON-compat alias (dashboard + WARN0079 in cluster_topo.go).
 	for _, cl := range repman.Clusters {
 		cl.RepmanArbitrationRequired = repman.ArbitrationRequired
+		cl.IsSplitBrain = repman.ArbitrationRequired
 		cl.RoleEstablished = repman.RoleEstablished
 		if repman.Conf.LogHeartbeat {
 			repman.Logrus.Infof("Heartbeat: cluster %s RepmanArbitrationRequired=%t RoleEstablished=%t",

--- a/server/server.go
+++ b/server/server.go
@@ -93,7 +93,18 @@ type ReplicationManager struct {
 	UUID                         string                             `json:"uuid"`
 	Hostname                     string                             `json:"hostname"`
 	Status                       string                             `json:"status"`
-	SplitBrain                   bool                               `json:"splitBrain"`
+	// ArbitrationRequired is true when a peer repman is unreachable and external
+	// arbitration is needed to decide repman-wide ownership.  Internal only;
+	// the public JSON contract uses splitBrain for backwards compatibility.
+	ArbitrationRequired bool `json:"-"`
+	// SplitBrain is the public JSON field for ArbitrationRequired, kept for
+	// backwards compatibility with older dashboards and swagger consumers.
+	SplitBrain bool `json:"splitBrain"`
+	// RoleEstablished becomes true after the authority cluster completes its
+	// first successful arbitrator election (bootstrap).  Once true, automatic
+	// split-brain recovery on unsupported/free plans is gated with ERR00104.
+	// Propagated to all cl.RoleEstablished fields each peer-heartbeat tick.
+	RoleEstablished bool `json:"-"`
 	ClusterList                  []string                           `json:"clusters"`
 	ImmutableClusterList         []string                           `json:"-"`
 	DeprecatedKeys               map[string]map[string]bool         `json:"-"`
@@ -1680,7 +1691,9 @@ func (repman *ReplicationManager) InitConfig(conf config.Config, init_git bool) 
 		repman.Logrus.Debug("No include directory in default section")
 	}
 
-	repman.ImmutableClusterList = strings.Split(repman.DiscoverClusters(firstRead), ",")
+	discoveredClusters := strings.Split(repman.DiscoverClusters(firstRead), ",")
+	sort.Strings(discoveredClusters)
+	repman.ImmutableClusterList = discoveredClusters
 
 	for _, clusterName := range repman.ImmutableClusterList {
 		clRead := firstRead.Sub(clusterName)
@@ -2361,6 +2374,7 @@ func (repman *ReplicationManager) Run() error {
 	} else {
 		repman.Status = ConstMonitorActif
 	}
+	repman.ArbitrationRequired = false
 	repman.SplitBrain = false
 	repman.Hostname, err = os.Hostname()
 	regtest := new(regtest.RegTest)
@@ -2901,6 +2915,44 @@ func (repman *ReplicationManager) initCluster(clusterName string) (*cluster.Clus
 	repman.currentCluster.DiskStatManager = repman.DiskStatManager
 	repman.currentCluster.Mailer = repman.Mailer
 	repman.currentCluster.Init(repman.VersionConfs[clusterName], clusterName, &repman.tlog, &repman.Logs, repman.termlength, repman.UUID, repman.Version, repman.Hostname)
+
+	// Mark the authority cluster (first in ImmutableClusterList).  Only this
+	// cluster is permitted to contact the arbitrator and update repman-wide role.
+	repman.currentCluster.IsAuthorityCluster = (clusterName == repman.authorityClusterName())
+
+	if repman.currentCluster.IsAuthorityCluster {
+		repman.currentCluster.SetArbitrationResultCallback(func(status string) {
+			repman.Lock()
+			defer repman.Unlock()
+			if status == cluster.ConstMonitorActif {
+				repman.Status = ConstMonitorActif
+			} else {
+				repman.Status = ConstMonitorStandby
+			}
+			// Mark repman-wide bootstrap as complete.  This is propagated to all
+			// cl.RoleEstablished fields on the next peer-heartbeat tick so that
+			// unsupported/free plans are gated on ERR00104 from that point on.
+			repman.RoleEstablished = true
+			repman.syncClustersFromRepmanRole()
+
+			// Loser-side split-brain master protection for all non-authority clusters.
+			// The authority cluster already ran LostArbitration() inline inside
+			// arbitratorElection(), so it is skipped here.  The reconciler queries
+			// the arbitrator's /winner-master endpoint using the authority cluster key
+			// to find who won and what master they reported for each target cluster.
+			if repman.Status == ConstMonitorStandby {
+				authName := repman.authorityClusterName()
+				for _, cl := range repman.Clusters {
+					if cl.IsAuthorityCluster {
+						continue
+					}
+					cl := cl // capture loop var for goroutine
+					go cl.ReconcileLostArbitrationMaster(authName)
+				}
+			}
+		})
+	}
+
 	repman.Lock()
 	repman.Clusters[clusterName] = repman.currentCluster
 	repman.Unlock()
@@ -3095,108 +3147,181 @@ func (repman *ReplicationManager) RecomputeGatewayConflicts(changedClusterName, 
 	}
 }
 
-func (repman *ReplicationManager) HeartbeatPeerSplitBrain(peer string, bcksplitbrain bool) bool {
-	timeout := time.Duration(time.Duration(repman.Conf.MonitoringTicker) * time.Second * 4)
-	/*	Host, _ := misc.SplitHostPort(peer)
-		ha, err := net.LookupHost(Host)
-		if err != nil {
-			repman.LogModulePrintf(repman.Conf.Verbose,config.ConstLogModGeneral,config.LvlErr,"Heartbeat: Resolv %s DNS err: %s", Host, err)
+// IsRepmanActive reports whether this replication-manager instance currently
+// holds the active (orchestrating) role.
+func (repman *ReplicationManager) IsRepmanActive() bool {
+	return repman.Status == ConstMonitorActif
+}
+
+// authorityClusterName returns the name of the single cluster authorised to
+// update repman-wide role after an arbitration result.  It is always the first
+// entry in ImmutableClusterList so the authority is deterministic and stable
+// for the lifetime of the process.
+func (repman *ReplicationManager) authorityClusterName() string {
+	if len(repman.ImmutableClusterList) > 0 {
+		return repman.ImmutableClusterList[0]
+	}
+	return ""
+}
+
+// SetRepmanRoleActive promotes this instance to the active repman role and
+// propagates the change to all monitored clusters.
+func (repman *ReplicationManager) SetRepmanRoleActive() {
+	repman.Status = ConstMonitorActif
+	repman.syncClustersFromRepmanRole()
+}
+
+// SetRepmanRoleStandby demotes this instance to the standby repman role and
+// propagates the change to all monitored clusters.
+func (repman *ReplicationManager) SetRepmanRoleStandby() {
+	repman.Status = ConstMonitorStandby
+	repman.syncClustersFromRepmanRole()
+}
+
+// syncClustersFromRepmanRole sets every monitored cluster's active/standby
+// status to match the current repman-wide role.  Existing per-cluster standby
+// protections continue to work because they key off cluster.Status.
+func (repman *ReplicationManager) syncClustersFromRepmanRole() {
+	for _, cl := range repman.Clusters {
+		if repman.IsRepmanActive() {
+			cl.SetActiveStatus(cluster.ConstMonitorActif)
 		} else {
-			repman.LogModulePrintf(repman.Conf.Verbose,config.ConstLogModGeneral,config.LvlErr,"Heartbeat: Resolv %s DNS say: %s", Host, ha[0])
+			cl.SetActiveStatus(cluster.ConstMonitorStandby)
 		}
-	*/
+	}
+}
+
+// fetchPeerHeartbeat contacts a single peer repman via /api/heartbeat.
+// It returns the peer's Status string, whether the response was valid (correct
+// secret, parseable JSON, not our own UUID), and whether the peer was reachable.
+// Peers that are reachable but invalid (self, secret mismatch, bad JSON) must
+// be ignored by the caller — they are neither counted as reachable-valid nor
+// as unreachable.
+func (repman *ReplicationManager) fetchPeerHeartbeat(peer string, logOnFirst bool) (status string, valid bool, reachable bool) {
+	timeout := time.Duration(time.Duration(repman.Conf.MonitoringTicker) * time.Second * 4)
 
 	scheme := "http://"
 	if strings.HasPrefix(peer, "https://") || strings.HasPrefix(peer, "http://") {
 		scheme = ""
 	}
 	url := scheme + peer + "/api/heartbeat"
-	client := &http.Client{
-		Timeout: timeout,
-	}
+	client := &http.Client{Timeout: timeout}
 	if repman.Conf.LogHeartbeat {
 		repman.Logrus.Debugf("Heartbeat: Sending peer request to node %s", peer)
 	}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		if !bcksplitbrain {
-			repman.Logrus.Debugf("Error building HTTP request: %s", err)
+		if logOnFirst {
+			repman.Logrus.Debugf("Heartbeat: Error building HTTP request to peer %s: %s", peer, err)
 		}
-		return true
+		return "", false, false
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		if !bcksplitbrain {
-			repman.Logrus.Debugf("Could not reach peer node, might be down or incorrect address")
+		if logOnFirst {
+			repman.Logrus.Debugf("Heartbeat: Could not reach peer node %s, arbitration may be needed", peer)
 		}
-		return true
+		return "", false, false
 	}
 	defer resp.Body.Close()
 	monjson, err := io.ReadAll(resp.Body)
 	if err != nil {
-		if !bcksplitbrain {
-			repman.Logrus.Debugf("Could not read body from peer response")
+		if logOnFirst {
+			repman.Logrus.Debugf("Heartbeat: Could not read body from peer %s response", peer)
 		}
-		return true
+		return "", false, true
 	}
 	if repman.Conf.LogHeartbeat {
-		repman.Logrus.Debugf("splitbrain http call result: %s ", monjson)
+		repman.Logrus.Debugf("Heartbeat: peer %s response: %s", peer, monjson)
 	}
-	// Use json.Decode for reading streams of JSON data
 	var h Heartbeat
 	if err := json.Unmarshal(monjson, &h); err != nil {
 		if repman.Conf.LogHeartbeat {
-			repman.Logrus.Debugf("Could not unmarshal JSON from peer response %s", err)
+			repman.Logrus.Debugf("Heartbeat: Could not unmarshal JSON from peer %s: %s", peer, err)
 		}
-		return true
-	} else {
-
-		if repman.Conf.LogHeartbeat {
-			repman.Logrus.Debugf("RETURN: %v", h)
-		}
-
-		if repman.Conf.LogHeartbeat {
-			repman.Logrus.Infof("No peer split brain setting status to %s", repman.Status)
-		}
-
+		return "", false, true
 	}
-
-	return false
+	if h.UUID == repman.UUID {
+		return "", false, true
+	}
+	if repman.Conf.ArbitrationSasSecret != "" && h.Secret != repman.Conf.ArbitrationSasSecret {
+		if repman.Conf.LogHeartbeat {
+			repman.Logrus.Debugf("Heartbeat: peer %s secret mismatch, ignoring", peer)
+		}
+		return "", false, true
+	}
+	if repman.Conf.LogHeartbeat {
+		repman.Logrus.Debugf("Heartbeat: peer %s reports status=%s uuid=%s", peer, h.Status, h.UUID)
+	}
+	return h.Status, true, true
 }
 
+// Heartbeat performs peer-to-peer repman heartbeats and propagates the
+// ArbitrationRequired flag to all monitored clusters.  It uses explicit
+// status-aware aggregation so that a reachable standby peer does not
+// suppress arbitration incorrectly.  It does NOT write cluster.IsSplitBrain.
+//
+// Decision logic:
+//   - local active  + any reachable active peer  → dual-active conflict  → arbitrate
+//   - local active  + only standby/no valid peer → we own it             → no arbitrate
+//   - local standby + any reachable active peer  → peer owns it          → no arbitrate
+//   - local standby + no reachable active peer   → need to establish     → arbitrate
 func (repman *ReplicationManager) Heartbeat() {
 	if cfgGroup == "arbitrator" {
-		repman.Logrus.Debugf("Arbitrator cannot send heartbeat to itself. Exiting")
+		repman.Logrus.Debugf("Heartbeat: Arbitrator cannot send heartbeat to itself. Exiting")
 		return
 	}
 
 	var peerList []string
-	// try to found an active peer replication-manager
 	if repman.Conf.ArbitrationPeerHosts != "" {
 		peerList = strings.Split(repman.Conf.ArbitrationPeerHosts, ",")
 	} else {
-		repman.Logrus.Debugf("Arbitration peer not specified. Disabling arbitration")
+		repman.Logrus.Debugf("Heartbeat: Arbitration peer not specified. Disabling arbitration")
 		repman.Conf.Arbitration = false
 		return
 	}
 
-	bcksplitbrain := repman.SplitBrain
+	prevRequired := repman.ArbitrationRequired
 
+	// Collect per-peer facts; peers that are reachable but invalid (self,
+	// secret mismatch, bad JSON) are silently skipped.
+	anyReachableActivePeer := false
 	for _, peer := range peerList {
-		repman.Lock()
-		repman.SplitBrain = repman.HeartbeatPeerSplitBrain(peer, bcksplitbrain)
-		repman.Unlock()
-		if repman.Conf.LogHeartbeat {
-			repman.Logrus.Infof("SplitBrain set to %t on peer %s", repman.SplitBrain, peer)
+		peerStatus, valid, _ := repman.fetchPeerHeartbeat(peer, !prevRequired)
+		if !valid {
+			continue
 		}
-	} //end check all peers
+		if peerStatus == ConstMonitorActif {
+			anyReachableActivePeer = true
+		}
+	}
 
-	// propagate SplitBrain state to clusters after peer negotiation
+	localIsActive := repman.IsRepmanActive()
+	var arbitrationNeeded bool
+	if localIsActive {
+		arbitrationNeeded = anyReachableActivePeer
+	} else {
+		arbitrationNeeded = !anyReachableActivePeer
+	}
+
+	repman.Lock()
+	repman.ArbitrationRequired = arbitrationNeeded
+	repman.SplitBrain = arbitrationNeeded // deprecated alias kept for JSON compat
+	repman.Unlock()
+
+	if repman.Conf.LogHeartbeat {
+		repman.Logrus.Infof("Heartbeat: localActive=%t anyReachableActivePeer=%t ArbitrationRequired=%t",
+			localIsActive, anyReachableActivePeer, repman.ArbitrationRequired)
+	}
+
+	// Propagate repman-wide arbitration state to all cluster fields.
+	// Cluster.IsSplitBrain is intentionally NOT touched here.
 	for _, cl := range repman.Clusters {
-		cl.IsSplitBrain = repman.SplitBrain
-
+		cl.RepmanArbitrationRequired = repman.ArbitrationRequired
+		cl.RoleEstablished = repman.RoleEstablished
 		if repman.Conf.LogHeartbeat {
-			repman.Logrus.Infof("SplitBrain set to %t on cluster %s", repman.SplitBrain, cl.Name)
+			repman.Logrus.Infof("Heartbeat: cluster %s RepmanArbitrationRequired=%t RoleEstablished=%t",
+				cl.Name, cl.RepmanArbitrationRequired, cl.RoleEstablished)
 		}
 	}
 }

--- a/server/server_arbitration_test.go
+++ b/server/server_arbitration_test.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"sort"
+	"testing"
+)
+
+// TestAuthorityClusterName_Empty returns "" when no clusters are configured.
+func TestAuthorityClusterName_Empty(t *testing.T) {
+	repman := &ReplicationManager{}
+	if got := repman.authorityClusterName(); got != "" {
+		t.Errorf("expected empty authority name with no clusters, got %q", got)
+	}
+}
+
+// TestAuthorityClusterName_Single returns the only cluster when there is one.
+func TestAuthorityClusterName_Single(t *testing.T) {
+	repman := &ReplicationManager{ImmutableClusterList: []string{"only-cluster"}}
+	if got := repman.authorityClusterName(); got != "only-cluster" {
+		t.Errorf("expected only-cluster, got %q", got)
+	}
+}
+
+// TestAuthorityClusterName_Deterministic verifies that authority selection is
+// stable: ImmutableClusterList is sorted, so both peers independently arrive at
+// the same first entry regardless of discovery order.
+func TestAuthorityClusterName_Deterministic(t *testing.T) {
+	// Simulate two peers discovering the same clusters in different orders.
+	peer1 := []string{"gamma", "alpha", "beta"}
+	peer2 := []string{"beta", "gamma", "alpha"}
+
+	sort.Strings(peer1)
+	sort.Strings(peer2)
+
+	r1 := &ReplicationManager{ImmutableClusterList: peer1}
+	r2 := &ReplicationManager{ImmutableClusterList: peer2}
+
+	a1 := r1.authorityClusterName()
+	a2 := r2.authorityClusterName()
+
+	if a1 != a2 {
+		t.Errorf("authority cluster mismatch between peers: %q vs %q", a1, a2)
+	}
+	if a1 != "alpha" {
+		t.Errorf("expected sorted-first cluster alpha, got %q", a1)
+	}
+}
+
+// TestRepmanRoleActive verifies SetRepmanRoleActive sets Status to active.
+func TestRepmanRoleActive(t *testing.T) {
+	repman := &ReplicationManager{}
+	repman.Clusters = nil
+	repman.Status = ConstMonitorStandby
+	repman.SetRepmanRoleActive()
+	if repman.Status != ConstMonitorActif {
+		t.Errorf("expected %q after SetRepmanRoleActive, got %q", ConstMonitorActif, repman.Status)
+	}
+}
+
+// TestRepmanRoleStandby verifies SetRepmanRoleStandby sets Status to standby.
+func TestRepmanRoleStandby(t *testing.T) {
+	repman := &ReplicationManager{}
+	repman.Clusters = nil
+	repman.Status = ConstMonitorActif
+	repman.SetRepmanRoleStandby()
+	if repman.Status != ConstMonitorStandby {
+		t.Errorf("expected %q after SetRepmanRoleStandby, got %q", ConstMonitorStandby, repman.Status)
+	}
+}

--- a/utils/dbhelper/arbitration.go
+++ b/utils/dbhelper/arbitration.go
@@ -169,6 +169,30 @@ func GetArbitrationMaster(db *sqlx.DB, secret string, cluster string) string {
 	return ""
 }
 
+// GetArbitrationWinnerUUID returns the UUID of the elected repman (status='E') for the
+// given authority cluster/secret pair.  Returns "" if no elected row exists.
+func GetArbitrationWinnerUUID(db *sqlx.DB, secret string, cluster string) string {
+	var uuid string
+	stmt := "SELECT uuid FROM " + heartbeatTable(db) + " WHERE cluster=? AND secret=? AND status='E'"
+	err := db.QueryRowx(stmt, cluster, secret).Scan(&uuid)
+	if err == nil {
+		return uuid
+	}
+	return ""
+}
+
+// GetHeartbeatMasterForUUID returns the last master URL reported by the repman instance
+// identified by uuid for the given cluster/secret pair.  Returns "" if no row exists.
+func GetHeartbeatMasterForUUID(db *sqlx.DB, secret string, cluster string, uuid string) string {
+	var master string
+	stmt := "SELECT master FROM " + heartbeatTable(db) + " WHERE cluster=? AND secret=? AND uuid=?"
+	err := db.QueryRowx(stmt, cluster, secret, uuid).Scan(&master)
+	if err == nil {
+		return master
+	}
+	return ""
+}
+
 // SetStatusActiveHeartbeat arbitrator can set or remove election flag "E"
 // NOTE: this function omits cluster from the INSERT, but the MySQL table's PRIMARY KEY
 // is (secret, cluster, uid), so it cannot be made MySQL-safe without adding cluster to

--- a/utils/dbhelper/arbitration_test.go
+++ b/utils/dbhelper/arbitration_test.go
@@ -174,6 +174,112 @@ func TestRequestArbitration_Winner_MySQL_SQL(t *testing.T) {
 	}
 }
 
+// ---- GetArbitrationWinnerUUID tests ----
+
+func TestGetArbitrationWinnerUUID_SQLite(t *testing.T) {
+	db := newSQLiteArbitrationDB(t)
+
+	// No elected row → returns ""
+	if got := GetArbitrationWinnerUUID(db, "secret1", "cluster1"); got != "" {
+		t.Errorf("expected empty UUID before election, got %q", got)
+	}
+
+	// After election, the elected UUID is returned.
+	RequestArbitration(db, "uuid-winner", "secret1", "cluster1", "master1", 1, 2, 0)
+	if got := GetArbitrationWinnerUUID(db, "secret1", "cluster1"); got != "uuid-winner" {
+		t.Errorf("GetArbitrationWinnerUUID: got %q, want uuid-winner", got)
+	}
+
+	// Different secret → no match.
+	if got := GetArbitrationWinnerUUID(db, "other-secret", "cluster1"); got != "" {
+		t.Errorf("expected empty UUID for wrong secret, got %q", got)
+	}
+}
+
+func TestGetArbitrationWinnerUUID_MySQL_SQL(t *testing.T) {
+	db, mock := mockDB(t, "mysql")
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"SELECT uuid FROM replication_manager_schema.heartbeat WHERE cluster=? AND secret=? AND status='E'",
+	)).WillReturnRows(sqlmock.NewRows([]string{"uuid"}).AddRow("uuid-winner"))
+
+	if got := GetArbitrationWinnerUUID(db, "secret1", "cluster1"); got != "uuid-winner" {
+		t.Errorf("got %q, want uuid-winner", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// ---- GetHeartbeatMasterForUUID tests ----
+
+func TestGetHeartbeatMasterForUUID_SQLite(t *testing.T) {
+	db := newSQLiteArbitrationDB(t)
+
+	// No row → returns ""
+	if got := GetHeartbeatMasterForUUID(db, "secret1", "cluster2", "uuid-winner"); got != "" {
+		t.Errorf("expected empty master before heartbeat, got %q", got)
+	}
+
+	// After writing a heartbeat for cluster2 with the winner's UUID, master is returned.
+	if err := WriteHeartbeat(db, "uuid-winner", "secret1", "cluster2", "master2", 1, 2, 0); err != nil {
+		t.Fatalf("WriteHeartbeat: %v", err)
+	}
+	if got := GetHeartbeatMasterForUUID(db, "secret1", "cluster2", "uuid-winner"); got != "master2" {
+		t.Errorf("GetHeartbeatMasterForUUID: got %q, want master2", got)
+	}
+
+	// Different UUID → no match.
+	if got := GetHeartbeatMasterForUUID(db, "secret1", "cluster2", "uuid-loser"); got != "" {
+		t.Errorf("expected empty master for non-winner UUID, got %q", got)
+	}
+}
+
+func TestGetHeartbeatMasterForUUID_MySQL_SQL(t *testing.T) {
+	db, mock := mockDB(t, "mysql")
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"SELECT master FROM replication_manager_schema.heartbeat WHERE cluster=? AND secret=? AND uuid=?",
+	)).WillReturnRows(sqlmock.NewRows([]string{"master"}).AddRow("master2"))
+
+	if got := GetHeartbeatMasterForUUID(db, "secret1", "cluster2", "uuid-winner"); got != "master2" {
+		t.Errorf("got %q, want master2", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// ---- End-to-end: loser-side master resolution via two-step lookup ----
+
+// TestLoserMasterResolution_SQLite verifies the combined two-step lookup flow used
+// by ReconcileLostArbitrationMaster: first get the winner UUID from the authority
+// cluster key, then get the master that winner reported for the target cluster.
+func TestLoserMasterResolution_SQLite(t *testing.T) {
+	db := newSQLiteArbitrationDB(t)
+
+	const secret = "s"
+	const authCluster = "auth-cluster"
+	const targetCluster = "target-cluster"
+	const winnerUUID = "uuid-A"
+
+	// Simulate: winning repman wins election on authority cluster.
+	RequestArbitration(db, winnerUUID, secret, authCluster, "auth-master", 1, 3, 0)
+
+	// Simulate: winning repman also publishes heartbeat for the target cluster.
+	if err := WriteHeartbeat(db, winnerUUID, secret, targetCluster, "target-master-A", 2, 3, 0); err != nil {
+		t.Fatalf("WriteHeartbeat: %v", err)
+	}
+
+	// Two-step lookup:
+	uuid := GetArbitrationWinnerUUID(db, secret, authCluster)
+	if uuid != winnerUUID {
+		t.Fatalf("GetArbitrationWinnerUUID: got %q, want %q", uuid, winnerUUID)
+	}
+	master := GetHeartbeatMasterForUUID(db, secret, targetCluster, uuid)
+	if master != "target-master-A" {
+		t.Errorf("GetHeartbeatMasterForUUID: got %q, want target-master-A", master)
+	}
+}
+
 func TestWriteHeartbeat_MySQL_SQL(t *testing.T) {
 	db, mock := mockDB(t, "mysql")
 


### PR DESCRIPTION
## Summary

This PR refactors and hardens the replication-manager arbitration flow so that active/standby election and split-brain master protection match the documented behavior at https://docs.signal18.io/architecture/arbitration/overview.

Key changes:
- Introduce a repman-wide arbitration state (, ) and keep  as a JSON compatibility alias.
- Rewrite peer heartbeat logic to be status-aware: arbitration only triggers on a real dual-active conflict or when a standby instance sees no active peer.
- Use a deterministic authority cluster (first sorted discovered cluster) to drive the repman-wide arbitrator election.
- Preserve  propagation so dashboards and  continue to work.
- Preserve split-brain master protection for non-authority clusters: all clusters publish arbitrator heartbeats, and a new read-only  lookup lets losers resolve the winner's master without triggering a new election.
- Gate automatic split-brain recovery after bootstrap by subscription plan ( on unsupported/free plans), while still allowing the initial bootstrap election for everyone.
- Send the  secret via  header instead of URL query string.
- Add guards against non-positive arbitrator HTTP timeouts.
- Surface winner-master canonicalization mismatches through  instead of silently no-oping.
- Add focused tests for authority selection and the loser-side reconciliation HTTP path.

## Why this matters

Arbitration is the mechanism that ensures exactly one replication-manager instance is active at a time during network partitions. Without a clear repman-wide role model and deterministic authority cluster, multi-instance deployments can disagree on ownership and leave databases with two writable masters. This PR closes those gaps while preserving backwards compatibility for existing API consumers and dashboards.

## Validation
- ok  	github.com/signal18/replication-manager/server	6.604s
- ok  	github.com/signal18/replication-manager/cluster	11.985s

Recommended additional review focus:
- The repman-wide semantics of the existing  endpoint.
- Whether the new public JSON fields  and  should remain exposed or become internal-only.