### PR TITLE
fix(startup): allocate CheckSumConfig at construction (durable follow-up to #1593)

### DIFF
--- a/server/config_save_test.go
+++ b/server/config_save_test.go
@@ -4,13 +4,43 @@ import (
 	"testing"
 
 	"github.com/signal18/replication-manager/config"
+	"github.com/spf13/viper"
 )
 
-// TestSaveGlobalConfigs_NilCheckSumConfig pins the boot-crash regression fixed by
-// the nil-map guard in SaveGlobalConfigs. A config save can be triggered before
-// CheckSumConfig is allocated — syncSubscriptionPlanFromCRM persists the plan
-// synchronously at the tail of InitConfig, well before the map is created later in
-// startup. Writing to a nil map panics; the save path must instead find it ready.
+// TestSetDefaultFlags_InitsCheckSumConfig verifies the source fix: CheckSumConfig is
+// allocated at the earliest startup init (before InitConfig and any save), so no
+// config-save path can hit a nil map.
+func TestSetDefaultFlags_InitsCheckSumConfig(t *testing.T) {
+	repman := &ReplicationManager{Conf: &config.Config{}}
+
+	repman.SetDefaultFlags(viper.New())
+
+	if repman.CheckSumConfig == nil {
+		t.Fatal("SetDefaultFlags must allocate CheckSumConfig")
+	}
+}
+
+// TestSaveDynamic_NilSafeAfterSetDefaultFlags exercises a direct writer. SaveDynamic
+// writes CheckSumConfig itself and is not individually guarded — the SetDefaultFlags
+// init is what keeps it (and ReloadTerms, Overwrite) nil-safe. Pins that guarantee.
+func TestSaveDynamic_NilSafeAfterSetDefaultFlags(t *testing.T) {
+	repman := &ReplicationManager{
+		Conf: &config.Config{WorkingDir: t.TempDir()},
+	}
+
+	repman.SetDefaultFlags(viper.New())
+
+	if _, err := repman.SaveDynamic(); err != nil {
+		t.Fatalf("SaveDynamic returned an error: %v", err)
+	}
+	if repman.CheckSumConfig == nil {
+		t.Fatal("CheckSumConfig must be set after SetDefaultFlags + SaveDynamic")
+	}
+}
+
+// TestSaveGlobalConfigs_NilCheckSumConfig pins the defensive guard in SaveGlobalConfigs:
+// a bare ReplicationManager (no SetDefaultFlags) with a nil CheckSumConfig must still
+// not panic when a save is triggered — the release-blocking boot regression.
 func TestSaveGlobalConfigs_NilCheckSumConfig(t *testing.T) {
 	repman := &ReplicationManager{
 		Conf: &config.Config{

--- a/server/server.go
+++ b/server/server.go
@@ -308,6 +308,15 @@ func (repman *ReplicationManager) SetDefaultFlags(v *viper.Viper) {
 		//	fmt.Printf("%s %v \n", f, v.Get(f))
 	}
 
+	// CheckSumConfig is written by every config-save path (SaveDynamic, SaveImmutable,
+	// Overwrite, ReloadTerms). Allocate it here — at the earliest startup init, before
+	// InitConfig and therefore before any save, however early (e.g. the subscription-plan
+	// sync at the tail of InitConfig) — so no writer can ever hit a nil map. Guarded so
+	// the repeated SetDefaultFlags calls (secret-store setup) don't reset live checksums.
+	if repman.CheckSumConfig == nil {
+		repman.CheckSumConfig = make(map[string]hash.Hash)
+	}
+
 	/*flags.VisitAll(func(f *pflag.Flag) {
 		fmt.Printf("%s,%v", f.Name, f.Value)
 		repman.DefaultFlagMapBis[f.Name] = f.Value
@@ -4299,10 +4308,10 @@ func (repman *ReplicationManager) SaveCallBack() error {
 func (repman *ReplicationManager) SaveGlobalConfigs() error {
 	var err error
 
-	// CheckSumConfig is created later in the startup sequence, but a config save can
-	// be triggered earlier — e.g. syncSubscriptionPlanFromCRM at the tail of InitConfig
-	// persists the subscription plan synchronously. Writing to a nil map panics, so make
-	// it on demand: any caller reaching a save must find the map ready.
+	// CheckSumConfig is allocated at startup in SetDefaultFlags, before any save can run.
+	// This guard is defensive insurance for callers that construct a ReplicationManager
+	// without that path (e.g. tests): writing to a nil map panics, so never let a save
+	// reach the writes below with the map unset.
 	if repman.CheckSumConfig == nil {
 		repman.CheckSumConfig = make(map[string]hash.Hash)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -2380,7 +2380,13 @@ func (repman *ReplicationManager) Run() error {
 	repman.CpuProfile = cpuprofile
 	repman.cApiLog = clog.New()
 	repman.clog = clog.New()
-	repman.CheckSumConfig = make(map[string]hash.Hash)
+	// Guarded: SetDefaultFlags already allocates this map before InitConfig runs, and
+	// InitConfig's subscription-plan sync may have already populated it with real
+	// checksums. Overwriting unconditionally here would discard that work and force
+	// the next SaveGlobalConfigs call to see a spurious checksum miss.
+	if repman.CheckSumConfig == nil {
+		repman.CheckSumConfig = make(map[string]hash.Hash)
+	}
 	repman.ApiLogAdapter = NewApiLogAdapter(repman.Conf.APIErrorSuppress, repman.Conf.APIErrorLimit, repman.Conf.APIErrorLimitDuration, repman.Conf.APIErrorDisregardPort)
 	repman.InitWebTTY()
 	repman.DiskStatManager = misc.NewDiskStatManager()


### PR DESCRIPTION
Follow-up to #1593 (whose guard is already on develop and fixes the boot crash). This adds the **durable source fix** that missed the #1593 merge by one commit.

## Change
Allocate `CheckSumConfig` in `SetDefaultFlags` — the earliest startup init, before `InitConfig` and any save — so **every** direct writer (`SaveDynamic`, `SaveImmutable`, `Overwrite`, `ReloadTerms`) is nil-safe, not just the `SaveGlobalConfigs` path. Addresses the review point that the `SaveGlobalConfigs`-local guard wouldn't cover future early direct writers (as `ReloadTerms` already is).

The `SaveGlobalConfigs` guard stays as cheap defensive insurance for callers that bypass `SetDefaultFlags` (e.g. tests). Conditional (`if nil`) so the repeated `SetDefaultFlags` calls from secret-store setup don't reset live checksums.

## Tests (all pass under `go test --tags server`)
- `SetDefaultFlags` allocates the map.
- A direct `SaveDynamic` after `SetDefaultFlags` doesn't panic (exercises a writer with no local guard).
- The `SaveGlobalConfigs` guard still covers a bare nil-map instance.

`go build --tags server` (pro) passes. Closes #1594.