### PR TITLE
Quiet go-mysql binlog syncer logs and contain constructor failures per cluster

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -566,6 +566,27 @@ func (cluster *Cluster) InitFromConf() {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Failover in automatic mode")
 	}
 
+	// go-mysql's replication.NewBinlogSyncer calls Logger.Fatal (os.Exit(1))
+	// when its ServerID is 0. The binlog syncer call sites (srv_binlog.go)
+	// derive that ServerID from check-binlog-server-id (offset 0 for the
+	// metadata/position syncers, +2000 for the query-event scanner) via
+	// binlogSyncerServerIDFor's uint32 conversion, which wraps — so check the
+	// actual computed value for both offsets, not just the literal inputs
+	// (0 and -2000) that happen to produce it, to also catch values like
+	// 4294967296 that wrap around to 0. Catch this once, loudly, at cluster
+	// startup rather than letting it silently kill the whole process the
+	// first time a binlog syncer opens.
+	if _, ok := binlogSyncerServerIDFor(cluster.Conf.CheckBinServerId, 0); !ok {
+		cluster.LogModulePrintf(true, config.ConstLogModPurge, config.LvlErr,
+			"check-binlog-server-id=%d produces an invalid binlog syncer server-id of 0: binlog metadata refresh and timestamp lookup will be disabled to avoid an unrecoverable go-mysql error. Set check-binlog-server-id to a different value.",
+			cluster.Conf.CheckBinServerId)
+	}
+	if _, ok := binlogSyncerServerIDFor(cluster.Conf.CheckBinServerId, 2000); !ok {
+		cluster.LogModulePrintf(true, config.ConstLogModPurge, config.LvlErr,
+			"check-binlog-server-id=%d produces an invalid binlog syncer server-id of 0 with the query-event scanner's +2000 offset: query-event scanning will be disabled to avoid an unrecoverable go-mysql error. Set check-binlog-server-id to a different value.",
+			cluster.Conf.CheckBinServerId)
+	}
+
 	//working directory of the cluster is working directory of server and cluster name
 	if _, err := os.Stat(cluster.WorkingDir); os.IsNotExist(err) {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Creating directory  %s", cluster.WorkingDir)

--- a/cluster/srv_binlog.go
+++ b/cluster/srv_binlog.go
@@ -60,6 +60,32 @@ func (server *ServerMonitor) binlogSyncerTLSConfig() *tls.Config {
 	return nil
 }
 
+// binlogSyncerServerIDFor computes the go-mysql server-id for check-binlog-server-id
+// plus offset, using the exact uint32 conversion go-mysql performs internally
+// (which wraps, so large values such as 4294967296 also produce 0, not just
+// literal 0 or -offset). Shared by binlogSyncerServerID and InitFromConf's
+// startup validation so the two can't drift apart on what counts as invalid.
+func binlogSyncerServerIDFor(checkBinServerId, offset int) (uint32, bool) {
+	id := uint32(checkBinServerId + offset)
+	return id, id != 0
+}
+
+// binlogSyncerServerID computes the go-mysql server-id for a binlog syncer
+// (check-binlog-server-id plus offset) and refuses a value of 0: go-mysql's
+// NewBinlogSyncer calls Logger.Fatal (os.Exit(1)) on ServerID==0 with no way
+// to recover. InitFromConf already logs a loud, one-time error at cluster
+// startup when the config produces this; this guard just makes sure the
+// syncer is never actually started with it, without re-logging every tick.
+func (server *ServerMonitor) binlogSyncerServerID(offset int) (uint32, bool) {
+	cluster := server.ClusterGroup
+	id, ok := binlogSyncerServerIDFor(cluster.Conf.CheckBinServerId, offset)
+	if !ok {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPurge, config.LvlDbg,
+			"check-binlog-server-id produces server-id 0 for %s, skipping binlog syncer", server.URL)
+	}
+	return id, ok
+}
+
 func (server *ServerMonitor) RefreshBinaryLogs() error {
 	var err error
 	cluster := server.ClusterGroup
@@ -126,13 +152,19 @@ func (server *ServerMonitor) RefreshBinlogMetaGoMySQL(meta *dbhelper.BinaryLogMe
 	cluster := server.ClusterGroup
 	port, _ := strconv.Atoi(server.Port)
 
+	serverID, ok := server.binlogSyncerServerID(0)
+	if !ok {
+		return errors.New("check-binlog-server-id produces an invalid server-id of 0")
+	}
+
 	cfg := replication.BinlogSyncerConfig{
-		ServerID: uint32(cluster.Conf.CheckBinServerId),
+		ServerID: serverID,
 		Flavor:   server.DBVersion.Flavor,
 		Host:     server.Host,
 		Port:     uint16(port),
 		User:     server.User,
 		Password: server.Pass,
+		Logger:   s18log.NewBinlogSyncerLogger(cluster, server.URL, "binlog-meta", config.ConstLogModPurge),
 	}
 
 	cfg.TLSConfig = server.binlogSyncerTLSConfig()
@@ -859,9 +891,13 @@ func (server *ServerMonitor) ReadAndExecBinaryLogsWithinRange(start backupmgr.Re
 	}
 
 	if start.Filename == end.Filename {
-		server.GetBinlogPositionFromTimestamp(uint32(start.Position), &end)
+		if err := server.GetBinlogPositionFromTimestamp(uint32(start.Position), &end); err != nil {
+			return fmt.Errorf("failed to resolve binlog end position: %w", err)
+		}
 	} else {
-		server.GetBinlogPositionFromTimestamp(4, &end)
+		if err := server.GetBinlogPositionFromTimestamp(4, &end); err != nil {
+			return fmt.Errorf("failed to resolve binlog end position: %w", err)
+		}
 	}
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Continue for injecting binary logs on %s until %s pos: %d", dest.URL, end.Filename, end.Position)
@@ -900,13 +936,19 @@ func (server *ServerMonitor) GetBinlogPositionFromTimestamp(start uint32, end *b
 	cluster := server.ClusterGroup
 	port, _ := strconv.Atoi(server.Port)
 
+	serverID, ok := server.binlogSyncerServerID(0)
+	if !ok {
+		return errors.New("check-binlog-server-id produces an invalid server-id of 0")
+	}
+
 	cfg := replication.BinlogSyncerConfig{
-		ServerID: uint32(cluster.Conf.CheckBinServerId),
+		ServerID: serverID,
 		Flavor:   server.DBVersion.Flavor,
 		Host:     server.Host,
 		Port:     uint16(port),
 		User:     server.User,
 		Password: server.Pass,
+		Logger:   s18log.NewBinlogSyncerLogger(cluster, server.URL, "binlog-position", config.ConstLogModPurge),
 	}
 
 	cfg.TLSConfig = server.binlogSyncerTLSConfig()
@@ -1087,16 +1129,22 @@ func (server *ServerMonitor) ScanBinlogQueryEvents() {
 		// Tear down the previous syncer cleanly before opening a new one.
 		server.CloseBinlogEventSyncer()
 
+		// Use a server-id that is distinct from the metadata syncer
+		// (CheckBinServerId) and from any real replica, to avoid
+		// "duplicate server-id" errors.
+		serverID, ok := server.binlogSyncerServerID(2000)
+		if !ok {
+			return
+		}
+
 		cfg := replication.BinlogSyncerConfig{
-			// Use a server-id that is distinct from the metadata syncer
-			// (CheckBinServerId) and from any real replica, to avoid
-			// "duplicate server-id" errors.
-			ServerID: uint32(cluster.Conf.CheckBinServerId + 2000),
+			ServerID: serverID,
 			Flavor:   server.DBVersion.Flavor,
 			Host:     server.Host,
 			Port:     uint16(port),
 			User:     server.User,
 			Password: server.Pass,
+			Logger:   s18log.NewBinlogSyncerLogger(cluster, server.URL, "binlog-scan", config.ConstLogModPurge),
 		}
 		cfg.TLSConfig = server.binlogSyncerTLSConfig()
 

--- a/cluster/srv_binlog.go
+++ b/cluster/srv_binlog.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"runtime/debug"
 	"slices"
 	"strconv"
 	"strings"
@@ -72,10 +73,13 @@ func binlogSyncerServerIDFor(checkBinServerId, offset int) (uint32, bool) {
 
 // binlogSyncerServerID computes the go-mysql server-id for a binlog syncer
 // (check-binlog-server-id plus offset) and refuses a value of 0: go-mysql's
-// NewBinlogSyncer calls Logger.Fatal (os.Exit(1)) on ServerID==0 with no way
-// to recover. InitFromConf already logs a loud, one-time error at cluster
-// startup when the config produces this; this guard just makes sure the
-// syncer is never actually started with it, without re-logging every tick.
+// NewBinlogSyncer calls Logger.Fatal on ServerID==0 with no way to recover
+// unless the call goes through newSafeBinlogSyncer. InitFromConf already logs
+// a loud, one-time error at cluster startup when the config produces this;
+// this guard just makes sure the syncer is never actually started with it,
+// without re-logging every tick. This is the primary prevention layer;
+// newSafeBinlogSyncer is the last-resort safety net if it's ever missed or a
+// future go-mysql version adds new Fatal conditions.
 func (server *ServerMonitor) binlogSyncerServerID(offset int) (uint32, bool) {
 	cluster := server.ClusterGroup
 	id, ok := binlogSyncerServerIDFor(cluster.Conf.CheckBinServerId, offset)
@@ -84,6 +88,43 @@ func (server *ServerMonitor) binlogSyncerServerID(offset int) (uint32, bool) {
 			"check-binlog-server-id produces server-id 0 for %s, skipping binlog syncer", server.URL)
 	}
 	return id, ok
+}
+
+// newSafeBinlogSyncer is the only place cluster code may call
+// replication.NewBinlogSyncer directly; every call site in this file must go
+// through it (enforced by TestBinlogSyncerConstructionOnlyThroughSafeWrapper
+// in srv_binlog_test.go).
+//
+// go-mysql's NewBinlogSyncer calls Logger.Fatal(...) synchronously on
+// ServerID==0, and BinlogSyncerLogger.Fatal panics with s18log.FatalError
+// rather than calling os.Exit(1) precisely so this constructor can recover
+// from it. binlogSyncerServerID already prevents ServerID==0 from reaching
+// this call in normal operation; this recover is defense in depth for a
+// validation gap, a future call site that forgets it, or a future go-mysql
+// version that fails closed somewhere else in the constructor.
+//
+// Recovery policy: this narrow boundary recovers ALL panics from the
+// constructor call, not just *FatalError, and always returns an error instead
+// — a single bad binlog syncer must never exit the process or affect other
+// clusters. Every recovery is force-logged at Error level with the panic
+// value and a stack trace via cfg.Logger.Recovered, regardless of what level
+// the caller that receives the returned error chooses to log it at, so this
+// specific failure mode is never silently downgraded to Debug.
+func newSafeBinlogSyncer(cfg replication.BinlogSyncerConfig) (syncer *replication.BinlogSyncer, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			syncer = nil
+			if fe, ok := r.(*s18log.FatalError); ok {
+				err = fmt.Errorf("binlog syncer construction failed: %w", fe)
+			} else {
+				err = fmt.Errorf("binlog syncer construction panicked: %v", r)
+			}
+			if l, ok := cfg.Logger.(*s18log.BinlogSyncerLogger); ok {
+				l.Recovered(fmt.Sprintf("recovered from panic constructing binlog syncer: %v\n%s", r, debug.Stack()))
+			}
+		}
+	}()
+	return replication.NewBinlogSyncer(cfg), nil
 }
 
 func (server *ServerMonitor) RefreshBinaryLogs() error {
@@ -169,7 +210,10 @@ func (server *ServerMonitor) RefreshBinlogMetaGoMySQL(meta *dbhelper.BinaryLogMe
 
 	cfg.TLSConfig = server.binlogSyncerTLSConfig()
 
-	syncer := replication.NewBinlogSyncer(cfg)
+	syncer, err := newSafeBinlogSyncer(cfg)
+	if err != nil {
+		return err
+	}
 	defer syncer.Close()
 
 	streamer, err := syncer.StartSync(mysql.Position{Name: meta.Filename, Pos: 0})
@@ -953,7 +997,10 @@ func (server *ServerMonitor) GetBinlogPositionFromTimestamp(start uint32, end *b
 
 	cfg.TLSConfig = server.binlogSyncerTLSConfig()
 
-	syncer := replication.NewBinlogSyncer(cfg)
+	syncer, err := newSafeBinlogSyncer(cfg)
+	if err != nil {
+		return err
+	}
 	defer syncer.Close()
 
 	streamer, err := syncer.StartSync(mysql.Position{Name: end.Filename, Pos: start})
@@ -1148,7 +1195,12 @@ func (server *ServerMonitor) ScanBinlogQueryEvents() {
 		}
 		cfg.TLSConfig = server.binlogSyncerTLSConfig()
 
-		syncer := replication.NewBinlogSyncer(cfg)
+		syncer, err := newSafeBinlogSyncer(cfg)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPlugin, config.LvlDbg,
+				"[binlog-scan] failed to create binlog syncer on %s: %v", server.URL, err)
+			return
+		}
 		// Start from the beginning of the current file so we see all events
 		// written since the last rotation.  Position 4 skips the 4-byte magic
 		// header that precedes the first real event.
@@ -1167,7 +1219,12 @@ func (server *ServerMonitor) ScanBinlogQueryEvents() {
 					"[binlog-scan] auto-enabled TLS with InsecureSkipVerify=true for %s (error 3159)."+
 						" Certificate authenticity is NOT verified — configure monitoring-ssl-ca/cert/key for full TLS validation.", server.URL)
 				cfg.TLSConfig = server.binlogSyncerTLSConfig()
-				syncer = replication.NewBinlogSyncer(cfg)
+				syncer, err = newSafeBinlogSyncer(cfg)
+				if err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPlugin, config.LvlDbg,
+						"[binlog-scan] failed to recreate binlog syncer on %s: %v", server.URL, err)
+					return
+				}
 				streamer, err = syncer.StartSync(mysql.Position{Name: currentFile, Pos: 4})
 				if err != nil {
 					syncer.Close()

--- a/cluster/srv_binlog_test.go
+++ b/cluster/srv_binlog_test.go
@@ -1,0 +1,159 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+
+package cluster
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-mysql-org/go-mysql/replication"
+	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/s18log"
+)
+
+type nopModulePrintf struct{}
+
+func (nopModulePrintf) LogModulePrintf(forcingLog bool, module int, level string, format string, args ...interface{}) int {
+	return 0
+}
+
+// recordingModulePrintf captures every force-logged ("loud") line so tests
+// can assert on visibility, independent of what a downstream caller does
+// with the returned error.
+type recordingModulePrintf struct {
+	forced []string
+}
+
+func (p *recordingModulePrintf) LogModulePrintf(forcingLog bool, module int, level string, format string, args ...interface{}) int {
+	if forcingLog {
+		p.forced = append(p.forced, level+": "+fmt.Sprintf(format, args...))
+	}
+	return 0
+}
+
+// TestNewSafeBinlogSyncer_RecoversFromServerIDZeroFatal is the last-resort
+// safety net test: go-mysql's replication.NewBinlogSyncer calls Logger.Fatal
+// synchronously when ServerID==0, and BinlogSyncerLogger.Fatal panics with
+// s18log.FatalError instead of calling os.Exit(1) precisely so this wrapper
+// can recover it. binlogSyncerServerID is expected to prevent ServerID==0
+// from ever reaching this call in normal operation, but if that guard is
+// ever missed, this must fail with an error, not take down the process.
+func TestNewSafeBinlogSyncer_RecoversFromServerIDZeroFatal(t *testing.T) {
+	cfg := replication.BinlogSyncerConfig{
+		ServerID: 0,
+		Flavor:   "mysql",
+		Host:     "127.0.0.1",
+		Port:     3306,
+		Logger:   s18log.NewBinlogSyncerLogger(nopModulePrintf{}, "127.0.0.1:3306", "test", 0),
+	}
+
+	syncer, err := newSafeBinlogSyncer(cfg)
+	if err == nil {
+		t.Fatal("expected an error for ServerID=0; without recovery this would have panicked/exited the test process")
+	}
+	if syncer != nil {
+		t.Fatal("expected a nil syncer alongside the error")
+	}
+	if !strings.Contains(err.Error(), "server ID") {
+		t.Fatalf("expected error to mention the server ID, got: %v", err)
+	}
+}
+
+// TestNewSafeBinlogSyncer_RecoveryIsLoud ensures a recovered constructor
+// panic is always force-logged at Error level with the panic value and a
+// stack trace, regardless of what level the caller receiving the returned
+// error chooses to log it at (some call sites only log the returned error at
+// Debug — see RefreshBinlogMetadata / ScanBinlogQueryEvents).
+func TestNewSafeBinlogSyncer_RecoveryIsLoud(t *testing.T) {
+	p := &recordingModulePrintf{}
+	cfg := replication.BinlogSyncerConfig{
+		ServerID: 0,
+		Flavor:   "mysql",
+		Host:     "127.0.0.1",
+		Port:     3306,
+		Logger:   s18log.NewBinlogSyncerLogger(p, "127.0.0.1:3306", "test", 0),
+	}
+
+	if _, err := newSafeBinlogSyncer(cfg); err == nil {
+		t.Fatal("expected an error for ServerID=0")
+	}
+
+	var recoveryLog string
+	for _, line := range p.forced {
+		if strings.Contains(line, "recovered from panic") {
+			recoveryLog = line
+			break
+		}
+	}
+	if recoveryLog == "" {
+		t.Fatalf("expected a force-logged recovery line, got forced logs: %v", p.forced)
+	}
+	if !strings.HasPrefix(recoveryLog, config.LvlErr+":") {
+		t.Fatalf("expected recovery to log at %s level, got: %q", config.LvlErr, recoveryLog)
+	}
+	if !strings.Contains(recoveryLog, "server ID") {
+		t.Fatalf("expected recovery log to include the panic value, got: %q", recoveryLog)
+	}
+	if !strings.Contains(recoveryLog, "newSafeBinlogSyncer") {
+		t.Fatalf("expected recovery log to include a stack trace mentioning newSafeBinlogSyncer, got: %q", recoveryLog)
+	}
+}
+
+// TestNewSafeBinlogSyncer_Succeeds sanity-checks that a valid config still
+// constructs a real syncer through the wrapper (i.e. the recover() doesn't
+// swallow the happy path).
+func TestNewSafeBinlogSyncer_Succeeds(t *testing.T) {
+	cfg := replication.BinlogSyncerConfig{
+		ServerID: 12345,
+		Flavor:   "mysql",
+		Host:     "127.0.0.1",
+		Port:     3306,
+		Logger:   s18log.NewBinlogSyncerLogger(nopModulePrintf{}, "127.0.0.1:3306", "test", 0),
+	}
+
+	syncer, err := newSafeBinlogSyncer(cfg)
+	if err != nil {
+		t.Fatalf("expected no error for a valid config, got: %v", err)
+	}
+	if syncer == nil {
+		t.Fatal("expected a non-nil syncer")
+	}
+	syncer.Close()
+}
+
+// TestBinlogSyncerConstructionOnlyThroughSafeWrapper guards against a future
+// call site bypassing newSafeBinlogSyncer and calling
+// replication.NewBinlogSyncer directly again, which would reopen the
+// unrecoverable-process-exit risk this file exists to close. The only
+// allowed direct call is the one inside newSafeBinlogSyncer itself.
+func TestBinlogSyncerConstructionOnlyThroughSafeWrapper(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const needle = "replication.NewBinlogSyncer("
+	total := 0
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		total += strings.Count(string(data), needle)
+	}
+
+	if total != 1 {
+		t.Fatalf("expected exactly 1 direct call to replication.NewBinlogSyncer across the cluster package "+
+			"(inside newSafeBinlogSyncer in srv_binlog.go), found %d. All binlog syncer construction must go "+
+			"through newSafeBinlogSyncer so a go-mysql Logger.Fatal (e.g. ServerID==0) can be recovered as an "+
+			"error instead of exiting the whole replication-manager process", total)
+	}
+}

