### PR TITLE
Improve active-passive topology detection and ServerStatus rendering

### DIFF
--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -1004,6 +1004,19 @@ func (cluster *Cluster) GetAppServerIdList() []string {
 
 func (cluster *Cluster) GetTopologyFromConf() string {
 
+	// An explicitly declared topology-target is authoritative: trust it directly
+	// rather than re-deriving it from the legacy per-topology booleans below, so
+	// that a target set only via config/API (without also setting the matching
+	// legacy bool) is not silently overwritten on every InitFromConf() call.
+	// An unset or default "master-slave" target is ambiguous (could just be the
+	// flag default), so it still falls through to the legacy inference below.
+	if cluster.Conf.TopologyTarget != "" && cluster.Conf.TopologyTarget != config.TopoMasterSlave {
+		if cluster.Conf.TopologyTarget == config.TopoMasterSlavePgStream || cluster.Conf.TopologyTarget == config.TopoMasterSlavePgLog {
+			cluster.IsPostgres = true
+		}
+		return cluster.Conf.TopologyTarget
+	}
+
 	targetTopology := config.TopoMasterSlave
 	if cluster.Conf.MultiMaster {
 		targetTopology = config.TopoMultiMaster

--- a/cluster/cluster_has.go
+++ b/cluster/cluster_has.go
@@ -30,6 +30,13 @@ func (cluster *Cluster) HasServer(srv *ServerMonitor) bool {
 	return false
 }
 
+// HasConfigTopoActivePassive reports whether the cluster is configured for
+// active-passive topology, either via the legacy boolean flag or an explicit
+// topology target.
+func (cluster *Cluster) HasConfigTopoActivePassive() bool {
+	return cluster.Conf.ActivePassive || cluster.Conf.TopologyTarget == config.TopoActivePassive
+}
+
 func (cluster *Cluster) HasValidBackup() bool {
 	logical := false
 	physical := false

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -177,6 +177,7 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 		cluster.Topology = config.TopoActivePassive
 		if cluster.GetMaster() == nil && cluster.Servers[0] != nil {
 			cluster.master = cluster.Servers[0]
+			cluster.vmaster = cluster.Servers[0]
 			cluster.master.SetMaster()
 		}
 		return nil
@@ -198,6 +199,7 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 
 				if sv.IsRunning() && !sv.IsSlave {
 					cluster.vmaster = sv
+					break
 				}
 			}
 		}

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -171,16 +171,41 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 	// Check topology Cluster all servers down
 	cluster.IsDown = cluster.AllServersFailed()
 
-	// if only one server
-	if len(cluster.Servers) == 1 || cluster.Conf.ActivePassive {
+	// If only one server is present, force runtime active-passive topology and
+	// promote that server as the designated master.
+	if len(cluster.Servers) == 1 {
 		cluster.Topology = config.TopoActivePassive
-
-		if len(cluster.Servers) == 1 {
-			for _, sv := range cluster.Servers {
-				cluster.master = sv
-			}
+		if cluster.GetMaster() == nil && cluster.Servers[0] != nil {
+			cluster.master = cluster.Servers[0]
+			cluster.master.SetMaster()
 		}
 		return nil
+	}
+
+	// Wait for at least one full monitoring pass so every server's IsSlave
+	// reflects a real Refresh() rather than its zero-value default, otherwise
+	// a preferred master that is actually a slave but hasn't been refreshed
+	// yet can be mistakenly elected as vmaster on the very first tick.
+	if !cluster.runOnceAfterTopology && cluster.GetMaster() == nil && cluster.HasConfigTopoActivePassive() {
+		prefMaster := cluster.getOnePreferedMaster()
+		if prefMaster != nil && !prefMaster.IsSlave {
+			cluster.vmaster = prefMaster
+		} else {
+			for _, sv := range cluster.Servers {
+				if sv == nil {
+					continue
+				}
+
+				if sv.IsRunning() && !sv.IsSlave {
+					cluster.vmaster = sv
+				}
+			}
+		}
+
+		if cluster.vmaster != nil {
+			cluster.master = cluster.vmaster
+			cluster.master.SetMaster()
+		}
 	}
 
 	// Check topology Cluster is down
@@ -343,8 +368,9 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 		}
 	}
 
-	// If no relay and master-slave is preferred
-	if !hasRelay && !hasCycling {
+	// If no relay and no cycle are detected, infer master-slave unless
+	// active-passive was configured explicitly.
+	if !hasRelay && !hasCycling && !cluster.HasConfigTopoActivePassive() {
 		cluster.Topology = config.TopoMasterSlave
 	}
 
@@ -499,9 +525,10 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 		cluster.SetState("ERR00092", state.State{ErrType: "ERROR", ErrDesc: fmt.Sprintf(clusterError["ERR00092"], cluster.Name, cluster.Topology, cluster.Conf.TopologyTarget), ErrFrom: "TOPO"})
 	}
 
-	// Remove master or vmaster read only if not in maintenance
+	// Remove read_only from the discovered master outside master-slave, but keep
+	// active-passive writable state under explicit topology handling.
 	mst := cluster.GetMaster()
-	if cluster.IsDiscovered() && mst != nil && mst.IsReadOnly() && !mst.IsMaintenance && cluster.Topology != config.TopoMasterSlave {
+	if cluster.IsDiscovered() && mst != nil && mst.IsReadOnly() && !mst.IsMaintenance && cluster.Topology != config.TopoMasterSlave && !cluster.HasConfigTopoActivePassive() {
 		mst.SetReadWrite()
 	}
 

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -230,7 +230,7 @@ type ServerMonitor struct {
 	IsRefreshingBinlog          bool
 	IsRefreshingBinlogMeta      bool
 	IsLoadingJobList            bool
-	jobsAPIHousekeepingDone     bool                        // true after schema ensured + jobs table dropped in API mode
+	jobsAPIHousekeepingDone     bool // true after schema ensured + jobs table dropped in API mode
 	NeedRefreshJobs             bool
 	lastJobsRefreshAttempt      time.Time
 	PointInTimeMeta             backupmgr.PointInTimeMeta
@@ -720,13 +720,7 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 
 			server.SetConfigRefreshCookie() // set cookie to refresh config
 
-			if cluster.Topology == config.TopoActivePassive {
-				if cluster.GetMaster() == nil {
-					server.SetMaster()
-				} else if cluster.GetMaster().Id != server.Id {
-					server.SetState(stateUnconn)
-				}
-			} else if cluster.GetTopology() != config.TopoMultiMasterWsrep || cluster.GetTopology() != config.TopoMultiMasterGrouprep {
+			if cluster.GetTopology() != config.TopoMultiMasterWsrep || cluster.GetTopology() != config.TopoMultiMasterGrouprep {
 				if server.IsGroupReplicationSlave {
 					server.SetState(stateSlave)
 				} else {
@@ -737,8 +731,9 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 			cluster.backendStateChangeProxies()
 			server.SendAlert()
 
-			// if autorejoin is set
-			if cluster.Conf.Autorejoin && cluster.IsActive() {
+			// Auto-rejoin is skipped for active-passive because the master is
+			// designated by topology handling rather than elected from replication.
+			if cluster.Conf.Autorejoin && cluster.IsActive() && cluster.GetTopology() != config.TopoActivePassive {
 				// rejoin if not staging server
 				if isStagingServer {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Preventing auto rejoin on staging server %s", server.URL)
@@ -779,8 +774,9 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 			}
 		} else if server.GetCluster().GetTopology() == config.TopoActivePassive {
 			if server.PrevState == stateSuspect || (server.PrevState == stateMaintenance && !server.IsMaintenance) {
-				//if active-passive topo and no replication, put the state at standalone
-				if cluster.GetMaster() == nil || cluster.GetMaster().Id == server.Id {
+				// In active-passive, only the designated master returns to master;
+				// other nodes stay unconnected until topology handling assigns them.
+				if cluster.GetMaster() != nil && cluster.GetMaster().Id == server.Id {
 					server.SetState(stateMaster)
 				} else {
 					server.SetState(stateUnconn)

--- a/cluster/srv_chk.go
+++ b/cluster/srv_chk.go
@@ -224,11 +224,6 @@ func (server *ServerMonitor) CheckReplication() string {
 		}
 	}
 
-	//Prevent maintenance label for topology active passive
-	if cluster.Topology == config.TopoActivePassive {
-		return "Master OK"
-	}
-
 	if server.IsMaintenance {
 		server.SetState(stateMaintenance)
 		return "Maintenance"

--- a/share/dashboard_react/src/components/ServerStatus.jsx
+++ b/share/dashboard_react/src/components/ServerStatus.jsx
@@ -1,75 +1,40 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import TagPill from './TagPill'
 
+function getStatus(state) {
+  switch (state) {
+    case 'SlaveErr':
+      return { stateValue: 'SLAVE_ERROR', colorScheme: 'orange' }
+    case 'SlaveLate':
+      return { stateValue: 'SLAVE_LATE', colorScheme: 'yellow' }
+    case 'RelayErr':
+      return { stateValue: 'RELAY_ERROR', colorScheme: 'orange' }
+    case 'RelayLate':
+      return { stateValue: 'RELAY_LATE', colorScheme: 'yellow' }
+    case 'StandAlone':
+      return { stateValue: 'STANDALONE', colorScheme: 'gray' }
+    case 'Master':
+      return { stateValue: state.toUpperCase(), colorScheme: 'blue' }
+    case 'Slave':
+      return { stateValue: state.toUpperCase(), colorScheme: 'gray' }
+    case 'Relay':
+      return { stateValue: state.toUpperCase(), colorScheme: 'gray' }
+    case 'Suspect':
+      return { stateValue: state.toUpperCase(), colorScheme: 'orange' }
+    case 'Failed':
+      return { stateValue: state.toUpperCase(), colorScheme: 'red' }
+    case 'AppRunning':
+      return { stateValue: state.toUpperCase(), colorScheme: 'blue' }
+    case 'AppWarning':
+      return { stateValue: state.toUpperCase(), colorScheme: 'orange' }
+    default:
+      return { stateValue: state.toUpperCase(), colorScheme: 'gray' }
+  }
+}
+
 function ServerStatus({ state, isVirtualMaster, isBlinking = false }) {
-  const [isVirtual, setIsVirtual] = useState('')
-  const [colorScheme, setColorScheme] = useState('gray')
-  const [stateValue, setStateValue] = useState(state ? state.toUpperCase() : '')
-
-  useEffect(() => {
-    if (state) {
-      setStateValue(state.toUpperCase())
-      switch (state) {
-        case 'SlaveErr':
-          setStateValue('SLAVE_ERROR')
-          setColorScheme('orange')
-          break
-        case 'SlaveLate':
-          setStateValue('SLAVE_LATE')
-          setColorScheme('yellow')
-          break
-        case 'RelayErr':
-          setStateValue('RELAY_ERROR')
-          setColorScheme('orange')
-          break
-        case 'RelayLate':
-          setStateValue('RELAY_LATE')
-          setColorScheme('yellow')
-          break
-        case 'StandAlone':
-          setStateValue('STANDALONE')
-          setColorScheme('gray')
-          break
-        case 'Master':
-          setColorScheme('blue')
-          break
-        case 'Slave':
-          setColorScheme('gray')
-          break
-        case 'Relay':
-          setColorScheme('gray')
-          break
-        case 'Suspect':
-          setColorScheme('orange')
-          break
-        case 'Failed':
-          setColorScheme('red')
-          break
-        case 'AppRunning':
-          setColorScheme('blue')
-          break
-        case 'AppWarning':
-          setColorScheme('orange')
-          break
-        default:
-          setStateValue(state.toUpperCase())
-          setColorScheme('gray')
-          break
-      }
-    }
-
-    if (isVirtualMaster) {
-      setIsVirtual('-VMaster')
-    } else {
-      setIsVirtual('')
-    }
-
-    return () => {
-      setColorScheme('gray')
-      setStateValue('')
-      setIsVirtual('')
-    }
-  }, [state, isVirtualMaster])
+  const { stateValue, colorScheme } = state ? getStatus(state) : { stateValue: '', colorScheme: 'gray' }
+  const isVirtual = isVirtualMaster ? '-VMaster' : ''
 
   return (
     <TagPill


### PR DESCRIPTION
- Add HasConfigTopoActivePassive() helper for active-passive configuration detection

- Promote single-server clusters to active-passive and designate master

- Move active-passive virtual master election into TopologyDiscover

- Skip master-slave topology inference when active-passive is configured

- Keep active-passive master writable state under explicit topology control

- Disable auto-rejoin for active-passive topologies

- Remove active-passive short-circuit in CheckReplication

- Refactor ServerStatus to a pure component without useEffect/useState