### PR TITLE
fix(app): refresh app templates from git reliably

### DIFF
--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -19,13 +19,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-var appTemplateRepoLocks sync.Map
-
-func getAppTemplateRepoLock(key string) *sync.Mutex {
-	mu, _ := appTemplateRepoLocks.LoadOrStore(key, &sync.Mutex{})
-	return mu.(*sync.Mutex)
-}
-
 func (cluster *Cluster) NewAppConfig(apphost, port string) *config.AppConfig {
 	agents := cluster.GetAppAgents(nil)
 	appcnf := &config.AppConfig{
@@ -1421,12 +1414,14 @@ func (cluster *Cluster) loadTemplateFromRepo(template string, forceRefresh bool)
 	if err != nil {
 		return nil, err
 	}
-	lock := getAppTemplateRepoLock(repoDir)
-	lock.Lock()
-	defer lock.Unlock()
 
+	// Uses config's shared repo lock so a concurrent refresh can't rename the
+	// dir mid-read. Must not hold the read lock across SyncAppTemplateRepoCache
+	// below (it takes the write lock; RWMutex isn't reentrant).
+	unlockRead := config.LockAppTemplateRepoRead(repoDir)
 	_, readErrBeforeSync := cluster.readTemplateFromRepoCache(repoDir, template)
 	hasStaleCopy := readErrBeforeSync == nil
+	unlockRead()
 
 	if forceRefresh || !hasStaleCopy {
 		if _, syncErr := cluster.Conf.SyncAppTemplateRepoCache(forceRefresh); syncErr != nil {
@@ -1438,6 +1433,9 @@ func (cluster *Cluster) loadTemplateFromRepo(template string, forceRefresh bool)
 			}
 		}
 	}
+
+	unlockRead = config.LockAppTemplateRepoRead(repoDir)
+	defer unlockRead()
 
 	content, err := cluster.readTemplateFromRepoCache(repoDir, template)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	masker "github.com/ggwhite/go-masker"
@@ -4127,17 +4128,28 @@ func (conf *Config) LoadAppTemplateList() ([]string, error) {
 
 func (conf *Config) LoadAppTemplateListWithRefresh(forceRefresh bool) ([]string, error) {
 	result := make([]string, 0)
-	repoDir, err := conf.SyncAppTemplateRepoCache(forceRefresh)
-	if err != nil {
-		return result, err
-	}
+	repoDir, syncErr := conf.SyncAppTemplateRepoCache(forceRefresh)
 	if repoDir == "" {
-		return result, nil
+		if errors.Is(syncErr, ErrAppTemplateRepoNotConfigured) {
+			return result, nil
+		}
+		return result, syncErr
 	}
 
-	err = filepath.WalkDir(repoDir, func(path string, d os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
+	// Hold the read lock for the whole walk so a concurrent forced refresh
+	// can't rename/delete repoDir mid-walk.
+	unlock := LockAppTemplateRepoRead(repoDir)
+	defer unlock()
+
+	if _, statErr := os.Stat(repoDir); statErr != nil {
+		// Nothing to fall back on (e.g. the first-ever sync failed and cleaned
+		// up after itself).
+		return result, syncErr
+	}
+
+	walkErr := filepath.WalkDir(repoDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
 		if d.IsDir() {
 			if d.Name() == ".git" {
@@ -4159,16 +4171,24 @@ func (conf *Config) LoadAppTemplateListWithRefresh(forceRefresh bool) ([]string,
 		}
 		return nil
 	})
-	if err != nil {
-		return result, err
+	if walkErr != nil {
+		return result, walkErr
 	}
 
-	return result, nil
+	// syncErr may be non-nil here (e.g. a transient forced-refresh failure)
+	// while result still holds the last-known-good list; return both instead
+	// of discarding a still-usable list.
+	return result, syncErr
 }
+
+// ErrAppTemplateRepoNotConfigured means the cluster simply has no
+// prov-app-template-repo set — a valid state (local/shared templates only),
+// not a sync failure.
+var ErrAppTemplateRepoNotConfigured = errors.New("no git repo configured")
 
 func (conf *Config) ResolveAppTemplateRepoCacheDir() (string, error) {
 	if strings.TrimSpace(conf.ProvAppTemplateRepo) == "" {
-		return "", errors.New("no git repo configured")
+		return "", ErrAppTemplateRepoNotConfigured
 	}
 	branch := strings.TrimSpace(conf.ProvAppTemplateRepoBranch)
 	if branch == "" {
@@ -4179,11 +4199,44 @@ func (conf *Config) ResolveAppTemplateRepoCacheDir() (string, error) {
 	return filepath.Join(conf.WorkingDir, ".templates", "repos", "apps", key), nil
 }
 
+// appTemplateRepoCacheLocks is the single lock domain (keyed by repoDir) for
+// every reader and writer of an app-template repo cache directory. Must stay
+// the only lock guarding these directories — a second independent lock (as
+// cluster/cluster_app.go used to have) lets a writer rename/delete the dir
+// out from under a reader that isn't using this registry. Forced refreshes
+// are never debounced/skipped here: forceRefresh=true means fetch from
+// source now, full stop.
+var appTemplateRepoCacheLocks sync.Map // map[string]*sync.RWMutex
+
+func appTemplateRepoRWLock(repoDir string) *sync.RWMutex {
+	v, _ := appTemplateRepoCacheLocks.LoadOrStore(repoDir, &sync.RWMutex{})
+	return v.(*sync.RWMutex)
+}
+
+// LockAppTemplateRepoWrite exclusively locks repoDir for cloning/recloning.
+// Call the returned func to release.
+func LockAppTemplateRepoWrite(repoDir string) func() {
+	mu := appTemplateRepoRWLock(repoDir)
+	mu.Lock()
+	return mu.Unlock
+}
+
+// LockAppTemplateRepoRead takes a shared read lock on repoDir: many readers
+// at once, never alongside a writer. Call the returned func to release.
+func LockAppTemplateRepoRead(repoDir string) func() {
+	mu := appTemplateRepoRWLock(repoDir)
+	mu.RLock()
+	return mu.RUnlock
+}
+
 func (conf *Config) SyncAppTemplateRepoCache(forceRefresh bool) (string, error) {
 	repoDir, err := conf.ResolveAppTemplateRepoCacheDir()
 	if err != nil {
 		return "", err
 	}
+
+	unlock := LockAppTemplateRepoWrite(repoDir)
+	defer unlock()
 
 	branch := strings.TrimSpace(conf.ProvAppTemplateRepoBranch)
 	if branch == "" {
@@ -4225,11 +4278,21 @@ func (conf *Config) SyncAppTemplateRepoCache(forceRefresh bool) (string, error) 
 
 	if _, statErr := os.Stat(repoDir); os.IsNotExist(statErr) {
 		if err := cloneRepo(repoDir); err != nil {
+			// go-git creates the target dir before fetching, so a failed clone
+			// leaves an empty/partial one behind; clean it up or a later
+			// non-forced call would trust it forever and never retry.
+			_ = os.RemoveAll(repoDir)
 			return repoDir, err
 		}
 		return repoDir, nil
 	} else if statErr != nil {
 		return repoDir, statErr
+	} else if !isValidGitClone(repoDir) {
+		// Broken/partial cache (or a non-git file some other caller left at
+		// this path). Route through the forceRefresh tmp-clone-then-rename
+		// path instead of deleting in place, so a failed recovery doesn't
+		// destroy whatever was already there.
+		forceRefresh = true
 	}
 
 	if !forceRefresh {
@@ -4258,6 +4321,17 @@ func (conf *Config) SyncAppTemplateRepoCache(forceRefresh bool) (string, error) 
 	_ = os.RemoveAll(backupDir)
 
 	return repoDir, nil
+}
+
+// isValidGitClone reports whether dir holds a usable git clone (as opposed to
+// an empty/partial directory left behind by an interrupted or failed clone).
+func isValidGitClone(dir string) bool {
+	repo, err := git.PlainOpen(dir)
+	if err != nil {
+		return false
+	}
+	_, err = repo.Head()
+	return err == nil
 }
 
 func GetKeyAliasMap() map[string]string {

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -3853,6 +3853,14 @@ func (repman *ReplicationManager) handlerMuxAppResolveTemplate(w http.ResponseWr
 	}
 }
 
+// setAppTemplateRepoErrorHeader exposes a repo sync failure to the client via
+// a response header while still returning 200 with the (possibly stale)
+// template list, so a failed refresh doesn't look identical to a successful one.
+func setAppTemplateRepoErrorHeader(w http.ResponseWriter, err error) {
+	w.Header().Set("Access-Control-Expose-Headers", "X-App-Template-Repo-Error")
+	w.Header().Set("X-App-Template-Repo-Error", strings.ReplaceAll(strings.ReplaceAll(err.Error(), "\r", " "), "\n", " "))
+}
+
 // @Summary Refresh App Template from Repo
 // @Description Retrieves the tree structure of the application template repository for a specific cluster.
 // @Tags Apps
@@ -3876,7 +3884,12 @@ func (repman *ReplicationManager) handlerMuxAppRefreshTemplateFromRepo(w http.Re
 		}
 
 		templates, _ := repman.GetAppTemplatesFromLocal(mycluster.Name)
-		repolist, _ := mycluster.Conf.LoadAppTemplateListWithRefresh(true)
+		repolist, repoErr := mycluster.Conf.LoadAppTemplateListWithRefresh(true)
+		if repoErr != nil {
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
+				"Error refreshing app template repository for cluster %s: %v", mycluster.Name, repoErr)
+			setAppTemplateRepoErrorHeader(w, repoErr)
+		}
 		for _, name := range repolist {
 			if strings.TrimSpace(name) != "" {
 				templates = append(templates, name)
@@ -3936,7 +3949,12 @@ func (repman *ReplicationManager) handlerMuxAppTemplatesList(w http.ResponseWrit
 
 	forceRefresh := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("forceRefresh")), "true")
 	templates, _ := repman.GetAppTemplatesFromLocal(mycluster.Name)
-	repolist, _ := mycluster.Conf.LoadAppTemplateListWithRefresh(forceRefresh)
+	repolist, repoErr := mycluster.Conf.LoadAppTemplateListWithRefresh(forceRefresh)
+	if repoErr != nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
+			"Error refreshing app template repository for cluster %s: %v", mycluster.Name, repoErr)
+		setAppTemplateRepoErrorHeader(w, repoErr)
+	}
 	templates = append(templates, "shared/dummy")
 	for _, name := range repolist {
 		if name != "" {

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Overview/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Overview/index.jsx
@@ -17,7 +17,8 @@ const Overview = ({ clusterName, config, appId, appName, appHost, appConfig, use
     const dispatch = useDispatch();
     const deployment = useSelector((state) => state.cluster?.app?.deployment);
     const substitution = useSelector((state) => state.cluster?.app?.substitution);
-    const dockerTemplates = useSelector((state) => state.globalClusters.monitor?.serviceTemplates);
+    const dockerTemplatesRaw = useSelector((state) => state.globalClusters.appTemplatesByCluster[clusterName]?.names);
+    const dockerTemplates = useMemo(() => dockerTemplatesRaw || [], [dockerTemplatesRaw]);
     const opensvcPools = useSelector((state) => state.cluster?.opensvcPools || []);
     const isOpenSVCOrchestrator = useSelector(
         (state) => state.cluster?.clusterData?.config?.provOrchestrator === "opensvc"

--- a/share/dashboard_react/src/Pages/ClusterApp/components/Templates/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/components/Templates/index.jsx
@@ -28,17 +28,18 @@ import { createLocalAppTemplateCopy, deleteAppTemplateContent, previewAppTemplat
 
 function Templates({ clusterName, appConfig, user }) {
   const dispatch = useDispatch()
-  const monitor = useSelector((state) => state.globalClusters.monitor)
-  const templateRepoError = useSelector((state) => state.globalClusters.templateRepoError)
+  const appTemplateNames = useSelector((state) => state.globalClusters.appTemplatesByCluster[clusterName]?.names)
+  const appTemplateMetadata = useSelector((state) => state.globalClusters.appTemplatesByCluster[clusterName]?.metadata)
+  const templateRepoError = useSelector((state) => state.globalClusters.appTemplatesByCluster[clusterName]?.error)
   const templateGuideError = useSelector((state) => state.globalClusters.templateGuideError)
   const templateMeta = useMemo(() => {
-    const meta = Array.isArray(monitor?.serviceTemplateMetadata) ? monitor.serviceTemplateMetadata : []
+    const meta = Array.isArray(appTemplateMetadata) ? appTemplateMetadata : []
     if (meta.length > 0) {
       return meta
     }
-    const names = Array.isArray(monitor?.serviceTemplates) ? monitor.serviceTemplates : []
+    const names = Array.isArray(appTemplateNames) ? appTemplateNames : []
     return names.map((name) => ({ name, origin: 'repo', scope: 'global', editable: false }))
-  }, [monitor?.serviceTemplateMetadata, monitor?.serviceTemplates])
+  }, [appTemplateMetadata, appTemplateNames])
 
   const [selectedTemplate, setSelectedTemplate] = useState(appConfig?.provAppTemplate || '')
   const [content, setContent] = useState('')

--- a/share/dashboard_react/src/Pages/ClusterApp/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterApp/index.jsx
@@ -44,9 +44,6 @@ function ClusterApp() {
       if (tabs.current[selectedTabRef.current] === 'Service OpenSVC') {
         dispatch(getAppService({ clusterName, serviceName: 'service-opensvc', appId }))
       }
-      if (tabs.current[selectedTabRef.current] === 'Templates') {
-        dispatch(refreshAppTemplateRepo({ clusterName, silent: true }))
-      }
     }
   }
 
@@ -83,6 +80,13 @@ function ClusterApp() {
       setSelectedApp(app)
     }
   }, [appId, clusterApps])
+
+  // Fetch once per cluster, not on every poll tick: Overview needs this
+  // before the user visits the Templates tab, but the list rarely changes.
+  useEffect(() => {
+    if (!clusterName) return
+    dispatch(refreshAppTemplateRepo({ clusterName, silent: true }))
+  }, [clusterName, dispatch])
 
   useEffect(() => {
     if (clusterData?.apiUsers && loggedUser) {

--- a/share/dashboard_react/src/components/Modals/NewServerModal.jsx
+++ b/share/dashboard_react/src/components/Modals/NewServerModal.jsx
@@ -181,9 +181,15 @@ const authTypes = [
 function NewServerModal({ clusterName, isOpen, closeModal }) {
   const dispatch = useDispatch()
   const { theme } = useTheme()
-  const { globalClusters: { monitor, clusters, appTemplatesByCluster } } = useSelector((state) => state)
+  const { globalClusters: { monitor, clusters, appTemplatesByCluster, pendingThunks } } = useSelector((state) => state)
   const appTemplateNamesRaw = appTemplatesByCluster[clusterName]?.names
   const appTemplateNames = useMemo(() => appTemplateNamesRaw || [], [appTemplateNamesRaw])
+  const templateRepoError = appTemplatesByCluster[clusterName]?.error
+  const appTemplateRefreshPendingKey = useMemo(
+    () => clusterName ? `globalClusters/refreshAppTemplateRepo:${clusterName}` : 'globalClusters/refreshAppTemplateRepo',
+    [clusterName]
+  )
+  const isRefreshingAppTemplates = Boolean(pendingThunks?.[appTemplateRefreshPendingKey])
   const [formState, formDispatch] = useReducer(formReducer, initialState)
   const { formData, tagOptions, templateOptions, errors } = formState
   const { host, port, monitorType, dockerImage, tag, dockerRegistry } = formData
@@ -326,6 +332,9 @@ function NewServerModal({ clusterName, isOpen, closeModal }) {
   }
 
   const handleRefreshAppTemplates = () => {
+    if (!clusterName || isRefreshingAppTemplates) {
+      return
+    }
     dispatch(refreshAppTemplateRepo({ clusterName, forceRefresh: true }))
   }
 
@@ -366,7 +375,12 @@ function NewServerModal({ clusterName, isOpen, closeModal }) {
                 <FormControl>
                   <Flex className={parentStyles.modalFieldWithAction}>
                     <FormLabel htmlFor='template' mb={0}>Template</FormLabel>
-                    <RMIconButton onClick={handleRefreshAppTemplates} icon={HiRefresh} tooltip='Refresh templates from repository' />
+                    <RMIconButton
+                      onClick={handleRefreshAppTemplates}
+                      icon={HiRefresh}
+                      tooltip={isRefreshingAppTemplates ? 'Refreshing templates from repository…' : 'Refresh templates from repository'}
+                      isDisabled={isRefreshingAppTemplates || !clusterName}
+                    />
                   </Flex>
                   <Dropdown
                     id='template'
@@ -375,6 +389,11 @@ function NewServerModal({ clusterName, isOpen, closeModal }) {
                     options={templateOptions}
                     selectedValue={template}
                   />
+                  <FormHelperText color={templateRepoError ? 'red.400' : undefined}>
+                    {isRefreshingAppTemplates
+                      ? 'Refreshing templates from repository…'
+                      : (templateRepoError || 'Choose a template from the repository, or leave this blank to provide a Docker image manually.')}
+                  </FormHelperText>
                 </FormControl>
 
                 {!template && (

--- a/share/dashboard_react/src/components/Modals/NewServerModal.jsx
+++ b/share/dashboard_react/src/components/Modals/NewServerModal.jsx
@@ -15,7 +15,7 @@ import {
   ModalOverlay,
   Stack
 } from '@chakra-ui/react'
-import { useEffect, useReducer } from 'react'
+import { useEffect, useMemo, useReducer } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { addServer, connectDockerRegistry } from '../../redux/clusterSlice'
 import Dropdown from '../Dropdown'
@@ -181,7 +181,9 @@ const authTypes = [
 function NewServerModal({ clusterName, isOpen, closeModal }) {
   const dispatch = useDispatch()
   const { theme } = useTheme()
-  const { globalClusters: { monitor, clusters } } = useSelector((state) => state)
+  const { globalClusters: { monitor, clusters, appTemplatesByCluster } } = useSelector((state) => state)
+  const appTemplateNamesRaw = appTemplatesByCluster[clusterName]?.names
+  const appTemplateNames = useMemo(() => appTemplateNamesRaw || [], [appTemplateNamesRaw])
   const [formState, formDispatch] = useReducer(formReducer, initialState)
   const { formData, tagOptions, templateOptions, errors } = formState
   const { host, port, monitorType, dockerImage, tag, dockerRegistry } = formData
@@ -230,15 +232,17 @@ function NewServerModal({ clusterName, isOpen, closeModal }) {
   }, [monitor?.serviceRepos])
 
   useEffect(() => {
-    if (monitor?.serviceTemplates?.length > 0) {
-      const templates = monitor?.serviceTemplates.map(item => ({
-        name: item,
-        value: item
-      }))
+    const templates = (appTemplateNames || []).map(item => ({
+      name: item,
+      value: item
+    }))
 
-      formDispatch({ type: 'SET_TEMPLATE_OPTIONS', payload: [{ name: 'No Template', value: '' }, ...templates] })
+    formDispatch({ type: 'SET_TEMPLATE_OPTIONS', payload: [{ name: 'No Template', value: '' }, ...templates] })
+
+    if (template && !(appTemplateNames || []).includes(template)) {
+      formDispatch({ type: 'SET_DOCKER_TEMPLATE', payload: '' })
     }
-  }, [monitor?.serviceTemplates])
+  }, [appTemplateNames, template])
 
   const handleCreateNewServer = () => {
     const monitorTypeError = monitorType?.length > 0 ? '' : 'Monitor type is required'
@@ -322,14 +326,16 @@ function NewServerModal({ clusterName, isOpen, closeModal }) {
   }
 
   const handleRefreshAppTemplates = () => {
-    dispatch(refreshAppTemplateRepo({ clusterName }))
+    dispatch(refreshAppTemplateRepo({ clusterName, forceRefresh: true }))
   }
 
   useEffect(() => {
     if (!isOpen) {
       formDispatch({ type: 'RESET_FORM' })
+    } else if (clusterName) {
+      dispatch(refreshAppTemplateRepo({ clusterName, silent: true }))
     }
-  }, [isOpen])
+  }, [isOpen, clusterName, dispatch])
 
   return (
     <Modal isOpen={isOpen} onClose={closeModal}>

--- a/share/dashboard_react/src/redux/globalClustersSlice.js
+++ b/share/dashboard_react/src/redux/globalClustersSlice.js
@@ -4,7 +4,20 @@ import { globalClustersService } from '../services/globalClustersService'
 
 const getThunkTypePrefix = (actionType) => actionType.replace(/\/(pending|fulfilled|rejected)$/, '')
 
-const getPendingKey = (typePrefix) => typePrefix
+// A thunk can opt in via `pendingKeyFor` to dedupe by arg (e.g. clusterName)
+// instead of by type prefix alone, so unrelated targets don't block each other.
+const pendingKeyResolvers = {} // typePrefix -> (arg) => string | undefined
+
+const getPendingKey = (typePrefix, arg) => {
+  const resolver = pendingKeyResolvers[typePrefix]
+  if (resolver) {
+    const suffix = resolver(arg)
+    if (suffix) {
+      return `${typePrefix}:${suffix}`
+    }
+  }
+  return typePrefix
+}
 
 const shouldTrackThunk = (action) => {
   if (!action?.meta?.requestId) {
@@ -14,13 +27,19 @@ const shouldTrackThunk = (action) => {
 }
 
 const createGuardedAsyncThunk = (typePrefix, payloadCreator, options = {}) => {
-  const { condition, ...restOptions } = options
+  const { condition, pendingKeyFor, bypassPendingGuard, ...restOptions } = options
+  if (pendingKeyFor) {
+    pendingKeyResolvers[typePrefix] = pendingKeyFor
+  }
   return createAsyncThunk(typePrefix, payloadCreator, {
     ...restOptions,
     condition: (arg, api) => {
-      const pendingKey = getPendingKey(typePrefix)
-      if (api.getState()?.globalClusters?.pendingThunks?.[pendingKey]) {
-        return false
+      const skipGuard = bypassPendingGuard ? bypassPendingGuard(arg) : false
+      if (!skipGuard) {
+        const pendingKey = getPendingKey(typePrefix, arg)
+        if (api.getState()?.globalClusters?.pendingThunks?.[pendingKey]) {
+          return false
+        }
       }
       if (condition) {
         const result = condition(arg, api)
@@ -368,17 +387,25 @@ export const refreshAppTemplateRepo = createGuardedAsyncThunk(
   async ({ clusterName, silent = false, forceRefresh = false }, thunkAPI) => {
     try {
       const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
-      const { data, status } = await globalClustersService.refreshAppTemplateRepo(clusterName, baseURL, forceRefresh)
+      const { data, status, headers } = await globalClustersService.refreshAppTemplateRepo(clusterName, baseURL, forceRefresh)
       if (status !== 200) {
         throw new Error(data)
       }
-      return { data, status }
+      const repoError = headers?.get?.('x-app-template-repo-error') || null
+      return { data, status, repoError }
     } catch (error) {
       if (!silent) {
         showErrorBanner('Error while refreshing app template repository', error, thunkAPI)
       }
       return handleError(error, thunkAPI)
     }
+  },
+  {
+    // Dedupe per cluster: an in-flight refresh for cluster A shouldn't block one for cluster B.
+    pendingKeyFor: (arg) => arg?.clusterName,
+    // An explicit forceRefresh must always reach the backend, even if a silent
+    // refresh for the same cluster is already in flight.
+    bypassPendingGuard: (arg) => Boolean(arg?.forceRefresh)
   }
 )
 
@@ -411,7 +438,10 @@ const initialState = {
   clusterPeers: null,
   clusterForSale: null,
   monitor: null,
-  templateRepoError: null,
+  appTemplatesByCluster: {},
+  // requestId of the latest dispatched refreshAppTemplateRepo per cluster, so
+  // an older in-flight request's response can't clobber a newer one's.
+  latestAppTemplateRequestByCluster: {},
   templateGuideContent: '',
   templateGuideError: null,
   terms: ``,
@@ -473,18 +503,45 @@ export const globalClustersSlice = createSlice({
       .addCase(getClusterForSale.rejected, (state, action) => {
         state.error = action.error
       })
+      .addCase(refreshAppTemplateRepo.pending, (state, action) => {
+        const clusterName = action.meta.arg?.clusterName
+        if (clusterName) {
+          state.latestAppTemplateRequestByCluster[clusterName] = action.meta.requestId
+        }
+      })
       .addCase(refreshAppTemplateRepo.fulfilled, (state, action) => {
+        const clusterName = action.meta.arg?.clusterName
+        if (!clusterName) {
+          return
+        }
+        // A newer request for this cluster has since been dispatched; discard this stale response.
+        if (state.latestAppTemplateRequestByCluster[clusterName] !== action.meta.requestId) {
+          return
+        }
         const templateRows = Array.isArray(action.payload.data) ? action.payload.data : []
         const templateNames = templateRows.map((row) => row?.name).filter(Boolean)
-        if (!state.monitor) {
-          state.monitor = {}
+        state.appTemplatesByCluster[clusterName] = {
+          names: templateNames,
+          metadata: templateRows,
+          error: action.payload.repoError || null
         }
-        state.monitor.serviceTemplates = templateNames
-        state.monitor.serviceTemplateMetadata = templateRows
-        state.templateRepoError = null
       })
       .addCase(refreshAppTemplateRepo.rejected, (state, action) => {
-        state.templateRepoError = action.error?.message || 'Failed to refresh app template repository'
+        const clusterName = action.meta.arg?.clusterName
+        if (!clusterName) {
+          return
+        }
+        if (state.latestAppTemplateRequestByCluster[clusterName] !== action.meta.requestId) {
+          return
+        }
+        const existing = state.appTemplatesByCluster[clusterName]
+        state.appTemplatesByCluster[clusterName] = {
+          names: existing?.names || [],
+          metadata: existing?.metadata || [],
+          // handleError() rejects via rejectWithValue, so the real message is
+          // in action.payload; action.error.message is just RTK's generic "Rejected".
+          error: action.payload?.errorMessage || action.error?.message || 'Failed to refresh app template repository'
+        }
       })
       .addCase(getAppTemplateStructureGuide.fulfilled, (state, action) => {
         state.templateGuideContent = action.payload?.data?.content || ''
@@ -516,12 +573,14 @@ export const globalClustersSlice = createSlice({
         state.error = action.error
       })
 
+    // Reference count, not a boolean: bypassPendingGuard can let two same-key
+    // requests run at once, and a boolean would go false when only one of them finishes.
     builder.addMatcher(
       (action) => action.type.endsWith('/pending') && shouldTrackThunk(action),
       (state, action) => {
         const typePrefix = getThunkTypePrefix(action.type)
-        const pendingKey = getPendingKey(typePrefix)
-        state.pendingThunks[pendingKey] = true
+        const pendingKey = getPendingKey(typePrefix, action.meta.arg)
+        state.pendingThunks[pendingKey] = (state.pendingThunks[pendingKey] || 0) + 1
       }
     )
 
@@ -530,8 +589,9 @@ export const globalClustersSlice = createSlice({
         (action.type.endsWith('/fulfilled') || action.type.endsWith('/rejected')) && shouldTrackThunk(action),
       (state, action) => {
         const typePrefix = getThunkTypePrefix(action.type)
-        const pendingKey = getPendingKey(typePrefix)
-        state.pendingThunks[pendingKey] = false
+        const pendingKey = getPendingKey(typePrefix, action.meta.arg)
+        const next = (state.pendingThunks[pendingKey] || 0) - 1
+        state.pendingThunks[pendingKey] = next > 0 ? next : 0
       }
     )
   }

--- a/share/dashboard_react/src/services/apiHelper.js
+++ b/share/dashboard_react/src/services/apiHelper.js
@@ -69,7 +69,7 @@ const handleResponse = async (response) => {
     data = await response.text();
   }
 
-  return { data, status: response.status };
+  return { data, status: response.status, headers: response.headers };
 };
 
 const performRequest = async (method, apiUrl, params, authValue, baseUrl = '') => {


### PR DESCRIPTION
## Summary
- harden app template repo cache refresh and recovery paths
- refresh app templates per cluster from git and keep explicit refreshes from being overwritten
- clarify add-monitor template refresh state in the modal

## Testing
- go test ./server ./config ./cluster
- npx eslint "src/components/Modals/NewServerModal.jsx"