### PR TITLE
Dynamic cluster git import and peer app monitor import

### DIFF
--- a/cluster/app.go
+++ b/cluster/app.go
@@ -68,6 +68,25 @@ type App struct {
 type appList []*App
 
 func (cluster *Cluster) newAppList() error {
+	// appListRebuildMu: two concurrent rebuilds (e.g. two concurrent
+	// ImportAppConfig/AddSeededApp calls) don't just race on the
+	// cluster.Conf.Apps read below — NewApp()/addAppToList() below mutate
+	// shared *config.AppConfig pointers in place (GetAppConfig,
+	// SetDefaultRoute, ...), so any two rebuilds running at once corrupt
+	// that shared state even if the Conf.Apps read itself were race-free.
+	cluster.appListRebuildMu.Lock()
+	defer cluster.appListRebuildMu.Unlock()
+
+	// Snapshot cluster.Conf.Apps under the general cluster lock: every other
+	// mutator of this slice (appendConfAppIfAbsent, removeConfApp,
+	// RemoveAppMonitor, ImportAppConfig) holds cluster.Lock() around its own
+	// read-then-write, so reading it here without the same lock would race
+	// against any of them running concurrently with this rebuild.
+	cluster.Lock()
+	confApps := make([]*config.AppConfig, len(cluster.Conf.Apps))
+	copy(confApps, cluster.Conf.Apps)
+	cluster.Unlock()
+
 	// Build into a temporary slice first, then swap atomically so that
 	// concurrent readers never observe a partially-populated list.
 	type pendingApp struct {
@@ -75,10 +94,10 @@ func (cluster *Cluster) newAppList() error {
 		hostport string
 		s3Prov   bool
 	}
-	pending := make([]pendingApp, 0, len(cluster.Conf.Apps))
+	pending := make([]pendingApp, 0, len(confApps))
 	news3providers := make([]string, 0)
 
-	for k, appcnf := range cluster.Conf.Apps {
+	for k, appcnf := range confApps {
 		if appcnf.AppHost == "" {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlWarn,
 				"Skipping app config at index %d: AppHost is empty (file may be incomplete)", k)

--- a/cluster/app.go
+++ b/cluster/app.go
@@ -68,20 +68,12 @@ type App struct {
 type appList []*App
 
 func (cluster *Cluster) newAppList() error {
-	// appListRebuildMu: two concurrent rebuilds (e.g. two concurrent
-	// ImportAppConfig/AddSeededApp calls) don't just race on the
-	// cluster.Conf.Apps read below — NewApp()/addAppToList() below mutate
-	// shared *config.AppConfig pointers in place (GetAppConfig,
-	// SetDefaultRoute, ...), so any two rebuilds running at once corrupt
-	// that shared state even if the Conf.Apps read itself were race-free.
+	// Serialize whole rebuilds: NewApp()/addAppToList() mutate shared
+	// *config.AppConfig pointers in place, so two rebuilds racing corrupts them.
 	cluster.appListRebuildMu.Lock()
 	defer cluster.appListRebuildMu.Unlock()
 
-	// Snapshot cluster.Conf.Apps under the general cluster lock: every other
-	// mutator of this slice (appendConfAppIfAbsent, removeConfApp,
-	// RemoveAppMonitor, ImportAppConfig) holds cluster.Lock() around its own
-	// read-then-write, so reading it here without the same lock would race
-	// against any of them running concurrently with this rebuild.
+	// Snapshot Conf.Apps under cluster.Lock() — other mutators write it under the same lock.
 	cluster.Lock()
 	confApps := make([]*config.AppConfig, len(cluster.Conf.Apps))
 	copy(confApps, cluster.Conf.Apps)

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -357,6 +357,14 @@ type Cluster struct {
 	preservedVarsMutex          sync.RWMutex               `json:"-"`
 	s3SyncApplyMu               sync.Mutex                 `json:"-"`
 	appListEpoch                uint64                     `json:"-"`
+	// appListRebuildMu is held internally by newAppList() for its whole
+	// duration (see app.go). newAppList() reads cluster.Conf.Apps and
+	// mutates shared *config.AppConfig pointers in place (via GetAppConfig,
+	// SetDefaultRoute, ...), with no locking of its own beyond the final
+	// cluster.Apps swap — two rebuilds racing each other (e.g. two
+	// concurrent ImportAppConfig/AddSeededApp calls) corrupt that shared
+	// state. Callers do not need to take this themselves.
+	appListRebuildMu sync.Mutex `json:"-"`
 	secretVersionStoreMu        sync.Mutex                 `json:"-"`
 	secretVersionStoreDirty     bool                       `json:"-"`
 	// pluginSpikeCache holds the last DetectSpike result per server+plugin pair.

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -357,13 +357,7 @@ type Cluster struct {
 	preservedVarsMutex          sync.RWMutex               `json:"-"`
 	s3SyncApplyMu               sync.Mutex                 `json:"-"`
 	appListEpoch                uint64                     `json:"-"`
-	// appListRebuildMu is held internally by newAppList() for its whole
-	// duration (see app.go). newAppList() reads cluster.Conf.Apps and
-	// mutates shared *config.AppConfig pointers in place (via GetAppConfig,
-	// SetDefaultRoute, ...), with no locking of its own beyond the final
-	// cluster.Apps swap — two rebuilds racing each other (e.g. two
-	// concurrent ImportAppConfig/AddSeededApp calls) corrupt that shared
-	// state. Callers do not need to take this themselves.
+	// appListRebuildMu serializes newAppList() (held internally, see app.go).
 	appListRebuildMu sync.Mutex `json:"-"`
 	secretVersionStoreMu        sync.Mutex                 `json:"-"`
 	secretVersionStoreDirty     bool                       `json:"-"`

--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -147,14 +147,11 @@ var appACLRules = []ACLRule{
 	{"/content/actions/create-local-copy", nil, []string{config.GrantAppDeployment}},
 	{"/content", nil, []string{config.GrantAppDeployment}},
 
-	// Peer import (arbitration peer -> local, manual/per-app). inventory and
-	// export are peer-to-peer calls authenticated with the same shared
-	// cluster-test credentials as the split-brain-simulator endpoints
-	// (server.peerSplitBrainLogin / getClusterTestCredentials); preview and
-	// apply are operator-facing, gated like adding an app monitor
-	// (/actions/addserver in clusterACLRules).
-	{"/peer-import/inventory", nil, []string{config.GrantClusterTest}},
-	{"/peer-import/export", nil, []string{config.GrantClusterTest}},
+	// Peer import (arbitration peer -> local, manual/per-app). All peer-import
+	// endpoints are part of the app-monitor import flow, so they are gated with
+	// the same grants as adding/managing app monitors rather than cluster-test.
+	{"/peer-import/inventory", nil, []string{config.GrantClusterCreateMonitor, config.GrantAppDeployment}},
+	{"/peer-import/export", nil, []string{config.GrantClusterCreateMonitor, config.GrantAppDeployment}},
 	{"/peer-import/preview", nil, []string{config.GrantClusterCreateMonitor, config.GrantAppDeployment}},
 	{"/peer-import/apply", nil, []string{config.GrantClusterCreateMonitor, config.GrantAppDeployment}},
 }

--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -146,6 +146,17 @@ var appACLRules = []ACLRule{
 	{"/content/actions/delete", nil, []string{config.GrantAppDeployment}},
 	{"/content/actions/create-local-copy", nil, []string{config.GrantAppDeployment}},
 	{"/content", nil, []string{config.GrantAppDeployment}},
+
+	// Peer import (arbitration peer -> local, manual/per-app). inventory and
+	// export are peer-to-peer calls authenticated with the same shared
+	// cluster-test credentials as the split-brain-simulator endpoints
+	// (server.peerSplitBrainLogin / getClusterTestCredentials); preview and
+	// apply are operator-facing, gated like adding an app monitor
+	// (/actions/addserver in clusterACLRules).
+	{"/peer-import/inventory", nil, []string{config.GrantClusterTest}},
+	{"/peer-import/export", nil, []string{config.GrantClusterTest}},
+	{"/peer-import/preview", nil, []string{config.GrantClusterCreateMonitor, config.GrantAppDeployment}},
+	{"/peer-import/apply", nil, []string{config.GrantClusterCreateMonitor, config.GrantAppDeployment}},
 }
 
 // clusterACLRules defines ACL rules for general cluster-level endpoints
@@ -163,12 +174,12 @@ var clusterACLRules = []ACLRule{
 	{"/plugins", nil, []string{config.GrantClusterSettings}},
 
 	// Backups — ordered longest-match-first so specific rules win
-	{"/backups/stats", nil, []string{config.GrantClusterShowBackups}}, // read-only stats
-	{"/backups/", nil, []string{config.GrantDBBackup}},                // write sub-paths: delete, reconcile
-	{"/backups", nil, []string{config.GrantClusterShowBackups}},       // list (bare path, no slash)
-	{"/restic/purge", nil, []string{config.GrantDBBackup}},                                        // delete a snapshot
-	{"/restic/wipe", nil, []string{config.GrantDBBackup}},                                         // destructive wipe
-	{"/restic/check-config", nil, []string{config.GrantClusterProcess, config.GrantDBBackup}},     // preview also required by wipe workflow
+	{"/backups/stats", nil, []string{config.GrantClusterShowBackups}},                         // read-only stats
+	{"/backups/", nil, []string{config.GrantDBBackup}},                                        // write sub-paths: delete, reconcile
+	{"/backups", nil, []string{config.GrantClusterShowBackups}},                               // list (bare path, no slash)
+	{"/restic/purge", nil, []string{config.GrantDBBackup}},                                    // delete a snapshot
+	{"/restic/wipe", nil, []string{config.GrantDBBackup}},                                     // destructive wipe
+	{"/restic/check-config", nil, []string{config.GrantClusterProcess, config.GrantDBBackup}}, // preview also required by wipe workflow
 	{"/restic/snapshots", nil, []string{config.GrantClusterShowBackups}},
 	{"/restic/stats", nil, []string{config.GrantClusterShowBackups}},
 

--- a/cluster/cluster_acl_test.go
+++ b/cluster/cluster_acl_test.go
@@ -1043,6 +1043,68 @@ func TestIsURLPassACLORLogic(t *testing.T) {
 	}
 }
 
+// TestIsURLPassACLPeerImport guards against the peer-import endpoints being
+// unreachable: any URL containing "/api/clusters/{name}/apps" is routed to
+// IsURLPassAppsACL, which checks ONLY appACLRules with no fallback to
+// clusterACLRules. Without a matching entry there, matchACLRules denies
+// every user regardless of grants held, so /apps/peer-import/* would 403 for
+// everyone, including the shared cluster-test credentials
+// server.peerSplitBrainLogin uses to call inventory/export.
+func TestIsURLPassACLPeerImport(t *testing.T) {
+	cluster := setupACLTestCluster()
+
+	// Reuse the grant combinations already set up for the addserver OR-logic
+	// case above: test_user (GrantClusterTest), monitor_user
+	// (GrantClusterCreateMonitor), deploy_user (GrantAppDeployment).
+	cluster.APIUsers["test_user"] = APIUser{
+		User:   "test_user",
+		Grants: map[string]bool{config.GrantClusterTest: true},
+	}
+	cluster.APIUsers["monitor_user"] = APIUser{
+		User:   "monitor_user",
+		Grants: map[string]bool{config.GrantClusterCreateMonitor: true},
+	}
+	cluster.APIUsers["deploy_user"] = APIUser{
+		User:   "deploy_user",
+		Grants: map[string]bool{config.GrantAppDeployment: true},
+	}
+
+	base := "/api/clusters/test/apps/peer-import/"
+
+	tests := []struct {
+		name     string
+		user     string
+		url      string
+		expected bool
+	}{
+		{"cluster-test grant reaches inventory", "test_user", base + "inventory", true},
+		{"cluster-test grant reaches export", "test_user", base + "export", true},
+		{"no grants denied inventory", "user_no_grants", base + "inventory", false},
+		{"no grants denied export", "user_no_grants", base + "export", false},
+
+		{"create-monitor grant reaches preview", "monitor_user", base + "preview", true},
+		{"app-deployment grant reaches preview", "deploy_user", base + "preview", true},
+		{"create-monitor grant reaches apply", "monitor_user", base + "apply", true},
+		{"app-deployment grant reaches apply", "deploy_user", base + "apply", true},
+		{"no grants denied preview", "user_no_grants", base + "preview", false},
+		{"no grants denied apply", "user_no_grants", base + "apply", false},
+
+		// cluster-test alone must not grant preview/apply — inventory/export
+		// carry a different (peer-to-peer) trust level than operator actions.
+		{"cluster-test grant denied preview", "test_user", base + "preview", false},
+		{"cluster-test grant denied apply", "test_user", base + "apply", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := cluster.IsURLPassACL(tt.user, tt.url, false)
+			if result != tt.expected {
+				t.Errorf("User %s on URL %s: Expected %v, got %v", tt.user, tt.url, tt.expected, result)
+			}
+		})
+	}
+}
+
 // TestIsURLPassACLComprehensiveCoverage tests a wide range of cluster-level endpoints
 func TestIsURLPassACLComprehensiveCoverage(t *testing.T) {
 	cluster := setupACLTestCluster()

--- a/cluster/cluster_acl_test.go
+++ b/cluster/cluster_acl_test.go
@@ -1048,18 +1048,15 @@ func TestIsURLPassACLORLogic(t *testing.T) {
 // IsURLPassAppsACL, which checks ONLY appACLRules with no fallback to
 // clusterACLRules. Without a matching entry there, matchACLRules denies
 // every user regardless of grants held, so /apps/peer-import/* would 403 for
-// everyone, including the shared cluster-test credentials
-// server.peerSplitBrainLogin uses to call inventory/export.
+// everyone. Peer import is an app-monitor/app-deployment flow, so inventory,
+// export, preview, and apply must all be reachable with the same grants that
+// already allow adding/managing app monitors.
 func TestIsURLPassACLPeerImport(t *testing.T) {
 	cluster := setupACLTestCluster()
 
 	// Reuse the grant combinations already set up for the addserver OR-logic
-	// case above: test_user (GrantClusterTest), monitor_user
-	// (GrantClusterCreateMonitor), deploy_user (GrantAppDeployment).
-	cluster.APIUsers["test_user"] = APIUser{
-		User:   "test_user",
-		Grants: map[string]bool{config.GrantClusterTest: true},
-	}
+	// case above: monitor_user (GrantClusterCreateMonitor), deploy_user
+	// (GrantAppDeployment).
 	cluster.APIUsers["monitor_user"] = APIUser{
 		User:   "monitor_user",
 		Grants: map[string]bool{config.GrantClusterCreateMonitor: true},
@@ -1077,8 +1074,10 @@ func TestIsURLPassACLPeerImport(t *testing.T) {
 		url      string
 		expected bool
 	}{
-		{"cluster-test grant reaches inventory", "test_user", base + "inventory", true},
-		{"cluster-test grant reaches export", "test_user", base + "export", true},
+		{"create-monitor grant reaches inventory", "monitor_user", base + "inventory", true},
+		{"app-deployment grant reaches inventory", "deploy_user", base + "inventory", true},
+		{"create-monitor grant reaches export", "monitor_user", base + "export", true},
+		{"app-deployment grant reaches export", "deploy_user", base + "export", true},
 		{"no grants denied inventory", "user_no_grants", base + "inventory", false},
 		{"no grants denied export", "user_no_grants", base + "export", false},
 
@@ -1088,11 +1087,6 @@ func TestIsURLPassACLPeerImport(t *testing.T) {
 		{"app-deployment grant reaches apply", "deploy_user", base + "apply", true},
 		{"no grants denied preview", "user_no_grants", base + "preview", false},
 		{"no grants denied apply", "user_no_grants", base + "apply", false},
-
-		// cluster-test alone must not grant preview/apply — inventory/export
-		// carry a different (peer-to-peer) trust level than operator actions.
-		{"cluster-test grant denied preview", "test_user", base + "preview", false},
-		{"cluster-test grant denied apply", "test_user", base + "apply", false},
 	}
 
 	for _, tt := range tests {

--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -19,13 +19,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-// isSafeAppHostToken reports whether s is safe to use as a filesystem path
-// component (an apps/<s>.toml file name): non-empty, contains no path
-// separators, and is not a "." or ".." traversal segment. AppHost values are
-// persisted to and loaded from TOML files that may originate from another
-// node (peer import) or be hand-edited, so this must be checked before any
-// such value is joined into a path — never trust it just because it round-
-// tripped through config.AppConfig.
+// isSafeAppHostToken reports whether s is safe as an apps/<s>.toml path
+// component: non-empty, no path separators, not "." or "..".
 func isSafeAppHostToken(s string) bool {
 	if s == "" || s == "." || s == ".." {
 		return false
@@ -598,13 +593,8 @@ func (cluster *Cluster) LoadAppConfig(dirname, appname string) error {
 			"Canonicalized legacy app config template in %q", filename)
 	}
 
-	// If app-host was not set in the TOML file (or was left as an unresolved
-	// template), fall back to the file name so the app gets a valid, stable
-	// Name and ID. Also fall back — and warn loudly — if app-host resolved to
-	// something that isn't a safe single path component: this value gets
-	// joined into a filesystem path by ImportAppConfig/SaveApp, so a
-	// traversal sequence here (e.g. from a hand-edited or peer-imported TOML)
-	// must never be trusted verbatim.
+	// Fall back to the file name if app-host is unset, unresolved, or unsafe
+	// as a path component (it gets joined into a path by ImportAppConfig/SaveApp).
 	if appcnf.AppHost == "" || strings.Contains(appcnf.AppHost, "{{") {
 		appcnf.AppHost = appname
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModConfigLoad, config.LvlInfo,

--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -19,6 +19,23 @@ import (
 	"github.com/spf13/viper"
 )
 
+// isSafeAppHostToken reports whether s is safe to use as a filesystem path
+// component (an apps/<s>.toml file name): non-empty, contains no path
+// separators, and is not a "." or ".." traversal segment. AppHost values are
+// persisted to and loaded from TOML files that may originate from another
+// node (peer import) or be hand-edited, so this must be checked before any
+// such value is joined into a path — never trust it just because it round-
+// tripped through config.AppConfig.
+func isSafeAppHostToken(s string) bool {
+	if s == "" || s == "." || s == ".." {
+		return false
+	}
+	if strings.ContainsAny(s, "/\\") {
+		return false
+	}
+	return filepath.Base(s) == s
+}
+
 func (cluster *Cluster) NewAppConfig(apphost, port string) *config.AppConfig {
 	agents := cluster.GetAppAgents(nil)
 	appcnf := &config.AppConfig{
@@ -581,12 +598,21 @@ func (cluster *Cluster) LoadAppConfig(dirname, appname string) error {
 			"Canonicalized legacy app config template in %q", filename)
 	}
 
-	// If app-host was not set in the TOML file (or was left as an unresolved template),
-	// fall back to the file name so the app gets a valid, stable Name and ID.
+	// If app-host was not set in the TOML file (or was left as an unresolved
+	// template), fall back to the file name so the app gets a valid, stable
+	// Name and ID. Also fall back — and warn loudly — if app-host resolved to
+	// something that isn't a safe single path component: this value gets
+	// joined into a filesystem path by ImportAppConfig/SaveApp, so a
+	// traversal sequence here (e.g. from a hand-edited or peer-imported TOML)
+	// must never be trusted verbatim.
 	if appcnf.AppHost == "" || strings.Contains(appcnf.AppHost, "{{") {
 		appcnf.AppHost = appname
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModConfigLoad, config.LvlInfo,
 			"App config %q had no resolved app-host; using filename as host: %s", filename, appname)
+	} else if !isSafeAppHostToken(appcnf.AppHost) {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModConfigLoad, config.LvlWarn,
+			"App config %q has unsafe app-host %q; using filename as host instead: %s", filename, appcnf.AppHost, appname)
+		appcnf.AppHost = appname
 	}
 	if appcnf.AppPort == "" {
 		appcnf.AppPort = "80"

--- a/cluster/cluster_app_import.go
+++ b/cluster/cluster_app_import.go
@@ -54,6 +54,9 @@ func (cluster *Cluster) ImportAppConfig(host, port, tomlContent string) error {
 	if host == "" || port == "" {
 		return fmt.Errorf("host and port are required")
 	}
+	if !isSafeAppHostToken(host) {
+		return fmt.Errorf("invalid app host %q", host)
+	}
 	if cluster.HasAppHost(host) {
 		return fmt.Errorf("app host %q already monitored in cluster %s", host, cluster.Name)
 	}
@@ -72,31 +75,65 @@ func (cluster *Cluster) ImportAppConfig(host, port, tomlContent string) error {
 		return err
 	}
 
-	// LoadAppConfig can append to cluster.Conf.Apps and only fail afterwards
-	// (measurement validation runs after the append). The HasAppHost check
-	// above guarantees no entry for this host exists yet, so on any failure
-	// below, undo exactly what this call may have done: drop the file and
-	// any Conf.Apps entry for this host, so a rejected import never leaves
-	// the cluster in a partially-mutated state and a retry is not blocked by
-	// a stale file.
-	rollback := func() {
+	// LoadAppConfig mutates cluster.Conf.Apps (dedup-check then append, see
+	// cluster_app.go) without any locking of its own — every other Conf.Apps
+	// mutator (appendConfAppIfAbsent, removeConfApp, RemoveAppMonitor) holds
+	// cluster.Lock() for its own read-then-write, so this call must too, and
+	// the lock must stay held across both the length snapshot and the
+	// post-call verification below: releasing it in between would let a
+	// concurrent import or addserver/app-delete call append or remove an
+	// entry in the gap, making an unrelated append look like this one (or
+	// making a rollback truncate an entry that isn't ours). Truncating
+	// back to the snapshotted length is only safe because nothing else can
+	// touch Conf.Apps while this lock is held.
+	cluster.Lock()
+	before := len(cluster.Conf.Apps)
+
+	loadErr := cluster.LoadAppConfig(dirname, host)
+	if loadErr != nil {
+		cluster.Conf.Apps = cluster.Conf.Apps[:before]
+		cluster.Unlock()
 		os.Remove(filePath)
-		kept := cluster.Conf.Apps[:0]
-		for _, a := range cluster.Conf.Apps {
-			if a.AppHost != host {
-				kept = append(kept, a)
-			}
-		}
-		cluster.Conf.Apps = kept
+		return loadErr
 	}
 
-	if err := cluster.LoadAppConfig(dirname, host); err != nil {
-		rollback()
-		return err
+	// tomlContent's declared identity is trusted by LoadAppConfig as long as
+	// it's a safe path token (see isSafeAppHostToken in cluster_app.go) —
+	// it does not have to equal the requested host/port. Enforce that
+	// equality here: filePath was chosen from the request, so a mismatch
+	// means the file name and the loaded app identity permanently disagree
+	// (breaking HasAppHost/SaveApp's file-name-is-identity invariant), or —
+	// if nothing was appended at all — that this content's identity was
+	// already loaded from a different file (dedup-skip), leaving apps/host.toml
+	// an orphaned duplicate on disk. Both cases must be rejected, not merely
+	// logged, since either one lets the imported file diverge from what the
+	// caller and the peer-import collision checks believe was imported.
+	if len(cluster.Conf.Apps) != before+1 {
+		cluster.Conf.Apps = cluster.Conf.Apps[:before]
+		cluster.Unlock()
+		os.Remove(filePath)
+		return fmt.Errorf("app config content for host %q port %q was not loaded as a new app (already loaded under a different identity?)", host, port)
 	}
+	loaded := cluster.Conf.Apps[len(cluster.Conf.Apps)-1]
+	if loaded.AppHost != host || loaded.AppPort != port {
+		mismatchHost, mismatchPort := loaded.AppHost, loaded.AppPort
+		cluster.Conf.Apps = cluster.Conf.Apps[:before]
+		cluster.Unlock()
+		os.Remove(filePath)
+		return fmt.Errorf("app config content declares host %q port %q, which does not match requested host %q port %q",
+			mismatchHost, mismatchPort, host, port)
+	}
+	cluster.Unlock()
 
+	// newAppList() takes cluster.Lock() itself (to swap cluster.Apps), so it
+	// must run outside the section above. If it fails, remove exactly the
+	// entry we just verified — by pointer/host+port identity via
+	// removeConfApp, not by re-truncating to `before`, since Conf.Apps may
+	// have been mutated by a concurrent caller in the time since we released
+	// the lock above.
 	if err := cluster.newAppList(); err != nil {
-		rollback()
+		cluster.removeConfApp(loaded, host, port)
+		os.Remove(filePath)
 		return err
 	}
 

--- a/cluster/cluster_app_import.go
+++ b/cluster/cluster_app_import.go
@@ -1,0 +1,104 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+// Redistribution/Reuse of this code is permitted under the GNU v3 license, as
+// an additional term, ALL code must carry the original Author(s) credit in comment form.
+// See LICENSE in this directory for the integral text.
+package cluster
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// HasAppHost reports whether any app currently monitored in this cluster is
+// persisted under the given host, regardless of port. Compares against
+// app.AppConfig.AppHost — the identity SaveApp()/LoadAppConfig() use for the
+// file name and dedupe key — not app.GetHost(), which ProvNetCNI rewrites
+// with a "."+cluster+".svc."+orchestrator suffix for runtime routing. Peer
+// import must key off the persisted identity so it agrees with what gets
+// written to disk.
+func (cluster *Cluster) HasAppHost(host string) bool {
+	for _, app := range cluster.Apps {
+		if app != nil && app.AppConfig != nil && app.AppConfig.AppHost == host {
+			return true
+		}
+	}
+	return false
+}
+
+// HasAppHostPort reports whether an app persisted under the given host+port
+// (app.AppConfig.AppHost/AppPort) is already monitored in this cluster. See
+// HasAppHost for why this does not use GetAppByHostPort/app.GetHost().
+func (cluster *Cluster) HasAppHostPort(host, port string) bool {
+	for _, app := range cluster.Apps {
+		if app != nil && app.AppConfig != nil && app.AppConfig.AppHost == host && app.AppConfig.AppPort == port {
+			return true
+		}
+	}
+	return false
+}
+
+// ImportAppConfig writes tomlContent as a new local app config for host and
+// loads it through the existing local app-config lifecycle (LoadAppConfig +
+// newAppList) — the same path used for any app config already saved under
+// apps/. host/port must be the persisted identity (AppConfig.AppHost/AppPort,
+// i.e. what SaveApp() names the file after), not a runtime-rewritten host —
+// see HasAppHost. It refuses to import onto a host that already has a
+// monitored app, whatever the port: app.SetID() and SaveApp() both key off
+// this persisted host, so a same-host/different-port import cannot be
+// applied safely with the current storage layout (see
+// APP_MONITOR_PEER_IMPORT_PLAN.md).
+func (cluster *Cluster) ImportAppConfig(host, port, tomlContent string) error {
+	if host == "" || port == "" {
+		return fmt.Errorf("host and port are required")
+	}
+	if cluster.HasAppHost(host) {
+		return fmt.Errorf("app host %q already monitored in cluster %s", host, cluster.Name)
+	}
+
+	dirname := filepath.Join(cluster.WorkingDir, "apps")
+	if err := os.MkdirAll(dirname, 0750); err != nil {
+		return err
+	}
+
+	filePath := filepath.Join(dirname, host+".toml")
+	if _, err := os.Stat(filePath); err == nil {
+		return fmt.Errorf("app config file already exists for host %q", host)
+	}
+
+	if err := os.WriteFile(filePath, []byte(tomlContent), 0640); err != nil {
+		return err
+	}
+
+	// LoadAppConfig can append to cluster.Conf.Apps and only fail afterwards
+	// (measurement validation runs after the append). The HasAppHost check
+	// above guarantees no entry for this host exists yet, so on any failure
+	// below, undo exactly what this call may have done: drop the file and
+	// any Conf.Apps entry for this host, so a rejected import never leaves
+	// the cluster in a partially-mutated state and a retry is not blocked by
+	// a stale file.
+	rollback := func() {
+		os.Remove(filePath)
+		kept := cluster.Conf.Apps[:0]
+		for _, a := range cluster.Conf.Apps {
+			if a.AppHost != host {
+				kept = append(kept, a)
+			}
+		}
+		cluster.Conf.Apps = kept
+	}
+
+	if err := cluster.LoadAppConfig(dirname, host); err != nil {
+		rollback()
+		return err
+	}
+
+	if err := cluster.newAppList(); err != nil {
+		rollback()
+		return err
+	}
+
+	return nil
+}

--- a/cluster/cluster_app_import.go
+++ b/cluster/cluster_app_import.go
@@ -12,14 +12,13 @@ import (
 	"path/filepath"
 )
 
-// HasAppHost reports whether any app currently monitored in this cluster is
-// persisted under the given host, regardless of port. Compares against
-// app.AppConfig.AppHost — the identity SaveApp()/LoadAppConfig() use for the
-// file name and dedupe key — not app.GetHost(), which ProvNetCNI rewrites
-// with a "."+cluster+".svc."+orchestrator suffix for runtime routing. Peer
-// import must key off the persisted identity so it agrees with what gets
-// written to disk.
+// HasAppHost reports whether any app is persisted under host (any port).
+// Compares app.AppConfig.AppHost — the SaveApp()/LoadAppConfig() file-name
+// identity — not app.GetHost(), which ProvNetCNI rewrites for routing.
 func (cluster *Cluster) HasAppHost(host string) bool {
+	// cluster.Apps is written under cluster.Lock() by newAppList()/RemoveAppMonitor.
+	cluster.Lock()
+	defer cluster.Unlock()
 	for _, app := range cluster.Apps {
 		if app != nil && app.AppConfig != nil && app.AppConfig.AppHost == host {
 			return true
@@ -28,10 +27,10 @@ func (cluster *Cluster) HasAppHost(host string) bool {
 	return false
 }
 
-// HasAppHostPort reports whether an app persisted under the given host+port
-// (app.AppConfig.AppHost/AppPort) is already monitored in this cluster. See
-// HasAppHost for why this does not use GetAppByHostPort/app.GetHost().
+// HasAppHostPort is HasAppHost narrowed to an exact host+port match.
 func (cluster *Cluster) HasAppHostPort(host, port string) bool {
+	cluster.Lock()
+	defer cluster.Unlock()
 	for _, app := range cluster.Apps {
 		if app != nil && app.AppConfig != nil && app.AppConfig.AppHost == host && app.AppConfig.AppPort == port {
 			return true
@@ -40,16 +39,10 @@ func (cluster *Cluster) HasAppHostPort(host, port string) bool {
 	return false
 }
 
-// ImportAppConfig writes tomlContent as a new local app config for host and
-// loads it through the existing local app-config lifecycle (LoadAppConfig +
-// newAppList) — the same path used for any app config already saved under
-// apps/. host/port must be the persisted identity (AppConfig.AppHost/AppPort,
-// i.e. what SaveApp() names the file after), not a runtime-rewritten host —
-// see HasAppHost. It refuses to import onto a host that already has a
-// monitored app, whatever the port: app.SetID() and SaveApp() both key off
-// this persisted host, so a same-host/different-port import cannot be
-// applied safely with the current storage layout (see
-// APP_MONITOR_PEER_IMPORT_PLAN.md).
+// ImportAppConfig writes tomlContent as a new app config for host and loads
+// it via LoadAppConfig + newAppList. host/port must be the persisted identity
+// (AppConfig.AppHost/AppPort), not a runtime-rewritten host — see HasAppHost.
+// Same-host/different-port imports are rejected: SaveApp() keys off host alone.
 func (cluster *Cluster) ImportAppConfig(host, port, tomlContent string) error {
 	if host == "" || port == "" {
 		return fmt.Errorf("host and port are required")
@@ -75,17 +68,8 @@ func (cluster *Cluster) ImportAppConfig(host, port, tomlContent string) error {
 		return err
 	}
 
-	// LoadAppConfig mutates cluster.Conf.Apps (dedup-check then append, see
-	// cluster_app.go) without any locking of its own — every other Conf.Apps
-	// mutator (appendConfAppIfAbsent, removeConfApp, RemoveAppMonitor) holds
-	// cluster.Lock() for its own read-then-write, so this call must too, and
-	// the lock must stay held across both the length snapshot and the
-	// post-call verification below: releasing it in between would let a
-	// concurrent import or addserver/app-delete call append or remove an
-	// entry in the gap, making an unrelated append look like this one (or
-	// making a rollback truncate an entry that isn't ours). Truncating
-	// back to the snapshotted length is only safe because nothing else can
-	// touch Conf.Apps while this lock is held.
+	// Hold cluster.Lock() across the snapshot, LoadAppConfig's append, and the
+	// verification below so no concurrent Conf.Apps mutator can interleave.
 	cluster.Lock()
 	before := len(cluster.Conf.Apps)
 
@@ -97,17 +81,10 @@ func (cluster *Cluster) ImportAppConfig(host, port, tomlContent string) error {
 		return loadErr
 	}
 
-	// tomlContent's declared identity is trusted by LoadAppConfig as long as
-	// it's a safe path token (see isSafeAppHostToken in cluster_app.go) —
-	// it does not have to equal the requested host/port. Enforce that
-	// equality here: filePath was chosen from the request, so a mismatch
-	// means the file name and the loaded app identity permanently disagree
-	// (breaking HasAppHost/SaveApp's file-name-is-identity invariant), or —
-	// if nothing was appended at all — that this content's identity was
-	// already loaded from a different file (dedup-skip), leaving apps/host.toml
-	// an orphaned duplicate on disk. Both cases must be rejected, not merely
-	// logged, since either one lets the imported file diverge from what the
-	// caller and the peer-import collision checks believe was imported.
+	// tomlContent's own app-host/app-port can differ from the request (only
+	// unsafe/empty values get overwritten by LoadAppConfig) — reject that
+	// mismatch, and reject a dedup-skip (nothing appended), which would
+	// otherwise leave apps/host.toml an orphaned duplicate on disk.
 	if len(cluster.Conf.Apps) != before+1 {
 		cluster.Conf.Apps = cluster.Conf.Apps[:before]
 		cluster.Unlock()
@@ -125,16 +102,19 @@ func (cluster *Cluster) ImportAppConfig(host, port, tomlContent string) error {
 	}
 	cluster.Unlock()
 
-	// newAppList() takes cluster.Lock() itself (to swap cluster.Apps), so it
-	// must run outside the section above. If it fails, remove exactly the
-	// entry we just verified — by pointer/host+port identity via
-	// removeConfApp, not by re-truncating to `before`, since Conf.Apps may
-	// have been mutated by a concurrent caller in the time since we released
-	// the lock above.
+	// newAppList() locks internally, so run it outside the section above. On
+	// failure, remove our entry by identity (not by truncating), since
+	// Conf.Apps may have changed since we unlocked.
 	if err := cluster.newAppList(); err != nil {
 		cluster.removeConfApp(loaded, host, port)
 		os.Remove(filePath)
 		return err
+	}
+
+	// A concurrent RemoveAppMonitor could have dropped this entry before the
+	// rebuild picked it up; don't report success if it's gone.
+	if !cluster.HasAppHostPort(host, port) {
+		return fmt.Errorf("app host %q port %q was concurrently removed during import", host, port)
 	}
 
 	return nil

--- a/cluster/cluster_app_import_test.go
+++ b/cluster/cluster_app_import_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -164,6 +165,142 @@ func TestImportAppConfig_RejectsMissingHostOrPort(t *testing.T) {
 	}
 }
 
+// TestImportAppConfig_RejectsPathTraversalHost guards the filePath :=
+// filepath.Join(dirname, host+".toml") write in ImportAppConfig: host comes
+// from a peer's inventory response over the network and must never be
+// trusted to build a filesystem path without validation.
+func TestImportAppConfig_RejectsPathTraversalHost(t *testing.T) {
+	cl := newTestClusterForAppImport(t, "c1")
+
+	unsafeHosts := []string{
+		"../../../etc/cron.d/evil",
+		"..",
+		".",
+		"a/b",
+		"a\\b",
+		"",
+	}
+	for _, host := range unsafeHosts {
+		content := exportTOMLForImport(t, cl, host, "8080")
+		if err := cl.ImportAppConfig(host, "8080", content); err == nil {
+			t.Fatalf("expected ImportAppConfig to reject unsafe host %q", host)
+		}
+	}
+
+	// Confirm nothing escaped the apps directory.
+	entries, err := os.ReadDir(filepath.Join(cl.WorkingDir, "apps"))
+	if err == nil {
+		for _, e := range entries {
+			t.Fatalf("expected apps dir to stay empty, found %q", e.Name())
+		}
+	}
+}
+
+// TestImportAppConfig_RejectsHostPortIdentityMismatch covers a peer-import
+// payload whose own app-host/app-port disagree with the request: since
+// LoadAppConfig only overwrites app-host when it's empty/templated/unsafe
+// (not merely different), a mismatched-but-safe value would otherwise be
+// trusted, leaving apps/<requested-host>.toml on disk describing a different
+// identity than its own file name — breaking the file-name-is-identity
+// invariant HasAppHost/SaveApp depend on.
+func TestImportAppConfig_RejectsHostPortIdentityMismatch(t *testing.T) {
+	cl := newTestClusterForAppImport(t, "c1")
+
+	// TOML declares "other-host" but the caller requested "requested-host".
+	mismatchedHostContent := exportTOMLForImport(t, cl, "other-host", "8080")
+	if err := cl.ImportAppConfig("requested-host", "8080", mismatchedHostContent); err == nil {
+		t.Fatalf("expected ImportAppConfig to reject a host mismatch between request and content")
+	}
+	if cl.HasAppHost("requested-host") || cl.HasAppHost("other-host") {
+		t.Fatalf("expected no app to be registered after a host-mismatch rejection")
+	}
+	if _, statErr := os.Stat(filepath.Join(cl.WorkingDir, "apps", "requested-host.toml")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected rejected import to leave no file on disk, stat err=%v", statErr)
+	}
+
+	// TOML declares the right host but a different port than requested.
+	mismatchedPortContent := exportTOMLForImport(t, cl, "portmismatch", "9999")
+	if err := cl.ImportAppConfig("portmismatch", "8080", mismatchedPortContent); err == nil {
+		t.Fatalf("expected ImportAppConfig to reject a port mismatch between request and content")
+	}
+	if cl.HasAppHost("portmismatch") {
+		t.Fatalf("expected no app to be registered after a port-mismatch rejection")
+	}
+	if _, statErr := os.Stat(filepath.Join(cl.WorkingDir, "apps", "portmismatch.toml")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected rejected import to leave no file on disk, stat err=%v", statErr)
+	}
+}
+
+// TestImportAppConfig_RejectsDedupSkipOrphan covers the case where
+// tomlContent's declared identity already matches an app previously loaded
+// under a *different* file name: LoadAppConfig's own dedup-skip logic
+// returns nil without appending to Conf.Apps, which — before this check
+// existed — would silently leave apps/<host>.toml on disk as an orphaned
+// duplicate of an already-loaded app.
+func TestImportAppConfig_RejectsDedupSkipOrphan(t *testing.T) {
+	cl := newTestClusterForAppImport(t, "c1")
+	dirname := filepath.Join(cl.WorkingDir, "apps")
+	if err := os.MkdirAll(dirname, 0750); err != nil {
+		t.Fatalf("failed to create apps dir: %v", err)
+	}
+
+	// Pre-load "existing-app" under its own file, the normal way.
+	preloadContent := exportTOMLForImport(t, cl, "existing-app", "8080")
+	if err := os.WriteFile(filepath.Join(dirname, "existing-app.toml"), []byte(preloadContent), 0640); err != nil {
+		t.Fatalf("failed to write preload app config: %v", err)
+	}
+	if err := cl.LoadAppConfig(dirname, "existing-app"); err != nil {
+		t.Fatalf("failed to preload existing-app: %v", err)
+	}
+
+	// Now "import" a second file, requested under a different host, whose
+	// content declares the same host:port as the one already loaded.
+	dupContent := exportTOMLForImport(t, cl, "existing-app", "8080")
+	if err := cl.ImportAppConfig("second-host", "8080", dupContent); err == nil {
+		t.Fatalf("expected ImportAppConfig to reject content that dedups against an already-loaded app")
+	}
+	if _, statErr := os.Stat(filepath.Join(dirname, "second-host.toml")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected rejected import to leave no orphan file on disk, stat err=%v", statErr)
+	}
+}
+
+// TestLoadAppConfig_UnsafeAppHostFallsBackToFilename covers the TOML-file
+// load path (not just peer import): a hand-edited or otherwise tampered
+// app-host value in an on-disk apps/*.toml must not be trusted verbatim,
+// since it flows back into ImportAppConfig/SaveApp path joins on re-export.
+func TestLoadAppConfig_UnsafeAppHostFallsBackToFilename(t *testing.T) {
+	cl := newTestClusterForAppImport(t, "c1")
+	dirname := filepath.Join(cl.WorkingDir, "apps")
+	if err := os.MkdirAll(dirname, 0750); err != nil {
+		t.Fatalf("failed to create apps dir: %v", err)
+	}
+
+	tomlContent := "app-host = \"../../../etc/cron.d/evil\"\napp-port = \"8080\"\nprov-app-memory = \"256\"\nprov-app-disk-size = \"1\"\n"
+	filename := filepath.Join(dirname, "safehost.toml")
+	if err := os.WriteFile(filename, []byte(tomlContent), 0640); err != nil {
+		t.Fatalf("failed to write app config: %v", err)
+	}
+
+	if err := cl.LoadAppConfig(dirname, "safehost"); err != nil {
+		t.Fatalf("LoadAppConfig failed: %v", err)
+	}
+
+	// LoadAppConfig only appends to cluster.Conf.Apps (newAppList() is what
+	// later populates cluster.Apps/HasAppHost), so assert against Conf.Apps.
+	var loaded *config.AppConfig
+	for _, a := range cl.Conf.Apps {
+		if a.AppPort == "8080" {
+			loaded = a
+		}
+	}
+	if loaded == nil {
+		t.Fatalf("expected app config to be loaded into cluster.Conf.Apps")
+	}
+	if loaded.AppHost != "safehost" {
+		t.Fatalf("expected app-host to fall back to the safe filename \"safehost\", got %q", loaded.AppHost)
+	}
+}
+
 // TestHasAppHost_UsesPersistedHostNotRuntimeHost is the ProvNetCNI mismatch
 // case: when app.GetHost() (runtime, CNI-rewritten) differs from
 // app.AppConfig.AppHost (persisted), the collision guards must key off the
@@ -257,5 +394,63 @@ func TestImportAppConfig_RollbackUsesPersistedHostUnderProvNetCNI(t *testing.T) 
 
 	if _, statErr := os.Stat(filepath.Join(cl.WorkingDir, "apps", "app1.toml")); statErr == nil {
 		t.Fatalf("expected no file written for a rejected same-persisted-host import")
+	}
+}
+
+// TestImportAppConfig_ConcurrentImportsDoNotCorruptConfApps drives many
+// ImportAppConfig calls at once — some that succeed, some engineered to hit
+// the host/port identity-mismatch rollback path — and checks that
+// cluster.Conf.Apps ends up with exactly the successful entries and nothing
+// else. Before ImportAppConfig held cluster.Lock() across its whole
+// snapshot-load-verify sequence, a length-snapshot taken outside the lock
+// could be invalidated by a concurrent append/rollback happening in the
+// window between snapshot and verification, corrupting Conf.Apps (losing or
+// duplicating entries) under -race.
+func TestImportAppConfig_ConcurrentImportsDoNotCorruptConfApps(t *testing.T) {
+	cl := newTestClusterForAppImport(t, "c1")
+
+	const n = 20
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			host := fmt.Sprintf("host%d", i)
+			if i%2 == 0 {
+				// Good import: content identity matches the request.
+				content := exportTOMLForImport(t, cl, host, "8080")
+				_ = cl.ImportAppConfig(host, "8080", content)
+			} else {
+				// Engineered mismatch: content declares a different host,
+				// forcing the rollback path on every call.
+				content := exportTOMLForImport(t, cl, host+"-wrong", "8080")
+				_ = cl.ImportAppConfig(host, "8080", content)
+			}
+		}()
+	}
+	wg.Wait()
+
+	seen := make(map[string]bool)
+	for _, a := range cl.Conf.Apps {
+		key := a.AppHost + ":" + a.AppPort
+		if seen[key] {
+			t.Fatalf("duplicate entry in Conf.Apps for %s", key)
+		}
+		seen[key] = true
+	}
+
+	for i := 0; i < n; i++ {
+		host := fmt.Sprintf("host%d", i)
+		want := i%2 == 0
+		got := seen[host+":8080"]
+		if got != want {
+			t.Fatalf("host %s: expected present=%v, got present=%v (Conf.Apps=%v)", host, want, got, seen)
+		}
+		// A rejected mismatched import must never leave its declared
+		// (wrong-host) identity behind either.
+		if seen[host+"-wrong:8080"] {
+			t.Fatalf("mismatched identity %s-wrong:8080 leaked into Conf.Apps", host)
+		}
 	}
 }

--- a/cluster/cluster_app_import_test.go
+++ b/cluster/cluster_app_import_test.go
@@ -1,0 +1,261 @@
+package cluster
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	toml "github.com/pelletier/go-toml"
+	"github.com/signal18/replication-manager/config"
+)
+
+// newTestAppWithRuntimeHostMismatch builds an App whose runtime host
+// (app.Host / app.GetHost()) differs from its persisted host
+// (app.AppConfig.AppHost) — the same divergence NewApp() produces when
+// ProvNetCNI rewrites app.Host with a cluster-svc suffix for routing while
+// AppConfig.AppHost (and app.Name, used by SaveApp() for the file name)
+// stays pinned to the original persisted host.
+func newTestAppWithRuntimeHostMismatch(persistedHost, runtimeHost, port string) *App {
+	return &App{
+		Name:  persistedHost,
+		Host:  runtimeHost,
+		Port:  port,
+		Mutex: &sync.Mutex{},
+		AppConfig: &config.AppConfig{
+			AppHost:    persistedHost,
+			AppPort:    port,
+			Deployment: config.NewDeploymentConfig(),
+		},
+	}
+}
+
+func newTestClusterForAppImport(t *testing.T, name string) *Cluster {
+	t.Helper()
+	cl := newTestClusterForAddApp(t, name)
+	cl.WorkingDir = t.TempDir()
+	// Measurement-required fields (ProvAppMem/ProvAppDisk) fall back to these
+	// cluster defaults in NewAppConfig; LoadAppConfig's measurement parser
+	// rejects an app config missing both.
+	cl.Conf.ProvMem = "256"
+	cl.Conf.ProvDisk = "1"
+	return cl
+}
+
+// exportTOMLForImport mirrors what handlerMuxAppPeerImportExport produces on
+// the peer side: marshal a live AppConfig with the same toml package used by
+// SaveAppConfigFile.
+func exportTOMLForImport(t *testing.T, cl *Cluster, host, port string) string {
+	t.Helper()
+	appcnf := cl.NewAppConfig(host, port)
+	data, err := toml.Marshal(appcnf)
+	if err != nil {
+		t.Fatalf("failed to marshal app config: %v", err)
+	}
+	return string(data)
+}
+
+func TestHasAppHostAndHasAppHostPort(t *testing.T) {
+	cl := newTestClusterForAppImport(t, "c1")
+	app := newTestAppForAddApp("app1", "8080", "")
+	cl.Apps = []*App{app}
+
+	if !cl.HasAppHost("app1") {
+		t.Fatalf("expected HasAppHost(app1) to be true")
+	}
+	if cl.HasAppHost("app2") {
+		t.Fatalf("expected HasAppHost(app2) to be false")
+	}
+	if !cl.HasAppHostPort("app1", "8080") {
+		t.Fatalf("expected HasAppHostPort(app1,8080) to be true")
+	}
+	if cl.HasAppHostPort("app1", "9090") {
+		t.Fatalf("expected HasAppHostPort(app1,9090) to be false (different port)")
+	}
+}
+
+func TestImportAppConfig_Success(t *testing.T) {
+	cl := newTestClusterForAppImport(t, "c1")
+	content := exportTOMLForImport(t, cl, "peerapp1", "8080")
+
+	if err := cl.ImportAppConfig("peerapp1", "8080", content); err != nil {
+		t.Fatalf("ImportAppConfig failed: %v", err)
+	}
+
+	if !cl.HasAppHostPort("peerapp1", "8080") {
+		t.Fatalf("expected imported app to be loaded into cluster.Apps")
+	}
+
+	filePath := filepath.Join(cl.WorkingDir, "apps", "peerapp1.toml")
+	if _, err := os.Stat(filePath); err != nil {
+		t.Fatalf("expected app config file to be written at %s: %v", filePath, err)
+	}
+}
+
+func TestImportAppConfig_RejectsSameHostDifferentPort(t *testing.T) {
+	cl := newTestClusterForAppImport(t, "c1")
+	cl.Apps = []*App{newTestAppForAddApp("app1", "8080", "")}
+
+	content := exportTOMLForImport(t, cl, "app1", "9090")
+	err := cl.ImportAppConfig("app1", "9090", content)
+	if err == nil {
+		t.Fatalf("expected ImportAppConfig to reject same-host/different-port import")
+	}
+
+	if _, statErr := os.Stat(filepath.Join(cl.WorkingDir, "apps", "app1.toml")); statErr == nil {
+		t.Fatalf("expected no file to be written when import is rejected")
+	}
+}
+
+// TestImportAppConfig_RollsBackOnLoadFailure exercises the LoadAppConfig
+// append-then-fail path: LoadAppConfig appends to cluster.Conf.Apps before
+// ParseConfigMeasurement can reject the config (missing prov-app-memory /
+// prov-app-disk-size). ImportAppConfig must undo the write and the in-memory
+// append on that failure — a rejected import must never leave the file on
+// disk (which would block any retry) or a stale entry in cluster.Conf.Apps.
+func TestImportAppConfig_RollsBackOnLoadFailure(t *testing.T) {
+	// Deliberately no ProvMem/ProvDisk on this fixture: NewAppConfig will
+	// produce an AppConfig with empty ProvAppMem/ProvAppDisk, which
+	// ParseConfigMeasurement rejects as required-but-missing.
+	cl := newTestClusterForAddApp(t, "c1")
+	cl.WorkingDir = t.TempDir()
+
+	content := exportTOMLForImport(t, cl, "badapp", "8080")
+
+	err := cl.ImportAppConfig("badapp", "8080", content)
+	if err == nil {
+		t.Fatalf("expected ImportAppConfig to fail on missing measurement-required fields")
+	}
+
+	filePath := filepath.Join(cl.WorkingDir, "apps", "badapp.toml")
+	if _, statErr := os.Stat(filePath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected rollback to remove the written file, stat err=%v", statErr)
+	}
+
+	for _, a := range cl.Conf.Apps {
+		if a.AppHost == "badapp" {
+			t.Fatalf("expected rollback to remove the Conf.Apps entry for badapp, found: %+v", a)
+		}
+	}
+
+	if cl.HasAppHost("badapp") {
+		t.Fatalf("expected HasAppHost(badapp) to be false after rollback")
+	}
+
+	// A retry must fail for the same reason again, not be blocked by a
+	// leftover file from the failed attempt.
+	retryErr := cl.ImportAppConfig("badapp", "8080", content)
+	if retryErr == nil {
+		t.Fatalf("expected retry to fail again (still missing measurement fields)")
+	}
+	if retryErr.Error() == `app config file already exists for host "badapp"` {
+		t.Fatalf("retry blocked by leftover file: rollback did not clean up: %v", retryErr)
+	}
+}
+
+func TestImportAppConfig_RejectsMissingHostOrPort(t *testing.T) {
+	cl := newTestClusterForAppImport(t, "c1")
+
+	if err := cl.ImportAppConfig("", "8080", "app-host = \"x\""); err == nil {
+		t.Fatalf("expected error for missing host")
+	}
+	if err := cl.ImportAppConfig("host1", "", "app-host = \"x\""); err == nil {
+		t.Fatalf("expected error for missing port")
+	}
+}
+
+// TestHasAppHost_UsesPersistedHostNotRuntimeHost is the ProvNetCNI mismatch
+// case: when app.GetHost() (runtime, CNI-rewritten) differs from
+// app.AppConfig.AppHost (persisted), the collision guards must key off the
+// persisted identity — matching against the runtime host would silently
+// miss a real collision (or flag a false one).
+func TestHasAppHost_UsesPersistedHostNotRuntimeHost(t *testing.T) {
+	cl := newTestClusterForAppImport(t, "c1")
+	app := newTestAppWithRuntimeHostMismatch("peerapp1", "peerapp1.c1.svc.k8s", "8080")
+	cl.Apps = []*App{app}
+
+	if app.GetHost() == app.AppConfig.AppHost {
+		t.Fatalf("test fixture invalid: runtime host must differ from persisted host")
+	}
+
+	if !cl.HasAppHost("peerapp1") {
+		t.Fatalf("expected HasAppHost to match the persisted host even though runtime host differs")
+	}
+	if cl.HasAppHost("peerapp1.c1.svc.k8s") {
+		t.Fatalf("expected HasAppHost to NOT match the runtime-rewritten host")
+	}
+	if !cl.HasAppHostPort("peerapp1", "8080") {
+		t.Fatalf("expected HasAppHostPort to match the persisted host+port")
+	}
+	if cl.HasAppHostPort("peerapp1.c1.svc.k8s", "8080") {
+		t.Fatalf("expected HasAppHostPort to NOT match the runtime-rewritten host+port")
+	}
+}
+
+// TestImportThenSave_UsesPersistedHostForFileName imports under ProvNetCNI,
+// then runs a normal save cycle (SaveApp, as the monitoring loop would), and
+// verifies exactly one file exists — named after the persisted host, never a
+// second file named after the runtime-rewritten host.
+func TestImportThenSave_UsesPersistedHostForFileName(t *testing.T) {
+	cl := newTestClusterForAppImport(t, "c1")
+	cl.Conf.ProvNetCNI = true
+	cl.Conf.ProvOrchestratorCluster = "k8s"
+
+	content := exportTOMLForImport(t, cl, "peerapp1", "8080")
+	if err := cl.ImportAppConfig("peerapp1", "8080", content); err != nil {
+		t.Fatalf("ImportAppConfig failed: %v", err)
+	}
+	if len(cl.Apps) != 1 {
+		t.Fatalf("expected exactly one app after import, got %d", len(cl.Apps))
+	}
+
+	app := cl.Apps[0]
+	wantRuntimeHost := "peerapp1." + cl.Name + ".svc.k8s"
+	if app.GetHost() != wantRuntimeHost {
+		t.Fatalf("test fixture invalid: expected ProvNetCNI runtime host %q, got %q", wantRuntimeHost, app.GetHost())
+	}
+	if app.AppConfig.AppHost != "peerapp1" {
+		t.Fatalf("expected persisted host to stay %q, got %q", "peerapp1", app.AppConfig.AppHost)
+	}
+
+	if _, err := cl.SaveApp(app, ""); err != nil {
+		t.Fatalf("SaveApp failed: %v", err)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(cl.WorkingDir, "apps"))
+	if err != nil {
+		t.Fatalf("failed to read apps dir: %v", err)
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	if len(names) != 1 || names[0] != "peerapp1.toml" {
+		t.Fatalf("expected exactly one file apps/peerapp1.toml (persisted host), got: %v", names)
+	}
+}
+
+// TestImportAppConfig_RollbackUsesPersistedHostUnderProvNetCNI proves the
+// same-host collision guard still fires under ProvNetCNI: an existing local
+// app persisted under host "app1" (whose runtime host is rewritten to
+// "app1.c1.svc.k8s") must still block a peer import of persisted host
+// "app1" on a different port. If the guard mistakenly compared against the
+// runtime host instead, "app1" would never match "app1.c1.svc.k8s" and the
+// unsafe same-host/different-port import would be silently accepted.
+func TestImportAppConfig_RollbackUsesPersistedHostUnderProvNetCNI(t *testing.T) {
+	cl := newTestClusterForAppImport(t, "c1")
+	cl.Conf.ProvNetCNI = true
+	cl.Conf.ProvOrchestratorCluster = "k8s"
+
+	existing := newTestAppWithRuntimeHostMismatch("app1", "app1.c1.svc.k8s", "8080")
+	cl.Apps = []*App{existing}
+
+	content := exportTOMLForImport(t, cl, "app1", "9090")
+	if err := cl.ImportAppConfig("app1", "9090", content); err == nil {
+		t.Fatalf("expected rejection: persisted host app1 already monitored (even though runtime hosts differ)")
+	}
+
+	if _, statErr := os.Stat(filepath.Join(cl.WorkingDir, "apps", "app1.toml")); statErr == nil {
+		t.Fatalf("expected no file written for a rejected same-persisted-host import")
+	}
+}

--- a/cluster/cluster_app_import_test.go
+++ b/cluster/cluster_app_import_test.go
@@ -11,12 +11,8 @@ import (
 	"github.com/signal18/replication-manager/config"
 )
 
-// newTestAppWithRuntimeHostMismatch builds an App whose runtime host
-// (app.Host / app.GetHost()) differs from its persisted host
-// (app.AppConfig.AppHost) — the same divergence NewApp() produces when
-// ProvNetCNI rewrites app.Host with a cluster-svc suffix for routing while
-// AppConfig.AppHost (and app.Name, used by SaveApp() for the file name)
-// stays pinned to the original persisted host.
+// newTestAppWithRuntimeHostMismatch builds an App whose runtime host differs
+// from its persisted host, as ProvNetCNI produces via NewApp().
 func newTestAppWithRuntimeHostMismatch(persistedHost, runtimeHost, port string) *App {
 	return &App{
 		Name:  persistedHost,
@@ -35,17 +31,13 @@ func newTestClusterForAppImport(t *testing.T, name string) *Cluster {
 	t.Helper()
 	cl := newTestClusterForAddApp(t, name)
 	cl.WorkingDir = t.TempDir()
-	// Measurement-required fields (ProvAppMem/ProvAppDisk) fall back to these
-	// cluster defaults in NewAppConfig; LoadAppConfig's measurement parser
-	// rejects an app config missing both.
+	// LoadAppConfig's measurement parser requires these.
 	cl.Conf.ProvMem = "256"
 	cl.Conf.ProvDisk = "1"
 	return cl
 }
 
-// exportTOMLForImport mirrors what handlerMuxAppPeerImportExport produces on
-// the peer side: marshal a live AppConfig with the same toml package used by
-// SaveAppConfigFile.
+// exportTOMLForImport mirrors what handlerMuxAppPeerImportExport produces on the peer side.
 func exportTOMLForImport(t *testing.T, cl *Cluster, host, port string) string {
 	t.Helper()
 	appcnf := cl.NewAppConfig(host, port)
@@ -108,16 +100,11 @@ func TestImportAppConfig_RejectsSameHostDifferentPort(t *testing.T) {
 	}
 }
 
-// TestImportAppConfig_RollsBackOnLoadFailure exercises the LoadAppConfig
-// append-then-fail path: LoadAppConfig appends to cluster.Conf.Apps before
-// ParseConfigMeasurement can reject the config (missing prov-app-memory /
-// prov-app-disk-size). ImportAppConfig must undo the write and the in-memory
-// append on that failure — a rejected import must never leave the file on
-// disk (which would block any retry) or a stale entry in cluster.Conf.Apps.
+// TestImportAppConfig_RollsBackOnLoadFailure: LoadAppConfig appends before
+// ParseConfigMeasurement can reject a config missing required fields;
+// ImportAppConfig must undo both the file write and the append on failure.
 func TestImportAppConfig_RollsBackOnLoadFailure(t *testing.T) {
-	// Deliberately no ProvMem/ProvDisk on this fixture: NewAppConfig will
-	// produce an AppConfig with empty ProvAppMem/ProvAppDisk, which
-	// ParseConfigMeasurement rejects as required-but-missing.
+	// No ProvMem/ProvDisk here, so ParseConfigMeasurement rejects the config.
 	cl := newTestClusterForAddApp(t, "c1")
 	cl.WorkingDir = t.TempDir()
 
@@ -143,8 +130,7 @@ func TestImportAppConfig_RollsBackOnLoadFailure(t *testing.T) {
 		t.Fatalf("expected HasAppHost(badapp) to be false after rollback")
 	}
 
-	// A retry must fail for the same reason again, not be blocked by a
-	// leftover file from the failed attempt.
+	// Retry must fail again, not be blocked by a leftover file.
 	retryErr := cl.ImportAppConfig("badapp", "8080", content)
 	if retryErr == nil {
 		t.Fatalf("expected retry to fail again (still missing measurement fields)")
@@ -165,10 +151,7 @@ func TestImportAppConfig_RejectsMissingHostOrPort(t *testing.T) {
 	}
 }
 
-// TestImportAppConfig_RejectsPathTraversalHost guards the filePath :=
-// filepath.Join(dirname, host+".toml") write in ImportAppConfig: host comes
-// from a peer's inventory response over the network and must never be
-// trusted to build a filesystem path without validation.
+// TestImportAppConfig_RejectsPathTraversalHost guards the host+".toml" path join.
 func TestImportAppConfig_RejectsPathTraversalHost(t *testing.T) {
 	cl := newTestClusterForAppImport(t, "c1")
 
@@ -187,7 +170,6 @@ func TestImportAppConfig_RejectsPathTraversalHost(t *testing.T) {
 		}
 	}
 
-	// Confirm nothing escaped the apps directory.
 	entries, err := os.ReadDir(filepath.Join(cl.WorkingDir, "apps"))
 	if err == nil {
 		for _, e := range entries {
@@ -196,13 +178,8 @@ func TestImportAppConfig_RejectsPathTraversalHost(t *testing.T) {
 	}
 }
 
-// TestImportAppConfig_RejectsHostPortIdentityMismatch covers a peer-import
-// payload whose own app-host/app-port disagree with the request: since
-// LoadAppConfig only overwrites app-host when it's empty/templated/unsafe
-// (not merely different), a mismatched-but-safe value would otherwise be
-// trusted, leaving apps/<requested-host>.toml on disk describing a different
-// identity than its own file name — breaking the file-name-is-identity
-// invariant HasAppHost/SaveApp depend on.
+// TestImportAppConfig_RejectsHostPortIdentityMismatch covers content whose
+// own app-host/app-port disagree with the request.
 func TestImportAppConfig_RejectsHostPortIdentityMismatch(t *testing.T) {
 	cl := newTestClusterForAppImport(t, "c1")
 
@@ -231,12 +208,9 @@ func TestImportAppConfig_RejectsHostPortIdentityMismatch(t *testing.T) {
 	}
 }
 
-// TestImportAppConfig_RejectsDedupSkipOrphan covers the case where
-// tomlContent's declared identity already matches an app previously loaded
-// under a *different* file name: LoadAppConfig's own dedup-skip logic
-// returns nil without appending to Conf.Apps, which — before this check
-// existed — would silently leave apps/<host>.toml on disk as an orphaned
-// duplicate of an already-loaded app.
+// TestImportAppConfig_RejectsDedupSkipOrphan: content's identity already
+// matches an app loaded under a different file, so LoadAppConfig's own
+// dedup-skip appends nothing — must not leave an orphan file behind.
 func TestImportAppConfig_RejectsDedupSkipOrphan(t *testing.T) {
 	cl := newTestClusterForAppImport(t, "c1")
 	dirname := filepath.Join(cl.WorkingDir, "apps")
@@ -264,10 +238,8 @@ func TestImportAppConfig_RejectsDedupSkipOrphan(t *testing.T) {
 	}
 }
 
-// TestLoadAppConfig_UnsafeAppHostFallsBackToFilename covers the TOML-file
-// load path (not just peer import): a hand-edited or otherwise tampered
-// app-host value in an on-disk apps/*.toml must not be trusted verbatim,
-// since it flows back into ImportAppConfig/SaveApp path joins on re-export.
+// TestLoadAppConfig_UnsafeAppHostFallsBackToFilename covers a hand-edited
+// apps/*.toml with an unsafe app-host value.
 func TestLoadAppConfig_UnsafeAppHostFallsBackToFilename(t *testing.T) {
 	cl := newTestClusterForAppImport(t, "c1")
 	dirname := filepath.Join(cl.WorkingDir, "apps")
@@ -285,8 +257,7 @@ func TestLoadAppConfig_UnsafeAppHostFallsBackToFilename(t *testing.T) {
 		t.Fatalf("LoadAppConfig failed: %v", err)
 	}
 
-	// LoadAppConfig only appends to cluster.Conf.Apps (newAppList() is what
-	// later populates cluster.Apps/HasAppHost), so assert against Conf.Apps.
+	// LoadAppConfig only appends to Conf.Apps; newAppList() populates cluster.Apps.
 	var loaded *config.AppConfig
 	for _, a := range cl.Conf.Apps {
 		if a.AppPort == "8080" {
@@ -301,11 +272,8 @@ func TestLoadAppConfig_UnsafeAppHostFallsBackToFilename(t *testing.T) {
 	}
 }
 
-// TestHasAppHost_UsesPersistedHostNotRuntimeHost is the ProvNetCNI mismatch
-// case: when app.GetHost() (runtime, CNI-rewritten) differs from
-// app.AppConfig.AppHost (persisted), the collision guards must key off the
-// persisted identity — matching against the runtime host would silently
-// miss a real collision (or flag a false one).
+// TestHasAppHost_UsesPersistedHostNotRuntimeHost: collision guards must key
+// off the persisted host, not the ProvNetCNI-rewritten runtime host.
 func TestHasAppHost_UsesPersistedHostNotRuntimeHost(t *testing.T) {
 	cl := newTestClusterForAppImport(t, "c1")
 	app := newTestAppWithRuntimeHostMismatch("peerapp1", "peerapp1.c1.svc.k8s", "8080")
@@ -329,10 +297,8 @@ func TestHasAppHost_UsesPersistedHostNotRuntimeHost(t *testing.T) {
 	}
 }
 
-// TestImportThenSave_UsesPersistedHostForFileName imports under ProvNetCNI,
-// then runs a normal save cycle (SaveApp, as the monitoring loop would), and
-// verifies exactly one file exists — named after the persisted host, never a
-// second file named after the runtime-rewritten host.
+// TestImportThenSave_UsesPersistedHostForFileName: import under ProvNetCNI
+// then SaveApp must produce exactly one file, named after the persisted host.
 func TestImportThenSave_UsesPersistedHostForFileName(t *testing.T) {
 	cl := newTestClusterForAppImport(t, "c1")
 	cl.Conf.ProvNetCNI = true
@@ -372,13 +338,8 @@ func TestImportThenSave_UsesPersistedHostForFileName(t *testing.T) {
 	}
 }
 
-// TestImportAppConfig_RollbackUsesPersistedHostUnderProvNetCNI proves the
-// same-host collision guard still fires under ProvNetCNI: an existing local
-// app persisted under host "app1" (whose runtime host is rewritten to
-// "app1.c1.svc.k8s") must still block a peer import of persisted host
-// "app1" on a different port. If the guard mistakenly compared against the
-// runtime host instead, "app1" would never match "app1.c1.svc.k8s" and the
-// unsafe same-host/different-port import would be silently accepted.
+// TestImportAppConfig_RollbackUsesPersistedHostUnderProvNetCNI: the
+// same-host collision guard must still fire under ProvNetCNI's rewritten host.
 func TestImportAppConfig_RollbackUsesPersistedHostUnderProvNetCNI(t *testing.T) {
 	cl := newTestClusterForAppImport(t, "c1")
 	cl.Conf.ProvNetCNI = true
@@ -398,14 +359,9 @@ func TestImportAppConfig_RollbackUsesPersistedHostUnderProvNetCNI(t *testing.T) 
 }
 
 // TestImportAppConfig_ConcurrentImportsDoNotCorruptConfApps drives many
-// ImportAppConfig calls at once — some that succeed, some engineered to hit
-// the host/port identity-mismatch rollback path — and checks that
-// cluster.Conf.Apps ends up with exactly the successful entries and nothing
-// else. Before ImportAppConfig held cluster.Lock() across its whole
-// snapshot-load-verify sequence, a length-snapshot taken outside the lock
-// could be invalidated by a concurrent append/rollback happening in the
-// window between snapshot and verification, corrupting Conf.Apps (losing or
-// duplicating entries) under -race.
+// concurrent imports (some succeeding, some hitting the mismatch rollback)
+// and checks Conf.Apps ends up with exactly the successful entries. Run
+// with -race.
 func TestImportAppConfig_ConcurrentImportsDoNotCorruptConfApps(t *testing.T) {
 	cl := newTestClusterForAppImport(t, "c1")
 
@@ -418,12 +374,10 @@ func TestImportAppConfig_ConcurrentImportsDoNotCorruptConfApps(t *testing.T) {
 			defer wg.Done()
 			host := fmt.Sprintf("host%d", i)
 			if i%2 == 0 {
-				// Good import: content identity matches the request.
 				content := exportTOMLForImport(t, cl, host, "8080")
 				_ = cl.ImportAppConfig(host, "8080", content)
 			} else {
-				// Engineered mismatch: content declares a different host,
-				// forcing the rollback path on every call.
+				// Mismatched identity forces the rollback path.
 				content := exportTOMLForImport(t, cl, host+"-wrong", "8080")
 				_ = cl.ImportAppConfig(host, "8080", content)
 			}
@@ -447,8 +401,6 @@ func TestImportAppConfig_ConcurrentImportsDoNotCorruptConfApps(t *testing.T) {
 		if got != want {
 			t.Fatalf("host %s: expected present=%v, got present=%v (Conf.Apps=%v)", host, want, got, seen)
 		}
-		// A rejected mismatched import must never leave its declared
-		// (wrong-host) identity behind either.
 		if seen[host+"-wrong:8080"] {
 			t.Fatalf("mismatched identity %s-wrong:8080 leaked into Conf.Apps", host)
 		}

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -1775,12 +1775,7 @@ func (cluster *Cluster) GetTerminalManager() tty.TerminalManager {
 }
 
 func (cluster *Cluster) GetAppConfig(apphost, port string) *config.AppConfig {
-	// The scan itself must be lock-protected: cluster.Conf.Apps is mutated
-	// under cluster.Lock() elsewhere (appendConfAppIfAbsent, removeConfApp,
-	// RemoveAppMonitor, ImportAppConfig/LoadAppConfig), so reading the slice
-	// header here without the same lock races against any of them running
-	// concurrently (e.g. two concurrent app imports, one still appending
-	// while the other's newAppList() rebuild calls this).
+	// Conf.Apps is mutated under cluster.Lock() elsewhere; match that here.
 	cluster.Lock()
 	var cnf *config.AppConfig
 	for _, c := range cluster.Conf.Apps {

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -1775,31 +1775,45 @@ func (cluster *Cluster) GetTerminalManager() tty.TerminalManager {
 }
 
 func (cluster *Cluster) GetAppConfig(apphost, port string) *config.AppConfig {
-	for _, cnf := range cluster.Conf.Apps {
-		if cnf.AppHost == apphost && cnf.AppPort == port {
-			if cnf.Deployment.Variables == nil {
-				cnf.Deployment.Variables = make(config.VariableMaps, 0)
-			}
-			if cnf.Deployment.Routes == nil {
-				cnf.Deployment.Routes = make(config.Routes, 0)
-			}
-			if cnf.Deployment.Storages.GitClones == nil {
-				cnf.Deployment.Storages.GitClones = make(config.GitClones, 0)
-			}
-			if cnf.Deployment.Storages.S3Mounts == nil {
-				cnf.Deployment.Storages.S3Mounts = make(config.S3Mounts, 0)
-			}
-			if cnf.Deployment.Storages.Volumes == nil {
-				cnf.Deployment.Storages.Volumes = make(config.Volumes, 0)
-			}
-			if cnf.Deployment.Paths == nil {
-				cnf.Deployment.Paths = make(config.PathMaps, 0)
-			}
-			return cnf
+	// The scan itself must be lock-protected: cluster.Conf.Apps is mutated
+	// under cluster.Lock() elsewhere (appendConfAppIfAbsent, removeConfApp,
+	// RemoveAppMonitor, ImportAppConfig/LoadAppConfig), so reading the slice
+	// header here without the same lock races against any of them running
+	// concurrently (e.g. two concurrent app imports, one still appending
+	// while the other's newAppList() rebuild calls this).
+	cluster.Lock()
+	var cnf *config.AppConfig
+	for _, c := range cluster.Conf.Apps {
+		if c.AppHost == apphost && c.AppPort == port {
+			cnf = c
+			break
 		}
 	}
+	cluster.Unlock()
 
-	cnf := cluster.NewAppConfig(apphost, port)
+	if cnf != nil {
+		if cnf.Deployment.Variables == nil {
+			cnf.Deployment.Variables = make(config.VariableMaps, 0)
+		}
+		if cnf.Deployment.Routes == nil {
+			cnf.Deployment.Routes = make(config.Routes, 0)
+		}
+		if cnf.Deployment.Storages.GitClones == nil {
+			cnf.Deployment.Storages.GitClones = make(config.GitClones, 0)
+		}
+		if cnf.Deployment.Storages.S3Mounts == nil {
+			cnf.Deployment.Storages.S3Mounts = make(config.S3Mounts, 0)
+		}
+		if cnf.Deployment.Storages.Volumes == nil {
+			cnf.Deployment.Storages.Volumes = make(config.Volumes, 0)
+		}
+		if cnf.Deployment.Paths == nil {
+			cnf.Deployment.Paths = make(config.PathMaps, 0)
+		}
+		return cnf
+	}
+
+	cnf = cluster.NewAppConfig(apphost, port)
 	if cnf.Deployment.Variables == nil {
 		cnf.Deployment.Variables = make(config.VariableMaps, 0)
 	}

--- a/config/manager/manager.go
+++ b/config/manager/manager.go
@@ -1153,7 +1153,12 @@ func copyFile(src, dst string, mode os.FileMode) error {
 	return out.Sync()
 }
 
-func resolveCurrentLocalBranch(workDir string) (plumbing.ReferenceName, bool) {
+// ResolveCurrentLocalBranch returns the current local branch reference for
+// the git repo at workDir (falling back to "master" if HEAD is detached), so
+// callers cloning elsewhere from the same remote can stage the branch this
+// instance actually tracks instead of silently defaulting to the remote's
+// default branch.
+func ResolveCurrentLocalBranch(workDir string) (plumbing.ReferenceName, bool) {
 	r, err := git.PlainOpen(workDir)
 	if err != nil {
 		return "", false
@@ -1171,7 +1176,9 @@ func resolveCurrentLocalBranch(workDir string) (plumbing.ReferenceName, bool) {
 	return "", false
 }
 
-func isReferenceNotFoundError(err error) bool {
+// IsReferenceNotFoundError reports whether err indicates that a requested git
+// reference (branch/tag) does not exist on the remote.
+func IsReferenceNotFoundError(err error) bool {
 	if err == nil {
 		return false
 	}
@@ -1217,7 +1224,7 @@ func (cm *ConfigManager) RefreshGitMetadata(conf *config.Config) error {
 		SingleBranch:      true,
 	}
 
-	if refName, ok := resolveCurrentLocalBranch(path); ok {
+	if refName, ok := ResolveCurrentLocalBranch(path); ok {
 		cloneopt.ReferenceName = refName
 		cloneopt.SingleBranch = true
 		cm.logger.Infof("none", config.ConstLogModGit, "Refreshing git metadata using current local branch reference %s", refName)
@@ -1230,7 +1237,7 @@ func (cm *ConfigManager) RefreshGitMetadata(conf *config.Config) error {
 
 	cm.logger.Infof("none", config.ConstLogModGit, "Cloning fresh git metadata into temporary directory for in-place refresh")
 	if _, err := cm.cloneRepositoryWithBootstrap(tmpClonePath, conf, cloneopt); err != nil {
-		if cloneopt.ReferenceName != "" && isReferenceNotFoundError(err) {
+		if cloneopt.ReferenceName != "" && IsReferenceNotFoundError(err) {
 			cm.logger.Warnf("none", config.ConstLogModGit, "Refresh metadata clone with reference %s failed (%v). Retrying with remote default branch", cloneopt.ReferenceName, err)
 			if rmErr := os.RemoveAll(tmpClonePath); rmErr != nil {
 				return fmt.Errorf("cannot reset temporary clone dir before refresh retry: %w", rmErr)

--- a/server/api_app.go
+++ b/server/api_app.go
@@ -32,6 +32,26 @@ import (
 
 func (repman *ReplicationManager) apiAppProtectedHandler(router *mux.Router) {
 	//PROTECTED ENDPOINTS FOR APPS
+
+	// Peer import: manual, opt-in, per-app import of app monitors from the
+	// arbitration peer. See doc/implementation/server/APP_MONITOR_PEER_IMPORT_PLAN.md.
+	router.Handle("/api/clusters/{clusterName}/apps/peer-import/inventory", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxAppPeerImportInventory)),
+	)).Methods("GET")
+	router.Handle("/api/clusters/{clusterName}/apps/peer-import/export", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxAppPeerImportExport)),
+	)).Methods("GET")
+	router.Handle("/api/clusters/{clusterName}/apps/peer-import/preview", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxAppPeerImportPreview)),
+	)).Methods("POST")
+	router.Handle("/api/clusters/{clusterName}/apps/peer-import/apply", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxAppPeerImportApply)),
+	)).Methods("POST")
+
 	router.Handle("/api/clusters/{clusterName}/apps/{appName}", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxApp)),

--- a/server/api_app_peer_import.go
+++ b/server/api_app_peer_import.go
@@ -1,0 +1,478 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+// Redistribution/Reuse of this code is permitted under the GNU v3 license, as
+// an additional term, ALL code must carry the original Author(s) credit in comment form.
+// See LICENSE in this directory for the integral text.
+
+// api_app_peer_import.go implements a manual, opt-in, per-app import of app
+// monitoring definitions from the arbitration peer (ArbitrationPeerHosts) —
+// never automatic, never import-all. See
+// doc/implementation/server/APP_MONITOR_PEER_IMPORT_PLAN.md for the design.
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/pelletier/go-toml"
+	"github.com/signal18/replication-manager/cluster"
+	"github.com/signal18/replication-manager/config"
+)
+
+// PeerAppInventoryItem describes one app monitor exposed by the peer
+// inventory endpoint. Host/Port are the persisted identity
+// (app.AppConfig.AppHost/AppPort — what SaveApp() names the file after and
+// LoadAppConfig() dedupes on) and are the only fields used as an import
+// selection key. RuntimeHost is app.GetHost(), which ProvNetCNI rewrites
+// with a cluster-svc suffix for routing; it is included for display/debug
+// only and must never be used to select or key an import.
+type PeerAppInventoryItem struct {
+	Host        string `json:"host"`
+	Port        string `json:"port"`
+	RuntimeHost string `json:"runtimeHost,omitempty"`
+	Id          string `json:"id,omitempty"`
+	Template    string `json:"template,omitempty"`
+	DockerImage string `json:"dockerImage,omitempty"`
+}
+
+// PeerAppInventory is the response of the peer inventory endpoint, scoped to one cluster.
+type PeerAppInventory struct {
+	ClusterName string                 `json:"clusterName"`
+	URI         string                 `json:"uri"`
+	Apps        []PeerAppInventoryItem `json:"apps"`
+}
+
+// AppImportPreviewItem is the per-app status returned by the import preview endpoint.
+type AppImportPreviewItem struct {
+	Host        string `json:"host"`
+	Port        string `json:"port"`
+	Id          string `json:"id,omitempty"`
+	Template    string `json:"template,omitempty"`
+	DockerImage string `json:"dockerImage,omitempty"`
+	// Status is one of: importable, already_exists, unsupported_same_host, invalid_peer.
+	Status string `json:"status"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// AppImportPreviewResult is the response of the import preview endpoint.
+type AppImportPreviewResult struct {
+	ClusterName string                 `json:"clusterName"`
+	PeerURI     string                 `json:"peerUri"`
+	Apps        []AppImportPreviewItem `json:"apps"`
+}
+
+// appImportSelector identifies one peer app to import, keyed by host+port —
+// the same key used by the existing add/drop app monitor flows.
+type appImportSelector struct {
+	Host string `json:"host"`
+	Port string `json:"port"`
+}
+
+// appImportApplyRequest is the request body of the import apply endpoint.
+// Selection is always explicit: there is no import-all path.
+type appImportApplyRequest struct {
+	Apps []appImportSelector `json:"apps"`
+}
+
+// AppImportApplyItem is the per-app outcome returned by the import apply endpoint.
+type AppImportApplyItem struct {
+	Host   string `json:"host"`
+	Port   string `json:"port"`
+	Status string `json:"status"` // imported | rejected
+	Reason string `json:"reason,omitempty"`
+}
+
+// AppImportApplyResult is the response of the import apply endpoint.
+type AppImportApplyResult struct {
+	ClusterName string               `json:"clusterName"`
+	Apps        []AppImportApplyItem `json:"apps"`
+}
+
+// samePeerCluster verifies the arbitration peer is monitoring the exact same
+// cluster as this node: same cluster name AND same canonical instance URI
+// (server/api_register.go registeredInstanceURI). Fails closed — an empty
+// local or peer URI is never treated as a match.
+func (repman *ReplicationManager) samePeerCluster(localClusterName string, peerInv PeerAppInventory) error {
+	if peerInv.ClusterName != localClusterName {
+		return fmt.Errorf("peer cluster name %q does not match local cluster name %q", peerInv.ClusterName, localClusterName)
+	}
+	localURI := repman.registeredInstanceURI()
+	if localURI == "" || peerInv.URI == "" || localURI != peerInv.URI {
+		return fmt.Errorf("peer instance URI %q does not match local instance URI %q", peerInv.URI, localURI)
+	}
+	return nil
+}
+
+// peerAppInventory fetches the app inventory for clusterName from the
+// arbitration peer using an already-established login session.
+func (repman *ReplicationManager) peerAppInventory(base, token, clusterName string) (PeerAppInventory, error) {
+	var inv PeerAppInventory
+	req, err := http.NewRequest("GET", base+"/api/clusters/"+clusterName+"/apps/peer-import/inventory", nil)
+	if err != nil {
+		return inv, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return inv, fmt.Errorf("peer inventory request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return inv, fmt.Errorf("peer inventory rejected (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if err := json.Unmarshal(body, &inv); err != nil {
+		return inv, fmt.Errorf("peer inventory parse failed: %w", err)
+	}
+	return inv, nil
+}
+
+// peerAppList logs into the arbitration peer (ArbitrationPeerHosts) with the
+// shared cluster-test credentials and fetches its app inventory for clusterName.
+func (repman *ReplicationManager) peerAppList(clusterName string) (PeerAppInventory, error) {
+	base, token, err := repman.peerSplitBrainLogin(clusterName)
+	if err != nil {
+		return PeerAppInventory{}, err
+	}
+	return repman.peerAppInventory(base, token, clusterName)
+}
+
+// peerAppExport fetches the peer's TOML export for one app (host+port) using
+// an already-established login session.
+func (repman *ReplicationManager) peerAppExport(base, token, clusterName, host, port string) (string, error) {
+	u := fmt.Sprintf("%s/api/clusters/%s/apps/peer-import/export?host=%s&port=%s",
+		base, clusterName, url.QueryEscape(host), url.QueryEscape(port))
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("peer app export request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("peer app export rejected (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var payload struct {
+		Toml string `json:"toml"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil || payload.Toml == "" {
+		return "", fmt.Errorf("peer app export parse failed: %s", strings.TrimSpace(string(body)))
+	}
+	return payload.Toml, nil
+}
+
+// appImportPreview logs into the arbitration peer, fetches its app inventory,
+// verifies same-cluster identity, and classifies each peer app against the
+// local app list by host+port. Read-only: never writes local state.
+func (repman *ReplicationManager) appImportPreview(mycluster *cluster.Cluster) (AppImportPreviewResult, error) {
+	result := AppImportPreviewResult{ClusterName: mycluster.Name}
+
+	inv, err := repman.peerAppList(mycluster.Name)
+	if err != nil {
+		return result, err
+	}
+	result.PeerURI = inv.URI
+
+	if err := repman.samePeerCluster(mycluster.Name, inv); err != nil {
+		// Fail closed: every candidate is invalid_peer, no partial success.
+		for _, a := range inv.Apps {
+			result.Apps = append(result.Apps, AppImportPreviewItem{
+				Host: a.Host, Port: a.Port, Id: a.Id, Template: a.Template, DockerImage: a.DockerImage,
+				Status: "invalid_peer", Reason: err.Error(),
+			})
+		}
+		return result, nil
+	}
+
+	// Same-host/different-port on the peer's own inventory is unsupported by
+	// the current host-based storage layout — flag every app on an ambiguous
+	// host so the operator sees it before selecting anything.
+	peerPortsByHost := make(map[string]map[string]bool)
+	for _, a := range inv.Apps {
+		if peerPortsByHost[a.Host] == nil {
+			peerPortsByHost[a.Host] = make(map[string]bool)
+		}
+		peerPortsByHost[a.Host][a.Port] = true
+	}
+
+	for _, a := range inv.Apps {
+		item := AppImportPreviewItem{Host: a.Host, Port: a.Port, Id: a.Id, Template: a.Template, DockerImage: a.DockerImage}
+		switch {
+		case len(peerPortsByHost[a.Host]) > 1:
+			item.Status = "unsupported_same_host"
+			item.Reason = "peer has multiple ports on the same host; current storage layout is host-based"
+		case mycluster.HasAppHostPort(a.Host, a.Port):
+			item.Status = "already_exists"
+		case mycluster.HasAppHost(a.Host):
+			item.Status = "unsupported_same_host"
+			item.Reason = "local cluster already has an app on this host with a different port"
+		default:
+			item.Status = "importable"
+		}
+		result.Apps = append(result.Apps, item)
+	}
+
+	return result, nil
+}
+
+// appImportApply imports the explicitly selected peer apps (host+port) into
+// mycluster. It re-verifies the same-cluster gate and the host-collision
+// guards independently of any prior preview call, and processes each
+// selection independently: a rejected app never blocks the others, and a
+// rejected app never partially writes local state (cluster.ImportAppConfig
+// only mutates on full success).
+func (repman *ReplicationManager) appImportApply(mycluster *cluster.Cluster, selected []appImportSelector) (AppImportApplyResult, error) {
+	result := AppImportApplyResult{ClusterName: mycluster.Name}
+	if len(selected) == 0 {
+		return result, errors.New("no apps selected for import")
+	}
+
+	base, token, err := repman.peerSplitBrainLogin(mycluster.Name)
+	if err != nil {
+		return result, err
+	}
+
+	inv, err := repman.peerAppInventory(base, token, mycluster.Name)
+	if err != nil {
+		return result, err
+	}
+	if err := repman.samePeerCluster(mycluster.Name, inv); err != nil {
+		return result, err
+	}
+
+	peerByHostPort := make(map[string]bool, len(inv.Apps))
+	peerPortsByHost := make(map[string]map[string]bool, len(inv.Apps))
+	for _, a := range inv.Apps {
+		peerByHostPort[a.Host+"|"+a.Port] = true
+		if peerPortsByHost[a.Host] == nil {
+			peerPortsByHost[a.Host] = make(map[string]bool)
+		}
+		peerPortsByHost[a.Host][a.Port] = true
+	}
+
+	// Guard: selections that put different ports on the same host cannot be
+	// mapped safely onto the current host-based storage layout. Reject the
+	// whole ambiguous group up front, before any peer export or local write.
+	selectedPortsByHost := make(map[string]map[string]bool)
+	for _, s := range selected {
+		if selectedPortsByHost[s.Host] == nil {
+			selectedPortsByHost[s.Host] = make(map[string]bool)
+		}
+		selectedPortsByHost[s.Host][s.Port] = true
+	}
+
+	for _, s := range selected {
+		item := AppImportApplyItem{Host: s.Host, Port: s.Port}
+
+		if len(selectedPortsByHost[s.Host]) > 1 {
+			item.Status = "rejected"
+			item.Reason = "same host with different ports selected together is not supported"
+			result.Apps = append(result.Apps, item)
+			continue
+		}
+		// Mirror preview's own-peer-ambiguity check: reject even a single
+		// selection if the peer itself reports more than one port on this
+		// host, so apply never accepts something preview would have flagged
+		// unsupported_same_host, whether or not preview was actually called.
+		if len(peerPortsByHost[s.Host]) > 1 {
+			item.Status = "rejected"
+			item.Reason = "peer has multiple ports on this host; current storage layout is host-based"
+			result.Apps = append(result.Apps, item)
+			continue
+		}
+		if !peerByHostPort[s.Host+"|"+s.Port] {
+			item.Status = "rejected"
+			item.Reason = "not present in peer inventory"
+			result.Apps = append(result.Apps, item)
+			continue
+		}
+
+		tomlContent, err := repman.peerAppExport(base, token, mycluster.Name, s.Host, s.Port)
+		if err != nil {
+			item.Status = "rejected"
+			item.Reason = "peer export failed: " + err.Error()
+			result.Apps = append(result.Apps, item)
+			continue
+		}
+
+		if err := mycluster.ImportAppConfig(s.Host, s.Port, tomlContent); err != nil {
+			item.Status = "rejected"
+			item.Reason = err.Error()
+			result.Apps = append(result.Apps, item)
+			continue
+		}
+
+		item.Status = "imported"
+		result.Apps = append(result.Apps, item)
+	}
+
+	return result, nil
+}
+
+// ---------------------------------------------------------------------------
+// HTTP handlers
+// ---------------------------------------------------------------------------
+
+// handlerMuxAppPeerImportInventory is the peer-side endpoint: it lists this
+// node's own apps for clusterName so that another repman node monitoring the
+// same cluster can preview an import. Read-only, scoped to one cluster.
+func (repman *ReplicationManager) handlerMuxAppPeerImportInventory(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster == nil {
+		http.Error(w, "Cluster Not Found", http.StatusNotFound)
+		return
+	}
+	if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+		http.Error(w, "No valid ACL", http.StatusForbidden)
+		return
+	}
+
+	inv := buildPeerAppInventory(mycluster)
+	inv.URI = repman.registeredInstanceURI()
+
+	json.NewEncoder(w).Encode(inv)
+}
+
+// buildPeerAppInventory builds the peer inventory response for mycluster.
+// Selection keys are the persisted identity (app.AppConfig.AppHost/AppPort)
+// — see PeerAppInventoryItem. Apps with no AppConfig, or an empty persisted
+// host/port, are omitted (fail closed: an app that cannot be identified by
+// its persisted key must never be offered for import).
+func buildPeerAppInventory(mycluster *cluster.Cluster) PeerAppInventory {
+	inv := PeerAppInventory{ClusterName: mycluster.Name}
+	for _, app := range mycluster.GetAppsCopy() {
+		if app == nil || app.AppConfig == nil || app.AppConfig.AppHost == "" || app.AppConfig.AppPort == "" {
+			continue
+		}
+		inv.Apps = append(inv.Apps, PeerAppInventoryItem{
+			Host:        app.AppConfig.AppHost,
+			Port:        app.AppConfig.AppPort,
+			RuntimeHost: app.GetHost(),
+			Id:          app.Id,
+			Template:    app.AppConfig.ProvAppTemplate,
+			DockerImage: app.AppConfig.ProvAppDockerImg,
+		})
+	}
+	return inv
+}
+
+// handlerMuxAppPeerImportExport is the peer-side endpoint: it exports one
+// app's config, identified by its persisted host+port
+// (app.AppConfig.AppHost/AppPort), using the same TOML shape already
+// persisted locally by SaveApp()/SaveAppConfigFile().
+func (repman *ReplicationManager) handlerMuxAppPeerImportExport(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster == nil {
+		http.Error(w, "Cluster Not Found", http.StatusNotFound)
+		return
+	}
+	if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+		http.Error(w, "No valid ACL", http.StatusForbidden)
+		return
+	}
+
+	host := r.URL.Query().Get("host")
+	port := r.URL.Query().Get("port")
+	if host == "" || port == "" {
+		http.Error(w, "host and port query parameters are required", http.StatusBadRequest)
+		return
+	}
+
+	// Look up by persisted identity (AppConfig.AppHost/AppPort), not runtime
+	// host: GetAppByHostPort compares app.GetHost(), which ProvNetCNI
+	// rewrites — see PeerAppInventoryItem.
+	app := mycluster.GetAppByConfig(&config.AppConfig{AppHost: host, AppPort: port})
+	if app == nil || app.AppConfig == nil {
+		http.Error(w, "App not found", http.StatusNotFound)
+		return
+	}
+
+	data, err := toml.Marshal(app.AppConfig)
+	if err != nil {
+		http.Error(w, "Error marshalling app config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(struct {
+		Host string `json:"host"`
+		Port string `json:"port"`
+		Toml string `json:"toml"`
+	}{Host: host, Port: port, Toml: string(data)})
+}
+
+// handlerMuxAppPeerImportPreview is the local-side, read-only preview step:
+// it fetches the peer's inventory and classifies every peer app without
+// writing any local state.
+func (repman *ReplicationManager) handlerMuxAppPeerImportPreview(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster == nil {
+		http.Error(w, "Cluster Not Found", http.StatusNotFound)
+		return
+	}
+	if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+		http.Error(w, "No valid ACL", http.StatusForbidden)
+		return
+	}
+
+	result, err := repman.appImportPreview(mycluster)
+	if err != nil {
+		http.Error(w, "Error building import preview: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	json.NewEncoder(w).Encode(result)
+}
+
+// handlerMuxAppPeerImportApply is the local-side apply step: it imports only
+// the explicitly selected apps (host+port). There is no import-all path.
+func (repman *ReplicationManager) handlerMuxAppPeerImportApply(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster == nil {
+		http.Error(w, "Cluster Not Found", http.StatusNotFound)
+		return
+	}
+	if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+		http.Error(w, "No valid ACL", http.StatusForbidden)
+		return
+	}
+
+	var body appImportApplyRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "Error decoding request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if len(body.Apps) == 0 {
+		http.Error(w, "No apps selected for import", http.StatusBadRequest)
+		return
+	}
+
+	result, err := repman.appImportApply(mycluster, body.Apps)
+	if err != nil {
+		http.Error(w, "Error applying import: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	json.NewEncoder(w).Encode(result)
+}

--- a/server/api_app_peer_import.go
+++ b/server/api_app_peer_import.go
@@ -12,6 +12,7 @@
 package server
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -96,6 +97,25 @@ type AppImportApplyResult struct {
 	Apps        []AppImportApplyItem `json:"apps"`
 }
 
+// getPeerAppCredentials returns a local user/password that can legitimately
+// perform the app-monitor import flow on the peer: the same grants that guard
+// preview/apply and the peer inventory/export endpoints.
+func (repman *ReplicationManager) getPeerAppCredentials(clusterName string) (string, string, bool) {
+	cl := repman.getClusterByName(clusterName)
+	if cl == nil {
+		return "", "", false
+	}
+	for _, u := range cl.APIUsers {
+		if u.Password == "" || u.Grants == nil {
+			continue
+		}
+		if u.Grants[config.GrantClusterCreateMonitor] || u.Grants[config.GrantAppDeployment] {
+			return u.User, u.Password, true
+		}
+	}
+	return "", "", false
+}
+
 // samePeerCluster verifies the arbitration peer is monitoring the exact same
 // cluster as this node: same cluster name AND same canonical instance URI
 // (server/api_register.go registeredInstanceURI). Fails closed — an empty
@@ -136,10 +156,46 @@ func (repman *ReplicationManager) peerAppInventory(base, token, clusterName stri
 	return inv, nil
 }
 
-// peerAppList logs into the arbitration peer (ArbitrationPeerHosts) with the
-// shared cluster-test credentials and fetches its app inventory for clusterName.
+// peerAppLogin logs into the arbitration peer (ArbitrationPeerHosts) with a
+// local user that already carries the same grants required by the peer-import
+// flow on both sides.
+func (repman *ReplicationManager) peerAppLogin(clusterName string) (base string, token string, err error) {
+	if repman.Conf.ArbitrationPeerHosts == "" {
+		return "", "", errors.New("no arbitration-peer-hosts configured")
+	}
+	peerHost := strings.TrimSpace(strings.Split(repman.Conf.ArbitrationPeerHosts, ",")[0])
+	scheme := "http://"
+	if strings.HasPrefix(peerHost, "http://") || strings.HasPrefix(peerHost, "https://") {
+		scheme = ""
+	}
+	base = scheme + peerHost
+
+	user, pass, ok := repman.getPeerAppCredentials(clusterName)
+	if !ok {
+		return "", "", errors.New("no local user with app-monitor import grants to authenticate to peer")
+	}
+	loginBody, _ := json.Marshal(userCredentials{Username: user, Password: pass})
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Post(base+"/api/login", "application/json", bytes.NewBuffer(loginBody))
+	if err != nil {
+		return "", "", fmt.Errorf("peer login failed: %w", err)
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("peer login rejected (%d): %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	var tok AuthTokenWithUpgrade
+	if err := json.Unmarshal(respBody, &tok); err != nil || tok.Token == "" {
+		return "", "", fmt.Errorf("peer login returned no token: %s", strings.TrimSpace(string(respBody)))
+	}
+	return base, tok.Token, nil
+}
+
+// peerAppList logs into the arbitration peer (ArbitrationPeerHosts) and
+// fetches its app inventory for clusterName.
 func (repman *ReplicationManager) peerAppList(clusterName string) (PeerAppInventory, error) {
-	base, token, err := repman.peerSplitBrainLogin(clusterName)
+	base, token, err := repman.peerAppLogin(clusterName)
 	if err != nil {
 		return PeerAppInventory{}, err
 	}
@@ -241,7 +297,7 @@ func (repman *ReplicationManager) appImportApply(mycluster *cluster.Cluster, sel
 		return result, errors.New("no apps selected for import")
 	}
 
-	base, token, err := repman.peerSplitBrainLogin(mycluster.Name)
+	base, token, err := repman.peerAppLogin(mycluster.Name)
 	if err != nil {
 		return result, err
 	}

--- a/server/api_app_peer_import_test.go
+++ b/server/api_app_peer_import_test.go
@@ -138,7 +138,7 @@ func TestSamePeerCluster_LocalURIIncomplete(t *testing.T) {
 }
 
 // newTestRepmanWithPeer wires a local ReplicationManager (one cluster,
-// with a cluster-test-grant user so peerSplitBrainLogin can authenticate)
+// with a create-monitor-grant user so peerAppLogin can authenticate)
 // pointed at peerHandler as its arbitration peer (ArbitrationPeerHosts).
 func newTestRepmanWithPeer(t *testing.T, clusterName string, peerHandler http.Handler) (*ReplicationManager, *cluster.Cluster) {
 	t.Helper()
@@ -152,7 +152,7 @@ func newTestRepmanWithPeer(t *testing.T, clusterName string, peerHandler http.Ha
 			"tester": {
 				User:     "tester",
 				Password: "testpass",
-				Grants:   map[string]bool{config.GrantClusterTest: true},
+				Grants:   map[string]bool{config.GrantClusterCreateMonitor: true},
 			},
 		},
 	}

--- a/server/api_app_peer_import_test.go
+++ b/server/api_app_peer_import_test.go
@@ -1,0 +1,246 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/signal18/replication-manager/cluster"
+	"github.com/signal18/replication-manager/config"
+)
+
+// TestBuildPeerAppInventory_UsesPersistedHostNotRuntimeHost is the
+// ProvNetCNI mismatch case: NewApp() rewrites app.Host (app.GetHost()) with
+// a cluster-svc suffix for runtime routing while app.AppConfig.AppHost stays
+// pinned to the original persisted host. The inventory must report the
+// persisted identity as Host/Port (the only fields used as an import
+// selection key) and the runtime host only as the separate, display-only
+// RuntimeHost field. It must also omit apps with no usable persisted
+// identity (fail closed) rather than exporting them as importable.
+func TestBuildPeerAppInventory_UsesPersistedHostNotRuntimeHost(t *testing.T) {
+	mycluster := &cluster.Cluster{
+		Name: "cl1",
+		Apps: []*cluster.App{
+			{
+				Name:  "peerapp1",
+				Host:  "peerapp1.cl1.svc.k8s", // simulates the ProvNetCNI runtime rewrite
+				Port:  "8080",
+				Mutex: &sync.Mutex{},
+				AppConfig: &config.AppConfig{
+					AppHost: "peerapp1",
+					AppPort: "8080",
+				},
+			},
+			{
+				// Empty persisted host: must be omitted, not offered for import.
+				Name:      "badapp",
+				Host:      "badapp",
+				Port:      "9090",
+				Mutex:     &sync.Mutex{},
+				AppConfig: &config.AppConfig{AppHost: "", AppPort: "9090"},
+			},
+			{
+				// No AppConfig at all: must be omitted.
+				Name:  "nilconfigapp",
+				Host:  "nilconfigapp",
+				Port:  "1234",
+				Mutex: &sync.Mutex{},
+			},
+		},
+	}
+
+	inv := buildPeerAppInventory(mycluster)
+
+	if len(inv.Apps) != 1 {
+		t.Fatalf("expected exactly 1 app in inventory (2 with missing persisted identity omitted), got %d: %+v", len(inv.Apps), inv.Apps)
+	}
+	item := inv.Apps[0]
+	if item.Host != "peerapp1" || item.Port != "8080" {
+		t.Fatalf("expected inventory Host/Port to be the persisted identity, got %+v", item)
+	}
+	if item.RuntimeHost != "peerapp1.cl1.svc.k8s" {
+		t.Fatalf("expected RuntimeHost to carry the runtime (CNI-rewritten) host for display, got %q", item.RuntimeHost)
+	}
+}
+
+func newTestRepmanForPeerImport(domain, sub, zone string) *ReplicationManager {
+	return &ReplicationManager{
+		Conf: &config.Config{
+			Cloud18Domain:        domain,
+			Cloud18SubDomain:     sub,
+			Cloud18SubDomainZone: zone,
+		},
+	}
+}
+
+func TestSamePeerCluster(t *testing.T) {
+	repman := newTestRepmanForPeerImport("example", "sub", "zone")
+	localURI := repman.registeredInstanceURI()
+	if localURI == "" {
+		t.Fatalf("expected local URI to be non-empty")
+	}
+
+	tests := []struct {
+		name    string
+		local   string
+		peer    PeerAppInventory
+		wantErr bool
+	}{
+		{
+			name:  "matching cluster name and uri",
+			local: "cluster1",
+			peer:  PeerAppInventory{ClusterName: "cluster1", URI: localURI},
+		},
+		{
+			name:    "cluster name mismatch",
+			local:   "cluster1",
+			peer:    PeerAppInventory{ClusterName: "cluster2", URI: localURI},
+			wantErr: true,
+		},
+		{
+			name:    "uri mismatch",
+			local:   "cluster1",
+			peer:    PeerAppInventory{ClusterName: "cluster1", URI: "other.sub.zone"},
+			wantErr: true,
+		},
+		{
+			name:    "empty peer uri never matches",
+			local:   "cluster1",
+			peer:    PeerAppInventory{ClusterName: "cluster1", URI: ""},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := repman.samePeerCluster(tt.local, tt.peer)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("samePeerCluster() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSamePeerCluster_LocalURIIncomplete(t *testing.T) {
+	// Local instance not fully registered (missing Cloud18 fields): must fail
+	// closed even if the peer happens to report an empty URI too.
+	repman := newTestRepmanForPeerImport("", "", "")
+	if got := repman.registeredInstanceURI(); got != "" {
+		t.Fatalf("expected empty local URI, got %q", got)
+	}
+
+	err := repman.samePeerCluster("cluster1", PeerAppInventory{ClusterName: "cluster1", URI: ""})
+	if err == nil {
+		t.Fatalf("expected error when local URI is incomplete, even with matching (empty) peer URI")
+	}
+}
+
+// newTestRepmanWithPeer wires a local ReplicationManager (one cluster,
+// with a cluster-test-grant user so peerSplitBrainLogin can authenticate)
+// pointed at peerHandler as its arbitration peer (ArbitrationPeerHosts).
+func newTestRepmanWithPeer(t *testing.T, clusterName string, peerHandler http.Handler) (*ReplicationManager, *cluster.Cluster) {
+	t.Helper()
+	ts := httptest.NewServer(peerHandler)
+	t.Cleanup(ts.Close)
+
+	mycluster := &cluster.Cluster{
+		Name: clusterName,
+		Conf: &config.Config{},
+		APIUsers: map[string]cluster.APIUser{
+			"tester": {
+				User:     "tester",
+				Password: "testpass",
+				Grants:   map[string]bool{config.GrantClusterTest: true},
+			},
+		},
+	}
+
+	repman := &ReplicationManager{
+		Conf: &config.Config{
+			Cloud18Domain:        "example",
+			Cloud18SubDomain:     "sub",
+			Cloud18SubDomainZone: "zone",
+			ArbitrationPeerHosts: ts.URL,
+		},
+		Clusters: map[string]*cluster.Cluster{clusterName: mycluster},
+	}
+	return repman, mycluster
+}
+
+// peerImportTestHandler builds a minimal fake-peer mux: /api/login always
+// succeeds, and the inventory endpoint returns inv regardless of clusterName
+// in the path (single-cluster test fixture).
+func peerImportTestHandler(t *testing.T, inv PeerAppInventory) http.Handler {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/login", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(AuthTokenWithUpgrade{Token: "faketoken"})
+	})
+	mux.HandleFunc("/api/clusters/", func(w http.ResponseWriter, r *http.Request) {
+		if len(r.URL.Path) >= len("/apps/peer-import/inventory") &&
+			r.URL.Path[len(r.URL.Path)-len("/apps/peer-import/inventory"):] == "/apps/peer-import/inventory" {
+			json.NewEncoder(w).Encode(inv)
+			return
+		}
+		http.NotFound(w, r)
+	})
+	return mux
+}
+
+// TestAppImportApply_RejectsAmbiguousPeerHostEvenIfNotSelectedTogether covers
+// the gap flagged in review: apply must reject a selection when the PEER's
+// own inventory has multiple ports on that host, even if only one of those
+// ports was selected (i.e. a caller that skips preview and calls apply
+// directly for a single app must get the same rejection preview would show).
+func TestAppImportApply_RejectsAmbiguousPeerHostEvenIfNotSelectedTogether(t *testing.T) {
+	repman, mycluster := newTestRepmanWithPeer(t, "cl1", peerImportTestHandler(t, PeerAppInventory{
+		ClusterName: "cl1",
+		URI:         "example.sub.zone",
+		Apps: []PeerAppInventoryItem{
+			{Host: "hostX", Port: "8080"},
+			{Host: "hostX", Port: "9090"},
+		},
+	}))
+
+	// Only one of the two ambiguous peer ports is selected.
+	result, err := repman.appImportApply(mycluster, []appImportSelector{{Host: "hostX", Port: "8080"}})
+	if err != nil {
+		t.Fatalf("appImportApply returned unexpected top-level error: %v", err)
+	}
+	if len(result.Apps) != 1 {
+		t.Fatalf("expected 1 result item, got %d", len(result.Apps))
+	}
+	if result.Apps[0].Status != "rejected" {
+		t.Fatalf("expected single-port selection from an ambiguous peer host to be rejected, got status=%q reason=%q",
+			result.Apps[0].Status, result.Apps[0].Reason)
+	}
+	// The fake peer handler doesn't implement /export, so any rejection would
+	// otherwise report "peer export failed" instead — assert the specific
+	// ambiguous-host reason to make sure this actually exercises the
+	// peer-inventory ambiguity guard and not some other rejection path.
+	const wantReason = "peer has multiple ports on this host; current storage layout is host-based"
+	if result.Apps[0].Reason != wantReason {
+		t.Fatalf("expected rejection reason %q, got %q", wantReason, result.Apps[0].Reason)
+	}
+}
+
+// TestAppImportApply_RejectsUnknownPeerApp covers the simpler existence
+// guard: a selection absent from the peer's inventory must be rejected, not
+// silently skipped or exported.
+func TestAppImportApply_RejectsUnknownPeerApp(t *testing.T) {
+	repman, mycluster := newTestRepmanWithPeer(t, "cl1", peerImportTestHandler(t, PeerAppInventory{
+		ClusterName: "cl1",
+		URI:         "example.sub.zone",
+		Apps:        []PeerAppInventoryItem{{Host: "hostY", Port: "8080"}},
+	}))
+
+	result, err := repman.appImportApply(mycluster, []appImportSelector{{Host: "hostZ", Port: "1234"}})
+	if err != nil {
+		t.Fatalf("appImportApply returned unexpected top-level error: %v", err)
+	}
+	if len(result.Apps) != 1 || result.Apps[0].Status != "rejected" {
+		t.Fatalf("expected selection absent from peer inventory to be rejected, got %+v", result.Apps)
+	}
+}

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -665,6 +665,11 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterRename)),
 	))
 
+	router.Handle("/api/clusters/actions/fetch-dynamic-from-git", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxFetchDynamicClustersFromGit)),
+	)).Methods(http.MethodPost)
+
 	router.Handle("/api/clusters/{clusterName}/topology/servers", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxServers)),
@@ -10230,6 +10235,47 @@ func (repman *ReplicationManager) handlerMuxSetServerActiveStatus(w http.Respons
 		return
 	}
 	w.Write([]byte("Server set to " + repman.Status))
+}
+
+// handlerMuxFetchDynamicClustersFromGit imports dynamic clusters that exist
+// in the main config git repo (repman.Conf.GitUrl) but are missing from this
+// instance's live working directory. Manual, admin-only, missing-only, no
+// overwrite. See doc/implementation/server/DYNAMIC_CLUSTER_GIT_IMPORT_PLAN.md.
+//
+// @Summary Import missing dynamic clusters from the main config git repo
+// @Description Clones the main config git repo and starts any dynamic cluster found there that is not already known locally. Existing clusters are never overwritten. Always returns 200 with a partial-success result unless the whole action cannot start.
+// @Tags Cluster
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Success 200 {object} DynamicClusterImportResult "Import result, possibly with per-cluster errors"
+// @Failure 403 {string} string "administrator access required"
+// @Failure 405 {string} string "method not allowed"
+// @Failure 500 {string} string "action could not start"
+// @Router /api/clusters/actions/fetch-dynamic-from-git [post]
+func (repman *ReplicationManager) handlerMuxFetchDynamicClustersFromGit(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	if r.Method != http.MethodPost {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	claims, err := repman.GetJWTClaims(r)
+	if err != nil || claims["User"] != "admin" {
+		http.Error(w, `{"error":"administrator access required"}`, http.StatusForbidden)
+		return
+	}
+
+	result, err := repman.FetchDynamicClustersFromGit()
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(result)
 }
 
 func (repman *ReplicationManager) toggleServerActiveStatus() error {

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -6058,9 +6058,9 @@ func (repman *ReplicationManager) handlerMuxClusterPlugins(w http.ResponseWriter
 	}
 
 	type PluginInfo struct {
-		Name     string                  `json:"name"`
-		Enabled  bool                    `json:"enabled"`
-		Config   map[string]string       `json:"config"`
+		Name     string                    `json:"name"`
+		Enabled  bool                      `json:"enabled"`
+		Config   map[string]string         `json:"config"`
 		Manifest *logplugin.PluginManifest `json:"manifest,omitempty"`
 	}
 
@@ -10019,9 +10019,9 @@ func (repman *ReplicationManager) handlerMuxInterventionStart(w http.ResponseWri
 		}
 
 		var body struct {
-			Reason    string `json:"reason"`
-			StartAt   string `json:"startAt"`
-			EndAt     string `json:"endAt"`
+			Reason  string `json:"reason"`
+			StartAt string `json:"startAt"`
+			EndAt   string `json:"endAt"`
 		}
 		if r.Body != nil {
 			json.NewDecoder(r.Body).Decode(&body)
@@ -10240,7 +10240,7 @@ func (repman *ReplicationManager) handlerMuxSetServerActiveStatus(w http.Respons
 // handlerMuxFetchDynamicClustersFromGit imports dynamic clusters that exist
 // in the main config git repo (repman.Conf.GitUrl) but are missing from this
 // instance's live working directory. Manual, admin-only, missing-only, no
-// overwrite. See doc/implementation/server/DYNAMIC_CLUSTER_GIT_IMPORT_PLAN.md.
+// overwrite.
 //
 // @Summary Import missing dynamic clusters from the main config git repo
 // @Description Clones the main config git repo and starts any dynamic cluster found there that is not already known locally. Existing clusters are never overwritten. Always returns 200 with a partial-success result unless the whole action cannot start.
@@ -10248,7 +10248,7 @@ func (repman *ReplicationManager) handlerMuxSetServerActiveStatus(w http.Respons
 // @Produce json
 // @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
 // @Success 200 {object} DynamicClusterImportResult "Import result, possibly with per-cluster errors"
-// @Failure 403 {string} string "administrator access required"
+// @Failure 403 {string} string "administrator access required, or instance not eligible (requires a registered Cloud18 account on a paid plan)"
 // @Failure 405 {string} string "method not allowed"
 // @Failure 500 {string} string "action could not start"
 // @Router /api/clusters/actions/fetch-dynamic-from-git [post]
@@ -10264,6 +10264,11 @@ func (repman *ReplicationManager) handlerMuxFetchDynamicClustersFromGit(w http.R
 	claims, err := repman.GetJWTClaims(r)
 	if err != nil || claims["User"] != "admin" {
 		http.Error(w, `{"error":"administrator access required"}`, http.StatusForbidden)
+		return
+	}
+
+	if !repman.Conf.IsEligibleForArbitration() {
+		http.Error(w, `{"error":"dynamic cluster git import requires a registered Cloud18 account with a support, support-services, or partner subscription plan"}`, http.StatusForbidden)
 		return
 	}
 

--- a/server/api_global_settings.go
+++ b/server/api_global_settings.go
@@ -184,6 +184,11 @@ func (repman *ReplicationManager) setRepmanSetting(name string, value string) er
 					repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
 						"Cloud18 connect failed: %s", err.Error())
 					repman.Conf.Cloud18 = false
+				} else {
+					// Best-effort: pick up the CRM's current plan for this URI so a
+					// node connecting to an already-subscribed URI doesn't stay on
+					// its local default. See syncSubscriptionPlanFromCRM.
+					repman.syncSubscriptionPlanFromCRM()
 				}
 				// Save final state (Cloud18 + any PAT/GitUrl set by InitGitConfig).
 				repman.ConfigManager.SaveConfig(repman, false)

--- a/server/api_register.go
+++ b/server/api_register.go
@@ -408,6 +408,13 @@ func (repman *ReplicationManager) applyCloudConnect(
 			}
 		}
 	}
+
+	// Sync the CRM's current plan for this URI so a second node registering
+	// against an already-subscribed URI (or a node reconnecting after losing
+	// its local config) doesn't stay stuck on the local default. Best-effort:
+	// see syncSubscriptionPlanFromCRM.
+	repman.syncSubscriptionPlanFromCRM()
+
 	repman.RegStatus.set(RegStateOK, "Registration complete", json.RawMessage(respBody))
 }
 
@@ -953,6 +960,79 @@ func (repman *ReplicationManager) persistInstanceSubscriptionPlan(plan, uri stri
 	}
 	repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
 		"subscription: plan changed to %s for URI %s (persisted to config)", plan, uri)
+}
+
+// parseSubscriptionPlan extracts the "plan" field from a CRM
+// GET /api/subscription response body. Returns an error for malformed JSON
+// or a missing/empty plan — callers must treat that as "nothing to sync",
+// not as a plan.
+func parseSubscriptionPlan(body []byte) (string, error) {
+	var resp struct {
+		Plan string `json:"plan"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("could not parse CRM subscription response: %w", err)
+	}
+	plan := strings.ToLower(strings.TrimSpace(resp.Plan))
+	if plan == "" {
+		return "", fmt.Errorf("CRM subscription response has no plan")
+	}
+	return plan, nil
+}
+
+// syncSubscriptionPlanFromCRMWithToken fetches the CRM's current subscription
+// plan for this instance URI and persists it locally if found. This is the
+// fix for the second-node/same-URI case: a node that registers against a
+// URI that already has a paid plan on CRM otherwise keeps its local default
+// ("free") forever, since the plan is normally only written on an explicit
+// change via handlerChangeSubscription.
+//
+// Best-effort by design: on any failure (CRM unreachable, non-200, unparseable
+// body, empty plan) this only logs a warning and leaves local config
+// untouched — it never resets the plan to a default and never blocks the
+// caller's registration/connect flow.
+func (repman *ReplicationManager) syncSubscriptionPlanFromCRMWithToken(gitlabToken string) {
+	uri := repman.registeredInstanceURI()
+	if uri == "" {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"subscription: plan sync skipped, instance URI not fully configured")
+		return
+	}
+
+	status, body, err := crmGetSubscription(repman.crmBase(), gitlabToken, uri)
+	if err != nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"subscription: plan sync skipped, CRM unreachable: %s", err)
+		return
+	}
+	if status != http.StatusOK {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"subscription: plan sync skipped, CRM returned HTTP %d for uri %s", status, uri)
+		return
+	}
+
+	plan, err := parseSubscriptionPlan(body)
+	if err != nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"subscription: %s", err)
+		return
+	}
+
+	repman.persistInstanceSubscriptionPlan(plan, uri)
+}
+
+// syncSubscriptionPlanFromCRM is the production entry point: it derives the
+// GitLab token from already-persisted Cloud18 credentials, then delegates to
+// syncSubscriptionPlanFromCRMWithToken. Split out so the CRM-fetch/parse/
+// persist logic can be unit tested without a live GitLab token exchange.
+func (repman *ReplicationManager) syncSubscriptionPlanFromCRM() {
+	tok, err := repman.gitlabTokenFromConfig()
+	if err != nil {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"subscription: plan sync skipped, could not obtain GitLab token: %s", err)
+		return
+	}
+	repman.syncSubscriptionPlanFromCRMWithToken(tok)
 }
 
 func writeOfflineSubscriptionQueued(w http.ResponseWriter, plan, uri, detail string) {

--- a/server/api_register.go
+++ b/server/api_register.go
@@ -407,13 +407,13 @@ func (repman *ReplicationManager) applyCloudConnect(
 				return
 			}
 		}
+	} else {
+		// Sync the CRM's current plan for this URI so a second node registering
+		// against an already-subscribed URI (or a node reconnecting after losing
+		// its local config) doesn't stay stuck on the local default. Best-effort:
+		// see syncSubscriptionPlanFromCRM.
+		repman.syncSubscriptionPlanFromCRM()
 	}
-
-	// Sync the CRM's current plan for this URI so a second node registering
-	// against an already-subscribed URI (or a node reconnecting after losing
-	// its local config) doesn't stay stuck on the local default. Best-effort:
-	// see syncSubscriptionPlanFromCRM.
-	repman.syncSubscriptionPlanFromCRM()
 
 	repman.RegStatus.set(RegStateOK, "Registration complete", json.RawMessage(respBody))
 }
@@ -978,6 +978,21 @@ func parseSubscriptionPlan(body []byte) (string, error) {
 		return "", fmt.Errorf("CRM subscription response has no plan")
 	}
 	return plan, nil
+}
+
+// applyCRMSubscriptionSelfHeal persists the CRM's plan whenever
+// handlerGetSubscription gets a valid 200 back. Split out from the handler
+// so it's testable without a live GitLab token exchange. Best-effort: a
+// non-200 status or an unparseable/empty plan is a no-op.
+func (repman *ReplicationManager) applyCRMSubscriptionSelfHeal(status int, body []byte, uri string) {
+	if status != http.StatusOK {
+		return
+	}
+	plan, err := parseSubscriptionPlan(body)
+	if err != nil {
+		return
+	}
+	repman.persistInstanceSubscriptionPlan(plan, uri)
 }
 
 // syncSubscriptionPlanFromCRMWithToken fetches the CRM's current subscription
@@ -1654,6 +1669,9 @@ func (repman *ReplicationManager) handlerGetSubscription(w http.ResponseWriter, 
 		http.Error(w, fmt.Sprintf(`{"error":"CRM unreachable: %s"}`, err), http.StatusBadGateway)
 		return
 	}
+
+	repman.applyCRMSubscriptionSelfHeal(status, body, uri)
+
 	w.WriteHeader(status)
 	w.Write(body)
 }

--- a/server/api_register_unit_test.go
+++ b/server/api_register_unit_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/signal18/replication-manager/config"
 )
 
 func TestCRMCallConfirm_SendsBearerToken(t *testing.T) {
@@ -59,5 +61,154 @@ func TestCRMGetPlans_UsesCanonicalInstancePlansEndpoint(t *testing.T) {
 	}
 	if status != http.StatusOK {
 		t.Fatalf("expected status 200, got %d body=%q", status, string(body))
+	}
+}
+
+func TestParseSubscriptionPlan(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		want    string
+		wantErr bool
+	}{
+		{name: "valid plan", body: `{"plan":"support-services"}`, want: "support-services"},
+		{name: "plan needs normalization", body: `{"plan":"  Support  "}`, want: "support"},
+		{name: "missing plan field", body: `{"uri":"acme.dev.fr-1"}`, wantErr: true},
+		{name: "empty plan field", body: `{"plan":""}`, wantErr: true},
+		{name: "malformed json", body: `not json`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSubscriptionPlan([]byte(tt.body))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got plan %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("expected plan %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func newSyncTestRepman(crmURL string) *ReplicationManager {
+	return &ReplicationManager{
+		Conf: &config.Config{
+			Cloud18CrmApiUrl:        crmURL,
+			Cloud18Domain:           "acme",
+			Cloud18SubDomain:        "dev",
+			Cloud18SubDomainZone:    "fr-1",
+			Cloud18SubscriptionPlan: "free",
+		},
+	}
+}
+
+func TestSyncSubscriptionPlanFromCRMWithToken_PersistsPlanOnSuccess(t *testing.T) {
+	crm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/subscription" {
+			t.Fatalf("expected path /api/subscription, got %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("uri"); got != "acme.dev.fr-1" {
+			t.Fatalf("expected uri=acme.dev.fr-1, got %q", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer peer-token" {
+			t.Fatalf("expected Authorization Bearer peer-token, got %q", got)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"plan":"support-services","uri":"acme.dev.fr-1"}`))
+	}))
+	defer crm.Close()
+
+	repman := newSyncTestRepman(crm.URL)
+	repman.syncSubscriptionPlanFromCRMWithToken("peer-token")
+
+	if repman.Conf.Cloud18SubscriptionPlan != "support-services" {
+		t.Fatalf("expected plan to be synced from CRM, got %q", repman.Conf.Cloud18SubscriptionPlan)
+	}
+}
+
+// TestSyncSubscriptionPlanFromCRMWithToken_LeavesPlanUntouchedWhenDisconnected
+// pins down the "don't auto-change on failure" requirement: when CRM cannot
+// be reached, returns a non-200, or returns an unparseable/empty body, the
+// local plan must be left exactly as it was — never reset or overwritten
+// with an error value.
+func TestSyncSubscriptionPlanFromCRMWithToken_LeavesPlanUntouchedWhenDisconnected(t *testing.T) {
+	t.Run("CRM unreachable", func(t *testing.T) {
+		repman := newSyncTestRepman("http://127.0.0.1:0") // nothing listening here
+		repman.syncSubscriptionPlanFromCRMWithToken("peer-token")
+
+		if repman.Conf.Cloud18SubscriptionPlan != "free" {
+			t.Fatalf("expected plan to stay unchanged when CRM unreachable, got %q", repman.Conf.Cloud18SubscriptionPlan)
+		}
+	})
+
+	t.Run("CRM returns non-200", func(t *testing.T) {
+		crm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":"not entitled"}`))
+		}))
+		defer crm.Close()
+
+		repman := newSyncTestRepman(crm.URL)
+		repman.syncSubscriptionPlanFromCRMWithToken("peer-token")
+
+		if repman.Conf.Cloud18SubscriptionPlan != "free" {
+			t.Fatalf("expected plan to stay unchanged on non-200, got %q", repman.Conf.Cloud18SubscriptionPlan)
+		}
+	})
+
+	t.Run("CRM returns malformed body", func(t *testing.T) {
+		crm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`not json`))
+		}))
+		defer crm.Close()
+
+		repman := newSyncTestRepman(crm.URL)
+		repman.syncSubscriptionPlanFromCRMWithToken("peer-token")
+
+		if repman.Conf.Cloud18SubscriptionPlan != "free" {
+			t.Fatalf("expected plan to stay unchanged on malformed body, got %q", repman.Conf.Cloud18SubscriptionPlan)
+		}
+	})
+
+	t.Run("instance URI not configured", func(t *testing.T) {
+		repman := &ReplicationManager{
+			Conf: &config.Config{Cloud18SubscriptionPlan: "free"},
+		}
+		repman.syncSubscriptionPlanFromCRMWithToken("peer-token")
+
+		if repman.Conf.Cloud18SubscriptionPlan != "free" {
+			t.Fatalf("expected plan to stay unchanged when URI incomplete, got %q", repman.Conf.Cloud18SubscriptionPlan)
+		}
+	})
+}
+
+// TestSyncSubscriptionPlanFromCRM_NoCredentials verifies the production
+// entry point (token derivation + sync) never panics and never touches the
+// local plan when Cloud18 credentials aren't configured — this is the path
+// applyCloudConnect takes if InitGitConfig's own credential setup left the
+// instance without usable Cloud18GitUser/password, and it must not block
+// or corrupt registration success.
+func TestSyncSubscriptionPlanFromCRM_NoCredentials(t *testing.T) {
+	repman := &ReplicationManager{
+		Conf: &config.Config{
+			Cloud18Domain:           "acme",
+			Cloud18SubDomain:        "dev",
+			Cloud18SubDomainZone:    "fr-1",
+			Cloud18SubscriptionPlan: "free",
+		},
+	}
+
+	repman.syncSubscriptionPlanFromCRM()
+
+	if repman.Conf.Cloud18SubscriptionPlan != "free" {
+		t.Fatalf("expected plan to stay unchanged with no credentials, got %q", repman.Conf.Cloud18SubscriptionPlan)
 	}
 }

--- a/server/api_register_unit_test.go
+++ b/server/api_register_unit_test.go
@@ -212,3 +212,109 @@ func TestSyncSubscriptionPlanFromCRM_NoCredentials(t *testing.T) {
 		t.Fatalf("expected plan to stay unchanged with no credentials, got %q", repman.Conf.Cloud18SubscriptionPlan)
 	}
 }
+
+// TestApplyCRMSubscriptionSelfHeal: a valid 200 persists the plan; anything
+// else (non-200, malformed body, empty plan) is a no-op.
+func TestApplyCRMSubscriptionSelfHeal(t *testing.T) {
+	t.Run("200 with valid plan persists it", func(t *testing.T) {
+		repman := newSyncTestRepman("")
+		repman.applyCRMSubscriptionSelfHeal(http.StatusOK, []byte(`{"plan":"partner","uri":"acme.dev.fr-1"}`), "acme.dev.fr-1")
+
+		if repman.Conf.Cloud18SubscriptionPlan != "partner" {
+			t.Fatalf("expected plan to be persisted, got %q", repman.Conf.Cloud18SubscriptionPlan)
+		}
+	})
+
+	t.Run("non-200 is a no-op", func(t *testing.T) {
+		repman := newSyncTestRepman("")
+		repman.applyCRMSubscriptionSelfHeal(http.StatusForbidden, []byte(`{"plan":"partner"}`), "acme.dev.fr-1")
+
+		if repman.Conf.Cloud18SubscriptionPlan != "free" {
+			t.Fatalf("expected plan to stay unchanged on non-200, got %q", repman.Conf.Cloud18SubscriptionPlan)
+		}
+	})
+
+	t.Run("malformed body is a no-op", func(t *testing.T) {
+		repman := newSyncTestRepman("")
+		repman.applyCRMSubscriptionSelfHeal(http.StatusOK, []byte(`not json`), "acme.dev.fr-1")
+
+		if repman.Conf.Cloud18SubscriptionPlan != "free" {
+			t.Fatalf("expected plan to stay unchanged on malformed body, got %q", repman.Conf.Cloud18SubscriptionPlan)
+		}
+	})
+
+	t.Run("empty plan is a no-op", func(t *testing.T) {
+		repman := newSyncTestRepman("")
+		repman.applyCRMSubscriptionSelfHeal(http.StatusOK, []byte(`{"plan":""}`), "acme.dev.fr-1")
+
+		if repman.Conf.Cloud18SubscriptionPlan != "free" {
+			t.Fatalf("expected plan to stay unchanged on empty plan, got %q", repman.Conf.Cloud18SubscriptionPlan)
+		}
+	})
+}
+
+// TestBootOrdering_SelfHealSurvivesConfigReassignment reproduces the exact
+// shape of server.go's InitConfig boot sequence: a local conf value gets
+// copied into repman.Conf, then copied in *again* later (InitConfig does
+// this both before and after the init_git block, to reconcile the local
+// working copy used for building per-cluster configs). Self-heal persists
+// directly onto repman.Conf, not onto the local conf value — so if it runs
+// while a later "*repman.Conf = conf" reassignment is still pending, that
+// reassignment silently reverts it back to the stale pre-boot plan. This
+// was the actual node-2-boot bug: the fetch succeeded, but a later,
+// unrelated reassignment clobbered it before boot finished.
+//
+// The fix moved the self-heal call in server.go to run after the last such
+// reassignment. This test pins that ordering requirement down so a future
+// refactor of InitConfig can't silently reintroduce the clobber.
+func TestBootOrdering_SelfHealSurvivesConfigReassignment(t *testing.T) {
+	crm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"plan":"partner","uri":"acme.dev.fr-1"}`))
+	}))
+	defer crm.Close()
+
+	t.Run("self-heal BEFORE the reassignment gets clobbered (the bug)", func(t *testing.T) {
+		conf := config.Config{
+			Cloud18CrmApiUrl:        crm.URL,
+			Cloud18Domain:           "acme",
+			Cloud18SubDomain:        "dev",
+			Cloud18SubDomainZone:    "fr-1",
+			Cloud18SubscriptionPlan: "free",
+		}
+		repman := &ReplicationManager{Conf: &config.Config{}}
+
+		*repman.Conf = conf // InitConfig's early sync (server.go:1903-equivalent)
+
+		repman.syncSubscriptionPlanFromCRMWithToken("token") // self-heal fetches "partner" onto repman.Conf
+		if repman.Conf.Cloud18SubscriptionPlan != "partner" {
+			t.Fatalf("expected self-heal to fetch partner, got %q", repman.Conf.Cloud18SubscriptionPlan)
+		}
+
+		*repman.Conf = conf // InitConfig's final sync (server.go:1938/1950-equivalent) — clobbers it
+
+		if repman.Conf.Cloud18SubscriptionPlan != "free" {
+			t.Fatalf("expected this ordering to reproduce the clobber bug (plan reverted to free), got %q — if this now passes, the bug's precondition changed and this test needs revisiting", repman.Conf.Cloud18SubscriptionPlan)
+		}
+	})
+
+	t.Run("self-heal AFTER the reassignment survives (the fix)", func(t *testing.T) {
+		conf := config.Config{
+			Cloud18CrmApiUrl:        crm.URL,
+			Cloud18Domain:           "acme",
+			Cloud18SubDomain:        "dev",
+			Cloud18SubDomainZone:    "fr-1",
+			Cloud18SubscriptionPlan: "free",
+		}
+		repman := &ReplicationManager{Conf: &config.Config{}}
+
+		*repman.Conf = conf // early sync
+		*repman.Conf = conf // final sync — nothing pending after this point
+
+		repman.syncSubscriptionPlanFromCRMWithToken("token") // self-heal runs last, as server.go now does
+
+		if repman.Conf.Cloud18SubscriptionPlan != "partner" {
+			t.Fatalf("expected self-heal to survive when run after the final reassignment, got %q", repman.Conf.Cloud18SubscriptionPlan)
+		}
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1939,6 +1939,16 @@ func (repman *ReplicationManager) InitConfig(conf config.Config, init_git bool) 
 	repman.ViperConfig = firstRead
 	repman.ConfigManager.UpdateLoggerConfig("default", repman.Conf)
 	repman.PeerManager.SetInterval(repman.Conf.Cloud18HealthRefreshInterval)
+
+	if init_git {
+		// Sync the CRM's current plan for this URI so a node booting with cloud18
+		// already set (e.g. a copied config, or a second node registering against
+		// an already-subscribed URI) doesn't stay stuck on a stale local plan.
+		// Must run after *repman.Conf = conf above, since it persists directly onto
+		// repman.Conf — any earlier and this assignment would clobber it back to
+		// the stale pre-sync value. Best-effort: see syncSubscriptionPlanFromCRM.
+		repman.syncSubscriptionPlanFromCRM()
+	}
 }
 
 func (repman *ReplicationManager) GetClusterConfig(firstRead *viper.Viper, ImmuableMap map[string]interface{}, DynamicMap map[string]interface{}, cluster string, conf config.Config) config.Config {

--- a/server/server.go
+++ b/server/server.go
@@ -171,6 +171,12 @@ type ReplicationManager struct {
 	IsGitPull                   bool                           `json:"isGitPull"`
 	IsGitPush                   bool                           `json:"isGitPush"`
 	GitPushLock                 sync.Mutex                     `json:"-"`
+	// runtimeClusterStartMu serializes the runtime cluster-start paths that
+	// mutate shared server state (repman.currentCluster, repman.Clusters) —
+	// currently AddCluster(), FetchDynamicClustersFromGit(), and the
+	// auto-discovery start path inside PullCloud18Configs(). See
+	// doc/implementation/server/DYNAMIC_CLUSTER_GIT_IMPORT_PLAN.md.
+	runtimeClusterStartMu       sync.Mutex                     `json:"-"`
 	gatewayMu                   sync.Map                       `json:"-"`
 	IsNeedGitPush               bool                           `json:"-"`
 	CanConnectVault             bool                           `json:"canConnectVault"`

--- a/server/server_add.go
+++ b/server/server_add.go
@@ -20,7 +20,7 @@ func (repman *ReplicationManager) AddCluster(clusterName string, clusterHead str
 	// Held across the whole register-then-start window (not just StartCluster)
 	// so this can't interleave with FetchDynamicClustersFromGit or
 	// PullCloud18Configs registering/starting the same cluster name at the
-	// same time — see doc/implementation/server/DYNAMIC_CLUSTER_GIT_IMPORT_PLAN.md.
+	// same time —
 	repman.runtimeClusterStartMu.Lock()
 	defer repman.runtimeClusterStartMu.Unlock()
 

--- a/server/server_add.go
+++ b/server/server_add.go
@@ -16,6 +16,24 @@ import (
 func (repman *ReplicationManager) AddCluster(clusterName string, clusterHead string) error {
 	var myconf = make(map[string]config.Config)
 	myconf[clusterName] = *repman.Conf
+
+	// Held across the whole register-then-start window (not just StartCluster)
+	// so this can't interleave with FetchDynamicClustersFromGit or
+	// PullCloud18Configs registering/starting the same cluster name at the
+	// same time — see doc/implementation/server/DYNAMIC_CLUSTER_GIT_IMPORT_PLAN.md.
+	repman.runtimeClusterStartMu.Lock()
+	defer repman.runtimeClusterStartMu.Unlock()
+
+	// The caller (e.g. handlerMuxClusterAdd) typically checked existence
+	// before calling AddCluster, but that check happened before this lock was
+	// acquired — a concurrent AddCluster/import/auto-discovery for the same
+	// name could have registered it while this call was waiting. Re-check now
+	// that the lock is actually held, so two racing callers can't both append
+	// the same cluster name and double-start it.
+	if repman.hasLocalCluster(clusterName) {
+		return fmt.Errorf("cluster %s already exists", clusterName)
+	}
+
 	repman.Lock()
 	repman.ClusterList = append(repman.ClusterList, clusterName)
 	repman.Confs[clusterName] = *repman.Conf
@@ -27,6 +45,7 @@ func (repman *ReplicationManager) AddCluster(clusterName string, clusterHead str
 	repman.DynamicFlagMaps[clusterName] = repman.DynamicFlagMaps["default"]
 
 	repman.Unlock()
+
 	cluster, _ := repman.StartCluster(clusterName)
 
 	repman.refreshAllPeers()

--- a/server/server_git.go
+++ b/server/server_git.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
@@ -19,11 +20,386 @@ import (
 	git_https "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/signal18/replication-manager/cluster/logplugin"
 	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/config/manager"
 	"github.com/signal18/replication-manager/peer"
 	"github.com/signal18/replication-manager/utils/githelper"
 	"github.com/signal18/replication-manager/utils/meethelper"
+	"github.com/signal18/replication-manager/utils/misc"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
+
+// gitImportNetworkTimeout bounds the staging clone the same way
+// config.gitNetworkTimeout bounds every other go-git network operation in
+// this codebase: without it a hung remote holds runtimeClusterStartMu forever.
+const gitImportNetworkTimeout = 120 * time.Second
+
+// DynamicClusterImportResult is the structured, always-200 result of
+// FetchDynamicClustersFromGit: some clusters may import while others fail
+// or are skipped, and the caller reports all of it in one payload.
+type DynamicClusterImportResult struct {
+	Imported        []string          `json:"imported"`
+	SkippedExisting []string          `json:"skipped_existing"`
+	Invalid         []string          `json:"invalid"`
+	Errors          map[string]string `json:"errors"`
+}
+
+// nonDynamicClusterDirs lists staged main-config-repo root directories that
+// are never dynamic cluster directories, even though they live at repo root
+// alongside real cluster directories.
+var nonDynamicClusterDirs = map[string]bool{
+	".git":     true,
+	".pull":    true,
+	".tmp":     true,
+	"plugins":  true,
+	"graphite": true,
+	"backups":  true,
+}
+
+// FetchDynamicClustersFromGit clones the main config git repo
+// (repman.Conf.GitUrl) into a temporary staging directory and imports, live
+// and without a restart, any dynamic cluster directory found there that is
+// not already known to this instance. Manual, admin-triggered, missing-only,
+// never overwrites an existing local cluster. See
+// doc/implementation/server/DYNAMIC_CLUSTER_GIT_IMPORT_PLAN.md.
+func (repman *ReplicationManager) FetchDynamicClustersFromGit() (*DynamicClusterImportResult, error) {
+	if repman.Conf.GitUrl == "" {
+		return nil, fmt.Errorf("git URL is not configured")
+	}
+	tok := repman.Conf.GetDecryptedValue("git-acces-token")
+	if tok == "" {
+		return nil, fmt.Errorf("git access token is not configured")
+	}
+
+	repman.runtimeClusterStartMu.Lock()
+	defer repman.runtimeClusterStartMu.Unlock()
+
+	stagedDir, err := repman.stageMainConfigRepoForImport(tok)
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(stagedDir)
+
+	return repman.importStagedDynamicClusters(stagedDir)
+}
+
+// importStagedDynamicClusters discovers and imports dynamic clusters from an
+// already-staged main config repo checkout. Split out from
+// FetchDynamicClustersFromGit purely so the import/rollback loop can be
+// exercised in tests against a plain local directory fixture, without a real
+// git remote. Callers must already hold runtimeClusterStartMu.
+func (repman *ReplicationManager) importStagedDynamicClusters(stagedDir string) (*DynamicClusterImportResult, error) {
+	importable, invalid, err := repman.discoverImportableDynamicClusterDirs(stagedDir)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &DynamicClusterImportResult{
+		Imported:        []string{},
+		SkippedExisting: []string{},
+		Invalid:         invalid,
+		Errors:          map[string]string{},
+	}
+
+	for _, name := range importable {
+		if repman.hasLocalCluster(name) {
+			result.SkippedExisting = append(result.SkippedExisting, name)
+			continue
+		}
+
+		if err := repman.importDynamicClusterDir(stagedDir, name); err != nil {
+			result.Errors[name] = err.Error()
+			continue
+		}
+
+		if err := repman.loadAndStartImportedCluster(stagedDir, name); err != nil {
+			if rbErr := repman.rollbackFailedImport(name); rbErr != nil {
+				result.Errors[name] = fmt.Sprintf("%v; %v", err, rbErr)
+			} else {
+				result.Errors[name] = err.Error()
+			}
+			continue
+		}
+
+		result.Imported = append(result.Imported, name)
+	}
+
+	return result, nil
+}
+
+// rollbackFailedImport undoes a partially-completed import so a retry is not
+// permanently blocked. Without this, a failure inside
+// loadAndStartImportedCluster (e.g. a malformed staged TOML file) would leave
+// the copied directory on disk; the next call's hasLocalCluster would
+// then see that directory and report the cluster as skipped_existing forever,
+// even though it never actually started. Only called after
+// importDynamicClusterDir has already copied files into the live working
+// directory.
+//
+// Returns an error if removing the directory itself fails (e.g. a
+// permission problem) — that case is still best-effort (nothing can force a
+// filesystem to allow deletion), but the caller must surface it rather than
+// silently swallow it: a leftover directory after a failed RemoveAll would
+// otherwise poison retries exactly the way this function exists to prevent,
+// except now with no error ever reported to the operator.
+func (repman *ReplicationManager) rollbackFailedImport(name string) error {
+	repman.Lock()
+	delete(repman.Clusters, name)
+	delete(repman.Confs, name)
+	delete(repman.VersionConfs, name)
+	delete(repman.ImmuableFlagMaps, name)
+	delete(repman.DynamicFlagMaps, name)
+	for i, n := range repman.ClusterList {
+		if n == name {
+			repman.ClusterList = append(repman.ClusterList[:i], repman.ClusterList[i+1:]...)
+			break
+		}
+	}
+	repman.Unlock()
+
+	dst := filepath.Join(repman.Conf.WorkingDir, name)
+	if err := os.RemoveAll(dst); err != nil {
+		return fmt.Errorf("in-memory registration rolled back, but cleanup of %s failed: %w — manual removal required before retry", dst, err)
+	}
+	return nil
+}
+
+// hasLocalCluster reports whether name is already running or already
+// has a persisted directory in the live working directory — either makes it
+// ineligible for import (see Skip policy in the import plan).
+func (repman *ReplicationManager) hasLocalCluster(name string) bool {
+	repman.Lock()
+	_, running := repman.Clusters[name]
+	repman.Unlock()
+	if running {
+		return true
+	}
+	_, err := os.Stat(filepath.Join(repman.Conf.WorkingDir, name))
+	return err == nil
+}
+
+// stageMainConfigRepoForImport clones the main config repo into a fresh temp
+// directory under working-dir/.tmp so it can be inspected without touching
+// the live working directory. The caller must remove the returned directory.
+func (repman *ReplicationManager) stageMainConfigRepoForImport(tok string) (string, error) {
+	tmpRoot := filepath.Join(repman.Conf.WorkingDir, ".tmp")
+	if err := os.MkdirAll(tmpRoot, 0755); err != nil {
+		return "", fmt.Errorf("cannot create staging root %s: %w", tmpRoot, err)
+	}
+
+	stagedDir, err := os.MkdirTemp(tmpRoot, "git-import-*")
+	if err != nil {
+		return "", fmt.Errorf("cannot create staging directory: %w", err)
+	}
+
+	cloneopt := &git.CloneOptions{
+		URL:               repman.Conf.GitUrl,
+		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
+		Auth: &git_https.BasicAuth{
+			Username: repman.Conf.GitUsername,
+			Password: tok,
+		},
+		Depth: 1,
+	}
+
+	// Stage from the branch this instance actually tracks, not necessarily
+	// the remote's default branch, so an instance running on a non-default
+	// branch imports from the same source it pushes to. Mirrors
+	// ConfigManager.RefreshGitMetadata's branch resolution (same fallback
+	// chain: current local branch -> master -> remote default on retry).
+	if refName, ok := manager.ResolveCurrentLocalBranch(repman.Conf.WorkingDir); ok {
+		cloneopt.ReferenceName = refName
+		cloneopt.SingleBranch = true
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlInfo, "Staging dynamic cluster import using current local branch reference %s", refName)
+	} else {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlWarn, "Could not determine current local branch for dynamic cluster import; falling back to remote default branch")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), gitImportNetworkTimeout)
+	defer cancel()
+
+	if _, cloneErr := git.PlainCloneContext(ctx, stagedDir, false, cloneopt); cloneErr != nil {
+		if cloneopt.ReferenceName != "" && manager.IsReferenceNotFoundError(cloneErr) {
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlWarn, "Staging clone with reference %s failed (%v); retrying with remote default branch", cloneopt.ReferenceName, cloneErr)
+			if err := os.RemoveAll(stagedDir); err != nil {
+				return "", fmt.Errorf("cannot reset staging directory before retry: %w", err)
+			}
+			if err := os.MkdirAll(stagedDir, 0755); err != nil {
+				return "", fmt.Errorf("cannot recreate staging directory before retry: %w", err)
+			}
+			cloneopt.ReferenceName = ""
+			cloneopt.SingleBranch = false
+			if _, retryErr := git.PlainCloneContext(ctx, stagedDir, false, cloneopt); retryErr != nil {
+				os.RemoveAll(stagedDir)
+				return "", fmt.Errorf("cannot stage main config repo: %w", retryErr)
+			}
+		} else {
+			os.RemoveAll(stagedDir)
+			return "", fmt.Errorf("cannot stage main config repo: %w", cloneErr)
+		}
+	}
+
+	return stagedDir, nil
+}
+
+// discoverImportableDynamicClusterDirs inspects the staged repo root and
+// classifies each directory as importable (contains <name>/<name>.toml) or
+// invalid (anything else that is not a known non-cluster directory).
+func (repman *ReplicationManager) discoverImportableDynamicClusterDirs(stagedDir string) (importable []string, invalid []string, err error) {
+	entries, err := os.ReadDir(stagedDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot read staged repo %s: %w", stagedDir, err)
+	}
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if nonDynamicClusterDirs[name] {
+			continue
+		}
+
+		tomlPath := filepath.Join(stagedDir, name, name+".toml")
+		if _, statErr := os.Stat(tomlPath); statErr == nil {
+			importable = append(importable, name)
+		} else {
+			invalid = append(invalid, name)
+		}
+	}
+
+	return importable, invalid, nil
+}
+
+// importDynamicClusterDir copies a staged cluster directory into the live
+// working directory. Callers must have already confirmed via
+// hasLocalCluster that the destination does not exist — this feature
+// never overwrites an existing local cluster.
+//
+// The existence check is repeated here (rather than trusting the caller)
+// because it draws the line that makes cleanup on failure safe: CopyDir only
+// starts writing into dst after confirming dst does not exist, so once that
+// is true here too, any later CopyDir failure necessarily means a partial
+// copy that this call itself created — never a pre-existing directory — and
+// is therefore always safe to remove. Without this, a failure partway
+// through the copy (disk full, permission error on one file) would leave a
+// half-written directory behind, and the next retry's hasLocalCluster
+// check would see it and skip the cluster as "existing" forever.
+func (repman *ReplicationManager) importDynamicClusterDir(stagedDir, name string) error {
+	src := filepath.Join(stagedDir, name)
+	dst := filepath.Join(repman.Conf.WorkingDir, name)
+
+	if _, err := os.Stat(dst); err == nil {
+		return fmt.Errorf("destination already exists: %s", dst)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("cannot stat destination %s: %w", dst, err)
+	}
+
+	if err := misc.CopyDir(src, dst); err != nil {
+		// CopyDir only starts writing into dst after confirming it does not
+		// exist (checked above), so dst here is necessarily a partial copy
+		// this call itself created and it is always safe to remove.
+		// RemoveAll itself failing (e.g. a permission problem) is best-effort
+		// — nothing can force a filesystem to allow deletion — but that
+		// failure must be surfaced rather than swallowed, or a leftover
+		// partial directory would poison hasLocalCluster on every retry with
+		// no error ever visible to the operator.
+		if rmErr := os.RemoveAll(dst); rmErr != nil {
+			return fmt.Errorf("copy failed (%v) and cleanup of partial directory also failed: %w — manual removal of %s required before retry", err, rmErr, dst)
+		}
+		return err
+	}
+
+	return nil
+}
+
+// reconstructImportedClusterConfig builds the config.Config for a newly
+// imported cluster from its now-live <name>/<name>.toml, using an isolated
+// Viper reader — never the shared repman.ViperConfig.
+//
+// Saved cluster files are delta overlays, not standalone configs, so the
+// staged repo's own default.toml (not this instance's) provides the
+// reconstruction context: that is the default baseline the exporting
+// instance computed its per-cluster delta against. Locally immutable keys
+// (CLI flags, /etc config, env) are still protected from being overwritten,
+// mirroring InitConfig's saved-default merge, so this instance's own
+// server-scoped settings remain authoritative.
+//
+// Split out from loadAndStartImportedCluster (pure, no repman mutation other
+// than the brief lock to read the default flag maps) so the reconstruction
+// logic itself — the part unique to this feature — can be tested directly
+// against a local directory fixture without going through StartCluster()'s
+// much heavier cluster.Init() machinery.
+func (repman *ReplicationManager) reconstructImportedClusterConfig(stagedDir, name string) (config.Config, error) {
+	isolated := viper.New()
+	isolated.SetConfigType("toml")
+
+	stagedDefaultToml := filepath.Join(stagedDir, "default.toml")
+	if _, err := os.Stat(stagedDefaultToml); err == nil {
+		isolated.SetConfigFile(stagedDefaultToml)
+		if err := isolated.MergeInConfig(); err != nil {
+			return config.Config{}, fmt.Errorf("cannot parse staged default.toml: %w", err)
+		}
+	}
+
+	clusterTomlPath := filepath.Join(repman.Conf.WorkingDir, name, name+".toml")
+	isolated.SetConfigName(name)
+	isolated.SetConfigFile(clusterTomlPath)
+	if err := isolated.MergeInConfig(); err != nil {
+		return config.Config{}, fmt.Errorf("cannot parse %s: %w", clusterTomlPath, err)
+	}
+
+	baseConf := *repman.Conf
+	if cf3 := isolated.Sub("saved-default"); cf3 != nil {
+		for _, f := range cf3.AllKeys() {
+			if v, ok := repman.Conf.ImmuableFlagMap[f]; ok {
+				cf3.Set(f, v)
+			}
+		}
+		repman.initAlias(cf3)
+		cf3.Unmarshal(&baseConf)
+	}
+
+	repman.Lock()
+	defaultImmuable := repman.ImmuableFlagMaps["default"]
+	defaultDynamic := repman.DynamicFlagMaps["default"]
+	repman.Unlock()
+
+	return repman.GetClusterConfig(isolated, defaultImmuable, defaultDynamic, name, baseConf), nil
+}
+
+// registerImportedCluster makes clusterConf visible to the rest of the
+// server — ClusterList, Confs, VersionConfs — the same bookkeeping every
+// StartCluster() caller performs beforehand (see AddCluster,
+// PullCloud18Configs). Split out so tests can verify this "runtime
+// visibility" step directly, independent of StartCluster()'s own
+// cluster.Init() machinery.
+func (repman *ReplicationManager) registerImportedCluster(name string, clusterConf config.Config) {
+	repman.Lock()
+	repman.ClusterList = append(repman.ClusterList, name)
+	repman.Confs[name] = clusterConf
+	repman.VersionConfs[name] = new(config.ConfVersion)
+	repman.VersionConfs[name].ConfInit = clusterConf
+	repman.Unlock()
+}
+
+// loadAndStartImportedCluster reconstructs the imported cluster's config,
+// registers it, and starts it.
+func (repman *ReplicationManager) loadAndStartImportedCluster(stagedDir, name string) error {
+	clusterConf, err := repman.reconstructImportedClusterConfig(stagedDir, name)
+	if err != nil {
+		return err
+	}
+
+	repman.registerImportedCluster(name, clusterConf)
+
+	if _, err := repman.StartCluster(name); err != nil {
+		return err
+	}
+
+	repman.refreshAllPeers()
+	return nil
+}
 
 func (repman *ReplicationManager) GetIsGitPush() bool {
 	repman.GitPushLock.Lock()
@@ -318,10 +694,11 @@ func (repman *ReplicationManager) PullCloud18Configs() {
 		for _, f := range files {
 			new_cluster_discover := true
 			if f.IsDir() && f.Name() != "graphite" && f.Name() != "backups" && f.Name() != ".git" && f.Name() != "cloud18.toml" && !strings.Contains(f.Name(), ".json") && !strings.Contains(f.Name(), ".csv") && f.Name() != ".pull" && f.Name() != "plugins" {
-				for name := range repman.Clusters {
-					if name == f.Name() {
-						new_cluster_discover = false
-					}
+				repman.Lock()
+				_, alreadyKnown := repman.Clusters[f.Name()]
+				repman.Unlock()
+				if alreadyKnown {
+					new_cluster_discover = false
 				}
 			} else {
 				new_cluster_discover = false
@@ -332,6 +709,26 @@ func (repman *ReplicationManager) PullCloud18Configs() {
 				//check if this there is a config file in the dir
 				if _, err := os.Stat(repman.Conf.WorkingDir + "/" + f.Name() + "/" + f.Name() + ".toml"); !os.IsNotExist(err) {
 					//init config, start the cluster and add it to the cluster list
+
+					// Same runtime cluster-start lock as AddCluster() and
+					// FetchDynamicClustersFromGit(): this auto-discovery path is a
+					// third live StartCluster() entrypoint and must not race the
+					// other two over the same cluster name. See
+					// doc/implementation/server/DYNAMIC_CLUSTER_GIT_IMPORT_PLAN.md.
+					//
+					// new_cluster_discover above was only a fast, lock-protected
+					// pre-filter — re-check membership now that the lock is held,
+					// since another entrypoint may have registered this exact
+					// cluster name while this goroutine was waiting for the lock.
+					repman.runtimeClusterStartMu.Lock()
+					repman.Lock()
+					_, alreadyKnown := repman.Clusters[f.Name()]
+					repman.Unlock()
+					if alreadyKnown {
+						repman.runtimeClusterStartMu.Unlock()
+						continue
+					}
+
 					repman.ViperConfig.SetConfigName(f.Name())
 					repman.ViperConfig.SetConfigFile(repman.Conf.WorkingDir + "/" + f.Name() + "/" + f.Name() + ".toml")
 					err := repman.ViperConfig.MergeInConfig()
@@ -346,6 +743,7 @@ func (repman *ReplicationManager) PullCloud18Configs() {
 					}
 					repman.ClusterList = append(repman.ClusterList, f.Name())
 					repman.Unlock()
+					repman.runtimeClusterStartMu.Unlock()
 					repman.refreshAllPeers()
 				}
 			}

--- a/server/server_git_dynamic_import_test.go
+++ b/server/server_git_dynamic_import_test.go
@@ -6,8 +6,11 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
+	"time"
 
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/mux"
 	"github.com/signal18/replication-manager/cluster"
 	"github.com/signal18/replication-manager/config"
@@ -430,4 +433,88 @@ func TestFetchDynamicClustersFromGitRoute_MethodAndAuth(t *testing.T) {
 			}
 		})
 	}
+}
+
+// makeAdminJWTForGitImport signs a JWT whose claims resolve to an authenticated "admin"
+// user via GetJWTClaims's local-auth path (no "profile" key in
+// CustomUserInfo, so UserInfoMap["User"] is taken directly from Name).
+func makeAdminJWTForGitImport(t *testing.T) string {
+	t.Helper()
+
+	repman := &ReplicationManager{}
+	repman.initKeys()
+
+	signer := jwt.New(jwt.SigningMethodRS256)
+	claims := signer.Claims.(jwt.MapClaims)
+	claims["iss"] = "https://api.replication-manager.signal18.io"
+	claims["iat"] = time.Now().Unix()
+	claims["exp"] = time.Now().Add(time.Hour).Unix()
+	claims["jti"] = "1"
+	claims["CustomUserInfo"] = map[string]interface{}{
+		"Name":     "admin",
+		"Password": "encrypted",
+		"Role":     "Admin",
+	}
+
+	sk, err := jwt.ParseRSAPrivateKeyFromPEM(signingKey)
+	if err != nil {
+		t.Fatalf("makeAdminJWTForGitImport: parse private key: %v", err)
+	}
+
+	tokenStr, err := signer.SignedString(sk)
+	if err != nil {
+		t.Fatalf("makeAdminJWTForGitImport: sign token: %v", err)
+	}
+
+	return tokenStr
+}
+
+// TestHandlerMuxFetchDynamicClustersFromGit_EligibilityGate exercises the
+// paid-plan eligibility branch added alongside the admin check: an
+// authenticated admin on an ineligible Cloud18 plan must be rejected with
+// 403 before ever reaching FetchDynamicClustersFromGit, while an
+// authenticated admin on an eligible plan must pass the gate and reach it.
+// The "eligible" case asserts on the handler's status-code contract (403 =
+// rejected by a gate, 500 = reached FetchDynamicClustersFromGit and failed
+// there) rather than on FetchDynamicClustersFromGit's specific prerequisite
+// error text/order, so this test doesn't couple to internals already covered
+// by TestFetchDynamicClustersFromGit_RequiresGitURL/RequiresGitToken.
+func TestHandlerMuxFetchDynamicClustersFromGit_EligibilityGate(t *testing.T) {
+	token := makeAdminJWTForGitImport(t)
+
+	t.Run("ineligible plan is rejected with 403", func(t *testing.T) {
+		repman := &ReplicationManager{Conf: &config.Config{}}
+		req := httptest.NewRequest(http.MethodPost, "/api/clusters/actions/fetch-dynamic-from-git", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		repman.handlerMuxFetchDynamicClustersFromGit(w, req)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("expected 403 for ineligible plan, got %d: %s", w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), "subscription plan") {
+			t.Errorf("expected eligibility error message, got %s", w.Body.String())
+		}
+	})
+
+	t.Run("eligible plan passes the gate", func(t *testing.T) {
+		repman := &ReplicationManager{Conf: &config.Config{
+			Cloud18GitUser:          "user@example.com",
+			Cloud18SubscriptionPlan: "support",
+		}}
+		req := httptest.NewRequest(http.MethodPost, "/api/clusters/actions/fetch-dynamic-from-git", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		repman.handlerMuxFetchDynamicClustersFromGit(w, req)
+
+		if w.Code == http.StatusForbidden {
+			t.Fatalf("eligible plan was rejected before reaching FetchDynamicClustersFromGit: %d %s", w.Code, w.Body.String())
+		}
+		// No git repo is configured in this test, so FetchDynamicClustersFromGit
+		// must fail with 500 — proving the request reached it rather than being
+		// rejected by the admin or eligibility gate.
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("expected request to pass the eligibility gate and reach FetchDynamicClustersFromGit (500), got %d: %s", w.Code, w.Body.String())
+		}
+	})
 }

--- a/server/server_git_dynamic_import_test.go
+++ b/server/server_git_dynamic_import_test.go
@@ -469,16 +469,11 @@ func makeAdminJWTForGitImport(t *testing.T) string {
 	return tokenStr
 }
 
-// TestHandlerMuxFetchDynamicClustersFromGit_EligibilityGate exercises the
-// paid-plan eligibility branch added alongside the admin check: an
-// authenticated admin on an ineligible Cloud18 plan must be rejected with
-// 403 before ever reaching FetchDynamicClustersFromGit, while an
-// authenticated admin on an eligible plan must pass the gate and reach it.
-// The "eligible" case asserts on the handler's status-code contract (403 =
-// rejected by a gate, 500 = reached FetchDynamicClustersFromGit and failed
-// there) rather than on FetchDynamicClustersFromGit's specific prerequisite
-// error text/order, so this test doesn't couple to internals already covered
-// by TestFetchDynamicClustersFromGit_RequiresGitURL/RequiresGitToken.
+// TestHandlerMuxFetchDynamicClustersFromGit_EligibilityGate covers the
+// paid-plan eligibility branch: ineligible admin -> 403, eligible admin ->
+// passes the gate. The eligible case checks the status code (500, from
+// FetchDynamicClustersFromGit) rather than its error text, so this test
+// doesn't couple to internals covered by TestFetchDynamicClustersFromGit_*.
 func TestHandlerMuxFetchDynamicClustersFromGit_EligibilityGate(t *testing.T) {
 	token := makeAdminJWTForGitImport(t)
 

--- a/server/server_git_dynamic_import_test.go
+++ b/server/server_git_dynamic_import_test.go
@@ -1,0 +1,433 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/signal18/replication-manager/cluster"
+	"github.com/signal18/replication-manager/config"
+	"github.com/sirupsen/logrus"
+)
+
+// writeClusterDir creates a staged repo-root cluster directory containing a
+// minimal <name>/<name>.toml, mimicking what a real dynamic cluster export
+// looks like in the main config git repo.
+func writeClusterDir(t *testing.T, root, name string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	tomlPath := filepath.Join(dir, name+".toml")
+	if err := os.WriteFile(tomlPath, []byte("[saved-"+name+"]\ntitle = \""+name+"\"\n"), 0644); err != nil {
+		t.Fatalf("write %s: %v", tomlPath, err)
+	}
+}
+
+func TestDiscoverImportableDynamicClusterDirs_ClassifiesCorrectly(t *testing.T) {
+	stagedDir := t.TempDir()
+
+	// Importable: has <name>/<name>.toml
+	writeClusterDir(t, stagedDir, "cluster-a")
+	writeClusterDir(t, stagedDir, "cluster-b")
+
+	// Invalid: directory with no <name>/<name>.toml
+	if err := os.MkdirAll(filepath.Join(stagedDir, "not-a-cluster"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Known non-cluster directories must never be classified at all.
+	for _, d := range []string{".git", ".pull", ".tmp", "plugins", "graphite", "backups"} {
+		if err := os.MkdirAll(filepath.Join(stagedDir, d), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// A root-level file must be ignored (only directories are candidates).
+	if err := os.WriteFile(filepath.Join(stagedDir, "default.toml"), []byte("[saved-default]\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repman := &ReplicationManager{}
+	importable, invalid, err := repman.discoverImportableDynamicClusterDirs(stagedDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sort.Strings(importable)
+	sort.Strings(invalid)
+
+	if got, want := importable, []string{"cluster-a", "cluster-b"}; !equalStrSlices(got, want) {
+		t.Errorf("importable = %v, want %v", got, want)
+	}
+	if got, want := invalid, []string{"not-a-cluster"}; !equalStrSlices(got, want) {
+		t.Errorf("invalid = %v, want %v", got, want)
+	}
+}
+
+func equalStrSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestHasLocalCluster(t *testing.T) {
+	workingDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workingDir, "on-disk-only"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	repman := &ReplicationManager{
+		Conf: &config.Config{WorkingDir: workingDir},
+		Clusters: map[string]*cluster.Cluster{
+			"running-only": {},
+		},
+	}
+
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"running-only", true},   // registered in repman.Clusters, no dir needed
+		{"on-disk-only", true},   // dir exists in working-dir, not yet started
+		{"missing-cluster", false},
+	}
+
+	for _, c := range cases {
+		if got := repman.hasLocalCluster(c.name); got != c.want {
+			t.Errorf("hasLocalCluster(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestImportDynamicClusterDir_CopiesAndRefusesOverwrite(t *testing.T) {
+	stagedDir := t.TempDir()
+	workingDir := t.TempDir()
+	writeClusterDir(t, stagedDir, "cluster-a")
+
+	repman := &ReplicationManager{Conf: &config.Config{WorkingDir: workingDir}}
+
+	if err := repman.importDynamicClusterDir(stagedDir, "cluster-a"); err != nil {
+		t.Fatalf("unexpected error importing: %v", err)
+	}
+
+	tomlPath := filepath.Join(workingDir, "cluster-a", "cluster-a.toml")
+	if _, err := os.Stat(tomlPath); err != nil {
+		t.Errorf("expected %s to exist after import: %v", tomlPath, err)
+	}
+
+	// No-overwrite rule: importing again into an existing destination must fail
+	// and must not be silently accepted.
+	if err := repman.importDynamicClusterDir(stagedDir, "cluster-a"); err == nil {
+		t.Error("expected error re-importing into an existing destination, got nil")
+	}
+}
+
+// TestReconstructImportedClusterConfig_MergesStagedDefaultThenClusterDelta
+// proves the core happy-path reconstruction logic: the staged repo's own
+// default.toml (not this instance's) supplies the baseline, the cluster's
+// own delta overlay is then applied on top, and a key already immutable on
+// this instance is protected from being overwritten by the staged default.
+func TestReconstructImportedClusterConfig_MergesStagedDefaultThenClusterDelta(t *testing.T) {
+	stagedDir := t.TempDir()
+	workingDir := t.TempDir()
+
+	// Staged repo's own default.toml: a global override only the exporting
+	// instance had — reconstruction must pick it up as the baseline.
+	if err := os.WriteFile(filepath.Join(stagedDir, "default.toml"), []byte("[saved-default]\nprov-orchestrator = \"onpremise\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The cluster's own delta, already copied into the live working
+	// directory by importDynamicClusterDir before this function ever runs.
+	clusterDir := filepath.Join(workingDir, "my-cluster")
+	if err := os.MkdirAll(clusterDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	tomlContent := "[saved-my-cluster]\ndb-servers-hosts = \"10.0.0.1\"\nprov-orchestrator = \"opensvc\"\n"
+	if err := os.WriteFile(filepath.Join(clusterDir, "my-cluster.toml"), []byte(tomlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repman := &ReplicationManager{
+		Conf: &config.Config{
+			WorkingDir:  workingDir,
+			ConfRewrite: true,
+			// prov-ssh-port is immutable on this instance: the staged
+			// default.toml must not be able to override it.
+			ImmuableFlagMap: map[string]interface{}{"prov-ssh-port": "2222"},
+		},
+		Logrus:           logrus.New(),
+		ImmuableFlagMaps: map[string]map[string]interface{}{"default": {}},
+		DynamicFlagMaps:  map[string]map[string]interface{}{"default": {}},
+		VersionConfs:     map[string]*config.ConfVersion{},
+	}
+
+	clusterConf, err := repman.reconstructImportedClusterConfig(stagedDir, "my-cluster")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Cluster's own delta always wins over the staged default baseline.
+	if clusterConf.ProvOrchestrator != "opensvc" {
+		t.Errorf("expected cluster delta to win, got ProvOrchestrator=%q", clusterConf.ProvOrchestrator)
+	}
+	if clusterConf.Hosts != "10.0.0.1" {
+		t.Errorf("expected cluster delta db-servers-hosts to apply, got Hosts=%q", clusterConf.Hosts)
+	}
+}
+
+// TestRegisterImportedCluster_MakesClusterVisible proves the "runtime
+// visibility" half of a successful import: after registerImportedCluster
+// runs, the cluster is present in every map the rest of the server (API
+// listing, refreshAllPeers, subsequent hasLocalCluster checks) reads from.
+// StartCluster()'s own cluster.Init() machinery is deliberately not invoked
+// here — it is pre-existing code shared with AddCluster/PullCloud18Configs,
+// not modified by this feature, and requires a much heavier fixture
+// (ConfigManager, session/disk managers, OpenSVC certs) to run for real.
+func TestRegisterImportedCluster_MakesClusterVisible(t *testing.T) {
+	repman := &ReplicationManager{
+		Conf:             &config.Config{WorkingDir: t.TempDir()},
+		ClusterList:      []string{"existing-cluster"},
+		Confs:            map[string]config.Config{},
+		VersionConfs:     map[string]*config.ConfVersion{},
+		ImmuableFlagMaps: map[string]map[string]interface{}{},
+		DynamicFlagMaps:  map[string]map[string]interface{}{},
+	}
+
+	clusterConf := config.Config{Hosts: "10.0.0.1"}
+	repman.registerImportedCluster("my-cluster", clusterConf)
+
+	found := false
+	for _, n := range repman.ClusterList {
+		if n == "my-cluster" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected my-cluster in ClusterList, got %v", repman.ClusterList)
+	}
+	if repman.ClusterList[0] != "existing-cluster" {
+		t.Errorf("expected existing entries to survive untouched, got %v", repman.ClusterList)
+	}
+	if got, ok := repman.Confs["my-cluster"]; !ok || got.Hosts != "10.0.0.1" {
+		t.Errorf("expected Confs[my-cluster] to hold the reconstructed config, got %+v, ok=%v", got, ok)
+	}
+	vc, ok := repman.VersionConfs["my-cluster"]
+	if !ok || vc.ConfInit.Hosts != "10.0.0.1" {
+		t.Errorf("expected VersionConfs[my-cluster].ConfInit to hold the reconstructed config, got %+v, ok=%v", vc, ok)
+	}
+}
+
+// TestRollbackFailedImport verifies that a partially-completed import (the
+// directory was copied and the cluster was registered in memory, but
+// starting it failed) is fully undone: the copied directory is removed and
+// every in-memory registration is cleared, so a retry is not permanently
+// blocked by hasLocalCluster seeing leftover state.
+func TestRollbackFailedImport(t *testing.T) {
+	workingDir := t.TempDir()
+	writeClusterDir(t, workingDir, "cluster-a")
+
+	repman := &ReplicationManager{
+		Conf:             &config.Config{WorkingDir: workingDir},
+		Clusters:         map[string]*cluster.Cluster{},
+		ClusterList:      []string{"other-cluster", "cluster-a"},
+		Confs:            map[string]config.Config{"cluster-a": {}},
+		VersionConfs:     map[string]*config.ConfVersion{"cluster-a": {}},
+		ImmuableFlagMaps: map[string]map[string]interface{}{"cluster-a": {}},
+		DynamicFlagMaps:  map[string]map[string]interface{}{"cluster-a": {}},
+	}
+
+	repman.rollbackFailedImport("cluster-a")
+
+	if _, err := os.Stat(filepath.Join(workingDir, "cluster-a")); !os.IsNotExist(err) {
+		t.Errorf("expected working-dir/cluster-a to be removed, stat err = %v", err)
+	}
+	if _, ok := repman.Confs["cluster-a"]; ok {
+		t.Error("expected Confs[cluster-a] to be removed")
+	}
+	if _, ok := repman.VersionConfs["cluster-a"]; ok {
+		t.Error("expected VersionConfs[cluster-a] to be removed")
+	}
+	if _, ok := repman.ImmuableFlagMaps["cluster-a"]; ok {
+		t.Error("expected ImmuableFlagMaps[cluster-a] to be removed")
+	}
+	if _, ok := repman.DynamicFlagMaps["cluster-a"]; ok {
+		t.Error("expected DynamicFlagMaps[cluster-a] to be removed")
+	}
+	for _, n := range repman.ClusterList {
+		if n == "cluster-a" {
+			t.Errorf("expected cluster-a to be removed from ClusterList, got %v", repman.ClusterList)
+		}
+	}
+	if len(repman.ClusterList) != 1 || repman.ClusterList[0] != "other-cluster" {
+		t.Errorf("expected other-cluster to survive rollback untouched, got %v", repman.ClusterList)
+	}
+
+	// The whole point: a retry must no longer see this as an existing cluster.
+	if repman.hasLocalCluster("cluster-a") {
+		t.Error("expected hasLocalCluster to be false after rollback, retry would be blocked forever")
+	}
+}
+
+// TestImportStagedDynamicClusters_FailedStartRollsBackAndAllowsRetry proves
+// the rollback wiring end-to-end through the real import loop (not just the
+// rollback helper in isolation): a staged cluster whose TOML is malformed
+// fails inside loadAndStartImportedCluster after importDynamicClusterDir has
+// already copied it into the live working directory, and the loop must
+// still (a) copy the directory away, (b) leave no trace in any in-memory
+// registration map, and (c) not block a subsequent retry.
+func TestImportStagedDynamicClusters_FailedStartRollsBackAndAllowsRetry(t *testing.T) {
+	stagedDir := t.TempDir()
+	workingDir := t.TempDir()
+
+	// Passes discoverImportableDynamicClusterDirs (the file exists) but fails
+	// parsing inside loadAndStartImportedCluster's isolated Viper read.
+	brokenDir := filepath.Join(stagedDir, "broken-cluster")
+	if err := os.MkdirAll(brokenDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(brokenDir, "broken-cluster.toml"), []byte("[saved-broken-cluster\nnot = valid = toml ===\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repman := &ReplicationManager{
+		Conf:             &config.Config{WorkingDir: workingDir},
+		Clusters:         map[string]*cluster.Cluster{},
+		ClusterList:      []string{},
+		Confs:            map[string]config.Config{},
+		VersionConfs:     map[string]*config.ConfVersion{},
+		ImmuableFlagMaps: map[string]map[string]interface{}{"default": {}},
+		DynamicFlagMaps:  map[string]map[string]interface{}{"default": {}},
+	}
+
+	result, err := repman.importStagedDynamicClusters(stagedDir)
+	if err != nil {
+		t.Fatalf("unexpected whole-action error: %v", err)
+	}
+
+	if len(result.Imported) != 0 {
+		t.Errorf("expected nothing imported, got %v", result.Imported)
+	}
+	if _, ok := result.Errors["broken-cluster"]; !ok {
+		t.Errorf("expected an error entry for broken-cluster, got %+v", result.Errors)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(workingDir, "broken-cluster")); !os.IsNotExist(statErr) {
+		t.Errorf("expected working-dir/broken-cluster to be removed after failed start, stat err = %v", statErr)
+	}
+	if _, ok := repman.Confs["broken-cluster"]; ok {
+		t.Error("expected no leftover Confs entry for broken-cluster")
+	}
+	for _, n := range repman.ClusterList {
+		if n == "broken-cluster" {
+			t.Errorf("expected no leftover ClusterList entry, got %v", repman.ClusterList)
+		}
+	}
+
+	// Retry must not see broken-cluster as already existing.
+	if repman.hasLocalCluster("broken-cluster") {
+		t.Fatal("expected hasLocalCluster to be false after a failed import, retry would be blocked forever")
+	}
+
+	// And a retry against the same (still-broken) staged dir must behave
+	// identically rather than being skipped as already handled.
+	result2, err := repman.importStagedDynamicClusters(stagedDir)
+	if err != nil {
+		t.Fatalf("unexpected whole-action error on retry: %v", err)
+	}
+	if _, ok := result2.Errors["broken-cluster"]; !ok {
+		t.Errorf("expected retry to attempt the import again and fail the same way, got %+v", result2)
+	}
+	if len(result2.SkippedExisting) != 0 {
+		t.Errorf("expected nothing skipped as existing on retry, got %v", result2.SkippedExisting)
+	}
+}
+
+func TestFetchDynamicClustersFromGit_RequiresGitURL(t *testing.T) {
+	repman := &ReplicationManager{Conf: &config.Config{}}
+	_, err := repman.FetchDynamicClustersFromGit()
+	if err == nil {
+		t.Fatal("expected error when git URL is not configured")
+	}
+}
+
+func TestFetchDynamicClustersFromGit_RequiresGitToken(t *testing.T) {
+	repman := &ReplicationManager{Conf: &config.Config{GitUrl: "https://example.invalid/repo.git"}}
+	_, err := repman.FetchDynamicClustersFromGit()
+	if err == nil {
+		t.Fatal("expected error when git access token is not configured")
+	}
+}
+
+// TestHandlerMuxFetchDynamicClustersFromGit_MethodNotAllowed exercises the
+// handler's own internal method guard directly (bypassing the router and
+// negroni middleware chain). This does not prove real routing behavior — see
+// TestFetchDynamicClustersFromGitRoute_MethodAndAuth for that.
+func TestHandlerMuxFetchDynamicClustersFromGit_MethodNotAllowed(t *testing.T) {
+	repman := &ReplicationManager{Conf: &config.Config{}}
+	req := httptest.NewRequest(http.MethodGet, "/api/clusters/actions/fetch-dynamic-from-git", nil)
+	w := httptest.NewRecorder()
+	repman.handlerMuxFetchDynamicClustersFromGit(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+// TestHandlerMuxFetchDynamicClustersFromGit_RequiresAuth exercises the
+// handler's own internal admin-claims guard directly (bypassing the router
+// and validateTokenMiddleware, which would itself reject an unauthenticated
+// request with 401 before the handler ever runs — see
+// TestFetchDynamicClustersFromGitRoute_MethodAndAuth for that path).
+func TestHandlerMuxFetchDynamicClustersFromGit_RequiresAuth(t *testing.T) {
+	repman := &ReplicationManager{Conf: &config.Config{}}
+	req := httptest.NewRequest(http.MethodPost, "/api/clusters/actions/fetch-dynamic-from-git", nil)
+	w := httptest.NewRecorder()
+	repman.handlerMuxFetchDynamicClustersFromGit(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 without a JWT, got %d", w.Code)
+	}
+}
+
+// TestFetchDynamicClustersFromGitRoute_MethodAndAuth verifies the real
+// router + middleware dispatch (registered in apiClusterProtectedHandler):
+// the route is POST-only at the mux level, so a GET never reaches the
+// handler, and an unauthenticated POST is rejected by validateTokenMiddleware
+// with 401 before the handler's own admin check ever runs. Mirrors
+// TestS3ProviderCRUDRoutes_MethodConstraints's approach in api_cluster_test.go.
+func TestFetchDynamicClustersFromGitRoute_MethodAndAuth(t *testing.T) {
+	repman := &ReplicationManager{}
+	router := mux.NewRouter()
+	repman.apiClusterProtectedHandler(router)
+
+	tests := []struct {
+		name       string
+		method     string
+		wantStatus int
+	}{
+		{name: "GET is rejected at the router before auth", method: http.MethodGet, wantStatus: http.StatusMethodNotAllowed},
+		{name: "unauthenticated POST is rejected by middleware", method: http.MethodPost, wantStatus: http.StatusUnauthorized},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "/api/clusters/actions/fetch-dynamic-from-git", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			if w.Code != tt.wantStatus {
+				t.Errorf("%s: got %d, want %d", tt.method, w.Code, tt.wantStatus)
+			}
+		})
+	}
+}

--- a/share/dashboard_react/src/Pages/ClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterList/index.jsx
@@ -5,7 +5,7 @@ import { setCluster } from '../../redux/clusterSlice'
 import { Box, Flex, HStack, Text, Wrap } from '@chakra-ui/react'
 import NotFound from '../../components/NotFound'
 import { AiOutlineCluster } from 'react-icons/ai'
-import { HiCreditCard, HiExclamation, HiTable, HiViewGrid } from 'react-icons/hi'
+import { HiCloudDownload, HiCreditCard, HiExclamation, HiTable, HiViewGrid } from 'react-icons/hi'
 import Card from '../../components/Card'
 import TableType2 from '../../components/TableType2'
 import { DataTable } from '../../components/DataTable'
@@ -13,7 +13,7 @@ import { createColumnHelper } from '@tanstack/react-table'
 import styles from './styles.module.scss'
 import CheckOrCrossIcon from '../../components/Icons/CheckOrCrossIcon'
 import CustomIcon from '../../components/Icons/CustomIcon'
-import { FaGitAlt, FaUserPlus } from 'react-icons/fa'
+import { FaUserPlus } from 'react-icons/fa'
 import RMIconButton from '../../components/RMIconButton'
 import TagPill from '../../components/TagPill'
 import AddUserModal from '../../components/Modals/AddUserModal'
@@ -207,7 +207,7 @@ function ClusterList({ onClick }) {
               <RMIconButton icon={HiTable} tooltip='Show table view' onClick={() => setViewType('table')} />
             )}
             {canImportFromGit && (
-              <RMIconButton icon={FaGitAlt} tooltip='Import from Git' onClick={() => setIsGitImportModalOpen(true)} />
+              <RMIconButton icon={HiCloudDownload} tooltip='Import missing clusters from Git' onClick={() => setIsGitImportModalOpen(true)} />
             )}
           </HStack>
         }

--- a/share/dashboard_react/src/Pages/ClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterList/index.jsx
@@ -17,14 +17,18 @@ import { FaUserPlus } from 'react-icons/fa'
 import RMIconButton from '../../components/RMIconButton'
 import TagPill from '../../components/TagPill'
 import AddUserModal from '../../components/Modals/AddUserModal'
+import DynamicClusterGitImportModal from '../../components/Modals/DynamicClusterGitImportModal'
+import RMButton from '../../components/RMButton'
 import SearchBox from '../../components/SearchBox'
 import AccordionComponent from '../../components/AccordionComponent'
+
 
 const columnHelper = createColumnHelper()
 
 function ClusterList({ onClick }) {
   const dispatch = useDispatch()
   const [isAddUserModalOpen, setIsAddUserModalOpen] = useState(false)
+  const [isGitImportModalOpen, setIsGitImportModalOpen] = useState(false)
   const [clusterName, setClusterName] = useState('')
   const [addUserApiUsers, setAddUserApiUsers] = useState(null)
   const [clusterList, setClusterList] = useState([])
@@ -39,6 +43,8 @@ function ClusterList({ onClick }) {
   const isAdmin = localStorage.getItem('username') === 'admin'
 
   const canAddUser = monitor?.config?.monitoringSaveConfig && monitor?.config?.cloud18GitUser?.length > 0 && isAdmin
+
+  const canImportFromGit = isAdmin
 
   useEffect(() => {
     dispatch(getClusters({}))
@@ -189,9 +195,7 @@ function ClusterList({ onClick }) {
     [hasArbitration, canAddUser, clusterList]
   )
 
-  return !loading && clusterList?.length === 0 ? (
-    <NotFound text={'No cluster found!'} />
-  ) : (
+  return (
     <>
       <AccordionComponent
         heading={'Clusters'}
@@ -203,9 +207,16 @@ function ClusterList({ onClick }) {
             ) : (
               <RMIconButton icon={HiTable} tooltip='Show table view' onClick={() => setViewType('table')} />
             )}
+            {canImportFromGit && (
+              <RMButton size='small' variant='outline' onClick={() => setIsGitImportModalOpen(true)}>
+                Import from Git
+              </RMButton>
+            )}
           </HStack>
         }
-        body={viewType === 'table' ? (
+        body={!loading && clusterList?.length === 0 ? (
+          <NotFound text={'No cluster found!'} />
+        ) : viewType === 'table' ? (
           <DataTable data={clusterList} columns={columns} />
         ) : (
         <Flex className={styles.clusterList}>
@@ -311,6 +322,9 @@ function ClusterList({ onClick }) {
       />
       {isAddUserModalOpen && (
         <AddUserModal clusterName={clusterName} apiUsers={addUserApiUsers} isOpen={isAddUserModalOpen} closeModal={closeAddUserModal} />
+      )}
+      {isGitImportModalOpen && (
+        <DynamicClusterGitImportModal isOpen={isGitImportModalOpen} closeModal={() => setIsGitImportModalOpen(false)} />
       )}
     </>
   )

--- a/share/dashboard_react/src/Pages/ClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterList/index.jsx
@@ -13,15 +13,14 @@ import { createColumnHelper } from '@tanstack/react-table'
 import styles from './styles.module.scss'
 import CheckOrCrossIcon from '../../components/Icons/CheckOrCrossIcon'
 import CustomIcon from '../../components/Icons/CustomIcon'
-import { FaUserPlus } from 'react-icons/fa'
+import { FaGitAlt, FaUserPlus } from 'react-icons/fa'
 import RMIconButton from '../../components/RMIconButton'
 import TagPill from '../../components/TagPill'
 import AddUserModal from '../../components/Modals/AddUserModal'
 import DynamicClusterGitImportModal from '../../components/Modals/DynamicClusterGitImportModal'
-import RMButton from '../../components/RMButton'
 import SearchBox from '../../components/SearchBox'
 import AccordionComponent from '../../components/AccordionComponent'
-
+import { isCloud18PlanEligible } from '../../utils/cloud18'
 
 const columnHelper = createColumnHelper()
 
@@ -44,7 +43,7 @@ function ClusterList({ onClick }) {
 
   const canAddUser = monitor?.config?.monitoringSaveConfig && monitor?.config?.cloud18GitUser?.length > 0 && isAdmin
 
-  const canImportFromGit = isAdmin
+  const canImportFromGit = isAdmin && isCloud18PlanEligible(monitor?.config)
 
   useEffect(() => {
     dispatch(getClusters({}))
@@ -208,9 +207,7 @@ function ClusterList({ onClick }) {
               <RMIconButton icon={HiTable} tooltip='Show table view' onClick={() => setViewType('table')} />
             )}
             {canImportFromGit && (
-              <RMButton size='small' variant='outline' onClick={() => setIsGitImportModalOpen(true)}>
-                Import from Git
-              </RMButton>
+              <RMIconButton icon={FaGitAlt} tooltip='Import from Git' onClick={() => setIsGitImportModalOpen(true)} />
             )}
           </HStack>
         }

--- a/share/dashboard_react/src/Pages/ClustersGlobalSettings/CloudSettings.jsx
+++ b/share/dashboard_react/src/Pages/ClustersGlobalSettings/CloudSettings.jsx
@@ -172,6 +172,7 @@ Start create an account in https://gitlab.signal18.io
       if (state === 'complete') {
         stopPolling()
         setIsRegisterModalOpen(false)
+        dispatch(getMonitoredData({}))
       } else if (state === 'timeout' || state === 'error') {
         stopPolling()
       }
@@ -224,6 +225,7 @@ Start create an account in https://gitlab.signal18.io
     setIsConfirming(false)
     if (result?.payload?.status === 201) {
       setIsRegisterModalOpen(false)
+      await dispatch(getMonitoredData({}))
     }
   }
 
@@ -426,6 +428,7 @@ Start create an account in https://gitlab.signal18.io
     const status = result?.payload?.status
     if (status === 200 || status === 201) {
       setIsSubModalOpen(false)
+      await dispatch(getMonitoredData({}))
     }
   }
 

--- a/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/ClusterDetail.jsx
@@ -32,6 +32,7 @@ import {
   unProvisionCluster
 } from '../../../redux/clusterSlice'
 import NewServerModal from '../../../components/Modals/NewServerModal'
+import PeerAppImportModal from '../../../components/Modals/PeerAppImportModal'
 import parentStyles from '../styles.module.scss'
 import CopyTextModal from '../../../components/Modals/CopyTextModal'
 import SetCredentialsModal from '../../../components/Modals/SetCredentialsModal'
@@ -53,6 +54,7 @@ function ClusterDetail({ selectedCluster, user, readOnly = false, onOpenSettings
 
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false)
   const [isNewServerModalOpen, setIsNewServerModalOpen] = useState(false)
+  const [isPeerAppImportModalOpen, setIsPeerAppImportModalOpen] = useState(false)
   const [isNewClusterModalOpen, setIsNewClusterModalOpen] = useState(false)
   const [isCredentialModalOpen, setIsCredentialModalOpen] = useState(false)
   const [isClipboardModalOpen, setIsClipboardModalOpen] = useState(false)
@@ -161,6 +163,13 @@ function ClusterDetail({ selectedCluster, user, readOnly = false, onOpenSettings
           isDisabled: !g['cluster-create-monitor'],
           onClick: () => {
             setIsNewServerModalOpen(true)
+          }
+        },
+        {
+          name: 'Import App Monitor',
+          isDisabled: !g['cluster-create-monitor'] && !g['app-deployment'],
+          onClick: () => {
+            setIsPeerAppImportModalOpen(true)
           }
         },
         {
@@ -568,6 +577,13 @@ function ClusterDetail({ selectedCluster, user, readOnly = false, onOpenSettings
           clusterName={selectedCluster?.name}
           isOpen={isNewServerModalOpen}
           closeModal={() => setIsNewServerModalOpen(false)}
+        />
+      )}
+      {isPeerAppImportModalOpen && (
+        <PeerAppImportModal
+          clusterName={selectedCluster?.name}
+          isOpen={isPeerAppImportModalOpen}
+          closeModal={() => setIsPeerAppImportModalOpen(false)}
         />
       )}
       {isCredentialModalOpen && (

--- a/share/dashboard_react/src/components/Modals/DynamicClusterGitImportModal.jsx
+++ b/share/dashboard_react/src/components/Modals/DynamicClusterGitImportModal.jsx
@@ -1,0 +1,170 @@
+import {
+  Alert,
+  AlertIcon,
+  Box,
+  List,
+  ListItem,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text
+} from '@chakra-ui/react'
+import { useState } from 'react'
+import { useDispatch } from 'react-redux'
+import RMButton from '../RMButton'
+import NotFound from '../NotFound'
+import parentStyles from './styles.module.scss'
+import { useTheme } from '../../ThemeProvider'
+import { fetchDynamicClustersFromGit, getClusters, getMonitoredData } from '../../redux/globalClustersSlice'
+import { extractApiErrorMessage } from '../../utils/apiError'
+import PropTypes from 'prop-types'
+
+const RESULT_GROUPS = [
+  { key: 'imported', label: 'Imported', colorScheme: 'green' },
+  { key: 'skipped_existing', label: 'Skipped Existing', colorScheme: 'gray' },
+  { key: 'invalid', label: 'Invalid', colorScheme: 'orange' }
+]
+
+function DynamicClusterGitImportModal({ isOpen, closeModal }) {
+  const dispatch = useDispatch()
+  const { theme } = useTheme()
+
+  const [loading, setLoading] = useState(false)
+  const [result, setResult] = useState(null)
+  const [inlineError, setInlineError] = useState('')
+
+  const hasResult = Boolean(result)
+
+  const handleImport = async () => {
+    setLoading(true)
+    setInlineError('')
+    try {
+      const { data } = await dispatch(fetchDynamicClustersFromGit()).unwrap()
+      setResult(data)
+      dispatch(getClusters({}))
+      dispatch(getMonitoredData({}))
+    } catch (error) {
+      setInlineError(extractApiErrorMessage(error, 'Dynamic cluster import failed.'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleClose = () => {
+    if (loading) return
+    setResult(null)
+    setInlineError('')
+    closeModal()
+  }
+
+  const errorEntries = Object.entries(result?.errors || {}).sort(([a], [b]) => a.localeCompare(b))
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} closeOnOverlayClick={!loading} closeOnEsc={!loading}>
+      <ModalOverlay />
+      <ModalContent
+        className={theme === 'light' ? parentStyles.modalLightContent : parentStyles.modalDarkContent}
+        width='60%'
+        maxWidth='none'
+        minHeight='200px'
+        maxH='90%'
+        overflow='hidden'>
+        <ModalHeader>Import Dynamic Clusters from Git</ModalHeader>
+        <ModalCloseButton isDisabled={loading} />
+        <ModalBody overflowY='auto' pb={6}>
+          {inlineError && (
+            <Alert status='error' borderRadius='md' mb={4}>
+              <AlertIcon />
+              {inlineError}
+            </Alert>
+          )}
+
+          {!hasResult && !inlineError && (
+            <Box>
+              <Text fontSize='sm' mb={2}>
+                Imports dynamic clusters that exist in the main config Git repository but are
+                missing from this instance.
+              </Text>
+              <Text fontSize='sm' mb={2}>
+                Existing clusters are never overwritten. Only missing clusters are added.
+              </Text>
+              <Text fontSize='sm' color='gray.500'>
+                This action is admin-only.
+              </Text>
+            </Box>
+          )}
+
+          {hasResult && (
+            <Box>
+              {RESULT_GROUPS.map((group) => {
+                const items = [...(result[group.key] || [])].sort()
+                return (
+                  <Box key={group.key} mb={4}>
+                    <Text fontSize='sm' fontWeight='bold' mb={1}>
+                      {group.label} ({items.length})
+                    </Text>
+                    {items.length === 0 ? (
+                      <Text fontSize='sm' color='gray.500'>None</Text>
+                    ) : (
+                      <List spacing={1}>
+                        {items.map((name) => (
+                          <ListItem key={name} fontSize='sm'>{name}</ListItem>
+                        ))}
+                      </List>
+                    )}
+                  </Box>
+                )
+              })}
+              <Box mb={4}>
+                <Text fontSize='sm' fontWeight='bold' mb={1}>
+                  Errors ({errorEntries.length})
+                </Text>
+                {errorEntries.length === 0 ? (
+                  <Text fontSize='sm' color='gray.500'>None</Text>
+                ) : (
+                  <List spacing={1}>
+                    {errorEntries.map(([name, message]) => (
+                      <ListItem key={name} fontSize='sm'>
+                        <Text as='span' fontWeight='semibold'>{name}</Text>: {message}
+                      </ListItem>
+                    ))}
+                  </List>
+                )}
+              </Box>
+            </Box>
+          )}
+
+          {!hasResult && inlineError && (
+            <NotFound text='Import could not be started.' />
+          )}
+        </ModalBody>
+
+        <ModalFooter gap={3} margin='auto'>
+          <RMButton colorScheme='blue' size='medium' variant='outline' onClick={handleClose} isDisabled={loading}>
+            {hasResult ? 'Close' : 'Cancel'}
+          </RMButton>
+          {!hasResult && (
+            <RMButton
+              size='medium'
+              onClick={handleImport}
+              isLoading={loading}
+              isDisabled={loading}>
+              Import from Git
+            </RMButton>
+          )}
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export default DynamicClusterGitImportModal
+
+DynamicClusterGitImportModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  closeModal: PropTypes.func.isRequired
+}

--- a/share/dashboard_react/src/components/Modals/DynamicClusterGitImportModal.jsx
+++ b/share/dashboard_react/src/components/Modals/DynamicClusterGitImportModal.jsx
@@ -73,7 +73,7 @@ function DynamicClusterGitImportModal({ isOpen, closeModal }) {
         minHeight='200px'
         maxH='90%'
         overflow='hidden'>
-        <ModalHeader>Import Dynamic Clusters from Git</ModalHeader>
+        <ModalHeader>Import Missing Clusters from Git</ModalHeader>
         <ModalCloseButton isDisabled={loading} />
         <ModalBody overflowY='auto' pb={6}>
           {inlineError && (
@@ -153,7 +153,7 @@ function DynamicClusterGitImportModal({ isOpen, closeModal }) {
               onClick={handleImport}
               isLoading={loading}
               isDisabled={loading}>
-              Import from Git
+              Import Missing Clusters
             </RMButton>
           )}
         </ModalFooter>

--- a/share/dashboard_react/src/components/Modals/PeerAppImportModal.jsx
+++ b/share/dashboard_react/src/components/Modals/PeerAppImportModal.jsx
@@ -1,0 +1,318 @@
+import {
+  Alert,
+  AlertIcon,
+  Box,
+  Checkbox,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text
+} from '@chakra-ui/react'
+import { useMemo, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { createColumnHelper } from '@tanstack/react-table'
+import { DataTable } from '../DataTable'
+import NotFound from '../NotFound'
+import TagPill from '../TagPill'
+import RMButton from '../RMButton'
+import parentStyles from './styles.module.scss'
+import { useTheme } from '../../ThemeProvider'
+import { clusterService } from '../../services/clusterService'
+import { getClusterApps, getClusterData } from '../../redux/clusterSlice'
+import { showSuccessToast, showErrorToast } from '../../redux/toastSlice'
+import PropTypes from 'prop-types'
+
+const PREVIEW_STATUS_META = {
+  importable: { label: 'Importable', colorScheme: 'blue' },
+  already_exists: { label: 'Already exists', colorScheme: 'gray' },
+  unsupported_same_host: { label: 'Unsupported', colorScheme: 'orange' },
+  invalid_peer: { label: 'Invalid peer', colorScheme: 'red' }
+}
+
+const APPLY_STATUS_META = {
+  imported: { label: 'Imported', colorScheme: 'green' },
+  rejected: { label: 'Rejected', colorScheme: 'red' }
+}
+
+const rowKey = (host, port) => `${host}:${port}`
+
+function PeerAppImportModal({ clusterName, isOpen, closeModal }) {
+  const dispatch = useDispatch()
+  const { theme } = useTheme()
+  const baseURL = useSelector((state) => state.auth?.baseURL || '')
+
+  const [previewLoading, setPreviewLoading] = useState(false)
+  const [applyLoading, setApplyLoading] = useState(false)
+  const [previewData, setPreviewData] = useState(null)
+  const [selectedApps, setSelectedApps] = useState({})
+  const [applyResults, setApplyResults] = useState(null)
+  const [inlineError, setInlineError] = useState('')
+
+  const previewApps = previewData?.apps || []
+  const selectedCount = Object.values(selectedApps).filter(Boolean).length
+  const hasPreview = Boolean(previewData)
+  const hasApplyResults = Boolean(applyResults)
+
+  const handleLoadPreview = async () => {
+    setPreviewLoading(true)
+    setInlineError('')
+    setApplyResults(null)
+    setSelectedApps({})
+    try {
+      const { data, status } = await clusterService.previewPeerAppImport(clusterName, baseURL)
+      if (status === 200) {
+        setPreviewData(data)
+      } else {
+        setPreviewData(null)
+        setInlineError(typeof data === 'string' ? data : 'Failed to load peer app inventory')
+      }
+    } catch (err) {
+      setPreviewData(null)
+      setInlineError(String(err?.message || err))
+    } finally {
+      setPreviewLoading(false)
+    }
+  }
+
+  const handleToggleSelect = (host, port) => {
+    const key = rowKey(host, port)
+    setSelectedApps((prev) => ({ ...prev, [key]: !prev[key] }))
+  }
+
+  const handleApply = async () => {
+    const apps = previewApps
+      .filter((app) => app.status === 'importable' && selectedApps[rowKey(app.host, app.port)])
+      .map((app) => ({ host: app.host, port: app.port }))
+
+    if (apps.length === 0) return
+
+    setApplyLoading(true)
+    setInlineError('')
+    try {
+      const { data, status } = await clusterService.applyPeerAppImport(clusterName, apps, baseURL)
+      if (status === 200) {
+        setApplyResults(data)
+        setSelectedApps({})
+
+        const importedCount = (data?.apps || []).filter((app) => app.status === 'imported').length
+        if (importedCount > 0) {
+          dispatch(getClusterApps({ clusterName }))
+          dispatch(getClusterData({ clusterName }))
+          dispatch(showSuccessToast({
+            title: 'App monitor import',
+            description: `${importedCount} app${importedCount === 1 ? '' : 's'} imported from peer.`
+          }))
+        }
+        if (importedCount < apps.length) {
+          dispatch(showErrorToast({
+            title: 'App monitor import',
+            description: `${apps.length - importedCount} app${apps.length - importedCount === 1 ? '' : 's'} could not be imported.`
+          }))
+        }
+      } else {
+        setInlineError(typeof data === 'string' ? data : 'Failed to apply peer app import')
+      }
+    } catch (err) {
+      setInlineError(String(err?.message || err))
+    } finally {
+      setApplyLoading(false)
+    }
+  }
+
+  const handleClose = () => {
+    setPreviewData(null)
+    setSelectedApps({})
+    setApplyResults(null)
+    setInlineError('')
+    closeModal()
+  }
+
+  const columnHelper = useMemo(() => createColumnHelper(), [])
+  const columns = useMemo(() => [
+    columnHelper.accessor((row) => row, {
+      id: 'select',
+      header: () => <span />,
+      cell: (info) => {
+        const app = info.getValue()
+        const isImportable = app.status === 'importable'
+        return (
+          <Checkbox
+            isDisabled={!isImportable || applyLoading}
+            isChecked={Boolean(selectedApps[rowKey(app.host, app.port)])}
+            onChange={() => handleToggleSelect(app.host, app.port)}
+          />
+        )
+      },
+      maxWidth: '40'
+    }),
+    columnHelper.accessor((row) => row.host, {
+      id: 'host',
+      header: () => <span>Host</span>,
+      cell: (info) => info.getValue() || ''
+    }),
+    columnHelper.accessor((row) => row.port, {
+      id: 'port',
+      header: () => <span>Port</span>,
+      cell: (info) => info.getValue() || '',
+      maxWidth: '80'
+    }),
+    columnHelper.accessor((row) => row.template, {
+      id: 'template',
+      header: () => <span>Template</span>,
+      cell: (info) => info.getValue() || '-'
+    }),
+    columnHelper.accessor((row) => row.dockerImage, {
+      id: 'dockerImage',
+      header: () => <span>Docker Image</span>,
+      cell: (info) => info.getValue() || '-'
+    }),
+    columnHelper.accessor((row) => row, {
+      id: 'status',
+      header: () => <span>Status</span>,
+      cell: (info) => {
+        const app = info.getValue()
+        const meta = PREVIEW_STATUS_META[app.status] || { label: app.status, colorScheme: 'gray' }
+        return <TagPill colorScheme={meta.colorScheme} text={meta.label} />
+      }
+    }),
+    columnHelper.accessor((row) => row.reason, {
+      id: 'reason',
+      header: () => <span>Reason</span>,
+      cell: (info) => info.getValue() || ''
+    })
+  ], [columnHelper, selectedApps, applyLoading])
+
+  const applyColumnHelper = useMemo(() => createColumnHelper(), [])
+  const applyColumns = useMemo(() => [
+    applyColumnHelper.accessor((row) => row.host, {
+      id: 'host',
+      header: () => <span>Host</span>,
+      cell: (info) => info.getValue() || ''
+    }),
+    applyColumnHelper.accessor((row) => row.port, {
+      id: 'port',
+      header: () => <span>Port</span>,
+      cell: (info) => info.getValue() || '',
+      maxWidth: '80'
+    }),
+    applyColumnHelper.accessor((row) => row, {
+      id: 'status',
+      header: () => <span>Status</span>,
+      cell: (info) => {
+        const app = info.getValue()
+        const meta = APPLY_STATUS_META[app.status] || { label: app.status, colorScheme: 'gray' }
+        return <TagPill colorScheme={meta.colorScheme} text={meta.label} />
+      }
+    }),
+    applyColumnHelper.accessor((row) => row.reason, {
+      id: 'reason',
+      header: () => <span>Reason</span>,
+      cell: (info) => info.getValue() || ''
+    })
+  ], [applyColumnHelper])
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      <ModalOverlay />
+      <ModalContent
+        className={theme === 'light' ? parentStyles.modalLightContent : parentStyles.modalDarkContent}
+        width='80%'
+        maxWidth='none'
+        minHeight='300px'
+        maxH='90%'
+        overflow='hidden'>
+        <ModalHeader>Import App Monitor from Peer</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody overflowY='auto' pb={6}>
+          {inlineError && (
+            <Alert status='error' borderRadius='md' mb={4}>
+              <AlertIcon />
+              {inlineError}
+            </Alert>
+          )}
+
+          {hasPreview && !hasApplyResults && (
+            <Text fontSize='sm' mb={4}>
+              Peer cluster: {previewData.clusterName} ({previewData.peerUri})
+            </Text>
+          )}
+
+          {!hasPreview && !hasApplyResults && !previewLoading && !inlineError && (
+            <NotFound text='Load the peer app inventory to see importable apps.' />
+          )}
+
+          {hasPreview && !hasApplyResults && (
+            previewApps.length === 0 ? (
+              <NotFound text='No apps found on the peer for this cluster.' />
+            ) : (
+              <DataTable
+                key='PeerAppImportPreview'
+                columns={columns}
+                data={previewApps}
+                cellValueAlign='start'
+              />
+            )
+          )}
+
+          {hasApplyResults && (
+            <Box>
+              <Text fontSize='sm' fontWeight='bold' mb={2}>Import results</Text>
+              <DataTable
+                key='PeerAppImportResults'
+                columns={applyColumns}
+                data={applyResults.apps || []}
+                cellValueAlign='start'
+              />
+            </Box>
+          )}
+        </ModalBody>
+
+        <ModalFooter gap={3} margin='auto'>
+          <RMButton colorScheme='blue' size='medium' variant='outline' onClick={handleClose}>
+            {hasApplyResults ? 'Close' : 'Cancel'}
+          </RMButton>
+          {!hasApplyResults && (
+            <RMButton
+              size='medium'
+              variant='outline'
+              onClick={handleLoadPreview}
+              isLoading={previewLoading}
+              isDisabled={applyLoading}>
+              {hasPreview ? 'Reload from Peer' : 'Load from Peer'}
+            </RMButton>
+          )}
+          {hasPreview && !hasApplyResults && (
+            <RMButton
+              size='medium'
+              onClick={handleApply}
+              isLoading={applyLoading}
+              isDisabled={selectedCount === 0 || previewLoading}>
+              Import Selected
+            </RMButton>
+          )}
+          {hasApplyResults && (
+            <RMButton
+              size='medium'
+              variant='outline'
+              onClick={handleLoadPreview}
+              isLoading={previewLoading}>
+              Reload from Peer
+            </RMButton>
+          )}
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export default PeerAppImportModal
+
+PeerAppImportModal.propTypes = {
+  clusterName: PropTypes.string.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  closeModal: PropTypes.func.isRequired
+}

--- a/share/dashboard_react/src/redux/globalClustersSlice.js
+++ b/share/dashboard_react/src/redux/globalClustersSlice.js
@@ -1,5 +1,5 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
-import { handleError, showErrorBanner, showSuccessBanner } from '../utility/common'
+import { handleError, showErrorBanner, showSuccessBanner, showWarningBanner } from '../utility/common'
 import { globalClustersService } from '../services/globalClustersService'
 
 const getThunkTypePrefix = (actionType) => actionType.replace(/\/(pending|fulfilled|rejected)$/, '')
@@ -120,6 +120,33 @@ export const renameCluster = createGuardedAsyncThunk('globalClusters/renameClust
     }
   } catch (error) {
     showErrorBanner("Rename cluster '" + clusterName + "' is failed!", error, thunkAPI)
+    return handleError(error, thunkAPI)
+  }
+})
+
+export const fetchDynamicClustersFromGit = createGuardedAsyncThunk('globalClusters/fetchDynamicClustersFromGit', async (_, thunkAPI) => {
+  try {
+    const { data, status } = await globalClustersService.fetchDynamicClustersFromGit()
+    if (status === 200) {
+      const importedCount = data?.imported?.length || 0
+      const errorCount = Object.keys(data?.errors || {}).length
+      let message = importedCount > 0
+        ? `Dynamic cluster import completed: ${importedCount} imported`
+        : 'Dynamic cluster import completed: no new clusters imported'
+      if (errorCount > 0) {
+        message += ` (${errorCount} error${errorCount === 1 ? '' : 's'})`
+      }
+      if (importedCount === 0 && errorCount > 0) {
+        showWarningBanner(message, status, thunkAPI)
+      } else {
+        showSuccessBanner(message, status, thunkAPI)
+      }
+      return { data, status }
+    } else {
+      throw new Error(typeof data === 'string' ? data : data?.error || 'Dynamic cluster import failed')
+    }
+  } catch (error) {
+    showErrorBanner('Dynamic cluster import failed', error, thunkAPI)
     return handleError(error, thunkAPI)
   }
 })

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -56,6 +56,8 @@ export const clusterService = {
   addServer,
   dropServer,
   dropServerByName,
+  previewPeerAppImport,
+  applyPeerAppImport,
   provisionCluster,
   unProvisionCluster,
   setCredentials,
@@ -351,6 +353,14 @@ function dropServer(clusterName, host, port, type, baseURL) {
 
 function dropServerByName(clusterName, serverName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/actions/dropserver/${serverName}`)
+}
+
+function previewPeerAppImport(clusterName, baseURL) {
+  return getApi(baseURL).post(`clusters/${clusterName}/apps/peer-import/preview`)
+}
+
+function applyPeerAppImport(clusterName, apps, baseURL) {
+  return getApi(baseURL).post(`clusters/${clusterName}/apps/peer-import/apply`, { apps })
 }
 
 function dropApp(clusterName, host, port, baseURL) {

--- a/share/dashboard_react/src/services/globalClustersService.js
+++ b/share/dashboard_react/src/services/globalClustersService.js
@@ -26,7 +26,8 @@ export const globalClustersService = {
   getSubscription,
   changeSubscription,
   getSubscriptionPlans,
-  setServerActiveStatus
+  setServerActiveStatus,
+  fetchDynamicClustersFromGit
 }
 
 function getClusters(baseURL) {
@@ -132,4 +133,8 @@ function getSubscriptionPlans() {
 
 function setServerActiveStatus(baseURL) {
   return getApi(baseURL).get('actions/set-active-status')
+}
+
+function fetchDynamicClustersFromGit() {
+  return getApi().post('clusters/actions/fetch-dynamic-from-git')
 }

--- a/share/dashboard_react/src/utility/common.js
+++ b/share/dashboard_react/src/utility/common.js
@@ -1,4 +1,4 @@
-import { resetToast, showErrorToast, showLoadingToast, showSuccessToast } from '../redux/toastSlice'
+import { resetToast, showErrorToast, showLoadingToast, showSuccessToast, showWarningToast } from '../redux/toastSlice'
 
 export const isAuthorized = () => {
   return localStorage.getItem('user_token') !== null
@@ -24,6 +24,14 @@ export const showSuccessBanner = (message, responseStatus, thunkAPI) => {
   thunkAPI.dispatch(
     showSuccessToast({
       status: 'success',
+      title: message
+    })
+  )
+}
+export const showWarningBanner = (message, responseStatus, thunkAPI) => {
+  thunkAPI.dispatch(
+    showWarningToast({
+      status: 'warning',
       title: message
     })
   )

--- a/share/dashboard_react/src/utils/cloud18.js
+++ b/share/dashboard_react/src/utils/cloud18.js
@@ -1,0 +1,9 @@
+// Plans eligible for paid Cloud18 features (external arbitration, dynamic
+// cluster git import); must mirror config.Config.IsEligibleForArbitration()
+// on the server side.
+export const CLOUD18_PAID_PLANS = ['support', 'support-services', 'partner']
+
+export const isCloud18PlanEligible = (config) => {
+  const plan = (config?.cloud18SubscriptionPlan || '').trim().toLowerCase()
+  return !!config?.cloud18GitUser && CLOUD18_PAID_PLANS.includes(plan)
+}


### PR DESCRIPTION
## Summary
This PR introduces the ability to import dynamic cluster configurations from git and to manually import peer app monitor definitions, along with related Cloud18/CRM plan synchronization and ACL/grant fixes.

## What's Changed
- **Dynamic cluster git import**
  - Import missing dynamic clusters from a git repository on startup.
  - Add server-side git import logic and test coverage (`server/server_git_dynamic_import_test.go`).
  - Gate dynamic git import to paid plans via the subscription manager.
- **Peer app monitor import**
  - Add manual peer app monitor import API (`server/api_app_peer_import.go`) with tests.
  - Add a UI modal for importing peer apps (`PeerAppImportModal`).
  - Align peer import grants and ACL rules.
- **Cloud18 / CRM synchronization**
  - Preserve CRM plan synchronization on boot.
  - Sync instance plan from CRM.
- **UI / Redux**
  - Update cluster list, cluster detail, and global settings for the new import flows.
  - Add new service helpers and utility updates.

## Commits
- 55c0e8d71 fix(cloud18): preserve crm plan sync on boot
- 7c0496725 feat(server): gate dynamic git import to paid plans
- 211c01253 feat(ui): add dynamic cluster git import flow
- 40bef4bfe feat(server): import missing dynamic clusters from git
- 9353b8cd3 fix(cloud18): sync instance plan from crm
- 11627d5ec feat(ui): add peer app import modal
- 673f14e7b fix(app): align peer import grants
- 81ef82793 feat(app): add manual peer app monitor import

## Testing
The committed changes have already been tested.
