### PR TITLE
test(arbitration): minority sim cuts the arbitrator on ALL clusters (realistic whole-DC partition)

### DIFF
--- a/cluster/cluster_splitbrain_simulator.go
+++ b/cluster/cluster_splitbrain_simulator.go
@@ -84,6 +84,24 @@ func (cluster *Cluster) SimulateArbitratorFailure(duration time.Duration) {
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "SPLITBRAIN SIMULATION: arbitrator link cut for cluster %s", cluster.Name)
 }
 
+// SimulateArbitratorFailureAll severs the arbitrator link on EVERY cluster this
+// instance drives, not just the receiver. A real partition isolates the whole DC
+// from the arbitrator (DC3) for ALL clusters at once; the per-cluster cut used by
+// SimulateArbitratorFailure produces the impossible "one cluster alone loses the
+// arbitrator" scenario, which is a test artifact, not a real failure mode. Minority
+// tests use this so every cluster goes minority TOGETHER, matching reality — a
+// uniform verdict, coherent server status, no per-cluster divergence.
+func (cluster *Cluster) SimulateArbitratorFailureAll(duration time.Duration) {
+	armed := 0
+	for _, c := range cluster.clusterList {
+		c.SimulateArbitratorFailure(duration)
+		armed++
+	}
+	if armed == 0 { // single-cluster / unit-test context: at least arm the receiver
+		cluster.SimulateArbitratorFailure(duration)
+	}
+}
+
 // SimulateMasterFailure severs only this cluster's connection to the MASTER on this
 // instance (slaves stay reachable). Used when the master is colocated on the
 // isolated/minority side: the majority instance loses the master but keeps

--- a/regtest/test_split_brain.go
+++ b/regtest/test_split_brain.go
@@ -129,8 +129,8 @@ func setMinorityWithMaster(cl *cluster.Cluster) {
 	secs := int64(minorityHold / time.Second)
 
 	// op 1/4 LOCAL — repman1 loses the arbitrator (DC3).
-	cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST", "op 1/4 LOCAL: cutting arbitrator link (repman1 -> arbitrator)")
-	cl.SimulateArbitratorFailure(minorityHold)
+	cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST", "op 1/4 LOCAL: cutting arbitrator link on ALL clusters (repman1 -> arbitrator) — a real DC partition loses the arbitrator for every cluster at once, not just this one")
+	cl.SimulateArbitratorFailureAll(minorityHold)
 
 	// op 2/4 LOCAL — darken repman1's inbound /api/heartbeat so repman2's
 	// outbound heartbeat to repman1 times out (repman2 -> repman1 direction).
@@ -178,8 +178,8 @@ func setMinorityWithoutMaster(cl *cluster.Cluster) {
 	secs := int64(minorityHold / time.Second)
 
 	// op 1/4 LOCAL — repman1 loses the arbitrator (DC3).
-	cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST", "op 1/4 LOCAL: cutting arbitrator link (repman1 -> arbitrator)")
-	cl.SimulateArbitratorFailure(minorityHold)
+	cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST", "op 1/4 LOCAL: cutting arbitrator link on ALL clusters (repman1 -> arbitrator) — a real DC partition loses the arbitrator for every cluster at once, not just this one")
+	cl.SimulateArbitratorFailureAll(minorityHold)
 
 	// op 2/4 LOCAL — darken repman1's inbound /api/heartbeat so repman2's
 	// outbound heartbeat to repman1 times out (repman2 -> repman1 direction).


### PR DESCRIPTION
## Why
The minority sims cut the arbitrator **per cluster** (op 1/4) while the peer/heartbeat cut (op 2-3) is already server-wide. That asymmetry created an **impossible scenario** — one cluster alone losing the arbitrator while its siblings keep it — which made a single belair test *scatter* the pair (belair→DR, the rest on the main) and look like a per-cluster arbitration bug. **A real DC partition loses the arbitrator (and peer) for every cluster at once.**

## Change
- `Cluster.SimulateArbitratorFailureAll` arms the arbitrator cut across **every** cluster the instance drives (mirrors the server-wide peer cut); falls back to the receiver alone in a single-cluster/unit-test context.
- `setMinorityWithMaster` / `setMinorityWithoutMaster` op 1 use it → all clusters go minority **together** (uniform verdict, coherent server status, no per-cluster divergence). Real DB failover stays scoped to expendable **belair** (op 4 master cut); sensitive clusters only transit minority/Standby.

## Value
This is the test that actually **validates** the arbitration for the real world — pair with #1578 (concurrent reports). Together they should show all clusters moving as one, server status going cleanly S/A (single-active), instead of scattering.

## ⚠️ Known follow-up (acceptable for now, per Stephane)
The cut is now server-wide, so a single-cluster tenant running this test would impact all clusters/tenants. The server-wide-impacting tests should be gated on a **global/admin grant**, not the per-cluster ACL. Tracked, not blocking.