### PR TITLE
fix(crash): recover empty lost-events delta after restart + reconcile stale rejoin verdict (crash-pill state)

### DIFF
--- a/cluster/crash.go
+++ b/cluster/crash.go
@@ -232,15 +232,14 @@ func (crash *Crash) backfillDeltaFromArchiveDir() {
 				crash.DeltaFlashbackDecoded = full
 			}
 		case strings.HasSuffix(name, ".sql"):
-			// The forward decode is <archivedBinlog>.sql. When several segments were
-			// captured, prefer the one for this crash's master log file; else take the
-			// first decode found (DeltaDecoded still empty).
-			binlog := strings.TrimSuffix(name, ".sql")
-			if crash.DeltaDecoded == "" || (crash.FailoverMasterLogFile != "" && strings.HasSuffix(binlog, crash.FailoverMasterLogFile)) {
+			// The forward decode is <archivedBinlog>.sql. A crash-bin dir holds exactly
+			// one binlog/.sql/.flashback.sql triple — saveBinlog names it from the
+			// crash's FailoverMasterLogFile, which is fixed for the life of a Crash — so
+			// the first forward .sql is the one. DeltaArchive is kept in lockstep with
+			// the decode it was rendered from.
+			if crash.DeltaDecoded == "" {
 				crash.DeltaDecoded = full
-				if crash.DeltaArchive == "" {
-					crash.DeltaArchive = crash.ArchiveDir + "/" + binlog
-				}
+				crash.DeltaArchive = strings.TrimSuffix(full, ".sql")
 			}
 		}
 	}

--- a/cluster/crash.go
+++ b/cluster/crash.go
@@ -179,11 +179,59 @@ func (cluster *Cluster) ensureCrashArchive(crash *Crash) string {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Could not create crash archive dir %s: %s", crash.ArchiveDir, err)
 		return crash.ArchiveDir
 	}
+	// Never persist an EMPTY delta over files already captured in this dir. A
+	// re-materialized crash object (disk-truth reload, peer fetch) can reach here
+	// without the delta metadata even though saveBinlog/decodeLostEvents already
+	// wrote the binlog + .sql beside crash.json — the save would then clobber the
+	// on-disk paths with "" and the lost-events viewer shows an empty delta after
+	// restart. Recover the paths from the dir first so a save can't drop them.
+	crash.backfillDeltaFromArchiveDir()
 	if err := crash.Save(crash.ArchiveDir + "/crash.json"); err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Could not write crash metadata %s/crash.json: %s", crash.ArchiveDir, err)
 	}
 	cluster.pruneCrashArchives(cluster.Conf.FailoverLogFileKeep)
 	return crash.ArchiveDir
+}
+
+// backfillDeltaFromArchiveDir re-links the decoded lost-events paths from the crash's
+// own archive dir when the in-memory record lost them. saveBinlog/decodeLostEvents write
+// the captured binlog and its <binlog>.sql (and, when reversible, <binlog>.flashback.sql)
+// into ArchiveDir, but a later save from a re-materialized crash object — or a reload from
+// a crash.json written before the decode — can leave DeltaDecoded empty while the files sit
+// on disk, so the viewer renders an empty delta. This resolves them from the dir. No-op when
+// DeltaDecoded is already set or no decode has been written yet.
+func (crash *Crash) backfillDeltaFromArchiveDir() {
+	if crash == nil || crash.ArchiveDir == "" || crash.DeltaDecoded != "" {
+		return
+	}
+	entries, err := os.ReadDir(crash.ArchiveDir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		full := crash.ArchiveDir + "/" + name
+		switch {
+		case strings.HasSuffix(name, ".flashback.sql"):
+			if crash.DeltaFlashbackDecoded == "" {
+				crash.DeltaFlashbackDecoded = full
+			}
+		case strings.HasSuffix(name, ".sql"):
+			// The forward decode is <archivedBinlog>.sql. When several segments were
+			// captured, prefer the one for this crash's master log file; else take the
+			// first decode found (DeltaDecoded still empty).
+			binlog := strings.TrimSuffix(name, ".sql")
+			if crash.DeltaDecoded == "" || (crash.FailoverMasterLogFile != "" && strings.HasSuffix(binlog, crash.FailoverMasterLogFile)) {
+				crash.DeltaDecoded = full
+				if crash.DeltaArchive == "" {
+					crash.DeltaArchive = crash.ArchiveDir + "/" + binlog
+				}
+			}
+		}
+	}
 }
 
 // pruneCrashArchives bounds crash-bin dirs to the <keep> most recent (dir name is
