### PR TITLE
fix(inject): dml traffic marker via proxy create-once (no replication break)

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -96,7 +96,7 @@ type Cluster struct {
 	Status                        string                 `json:"activePassiveStatus" groups:"web"`
 	IsSplitBrain                  bool                   `json:"isSplitBrain" groups:"web"`
 	IsSplitBrainBck               bool                   `json:"-"`
-	injectTrafficTableReady       bool                   `json:"-"` // dml marker schema created once via the proxy
+	injectTrafficTableReady       map[string]bool        `json:"-"` // dml marker schema created once per proxy target
 	IsFailedArbitrator            bool                   `json:"isFailedArbitrator" groups:"web"`
 	IsLostMajority                bool                   `json:"isLostMajority" groups:"web"`
 	IsDown                        bool                   `json:"isDown" groups:"web"`

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -96,7 +96,7 @@ type Cluster struct {
 	Status                        string                 `json:"activePassiveStatus" groups:"web"`
 	IsSplitBrain                  bool                   `json:"isSplitBrain" groups:"web"`
 	IsSplitBrainBck               bool                   `json:"-"`
-	injectTrafficTableReady       bool                   `json:"-"` // dml marker table ensured on all servers
+	injectTrafficTableReady       bool                   `json:"-"` // dml marker schema created once via the proxy
 	IsFailedArbitrator            bool                   `json:"isFailedArbitrator" groups:"web"`
 	IsLostMajority                bool                   `json:"isLostMajority" groups:"web"`
 	IsDown                        bool                   `json:"isDown" groups:"web"`

--- a/cluster/prx.go
+++ b/cluster/prx.go
@@ -280,27 +280,6 @@ func (cluster *Cluster) newProxyList() error {
 // REPLACE VIEW, is DDL and poisoned every flashback). ddl is kept for tests
 // exercising the reseed path and for non-GTID positional rejoin, whose
 // binlog search greps the UUID as plain text (a row image is not greppable).
-// ensureInjectTrafficTable creates the one-row dml marker table on EVERY
-// server directly, once, when traffic starts. It must exist on the slaves too
-// — the per-tick REPLACE is a ROW event, and a slave missing the table (e.g.
-// freshly bootstrapped after a RESET MASTER that dropped the CREATE from the
-// binlog) errors its SQL thread on the replicated row. CREATE TABLE IF NOT
-// EXISTS on each server's own connection makes it independent of binlog
-// history. The DDL runs once (injectTrafficTableReady), never per tick.
-func (cluster *Cluster) ensureInjectTrafficTable() {
-	for _, srv := range cluster.Servers {
-		if srv == nil || srv.Conn == nil || srv.IsDown() {
-			return // retry next tick until every server has it
-		}
-	}
-	for _, srv := range cluster.Servers {
-		srv.Conn.Exec("CREATE DATABASE IF NOT EXISTS replication_manager_schema")
-		srv.Conn.Exec("CREATE TABLE IF NOT EXISTS replication_manager_schema.pseudo_gtid_hist (id INT PRIMARY KEY, uuid VARCHAR(64), ts TIMESTAMP)")
-		srv.Conn.Exec("CREATE OR REPLACE VIEW replication_manager_schema.pseudo_gtid_v AS SELECT uuid FROM replication_manager_schema.pseudo_gtid_hist WHERE id=1")
-	}
-	cluster.injectTrafficTableReady = true
-}
-
 // injectTrafficUsesDDL reports whether the pseudo-GTID / traffic marker must
 // be the greppable DDL view rather than the flashback-able DML row. Forced by
 // OLD-STYLE POSITIONAL replication (force-slave-no-gtid-mode): its rejoin
@@ -320,9 +299,21 @@ func (cluster *Cluster) injectTrafficMarker(db *sqlx.DB, definer string) error {
 		_, err := db.Exec("CREATE OR REPLACE " + definer + " VIEW replication_manager_schema.pseudo_gtid_v as select '" + uuid + "' from dual")
 		return err
 	}
-	// dml (default): advance the one-row marker with a ROW-logged REPLACE — the
-	// marker change is the flashback-able event. The table is created up front
-	// on all servers (ensureInjectTrafficTable), so this is just the write.
+	// dml: a single-row REPLACE — a ROW event flashback can reverse. The table
+	// and seed row are created ONCE, via THIS proxy connection (the same path
+	// the REPLACE takes), so the CREATE lands on the master, is binlogged, and
+	// flows to every slave in the SAME binlog stream BEFORE any REPLACE that
+	// follows it. Binlog ordering guarantees a slave applies the CREATE before
+	// the REPLACE (no 1032), and a reseeded node gets the table in its
+	// snapshot — so no presence-checking state is needed. IF NOT EXISTS makes
+	// the one-time setup idempotent across restarts.
+	if !cluster.injectTrafficTableReady {
+		db.Exec("CREATE DATABASE IF NOT EXISTS replication_manager_schema")
+		db.Exec("CREATE TABLE IF NOT EXISTS replication_manager_schema.pseudo_gtid_hist (id INT PRIMARY KEY, uuid VARCHAR(64), ts TIMESTAMP)")
+		db.Exec("INSERT IGNORE INTO replication_manager_schema.pseudo_gtid_hist (id, uuid, ts) VALUES (1, '" + uuid + "', NOW())")
+		db.Exec("CREATE OR REPLACE " + definer + " VIEW replication_manager_schema.pseudo_gtid_v AS SELECT uuid FROM replication_manager_schema.pseudo_gtid_hist WHERE id=1")
+		cluster.injectTrafficTableReady = true
+	}
 	_, err := db.Exec("REPLACE INTO replication_manager_schema.pseudo_gtid_hist (id, uuid, ts) VALUES (1, '" + uuid + "', NOW())")
 	return err
 }
@@ -339,11 +330,6 @@ func (cluster *Cluster) InjectProxiesTraffic() {
 	// advance under the pen of the instance that holds authority.
 	if cluster.Conf.Arbitration && !cluster.IsActive() {
 		return
-	}
-	// dml marker: make sure the one-row table exists on every server before
-	// the first REPLACE, so slaves never error on the replicated row event.
-	if !cluster.injectTrafficUsesDDL() && !cluster.injectTrafficTableReady {
-		cluster.ensureInjectTrafficTable()
 	}
 	// Found server from ServerId
 	if cluster.Conf.TopologyStaging && cluster.Conf.TestInjectTrafficStaging {

--- a/cluster/prx.go
+++ b/cluster/prx.go
@@ -293,7 +293,7 @@ func (cluster *Cluster) injectTrafficUsesDDL() bool {
 	return cluster.Conf.ForceSlaveNoGtid || cluster.Conf.InjectTrafficMode == "ddl"
 }
 
-func (cluster *Cluster) injectTrafficMarker(db *sqlx.DB, definer string) error {
+func (cluster *Cluster) injectTrafficMarker(db *sqlx.DB, definer string, readyKey string) error {
 	uuid := misc.GetUUID()
 	if cluster.injectTrafficUsesDDL() {
 		_, err := db.Exec("CREATE OR REPLACE " + definer + " VIEW replication_manager_schema.pseudo_gtid_v as select '" + uuid + "' from dual")
@@ -307,12 +307,29 @@ func (cluster *Cluster) injectTrafficMarker(db *sqlx.DB, definer string) error {
 	// the REPLACE (no 1032), and a reseeded node gets the table in its
 	// snapshot — so no presence-checking state is needed. IF NOT EXISTS makes
 	// the one-time setup idempotent across restarts.
-	if !cluster.injectTrafficTableReady {
+	if cluster.injectTrafficTableReady == nil {
+		cluster.injectTrafficTableReady = make(map[string]bool)
+	}
+	if !cluster.injectTrafficTableReady[readyKey] {
 		db.Exec("CREATE DATABASE IF NOT EXISTS replication_manager_schema")
-		db.Exec("CREATE TABLE IF NOT EXISTS replication_manager_schema.pseudo_gtid_hist (id INT PRIMARY KEY, uuid VARCHAR(64), ts TIMESTAMP)")
-		db.Exec("INSERT IGNORE INTO replication_manager_schema.pseudo_gtid_hist (id, uuid, ts) VALUES (1, '" + uuid + "', NOW())")
+		// Only latch on a CONFIRMED CREATE TABLE. If it fails (a restricted
+		// write-heartbeat credential without CREATE, a read-only master
+		// mid-switchover, a timeout), do NOT set the guard and do NOT fall
+		// through to the REPLACE — that would write to a table that may not
+		// exist and reintroduce the 1032 this fix removes. Return the error so
+		// the next tick retries. Keyed per proxy target so a staging target
+		// cannot flip the guard for the main production master.
+		if _, err := db.Exec("CREATE TABLE IF NOT EXISTS replication_manager_schema.pseudo_gtid_hist (id INT PRIMARY KEY, uuid VARCHAR(64), ts TIMESTAMP)"); err != nil {
+			return err
+		}
+		if _, err := db.Exec("INSERT IGNORE INTO replication_manager_schema.pseudo_gtid_hist (id, uuid, ts) VALUES (1, '" + uuid + "', NOW())"); err != nil {
+			return err
+		}
 		db.Exec("CREATE OR REPLACE " + definer + " VIEW replication_manager_schema.pseudo_gtid_v AS SELECT uuid FROM replication_manager_schema.pseudo_gtid_hist WHERE id=1")
-		cluster.injectTrafficTableReady = true
+		cluster.injectTrafficTableReady[readyKey] = true
+		// The seed INSERT above already advanced the marker this tick — skip
+		// the otherwise-redundant REPLACE with the same uuid.
+		return nil
 	}
 	_, err := db.Exec("REPLACE INTO replication_manager_schema.pseudo_gtid_hist (id, uuid, ts) VALUES (1, '" + uuid + "', NOW())")
 	return err
@@ -347,7 +364,7 @@ func (cluster *Cluster) InjectProxiesTraffic() {
 				} else {
 					definer = ""
 				}
-				if err := cluster.injectTrafficMarker(db, definer); err != nil {
+				if err := cluster.injectTrafficMarker(db, definer, pr.GetId()); err != nil {
 					cluster.SetState("ERR00050", state.State{ErrType: "ERROR", ErrDesc: fmt.Sprintf(clusterError["ERR00050"], err), ErrFrom: "TOPO"})
 				}
 				db.Close()
@@ -370,7 +387,7 @@ func (cluster *Cluster) InjectProxiesTraffic() {
 				} else {
 					definer = ""
 				}
-				if err := cluster.injectTrafficMarker(db, definer); err != nil {
+				if err := cluster.injectTrafficMarker(db, definer, pr.GetId()); err != nil {
 					cluster.SetState("ERR00050", state.State{ErrType: "ERROR", ErrDesc: fmt.Sprintf(clusterError["ERR00050"], err), ErrFrom: "TOPO"})
 				}
 				db.Close()

--- a/server/server.go
+++ b/server/server.go
@@ -1044,7 +1044,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.BoolVar(&conf.Test, "test", false, "Enable non regression tests")
 	flags.BoolVar(&conf.TestInjectTraffic, "test-inject-traffic", false, "Inject some database traffic via proxy")
 	flags.BoolVar(&conf.TestInjectTrafficStaging, "test-inject-traffic-staging", false, "Inject some database traffic via proxy to staging")
-	flags.StringVar(&conf.InjectTrafficMode, "inject-traffic-mode", "dml", "Pseudo-GTID / traffic marker format: dml (row event, flashback-able — safe default) or ddl (CREATE OR REPLACE VIEW, greppable in any binlog format for non-GTID positional rejoin, but NOT flashback-able)")
+	flags.StringVar(&conf.InjectTrafficMode, "inject-traffic-mode", "ddl", "Pseudo-GTID / traffic marker format: ddl (CREATE OR REPLACE VIEW — self-contained idempotent DDL: needs no table on newly-monitored/reseeded nodes, greppable for positional rejoin; battle-tested DEFAULT) or dml (single-row REPLACE, flashback-able but requires the marker table+row to replicate consistently from the master — EXPERIMENTAL, breaks row replication if the table is provisioned out-of-band)")
 	flags.IntVar(&conf.SysbenchTime, "sysbench-time", 100, "Time to run benchmark")
 	flags.IntVar(&conf.SysbenchThreads, "sysbench-threads", 4, "Number of threads to run benchmark")
 	flags.StringVar(&conf.SysbenchTest, "sysbench-test", "oltp_read_write", "oltp_read_write|tpcc|oltp_read_only|oltp_update_index|oltp_update_non_index")


### PR DESCRIPTION
## What

Correct the `inject-traffic-mode=dml` marker so it no longer breaks replication.

## Why

The DML marker created the pseudo-GTID table **out-of-band on each node** (`ensureInjectTrafficTable`, currently on develop). The master's per-tick in-place `REPLACE` of row `id=1` then replicated as a ROW update whose *before-image* the empty/independently-created slave table didn't have → `1032 HA_ERR_KEY_NOT_FOUND`, slave goes `SlaveErr`. Observed live on belair/db1.

This is why the original marker was a `CREATE OR REPLACE VIEW`: self-contained DDL that needs no table on newly-monitored/reseeded nodes.

## Fix

Create the table the **same way the marker is written — via the proxy, once, when traffic starts**. That CREATE lands on the master, is binlogged, and flows to every slave in the **same binlog stream before** any `REPLACE` that follows it. Binlog ordering guarantees a slave applies the CREATE before the REPLACE (no 1032), and a reseeded node gets the table in its snapshot. So there is **nothing to check** — no `CanInjectTraffic` state, no per-node presence probe, no `information_schema`/`SHOW CREATE` lookup, no new-node tracking. One idempotent create-once guard.

- Default is `ddl` (self-contained view, battle-tested); `dml` is experimental/opt-in and topology-aware (`force-slave-no-gtid-mode` keeps the greppable view for positional rejoin).
- `injectTrafficMarker` creates DB+table+seed+view via the proxy `db` on first call, then `REPLACE`s — all on the same connection.
- Removes the earlier over-engineered state machine.

## Testing note

Touches the traffic-injection / replication path — must run through the OpenSVC **topology matrix** (master-slave GTID + master-master old-style positional, across db/proxy versions) before merge. Do not merge until the matrix is green.
