### PR TITLE
fix(cloud18): sync instance plan from crm

### DIFF
--- a/server/api_global_settings.go
+++ b/server/api_global_settings.go
@@ -184,6 +184,11 @@ func (repman *ReplicationManager) setRepmanSetting(name string, value string) er
 					repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
 						"Cloud18 connect failed: %s", err.Error())
 					repman.Conf.Cloud18 = false
+				} else {
+					// Best-effort: pick up the CRM's current plan for this URI so a
+					// node connecting to an already-subscribed URI doesn't stay on
+					// its local default. See syncSubscriptionPlanFromCRM.
+					repman.syncSubscriptionPlanFromCRM()
 				}
 				// Save final state (Cloud18 + any PAT/GitUrl set by InitGitConfig).
 				repman.ConfigManager.SaveConfig(repman, false)

--- a/server/api_register.go
+++ b/server/api_register.go
@@ -408,6 +408,13 @@ func (repman *ReplicationManager) applyCloudConnect(
 			}
 		}
 	}
+
+	// Sync the CRM's current plan for this URI so a second node registering
+	// against an already-subscribed URI (or a node reconnecting after losing
+	// its local config) doesn't stay stuck on the local default. Best-effort:
+	// see syncSubscriptionPlanFromCRM.
+	repman.syncSubscriptionPlanFromCRM()
+
 	repman.RegStatus.set(RegStateOK, "Registration complete", json.RawMessage(respBody))
 }
 
@@ -953,6 +960,79 @@ func (repman *ReplicationManager) persistInstanceSubscriptionPlan(plan, uri stri
 	}
 	repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
 		"subscription: plan changed to %s for URI %s (persisted to config)", plan, uri)
