### PR TITLE
fix(rejoin): freeze old master before capturing lost events + show election anchors

### DIFF
--- a/cluster/srv_rejoin.go
+++ b/cluster/srv_rejoin.go
@@ -103,7 +103,7 @@ func (server *ServerMonitor) RejoinMaster() error {
 					}
 				} //crash info is available
 				if cluster.Conf.AutorejoinBackupBinlog {
-					server.backupBinlog(crash)
+					server.freezeThenCaptureLostEvents(crash)
 				}
 
 				err := server.rejoinMasterIncremental(crash)
@@ -733,6 +733,66 @@ func (server *ServerMonitor) purgeCrashBinArchives(keep int) {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Pruned crash archive %s (keeping the %d most recent)", name, keep)
 	}
 }
+// freezeThenCaptureLostEvents captures the diverged old master's binlog tail
+// AFTER stopping it from growing. This is the fix for the empty-capture bug:
+// the previous code captured from crash.FailoverMasterLogPos while the old
+// master was STILL being written. During a split the proxy keeps routing
+// writes to whatever it thinks is master — it connects SUPER, so read_only
+// does not stop it, and the traffic marker fires every tick — so the divergent
+// tail kept growing PAST the one-shot snapshot and the capture came back empty
+// (proven on belair: anchor correct, moment ~35s too early). FLUSH TABLES WITH
+// READ LOCK is the only thing that blocks even SUPER; take it, confirm the
+// binlog position has stopped advancing, THEN capture the whole delta, then
+// release so rejoinMasterIncremental can write.
+func (server *ServerMonitor) freezeThenCaptureLostEvents(crash *Crash) error {
+	cluster := server.ClusterGroup
+	froze := false
+	if err := server.FreezeWithReadLock(); err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "WARNING", "Could not freeze %s before lost-events capture (%s) — capturing live, the divergent tail may still be growing", server.URL, err)
+	} else {
+		froze = true
+		server.waitBinlogSettle()
+	}
+	err := server.backupBinlog(crash)
+	if froze {
+		server.UnfreezeReadLock()
+	}
+	return err
+}
+
+// waitBinlogSettle blocks until the server's binlog position stops advancing
+// (two consecutive identical SHOW MASTER STATUS reads) or a short timeout. It
+// is called right after FreezeWithReadLock: FTWRL already waits for in-flight
+// writes and blocks new commits, so the position is expected to be stable
+// immediately — this poll just CONFIRMS it (and logs the settled anchor) before
+// the capture, honoring "confirm its GTID stops advancing, then capture".
+func (server *ServerMonitor) waitBinlogSettle() {
+	cluster := server.ClusterGroup
+	var lastFile string
+	var lastPos uint
+	stable := 0
+	for i := 0; i < 10; i++ {
+		ms, _, err := dbhelper.GetMasterStatus(server.Conn, server.DBVersion)
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "WARNING", "Could not read master status of %s while waiting for binlog to settle: %s", server.URL, err)
+			return
+		}
+		if ms.File == lastFile && ms.Position == lastPos {
+			stable++
+			if stable >= 1 {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "INFO", "Binlog of %s settled at %s:%d under read-lock freeze — capturing lost events", server.URL, ms.File, ms.Position)
+				return
+			}
+		} else {
+			stable = 0
+			lastFile = ms.File
+			lastPos = ms.Position
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "WARNING", "Binlog of %s still advancing after freeze wait (last %s:%d) — capturing anyway", server.URL, lastFile, lastPos)
+}
+
 func (server *ServerMonitor) backupBinlog(crash *Crash) error {
 	cluster := server.ClusterGroup
 	if _, err := os.Stat(cluster.GetMysqlBinlogPath()); os.IsNotExist(err) {

--- a/share/dashboard_react/src/components/Modals/CrashesModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/CrashesModal/index.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react'
 import {
   Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalFooter, ModalCloseButton,
   Text, Badge, Table, Thead, Tbody, Tr, Th, Td, Button,
-  HStack, Alert, AlertIcon
+  HStack, VStack, Box, Alert, AlertIcon, IconButton
 } from '@chakra-ui/react'
 import { useTheme } from '../../../ThemeProvider'
 import parentStyles from '../styles.module.scss'
@@ -16,6 +16,7 @@ function CrashesModal({ isOpen, closeModal, clusterName, crashes }) {
   const { theme } = useTheme()
   const isLight = theme === 'light'
   const [viewCrash, setViewCrash] = useState(null)
+  const [expanded, setExpanded] = useState(null)
   const pauseRef = useRef(false)
 
   useEffect(() => {
@@ -44,10 +45,45 @@ function CrashesModal({ isOpen, closeModal, clusterName, crashes }) {
     return { id: url, host, port, ts: crash?.UnixTimestamp || 0 }
   }
 
+  // Global CSS forces --text-color !important on badge text: 'subtle' gives a
+  // readable dark-on-light badge in light mode, 'solid' a white-on-color badge
+  // in dark mode. Anything else washes out in one of the two themes.
+  const badgeVariant = isLight ? 'subtle' : 'solid'
+
   const verdict = (crash) => {
-    if (!crash.deltaAnalyzed) return <Badge colorScheme='orange'>not analyzed</Badge>
-    if (crash.deltaFlashable) return <Badge colorScheme='green'>flashback-able</Badge>
-    return <Badge colorScheme='red'>not flashback-able</Badge>
+    if (!crash.deltaAnalyzed) return <Badge variant={badgeVariant} colorScheme='orange'>not analyzed</Badge>
+    if (crash.deltaFlashable) return <Badge variant={badgeVariant} colorScheme='green'>flashback-able</Badge>
+    return <Badge variant={badgeVariant} colorScheme='red'>not flashback-able</Badge>
+  }
+
+  // The exact anchors captured at the moment the new master was elected — the
+  // frame every recovery is computed against. The old-master position is the
+  // start of the divergent tail (where the elected slave stopped reading); the
+  // election GTID is the SET gtid_slave_pos target for a logical rejoin.
+  const anchorRow = (crash) => {
+    const gtid = crash.failoverIOGtidString || '-'
+    const oldPos = `${crash.FailoverMasterLogFile || '?'}:${crash.FailoverMasterLogPos || '?'}`
+    const newPos = `${crash.NewMasterLogFile || '?'}:${crash.NewMasterLogPos || '?'}`
+    const item = (label, value, hint) => (
+      <Box>
+        <Text fontSize='2xs' textTransform='uppercase' opacity={0.7}>{label}</Text>
+        <Text fontSize='xs' fontFamily='mono'>{value}</Text>
+        {hint && <Text fontSize='2xs' opacity={0.6}>{hint}</Text>}
+      </Box>
+    )
+    return (
+      <Box
+        bg={isLight ? 'gray.50' : 'whiteAlpha.100'}
+        borderLeft='3px solid'
+        borderColor={isLight ? 'gray.300' : 'whiteAlpha.400'}
+      >
+        <VStack align='stretch' spacing={2} py={2} px={3}>
+          {item('Election GTID', gtid, 'gtid_slave_pos target for logical rejoin of the old master')}
+          {item(`Old master ${crash.URL || ''} stopped at`, oldPos, 'start of the divergent tail — capture anchor')}
+          {item(`New master ${crash.ElectedMasterURL || ''} at election`, newPos, '')}
+        </VStack>
+      </Box>
+    )
   }
 
   return (
@@ -66,6 +102,7 @@ function CrashesModal({ isOpen, closeModal, clusterName, crashes }) {
             <Table size='sm' variant='simple'>
               <Thead>
                 <Tr>
+                  <Th w='1'></Th>
                   <Th>Time</Th>
                   <Th>Failed Master</Th>
                   <Th>Elected Master</Th>
@@ -76,24 +113,40 @@ function CrashesModal({ isOpen, closeModal, clusterName, crashes }) {
               </Thead>
               <Tbody>
                 {list.map((crash, i) => (
-                  <Tr key={i}>
-                    <Td fontSize='xs'>{crash.UnixTimestamp ? new Date(crash.UnixTimestamp * 1000).toLocaleString() : '-'}</Td>
-                    <Td fontSize='xs' fontFamily='mono'>{crash.URL}</Td>
-                    <Td fontSize='xs' fontFamily='mono'>{crash.ElectedMasterURL}</Td>
-                    <Td fontSize='xs'>{crash.Switchover ? 'switchover' : 'failover'}</Td>
-                    <Td>
-                      <HStack spacing={1}>
-                        {verdict(crash)}
-                        {crash.deltaAnalyzed && <Badge>{crash.deltaTransactions} tx</Badge>}
-                        {crash.deltaDdl > 0 && <Badge colorScheme='red'>{crash.deltaDdl} DDL</Badge>}
-                      </HStack>
-                    </Td>
-                    <Td>
-                      <Button size='xs' onClick={() => setViewCrash(crash)}>
-                        Lost Events
-                      </Button>
-                    </Td>
-                  </Tr>
+                  <React.Fragment key={i}>
+                    <Tr>
+                      <Td px={1}>
+                        <IconButton
+                          size='xs' variant='ghost' aria-label='Show election anchors'
+                          fontSize='sm'
+                          icon={<span>{expanded === i ? '▾' : '▸'}</span>}
+                          onClick={() => setExpanded(expanded === i ? null : i)}
+                        />
+                      </Td>
+                      <Td fontSize='xs'>{crash.UnixTimestamp ? new Date(crash.UnixTimestamp * 1000).toLocaleString() : '-'}</Td>
+                      <Td fontSize='xs' fontFamily='mono'>{crash.URL}</Td>
+                      <Td fontSize='xs' fontFamily='mono'>{crash.ElectedMasterURL}</Td>
+                      <Td fontSize='xs'>{crash.Switchover ? 'switchover' : 'failover'}</Td>
+                      <Td>
+                        <HStack spacing={1}>
+                          {verdict(crash)}
+                          {crash.deltaAnalyzed && <Badge variant={badgeVariant}>{crash.deltaTransactions} tx</Badge>}
+                          {crash.deltaDdl > 0 && <Badge variant={badgeVariant} colorScheme='red'>{crash.deltaDdl} DDL</Badge>}
+                        </HStack>
+                      </Td>
+                      <Td>
+                        <Button size='xs' onClick={() => setViewCrash(crash)}>
+                          Lost Events
+                        </Button>
+                      </Td>
+                    </Tr>
+                    {expanded === i && (
+                      <Tr>
+                        <Td></Td>
+                        <Td colSpan={6} p={0}>{anchorRow(crash)}</Td>
+                      </Tr>
+                    )}
+                  </React.Fragment>
                 ))}
               </Tbody>
             </Table>

--- a/share/dashboard_react/src/components/Modals/LostEventsModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/LostEventsModal/index.jsx
@@ -20,6 +20,9 @@ const PAGE_BYTES = 262144
 function LostEventsModal({ isOpen, closeModal, clusterName, server }) {
   const { theme } = useTheme()
   const isLight = theme === 'light'
+  // Global CSS forces --text-color !important on badge text: 'subtle' reads in
+  // light mode, 'solid' in dark. See CrashesModal for the same constraint.
+  const badgeVariant = isLight ? 'subtle' : 'solid'
 
   const [crash, setCrash] = useState(null)
   const [noCrash, setNoCrash] = useState(false)
@@ -143,17 +146,17 @@ function LostEventsModal({ isOpen, closeModal, clusterName, server }) {
               <HStack mb={3} spacing={2} flexWrap='wrap'>
                 {crash.deltaAnalyzed ? (
                   crash.deltaFlashable ? (
-                    <Badge colorScheme='green'>Flashback-able</Badge>
+                    <Badge variant={badgeVariant} colorScheme='green'>Flashback-able</Badge>
                   ) : (
-                    <Badge colorScheme='red'>Not flashback-able</Badge>
+                    <Badge variant={badgeVariant} colorScheme='red'>Not flashback-able</Badge>
                   )
                 ) : (
-                  <Badge colorScheme='orange'>Not analyzed</Badge>
+                  <Badge variant={badgeVariant} colorScheme='orange'>Not analyzed</Badge>
                 )}
-                <Badge>{crash.deltaTransactions} transactions</Badge>
-                <Badge>{crash.deltaRowEvents} row events</Badge>
-                {crash.deltaDdl > 0 && <Badge colorScheme='red'>{crash.deltaDdl} DDL</Badge>}
-                {crash.deltaStatementDml > 0 && <Badge colorScheme='red'>{crash.deltaStatementDml} statement DML</Badge>}
+                <Badge variant={badgeVariant}>{crash.deltaTransactions} transactions</Badge>
+                <Badge variant={badgeVariant}>{crash.deltaRowEvents} row events</Badge>
+                {crash.deltaDdl > 0 && <Badge variant={badgeVariant} colorScheme='red'>{crash.deltaDdl} DDL</Badge>}
+                {crash.deltaStatementDml > 0 && <Badge variant={badgeVariant} colorScheme='red'>{crash.deltaStatementDml} statement DML</Badge>}
               </HStack>
               {crash.deltaAnalyzed && !crash.deltaFlashable && (
                 <Alert status='warning' borderRadius='md' mb={3}>


### PR DESCRIPTION
## What

Fix the empty lost-events capture, and surface the election-moment anchors in the crash viewer.

## Why (proven on belair)

`backupBinlog` captured the diverged old master's tail from the **correct anchor** (`crash.FailoverMasterLogPos`) but at the **wrong moment** — while the old master was *still being written*. During a split the proxy keeps writing to whatever it routes as master: it connects **SUPER**, so `read_only` does not stop it, and the traffic marker fires every tick. The divergent tail kept growing **past** the one-shot snapshot, so the capture came back as a ~296-byte empty stub. Timeline proof: anchor `binlog.000001:133821` was exactly the start of the first divergent GTID, but the capture ran ~35s before the old master finished diverging (GTIDs 492..502 landed after the snapshot).

## Fix

- `freezeThenCaptureLostEvents` wraps the capture: **FLUSH TABLES WITH READ LOCK** the old master first (the only thing that blocks even SUPER), `waitBinlogSettle` confirms `SHOW MASTER STATUS` has stopped advancing, **then** `backupBinlog`, then release so `rejoinMasterIncremental` can write. `FreezeWithReadLock` already existed but was gated behind `arbitration-minority-freeze=false`; the capture path now freezes unconditionally for the snapshot window only.
- **Crash viewer**: CrashesModal gains an expandable per-row panel showing the anchors every recovery is computed against — election GTID (`gtid_slave_pos` target), old-master stop position (start of the divergent tail), new-master position at election. These were in `failover.json` but never displayed.
- Fix the recurring dark-mode badge bug in both crash modals (subtle→solid in dark so the forced `--text-color` light-gray text contrasts the background).

## Testing note

Touches the failover/rejoin path — run through the OpenSVC topology matrix on **belair** before merge. Keep a divergence reproduction available (the proxy-marker-during-split behavior) to validate the capture is now non-empty.