### PR TITLE
fix(arbitration): fire per-cluster reports concurrently every split-tick (keep leases in sync)

### DIFF
--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -1305,18 +1305,28 @@ func (cl *Cluster) SetArbitratorReport() error {
 		return errors.New("split-brain simulation: arbitrator link down")
 	}
 
+	// Read the topology inputs under the cluster lock so this report is safe to
+	// fire CONCURRENTLY from the server heartbeat every split-tick. cluster.Servers
+	// is REASSIGNED (make/append/delete) during TopologyDiscover and server-delete
+	// under this same lock; an unlocked read racing that reassignment can tear the
+	// slice header and panic. The hold is ONLY the quick reads (no I/O) — the
+	// network POST below runs UNLOCKED, so we never block TopologyDiscover on HTTP.
+	cl.Lock()
 	cl.IsLostMajority = cl.LostMajority()
-	// SplitBrain
+	var mst string
+	if m := cl.GetMaster(); m != nil {
+		mst = m.URL
+	}
+	srvs := cl.GetServers()
+	hosts := len(srvs)
+	failed := cl.CountFailed(srvs)
+	status := cl.Status
+	name := cl.Name
+	cl.Unlock()
 
 	url := cl.arbitratorURL("/heartbeat")
-	var mst string
-	if cl.GetMaster() != nil {
-		mst = cl.GetMaster().URL
-	}
-	hosts := len(cl.GetServers())
-	failed := cl.CountFailed(cl.GetServers())
-	cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModArbitration, config.LvlDbg, "SetArbitratorReport: sending hosts=%d failed=%d cluster=%s", hosts, failed, cl.GetName())
-	var jsonStr = []byte(`{"uuid":"` + cl.runUUID + `","secret":"` + cl.Conf.ArbitrationSasSecret + `","cluster":"` + cl.GetName() + `","master":"` + mst + `","id":` + strconv.Itoa(cl.Conf.ArbitrationSasUniqueId) + `,"status":"` + cl.Status + `","hosts":` + strconv.Itoa(hosts) + `,"failed":` + strconv.Itoa(failed) + `}`)
+	cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModArbitration, config.LvlDbg, "SetArbitratorReport: sending hosts=%d failed=%d cluster=%s", hosts, failed, name)
+	var jsonStr = []byte(`{"uuid":"` + cl.runUUID + `","secret":"` + cl.Conf.ArbitrationSasSecret + `","cluster":"` + name + `","master":"` + mst + `","id":` + strconv.Itoa(cl.Conf.ArbitrationSasUniqueId) + `,"status":"` + status + `","hosts":` + strconv.Itoa(hosts) + `,"failed":` + strconv.Itoa(failed) + `}`)
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
 	if err != nil {
 		if cl.Conf.LogHeartbeat {

--- a/server/server.go
+++ b/server/server.go
@@ -3493,10 +3493,18 @@ func (repman *ReplicationManager) Heartbeat() {
 	// The report carries the cluster status: the arbitrator maintains its
 	// authority LEASE from it (claim on Active, release on Standby), so it
 	// always knows who legitimately drives — without any periodic traffic.
-	if repman.Conf.Arbitration && (repman.Status != repman.lastReportedStatus || repman.SplitBrain != repman.lastReportedSplitBrain) {
-		repman.lastReportedStatus = repman.Status
-		repman.lastReportedSplitBrain = repman.SplitBrain
-		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModHeartBeat, config.LvlInfo, "Server transition (status=%s splitbrain=%t): reporting to arbitrator", repman.Status, repman.SplitBrain)
+	// During split brain, refresh EVERY tick (not only on transition) so all
+	// clusters' arbitrator leases stay fresh IN SYNC — none passes the freshness
+	// timeout and self-promotes to winner, which is the per-cluster divergence
+	// (stranded flacq). Reports fire concurrently; SetArbitratorReport reads its
+	// inputs under the cluster lock so that is race-safe.
+	arbTransition := repman.Status != repman.lastReportedStatus || repman.SplitBrain != repman.lastReportedSplitBrain
+	if repman.Conf.Arbitration && (arbTransition || repman.SplitBrain) {
+		if arbTransition {
+			repman.lastReportedStatus = repman.Status
+			repman.lastReportedSplitBrain = repman.SplitBrain
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModHeartBeat, config.LvlInfo, "Server transition (status=%s splitbrain=%t): reporting to arbitrator", repman.Status, repman.SplitBrain)
+		}
 		for _, cl := range repman.Clusters {
 			if !cl.Conf.Arbitration || !cl.Conf.IsEligibleForArbitration() {
 				continue


### PR DESCRIPTION
## Problem
Per-cluster arbitration divergence — clusters landing on different sides of a split (belair/crm/curepipe on DR, flacq stranded on the main). Their arbitrator leases were refreshed on **staggered per-cluster ticks**: a lagging cluster's lease passed the freshness timeout, the arbitrator dropped it, and its next election won against nobody → self-promote → split ownership / dual-active summary / colliding git pushes.

## Fix
- **server heartbeat** now refreshes the arbitrator reports **every tick while split brain is set** (not only on transition), fired concurrently per cluster, so all leases stay fresh **in sync** and none starves.
- **`SetArbitratorReport`** reads its topology inputs (hosts/failed/master/status) **under the cluster lock** before the network POST — `cluster.Servers` is reassigned (make/append/delete) under that same lock during `TopologyDiscover`, so firing the report concurrently from the server loop without the guard could tear the slice and panic. Lock held only for the quick reads; POST runs unlocked.

## Validated live (belair test pair, 2026-07-11)
Deployed to both repman instances; fired `testSetMinorityWithMaster` on belair. belair failed over to DR cleanly (minority stood down, majority took over) and **crm/curepipe/flacq held uniform node1-Active / DR-Standby the entire time — no scatter, no flapping**. Cleanest the pair has been.

## Scope
Interim. Stops divergence **forming** via lease starvation. Does not change the server-status rollup (a legitimately split cluster still double-counts) and does not un-diverge an already-split pair. Real cure is B (per-repman lease, arbitrator-side) — tracked separately. Arbitration path → belair + nightly-arb + topology matrix.