### PR TITLE
fix(startup): guard nil CheckSumConfig — boot panic when subscription-plan sync saves during InitConfig

### DIFF
--- a/server/config_save_test.go
+++ b/server/config_save_test.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+)
+
+// TestSaveGlobalConfigs_NilCheckSumConfig pins the boot-crash regression fixed by
+// the nil-map guard in SaveGlobalConfigs. A config save can be triggered before
+// CheckSumConfig is allocated — syncSubscriptionPlanFromCRM persists the plan
+// synchronously at the tail of InitConfig, well before the map is created later in
+// startup. Writing to a nil map panics; the save path must instead find it ready.
+func TestSaveGlobalConfigs_NilCheckSumConfig(t *testing.T) {
+	repman := &ReplicationManager{
+		Conf: &config.Config{
+			ConfRewrite: true,
+			WorkingDir:  t.TempDir(),
+		},
+	}
+
+	// CheckSumConfig left nil on purpose, reproducing the early-startup state.
+	if err := repman.SaveGlobalConfigs(); err != nil {
+		t.Fatalf("SaveGlobalConfigs returned an error with nil CheckSumConfig: %v", err)
+	}
+
+	if repman.CheckSumConfig == nil {
+		t.Fatal("SaveGlobalConfigs must lazily initialize CheckSumConfig when nil")
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -4299,6 +4299,14 @@ func (repman *ReplicationManager) SaveCallBack() error {
 func (repman *ReplicationManager) SaveGlobalConfigs() error {
 	var err error
 
+	// CheckSumConfig is created later in the startup sequence, but a config save can
+	// be triggered earlier — e.g. syncSubscriptionPlanFromCRM at the tail of InitConfig
+	// persists the subscription plan synchronously. Writing to a nil map panics, so make
+	// it on demand: any caller reaching a save must find the map ready.
+	if repman.CheckSumConfig == nil {
+		repman.CheckSumConfig = make(map[string]hash.Hash)
+	}
+
 	_, file, no, ok := runtime.Caller(1)
 	if ok {
 		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModConfigLoad, config.LvlDbg, "Saved called from %s#%d\n", file, no)


### PR DESCRIPTION
## Crash

```
server.(*ReplicationManager).SaveDynamic          server/server.go:4222
server.(*ReplicationManager).SaveGlobalConfigs    server/server.go:4311
server.(*ReplicationManager).SaveCallBack         server/server.go:4294
config/manager.(*ConfigManager).SaveConfig        config/manager/manager.go:388
server.(*ReplicationManager).persistInstanceSubscriptionPlan   server/api_register.go:947
server.(*ReplicationManager).syncSubscriptionPlanFromCRM(WithToken)  server/api_register.go:1036/1050
server.(*ReplicationManager).InitConfig           server/server.go:1955
```

## Root cause

`syncSubscriptionPlanFromCRM()` runs at the **tail of `InitConfig`** (server.go:1955) and persists the plan **synchronously** — `SaveConfig(repman, true)` → `SaveGlobalConfigs` → `SaveDynamic`. But `CheckSumConfig` isn't created until **line 2374**, a later startup step. `SaveDynamic` writes `repman.CheckSumConfig["saved"] = new_h` to a **nil map → panic ("assignment to entry in nil map")**, crashing on boot.

Surfaced by the #1591 merge: the config-sync rework (`SaveConfig`/`SaveGlobalConfigs`) met develop's subscription-plan sync, which fires a save earlier in startup than any save ran before.

## Fix

Lazily initialize `CheckSumConfig` at the top of `SaveGlobalConfigs` — order-independent, so any early save finds the map ready. Config **content is unaffected**: `Conf`, `DefaultFlagMap` (server.go:299) and `ImmuableFlagMap` (server.go:1910) are all populated before the sync runs, so the persisted `default.toml` is correct.

## Validation

- `go build --tags server` passes (pro binary).
- Fix is on the exact panic path and covers `SaveDynamic` + `SaveImmutable` reached via `SaveGlobalConfigs`.

Blocks the **v3.1.32** release — recommend merge + rebuild.