### PR TITLE
feat(restic): add manual s3 bucket creation

### DIFF
--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -176,6 +176,7 @@ var clusterACLRules = []ACLRule{
 	{"/backups", nil, []string{config.GrantClusterShowBackups}},                               // list (bare path, no slash)
 	{"/restic/purge", nil, []string{config.GrantDBBackup}},                                    // delete a snapshot
 	{"/restic/wipe", nil, []string{config.GrantDBBackup}},                                     // destructive wipe
+	{"/restic/create-bucket", nil, []string{config.GrantDBBackup}},                            // remote storage mutation
 	{"/restic/check-config", nil, []string{config.GrantClusterProcess, config.GrantDBBackup}}, // preview also required by wipe workflow
 	{"/restic/snapshots", nil, []string{config.GrantClusterShowBackups}},
 	{"/restic/stats", nil, []string{config.GrantClusterShowBackups}},

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -23,6 +23,7 @@ import (
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/backupmgr"
 	"github.com/signal18/replication-manager/utils/misc"
+	"github.com/signal18/replication-manager/utils/s3helper"
 	"github.com/signal18/replication-manager/utils/splitdump"
 	"github.com/signal18/replication-manager/utils/state"
 	"github.com/signal18/replication-manager/utils/version"
@@ -73,7 +74,7 @@ func parseLegacyS3ResticRepo(rawURL string) (endpoint, bucket, prefix string, er
 			return "", "", "", fmt.Errorf("S3 repository URL %q has a scheme and host but no bucket", rawURL)
 		}
 		endpoint = rest[:schemeSep+3+slashIdx] // "scheme://host"
-		rest = afterScheme[slashIdx+1:]         // "bucket[/prefix]"
+		rest = afterScheme[slashIdx+1:]        // "bucket[/prefix]"
 	} else {
 		// No scheme: first path segment is either a bare hostname (contains "." or ":")
 		// or the bucket name. This mirrors how restic itself distinguishes the two forms:
@@ -270,6 +271,65 @@ func (cluster *Cluster) ResticS3EffectivePrefixForInit() (string, bool) {
 	return res.Prefix, true
 }
 
+// ResticEnsureBucketResult is the response returned by ResticEnsureS3Bucket.
+type ResticEnsureBucketResult struct {
+	Bucket   string `json:"bucket"`
+	Endpoint string `json:"endpoint,omitempty"`
+	Created  bool   `json:"created"`
+	Message  string `json:"message"`
+}
+
+// ResticEnsureS3Bucket creates the bucket for the cluster's saved Restic S3
+// configuration if it does not already exist, and is a no-op success when it
+// already exists and is accessible.
+//
+// The effective S3 target is resolved from the cluster/config layer via
+// resolveResticS3, not from ResticManager runtime state, so this works even
+// when S3 is not the currently active repository type (e.g. local or sftp is
+// active) and even when backup-restic itself is not yet enabled — allowing
+// the bucket to be pre-provisioned before turning Restic on.
+//
+// The cluster argument to resolveResticS3 is deliberately nil: passing the
+// live cluster would let auto mode resolve through cluster.resolvedS3Mode,
+// the mode cached from the startup S3 probe. That cache is runtime state, not
+// config, and it actively works against this endpoint's own purpose — it
+// prefers "new" but falls back to "legacy" precisely when the new bucket
+// isn't reachable yet (e.g. it doesn't exist), which is the exact moment a
+// user clicks this button. Resolving without the cluster keeps this endpoint
+// on the same presence-based heuristic the dashboard uses to decide what to
+// display/enable, so both sides always agree on the target bucket.
+func (cluster *Cluster) ResticEnsureS3Bucket() (ResticEnsureBucketResult, error) {
+	res, err := resolveResticS3(cluster.Conf, cluster.Name, nil)
+	if err != nil {
+		return ResticEnsureBucketResult{}, err
+	}
+	if res.Bucket == "" {
+		return ResticEnsureBucketResult{}, fmt.Errorf("no S3 bucket resolved from the saved restic configuration")
+	}
+
+	sessionToken := resticAdditionalEnvSessionToken(cluster.Conf.BackupResticAdditionalEnv, os.Environ())
+	client, err := s3helper.NewClient(res.AccessKeyID, res.AccessSecret, sessionToken, res.Region, res.Endpoint)
+	if err != nil {
+		return ResticEnsureBucketResult{}, err
+	}
+
+	created, err := s3helper.EnsureBucket(client, res.Bucket)
+	if err != nil {
+		return ResticEnsureBucketResult{}, err
+	}
+
+	message := "Bucket already exists."
+	if created {
+		message = "Bucket created."
+	}
+	return ResticEnsureBucketResult{
+		Bucket:   res.Bucket,
+		Endpoint: res.Endpoint,
+		Created:  created,
+		Message:  message,
+	}, nil
+}
+
 func isWithinParentPath(parent, child string) bool {
 	parent = filepath.Clean(parent)
 	child = filepath.Clean(child)
@@ -430,6 +490,35 @@ func parseResticAdditionalEnvOverrides(raw string) (map[string]string, map[strin
 	}
 
 	return overrides, allowlist, nil
+}
+
+// resticAdditionalEnvSessionToken extracts an optional AWS_SESSION_TOKEN for
+// STS/temporary credentials from the same backup-restic-additional-env
+// allowlist mechanism filterResticEnv uses for the restic subprocess env, so
+// direct S3 API calls (e.g. ResticEnsureS3Bucket) honor the same
+// session-token configuration as actual restic invocations. baseEnv mirrors
+// filterResticEnv's source of truth (os.Environ()) for the case where the
+// token is allowlisted by bare key and expected to come from the server's own
+// process environment rather than an inline override value.
+func resticAdditionalEnvSessionToken(additionalEnv string, baseEnv []string) string {
+	const key = "AWS_SESSION_TOKEN"
+	overrides, allowlist, err := parseResticAdditionalEnvOverrides(additionalEnv)
+	if err != nil {
+		return ""
+	}
+	if _, ok := allowlist[key]; !ok {
+		return ""
+	}
+	if value, ok := overrides[key]; ok {
+		return value
+	}
+	for _, env := range baseEnv {
+		envKey, value, hasValue := strings.Cut(env, "=")
+		if hasValue && envKey == key {
+			return value
+		}
+	}
+	return ""
 }
 
 func ValidateResticAdditionalEnvOverrides(raw string) error {

--- a/cluster/cluster_bck.go
+++ b/cluster/cluster_bck.go
@@ -1078,9 +1078,22 @@ func (cluster *Cluster) promoteResticS3ModeOnBootSuccess() {
 	}
 }
 
+// ResticInitRepoWithOptions initializes the cluster's restic repository. For
+// S3 repositories, it first attempts to pre-create the bucket via
+// ResticEnsureS3Bucket so that init isn't blocked by a missing bucket that the
+// user simply hasn't provisioned yet. That pre-check is best-effort: a failure
+// is logged, not returned, so restic's own init still runs and surfaces its
+// own (more specific) error if the bucket genuinely isn't usable.
 func (cluster *Cluster) ResticInitRepoWithOptions(options backupmgr.ResticInitOption) error {
 	if !cluster.Conf.BackupRestic {
 		return nil
+	}
+
+	if cluster.Conf.BackupResticAws {
+		if _, err := cluster.ResticEnsureS3Bucket(); err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlWarn,
+				"Restic S3 bucket pre-check before init failed (continuing; init will report its own error if the bucket is unusable): %s", err)
+		}
 	}
 
 	if cluster.ResticManager == nil {

--- a/cluster/cluster_bck_test.go
+++ b/cluster/cluster_bck_test.go
@@ -2316,3 +2316,68 @@ func TestResticEnsureS3Bucket_UsesSessionTokenFromAdditionalEnv(t *testing.T) {
 		t.Errorf("expected X-Amz-Security-Token=my-session-token to reach S3, got %q", gotToken)
 	}
 }
+
+// TestResticInitRepoWithOptions_PreCreatesS3Bucket verifies that init
+// pre-creates a missing S3 bucket via ResticEnsureS3Bucket before attempting
+// the actual restic init, so the "Create bucket" button's stated behavior -
+// that init/backup no longer needs the bucket pre-provisioned by hand - is
+// actually true rather than aspirational UI copy.
+func TestResticInitRepoWithOptions_PreCreatesS3Bucket(t *testing.T) {
+	srv := newFakeS3BucketServer(t) // no bucket exists yet
+	cluster := newS3ModeCluster(&config.Config{
+		BackupRestic:               true,
+		BackupResticAws:            true,
+		BackupResticS3Mode:         config.ConstResticS3ModeNew,
+		BackupResticAwsBucket:      "init-precreate-bucket",
+		BackupResticAwsEndpoint:    srv.URL,
+		BackupResticAwsAccessKeyId: "AKIAFAKE",
+		BackupResticAwsRegion:      "us-east-1",
+	})
+	sm := new(state.StateMachine)
+	sm.Init()
+	cluster.StateMachine = sm
+
+	// The restic init step itself will fail in this test environment (no real
+	// restic binary/repository) - only the bucket pre-check side effect is
+	// under test here, so the returned error is intentionally ignored.
+	_ = cluster.ResticInitRepoWithOptions(backupmgr.ResticInitOption{})
+
+	result, err := cluster.ResticEnsureS3Bucket()
+	if err != nil {
+		t.Fatalf("unexpected error re-checking bucket: %v", err)
+	}
+	if result.Created {
+		t.Fatal("expected bucket to already exist (created during init pre-check), but it did not")
+	}
+}
+
+// TestResticInitRepoWithOptions_ProceedsWhenBucketPreCheckFails verifies that
+// a failing bucket pre-check (e.g. access denied) does not block init from
+// still being attempted - the pre-check is best-effort only, and restic's own
+// init error is what should surface for a genuinely unusable bucket.
+func TestResticInitRepoWithOptions_ProceedsWhenBucketPreCheckFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	t.Cleanup(srv.Close)
+
+	cluster := newS3ModeCluster(&config.Config{
+		BackupRestic:               true,
+		BackupResticAws:            true,
+		BackupResticS3Mode:         config.ConstResticS3ModeNew,
+		BackupResticAwsBucket:      "denied-bucket",
+		BackupResticAwsEndpoint:    srv.URL,
+		BackupResticAwsAccessKeyId: "AKIAFAKE",
+		BackupResticAwsRegion:      "us-east-1",
+	})
+	sm := new(state.StateMachine)
+	sm.Init()
+	cluster.StateMachine = sm
+
+	// Must not panic and must reach (and fail in) the real init step rather
+	// than returning early because the bucket pre-check errored.
+	err := cluster.ResticInitRepoWithOptions(backupmgr.ResticInitOption{})
+	if err == nil {
+		t.Fatal("expected init to still attempt and fail (no real restic binary here), not return nil early")
+	}
+}

--- a/cluster/cluster_bck_test.go
+++ b/cluster/cluster_bck_test.go
@@ -3,6 +3,8 @@ package cluster
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1457,14 +1459,14 @@ func newSavedSourceCluster(t *testing.T, conf *config.Config, password, awsSecre
 // appendCluster=true when BackupResticAws was false, corrupting the saved S3 prefix.
 func TestSavedS3SourceAppendClusterFalseNonAwsDest(t *testing.T) {
 	cluster := newSavedSourceCluster(t, &config.Config{
-		BackupRestic:                true,
-		BackupResticAws:             false, // current destination is local, not S3
+		BackupRestic:                  true,
+		BackupResticAws:               false, // current destination is local, not S3
 		BackupResticRepoAppendCluster: false,
-		BackupResticAwsBucket:       "mybucket",
-		BackupResticAwsPrefix:       "myprefix",
-		BackupResticAwsEndpoint:     "https://s3.example.com",
-		BackupResticAwsRegion:       "us-east-1",
-		BackupResticAwsAccessKeyId:  "AKID",
+		BackupResticAwsBucket:         "mybucket",
+		BackupResticAwsPrefix:         "myprefix",
+		BackupResticAwsEndpoint:       "https://s3.example.com",
+		BackupResticAwsRegion:         "us-east-1",
+		BackupResticAwsAccessKeyId:    "AKID",
 	}, "resticpass", "secretkey")
 
 	resolved, err := cluster.resticResolveSavedCopySource(config.ConstBackupArchiveModeResticAws, "")
@@ -1492,14 +1494,14 @@ func TestSavedS3SourceAppendClusterFalseNonAwsDest(t *testing.T) {
 // the saved S3 resolution appends it exactly once.
 func TestSavedS3SourceAppendClusterTrueAddsClusterName(t *testing.T) {
 	cluster := newSavedSourceCluster(t, &config.Config{
-		BackupRestic:                true,
-		BackupResticAws:             false, // current destination is local — should not affect S3 source
+		BackupRestic:                  true,
+		BackupResticAws:               false, // current destination is local — should not affect S3 source
 		BackupResticRepoAppendCluster: true,
-		BackupResticAwsBucket:       "mybucket",
-		BackupResticAwsPrefix:       "backup",
-		BackupResticAwsEndpoint:     "",
-		BackupResticAwsRegion:       "eu-west-1",
-		BackupResticAwsAccessKeyId:  "AKID",
+		BackupResticAwsBucket:         "mybucket",
+		BackupResticAwsPrefix:         "backup",
+		BackupResticAwsEndpoint:       "",
+		BackupResticAwsRegion:         "eu-west-1",
+		BackupResticAwsAccessKeyId:    "AKID",
 	}, "pass", "secret")
 
 	resolved, err := cluster.resticResolveSavedCopySource(config.ConstBackupArchiveModeResticAws, "")
@@ -1517,13 +1519,13 @@ func TestSavedS3SourceAppendClusterTrueAddsClusterName(t *testing.T) {
 // change the copy option already stored in the queue.
 func TestSavedS3SourceFreezeOnQueueTime(t *testing.T) {
 	conf := &config.Config{
-		BackupRestic:                true,
-		BackupResticAws:             false,
+		BackupRestic:                  true,
+		BackupResticAws:               false,
 		BackupResticRepoAppendCluster: true,
-		BackupResticAwsBucket:       "original-bucket",
-		BackupResticAwsPrefix:       "pfx",
-		BackupResticAwsRegion:       "us-east-1",
-		BackupResticAwsAccessKeyId:  "AKID",
+		BackupResticAwsBucket:         "original-bucket",
+		BackupResticAwsPrefix:         "pfx",
+		BackupResticAwsRegion:         "us-east-1",
+		BackupResticAwsAccessKeyId:    "AKID",
 	}
 	cluster := newSavedSourceCluster(t, conf, "original-pass", "original-secret")
 
@@ -1595,9 +1597,9 @@ func TestSavedS3SourceRejectsHybridPayload(t *testing.T) {
 // backup-restic-repository (S3 URL) are absent or unusable.
 func TestSavedS3SourceRejectsWhenNeitherStructuredNorLegacy(t *testing.T) {
 	cluster := newSavedSourceCluster(t, &config.Config{
-		BackupRestic:            true,
-		BackupResticAwsBucket:   "",            // no structured bucket
-		BackupResticRepository:  "/local/path", // not an S3 URL
+		BackupRestic:           true,
+		BackupResticAwsBucket:  "",            // no structured bucket
+		BackupResticRepository: "/local/path", // not an S3 URL
 	}, "pass", "secret")
 
 	opt := backupmgr.ResticCopyOption{
@@ -1977,7 +1979,7 @@ func TestPromoteResticS3Mode_HookClearsItself(t *testing.T) {
 	// Call twice to verify the hook clears itself after the first invocation.
 	cluster.promoteResticS3ModeOnBootSuccess()
 	cluster.Conf.BackupResticS3Mode = config.ConstResticS3ModeAuto // reset manually
-	cluster.promoteResticS3ModeOnBootSuccess()                      // second call should be no-op (hook already nil)
+	cluster.promoteResticS3ModeOnBootSuccess()                     // second call should be no-op (hook already nil)
 	// The hook should have been cleared on the first call; the second should be a no-op.
 	if rm.OnBootFetchSuccess != nil {
 		t.Error("expected OnBootFetchSuccess to be nil after first invocation")
@@ -2059,5 +2061,258 @@ func TestSavedS3SourceObeysS3ModeLegacy(t *testing.T) {
 	}
 	if strings.Contains(resolved.AWS.Bucket, "new") {
 		t.Errorf("new bucket leaked into resolved config: %q", resolved.AWS.Bucket)
+	}
+}
+
+// ── ResticEnsureS3Bucket tests ────────────────────────────────────────────────
+
+// newFakeS3BucketServer starts a minimal path-style S3 stub answering
+// HeadBucket/CreateBucket for ResticEnsureS3Bucket tests. It does not validate
+// SigV4 signatures - these tests exercise the resolve-then-call-S3 wiring, not
+// AWS request authentication.
+func newFakeS3BucketServer(t *testing.T, existingBuckets ...string) *httptest.Server {
+	t.Helper()
+	buckets := map[string]bool{}
+	for _, b := range existingBuckets {
+		buckets[b] = true
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bucket := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/"), "/", 2)[0]
+		switch r.Method {
+		case http.MethodHead:
+			if buckets[bucket] {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		case http.MethodPut:
+			buckets[bucket] = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotImplemented)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestResticEnsureS3Bucket_CreatesMissingBucket(t *testing.T) {
+	srv := newFakeS3BucketServer(t)
+	cluster := newS3ModeCluster(&config.Config{
+		BackupResticS3Mode:         config.ConstResticS3ModeNew,
+		BackupResticAwsBucket:      "missing-bucket",
+		BackupResticAwsEndpoint:    srv.URL,
+		BackupResticAwsAccessKeyId: "AKIAFAKE",
+		BackupResticAwsRegion:      "us-east-1",
+	})
+
+	result, err := cluster.ResticEnsureS3Bucket()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Created {
+		t.Fatal("expected created=true for missing bucket")
+	}
+	if result.Bucket != "missing-bucket" {
+		t.Errorf("expected bucket=missing-bucket, got %q", result.Bucket)
+	}
+}
+
+func TestResticEnsureS3Bucket_ExistingBucketIsNoOp(t *testing.T) {
+	srv := newFakeS3BucketServer(t, "existing-bucket")
+	cluster := newS3ModeCluster(&config.Config{
+		BackupResticS3Mode:         config.ConstResticS3ModeNew,
+		BackupResticAwsBucket:      "existing-bucket",
+		BackupResticAwsEndpoint:    srv.URL,
+		BackupResticAwsAccessKeyId: "AKIAFAKE",
+		BackupResticAwsRegion:      "us-east-1",
+	})
+
+	result, err := cluster.ResticEnsureS3Bucket()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Created {
+		t.Fatal("expected created=false for already-existing bucket")
+	}
+}
+
+func TestResticEnsureS3Bucket_LegacyURLMode(t *testing.T) {
+	srv := newFakeS3BucketServer(t)
+	cluster := newS3ModeCluster(&config.Config{
+		BackupResticS3Mode:         config.ConstResticS3ModeLegacy,
+		BackupResticRepository:     "s3:" + srv.URL + "/legacy-bucket",
+		BackupResticAwsAccessKeyId: "AKIAFAKE",
+		BackupResticAwsRegion:      "us-east-1",
+	})
+
+	result, err := cluster.ResticEnsureS3Bucket()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Created {
+		t.Fatal("expected created=true for missing legacy-mode bucket")
+	}
+	if result.Bucket != "legacy-bucket" {
+		t.Errorf("expected bucket=legacy-bucket, got %q", result.Bucket)
+	}
+}
+
+// TestResticEnsureS3Bucket_WorksWhenResticDisabled verifies bucket
+// pre-provisioning works even before backup-restic is turned on: the cluster
+// method itself performs no BackupRestic gating (the HTTP handler is the layer
+// that intentionally skips the "must be enabled" check for this endpoint).
+func TestResticEnsureS3Bucket_WorksWhenResticDisabled(t *testing.T) {
+	srv := newFakeS3BucketServer(t)
+	cluster := newS3ModeCluster(&config.Config{
+		BackupRestic:               false,
+		BackupResticS3Mode:         config.ConstResticS3ModeNew,
+		BackupResticAwsBucket:      "preprovision-bucket",
+		BackupResticAwsEndpoint:    srv.URL,
+		BackupResticAwsAccessKeyId: "AKIAFAKE",
+		BackupResticAwsRegion:      "us-east-1",
+	})
+
+	result, err := cluster.ResticEnsureS3Bucket()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Created {
+		t.Fatal("expected created=true")
+	}
+}
+
+// TestResticEnsureS3Bucket_WorksWhenS3NotActiveRepositoryType verifies the
+// saved S3 target is used even when a different repository type (local) is
+// the currently active one.
+func TestResticEnsureS3Bucket_WorksWhenS3NotActiveRepositoryType(t *testing.T) {
+	srv := newFakeS3BucketServer(t)
+	cluster := newS3ModeCluster(&config.Config{
+		BackupArchiveMode:           config.ConstBackupArchiveModeResticLocal,
+		BackupResticLocalRepository: "/var/lib/repman/backup/archive",
+		BackupResticS3Mode:          config.ConstResticS3ModeNew,
+		BackupResticAwsBucket:       "inactive-type-bucket",
+		BackupResticAwsEndpoint:     srv.URL,
+		BackupResticAwsAccessKeyId:  "AKIAFAKE",
+		BackupResticAwsRegion:       "us-east-1",
+	})
+
+	result, err := cluster.ResticEnsureS3Bucket()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Created {
+		t.Fatal("expected created=true")
+	}
+}
+
+func TestResticEnsureS3Bucket_UnresolvableAutoModeRejected(t *testing.T) {
+	cluster := newS3ModeCluster(&config.Config{
+		BackupResticS3Mode:     config.ConstResticS3ModeAuto,
+		BackupResticAwsBucket:  "",
+		BackupResticRepository: "", // not an S3 URL either
+	})
+
+	if _, err := cluster.ResticEnsureS3Bucket(); err == nil {
+		t.Fatal("expected error for unresolvable auto mode")
+	}
+}
+
+// TestResticEnsureS3Bucket_IgnoresRuntimeProbeCache is a regression test: auto
+// mode must resolve from field presence only, never from cluster.resolvedS3Mode
+// (the mode cached by the startup S3 probe). That cache prefers "new" but
+// falls back to "legacy" specifically when the new bucket isn't reachable yet
+// - i.e. exactly the situation a user is in when clicking "create bucket if
+// missing". If this method honored the cache, it would silently target (or
+// no-op against) the legacy bucket instead of creating the new one the user
+// actually asked for, with no way for the dashboard to know since it has no
+// visibility into resolvedS3Mode.
+func TestResticEnsureS3Bucket_IgnoresRuntimeProbeCache(t *testing.T) {
+	srv := newFakeS3BucketServer(t, "legacy-bucket") // legacy exists; new does not
+	cluster := newS3ModeCluster(&config.Config{
+		BackupResticS3Mode:         config.ConstResticS3ModeAuto,
+		BackupResticAwsBucket:      "new-bucket",
+		BackupResticAwsEndpoint:    srv.URL,
+		BackupResticAwsAccessKeyId: "AKIAFAKE",
+		BackupResticAwsRegion:      "us-east-1",
+		BackupResticRepository:     "s3:" + srv.URL + "/legacy-bucket",
+	})
+	// Simulate a startup auto-probe that fell back to legacy because the new
+	// bucket wasn't reachable at boot time.
+	cluster.resolvedS3Mode = config.ConstResticS3ModeLegacy
+
+	result, err := cluster.ResticEnsureS3Bucket()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Bucket != "new-bucket" {
+		t.Errorf("expected target bucket=new-bucket (presence-based resolution), got %q; resolvedS3Mode cache leaked into result", result.Bucket)
+	}
+	if !result.Created {
+		t.Error("expected created=true for the missing new-bucket")
+	}
+}
+
+func TestResticAdditionalEnvSessionTokenNotAllowlisted(t *testing.T) {
+	if token := resticAdditionalEnvSessionToken("", nil); token != "" {
+		t.Errorf("expected empty token when not allowlisted, got %q", token)
+	}
+	if token := resticAdditionalEnvSessionToken("AWS_REGION", nil); token != "" {
+		t.Errorf("expected empty token for unrelated allowlist entry, got %q", token)
+	}
+}
+
+func TestResticAdditionalEnvSessionTokenInlineOverride(t *testing.T) {
+	token := resticAdditionalEnvSessionToken("AWS_SESSION_TOKEN=inline-token-value", nil)
+	if token != "inline-token-value" {
+		t.Errorf("expected inline override value, got %q", token)
+	}
+}
+
+func TestResticAdditionalEnvSessionTokenFromBaseEnv(t *testing.T) {
+	baseEnv := []string{"PATH=/usr/bin", "AWS_SESSION_TOKEN=from-process-env"}
+	token := resticAdditionalEnvSessionToken("AWS_SESSION_TOKEN", baseEnv)
+	if token != "from-process-env" {
+		t.Errorf("expected token sourced from baseEnv, got %q", token)
+	}
+}
+
+func TestResticAdditionalEnvSessionTokenInvalidSyntax(t *testing.T) {
+	if token := resticAdditionalEnvSessionToken(`AWS_SESSION_TOKEN="unterminated`, nil); token != "" {
+		t.Errorf("expected empty token on parse error, got %q", token)
+	}
+}
+
+// TestResticEnsureS3Bucket_UsesSessionTokenFromAdditionalEnv is an end-to-end
+// regression test: an allowlisted AWS_SESSION_TOKEN must reach the S3 client
+// used for bucket creation, mirroring how it already reaches the restic
+// subprocess via filterResticEnv/ResticGetEnv.
+func TestResticEnsureS3Bucket_UsesSessionTokenFromAdditionalEnv(t *testing.T) {
+	var gotToken string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotToken = r.Header.Get("X-Amz-Security-Token")
+		switch r.Method {
+		case http.MethodHead:
+			w.WriteHeader(http.StatusNotFound)
+		case http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	cluster := newS3ModeCluster(&config.Config{
+		BackupResticS3Mode:         config.ConstResticS3ModeNew,
+		BackupResticAwsBucket:      "sts-bucket",
+		BackupResticAwsEndpoint:    srv.URL,
+		BackupResticAwsAccessKeyId: "AKIAFAKE",
+		BackupResticAwsRegion:      "us-east-1",
+		BackupResticAdditionalEnv:  "AWS_SESSION_TOKEN=my-session-token",
+	})
+
+	if _, err := cluster.ResticEnsureS3Bucket(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotToken != "my-session-token" {
+		t.Errorf("expected X-Amz-Security-Token=my-session-token to reach S3, got %q", gotToken)
 	}
 }

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -255,6 +255,11 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxResticWipeRepo)),
 	))
 
+	router.Handle("/api/clusters/{clusterName}/restic/create-bucket", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxResticCreateBucket)),
+	)).Methods("POST")
+
 	router.Handle("/api/clusters/{clusterName}/certificates", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterCertificates)),
@@ -8220,6 +8225,55 @@ func (repman *ReplicationManager) handlerMuxResticWipeRepo(w http.ResponseWriter
 
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(map[string]string{"message": "Repository wiped successfully."})
+	})
+}
+
+// handlerMuxResticCreateBucket handles the HTTP request to create the S3 bucket
+// backing the cluster's saved Restic S3 configuration, if it does not already
+// exist.
+//
+// This action is scoped to Restic-managed S3 repositories: it resolves the
+// saved S3 target via cluster/config logic (not active ResticManager runtime
+// state), so it also works when S3 is not the active repository type, or when
+// backup-restic is not yet enabled (pre-provisioning). It is not intended as a
+// general S3 administration API.
+//
+// The handler enforces GrantDBBackup directly so that a generic /restic grant
+// alone cannot authorize this remote storage mutation — URL-based ACL
+// fallback is intentionally bypassed, matching handlerMuxResticWipeRepo.
+// @Summary Create Restic S3 Bucket
+// @Description Idempotently creates the S3 bucket for the cluster's saved Restic S3 configuration if missing. Returns created=false when the bucket already exists and is accessible.
+// @Tags ClusterRestic
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Success 200 {object} cluster.ResticEnsureBucketResult "Bucket created or already exists"
+// @Failure 400 {object} map[string]string "Invalid request or non-S3 configuration"
+// @Failure 403 {string} string "No valid ACL or insufficient grant (db-backup required)"
+// @Failure 500 {string} string "No cluster"
+// @Router /api/clusters/{clusterName}/restic/create-bucket [post]
+func (repman *ReplicationManager) handlerMuxResticCreateBucket(w http.ResponseWriter, r *http.Request) {
+	repman.withResticCluster(w, r, false, func(mycluster *cluster.Cluster, vars map[string]string) {
+		// Enforce GrantDBBackup explicitly: URL-based ACL matching falls back to the
+		// generic /restic rule (GrantClusterProcess) via hierarchical pattern matching,
+		// which would allow users without backup permissions to mutate remote storage.
+		username := repman.GetUserFromRequest(r)
+		if u, ok := mycluster.APIUsers[username]; !ok || !u.Grants[config.GrantDBBackup] {
+			http.Error(w, "No valid ACL", http.StatusForbidden)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		result, err := mycluster.ResticEnsureS3Bucket()
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(result)
 	})
 }
 

--- a/server/api_restic_test.go
+++ b/server/api_restic_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -147,5 +148,303 @@ func TestHandlerResticCopy_ValidRequest(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "queued") {
 		t.Errorf("expected response body to mention 'queued', got: %s", w.Body.String())
+	}
+}
+
+// ── handlerMuxResticCreateBucket tests ────────────────────────────────────────
+
+// newFakeS3BucketServer starts a minimal path-style S3 stub answering
+// HeadBucket/CreateBucket for handlerMuxResticCreateBucket tests. It does not
+// validate SigV4 signatures - these tests exercise ACL/routing/resolution
+// wiring, not AWS request authentication.
+func newFakeS3BucketServer(t *testing.T, existingBuckets ...string) *httptest.Server {
+	t.Helper()
+	buckets := map[string]bool{}
+	for _, b := range existingBuckets {
+		buckets[b] = true
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bucket := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/"), "/", 2)[0]
+		switch r.Method {
+		case http.MethodHead:
+			if buckets[bucket] {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		case http.MethodPut:
+			buckets[bucket] = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotImplemented)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newCreateBucketRepman builds a ReplicationManager with JWT keys initialised
+// and the named cluster registered, with a single API user granted exactly
+// the given grants. Unlike newResticRepman, conf is caller-supplied so tests
+// can set arbitrary S3/legacy/auto-mode fields.
+func newCreateBucketRepman(t *testing.T, clusterName string, conf *config.Config, grants map[string]bool) (*ReplicationManager, string) {
+	t.Helper()
+
+	const (
+		testUser = "create-bucket-test-user"
+		testPass = "create-bucket-test-pass"
+	)
+
+	cl := &cluster.Cluster{
+		Name: clusterName,
+		Conf: conf,
+	}
+	cl.APIUsers = map[string]cluster.APIUser{
+		testUser: {
+			User:     testUser,
+			Password: testPass,
+			Grants:   grants,
+		},
+	}
+
+	repman := &ReplicationManager{
+		Clusters: map[string]*cluster.Cluster{clusterName: cl},
+		Conf:     &config.Config{TokenTimeout: 1},
+	}
+	repman.initKeys()
+
+	tok, err := repman.issueJWT(map[string]interface{}{
+		"Name":     testUser,
+		"Password": testPass,
+	}, "")
+	if err != nil {
+		t.Fatalf("issueJWT: %v", err)
+	}
+	return repman, tok
+}
+
+func newS3BucketTestConf(endpoint, bucket string) *config.Config {
+	conf := &config.Config{
+		BackupResticS3Mode:         config.ConstResticS3ModeNew,
+		BackupResticAwsBucket:      bucket,
+		BackupResticAwsEndpoint:    endpoint,
+		BackupResticAwsAccessKeyId: "AKIAFAKE",
+		BackupResticAwsRegion:      "us-east-1",
+	}
+	conf.Secrets = map[string]config.Secret{
+		"backup-restic-aws-access-secret": {Value: "secret"},
+	}
+	return conf
+}
+
+func TestHandlerResticCreateBucket_NoCluster(t *testing.T) {
+	repman := newTestRepmanWithCluster(t, "other-cluster", newTestClusterForAPI(t))
+	req := httptest.NewRequest(http.MethodPost, "/api/clusters/missing/restic/create-bucket", nil)
+	req = setMuxVars(req, map[string]string{"clusterName": "missing"})
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxResticCreateBucket(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for missing cluster, got %d", w.Code)
+	}
+}
+
+func TestHandlerResticCreateBucket_NoACL(t *testing.T) {
+	cl := newTestClusterForAPI(t)
+	repman := newTestRepmanWithCluster(t, "test-cluster", cl)
+	req := httptest.NewRequest(http.MethodPost, "/api/clusters/test-cluster/restic/create-bucket", nil)
+	req = setMuxVars(req, map[string]string{"clusterName": "test-cluster"})
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxResticCreateBucket(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 without JWT, got %d", w.Code)
+	}
+}
+
+func TestHandlerResticCreateBucket_ProcessOnlyUserDenied(t *testing.T) {
+	srv := newFakeS3BucketServer(t)
+	conf := newS3BucketTestConf(srv.URL, "some-bucket")
+	repman, tok := newCreateBucketRepman(t, "test-cluster", conf, map[string]bool{config.GrantClusterProcess: true})
+	req := httptest.NewRequest(http.MethodPost, "/api/clusters/test-cluster/restic/create-bucket", nil)
+	req = setMuxVars(req, map[string]string{"clusterName": "test-cluster"})
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tok))
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxResticCreateBucket(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for GrantClusterProcess-only user, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlerResticCreateBucket_BackupUserAllowed(t *testing.T) {
+	srv := newFakeS3BucketServer(t)
+	conf := newS3BucketTestConf(srv.URL, "missing-bucket")
+	repman, tok := newCreateBucketRepman(t, "test-cluster", conf, map[string]bool{config.GrantDBBackup: true})
+	req := httptest.NewRequest(http.MethodPost, "/api/clusters/test-cluster/restic/create-bucket", nil)
+	req = setMuxVars(req, map[string]string{"clusterName": "test-cluster"})
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tok))
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxResticCreateBucket(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for db-backup user, got %d: %s", w.Code, w.Body.String())
+	}
+	var result cluster.ResticEnsureBucketResult
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if !result.Created {
+		t.Errorf("expected created=true for missing bucket, got %+v", result)
+	}
+	if result.Bucket != "missing-bucket" {
+		t.Errorf("expected bucket=missing-bucket, got %q", result.Bucket)
+	}
+}
+
+func TestHandlerResticCreateBucket_NonS3ConfigRejected(t *testing.T) {
+	conf := &config.Config{
+		BackupResticS3Mode:     config.ConstResticS3ModeAuto,
+		BackupResticAwsBucket:  "",
+		BackupResticRepository: "/local/path/not/s3",
+	}
+	repman, tok := newCreateBucketRepman(t, "test-cluster", conf, map[string]bool{config.GrantDBBackup: true})
+	req := httptest.NewRequest(http.MethodPost, "/api/clusters/test-cluster/restic/create-bucket", nil)
+	req = setMuxVars(req, map[string]string{"clusterName": "test-cluster"})
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tok))
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxResticCreateBucket(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for non-S3 config, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlerResticCreateBucket_UnresolvableAutoModeRejected(t *testing.T) {
+	conf := &config.Config{
+		BackupResticS3Mode:     config.ConstResticS3ModeAuto,
+		BackupResticAwsBucket:  "",
+		BackupResticRepository: "",
+	}
+	repman, tok := newCreateBucketRepman(t, "test-cluster", conf, map[string]bool{config.GrantDBBackup: true})
+	req := httptest.NewRequest(http.MethodPost, "/api/clusters/test-cluster/restic/create-bucket", nil)
+	req = setMuxVars(req, map[string]string{"clusterName": "test-cluster"})
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tok))
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxResticCreateBucket(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unresolvable auto mode, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandlerResticCreateBucket_ResticDisabledStillWorks verifies pre-provisioning
+// works even when backup-restic itself is not yet enabled.
+func TestHandlerResticCreateBucket_ResticDisabledStillWorks(t *testing.T) {
+	srv := newFakeS3BucketServer(t)
+	conf := newS3BucketTestConf(srv.URL, "preprovision-bucket")
+	conf.BackupRestic = false
+	repman, tok := newCreateBucketRepman(t, "test-cluster", conf, map[string]bool{config.GrantDBBackup: true})
+	req := httptest.NewRequest(http.MethodPost, "/api/clusters/test-cluster/restic/create-bucket", nil)
+	req = setMuxVars(req, map[string]string{"clusterName": "test-cluster"})
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tok))
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxResticCreateBucket(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 when restic disabled but S3 config saved, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandlerResticCreateBucket_InactiveRepositoryTypeStillWorks verifies the
+// saved S3 target is used even when a different repository type (local) is
+// the currently active one.
+func TestHandlerResticCreateBucket_InactiveRepositoryTypeStillWorks(t *testing.T) {
+	srv := newFakeS3BucketServer(t)
+	conf := newS3BucketTestConf(srv.URL, "inactive-type-bucket")
+	conf.BackupArchiveMode = config.ConstBackupArchiveModeResticLocal
+	conf.BackupResticLocalRepository = "/var/lib/repman/backup/archive"
+	repman, tok := newCreateBucketRepman(t, "test-cluster", conf, map[string]bool{config.GrantDBBackup: true})
+	req := httptest.NewRequest(http.MethodPost, "/api/clusters/test-cluster/restic/create-bucket", nil)
+	req = setMuxVars(req, map[string]string{"clusterName": "test-cluster"})
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tok))
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxResticCreateBucket(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 when S3 saved but local is active, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlerResticCreateBucket_LegacyURLMode(t *testing.T) {
+	srv := newFakeS3BucketServer(t)
+	conf := &config.Config{
+		BackupResticS3Mode:         config.ConstResticS3ModeLegacy,
+		BackupResticRepository:     "s3:" + srv.URL + "/legacy-bucket",
+		BackupResticAwsAccessKeyId: "AKIAFAKE",
+		BackupResticAwsRegion:      "us-east-1",
+	}
+	conf.Secrets = map[string]config.Secret{
+		"backup-restic-aws-access-secret": {Value: "secret"},
+	}
+	repman, tok := newCreateBucketRepman(t, "test-cluster", conf, map[string]bool{config.GrantDBBackup: true})
+	req := httptest.NewRequest(http.MethodPost, "/api/clusters/test-cluster/restic/create-bucket", nil)
+	req = setMuxVars(req, map[string]string{"clusterName": "test-cluster"})
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tok))
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxResticCreateBucket(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for legacy S3 URL mode, got %d: %s", w.Code, w.Body.String())
+	}
+	var result cluster.ResticEnsureBucketResult
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if result.Bucket != "legacy-bucket" {
+		t.Errorf("expected bucket=legacy-bucket, got %q", result.Bucket)
+	}
+}
+
+// TestHandlerResticCreateBucket_ResponseDistinguishesCreatedTrueFalse verifies
+// the first call against a missing bucket reports created=true, and a second
+// call against the same (now-existing) bucket reports created=false.
+func TestHandlerResticCreateBucket_ResponseDistinguishesCreatedTrueFalse(t *testing.T) {
+	srv := newFakeS3BucketServer(t)
+	conf := newS3BucketTestConf(srv.URL, "idempotent-bucket")
+	repman, tok := newCreateBucketRepman(t, "test-cluster", conf, map[string]bool{config.GrantDBBackup: true})
+
+	doRequest := func() cluster.ResticEnsureBucketResult {
+		req := httptest.NewRequest(http.MethodPost, "/api/clusters/test-cluster/restic/create-bucket", nil)
+		req = setMuxVars(req, map[string]string{"clusterName": "test-cluster"})
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tok))
+		w := httptest.NewRecorder()
+		repman.handlerMuxResticCreateBucket(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var result cluster.ResticEnsureBucketResult
+		if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+			t.Fatalf("failed to decode response: %v", err)
+		}
+		return result
+	}
+
+	first := doRequest()
+	if !first.Created {
+		t.Errorf("expected created=true on first call, got %+v", first)
+	}
+	second := doRequest()
+	if second.Created {
+		t.Errorf("expected created=false on second (idempotent) call, got %+v", second)
 	}
 }

--- a/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
@@ -9,7 +9,7 @@ import Dropdown from '../../components/Dropdown'
 import ConfirmModal from '../../components/Modals/ConfirmModal'
 import { useTheme } from '../../ThemeProvider'
 import { setSetting, switchSetting } from '../../redux/settingsSlice'
-import { resticInitRepo, resticCheckConfig, resticCopyRepo, resticWipeRepo, getResticCurrentTask } from '../../redux/clusterSlice'
+import { resticInitRepo, resticCheckConfig, resticCopyRepo, resticWipeRepo, resticCreateBucket, getResticCurrentTask } from '../../redux/clusterSlice'
 import styles from './styles.module.scss'
 import tableStyles from '../../components/TableType2/styles.module.scss'
 
@@ -245,6 +245,37 @@ const TAB_LABELS = {
 
 const TAB_ORDER = ['local', 's3', 'sftp']
 
+// Mirrors parseLegacyS3ResticRepo in cluster/cluster_bck.go, for client-side
+// display of the effective bucket/endpoint target only. The server remains
+// the source of truth: it re-resolves and validates the real target itself.
+function parseLegacyS3Repo(rawURL) {
+  if (!rawURL || !rawURL.startsWith('s3:')) return null
+  let rest = rawURL.slice(3).trim()
+  if (!rest) return null
+  let endpoint = ''
+  if (rest.startsWith('https://') || rest.startsWith('http://')) {
+    const schemeSep = rest.indexOf('://')
+    const afterScheme = rest.slice(schemeSep + 3)
+    const slashIdx = afterScheme.indexOf('/')
+    if (slashIdx < 0) return null
+    endpoint = rest.slice(0, schemeSep + 3 + slashIdx)
+    rest = afterScheme.slice(slashIdx + 1)
+  } else {
+    const slashIdx = rest.indexOf('/')
+    if (slashIdx >= 0) {
+      const first = rest.slice(0, slashIdx)
+      if (/[.:]/.test(first)) {
+        endpoint = first
+        rest = rest.slice(slashIdx + 1)
+      }
+    }
+  }
+  const slashIdx = rest.indexOf('/')
+  const bucket = (slashIdx < 0 ? rest : rest.slice(0, slashIdx)).trim()
+  if (!bucket) return null
+  return { bucket, endpoint }
+}
+
 function ResticRepositorySettings({
   clusterName,
   config,
@@ -469,6 +500,52 @@ function ResticRepositorySettings({
   // savedS3Available: structured bucket config OR a legacy backup-restic-repository S3 URL
   const savedS3LegacyAvailable = !awsBucket && legacyRepoPath.startsWith('s3:')
   const savedS3Available = Boolean(awsBucket) || savedS3LegacyAvailable
+
+  // Create-bucket action targets the saved S3 config, even when S3 is not the
+  // active repository type - so its target is derived independently of archiveMode.
+  const legacyParsedS3 = parseLegacyS3Repo(config?.backupResticRepository || '')
+  const createBucketTargetBucket = resolvedS3Mode === 'new' ? awsBucket : (legacyParsedS3?.bucket || '')
+  const createBucketTargetEndpoint = resolvedS3Mode === 'new' ? trimmedEndpoint : (legacyParsedS3?.endpoint || '')
+  // Deliberately NOT savedS3Available: that flag means "some S3 config exists
+  // anywhere" (fine for the copy-source dropdown, which can use either saved
+  // config regardless of mode). This button acts on the currently selected
+  // s3Mode specifically, so it must gate on that mode's own resolved target -
+  // otherwise e.g. explicit mode=new with an empty bucket but a valid legacy
+  // URL would show enabled here while the server rejects it with a 400.
+  const hasResolvableS3Target = Boolean(createBucketTargetBucket)
+  const [createBucketLoading, setCreateBucketLoading] = useState(false)
+  const [createBucketResult, setCreateBucketResult] = useState(null)
+  // Signature of the fields that determine the saved S3 bucket-create target -
+  // used to invalidate stale createBucketResult feedback.
+  const s3BucketTargetSignature = [
+    s3Mode,
+    awsBucket,
+    awsPrefix,
+    awsEndpoint,
+    config?.backupResticRepository || '',
+    appendCluster
+  ].join('|')
+
+  useEffect(() => {
+    setCreateBucketResult(null)
+  }, [s3BucketTargetSignature])
+
+  const handleCreateBucket = async () => {
+    setCreateBucketLoading(true)
+    setCreateBucketResult(null)
+    try {
+      const result = await dispatch(resticCreateBucket({ clusterName })).unwrap()
+      const data = result?.data
+      setCreateBucketResult({
+        status: 'ok',
+        message: data?.message || (data?.created ? 'Bucket created.' : 'Bucket already exists.')
+      })
+    } catch (error) {
+      setCreateBucketResult({ status: 'error', message: error?.errorMessage || error?.message || String(error) })
+    } finally {
+      setCreateBucketLoading(false)
+    }
+  }
 
   const handleCheckRepo = async () => {
     setIsCheckLoading(true)
@@ -1319,6 +1396,46 @@ function ResticRepositorySettings({
                             </Text>
                           </GridItem>
                         </Grid>
+
+                        <Stack spacing={1} pt={1}>
+                          {resolvedS3Mode === 'legacy' && createBucketTargetBucket && (
+                            <Text className={styles.helperText}>
+                              Legacy mode target — bucket: <strong>{createBucketTargetBucket}</strong>
+                              {createBucketTargetEndpoint && (
+                                <> · endpoint: <strong>{createBucketTargetEndpoint}</strong></>
+                              )}
+                            </Text>
+                          )}
+                          <Box>
+                            <RMButton
+                              size='sm'
+                              colorScheme='blue'
+                              leftIcon={<HiDatabase />}
+                              onClick={handleCreateBucket}
+                              isLoading={createBucketLoading}
+                              isDisabled={user?.grants['db-backup'] === false || !hasResolvableS3Target}
+                            >
+                              Create bucket if missing
+                            </RMButton>
+                          </Box>
+                          {!hasResolvableS3Target && (
+                            <Text className={styles.helperText}>
+                              Complete the bucket / mode / legacy URL configuration above before creating the bucket.
+                            </Text>
+                          )}
+                          {createBucketResult && (
+                            <Alert
+                              status={createBucketResult.status === 'ok' ? 'success' : 'error'}
+                              size='sm'
+                              borderRadius='md'
+                              bg={isLight ? undefined : createBucketResult.status === 'ok' ? 'rgba(72,187,120,0.15)' : 'rgba(245,101,101,0.15)'}
+                              color='var(--text-color)'
+                            >
+                              <AlertIcon />
+                              <Text fontSize='sm'>{createBucketResult.message}</Text>
+                            </Alert>
+                          )}
+                        </Stack>
                       </Stack>
 
                       {/* 4. Advanced compatibility fallback */}

--- a/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/ResticRepositorySettings.jsx
@@ -1,6 +1,6 @@
 import { Box, Badge, Flex, FormControl, FormLabel, Grid, GridItem, HStack, Icon, Input, Select, Stack, Tab, TabList, TabPanel, TabPanels, Tabs, Text, VStack, Checkbox, Alert, AlertIcon, Divider, useDisclosure } from '@chakra-ui/react'
 import React, { useState, useEffect, useRef } from 'react'
-import { HiChevronDown, HiChevronUp, HiQuestionMarkCircle, HiCheckCircle, HiDatabase, HiArrowCircleRight, HiShieldExclamation, HiTrash, HiLockClosed } from 'react-icons/hi'
+import { HiChevronDown, HiChevronUp, HiQuestionMarkCircle, HiCheckCircle, HiDatabase, HiArrowCircleRight, HiShieldExclamation, HiTrash, HiLockClosed, HiPlusCircle } from 'react-icons/hi'
 import RMIconButton from '../../components/RMIconButton'
 import RMButton from '../../components/RMButton'
 import RMSwitch from '../../components/RMSwitch'
@@ -1325,15 +1325,53 @@ function ResticRepositorySettings({
                             </HStack>
                           </GridItem>
                           <GridItem className={styles.valueCell}>
-                            <TextForm
-                              value={config?.backupResticAwsBucket}
-                              confirmTitle={`Confirm backup-restic-aws-bucket to `}
-                              className={styles.textbox}
-                              size='sm'
-                              placeholder='bucket-name'
-                              regexPattern='^[^/\\\\]*$'
-                              onSave={(value) => handleSettingChange('backup-restic-aws-bucket', value)}
-                            />
+                            <HStack spacing={2} align='flex-start' justify='flex-start'>
+                              <TextForm
+                                value={config?.backupResticAwsBucket}
+                                confirmTitle={`Confirm backup-restic-aws-bucket to `}
+                                className={styles.textbox}
+                                size='sm'
+                                placeholder='bucket-name'
+                                regexPattern='^[^/\\\\]*$'
+                                onSave={(value) => handleSettingChange('backup-restic-aws-bucket', value)}
+                              />
+                              <RMIconButton
+                                icon={HiPlusCircle}
+                                size='sm'
+                                variant='outline'
+                                colorScheme='blue'
+                                tooltip='Create bucket'
+                                aria-label='Create bucket'
+                                onClick={handleCreateBucket}
+                                isLoading={createBucketLoading}
+                                isDisabled={user?.grants['db-backup'] === false || !hasResolvableS3Target}
+                                confirm
+                                confirmTitle='Create bucket?'
+                                confirmBody={
+                                  <Stack spacing={2} align='flex-start'>
+                                    <Text fontSize='sm'>
+                                      Optional pre-setup — init/backup already auto-create the bucket if missing.
+                                      Existing buckets are left unchanged.
+                                    </Text>
+                                    <Box
+                                      fontSize='sm'
+                                      fontFamily='monospace'
+                                      bg={isLight ? 'gray.100' : 'var(--tertiary-color)'}
+                                      p={2}
+                                      borderRadius='md'
+                                      wordBreak='break-all'
+                                      w='full'
+                                    >
+                                      {createBucketTargetEndpoint && (
+                                        <Text>endpoint: <strong>{createBucketTargetEndpoint}</strong></Text>
+                                      )}
+                                      <Text>bucket: <strong>{createBucketTargetBucket || '(unresolved)'}</strong></Text>
+                                    </Box>
+                                  </Stack>
+                                }
+                                confirmButtonText='Create bucket'
+                              />
+                            </HStack>
                             <Text className={styles.helperText}>Bucket name must not contain &apos;/&apos; or &apos;\\&apos;.</Text>
                           </GridItem>
                         </Grid>
@@ -1397,45 +1435,27 @@ function ResticRepositorySettings({
                           </GridItem>
                         </Grid>
 
-                        <Stack spacing={1} pt={1}>
-                          {resolvedS3Mode === 'legacy' && createBucketTargetBucket && (
-                            <Text className={styles.helperText}>
-                              Legacy mode target — bucket: <strong>{createBucketTargetBucket}</strong>
-                              {createBucketTargetEndpoint && (
-                                <> · endpoint: <strong>{createBucketTargetEndpoint}</strong></>
-                              )}
-                            </Text>
-                          )}
-                          <Box>
-                            <RMButton
-                              size='sm'
-                              colorScheme='blue'
-                              leftIcon={<HiDatabase />}
-                              onClick={handleCreateBucket}
-                              isLoading={createBucketLoading}
-                              isDisabled={user?.grants['db-backup'] === false || !hasResolvableS3Target}
-                            >
-                              Create bucket if missing
-                            </RMButton>
-                          </Box>
-                          {!hasResolvableS3Target && (
-                            <Text className={styles.helperText}>
-                              Complete the bucket / mode / legacy URL configuration above before creating the bucket.
-                            </Text>
-                          )}
-                          {createBucketResult && (
-                            <Alert
-                              status={createBucketResult.status === 'ok' ? 'success' : 'error'}
-                              size='sm'
-                              borderRadius='md'
-                              bg={isLight ? undefined : createBucketResult.status === 'ok' ? 'rgba(72,187,120,0.15)' : 'rgba(245,101,101,0.15)'}
-                              color='var(--text-color)'
-                            >
-                              <AlertIcon />
-                              <Text fontSize='sm'>{createBucketResult.message}</Text>
-                            </Alert>
-                          )}
-                        </Stack>
+                        {(hasResolvableS3Target === false || createBucketResult) && (
+                          <Stack spacing={1} pt={1}>
+                            {!hasResolvableS3Target && (
+                              <Text className={styles.helperText}>
+                                &quot;Create bucket&quot; is disabled: complete the bucket / mode / legacy URL configuration above first.
+                              </Text>
+                            )}
+                            {createBucketResult && (
+                              <Alert
+                                status={createBucketResult.status === 'ok' ? 'success' : 'error'}
+                                size='sm'
+                                borderRadius='md'
+                                bg={isLight ? undefined : createBucketResult.status === 'ok' ? 'rgba(72,187,120,0.15)' : 'rgba(245,101,101,0.15)'}
+                                color='var(--text-color)'
+                              >
+                                <AlertIcon />
+                                <Text fontSize='sm'>{createBucketResult.message}</Text>
+                              </Alert>
+                            )}
+                          </Stack>
+                        )}
                       </Stack>
 
                       {/* 4. Advanced compatibility fallback */}

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -527,6 +527,25 @@ export const resticWipeRepo = (clusterName, payload) => async (dispatch, getStat
   }
 }
 
+export const resticCreateBucket = createGuardedAsyncThunk(
+  'cluster/resticCreateBucket',
+  async ({ clusterName }, thunkAPI) => {
+    try {
+      const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+      const { data, status } = await clusterService.resticCreateBucket(clusterName, baseURL)
+      if (!status || status < 200 || status >= 300) {
+        const msg = (data && typeof data === 'object' && (data.error || data.message))
+          ? (data.error || data.message)
+          : (typeof data === 'string' && data) ? data : 'Create bucket request failed'
+        return thunkAPI.rejectWithValue({ errorMessage: msg, errorStatus: status || 500 })
+      }
+      return { data, status }
+    } catch (error) {
+      return handleError(error, thunkAPI)
+    }
+  }
+)
+
 export const getJobs = createGuardedAsyncThunk('cluster/getJobs', async ({ clusterName }, thunkAPI) => {
   try {
     const baseURL = thunkAPI.getState()?.auth?.baseURL || ''

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -38,6 +38,7 @@ export const clusterService = {
   resticCheckConfig,
   resticCopyRepo,
   resticWipeRepo,
+  resticCreateBucket,
 
   // Security / workload remediation APIs
   fixSecState,
@@ -975,6 +976,10 @@ function resticCopyRepo(clusterName, payload, baseURL) {
 
 function resticWipeRepo(clusterName, payload, baseURL) {
   return getApi(baseURL).post(`clusters/${clusterName}/restic/wipe`, payload)
+}
+
+function resticCreateBucket(clusterName, baseURL) {
+  return getApi(baseURL).post(`clusters/${clusterName}/restic/create-bucket`)
 }
 
 function fixSecState(clusterName, errKey, baseURL, tag) {

--- a/utils/s3helper/s3.go
+++ b/utils/s3helper/s3.go
@@ -68,6 +68,84 @@ func CheckObjectExists(client *s3.Client, bucket, key string) (bool, error) {
 	return true, nil
 }
 
+// bucketAPI is the subset of the S3 client used by EnsureBucket, factored out
+// for testability with a fake implementation.
+type bucketAPI interface {
+	HeadBucket(ctx context.Context, params *s3.HeadBucketInput, optFns ...func(*s3.Options)) (*s3.HeadBucketOutput, error)
+	CreateBucket(ctx context.Context, params *s3.CreateBucketInput, optFns ...func(*s3.Options)) (*s3.CreateBucketOutput, error)
+}
+
+// EnsureBucket makes the given bucket exist and be accessible with the
+// client's configured credentials, creating it if missing. It is idempotent:
+// an existing, accessible bucket is treated as success with created=false.
+func EnsureBucket(client *s3.Client, bucket string) (created bool, err error) {
+	return ensureBucket(client, bucket, client.Options().Region)
+}
+
+func ensureBucket(client bucketAPI, bucket, region string) (bool, error) {
+	bucket = strings.TrimSpace(bucket)
+	if bucket == "" {
+		return false, fmt.Errorf("S3 bucket name is required")
+	}
+
+	if err := probeBucketAccess(client, bucket); err == nil {
+		return false, nil
+	} else if !isS3ErrorCode(err, "NotFound", "NoSuchBucket") {
+		return false, err
+	}
+
+	_, createErr := client.CreateBucket(context.Background(), &s3.CreateBucketInput{
+		Bucket:                    aws.String(bucket),
+		CreateBucketConfiguration: bucketLocationConfiguration(region),
+	})
+	if createErr == nil {
+		return true, nil
+	}
+
+	if isS3ErrorCode(createErr, "BucketAlreadyOwnedByYou") {
+		return false, nil
+	}
+	if isS3ErrorCode(createErr, "BucketAlreadyExists") {
+		// Owned by another account, or eventual-consistency race with our own
+		// probe above. Re-check access before treating it as an error.
+		if probeErr := probeBucketAccess(client, bucket); probeErr == nil {
+			return false, nil
+		}
+		return false, fmt.Errorf("S3 bucket %s already exists and is not accessible with configured credentials", bucket)
+	}
+
+	return false, fmt.Errorf("S3 CreateBucket failed: %w", createErr)
+}
+
+func probeBucketAccess(client bucketAPI, bucket string) error {
+	_, err := client.HeadBucket(context.Background(), &s3.HeadBucketInput{Bucket: aws.String(bucket)})
+	if err == nil {
+		return nil
+	}
+	if isS3ErrorCode(err, "NotFound", "NoSuchBucket") {
+		return err
+	}
+	if isS3ErrorCode(err, "Forbidden", "AccessDenied") {
+		return fmt.Errorf("access denied to S3 bucket %s (check credentials/permissions)", bucket)
+	}
+	return fmt.Errorf("S3 HeadBucket failed: %w", err)
+}
+
+// bucketLocationConfiguration returns the CreateBucketConfiguration required
+// for region-specific bucket creation. AWS rejects an explicit
+// LocationConstraint for us-east-1 (its implicit default region), and
+// S3-compatible providers with no configured region expect no constraint at
+// all, so both cases return nil.
+func bucketLocationConfiguration(region string) *types.CreateBucketConfiguration {
+	region = strings.TrimSpace(region)
+	if region == "" || strings.EqualFold(region, "us-east-1") {
+		return nil
+	}
+	return &types.CreateBucketConfiguration{
+		LocationConstraint: types.BucketLocationConstraint(region),
+	}
+}
+
 type DeletePrefixOptions struct {
 	DryRun                bool
 	MaxObjects            int

--- a/utils/s3helper/s3_test.go
+++ b/utils/s3helper/s3_test.go
@@ -191,3 +191,162 @@ func TestEnsurePrefixMarkerCreatesWhenEmpty(t *testing.T) {
 		t.Fatalf("expected marker to be created")
 	}
 }
+
+// fakeBucketClient implements bucketAPI for EnsureBucket tests.
+type fakeBucketClient struct {
+	// headErrs is consumed in order across successive HeadBucket calls; the
+	// last entry is reused once exhausted. A nil entry means success.
+	headErrs      []error
+	headCalls     int
+	createErr     error
+	createCalls   int
+	createdConfig *types.CreateBucketConfiguration
+}
+
+func (f *fakeBucketClient) HeadBucket(ctx context.Context, params *s3.HeadBucketInput, optFns ...func(*s3.Options)) (*s3.HeadBucketOutput, error) {
+	idx := f.headCalls
+	if idx >= len(f.headErrs) {
+		idx = len(f.headErrs) - 1
+	}
+	f.headCalls++
+	if idx >= 0 && f.headErrs[idx] != nil {
+		return nil, f.headErrs[idx]
+	}
+	return &s3.HeadBucketOutput{}, nil
+}
+
+func (f *fakeBucketClient) CreateBucket(ctx context.Context, params *s3.CreateBucketInput, optFns ...func(*s3.Options)) (*s3.CreateBucketOutput, error) {
+	f.createCalls++
+	f.createdConfig = params.CreateBucketConfiguration
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	return &s3.CreateBucketOutput{}, nil
+}
+
+func TestEnsureBucketEmptyName(t *testing.T) {
+	client := &fakeBucketClient{}
+	if _, err := ensureBucket(client, "  ", ""); err == nil {
+		t.Fatal("expected error for empty bucket name")
+	}
+	if client.headCalls != 0 || client.createCalls != 0 {
+		t.Fatalf("expected no S3 calls for empty bucket name, got head=%d create=%d", client.headCalls, client.createCalls)
+	}
+}
+
+func TestEnsureBucketExistingAccessible(t *testing.T) {
+	client := &fakeBucketClient{headErrs: []error{nil}}
+	created, err := ensureBucket(client, "mybucket", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if created {
+		t.Fatal("expected created=false for already-accessible bucket")
+	}
+	if client.createCalls != 0 {
+		t.Fatalf("expected no CreateBucket call, got %d", client.createCalls)
+	}
+}
+
+func TestEnsureBucketMissingCreates(t *testing.T) {
+	client := &fakeBucketClient{headErrs: []error{&smithy.GenericAPIError{Code: "NotFound"}}}
+	created, err := ensureBucket(client, "mybucket", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !created {
+		t.Fatal("expected created=true for missing bucket")
+	}
+	if client.createCalls != 1 {
+		t.Fatalf("expected one CreateBucket call, got %d", client.createCalls)
+	}
+}
+
+func TestEnsureBucketAccessDenied(t *testing.T) {
+	client := &fakeBucketClient{headErrs: []error{&smithy.GenericAPIError{Code: "Forbidden"}}}
+	if _, err := ensureBucket(client, "mybucket", ""); err == nil {
+		t.Fatal("expected access-denied error")
+	}
+	if client.createCalls != 0 {
+		t.Fatalf("expected no CreateBucket call on access denied, got %d", client.createCalls)
+	}
+}
+
+func TestEnsureBucketCreateBucketAlreadyOwnedByYou(t *testing.T) {
+	client := &fakeBucketClient{
+		headErrs:  []error{&smithy.GenericAPIError{Code: "NotFound"}},
+		createErr: &smithy.GenericAPIError{Code: "BucketAlreadyOwnedByYou"},
+	}
+	created, err := ensureBucket(client, "mybucket", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if created {
+		t.Fatal("expected created=false when BucketAlreadyOwnedByYou")
+	}
+}
+
+func TestEnsureBucketCreateBucketAlreadyExistsButAccessible(t *testing.T) {
+	// First HeadBucket (pre-create probe) reports missing; the race-recovery
+	// probe after BucketAlreadyExists reports accessible.
+	client := &fakeBucketClient{
+		headErrs:  []error{&smithy.GenericAPIError{Code: "NotFound"}, nil},
+		createErr: &smithy.GenericAPIError{Code: "BucketAlreadyExists"},
+	}
+	created, err := ensureBucket(client, "mybucket", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if created {
+		t.Fatal("expected created=false when bucket already exists and is accessible")
+	}
+}
+
+func TestEnsureBucketCreateBucketAlreadyExistsNotAccessible(t *testing.T) {
+	client := &fakeBucketClient{
+		headErrs:  []error{&smithy.GenericAPIError{Code: "NotFound"}, &smithy.GenericAPIError{Code: "Forbidden"}},
+		createErr: &smithy.GenericAPIError{Code: "BucketAlreadyExists"},
+	}
+	if _, err := ensureBucket(client, "mybucket", ""); err == nil {
+		t.Fatal("expected error when bucket already exists and is not accessible")
+	}
+}
+
+func TestEnsureBucketCreateBucketGenericError(t *testing.T) {
+	client := &fakeBucketClient{
+		headErrs:  []error{&smithy.GenericAPIError{Code: "NotFound"}},
+		createErr: &smithy.GenericAPIError{Code: "InternalError"},
+	}
+	if _, err := ensureBucket(client, "mybucket", ""); err == nil {
+		t.Fatal("expected error for generic CreateBucket failure")
+	}
+}
+
+func TestBucketLocationConfigurationUsEast1(t *testing.T) {
+	if cfg := bucketLocationConfiguration("us-east-1"); cfg != nil {
+		t.Fatalf("expected nil LocationConstraint for us-east-1, got %+v", cfg)
+	}
+	if cfg := bucketLocationConfiguration(""); cfg != nil {
+		t.Fatalf("expected nil LocationConstraint for empty region, got %+v", cfg)
+	}
+}
+
+func TestBucketLocationConfigurationOtherRegion(t *testing.T) {
+	cfg := bucketLocationConfiguration("eu-west-1")
+	if cfg == nil {
+		t.Fatal("expected non-nil LocationConstraint for eu-west-1")
+	}
+	if cfg.LocationConstraint != types.BucketLocationConstraint("eu-west-1") {
+		t.Fatalf("unexpected LocationConstraint: %v", cfg.LocationConstraint)
+	}
+}
+
+func TestEnsureBucketPassesRegionToCreateBucketConfiguration(t *testing.T) {
+	client := &fakeBucketClient{headErrs: []error{&smithy.GenericAPIError{Code: "NotFound"}}}
+	if _, err := ensureBucket(client, "mybucket", "eu-west-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.createdConfig == nil || client.createdConfig.LocationConstraint != types.BucketLocationConstraint("eu-west-1") {
+		t.Fatalf("expected region-specific CreateBucketConfiguration, got %+v", client.createdConfig)
+	}
+}


### PR DESCRIPTION
## Summary
- add a manual Restic S3 bucket creation action in the repository settings UI
- add backend S3 bucket ensure/create support with explicit db-backup permission enforcement
- pre-create the S3 bucket before restic init and add coverage for UI/server/cluster/s3 helper flows

## Testing
- go test ./utils/s3helper ./cluster ./server
- go test ./cluster