### PR TITLE
fix(ui): dark-mode contrast fixes (security modal badges + global dashboard alerts)

### DIFF
--- a/share/dashboard_react/src/Pages/GlobalItems/index.jsx
+++ b/share/dashboard_react/src/Pages/GlobalItems/index.jsx
@@ -4,6 +4,7 @@ import { Box, Flex, Text, Divider, Spinner, Button } from '@chakra-ui/react'
 import Card from '../../components/Card'
 import Gauge from '../../components/Gauge'
 import TagPill from '../../components/TagPill'
+import { useTheme } from '../../ThemeProvider'
 import styles from './styles.module.scss'
 import Logs from '../Dashboard/components/Logs'
 import AccordionComponent from '../../components/AccordionComponent'
@@ -242,6 +243,8 @@ export function GlobalLogs() {
 }
 
 function AlertSection({ title, items, colorScheme, onOpenModal }) {
+  const { theme } = useTheme()
+  const isLight = theme === 'light'
   const previewItems = items.slice(0, 3)
   const remainingCount = Math.max(items.length - previewItems.length, 0)
 
@@ -261,7 +264,7 @@ function AlertSection({ title, items, colorScheme, onOpenModal }) {
             <>
               <Text fontSize='xs' opacity={0.7}>Showing latest {previewItems.length} of {items.length}.</Text>
               {previewItems.map((item, index) => (
-                <Box key={`${item?.number ?? 'alert'}-${index}`} p='8px' borderRadius='6px' bg='gray.50'>
+                <Box key={`${item?.number ?? 'alert'}-${index}`} p='8px' borderRadius='6px' bg={isLight ? 'gray.50' : 'whiteAlpha.100'}>
                   <Text fontSize='xs' opacity={0.7}>{item?.number ?? 'N/A'} • {item?.from ?? 'N/A'}</Text>
                   <Text fontSize='sm'>{item?.desc ?? 'N/A'}</Text>
                 </Box>

--- a/share/dashboard_react/src/components/Modals/SecurityScoreModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/SecurityScoreModal/index.jsx
@@ -39,6 +39,10 @@ const GRADE_COLOR = { A: 'green', B: 'teal', C: 'yellow', D: 'orange', F: 'red' 
 
 function SecurityScoreModal({ isOpen, closeModal }) {
   const { theme } = useTheme()
+  // Global CSS forces --text-color !important on badge text, so a 'subtle'
+  // badge in dark mode renders white text on a pale tint (unreadable). Use
+  // 'subtle' in light, 'solid' in dark. See CrashesModal for the full note.
+  const badgeVariant = theme === 'light' ? 'subtle' : 'solid'
   const dispatch = useDispatch()
   const { isMobile, isTablet, isDesktop } = useSelector((state) => state.common)
   const clusterData = useSelector((state) => state.cluster.clusterData)
@@ -135,7 +139,7 @@ function SecurityScoreModal({ isOpen, closeModal }) {
                       isDisabled={!!fixing[`${errKey}:${fix.tag}`]}
                       onClick={() => handleFix(errKey, fix.tag)}>
                       {fix.tag}
-                      {fix.risk === 'disruptive' && <Badge ml={2} colorScheme='orange' fontSize='xs'>restart</Badge>}
+                      {fix.risk === 'disruptive' && <Badge ml={2} variant={badgeVariant} colorScheme='orange' fontSize='xs'>restart</Badge>}
                     </MenuItem>
                   ))}
                 </MenuList>
@@ -199,7 +203,7 @@ function SecurityScoreModal({ isOpen, closeModal }) {
             {checks.map(({ label, pass }) => (
               <GridItem key={label}>
                 <HStack spacing={2}>
-                  <Badge colorScheme={pass ? 'green' : 'red'} minW='40px' textAlign='center'>
+                  <Badge variant={badgeVariant} colorScheme={pass ? 'green' : 'red'} minW='40px' textAlign='center'>
                     {pass ? 'PASS' : 'FAIL'}
                   </Badge>
                   <Text fontSize='sm'>{label}</Text>


### PR DESCRIPTION
Two instances of the same recurring dark-mode contrast bug, both unrelated to crash recovery (the crash-viewer version is in #1575).

**Security Score modal** — global `_global.scss` forces `color: var(--text-color) !important` on badge text (light-gray `#e7e9ef` in dark). On a `subtle` badge (pale tint) that text is invisible. PASS/FAIL and `restart` badges now use `variant={subtle in light / solid in dark}` so the background contrasts the forced text color in both themes.

**Global dashboard alerts** — the Errors/Infos preview items rendered on an unconditional `bg='gray.50'` (near-white) box; in dark mode the light-gray text sat on white and was unreadable. Box background is now theme-aware (`gray.50` light / `whiteAlpha.100` dark).