--- a/utils/s18log/binlog_syncer_logger.go
+++ b/utils/s18log/binlog_syncer_logger.go
@@ -1,0 +1,150 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+
+package s18log
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/signal18/replication-manager/config"
+)
+
+// ModulePrintf is the subset of the cluster's module-based logger that
+// BinlogSyncerLogger needs. *cluster.Cluster satisfies this via its existing
+// LogModulePrintf method, so no import back into the cluster package is required.
+type ModulePrintf interface {
+	LogModulePrintf(forcingLog bool, module int, level string, format string, args ...interface{}) int
+}
+
+// BinlogSyncerLogger adapts go-mysql's replication.BinlogSyncer logger
+// (siddontang/go-log/loggers.Advanced) to a cluster's module-based logger.
+//
+// go-mysql's default logger writes every connection lifecycle event
+// ("create BinlogSyncer with config ...", "rotate to ...", "syncer is
+// closing...") to stdout at Info level, unconditionally. Since
+// replication-manager opens a syncer per monitoring tick (binlog metadata
+// refresh, timestamp lookup, query-event scan), this floods the logs with
+// routine noise.
+//
+// All call sites use config.ConstLogModPurge, so every level is mapped
+// (never dropped) and gated purely by the existing log-binlog-purge /
+// log-level-binlog-purge knobs — the same knobs that already control the
+// rest of the binlog purge logging. Raising log-level-binlog-purge to
+// INFO/DEBUG re-enables the routine chatter for troubleshooting without any
+// new config. This intentionally does NOT honor cluster.Conf.Verbose as a
+// force-print override (the repo-wide convention elsewhere): verbose mode
+// would otherwise make this logger impossible to fully suppress.
+//
+// Fatal/Panic are the one deliberate exception: they are always force-logged
+// regardless of the module gate. NewBinlogSyncer calls Logger.Fatal (then
+// os.Exit(1)) when ServerID==0, and nothing else in the monitoring loop
+// captures that failure — silently dropping the line would turn a
+// misconfiguration into an unexplained process exit.
+type BinlogSyncerLogger struct {
+	printer   ModulePrintf
+	serverURL string
+	context   string // short tag identifying the call site, e.g. "binlog-meta"
+	module    int    // config.ConstLogMod* to attribute the message to
+}
+
+// NewBinlogSyncerLogger builds a BinlogSyncerLogger scoped to a single server
+// and call site.
+func NewBinlogSyncerLogger(printer ModulePrintf, serverURL, context string, module int) *BinlogSyncerLogger {
+	return &BinlogSyncerLogger{printer: printer, serverURL: serverURL, context: context, module: module}
+}
+
+func (l *BinlogSyncerLogger) format(msg string) string {
+	return fmt.Sprintf("[%s] %s: %s", l.context, l.serverURL, msg)
+}
+
+func (l *BinlogSyncerLogger) log(forcingLog bool, level, msg string) {
+	l.printer.LogModulePrintf(forcingLog, l.module, level, "%s", l.format(msg))
+}
+
+func (l *BinlogSyncerLogger) Debug(args ...interface{}) {
+	l.log(false, config.LvlDbg, fmt.Sprint(args...))
+}
+func (l *BinlogSyncerLogger) Debugf(f string, args ...interface{}) {
+	l.log(false, config.LvlDbg, fmt.Sprintf(f, args...))
+}
+func (l *BinlogSyncerLogger) Debugln(args ...interface{}) {
+	l.log(false, config.LvlDbg, fmt.Sprintln(args...))
+}
+
+func (l *BinlogSyncerLogger) Info(args ...interface{}) {
+	l.log(false, config.LvlInfo, fmt.Sprint(args...))
+}
+func (l *BinlogSyncerLogger) Infof(f string, args ...interface{}) {
+	l.log(false, config.LvlInfo, fmt.Sprintf(f, args...))
+}
+func (l *BinlogSyncerLogger) Infoln(args ...interface{}) {
+	l.log(false, config.LvlInfo, fmt.Sprintln(args...))
+}
+
+// Print* is never actually called by go-mysql's BinlogSyncer; mapped to
+// Debug level to keep it consistent with the rest of the adapter should any
+// caller reach it via the loggers.Standard interface.
+func (l *BinlogSyncerLogger) Print(args ...interface{}) {
+	l.log(false, config.LvlDbg, fmt.Sprint(args...))
+}
+func (l *BinlogSyncerLogger) Printf(f string, args ...interface{}) {
+	l.log(false, config.LvlDbg, fmt.Sprintf(f, args...))
+}
+func (l *BinlogSyncerLogger) Println(args ...interface{}) {
+	l.log(false, config.LvlDbg, fmt.Sprintln(args...))
+}
+
+func (l *BinlogSyncerLogger) Warn(args ...interface{}) {
+	l.log(false, config.LvlWarn, fmt.Sprint(args...))
+}
+func (l *BinlogSyncerLogger) Warnf(f string, args ...interface{}) {
+	l.log(false, config.LvlWarn, fmt.Sprintf(f, args...))
+}
+func (l *BinlogSyncerLogger) Warnln(args ...interface{}) {
+	l.log(false, config.LvlWarn, fmt.Sprintln(args...))
+}
+
+func (l *BinlogSyncerLogger) Error(args ...interface{}) {
+	l.log(false, config.LvlErr, fmt.Sprint(args...))
+}
+func (l *BinlogSyncerLogger) Errorf(f string, args ...interface{}) {
+	l.log(false, config.LvlErr, fmt.Sprintf(f, args...))
+}
+func (l *BinlogSyncerLogger) Errorln(args ...interface{}) {
+	l.log(false, config.LvlErr, fmt.Sprintln(args...))
+}
+
+// Fatal* mirrors go-log's default logger (log as error, then os.Exit(1)).
+// Always force-logged — see the type doc comment for why.
+func (l *BinlogSyncerLogger) Fatal(args ...interface{}) {
+	l.log(true, config.LvlErr, fmt.Sprint(args...))
+	os.Exit(1)
+}
+func (l *BinlogSyncerLogger) Fatalf(f string, args ...interface{}) {
+	l.log(true, config.LvlErr, fmt.Sprintf(f, args...))
+	os.Exit(1)
+}
+func (l *BinlogSyncerLogger) Fatalln(args ...interface{}) {
+	l.log(true, config.LvlErr, fmt.Sprintln(args...))
+	os.Exit(1)
+}
+
+// Panic* mirrors go-log's default logger (log as error, then panic). Always
+// force-logged — see the type doc comment for why.
+func (l *BinlogSyncerLogger) Panic(args ...interface{}) {
+	msg := fmt.Sprint(args...)
+	l.log(true, config.LvlErr, msg)
+	panic(msg)
+}
+func (l *BinlogSyncerLogger) Panicf(f string, args ...interface{}) {
+	msg := fmt.Sprintf(f, args...)
+	l.log(true, config.LvlErr, msg)
+	panic(msg)
+}
+func (l *BinlogSyncerLogger) Panicln(args ...interface{}) {
+	msg := fmt.Sprintln(args...)
+	l.log(true, config.LvlErr, msg)
+	panic(msg)
+}

