### PR TITLE
Fix active-passive topology detection and handling

### DIFF
--- a/cluster/cluster_has.go
+++ b/cluster/cluster_has.go
@@ -30,6 +30,10 @@ func (cluster *Cluster) HasServer(srv *ServerMonitor) bool {
 	return false
 }
 
+func (cluster *Cluster) HasConfigTopoActivePassive() bool {
+	return cluster.Conf.ActivePassive || cluster.Conf.TopologyTarget == config.TopoActivePassive
+}
+
 func (cluster *Cluster) HasValidBackup() bool {
 	logical := false
 	physical := false

--- a/cluster/cluster_has.go
+++ b/cluster/cluster_has.go
@@ -34,6 +34,14 @@ func (cluster *Cluster) HasConfigTopoActivePassive() bool {
 	return cluster.Conf.ActivePassive || cluster.Conf.TopologyTarget == config.TopoActivePassive
 }
 
+// IsProxyRoutingFrozen returns true when the cluster runs an active-passive
+// topology, in which case proxies must only monitor backend state and must
+// never receive commands that change routing (master/reader assignment,
+// drain/ready, maintenance, backend state change or failover).
+func (cluster *Cluster) IsProxyRoutingFrozen() bool {
+	return cluster.GetTopology() == config.TopoActivePassive
+}
+
 func (cluster *Cluster) HasValidBackup() bool {
 	logical := false
 	physical := false

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -181,6 +181,27 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 		return nil
 	}
 
+	if cluster.master == nil && cluster.HasConfigTopoActivePassive() {
+		prefMaster := cluster.getOnePreferedMaster()
+		if prefMaster != nil {
+			cluster.master = prefMaster
+		} else {
+			for _, sv := range cluster.Servers {
+				if sv == nil {
+					continue
+				}
+
+				if sv.IsRunning() {
+					cluster.master = sv
+				}
+			}
+		}
+
+		if cluster.master != nil {
+			cluster.master.SetMaster()
+		}
+	}
+
 	// Check topology Cluster is down
 	cluster.TopologyClusterDown()
 	cluster.CheckSameServerID()

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -183,7 +183,7 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 
 	if cluster.GetMaster() == nil && cluster.HasConfigTopoActivePassive() {
 		prefMaster := cluster.getOnePreferedMaster()
-		if prefMaster != nil {
+		if prefMaster != nil && !prefMaster.IsSlave {
 			cluster.vmaster = prefMaster
 		} else {
 			for _, sv := range cluster.Servers {

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -184,7 +184,7 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 	if cluster.master == nil && cluster.HasConfigTopoActivePassive() {
 		prefMaster := cluster.getOnePreferedMaster()
 		if prefMaster != nil {
-			cluster.master = prefMaster
+			cluster.vmaster = prefMaster
 		} else {
 			for _, sv := range cluster.Servers {
 				if sv == nil {
@@ -192,13 +192,13 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 				}
 
 				if sv.IsRunning() {
-					cluster.master = sv
+					cluster.vmaster = sv
 				}
 			}
 		}
 
-		if cluster.master != nil {
-			cluster.master.SetMaster()
+		if cluster.vmaster != nil {
+			cluster.vmaster.SetMaster()
 		}
 	}
 

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -171,14 +171,12 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 	// Check topology Cluster all servers down
 	cluster.IsDown = cluster.AllServersFailed()
 
-	// if only one server
-	if len(cluster.Servers) == 1 || cluster.Conf.ActivePassive {
+	// if only one server auto set runtime topology to topology-active-passive
+	if len(cluster.Servers) == 1 {
 		cluster.Topology = config.TopoActivePassive
-
-		if len(cluster.Servers) == 1 {
-			for _, sv := range cluster.Servers {
-				cluster.master = sv
-			}
+		if cluster.master == nil && cluster.Servers[0] != nil {
+			cluster.master = cluster.Servers[0]
+			cluster.master.SetMaster()
 		}
 		return nil
 	}
@@ -344,7 +342,7 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 	}
 
 	// If no relay and master-slave is preferred
-	if !hasRelay && !hasCycling {
+	if !hasRelay && !hasCycling && !cluster.HasConfigTopoActivePassive() {
 		cluster.Topology = config.TopoMasterSlave
 	}
 
@@ -501,7 +499,7 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 
 	// Remove master or vmaster read only if not in maintenance
 	mst := cluster.GetMaster()
-	if cluster.IsDiscovered() && mst != nil && mst.IsReadOnly() && !mst.IsMaintenance && cluster.Topology != config.TopoMasterSlave {
+	if cluster.IsDiscovered() && mst != nil && mst.IsReadOnly() && !mst.IsMaintenance && cluster.Topology != config.TopoMasterSlave && !cluster.HasConfigTopoActivePassive() {
 		mst.SetReadWrite()
 	}
 

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -191,7 +191,7 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 					continue
 				}
 
-				if sv.IsRunning() {
+				if sv.IsRunning() && !sv.IsSlave {
 					cluster.vmaster = sv
 				}
 			}

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -181,7 +181,11 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 		return nil
 	}
 
-	if cluster.GetMaster() == nil && cluster.HasConfigTopoActivePassive() {
+	// Wait for at least one full monitoring pass so every server's IsSlave
+	// reflects a real Refresh() rather than its zero-value default, otherwise
+	// a preferred master that is actually a slave but hasn't been refreshed
+	// yet can be mistakenly elected as vmaster on the very first tick.
+	if !cluster.runOnceAfterTopology && cluster.GetMaster() == nil && cluster.HasConfigTopoActivePassive() {
 		prefMaster := cluster.getOnePreferedMaster()
 		if prefMaster != nil && !prefMaster.IsSlave {
 			cluster.vmaster = prefMaster

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -174,14 +174,14 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 	// if only one server auto set runtime topology to topology-active-passive
 	if len(cluster.Servers) == 1 {
 		cluster.Topology = config.TopoActivePassive
-		if cluster.master == nil && cluster.Servers[0] != nil {
+		if cluster.GetMaster() == nil && cluster.Servers[0] != nil {
 			cluster.master = cluster.Servers[0]
 			cluster.master.SetMaster()
 		}
 		return nil
 	}
 
-	if cluster.master == nil && cluster.HasConfigTopoActivePassive() {
+	if cluster.GetMaster() == nil && cluster.HasConfigTopoActivePassive() {
 		prefMaster := cluster.getOnePreferedMaster()
 		if prefMaster != nil {
 			cluster.vmaster = prefMaster

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -198,7 +198,8 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 		}
 
 		if cluster.vmaster != nil {
-			cluster.vmaster.SetMaster()
+			cluster.master = cluster.vmaster
+			cluster.master.SetMaster()
 		}
 	}
 

--- a/cluster/prx.go
+++ b/cluster/prx.go
@@ -371,6 +371,10 @@ func (cluster *Cluster) IsProxyEqualMaster() bool {
 }
 
 func (cluster *Cluster) SetProxyServerMaintenance(serverid uint64) {
+	if cluster.IsProxyRoutingFrozen() {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "Active-passive topology: skip proxy maintenance notification")
+		return
+	}
 	// Found server from ServerId
 	server := cluster.GetServerFromId(serverid)
 	for _, pr := range cluster.Proxies {
@@ -381,6 +385,10 @@ func (cluster *Cluster) SetProxyServerMaintenance(serverid uint64) {
 
 // called  by server monitor if state change
 func (cluster *Cluster) backendStateChangeProxies() {
+	if cluster.IsProxyRoutingFrozen() {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "Active-passive topology: skip proxy backend state change")
+		return
+	}
 	for _, pr := range cluster.Proxies {
 		//	pr.SetLock()
 		pr.BackendsStateChange()
@@ -437,6 +445,10 @@ func (cluster *Cluster) refreshProxies(wcg *sync.WaitGroup) {
 }
 
 func (cluster *Cluster) failoverProxies() {
+	if cluster.IsProxyRoutingFrozen() {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlDbg, "Active-passive topology: skip proxy failover notification")
+		return
+	}
 	for _, pr := range cluster.Proxies {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxy, config.LvlInfo, "Failover Proxy Type: %s Host: %s Port: %s", pr.GetType(), pr.GetHost(), pr.GetPort())
 		pr.Failover()

--- a/cluster/prx_haproxy.go
+++ b/cluster/prx_haproxy.go
@@ -180,6 +180,8 @@ func (proxy *HaproxyProxy) Init() {
 
 func (proxy *HaproxyProxy) Refresh() error {
 	cluster := proxy.ClusterGroup
+	// Active-passive topology: only collect backend status, never push routing changes.
+	frozen := cluster.IsProxyRoutingFrozen()
 	stagingsrv := cluster.StagingServer
 	if stagingsrv == nil {
 		stagingsrv = cluster.SetStandaloneAsStaging()
@@ -341,28 +343,30 @@ func (proxy *HaproxyProxy) Refresh() error {
 					foundMasterInStat = true
 					proxy.BackendsWrite = append(proxy.BackendsWrite, bkw)
 
-					if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
-						if !srv.IsStandAlone() {
-							if stagingsrv != nil {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "[Staging] Detecting wrong master server in haproxy %s fixing it to standalone %s %s", proxy.Host+":"+proxy.Port, stagingsrv.Host, stagingsrv.Port)
-								msg, err := haRuntime.SetMaster(cluster.Conf.HaproxyStagingBackend, stagingsrv.Host, stagingsrv.Port)
-								if err != nil {
-									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
-								} else {
-									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
+					if !frozen {
+						if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
+							if !srv.IsStandAlone() {
+								if stagingsrv != nil {
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "[Staging] Detecting wrong master server in haproxy %s fixing it to standalone %s %s", proxy.Host+":"+proxy.Port, stagingsrv.Host, stagingsrv.Port)
+									msg, err := haRuntime.SetMaster(cluster.Conf.HaproxyStagingBackend, stagingsrv.Host, stagingsrv.Port)
+									if err != nil {
+										cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
+									} else {
+										cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "%s: %s (staging: %s)", proxy.Host+":"+proxy.Port, msg, stagingsrv.Host+":"+stagingsrv.Port)
+									}
 								}
 							}
-						}
-					} else {
-						if !srv.IsMaster() {
-							master := cluster.GetMaster()
-							if master != nil {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "Detecting wrong master server in haproxy %s fixing it to master %s %s", proxy.Host+":"+proxy.Port, master.Host, master.Port)
-								msg, err := haRuntime.SetMaster(cluster.Conf.HaproxyAPIWriteBackend, master.Host, master.Port)
-								if err != nil {
-									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
-								} else {
-									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
+						} else {
+							if !srv.IsMaster() {
+								master := cluster.GetMaster()
+								if master != nil {
+									cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "Detecting wrong master server in haproxy %s fixing it to master %s %s", proxy.Host+":"+proxy.Port, master.Host, master.Port)
+									msg, err := haRuntime.SetMaster(cluster.Conf.HaproxyAPIWriteBackend, master.Host, master.Port)
+									if err != nil {
+										cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlErr, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
+									} else {
+										cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlDbg, "%s: %s (master: %s)", proxy.Host+":"+proxy.Port, msg, master.Host+":"+master.Port)
+									}
 								}
 							}
 						}
@@ -410,7 +414,13 @@ func (proxy *HaproxyProxy) Refresh() error {
 
 				proxy.BackendsRead = append(proxy.BackendsRead, bkr)
 
-				if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
+				if frozen {
+					if srv.IsMaster() {
+						masterReadFound = true
+						masterReadSvname = bkr.Svname
+						masterReadStatus = line[17]
+					}
+				} else if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
 					if stagingsrv != nil {
 						if srv.Id == stagingsrv.Id { // Only activate staging server for read
 							if line[17] == "DRAIN" {
@@ -462,26 +472,28 @@ func (proxy *HaproxyProxy) Refresh() error {
 					}
 				}
 
-				if srv.IsMaintenance && line[17] == "UP" {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy detecting server %s in maintenance but proxy %s reports UP  ", srv.URL, proxy.Host+":"+proxy.Port)
-					proxy.SetMaintenance(srv)
-					proxy.setLastReadBackendStatus("MAINT")
-					if srv.IsMaster() {
-						masterReadStatus = "MAINT"
+				if !frozen {
+					if srv.IsMaintenance && line[17] == "UP" {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy detecting server %s in maintenance but proxy %s reports UP  ", srv.URL, proxy.Host+":"+proxy.Port)
+						proxy.SetMaintenance(srv)
+						proxy.setLastReadBackendStatus("MAINT")
+						if srv.IsMaster() {
+							masterReadStatus = "MAINT"
+						}
 					}
-				}
-				if !srv.IsMaintenance && line[17] == "MAINT" {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy detecting server %s UP but proxy %s reports in maintenance ", srv.URL, proxy.Host+":"+proxy.Port)
-					proxy.SetMaintenance(srv)
-					proxy.setLastReadBackendStatus("UP")
-					if srv.IsMaster() {
-						masterReadStatus = "UP"
+					if !srv.IsMaintenance && line[17] == "MAINT" {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy detecting server %s UP but proxy %s reports in maintenance ", srv.URL, proxy.Host+":"+proxy.Port)
+						proxy.SetMaintenance(srv)
+						proxy.setLastReadBackendStatus("UP")
+						if srv.IsMaster() {
+							masterReadStatus = "UP"
+						}
 					}
 				}
 			}
 		}
 	}
-	if masterReadFound {
+	if masterReadFound && !frozen {
 		shouldRead := proxy.masterShouldBeReader()
 		if !shouldRead && masterReadStatus == "UP" {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "HAProxy master is not configured as reader but state is UP in haproxy %s", proxy.Host+":"+proxy.Port)
@@ -504,7 +516,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 	}
 	if !foundMasterInStat {
 		if cluster.Conf.TopologyStaging && proxy.IsInStaging() {
-			if stagingsrv != nil {
+			if !frozen && stagingsrv != nil {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModHAProxy, config.LvlInfo, "[Staging] HAProxy has standalone in cluster but not in haproxy %s fixing it to standalone %s %s", proxy.Host+":"+proxy.Port, stagingsrv.Host, stagingsrv.Port)
 				msg, err := haRuntime.SetMaster(cluster.Conf.HaproxyStagingBackend, stagingsrv.Host, stagingsrv.Port)
 				if err != nil {
@@ -514,6 +526,11 @@ func (proxy *HaproxyProxy) Refresh() error {
 				}
 			}
 		} else {
+			// Not gated by frozen: this only ever fires while the write backend has
+			// literally no server row at all (fresh Init()). It establishes the
+			// active-passive baseline once; afterwards foundMasterInStat is always
+			// true (HAProxy keeps listing the row regardless of up/down/maint), so
+			// this can't become an ongoing routing correction.
 			master := cluster.GetMaster()
 			if master != nil && master.IsLeader() {
 				res, err := haRuntime.SetMaster(cluster.Conf.HaproxyAPIWriteBackend, master.Host, master.Port)

--- a/cluster/prx_proxysql.go
+++ b/cluster/prx_proxysql.go
@@ -296,6 +296,8 @@ func (proxy *ProxySQLProxy) Refresh() error {
 	if !cluster.Conf.ProxysqlOn {
 		return nil
 	}
+	// Active-passive topology: only collect backend status, never push routing changes.
+	frozen := cluster.IsProxyRoutingFrozen()
 
 	psql, err := proxy.Connect()
 	if err != nil {
@@ -362,7 +364,27 @@ func (proxy *ProxySQLProxy) Refresh() error {
 			IsBackendReader = false
 		}
 
-		if cluster.Conf.TopologyStaging && proxy.IsStaging {
+		if frozen && cluster.Conf.ProxysqlBootstrap && cluster.IsDiscovered() && s.IsLeader() && len(proxy.BackendsWrite) == 0 {
+			// Active-passive: establish the initial writer once, even though the
+			// ongoing corrective routing changes below stay frozen. This only
+			// fires while no writer at all is configured yet (proxy.BackendsWrite
+			// is the previous refresh's snapshot), so it can't turn into a
+			// routing correction once a writer exists.
+			if psql.ExistAsWriterOrOffline(misc.Unbracket(s.Host), s.Port) {
+				err = psql.SetOnline(misc.Unbracket(s.Host), s.Port)
+				if err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlErr, "Monitor ProxySQL setting online failed server %s: %s", s.URL, err.Error())
+				}
+			} else {
+				err = psql.AddServerAsWriter(misc.Unbracket(s.Host), s.Port, proxy.UseSSL())
+				if err != nil {
+					cluster.SetState("ERR00071", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00071"], proxy.Name, s.URL), ErrFrom: "PRX", ServerUrl: proxy.Name})
+				}
+			}
+			updated = true
+		}
+
+		if !frozen && cluster.Conf.TopologyStaging && proxy.IsStaging {
 			if cluster.IsDiscovered() {
 				if s == stagingsrv {
 					psql.SetMonitorIsAlsoWriter(true)
@@ -427,7 +449,7 @@ func (proxy *ProxySQLProxy) Refresh() error {
 					}
 				}
 			}
-		} else if cluster.Conf.ProxysqlBootstrap && cluster.IsDiscovered() { // nothing should be done if no bootstrap
+		} else if !frozen && cluster.Conf.ProxysqlBootstrap && cluster.IsDiscovered() { // nothing should be done if no bootstrap
 			// if ProxySQL and replication-manager states differ, resolve the conflict
 			if bke.PrxStatus == "OFFLINE_HARD" && s.State == stateSlave && !s.IsIgnored() {
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModProxySQL, config.LvlDbg, "Monitor ProxySQL setting online as reader rejoining server %s", s.URL)

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -230,7 +230,7 @@ type ServerMonitor struct {
 	IsRefreshingBinlog          bool
 	IsRefreshingBinlogMeta      bool
 	IsLoadingJobList            bool
-	jobsAPIHousekeepingDone     bool                        // true after schema ensured + jobs table dropped in API mode
+	jobsAPIHousekeepingDone     bool // true after schema ensured + jobs table dropped in API mode
 	NeedRefreshJobs             bool
 	lastJobsRefreshAttempt      time.Time
 	PointInTimeMeta             backupmgr.PointInTimeMeta
@@ -705,13 +705,7 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 
 			server.SetConfigRefreshCookie() // set cookie to refresh config
 
-			if cluster.Topology == config.TopoActivePassive {
-				if cluster.GetMaster() == nil {
-					server.SetMaster()
-				} else if cluster.GetMaster().Id != server.Id {
-					server.SetState(stateUnconn)
-				}
-			} else if cluster.GetTopology() != config.TopoMultiMasterWsrep || cluster.GetTopology() != config.TopoMultiMasterGrouprep {
+			if cluster.GetTopology() != config.TopoMultiMasterWsrep || cluster.GetTopology() != config.TopoMultiMasterGrouprep {
 				if server.IsGroupReplicationSlave {
 					server.SetState(stateSlave)
 				} else {
@@ -723,7 +717,7 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 			server.SendAlert()
 
 			// if autorejoin is set
-			if cluster.Conf.Autorejoin && cluster.IsActive() {
+			if cluster.Conf.Autorejoin && cluster.IsActive() && cluster.GetTopology() != config.TopoActivePassive {
 				// rejoin if not staging server
 				if isStagingServer {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Preventing auto rejoin on staging server %s", server.URL)
@@ -765,7 +759,7 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 		} else if server.GetCluster().GetTopology() == config.TopoActivePassive {
 			if server.PrevState == stateSuspect || (server.PrevState == stateMaintenance && !server.IsMaintenance) {
 				//if active-passive topo and no replication, put the state at standalone
-				if cluster.GetMaster() == nil || cluster.GetMaster().Id == server.Id {
+				if cluster.GetMaster() != nil && cluster.GetMaster().Id == server.Id {
 					server.SetState(stateMaster)
 				} else {
 					server.SetState(stateUnconn)

--- a/cluster/srv_chk.go
+++ b/cluster/srv_chk.go
@@ -224,11 +224,6 @@ func (server *ServerMonitor) CheckReplication() string {
 		}
 	}
 
-	//Prevent maintenance label for topology active passive
-	if cluster.Topology == config.TopoActivePassive {
-		return "Master OK"
-	}
-
 	if server.IsMaintenance {
 		server.SetState(stateMaintenance)
 		return "Maintenance"

--- a/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react'
 import Card from '../../../components/Card'
-import { Box, Flex, Text, Wrap } from '@chakra-ui/react'
+import { Box, Flex, Text, Tooltip, Wrap, Icon } from '@chakra-ui/react'
 import TagPill from '../../../components/TagPill'
+import { FaSnowflake } from 'react-icons/fa'
 import { useDispatch, useSelector } from 'react-redux'
 import TableType2 from '../../../components/TableType2'
 import ConfirmModal from '../../../components/Modals/ConfirmModal'
@@ -508,6 +509,13 @@ function ClusterDetail({ selectedCluster, user, readOnly = false, onOpenSettings
               ) : selectedCluster?.activePassiveStatus === 'S' ? (
                 <TagPill colorScheme='orange' text={'Standby'} isBlinking={true} />
               ) : null}
+              {selectedCluster?.topology === 'active-passive' && (
+                <Tooltip label='Active-passive topology: proxies are only monitored, replication-manager will never send routing changes to them'>
+                  <span>
+                    <Icon as={FaSnowflake} color='cyan.400' boxSize={4} verticalAlign='middle' />
+                  </span>
+                </Tooltip>
+              )}
               {selectedCluster?.config?.arbitrationExternal && (
                 <TagPill
                   colorScheme={selectedCluster?.isFailedArbitrator ? 'red' : 'green'}

--- a/share/dashboard_react/src/Pages/Dashboard/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/index.jsx
@@ -3,7 +3,7 @@ import ClusterDetail from './components/ClusterDetail'
 import HADetail from './components/HADetail/index.jsx'
 import { useSelector } from 'react-redux'
 import ClusterWorkload from './components/ClusterWorkload'
-import { Flex, HStack, Tooltip, Box, Text } from '@chakra-ui/react'
+import { Flex, HStack, Tooltip, Box, Text, Icon } from '@chakra-ui/react'
 import AccordionComponent from '../../components/AccordionComponent/index.jsx'
 import { GeneralLogs, TaskLogs, SecurityLogs, WorkloadLogs, DDLLogs, VariableChangeLogs } from './components/Logs'
 import DBServers from './components/DBServers'
@@ -11,6 +11,25 @@ import Proxies from './components/Proxies'
 import Apps from './components/Apps/index.jsx'
 import RMIconButton from '../../components/RMIconButton'
 import { HiCog } from 'react-icons/hi'
+import { FaSnowflake } from 'react-icons/fa'
+// Accordion heading for Proxies with a snowflake badge when active-passive freezes routing changes
+function ProxiesHeading({ isRoutingFrozen }) {
+  return (
+    <HStack spacing={2}>
+      <Text as='span'>Proxies</Text>
+      {isRoutingFrozen && (
+        <Tooltip
+          label='Active-passive topology: proxies are only monitored, replication-manager will never send routing changes to them'
+          placement='right'
+          hasArrow>
+          <span>
+            <Icon as={FaSnowflake} color='cyan.400' boxSize={4} verticalAlign='middle' />
+          </span>
+        </Tooltip>
+      )}
+    </HStack>
+  )
+}
 // Accordion heading with a "?" tooltip explaining log content
 function LogHeading({ title, description }) {
   return (
@@ -74,7 +93,7 @@ function Dashboard({ selectedCluster, user, openSettings = {} }) {
 
       {selectedCluster && (
         <AccordionComponent
-          heading={'Proxies'}
+          heading={<ProxiesHeading isRoutingFrozen={selectedCluster?.topology === 'active-passive'} />}
           panelSX={{ overflowX: 'auto', p: 0 }}
           headerActions={gearButton(openSettings.proxies, 'Proxy Settings')}
           body={<Proxies selectedCluster={selectedCluster} user={user} />}

--- a/share/dashboard_react/src/components/ServerStatus.jsx
+++ b/share/dashboard_react/src/components/ServerStatus.jsx
@@ -1,75 +1,40 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import TagPill from './TagPill'
 
+function getStatus(state) {
+  switch (state) {
+    case 'SlaveErr':
+      return { stateValue: 'SLAVE_ERROR', colorScheme: 'orange' }
+    case 'SlaveLate':
+      return { stateValue: 'SLAVE_LATE', colorScheme: 'yellow' }
+    case 'RelayErr':
+      return { stateValue: 'RELAY_ERROR', colorScheme: 'orange' }
+    case 'RelayLate':
+      return { stateValue: 'RELAY_LATE', colorScheme: 'yellow' }
+    case 'StandAlone':
+      return { stateValue: 'STANDALONE', colorScheme: 'gray' }
+    case 'Master':
+      return { stateValue: state.toUpperCase(), colorScheme: 'blue' }
+    case 'Slave':
+      return { stateValue: state.toUpperCase(), colorScheme: 'gray' }
+    case 'Relay':
+      return { stateValue: state.toUpperCase(), colorScheme: 'gray' }
+    case 'Suspect':
+      return { stateValue: state.toUpperCase(), colorScheme: 'orange' }
+    case 'Failed':
+      return { stateValue: state.toUpperCase(), colorScheme: 'red' }
+    case 'AppRunning':
+      return { stateValue: state.toUpperCase(), colorScheme: 'blue' }
+    case 'AppWarning':
+      return { stateValue: state.toUpperCase(), colorScheme: 'orange' }
+    default:
+      return { stateValue: state.toUpperCase(), colorScheme: 'gray' }
+  }
+}
+
 function ServerStatus({ state, isVirtualMaster, isBlinking = false }) {
-  const [isVirtual, setIsVirtual] = useState('')
-  const [colorScheme, setColorScheme] = useState('gray')
-  const [stateValue, setStateValue] = useState(state ? state.toUpperCase() : '')
-
-  useEffect(() => {
-    if (state) {
-      setStateValue(state.toUpperCase())
-      switch (state) {
-        case 'SlaveErr':
-          setStateValue('SLAVE_ERROR')
-          setColorScheme('orange')
-          break
-        case 'SlaveLate':
-          setStateValue('SLAVE_LATE')
-          setColorScheme('yellow')
-          break
-        case 'RelayErr':
-          setStateValue('RELAY_ERROR')
-          setColorScheme('orange')
-          break
-        case 'RelayLate':
-          setStateValue('RELAY_LATE')
-          setColorScheme('yellow')
-          break
-        case 'StandAlone':
-          setStateValue('STANDALONE')
-          setColorScheme('gray')
-          break
-        case 'Master':
-          setColorScheme('blue')
-          break
-        case 'Slave':
-          setColorScheme('gray')
-          break
-        case 'Relay':
-          setColorScheme('gray')
-          break
-        case 'Suspect':
-          setColorScheme('orange')
-          break
-        case 'Failed':
-          setColorScheme('red')
-          break
-        case 'AppRunning':
-          setColorScheme('blue')
-          break
-        case 'AppWarning':
-          setColorScheme('orange')
-          break
-        default:
-          setStateValue(state.toUpperCase())
-          setColorScheme('gray')
-          break
-      }
-    }
-
-    if (isVirtualMaster) {
-      setIsVirtual('-VMaster')
-    } else {
-      setIsVirtual('')
-    }
-
-    return () => {
-      setColorScheme('gray')
-      setStateValue('')
-      setIsVirtual('')
-    }
-  }, [state, isVirtualMaster])
+  const { stateValue, colorScheme } = state ? getStatus(state) : { stateValue: '', colorScheme: 'gray' }
+  const isVirtual = isVirtualMaster ? '-VMaster' : ''
 
   return (
     <TagPill


### PR DESCRIPTION
- Add HasConfigTopoActivePassive() helper to detect active-passive from config
- Only auto-set active-passive topology for single-node clusters, not from config flag
- Avoid overriding active-passive with master-slave topology when configured
- Prevent read-only removal and auto-rejoin in active-passive mode
- Simplify master state logic in Ping() and remove active-passive bypass in CheckReplication()