@@ -571,6 +619,12 @@ func (cluster *Cluster) LoadFailoverHistory() {
 		if data, err := os.ReadFile(dirPath + "/crash.json"); err == nil {
 			crash := new(Crash)
 			if json.Unmarshal(data, crash) == nil {
+				// The dir is authoritative for its own location; a crash.json written
+				// before the decode (or by a re-materialized object) can carry empty
+				// delta paths while the binlog + .sql sit right here. Re-link them so a
+				// restart does not lose the lost-events delta.
+				crash.ArchiveDir = dirPath
+				crash.backfillDeltaFromArchiveDir()
 				history = append(history, crash)
 			}
 			continue

--- a/cluster/crash.go
+++ b/cluster/crash.go
@@ -122,7 +122,19 @@ const (
 	RejoinResultNoMethod      = "no-rejoin-method"   // not flashback-able and no SST method armed
 	RejoinResultPeerUnreached = "peer-unreachable"   // minority could not fetch the verdict (transient split)
 	RejoinResultFailed        = "failed"             // generic execution failure
+	RejoinResultRecovered     = "recovered"          // a FAILED rejoin whose node later became a healthy slave by other means (manual start-slave, save+start, attach) — reconciled so history stops reporting a stale failure
 )
+
+// isRejoinFailedResult reports whether a finished rejoin outcome is a FAILURE that
+// the GUI blinks on and that assertRejoinResultStates raises a WARNING for. Kept in
+// sync with the frontend REJOIN_FAILED set (Navbar / LostEventsModal / HADetail).
+func isRejoinFailedResult(result string) bool {
+	switch result {
+	case RejoinResultNotFlashback, RejoinResultNoMethod, RejoinResultFailed, RejoinResultPeerUnreached:
+		return true
+	}
+	return false
+}
 
 // Collection of Crash reports
 // swagger:response crashList

--- a/cluster/crash_delta_test.go
+++ b/cluster/crash_delta_test.go
@@ -1,0 +1,50 @@
+package cluster
+
+import (
+	"os"
+	"testing"
+)
+
+// TestBackfillDeltaFromArchiveDir pins the delta-persistence recovery: when a crash's
+// metadata lost the decoded paths but the binlog + .sql are still in its archive dir
+// (the observed empty-delta-after-restart bug), backfill re-links them from disk.
+func TestBackfillDeltaFromArchiveDir(t *testing.T) {
+	dir := t.TempDir()
+	binlog := "curepipe-server123-log-bin.000014"
+	for name, body := range map[string]string{
+		binlog:                    "BINLOG",
+		binlog + ".sql":           "DELTA SQL",
+		binlog + ".flashback.sql": "UNDO SQL",
+	} {
+		if err := os.WriteFile(dir+"/"+name, []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	crash := &Crash{ArchiveDir: dir, FailoverMasterLogFile: "log-bin.000014"}
+	crash.backfillDeltaFromArchiveDir()
+
+	if want := dir + "/" + binlog + ".sql"; crash.DeltaDecoded != want {
+		t.Fatalf("DeltaDecoded = %q, want %q", crash.DeltaDecoded, want)
+	}
+	if want := dir + "/" + binlog; crash.DeltaArchive != want {
+		t.Fatalf("DeltaArchive = %q, want %q", crash.DeltaArchive, want)
+	}
+	if want := dir + "/" + binlog + ".flashback.sql"; crash.DeltaFlashbackDecoded != want {
+		t.Fatalf("DeltaFlashbackDecoded = %q, want %q", crash.DeltaFlashbackDecoded, want)
+	}
+}
+
+// TestBackfillDeltaFromArchiveDir_NoClobber verifies backfill never overwrites a delta
+// path that is already set (the in-memory record is authoritative when present).
+func TestBackfillDeltaFromArchiveDir_NoClobber(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(dir+"/some-log-bin.000001.sql", []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	crash := &Crash{ArchiveDir: dir, DeltaDecoded: "/already/set.sql"}
+	crash.backfillDeltaFromArchiveDir()
+	if crash.DeltaDecoded != "/already/set.sql" {
+		t.Fatalf("backfill overwrote an existing DeltaDecoded: %q", crash.DeltaDecoded)
+	}
+}

--- a/cluster/crash_delta_test.go
+++ b/cluster/crash_delta_test.go
@@ -1,3 +1,13 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// Authors: Guillaume Lefranc <guillaume@signal18.io>
+//
+//	Stephane Varoqui  <svaroqui@gmail.com>
+//
+// This source code is licensed under the GNU General Public License, version 3.
+// Redistribution/Reuse of this code is permitted under the GNU v3 license, as
+// an additional term, ALL code must carry the original Author(s) credit in comment form.
+// See LICENSE in this directory for the integral text.
 package cluster
 
 import (

--- a/cluster/srv_lostevents.go
+++ b/cluster/srv_lostevents.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/go-mysql-org/go-mysql/replication"
 	"github.com/signal18/replication-manager/config"
@@ -195,10 +196,25 @@ func (cluster *Cluster) assertRejoinResultStates() {
 			latest[cr.URL] = cr
 		}
 	}
+	reconciled := false
 	for url, cr := range latest {
 		srv := cluster.GetServerFromURL(url)
 		if srv != nil && srv.IsSlave && !srv.IsFailed() {
 			if m, _ := cluster.GetMasterFromReplication(srv); m != nil && m.URL == cr.ElectedMasterURL {
+				// Resolved: the node is a healthy slave of the elected master. If the
+				// durable record still carries a FAILED verdict, the node recovered by
+				// other means — manual start-slave, save+start, or a later attach the
+				// one-shot guard blocked from re-stamping. Rewrite it to "recovered" so
+				// history is truthful and the GUI stops blinking a stale failure.
+				if isRejoinFailedResult(cr.RejoinResult) {
+					cr.RejoinResult = RejoinResultRecovered
+					cr.RejoinResultTs = time.Now().Unix()
+					if cr.ArchiveDir != "" {
+						cluster.ensureCrashArchive(cr)
+					}
+					reconciled = true
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Rejoin of %s reconciled to recovered: node is a healthy slave of the elected master", url)
+				}
 				continue // resolved: rejoined as slave of the elected master
 			}
 		}
@@ -208,6 +224,11 @@ func (cluster *Cluster) assertRejoinResultStates() {
 		case RejoinResultPeerUnreached:
 			cluster.SetState("WARN0187", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0187"], url), ErrFrom: "REJOIN", ServerUrl: url})
 		}
+	}
+	if reconciled {
+		// Rebuild history from disk so the reconciled "recovered" outcome is the one
+		// served to the API/GUI (and re-deduped), mirroring finishRejoin.
+		cluster.LoadFailoverHistory()
 	}
 }
 

--- a/share/dashboard_react/src/components/Modals/LostEventsModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/LostEventsModal/index.jsx
@@ -22,7 +22,8 @@ const REJOIN_LABEL = {
   'not-flashback-able': 'Rejoin failed: not flashback-able',
   'no-rejoin-method': 'Rejoin failed: no method',
   'failed': 'Rejoin failed',
-  'peer-unreachable': 'Rejoin pending: peer unreachable'
+  'peer-unreachable': 'Rejoin pending: peer unreachable',
+  'recovered': 'Recovered (healthy slave)'
 }
 
 // Operator rejoin methods — mirror the backend (crash.go). ALL are always offered:


### PR DESCRIPTION
Two crash/rejoin ("crash pill") state bugs found during review of a real crash on curepipe, both confirmed against the live crash-bin dirs on node1.

## 1. Empty lost-events delta after a restart (`e1c0bf12d`)

**Symptom:** open the Last Divergence / binlog viewer for a crashed node → empty delta, but only after a repman restart.

**Root cause (confirmed on curepipe db1):** `crash-bin-<ts>/` holds the captured binlog + decoded `<binlog>.sql`, but its `crash.json` recorded `deltaArchive:"" deltaDecoded:"" deltaAnalyzed:false`. `saveBinlog`/`decodeLostEvents` wrote the delta and saved `crash.json` *with* the paths, then a later save from a **re-materialized** crash object (disk-truth reload / peer fetch) went through `ensureCrashArchive` and clobbered those fields with empties. On restart `LoadFailoverHistory` reads the empty paths → viewer shows nothing, even though the `.sql` is right beside `crash.json`.

**Fix:** `backfillDeltaFromArchiveDir` re-links `deltaDecoded` / `deltaArchive` / `deltaFlashbackDecoded` from the dir when empty. Called:
- before every `crash.json` save (`ensureCrashArchive`) — a save can never persist empties over already-captured files;
- on load (`LoadFailoverHistory`) — existing broken records self-heal on the next restart.

+2 unit tests (backfill resolves paths; never overwrites a set path).

## 2. Crash button blinks red on a clean, repaired topology (`d2c05fca6`)

**Symptom:** a failed direct-master rejoin leaves the crash button blinking forever, even after the node is fixed (e.g. a manual start-slave) and the topology is clean.

**Root cause:** a failed rejoin stamps a terminal `rejoinResult` (`failed` / `no-rejoin-method` / ...) into durable `FailoverHistory`. It's one-shot, so the rejoin path never re-runs to overwrite it. The backend already stops raising `WARN0186` once the node is a healthy slave of the elected master (`assertRejoinResultStates` "resolved" branch) — but the GUI blink reads the **raw** `rejoinResult` from history, which still says `failed`.

**Fix:** at that same resolved point, rewrite the durable record to `RejoinResultRecovered` ("recovered") and re-persist. History becomes truthful; the blink clears. Frontend already treats non-`REJOIN_FAILED` results as resolved (no blink).

## Scope / testing
Both touch orchestrator/crash-state — intended for the OpenSVC topology-matrix run. `go build ./cluster/` passes; the two backfill unit tests pass under `go test --tags server`.