+}
+
+// parseSubscriptionPlan extracts the "plan" field from a CRM
+// GET /api/subscription response body. Returns an error for malformed JSON
+// or a missing/empty plan — callers must treat that as "nothing to sync",
+// not as a plan.
+func parseSubscriptionPlan(body []byte) (string, error) {
+	var resp struct {
+		Plan string `json:"plan"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("could not parse CRM subscription response: %w", err)
+	}
+	plan := strings.ToLower(strings.TrimSpace(resp.Plan))
+	if plan == "" {
+		return "", fmt.Errorf("CRM subscription response has no plan")
+	}
+	return plan, nil
+}
+
+// syncSubscriptionPlanFromCRMWithToken fetches the CRM's current subscription
+// plan for this instance URI and persists it locally if found. This is the
+// fix for the second-node/same-URI case: a node that registers against a
+// URI that already has a paid plan on CRM otherwise keeps its local default
+// ("free") forever, since the plan is normally only written on an explicit
+// change via handlerChangeSubscription.
+//
+// Best-effort by design: on any failure (CRM unreachable, non-200, unparseable
+// body, empty plan) this only logs a warning and leaves local config
+// untouched — it never resets the plan to a default and never blocks the
+// caller's registration/connect flow.
+func (repman *ReplicationManager) syncSubscriptionPlanFromCRMWithToken(gitlabToken string) {
+	uri := repman.registeredInstanceURI()
+	if uri == "" {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"subscription: plan sync skipped, instance URI not fully configured")
+		return
+	}
+
+	status, body, err := crmGetSubscription(repman.crmBase(), gitlabToken, uri)
+	if err != nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"subscription: plan sync skipped, CRM unreachable: %s", err)
+		return
+	}
+	if status != http.StatusOK {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"subscription: plan sync skipped, CRM returned HTTP %d for uri %s", status, uri)
+		return
+	}
+
+	plan, err := parseSubscriptionPlan(body)
+	if err != nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"subscription: %s", err)
+		return
+	}
+
+	repman.persistInstanceSubscriptionPlan(plan, uri)
+}
+
+// syncSubscriptionPlanFromCRM is the production entry point: it derives the
+// GitLab token from already-persisted Cloud18 credentials, then delegates to
+// syncSubscriptionPlanFromCRMWithToken. Split out so the CRM-fetch/parse/
+// persist logic can be unit tested without a live GitLab token exchange.
+func (repman *ReplicationManager) syncSubscriptionPlanFromCRM() {
+	tok, err := repman.gitlabTokenFromConfig()
+	if err != nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"subscription: plan sync skipped, could not obtain GitLab token: %s", err)
+		return
+	}
+	repman.syncSubscriptionPlanFromCRMWithToken(tok)
 }
 
 func writeOfflineSubscriptionQueued(w http.ResponseWriter, plan, uri, detail string) {

--- a/server/api_register_unit_test.go
+++ b/server/api_register_unit_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/signal18/replication-manager/config"
 )
 
 func TestCRMCallConfirm_SendsBearerToken(t *testing.T) {
@@ -59,5 +61,154 @@ func TestCRMGetPlans_UsesCanonicalInstancePlansEndpoint(t *testing.T) {
 	}
 	if status != http.StatusOK {
 		t.Fatalf("expected status 200, got %d body=%q", status, string(body))
+	}
+}
+
+func TestParseSubscriptionPlan(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		want    string
+		wantErr bool
+	}{
+		{name: "valid plan", body: `{"plan":"support-services"}`, want: "support-services"},
+		{name: "plan needs normalization", body: `{"plan":"  Support  "}`, want: "support"},
+		{name: "missing plan field", body: `{"uri":"acme.dev.fr-1"}`, wantErr: true},
+		{name: "empty plan field", body: `{"plan":""}`, wantErr: true},
+		{name: "malformed json", body: `not json`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSubscriptionPlan([]byte(tt.body))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got plan %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("expected plan %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func newSyncTestRepman(crmURL string) *ReplicationManager {
+	return &ReplicationManager{
+		Conf: &config.Config{
+			Cloud18CrmApiUrl:        crmURL,
+			Cloud18Domain:           "acme",
+			Cloud18SubDomain:        "dev",
+			Cloud18SubDomainZone:    "fr-1",
+			Cloud18SubscriptionPlan: "free",
+		},
+	}
+}
+
+func TestSyncSubscriptionPlanFromCRMWithToken_PersistsPlanOnSuccess(t *testing.T) {
+	crm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/subscription" {
+			t.Fatalf("expected path /api/subscription, got %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("uri"); got != "acme.dev.fr-1" {
+			t.Fatalf("expected uri=acme.dev.fr-1, got %q", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer peer-token" {
+			t.Fatalf("expected Authorization Bearer peer-token, got %q", got)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"plan":"support-services","uri":"acme.dev.fr-1"}`))
+	}))
+	defer crm.Close()
+
+	repman := newSyncTestRepman(crm.URL)
+	repman.syncSubscriptionPlanFromCRMWithToken("peer-token")
+
+	if repman.Conf.Cloud18SubscriptionPlan != "support-services" {
+		t.Fatalf("expected plan to be synced from CRM, got %q", repman.Conf.Cloud18SubscriptionPlan)
+	}
+}
+
+// TestSyncSubscriptionPlanFromCRMWithToken_LeavesPlanUntouchedWhenDisconnected
+// pins down the "don't auto-change on failure" requirement: when CRM cannot
+// be reached, returns a non-200, or returns an unparseable/empty body, the
+// local plan must be left exactly as it was — never reset or overwritten
+// with an error value.
+func TestSyncSubscriptionPlanFromCRMWithToken_LeavesPlanUntouchedWhenDisconnected(t *testing.T) {
+	t.Run("CRM unreachable", func(t *testing.T) {
+		repman := newSyncTestRepman("http://127.0.0.1:0") // nothing listening here
+		repman.syncSubscriptionPlanFromCRMWithToken("peer-token")
+
+		if repman.Conf.Cloud18SubscriptionPlan != "free" {
+			t.Fatalf("expected plan to stay unchanged when CRM unreachable, got %q", repman.Conf.Cloud18SubscriptionPlan)
+		}
+	})
+
+	t.Run("CRM returns non-200", func(t *testing.T) {
+		crm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":"not entitled"}`))
+		}))
+		defer crm.Close()
+
+		repman := newSyncTestRepman(crm.URL)
+		repman.syncSubscriptionPlanFromCRMWithToken("peer-token")
+
+		if repman.Conf.Cloud18SubscriptionPlan != "free" {
+			t.Fatalf("expected plan to stay unchanged on non-200, got %q", repman.Conf.Cloud18SubscriptionPlan)
+		}
+	})
+
+	t.Run("CRM returns malformed body", func(t *testing.T) {
+		crm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`not json`))
+		}))
+		defer crm.Close()
+
+		repman := newSyncTestRepman(crm.URL)
+		repman.syncSubscriptionPlanFromCRMWithToken("peer-token")
+
+		if repman.Conf.Cloud18SubscriptionPlan != "free" {
+			t.Fatalf("expected plan to stay unchanged on malformed body, got %q", repman.Conf.Cloud18SubscriptionPlan)
+		}
+	})
+
+	t.Run("instance URI not configured", func(t *testing.T) {
+		repman := &ReplicationManager{
+			Conf: &config.Config{Cloud18SubscriptionPlan: "free"},
+		}
+		repman.syncSubscriptionPlanFromCRMWithToken("peer-token")
+
+		if repman.Conf.Cloud18SubscriptionPlan != "free" {
+			t.Fatalf("expected plan to stay unchanged when URI incomplete, got %q", repman.Conf.Cloud18SubscriptionPlan)
+		}
+	})
+}
+
+// TestSyncSubscriptionPlanFromCRM_NoCredentials verifies the production
+// entry point (token derivation + sync) never panics and never touches the
+// local plan when Cloud18 credentials aren't configured — this is the path
+// applyCloudConnect takes if InitGitConfig's own credential setup left the
+// instance without usable Cloud18GitUser/password, and it must not block
+// or corrupt registration success.
+func TestSyncSubscriptionPlanFromCRM_NoCredentials(t *testing.T) {
+	repman := &ReplicationManager{
+		Conf: &config.Config{
+			Cloud18Domain:           "acme",
+			Cloud18SubDomain:        "dev",
+			Cloud18SubDomainZone:    "fr-1",
+			Cloud18SubscriptionPlan: "free",
+		},
+	}
+
+	repman.syncSubscriptionPlanFromCRM()
+
+	if repman.Conf.Cloud18SubscriptionPlan != "free" {
+		t.Fatalf("expected plan to stay unchanged with no credentials, got %q", repman.Conf.Cloud18SubscriptionPlan)
 	}
 }


### PR DESCRIPTION
## Summary
- sync the local Cloud18 subscription plan from CRM after connect or registration
- add best-effort helpers to fetch and persist the CRM plan without blocking the flow
- cover the CRM plan parsing and sync behavior with unit tests

## Testing
- Not run

## Contributor Agreement

By submitting this pull request, I agree to the terms outlined in the [Contributor Agreement](CONTRIBUTING.md).