### PR TITLE
Scope backup disk space alerts to backup-relevant paths only

### DIFF
--- a/cluster/cluster_chk.go
+++ b/cluster/cluster_chk.go
@@ -26,6 +26,7 @@ import (
 	"github.com/signal18/replication-manager/router/maxscale"
 	"github.com/signal18/replication-manager/utils/alert"
 	"github.com/signal18/replication-manager/utils/dbhelper"
+	"github.com/signal18/replication-manager/utils/misc"
 	"github.com/signal18/replication-manager/utils/state"
 )
 
@@ -1394,7 +1395,7 @@ func (cluster *Cluster) CheckDisksUsage() {
 		reducePolicy = "Considering reducing restic keep-* policies to save disk space."
 	}
 
-	overThreshold := cluster.DiskStatManager.GetOverThresholdPaths(float64(cluster.Conf.BackupDiskTresholdWarn), float64(cluster.Conf.BackupDiskTresholdCrit))
+	overThreshold := cluster.getOverThresholdBackupPaths(float64(cluster.Conf.BackupDiskTresholdWarn), float64(cluster.Conf.BackupDiskTresholdCrit))
 	for level, statlist := range overThreshold {
 		switch level {
 		case "critical":
@@ -1403,6 +1404,43 @@ func (cluster *Cluster) CheckDisksUsage() {
 			cluster.SetState("WARN0139", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0139"], statlist, cluster.Conf.BackupDiskTresholdWarn), ErrFrom: "JOB"})
 		}
 	}
+}
+
+// getOverThresholdBackupPaths checks disk usage only for paths this cluster
+// actually uses for backup storage (see GetBackupDiskPaths), rather than
+// every mount tracked in the shared DiskStatManager. The manager is shared
+// across all clusters and, on containerized hosts, accumulates bind mounts
+// (e.g. /etc/hostname, /etc/resolv.conf) that are unrelated to backups but
+// would otherwise be reported as over-threshold "backup partitions".
+// Multiple backup paths that resolve to the same underlying filesystem are
+// deduplicated so a single full partition doesn't produce repeated alerts.
+// Identity is the resolved stat's own Path (the mount/directory the stat was
+// recorded under, see DiskStatManager.UpdateStat), not the usage numbers -
+// two distinct filesystems can easily report identical totals/usage.
+func (cluster *Cluster) getOverThresholdBackupPaths(warn, crit float64) map[string][]misc.DiskUsagePercentage {
+	overThreshold := make(map[string][]misc.DiskUsagePercentage)
+	seen := make(map[string]bool)
+
+	for _, path := range cluster.GetBackupDiskPaths() {
+		stat, err := cluster.GetDiskStat(path)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "Cannot get disk stat for backup path %s: %s", path, err)
+			continue
+		}
+
+		if seen[stat.Path] {
+			continue
+		}
+		seen[stat.Path] = true
+
+		if stat.UsedPercent > crit {
+			overThreshold["critical"] = append(overThreshold["critical"], misc.DiskUsagePercentage{Path: path, UsedPercent: stat.UsedPercent})
+		} else if stat.UsedPercent > warn {
+			overThreshold["warning"] = append(overThreshold["warning"], misc.DiskUsagePercentage{Path: path, UsedPercent: stat.UsedPercent})
+		}
+	}
+
+	return overThreshold
 }
 
 func (cluster *Cluster) CheckAllBackupEstimatedSize() {

--- a/cluster/cluster_disk_alert_test.go
+++ b/cluster/cluster_disk_alert_test.go
@@ -1,0 +1,267 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+
+package cluster
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shirou/gopsutil/disk"
+	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/misc"
+	"github.com/signal18/replication-manager/utils/state"
+)
+
+// newDiskAlertTestCluster builds a minimal cluster with one server and a
+// fresh DiskStatManager, suitable for exercising CheckDisksUsage without a
+// live database connection.
+func newDiskAlertTestCluster(t *testing.T, numServers int) *Cluster {
+	t.Helper()
+	cluster := &Cluster{
+		Name: "disk-alert-cluster",
+		Conf: &config.Config{
+			WorkingDir:             t.TempDir(),
+			BackupCheckFreeSpace:   true,
+			BackupDiskTresholdWarn: 70,
+			BackupDiskTresholdCrit: 90,
+		},
+		StateMachine:    &state.StateMachine{},
+		DiskStatManager: misc.NewDiskStatManager(),
+	}
+	cluster.StateMachine.Init()
+
+	for i := 0; i < numServers; i++ {
+		server := &ServerMonitor{
+			Host:         "127.0.0.1",
+			Port:         hostPortFor(i),
+			ClusterGroup: cluster,
+		}
+		cluster.Servers = append(cluster.Servers, server)
+	}
+
+	return cluster
+}
+
+func hostPortFor(i int) string {
+	return []string{"3306", "3307", "3308"}[i]
+}
+
+// registerDiskStat injects a disk usage stat directly into the cluster's
+// DiskStatManager keyed by the cleaned path, bypassing any real syscall. The
+// stat's identity (Path) is set to the same path, as real disk.Usage() calls
+// do (see RefreshDiskStats/UpdateDiskStat).
+func registerDiskStat(cluster *Cluster, path string, total, used uint64) {
+	registerDiskStatWithIdentity(cluster, path, path, total, used)
+}
+
+// registerDiskStatWithIdentity is like registerDiskStat but lets the stat's
+// identity (Path) differ from the map key, so tests can simulate two
+// distinct filesystems (different identity) that happen to report identical
+// usage numbers.
+func registerDiskStatWithIdentity(cluster *Cluster, key, identity string, total, used uint64) {
+	free := total - used
+	usedPercent := float64(0)
+	if total > 0 {
+		usedPercent = float64(used) / float64(total) * 100
+	}
+	cluster.DiskStatManager.UpdateStat(filepath.Clean(key), &disk.UsageStat{
+		Path:        identity,
+		Total:       total,
+		Free:        free,
+		Used:        used,
+		UsedPercent: usedPercent,
+	})
+}
+
+func openStateDescs(cluster *Cluster, key string) []string {
+	var descs []string
+	for _, s := range cluster.StateMachine.GetOpenStates() {
+		if s.ErrKey == key {
+			descs = append(descs, s.ErrDesc)
+		}
+	}
+	return descs
+}
+
+// TestCheckDisksUsageIgnoresUnrelatedMounts verifies that unrelated
+// system/container mounts tracked in the shared DiskStatManager (bind mounts
+// like /etc/hostname, /etc/hosts, /etc/resolv.conf, /usr/share/zoneinfo/...,
+// or the repo root) never appear in the backup disk space alert, even when
+// they are themselves over threshold. Only the cluster's actual backup path
+// should be reported.
+func TestCheckDisksUsageIgnoresUnrelatedMounts(t *testing.T) {
+	cluster := newDiskAlertTestCluster(t, 1)
+	backupPath := cluster.Servers[0].GetMyBackupDirectoryPath()
+
+	// The real backup path is over the critical threshold.
+	registerDiskStat(cluster, backupPath, 100, 95)
+
+	// Unrelated mounts/bind-mounts, also "over threshold", must be ignored.
+	registerDiskStat(cluster, "/etc/hostname", 100, 99)
+	registerDiskStat(cluster, "/etc/hosts", 100, 99)
+	registerDiskStat(cluster, "/etc/resolv.conf", 100, 99)
+	registerDiskStat(cluster, "/usr/share/zoneinfo/Etc/UTC", 100, 99)
+	registerDiskStat(cluster, "/go/src/github.com/signal18/replication-manager", 100, 99)
+	registerDiskStat(cluster, "/", 100, 99)
+
+	cluster.CheckDisksUsage()
+
+	descs := openStateDescs(cluster, "WARN0140")
+	if len(descs) != 1 {
+		t.Fatalf("expected exactly one WARN0140 state, got %d: %v", len(descs), descs)
+	}
+
+	desc := descs[0]
+	if !strings.Contains(desc, backupPath) {
+		t.Errorf("expected alert to mention backup path %q, got: %s", backupPath, desc)
+	}
+
+	for _, bogus := range []string{"/etc/hostname", "/etc/hosts", "/etc/resolv.conf", "/usr/share/zoneinfo", "/go/src/github.com"} {
+		if strings.Contains(desc, bogus) {
+			t.Errorf("alert should not mention unrelated mount %q, got: %s", bogus, desc)
+		}
+	}
+
+	if warnDescs := openStateDescs(cluster, "WARN0139"); len(warnDescs) != 0 {
+		t.Errorf("did not expect WARN0139 alongside WARN0140, got: %v", warnDescs)
+	}
+}
+
+// TestCheckDisksUsageDedupsSameMount verifies that when multiple backup
+// directories (e.g. from different servers) resolve to the same underlying
+// mount, the over-threshold alert lists that filesystem once rather than
+// once per directory. The shared mount is registered at the common parent
+// of both server backup directories, so GetStatByClosestMount resolves both
+// to the exact same stat record (same identity), mirroring how a real
+// mounted volume covering both directories would be tracked.
+func TestCheckDisksUsageDedupsSameMount(t *testing.T) {
+	cluster := newDiskAlertTestCluster(t, 2)
+
+	sharedMount := filepath.Join(cluster.Conf.WorkingDir, config.ConstStreamingSubDir, cluster.Name)
+	registerDiskStat(cluster, sharedMount, 100, 95)
+
+	cluster.CheckDisksUsage()
+
+	descs := openStateDescs(cluster, "WARN0140")
+	if len(descs) != 1 {
+		t.Fatalf("expected exactly one WARN0140 state, got %d: %v", len(descs), descs)
+	}
+
+	// Both servers' directories resolved to the same stat identity, so the
+	// resulting statlist should only mention the mount once.
+	occurrences := strings.Count(descs[0], "95")
+	if occurrences != 1 {
+		t.Errorf("expected the over-threshold mount to be reported once, got %d occurrences in: %s", occurrences, descs[0])
+	}
+}
+
+// TestCheckDisksUsageReportsDistinctMountsWithSameUsage verifies that two
+// genuinely different filesystems that happen to report identical
+// total/used numbers (e.g. two 1TB volumes both 95% full) are NOT collapsed
+// into a single alert entry. Dedup must be based on filesystem identity, not
+// on the usage numbers themselves.
+func TestCheckDisksUsageReportsDistinctMountsWithSameUsage(t *testing.T) {
+	cluster := newDiskAlertTestCluster(t, 2)
+
+	for i, srv := range cluster.Servers {
+		identity := fmt.Sprintf("/mnt/backup-vol-%d", i)
+		registerDiskStatWithIdentity(cluster, srv.GetMyBackupDirectoryPath(), identity, 100, 95)
+	}
+
+	cluster.CheckDisksUsage()
+
+	descs := openStateDescs(cluster, "WARN0140")
+	if len(descs) != 1 {
+		t.Fatalf("expected exactly one WARN0140 state, got %d: %v", len(descs), descs)
+	}
+
+	for _, srv := range cluster.Servers {
+		backupPath := srv.GetMyBackupDirectoryPath()
+		if !strings.Contains(descs[0], backupPath) {
+			t.Errorf("expected alert to mention distinct mount's backup path %q, got: %s", backupPath, descs[0])
+		}
+	}
+}
+
+// TestGetBackupDiskPathsResolvesRemoteResticToLocalStaging verifies that a
+// remote restic repository spec (s3:, sftp:) never leaks into the set of
+// paths checked for local disk usage; GetResticEffectiveLocalRepoPath always
+// resolves remote specs to the local staging directory instead.
+func TestGetBackupDiskPathsResolvesRemoteResticToLocalStaging(t *testing.T) {
+	cluster := newDiskAlertTestCluster(t, 1)
+	cluster.Conf.BackupRestic = true
+	cluster.Conf.BackupResticLocalRepository = "s3:https://minio.example.com/bucket"
+
+	paths := cluster.GetBackupDiskPaths()
+
+	for _, p := range paths {
+		if strings.HasPrefix(p, "s3:") || strings.HasPrefix(p, "sftp:") {
+			t.Fatalf("remote restic repo spec leaked into local disk paths: %v", paths)
+		}
+	}
+
+	localStagingDir := cluster.GetResticEffectiveLocalRepoPath()
+	found := false
+	for _, p := range paths {
+		if p == localStagingDir {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected local restic staging dir %q in backup disk paths, got: %v", localStagingDir, paths)
+	}
+}
+
+// TestGetBackupDiskPathsSkipsResticWhenDisabled verifies that the restic
+// staging directory is only included when restic backups are enabled, since
+// it is otherwise unused local storage.
+func TestGetBackupDiskPathsSkipsResticWhenDisabled(t *testing.T) {
+	cluster := newDiskAlertTestCluster(t, 1)
+	cluster.Conf.BackupRestic = false
+
+	paths := cluster.GetBackupDiskPaths()
+
+	localStagingDir := cluster.GetResticEffectiveLocalRepoPath()
+	for _, p := range paths {
+		if p == localStagingDir {
+			t.Errorf("did not expect restic staging dir %q when backup-restic is disabled, got: %v", localStagingDir, paths)
+		}
+	}
+}
+
+// TestGetBackupDiskPathsUsesResticAppendClusterPath verifies that when
+// backup-restic-repo-append-cluster is enabled, the disk path checked is the
+// actual per-cluster repo directory restic writes to (localRepoPath/<cluster>),
+// not its parent. GetResticLocalDir alone does not apply this join and would
+// report the parent directory instead of the real repo mount.
+func TestGetBackupDiskPathsUsesResticAppendClusterPath(t *testing.T) {
+	cluster := newDiskAlertTestCluster(t, 1)
+	cluster.Conf.BackupRestic = true
+	cluster.Conf.BackupResticRepoAppendCluster = true
+	cluster.Conf.BackupResticLocalRepository = "/mnt/restic-repo"
+
+	expected := filepath.Join("/mnt/restic-repo", cluster.Name)
+
+	effective := cluster.GetResticEffectiveLocalRepoPath()
+	if effective != expected {
+		t.Fatalf("expected effective restic repo path %q, got %q", expected, effective)
+	}
+
+	paths := cluster.GetBackupDiskPaths()
+	found := false
+	for _, p := range paths {
+		if p == expected {
+			found = true
+		}
+		if p == "/mnt/restic-repo" {
+			t.Errorf("backup disk paths should not contain the parent repo dir %q instead of the cluster-specific path", p)
+		}
+	}
+	if !found {
+		t.Errorf("expected cluster-specific restic repo path %q in backup disk paths, got: %v", expected, paths)
+	}
+}

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -1652,6 +1652,66 @@ func (cluster *Cluster) GetResticLocalDir() string {
 	return cluster.Conf.WorkingDir + "/" + config.ConstStreamingSubDir + "/archive/" + cluster.Name
 }
 
+// GetResticEffectiveLocalRepoPath returns the local filesystem path restic
+// actually uses as its repository for local backups, applying the same
+// backup-restic-repo-append-cluster resolution as ResticGetEnv (cluster_bck.go).
+// GetResticLocalDir does not apply that join, so on its own it can point at
+// the parent of the real per-cluster repo directory when append-cluster is
+// enabled. Remote specs (s3:, sftp:) never reach resolveResticRepoPolicy's
+// join logic; they fall back to the local per-cluster staging directory,
+// same as GetResticLocalDir. This is a pure read: no filesystem writes.
+func (cluster *Cluster) GetResticEffectiveLocalRepoPath() string {
+	defaultDir := filepath.Join(cluster.Conf.WorkingDir, config.ConstStreamingSubDir, "archive", cluster.Name)
+
+	repo := cluster.Conf.BackupResticLocalRepository
+	if repo == "" || config.IsSftpResticRepository(repo) || config.IsS3ResticRepository(repo) {
+		return defaultDir
+	}
+
+	localRepoPath, appendCluster := resolveResticRepoPolicy(cluster.Conf, repo, cluster)
+	if localRepoPath == "" {
+		return defaultDir
+	}
+	if appendCluster && shouldAppendClusterNameLocal(localRepoPath, cluster.Name) {
+		return filepath.Join(localRepoPath, cluster.Name)
+	}
+	return localRepoPath
+}
+
+// GetBackupDiskPaths returns the local filesystem paths this cluster relies
+// on for backup storage: each server's backup output directory, plus the
+// local restic repository/staging directory when restic backups are
+// enabled. Used to scope disk space monitoring to backup-relevant storage
+// instead of every mount visible to the process. It performs no filesystem
+// writes and never returns remote restic repo specs (s3:, sftp:) since
+// GetResticEffectiveLocalRepoPath already resolves those to a local staging
+// path.
+func (cluster *Cluster) GetBackupDiskPaths() []string {
+	seen := make(map[string]bool)
+	paths := make([]string, 0, len(cluster.Servers)+1)
+
+	add := func(p string) {
+		if p == "" || seen[p] {
+			return
+		}
+		seen[p] = true
+		paths = append(paths, p)
+	}
+
+	for _, server := range cluster.Servers {
+		if server == nil {
+			continue
+		}
+		add(server.GetMyBackupDirectoryPath())
+	}
+
+	if cluster.Conf.BackupRestic {
+		add(cluster.GetResticEffectiveLocalRepoPath())
+	}
+
+	return paths
+}
+
 func (cluster *Cluster) GetExecEnv() []string {
 	adminuser := "admin"
 	adminpassword := "repman"

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -1763,18 +1763,26 @@ func (server *ServerMonitor) JobReseedBackupScript() error {
 	return nil
 }
 
+// GetMyBackupDirectoryPath returns this server's backup output directory
+// without creating it on disk. Use GetMyBackupDirectory when the directory
+// needs to exist, e.g. before writing a backup file.
+func (server *ServerMonitor) GetMyBackupDirectoryPath() string {
+	cluster := server.ClusterGroup
+	return cluster.Conf.WorkingDir + "/" + config.ConstStreamingSubDir + "/" + cluster.Name + "/" + server.Host + "_" + server.Port + "/"
+}
+
 func (server *ServerMonitor) GetMyBackupDirectory() string {
 	cluster := server.ClusterGroup
-	s3dir := cluster.Conf.WorkingDir + "/" + config.ConstStreamingSubDir + "/" + cluster.Name + "/" + server.Host + "_" + server.Port
+	s3dir := server.GetMyBackupDirectoryPath()
 
 	if _, err := os.Stat(s3dir); os.IsNotExist(err) {
 		err := os.MkdirAll(s3dir, os.ModePerm)
 		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Create backup path failed: %s", s3dir, err)
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Create backup path failed: %s: %s", s3dir, err)
 		}
 	}
 
-	return s3dir + "/"
+	return s3dir
 
 }
 
@@ -2889,12 +2897,13 @@ func (server *ServerMonitor) BackupRestic(backupMethod backupmgr.BackupMethod, u
 
 	var needpurge bool
 
-	defer cluster.UpdateDiskStat(cluster.GetResticLocalDir())
+	resticLocalDir := cluster.GetResticEffectiveLocalRepoPath()
+	defer cluster.UpdateDiskStat(resticLocalDir)
 
 	if cluster.Conf.BackupCheckFreeSpace {
-		diskstat, err := cluster.GetDiskStat(cluster.GetResticLocalDir())
+		diskstat, err := cluster.GetDiskStat(resticLocalDir)
 		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error getting disk stat for restic backup dir: %s", cluster.GetResticLocalDir())
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error getting disk stat for restic backup dir: %s", resticLocalDir)
 			cluster.ResticManager.PauseWorkerOnDisk()
 		} else {
 			// Use specific treshold if defined


### PR DESCRIPTION
Previously CheckDisksUsage() reported every mounted filesystem tracked by the shared DiskStatManager, so unrelated container bind mounts such as /etc/hostname, /etc/hosts, /etc/resolv.conf, /usr/share/zoneinfo and the repo root appeared in the backup partition space alert.

Changes:
- Introduce GetMyBackupDirectoryPath() as a pure path helper (no mkdir) and keep GetMyBackupDirectory() for callers that need the directory to exist.
- Add GetBackupDiskPaths() returning each server's backup output directory plus the effective local restic repo path when restic is enabled.
- Add GetResticEffectiveLocalRepoPath() applying the same append-cluster resolution used by ResticGetEnv(), so the alert checks the real per-cluster repo directory instead of its parent.
- Make CheckDisksUsage() evaluate only backup-relevant paths and dedupe by the resolved stat's mount identity rather than usage numbers, so two distinct full filesystems are not collapsed.
- Use the effective local restic repo path in BackupRestic() disk checks.
- Add cluster/cluster_disk_alert_test.go covering unrelated mounts, same mount dedup, distinct mounts with identical usage, remote s3:/sftp: specs, disabled restic, and append-cluster restic resolution.