--- a/utils/s18log/binlog_syncer_logger.go
+++ b/utils/s18log/binlog_syncer_logger.go
@@ -23,19 +23,23 @@ type ModulePrintf interface {
 //
 // go-mysql's default logger writes every connection lifecycle event
 // ("create BinlogSyncer with config ...", "rotate to ...", "syncer is
-// closing...") to stdout at Info level, unconditionally. Since
-// replication-manager opens a syncer per monitoring tick (binlog metadata
-// refresh, timestamp lookup, query-event scan), this floods the logs with
-// routine noise.
+// closing...") to stdout at Info level, unconditionally. replication-manager
+// opens one of these syncers for binlog metadata refresh on every monitoring
+// tick, plus query-event scanning each tick when MonitorBinlogEvents is
+// enabled, plus timestamp lookups during PITR binlog replay — frequent
+// enough in the common case that this floods the logs with routine noise.
 //
 // All call sites use config.ConstLogModPurge, so every level is mapped
 // (never dropped) and gated purely by the existing log-binlog-purge /
 // log-level-binlog-purge knobs — the same knobs that already control the
-// rest of the binlog purge logging. Raising log-level-binlog-purge to
-// INFO/DEBUG re-enables the routine chatter for troubleshooting without any
-// new config. This intentionally does NOT honor cluster.Conf.Verbose as a
-// force-print override (the repo-wide convention elsewhere): verbose mode
-// would otherwise make this logger impossible to fully suppress.
+// rest of the binlog purge logging. Upstream Info is deliberately downgraded
+// to DEBUG here (see the Info* methods below) since it is otherwise the
+// dominant source of noise; Warn/Error/Fatal/Panic keep their original
+// severity. Raising log-level-binlog-purge to DEBUG re-enables the routine
+// chatter for troubleshooting without any new config. This intentionally
+// does NOT honor cluster.Conf.Verbose as a force-print override (the
+// repo-wide convention elsewhere): verbose mode would otherwise make this
+// logger impossible to fully suppress.
 //
 // Fatal/Panic are the one deliberate exception: they are always force-logged
 // regardless of the module gate. NewBinlogSyncer calls Logger.Fatal (then
@@ -73,14 +77,22 @@ func (l *BinlogSyncerLogger) Debugln(args ...interface{}) {
 	l.log(false, config.LvlDbg, fmt.Sprintln(args...))
 }
 
+// Info* is downgraded to DEBUG here: go-mysql logs routine connection
+// lifecycle events (create/open/close, rotate, kill last connection) at Info
+// unconditionally, and replication-manager opens a syncer per monitoring
+// tick, so passing these through at Info would flood the logs. Raise
+// log-level-binlog-purge to DEBUG to see them again. This does not affect
+// replication-manager's own binlog-purge Info logs (e.g. "Refreshed oldest
+// timestamp..."), which are logged directly via cluster.LogModulePrintf, not
+// through this adapter.
 func (l *BinlogSyncerLogger) Info(args ...interface{}) {
-	l.log(false, config.LvlInfo, fmt.Sprint(args...))
+	l.log(false, config.LvlDbg, fmt.Sprint(args...))
 }
 func (l *BinlogSyncerLogger) Infof(f string, args ...interface{}) {
-	l.log(false, config.LvlInfo, fmt.Sprintf(f, args...))
+	l.log(false, config.LvlDbg, fmt.Sprintf(f, args...))
 }
 func (l *BinlogSyncerLogger) Infoln(args ...interface{}) {
-	l.log(false, config.LvlInfo, fmt.Sprintln(args...))
+	l.log(false, config.LvlDbg, fmt.Sprintln(args...))
 }
 
 // Print* is never actually called by go-mysql's BinlogSyncer; mapped to

--- a/utils/s18log/binlog_syncer_logger.go
+++ b/utils/s18log/binlog_syncer_logger.go
@@ -6,7 +6,6 @@ package s18log
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/signal18/replication-manager/config"
 )
@@ -42,10 +41,13 @@ type ModulePrintf interface {
 // logger impossible to fully suppress.
 //
 // Fatal/Panic are the one deliberate exception: they are always force-logged
-// regardless of the module gate. NewBinlogSyncer calls Logger.Fatal (then
-// os.Exit(1)) when ServerID==0, and nothing else in the monitoring loop
-// captures that failure — silently dropping the line would turn a
-// misconfiguration into an unexplained process exit.
+// regardless of the module gate. NewBinlogSyncer calls Logger.Fatal when
+// ServerID==0, and nothing else in the monitoring loop captures that failure
+// — silently dropping the line would turn a misconfiguration into an
+// unexplained process exit. Fatal* panics with the FatalError sentinel below
+// instead of calling os.Exit(1), so a recover()-based wrapper around the
+// syncer constructor (cluster.newSafeBinlogSyncer) can turn it into an
+// ordinary error instead of killing the whole replication-manager process.
 type BinlogSyncerLogger struct {
 	printer   ModulePrintf
 	serverURL string
@@ -128,19 +130,52 @@ func (l *BinlogSyncerLogger) Errorln(args ...interface{}) {
 	l.log(false, config.LvlErr, fmt.Sprintln(args...))
 }
 
-// Fatal* mirrors go-log's default logger (log as error, then os.Exit(1)).
-// Always force-logged — see the type doc comment for why.
+// FatalError is the panic value used by Fatal*/Fatalf/Fatalln in place of
+// os.Exit(1). go-mysql's replication.NewBinlogSyncer calls Logger.Fatal(...)
+// when its ServerID is 0, with no way to recover short of intercepting the
+// panic.
+//
+// Recovery policy: cluster.newSafeBinlogSyncer is the sole, narrow boundary
+// that recovers this. It deliberately recovers ALL panics raised during
+// construction, not just *FatalError — a single misconfigured or unexpected
+// binlog syncer must never be allowed to exit the process or take down other
+// monitored clusters, so the boundary fails safe regardless of the panic's
+// type. *FatalError is distinguished from other panics only to produce a
+// clearer wrapped error message; both are contained the same way.
+type FatalError struct {
+	msg string
+}
+
+func (e *FatalError) Error() string { return e.msg }
+
+// Recovered force-logs msg at Error level, unconditionally (like Fatal/Panic
+// — see the type doc comment for why). It is meant to be called by a
+// recover()-based wrapper (cluster.newSafeBinlogSyncer) right after it
+// catches a panic raised during construction, so the recovery itself is
+// always high-visibility — independent of whatever level a caller further
+// up the stack chooses to log its returned error at.
+func (l *BinlogSyncerLogger) Recovered(msg string) {
+	l.log(true, config.LvlErr, msg)
+}
+
+// Fatal* mirrors go-log's default logger in that it always logs as error
+// first, but panics with FatalError instead of calling os.Exit(1) — see the
+// FatalError doc comment for why. Always force-logged — see the type doc
+// comment for why.
 func (l *BinlogSyncerLogger) Fatal(args ...interface{}) {
-	l.log(true, config.LvlErr, fmt.Sprint(args...))
-	os.Exit(1)
+	msg := fmt.Sprint(args...)
+	l.log(true, config.LvlErr, msg)
+	panic(&FatalError{msg: msg})
 }
 func (l *BinlogSyncerLogger) Fatalf(f string, args ...interface{}) {
-	l.log(true, config.LvlErr, fmt.Sprintf(f, args...))
-	os.Exit(1)
+	msg := fmt.Sprintf(f, args...)
+	l.log(true, config.LvlErr, msg)
+	panic(&FatalError{msg: msg})
 }
 func (l *BinlogSyncerLogger) Fatalln(args ...interface{}) {
-	l.log(true, config.LvlErr, fmt.Sprintln(args...))
-	os.Exit(1)
+	msg := fmt.Sprintln(args...)
+	l.log(true, config.LvlErr, msg)
+	panic(&FatalError{msg: msg})
 }
 
 // Panic* mirrors go-log's default logger (log as error, then panic). Always

--- a/utils/s18log/binlog_syncer_logger_test.go
+++ b/utils/s18log/binlog_syncer_logger_test.go
@@ -1,0 +1,63 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+
+package s18log
+
+import (
+	"strings"
+	"testing"
+)
+
+type recordingPrinter struct {
+	forcedLevels []string
+}
+
+func (p *recordingPrinter) LogModulePrintf(forcingLog bool, module int, level string, format string, args ...interface{}) int {
+	if forcingLog {
+		p.forcedLevels = append(p.forcedLevels, level)
+	}
+	return 0
+}
+
+// TestBinlogSyncerLogger_FatalPanicsWithFatalErrorSentinel guards against a
+// regression back to os.Exit(1): go-mysql's NewBinlogSyncer calls
+// Logger.Fatal on ServerID==0, and cluster.newSafeBinlogSyncer depends on
+// Fatal* panicking with *FatalError (recoverable) rather than exiting the
+// process (unrecoverable) so one bad binlog syncer can't kill the daemon.
+func TestBinlogSyncerLogger_FatalPanicsWithFatalErrorSentinel(t *testing.T) {
+	cases := []struct {
+		name string
+		call func(l *BinlogSyncerLogger)
+	}{
+		{"Fatal", func(l *BinlogSyncerLogger) { l.Fatal("boom") }},
+		{"Fatalf", func(l *BinlogSyncerLogger) { l.Fatalf("boom %d", 1) }},
+		{"Fatalln", func(l *BinlogSyncerLogger) { l.Fatalln("boom") }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &recordingPrinter{}
+			l := NewBinlogSyncerLogger(p, "127.0.0.1:3306", "test", 0)
+
+			defer func() {
+				r := recover()
+				if r == nil {
+					t.Fatal("expected Fatal* to panic instead of calling os.Exit(1)")
+				}
+				fe, ok := r.(*FatalError)
+				if !ok {
+					t.Fatalf("expected panic value of type *FatalError, got %T: %v", r, r)
+				}
+				if !strings.Contains(fe.Error(), "boom") {
+					t.Fatalf("expected FatalError message to contain original message, got %q", fe.Error())
+				}
+				if len(p.forcedLevels) == 0 {
+					t.Fatal("expected Fatal* to force-log before panicking")
+				}
+			}()
+
+			tc.call(l)
+		})
+	}
+}


### PR DESCRIPTION
This PR hardens replication-managers go-mysql binlog syncer integration in two ways:

- routes `replication.BinlogSyncer` logging through `s18log.BinlogSyncerLogger` under `ConstLogModPurge`, downgrading noisy lifecycle Info logs to DEBUG while preserving Warn/Error visibility
- validates computed binlog syncer server IDs before construction and reports invalid `check-binlog-server-id` values once at cluster startup
- contains `go-mysql` constructor failures per cluster by converting the loggers `Fatal*` path into a recoverable failure, wrapping `replication.NewBinlogSyncer(...)` in a safe constructor, and loudly logging recovered panics instead of exiting the whole process
- keeps PITR/binlog replay safe by propagating `GetBinlogPositionFromTimestamp` failures instead of continuing with an unset stop position
- adds regression tests for the logger adapter, safe constructor recovery, and enforcement that cluster code only constructs binlog syncers through the wrapper

This ensures one clusters bad binlog syncer path cannot take down replication-manager or other monitored clusters while still leaving strong visibility for binlog-related failures.