### PR TITLE
feat(schema): add schema advisor plugins

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -2708,6 +2708,17 @@ func (cluster *Cluster) MonitorMasterTableSchema() error {
 
 	cluster.WorkLoad.DBIndexSize = totindexsize
 	cluster.WorkLoad.DBTableSize = tottablesize
+
+	// Enrich BLOB/TEXT candidate columns with MariaDB compression detection and
+	// a bounded-sample observed average byte length, consumed by the
+	// plugin-schema-lob-compression schema advisor plugin. No-op on non-MariaDB
+	// and for tables under the minimum candidate size; every query is bounded
+	// and failures are skipped silently — see dbhelper.EnrichLobColumns.
+	if cluster.Conf.MonitorSchemaColumns {
+		lobLogs := dbhelper.EnrichLobColumns(cmaster.Conn, cmaster.DBVersion, tables)
+		cluster.LogSQL(lobLogs, nil, cmaster.URL, "Monitor", config.LvlDbg, "LOB column enrichment on %s", cmaster.URL)
+	}
+
 	cmaster.DictTables = dbhelper.FromNormalTablesMap(cmaster.DictTables, tables)
 
 	return nil

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -161,6 +161,8 @@ type Cluster struct {
 	LogWorkload                   s18log.HttpLog         `json:"-" groups:"web"`
 	LogDDL                        s18log.HttpLog         `json:"-" groups:"web"`
 	LogVariableChange             s18log.HttpLog         `json:"-" groups:"web"`
+	// LogSchema is a dedicated rotating buffer for schema advisory findings, mirrors LogSecurity/LogWorkload.
+	LogSchema s18log.HttpLog `json:"-" groups:"web"`
 	LogSlack                      *slackman.SlackManager `json:"-"`
 	JobResults                    *config.TasksMap       `json:"jobResults" groups:"web"`
 	FalsePositiveChecks           map[string]bool        `json:"falsePositiveChecks" groups:"web"`
@@ -281,6 +283,8 @@ type Cluster struct {
 	// WorkloadLogrus is a dedicated logrus.Logger that writes to workload.log.
 	// Set by the server on cluster init. Nil when no log-file is configured.
 	WorkloadLogrus *log.Logger `json:"-"`
+	// SchemaLogrus is a dedicated logrus.Logger that writes to schema.log.
+	SchemaLogrus *log.Logger `json:"-"`
 	// MaintenanceLogrus is a dedicated logrus.Logger that writes to maintenance.log.
 	// Receives ConstLogModMaintenance events: backup, SST, task execution, purge, etc.
 	// Set by the server on cluster init. Nil when no log-file is configured.
@@ -559,6 +563,7 @@ func (cluster *Cluster) InitFromConf() {
 	cluster.LogWorkload = s18log.NewHttpLog(200)
 	cluster.LogDDL = s18log.NewHttpLog(200)
 	cluster.LogVariableChange = s18log.NewHttpLog(200)
+	cluster.LogSchema = s18log.NewHttpLog(200)
 
 	cluster.MonitorType = config.GetMonitorType()
 	cluster.TopologyType = config.GetTopologyType()

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -1971,6 +1971,8 @@ func (cluster *Cluster) GetWebLogsByType(logtype string) any {
 		return &cluster.LogWorkload
 	case "ddl":
 		return &cluster.LogDDL
+	case "schema":
+		return &cluster.LogSchema
 	case "variable-change":
 		return &cluster.LogVariableChange
 	case "sysbench":
@@ -1987,6 +1989,7 @@ func (cluster *Cluster) GetAllWebLogs() map[string]any {
 	logs["security"] = &cluster.LogSecurity
 	logs["workload"] = &cluster.LogWorkload
 	logs["ddl"] = &cluster.LogDDL
+	logs["schema"] = &cluster.LogSchema
 	logs["variable-change"] = &cluster.LogVariableChange
 	logs["sysbench"] = &cluster.SysbenchHistory
 	return logs

--- a/cluster/logplugin/external.go
+++ b/cluster/logplugin/external.go
@@ -297,15 +297,21 @@ func manifestToPrerequisites(m *PluginManifest) []Prerequisite {
 
 // DefaultSeverity implements LogPluginWithDefaultSeverity.
 // Used by RunLogPlugins to route debug messages to the correct dedicated log
-// when Evaluate returns zero findings (compliant server — no issue detected).
+// when Evaluate returns zero findings (compliant server — no issue detected),
+// and to route WARN0312 (missing monitoring prerequisite) to the right state
+// machine before Evaluate has even run.
 //
 // Naming conventions used for inference:
+//   plugin-schema-*                        → SeveritySchema   (schema advisory)
 //   plugin-security-* and plugin-score-*  → SeveritySecurity (security/compliance audit)
 //   plugin-binlog-*                        → SeveritySecurity (binlog audit for cleartext creds / PII)
 //   plugin-*privilege* or plugin-*off-hours* → SeveritySecurity (access-control auditing)
 //   everything else                        → SeverityWorkload  (performance / spike detection)
 func (p *ExternalLogPlugin) DefaultSeverity() Severity {
 	n := p.name
+	if strings.HasPrefix(n, "plugin-schema-") {
+		return SeveritySchema
+	}
 	if strings.HasPrefix(n, "plugin-security-") ||
 		strings.HasPrefix(n, "plugin-score-") ||
 		strings.HasPrefix(n, "plugin-binlog-") ||
@@ -389,7 +395,7 @@ func (p *ExternalLogPlugin) Evaluate(src LogSource) EvaluateResult {
 	findings := make([]Finding, 0, len(resp.Findings))
 	for _, sf := range resp.Findings {
 		sev := Severity(strings.ToUpper(sf.Severity))
-		if sev != SeverityWarning && sev != SeverityError && sev != SeveritySecurity && sev != SeverityWorkload {
+		if sev != SeverityWarning && sev != SeverityError && sev != SeveritySecurity && sev != SeverityWorkload && sev != SeveritySchema {
 			sev = SeverityWarning
 		}
 		remeds := make([]Remediation, 0, len(sf.Remediations))

--- a/cluster/logplugin/external_test.go
+++ b/cluster/logplugin/external_test.go
@@ -263,6 +263,26 @@ func TestExternalPlugin_InvalidJSONReturnsWARN0203(t *testing.T) {
 	}
 }
 
+func TestExternalPlugin_SchemaSeverityPreserved(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script plugins not tested on Windows")
+	}
+	dir := t.TempDir()
+	resp := stdioResponse{Findings: []stdioFinding{
+		{ErrKey: "SCH0001", Severity: "SCHEMA", Description: "wide row"},
+	}}
+	binPath := writeFakePlugin(t, dir, "schema-row-size", resp)
+
+	p := NewExternalLogPlugin("schema-row-size", binPath, 5*time.Second)
+	findings := p.Evaluate(LogSource{ServerURL: "127.0.0.1:3306"}).Findings
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Severity != SeveritySchema {
+		t.Errorf("expected SeveritySchema preserved, got %s", findings[0].Severity)
+	}
+}
+
 func TestExternalPlugin_UnknownSeverityDefaultsToWarning(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell script plugins not tested on Windows")

--- a/cluster/logplugin/logplugin.go
+++ b/cluster/logplugin/logplugin.go
@@ -269,17 +269,24 @@ type StdioTableColumn struct {
 	Nullable  bool   `json:"nullable"`
 	Charset   string `json:"charset,omitempty"`
 	Collation string `json:"collation,omitempty"`
+	// Compressed is true when the column declares MariaDB per-column
+	// COMPRESSED storage. Only populated for BLOB/TEXT candidate columns.
+	Compressed bool `json:"compressed,omitempty"`
+	// AvgByteLength is a bounded-sample observed average byte length
+	// (BLOB/TEXT candidate columns only). Zero means not sampled.
+	AvgByteLength int64 `json:"avg_byte_length,omitempty"`
 }
 
 // StdioTable mirrors wire.Table.
 type StdioTable struct {
-	Schema     string             `json:"schema"`
-	Name       string             `json:"name"`
-	Engine     string             `json:"engine"`
-	RowFormat  string             `json:"row_format"`
-	Rows       int64              `json:"rows,omitempty"`
-	DataLength int64              `json:"data_length,omitempty"`
-	Columns    []StdioTableColumn `json:"columns,omitempty"`
+	Schema       string             `json:"schema"`
+	Name         string             `json:"name"`
+	Engine       string             `json:"engine"`
+	RowFormat    string             `json:"row_format"`
+	Rows         int64              `json:"rows,omitempty"`
+	DataLength   int64              `json:"data_length,omitempty"`
+	AvgRowLength int64              `json:"avg_row_length,omitempty"`
+	Columns      []StdioTableColumn `json:"columns,omitempty"`
 }
 
 // ClusterContext carries cluster-level facts passed to every plugin.

--- a/cluster/logplugin/plugins/plugin-schema-lob-compression/main.go
+++ b/cluster/logplugin/plugins/plugin-schema-lob-compression/main.go
@@ -1,0 +1,98 @@
+// plugin-schema-lob-compression flags MariaDB BLOB/TEXT columns with a large
+// observed average size that are not using MariaDB's per-column COMPRESSED
+// storage attribute.
+//
+// Observed average size and compression status are not computed here — they
+// are gathered during schema monitoring under bounded guardrails (a fixed
+// row-sample LIMIT, no full-table AVG(LENGTH()) scan, short timeout, silent
+// skip-on-failure — see utils/dbhelper/schema_lob.go) and handed to this
+// plugin via the wire Tables snapshot. This plugin only applies the
+// threshold/compression check; it never talks to the database directly.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/signal18/replication-manager/cluster/logplugin/plugins/wire"
+)
+
+func main() {
+	var req wire.Request
+	if err := json.NewDecoder(os.Stdin).Decode(&req); err != nil {
+		fmt.Fprintf(os.Stderr, "decode error: %v\n", err)
+		os.Exit(1)
+	}
+
+	findings := evaluateTables(req)
+	json.NewEncoder(os.Stdout).Encode(wire.Response{Findings: findings})
+}
+
+// evaluateTables inspects every BLOB/TEXT column in req.Tables and returns at
+// most one SCH0002 finding aggregating every column whose sampled average
+// byte length exceeds the threshold and that is not already COMPRESSED.
+// MariaDB-only — MySQL and other flavors do not support per-column compression.
+//
+// All findings from one plugin run share the fixed ErrKey "SCH0002", and the
+// repman state machine keys open states as ErrKey@server — only the first
+// state written for a given key survives a monitoring cycle (see
+// state.Map.Add). Emitting one finding per column would silently drop every
+// column after the first, so every offense is folded into a single finding's
+// description instead, matching the aggregation pattern used by
+// plugin-security-hardening's SEC0107/SEC0108.
+func evaluateTables(req wire.Request) []wire.Finding {
+	if !strings.EqualFold(req.ServerVersion.Flavor, "MariaDB") {
+		return nil
+	}
+
+	threshold := wire.CfgInt(req.Config, "avg-length-threshold-bytes", wire.EnvInt("REPMAN_SCHEMA_LOB_COMPRESSION_THRESHOLD_BYTES", 8192))
+
+	var offenses []string
+	for _, t := range req.Tables {
+		for _, c := range t.Columns {
+			if !isLobType(c.Type) {
+				continue
+			}
+			if c.Compressed {
+				continue
+			}
+			if c.AvgByteLength <= 0 || int64(c.AvgByteLength) <= int64(threshold) {
+				continue
+			}
+
+			offenses = append(offenses, fmt.Sprintf(
+				"%s.%s.%s (%s, avg=%dB, suggest: ALTER TABLE %s.%s MODIFY %s %s COMPRESSED;)",
+				t.Schema, t.Name, c.Name, c.Type, c.AvgByteLength, t.Schema, t.Name, c.Name, c.Type,
+			))
+		}
+	}
+
+	if len(offenses) == 0 {
+		return nil
+	}
+	sort.Strings(offenses)
+
+	desc := fmt.Sprintf(
+		"%d BLOB/TEXT column(s) exceed the %d-byte average-size threshold and are not using MariaDB per-column"+
+			" compression. Large uncompressed BLOB/TEXT columns waste storage and I/O; per-column COMPRESSED is a"+
+			" cheap win for exactly this case. Columns: %s",
+		len(offenses), threshold, strings.Join(offenses, "; "),
+	)
+
+	return []wire.Finding{{
+		ErrKey:      "SCH0002",
+		Severity:    "SCHEMA",
+		Description: desc,
+	}}
+}
+
+// isLobType reports whether colType (e.g. "text", "mediumblob") is a
+// BLOB/TEXT family type. Mirrors dbhelper.IsLobColumnType — kept independent
+// since plugins carry no replication-manager dependency at runtime.
+func isLobType(colType string) bool {
+	lower := strings.ToLower(colType)
+	return strings.Contains(lower, "blob") || strings.Contains(lower, "text")
+}

--- a/cluster/logplugin/plugins/plugin-schema-lob-compression/main.go
+++ b/cluster/logplugin/plugins/plugin-schema-lob-compression/main.go
@@ -1,3 +1,8 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// Author: Ahmad Faruk <ahmad@signal18.io>
+// This source code is licensed under the GNU General Public License, version 3.
+
 // plugin-schema-lob-compression flags MariaDB BLOB/TEXT columns with a large
 // observed average size that are not using MariaDB's per-column COMPRESSED
 // storage attribute.

--- a/cluster/logplugin/plugins/plugin-schema-lob-compression/main.go
+++ b/cluster/logplugin/plugins/plugin-schema-lob-compression/main.go
@@ -54,6 +54,7 @@ func evaluateTables(req wire.Request) []wire.Finding {
 	}
 
 	threshold := wire.CfgInt(req.Config, "avg-length-threshold-bytes", wire.EnvInt("REPMAN_SCHEMA_LOB_COMPRESSION_THRESHOLD_BYTES", 8192))
+	maskIdentifiers := wire.CfgBool(req.Config, "mask-identifiers", false)
 
 	var offenses []string
 	for _, t := range req.Tables {
@@ -68,6 +69,13 @@ func evaluateTables(req wire.Request) []wire.Finding {
 				continue
 			}
 
+			if maskIdentifiers {
+				offenses = append(offenses, fmt.Sprintf(
+					"%s (%s, avg=%dB)",
+					wire.MaskQualified(t.Schema, t.Name, c.Name), c.Type, c.AvgByteLength,
+				))
+				continue
+			}
 			offenses = append(offenses, fmt.Sprintf(
 				"%s.%s.%s (%s, avg=%dB, suggest: ALTER TABLE %s.%s MODIFY %s %s COMPRESSED;)",
 				t.Schema, t.Name, c.Name, c.Type, c.AvgByteLength, t.Schema, t.Name, c.Name, c.Type,

--- a/cluster/logplugin/plugins/plugin-schema-lob-compression/main_test.go
+++ b/cluster/logplugin/plugins/plugin-schema-lob-compression/main_test.go
@@ -154,3 +154,29 @@ func TestEvaluateTables_MultipleOffendingColumnsAggregateIntoOneFinding(t *testi
 		t.Errorf("expected offense count in description, got: %s", findings[0].Description)
 	}
 }
+
+// TestEvaluateTables_MaskIdentifiers guards the PCI-DSS-style compliance
+// option: with mask-identifiers=true, neither the real names nor the
+// suggested ALTER TABLE statement (which would leak them) may appear.
+func TestEvaluateTables_MaskIdentifiers(t *testing.T) {
+	req := mariaDBRequest([]wire.Table{
+		{Schema: "payments", Name: "credit_cards", Columns: []wire.TableColumn{
+			{Name: "card_number", Type: "text", Compressed: false, AvgByteLength: 9000},
+		}},
+	})
+	req.Config = map[string]string{"mask-identifiers": "true"}
+	findings := evaluateTables(req)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	desc := findings[0].Description
+	if strings.Contains(desc, "credit_cards") || strings.Contains(desc, "card_number") || strings.Contains(desc, "payments") {
+		t.Errorf("expected real identifiers masked out of description, got: %s", desc)
+	}
+	if strings.Contains(desc, "ALTER TABLE") {
+		t.Errorf("expected suggested ALTER TABLE (would leak real names) to be dropped when masking, got: %s", desc)
+	}
+	if !strings.Contains(desc, wire.MaskIdentifier("credit_cards")) {
+		t.Errorf("expected masked table name in description, got: %s", desc)
+	}
+}

--- a/cluster/logplugin/plugins/plugin-schema-lob-compression/main_test.go
+++ b/cluster/logplugin/plugins/plugin-schema-lob-compression/main_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/signal18/replication-manager/cluster/logplugin/plugins/wire"
+)
+
+// ---- isLobType ----------------------------------------------------------------
+
+func TestIsLobType(t *testing.T) {
+	cases := []struct {
+		colType string
+		want    bool
+	}{
+		{"text", true},
+		{"TEXT", true},
+		{"mediumtext", true},
+		{"longblob", true},
+		{"blob", true},
+		{"varchar(255)", false},
+		{"int(11)", false},
+	}
+	for _, tc := range cases {
+		if got := isLobType(tc.colType); got != tc.want {
+			t.Errorf("isLobType(%q) = %v, want %v", tc.colType, got, tc.want)
+		}
+	}
+}
+
+// ---- evaluateTables -------------------------------------------------------------
+
+func mariaDBRequest(tables []wire.Table) wire.Request {
+	return wire.Request{
+		ServerVersion: wire.ServerVersion{Flavor: "MariaDB", Major: 10, Minor: 6},
+		Tables:        tables,
+	}
+}
+
+func TestEvaluateTables_FlagsLargeUncompressedColumn(t *testing.T) {
+	req := mariaDBRequest([]wire.Table{
+		{Schema: "s", Name: "t", Columns: []wire.TableColumn{
+			{Name: "payload", Type: "text", Compressed: false, AvgByteLength: 9000},
+		}},
+	})
+	findings := evaluateTables(req)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+	if findings[0].ErrKey != "SCH0002" {
+		t.Errorf("wrong ErrKey: %s", findings[0].ErrKey)
+	}
+	if findings[0].Severity != "SCHEMA" {
+		t.Errorf("wrong severity: %s", findings[0].Severity)
+	}
+}
+
+func TestEvaluateTables_SkipsCompressedColumn(t *testing.T) {
+	req := mariaDBRequest([]wire.Table{
+		{Schema: "s", Name: "t", Columns: []wire.TableColumn{
+			{Name: "payload", Type: "text", Compressed: true, AvgByteLength: 9000},
+		}},
+	})
+	if findings := evaluateTables(req); len(findings) != 0 {
+		t.Errorf("expected 0 findings for a compressed column, got %d", len(findings))
+	}
+}
+
+func TestEvaluateTables_SkipsUnderThreshold(t *testing.T) {
+	req := mariaDBRequest([]wire.Table{
+		{Schema: "s", Name: "t", Columns: []wire.TableColumn{
+			{Name: "payload", Type: "text", Compressed: false, AvgByteLength: 100},
+		}},
+	})
+	if findings := evaluateTables(req); len(findings) != 0 {
+		t.Errorf("expected 0 findings under threshold, got %d", len(findings))
+	}
+}
+
+func TestEvaluateTables_SkipsUnsampledColumn(t *testing.T) {
+	// AvgByteLength == 0 means "not sampled" (small table, sampling failed, etc.)
+	// — must not be treated as "0 bytes, therefore fine" nor flagged.
+	req := mariaDBRequest([]wire.Table{
+		{Schema: "s", Name: "t", Columns: []wire.TableColumn{
+			{Name: "payload", Type: "text", Compressed: false, AvgByteLength: 0},
+		}},
+	})
+	if findings := evaluateTables(req); len(findings) != 0 {
+		t.Errorf("expected 0 findings for an unsampled column, got %d", len(findings))
+	}
+}
+
+func TestEvaluateTables_SkipsNonLobColumn(t *testing.T) {
+	req := mariaDBRequest([]wire.Table{
+		{Schema: "s", Name: "t", Columns: []wire.TableColumn{
+			{Name: "note", Type: "varchar(255)", Compressed: false, AvgByteLength: 9000},
+		}},
+	})
+	if findings := evaluateTables(req); len(findings) != 0 {
+		t.Errorf("expected 0 findings for a non-LOB column, got %d", len(findings))
+	}
+}
+
+func TestEvaluateTables_SkipsNonMariaDB(t *testing.T) {
+	req := wire.Request{
+		ServerVersion: wire.ServerVersion{Flavor: "MySQL", Major: 8, Minor: 0},
+		Tables: []wire.Table{
+			{Schema: "s", Name: "t", Columns: []wire.TableColumn{
+				{Name: "payload", Type: "text", Compressed: false, AvgByteLength: 9000},
+			}},
+		},
+	}
+	if findings := evaluateTables(req); len(findings) != 0 {
+		t.Errorf("expected 0 findings for non-MariaDB flavor, got %d", len(findings))
+	}
+}
+
+func TestEvaluateTables_ConfiguredThreshold(t *testing.T) {
+	req := mariaDBRequest([]wire.Table{
+		{Schema: "s", Name: "t", Columns: []wire.TableColumn{
+			{Name: "payload", Type: "text", Compressed: false, AvgByteLength: 500},
+		}},
+	})
+	req.Config = map[string]string{"avg-length-threshold-bytes": "100"}
+	if findings := evaluateTables(req); len(findings) != 1 {
+		t.Errorf("expected 1 finding with lowered threshold, got %d", len(findings))
+	}
+}
+
+// TestEvaluateTables_MultipleOffendingColumnsAggregateIntoOneFinding guards
+// against the state-collision bug: repman's state machine keys open states
+// as ErrKey@server and only keeps the first write per key for a monitoring
+// cycle (state.Map.Add), so multiple SCH0002 findings for the same server
+// would silently drop every column after the first. All offenses must be
+// folded into a single finding.
+func TestEvaluateTables_MultipleOffendingColumnsAggregateIntoOneFinding(t *testing.T) {
+	req := mariaDBRequest([]wire.Table{
+		{Schema: "s", Name: "t1", Columns: []wire.TableColumn{
+			{Name: "body", Type: "longtext", Compressed: false, AvgByteLength: 9000},
+		}},
+		{Schema: "s", Name: "t2", Columns: []wire.TableColumn{
+			{Name: "payload", Type: "blob", Compressed: false, AvgByteLength: 20000},
+		}},
+	})
+	findings := evaluateTables(req)
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 aggregated finding for 2 offending columns (state-collision guard), got %d", len(findings))
+	}
+	if !strings.Contains(findings[0].Description, "t1.body") || !strings.Contains(findings[0].Description, "t2.payload") {
+		t.Errorf("expected both offending columns named in the aggregated description, got: %s", findings[0].Description)
+	}
+	if !strings.Contains(findings[0].Description, "2 BLOB/TEXT column(s)") {
+		t.Errorf("expected offense count in description, got: %s", findings[0].Description)
+	}
+}

--- a/cluster/logplugin/plugins/plugin-schema-lob-compression/plugin-schema-lob-compression.manifest.json
+++ b/cluster/logplugin/plugins/plugin-schema-lob-compression/plugin-schema-lob-compression.manifest.json
@@ -1,0 +1,21 @@
+{
+  "description": "Large Uncompressed BLOB/TEXT (MariaDB) — SCH0002\n\nFlags MariaDB BLOB/TEXT columns with a large observed average size (bounded-sampled during schema monitoring, never a full-table scan) that are not using MariaDB's per-column COMPRESSED storage attribute. Large uncompressed LOB columns waste storage and I/O; per-column compression is a cheap win for exactly this case. MariaDB-only. All offending columns on a server are reported in a single SCH0002 finding (one finding per plugin run), not one finding per column.",
+  "prerequisites": [
+    {
+      "config_key": "monitoring-schema-columns",
+      "description": "Schema column metadata (types, LOB compression/avg-length enrichment) must be monitored (monitoring-schema-columns=true) — without it this check silently sees no columns and reports no findings"
+    }
+  ],
+  "config_keys": [
+    {
+      "key": "avg-length-threshold-bytes",
+      "label": "Average size threshold (bytes)",
+      "type": "int",
+      "default": "8192",
+      "min": 1,
+      "max": 1073741824,
+      "step": 1,
+      "help": "BLOB/TEXT columns whose sampled observed average byte length exceeds this value, and that are not COMPRESSED, are flagged."
+    }
+  ]
+}

--- a/cluster/logplugin/plugins/plugin-schema-lob-compression/plugin-schema-lob-compression.manifest.json
+++ b/cluster/logplugin/plugins/plugin-schema-lob-compression/plugin-schema-lob-compression.manifest.json
@@ -16,6 +16,13 @@
       "max": 1073741824,
       "step": 1,
       "help": "BLOB/TEXT columns whose sampled observed average byte length exceeds this value, and that are not COMPRESSED, are flagged."
+    },
+    {
+      "key": "mask-identifiers",
+      "label": "Mask table/column names",
+      "type": "bool",
+      "default": "false",
+      "help": "Partially obscure schema, table, and column names in the finding description (e.g. \"window\" -> \"wi???ow\") and drop the suggested ALTER TABLE statement, so the log entry is not directly useful to someone who only has log access. For PCI-DSS/compliance deployments where the findings log is more widely readable than the database schema itself."
     }
   ]
 }

--- a/cluster/logplugin/plugins/plugin-schema-row-size/main.go
+++ b/cluster/logplugin/plugins/plugin-schema-row-size/main.go
@@ -1,3 +1,8 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// Author: Ahmad Faruk <ahmad@signal18.io>
+// This source code is licensed under the GNU General Public License, version 3.
+
 // plugin-schema-row-size flags InnoDB tables whose short, always-inline-stored
 // VARCHAR columns already sum past InnoDB's per-row storage budget.
 //

--- a/cluster/logplugin/plugins/plugin-schema-row-size/main.go
+++ b/cluster/logplugin/plugins/plugin-schema-row-size/main.go
@@ -1,0 +1,261 @@
+// plugin-schema-row-size flags InnoDB tables whose short, always-inline-stored
+// VARCHAR columns already sum past InnoDB's per-row storage budget.
+//
+// InnoDB inline row budget:
+//
+//	Documented for a 16K page: slightly less than half a page (~8126 bytes).
+//	This plugin generalises that as page_size/2 - 66 (the constant that
+//	reproduces 8126 for page_size=16384), special-cases 64K pages (which are
+//	NOT simply half-page in practice), and applies a small extra discount for
+//	ROW_FORMAT=COMPRESSED tables since KEY_BLOCK_SIZE is not available in the
+//	schema snapshot.
+//
+// VARCHAR selection (per issue #1592):
+//
+//	Only VARCHAR columns whose declared byte width (declared char length ×
+//	charset max-bytes-per-char) is under 256 bytes are summed — those are the
+//	columns InnoDB always stores fully inline with a 1-byte length prefix, so
+//	their contribution to row pressure is certain regardless of row_format.
+//	Wider VARCHAR/TEXT/BLOB columns are candidates for partial/full off-page
+//	storage and are deliberately excluded from the sum — including them would
+//	make the check less certain, not more accurate.
+//
+// This is advisory and intentionally conservative, not a byte-exact replica
+// of InnoDB's internal record format.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/signal18/replication-manager/cluster/logplugin/plugins/wire"
+)
+
+// charsetBytesPerChar maps common MySQL/MariaDB charset names to their
+// maximum bytes-per-character. Unknown charsets fall back to 4 (conservative
+// — better to overestimate row pressure than miss a real risk).
+var charsetBytesPerChar = map[string]int{
+	"utf8mb4": 4,
+	"utf8mb3": 3,
+	"utf8":    3,
+	"ucs2":    2,
+	"utf16":   4,
+	"utf16le": 4,
+	"utf32":   4,
+	"latin1":  1,
+	"latin2":  1,
+	"latin5":  1,
+	"latin7":  1,
+	"ascii":   1,
+	"binary":  1,
+	"cp850":   1,
+	"cp852":   1,
+	"cp866":   1,
+	"cp1250":  1,
+	"cp1251":  1,
+	"cp1256":  1,
+	"cp1257":  1,
+	"koi8r":   1,
+	"koi8u":   1,
+	"greek":   1,
+	"hebrew":  1,
+	"gbk":     2,
+	"big5":    2,
+	"sjis":    2,
+	"cp932":   2,
+	"euckr":   2,
+	"eucjpms": 3,
+	"gb18030": 4,
+}
+
+const defaultBytesPerChar = 4
+
+// maxColumnsPerTableInDescription caps how many offending columns are listed
+// per table in the aggregated finding description, so a table with hundreds
+// of short VARCHAR columns doesn't blow up the description size.
+const maxColumnsPerTableInDescription = 15
+
+var varcharTypeRe = regexp.MustCompile(`(?i)^varchar\((\d+)\)`)
+
+func main() {
+	var req wire.Request
+	if err := json.NewDecoder(os.Stdin).Decode(&req); err != nil {
+		fmt.Fprintf(os.Stderr, "decode error: %v\n", err)
+		os.Exit(1)
+	}
+
+	findings := evaluateTables(req)
+	json.NewEncoder(os.Stdout).Encode(wire.Response{Findings: findings})
+}
+
+// tableOffense is one InnoDB table whose short, always-inline-stored VARCHAR
+// columns sum past the estimated InnoDB inline row budget.
+type tableOffense struct {
+	schema, name, rowFormat, pageSize string
+	sum, budget, avgRowLength         int64
+	columns                           []string
+}
+
+// evaluateTables inspects every InnoDB table in req.Tables and returns at
+// most one SCH0001 finding aggregating every offending table found.
+//
+// All findings from one plugin run share the fixed ErrKey "SCH0001", and the
+// repman state machine keys open states as ErrKey@server — only the first
+// state written for a given key survives a monitoring cycle (see
+// state.Map.Add). Emitting one finding per table would silently drop every
+// table after the first, so every offense is folded into a single finding's
+// description instead, matching the aggregation pattern used by
+// plugin-security-hardening's SEC0107/SEC0108.
+func evaluateTables(req wire.Request) []wire.Finding {
+	inlineMaxBytes := wire.CfgInt(req.Config, "inline-varchar-max-bytes", wire.EnvInt("REPMAN_SCHEMA_ROW_SIZE_INLINE_MAX_BYTES", 256))
+
+	var offenses []tableOffense
+	for _, t := range req.Tables {
+		if !strings.EqualFold(t.Engine, "InnoDB") {
+			continue
+		}
+
+		budget := innodbRowBudget(req.ServerVariables["innodb_page_size"], t.RowFormat)
+
+		type contribution struct {
+			name  string
+			bytes int
+		}
+		var contributions []contribution
+		sum := 0
+		for _, c := range t.Columns {
+			byteWidth, ok := varcharByteWidth(c.Type, c.Charset)
+			if !ok || byteWidth >= inlineMaxBytes {
+				continue
+			}
+			prefix := 1
+			if byteWidth > 255 {
+				prefix = 2
+			}
+			width := byteWidth + prefix
+			sum += width
+			contributions = append(contributions, contribution{name: c.Name, bytes: width})
+		}
+
+		if int64(sum) <= budget || len(contributions) == 0 {
+			continue
+		}
+
+		sort.Slice(contributions, func(i, j int) bool { return contributions[i].bytes > contributions[j].bytes })
+		colDesc := make([]string, 0, len(contributions))
+		for i, c := range contributions {
+			if i >= maxColumnsPerTableInDescription {
+				colDesc = append(colDesc, fmt.Sprintf("(+%d more)", len(contributions)-maxColumnsPerTableInDescription))
+				break
+			}
+			colDesc = append(colDesc, fmt.Sprintf("%s(%dB)", c.name, c.bytes))
+		}
+
+		offenses = append(offenses, tableOffense{
+			schema:       t.Schema,
+			name:         t.Name,
+			rowFormat:    orDefault(t.RowFormat, "(default)"),
+			pageSize:     orDefault(req.ServerVariables["innodb_page_size"], "16384"),
+			sum:          int64(sum),
+			budget:       budget,
+			avgRowLength: t.AvgRowLength,
+			columns:      colDesc,
+		})
+	}
+
+	if len(offenses) == 0 {
+		return nil
+	}
+
+	sort.Slice(offenses, func(i, j int) bool {
+		if offenses[i].schema != offenses[j].schema {
+			return offenses[i].schema < offenses[j].schema
+		}
+		return offenses[i].name < offenses[j].name
+	})
+
+	parts := make([]string, 0, len(offenses))
+	for _, o := range offenses {
+		part := fmt.Sprintf("%s.%s (sum=%dB, limit=%dB, row_format=%s, page_size=%s, columns: %s)",
+			o.schema, o.name, o.sum, o.budget, o.rowFormat, o.pageSize, strings.Join(o.columns, ", "))
+		if o.avgRowLength > 0 {
+			part += fmt.Sprintf(" [observed avg_row_length=%dB]", o.avgRowLength)
+		}
+		parts = append(parts, part)
+	}
+
+	desc := fmt.Sprintf(
+		"%d InnoDB table(s) have short inline-stored VARCHAR columns summing past the estimated InnoDB inline"+
+			" row budget. Rows past this budget either fail with \"Row size too large\" or force additional columns"+
+			" off-page, hurting scan performance. Consider narrowing these columns, moving less-hot data to a"+
+			" companion table, or switching to ROW_FORMAT=DYNAMIC/COMPRESSED if not already in use. Tables: %s",
+		len(offenses), strings.Join(parts, "; "),
+	)
+
+	return []wire.Finding{{
+		ErrKey:      "SCH0001",
+		Severity:    "SCHEMA",
+		Description: desc,
+	}}
+}
+
+// varcharByteWidth returns the declared byte width of a VARCHAR column
+// (declared char length × charset max-bytes-per-char) and whether colType is
+// a VARCHAR at all.
+func varcharByteWidth(colType, charset string) (int, bool) {
+	m := varcharTypeRe.FindStringSubmatch(strings.TrimSpace(colType))
+	if m == nil {
+		return 0, false
+	}
+	declaredChars, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, false
+	}
+	bpc, ok := charsetBytesPerChar[strings.ToLower(charset)]
+	if !ok {
+		bpc = defaultBytesPerChar
+	}
+	return declaredChars * bpc, true
+}
+
+// innodbRowBudget estimates the maximum bytes InnoDB can store inline for a
+// single row, given innodb_page_size and row_format. See package doc for the
+// derivation — this deliberately reproduces the documented ~8126-byte limit
+// for the default 16K page size.
+func innodbRowBudget(pageSizeStr, rowFormat string) int64 {
+	pageSize, err := strconv.ParseInt(strings.TrimSpace(pageSizeStr), 10, 64)
+	if err != nil || pageSize <= 0 {
+		pageSize = 16384 // InnoDB default
+	}
+
+	var budget int64
+	if pageSize >= 65536 {
+		// 64K pages are not simply half-page in practice; MySQL/MariaDB
+		// restrict effective inline row storage well below that. Use a
+		// quarter-page estimate with the same fixed overhead as the general
+		// formula, which is conservative relative to commonly cited ~16K limits.
+		budget = pageSize/4 - 66
+	} else {
+		budget = pageSize/2 - 66
+	}
+
+	if strings.EqualFold(rowFormat, "Compressed") {
+		// KEY_BLOCK_SIZE is not available in the schema snapshot, so apply a
+		// conservative discount — compressed tables generally have a smaller
+		// effective inline budget than their uncompressed innodb_page_size implies.
+		budget = budget * 9 / 10
+	}
+	return budget
+}
+
+func orDefault(v, def string) string {
+	if strings.TrimSpace(v) == "" {
+		return def
+	}
+	return v
+}

--- a/cluster/logplugin/plugins/plugin-schema-row-size/main.go
+++ b/cluster/logplugin/plugins/plugin-schema-row-size/main.go
@@ -118,6 +118,7 @@ type tableOffense struct {
 // plugin-security-hardening's SEC0107/SEC0108.
 func evaluateTables(req wire.Request) []wire.Finding {
 	inlineMaxBytes := wire.CfgInt(req.Config, "inline-varchar-max-bytes", wire.EnvInt("REPMAN_SCHEMA_ROW_SIZE_INLINE_MAX_BYTES", 256))
+	maskIdentifiers := wire.CfgBool(req.Config, "mask-identifiers", false)
 
 	var offenses []tableOffense
 	for _, t := range req.Tables {
@@ -158,12 +159,20 @@ func evaluateTables(req wire.Request) []wire.Finding {
 				colDesc = append(colDesc, fmt.Sprintf("(+%d more)", len(contributions)-maxColumnsPerTableInDescription))
 				break
 			}
-			colDesc = append(colDesc, fmt.Sprintf("%s(%dB)", c.name, c.bytes))
+			name := c.name
+			if maskIdentifiers {
+				name = wire.MaskIdentifier(name)
+			}
+			colDesc = append(colDesc, fmt.Sprintf("%s(%dB)", name, c.bytes))
 		}
 
+		schema, name := t.Schema, t.Name
+		if maskIdentifiers {
+			schema, name = wire.MaskIdentifier(schema), wire.MaskIdentifier(name)
+		}
 		offenses = append(offenses, tableOffense{
-			schema:       t.Schema,
-			name:         t.Name,
+			schema:       schema,
+			name:         name,
 			rowFormat:    orDefault(t.RowFormat, "(default)"),
 			pageSize:     orDefault(req.ServerVariables["innodb_page_size"], "16384"),
 			sum:          int64(sum),

--- a/cluster/logplugin/plugins/plugin-schema-row-size/main_test.go
+++ b/cluster/logplugin/plugins/plugin-schema-row-size/main_test.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/signal18/replication-manager/cluster/logplugin/plugins/wire"
+)
+
+// ---- varcharByteWidth --------------------------------------------------------
+
+func TestVarcharByteWidth(t *testing.T) {
+	cases := []struct {
+		colType   string
+		charset   string
+		wantBytes int
+		wantOK    bool
+	}{
+		{"varchar(255)", "utf8mb4", 1020, true},
+		{"VARCHAR(50)", "latin1", 50, true},
+		{"varchar(100)", "", 400, true}, // unknown charset falls back to conservative 4 bytes/char
+		{"varchar(100)", "utf8mb3", 300, true},
+		{"text", "utf8mb4", 0, false},
+		{"blob", "", 0, false},
+		{"int(11)", "", 0, false},
+		{"char(10)", "latin1", 0, false}, // CHAR is not VARCHAR — intentionally excluded
+	}
+	for _, tc := range cases {
+		gotBytes, gotOK := varcharByteWidth(tc.colType, tc.charset)
+		if gotOK != tc.wantOK {
+			t.Errorf("varcharByteWidth(%q, %q) ok = %v, want %v", tc.colType, tc.charset, gotOK, tc.wantOK)
+			continue
+		}
+		if gotOK && gotBytes != tc.wantBytes {
+			t.Errorf("varcharByteWidth(%q, %q) = %d bytes, want %d", tc.colType, tc.charset, gotBytes, tc.wantBytes)
+		}
+	}
+}
+
+// ---- innodbRowBudget ---------------------------------------------------------
+
+func TestInnodbRowBudget_16KPage(t *testing.T) {
+	// Documented ~8126-byte limit for the default 16K page must be reproduced exactly.
+	got := innodbRowBudget("16384", "")
+	if got != 8126 {
+		t.Errorf("innodbRowBudget(16384, \"\") = %d, want 8126", got)
+	}
+}
+
+func TestInnodbRowBudget_DefaultsWhenMissing(t *testing.T) {
+	got := innodbRowBudget("", "")
+	if got != 8126 {
+		t.Errorf("innodbRowBudget(\"\", \"\") = %d, want 8126 (16K default)", got)
+	}
+	got = innodbRowBudget("not-a-number", "")
+	if got != 8126 {
+		t.Errorf("innodbRowBudget(garbage, \"\") = %d, want 8126 (16K default)", got)
+	}
+}
+
+func TestInnodbRowBudget_SmallerPages(t *testing.T) {
+	if got := innodbRowBudget("8192", ""); got != 8192/2-66 {
+		t.Errorf("innodbRowBudget(8192, \"\") = %d, want %d", got, 8192/2-66)
+	}
+	if got := innodbRowBudget("4096", ""); got != 4096/2-66 {
+		t.Errorf("innodbRowBudget(4096, \"\") = %d, want %d", got, 4096/2-66)
+	}
+}
+
+func TestInnodbRowBudget_64KPageIsSpecialCased(t *testing.T) {
+	got := innodbRowBudget("65536", "")
+	halfPage := int64(65536 / 2)
+	if got >= halfPage {
+		t.Errorf("innodbRowBudget(65536, \"\") = %d, must be well under half-page (%d)", got, halfPage)
+	}
+}
+
+func TestInnodbRowBudget_CompressedRowFormatDiscount(t *testing.T) {
+	uncompressed := innodbRowBudget("16384", "Dynamic")
+	compressed := innodbRowBudget("16384", "Compressed")
+	if compressed >= uncompressed {
+		t.Errorf("compressed budget (%d) should be lower than uncompressed budget (%d)", compressed, uncompressed)
+	}
+}
+
+// ---- end-to-end finding logic (via main()'s table loop, exercised through a
+// small helper since main() itself talks to stdin/stdout) -------------------
+
+func TestEvaluateTables_FlagsWideRow(t *testing.T) {
+	// 40 VARCHAR(63) utf8mb4 columns: 63*4=252 bytes (under the 256-byte inline
+	// threshold) + 1-byte prefix = 253 each. 40 * 253 = 10120, past the
+	// ~8126-byte 16K-page budget.
+	cols := make([]wire.TableColumn, 0, 40)
+	for i := 0; i < 40; i++ {
+		cols = append(cols, wire.TableColumn{Name: "c", Type: "varchar(63)", Charset: "utf8mb4"})
+	}
+	req := wire.Request{
+		ServerVariables: map[string]string{"innodb_page_size": "16384"},
+		Tables: []wire.Table{
+			{Schema: "s", Name: "wide", Engine: "InnoDB", RowFormat: "Dynamic", Columns: cols},
+		},
+	}
+	findings := evaluateTables(req)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+	if findings[0].ErrKey != "SCH0001" {
+		t.Errorf("wrong ErrKey: %s", findings[0].ErrKey)
+	}
+	if findings[0].Severity != "SCHEMA" {
+		t.Errorf("wrong severity: %s", findings[0].Severity)
+	}
+}
+
+func TestEvaluateTables_SkipsNonInnoDB(t *testing.T) {
+	cols := make([]wire.TableColumn, 0, 40)
+	for i := 0; i < 40; i++ {
+		cols = append(cols, wire.TableColumn{Name: "c", Type: "varchar(63)", Charset: "utf8mb4"})
+	}
+	req := wire.Request{
+		ServerVariables: map[string]string{"innodb_page_size": "16384"},
+		Tables: []wire.Table{
+			{Schema: "s", Name: "wide", Engine: "MyISAM", RowFormat: "Dynamic", Columns: cols},
+		},
+	}
+	if findings := evaluateTables(req); len(findings) != 0 {
+		t.Errorf("expected 0 findings for non-InnoDB table, got %d", len(findings))
+	}
+}
+
+func TestEvaluateTables_SkipsWideVarcharsPast256Bytes(t *testing.T) {
+	// VARCHAR(1000) latin1 = 1000 bytes, at/above the 256-byte inline threshold —
+	// deliberately excluded from the sum regardless of count.
+	cols := make([]wire.TableColumn, 0, 20)
+	for i := 0; i < 20; i++ {
+		cols = append(cols, wire.TableColumn{Name: "c", Type: "varchar(1000)", Charset: "latin1"})
+	}
+	req := wire.Request{
+		ServerVariables: map[string]string{"innodb_page_size": "16384"},
+		Tables: []wire.Table{
+			{Schema: "s", Name: "wide", Engine: "InnoDB", RowFormat: "Dynamic", Columns: cols},
+		},
+	}
+	if findings := evaluateTables(req); len(findings) != 0 {
+		t.Errorf("expected 0 findings when all VARCHARs are >= inline threshold, got %d", len(findings))
+	}
+}
+
+func TestEvaluateTables_UnderBudgetNotFlagged(t *testing.T) {
+	req := wire.Request{
+		ServerVariables: map[string]string{"innodb_page_size": "16384"},
+		Tables: []wire.Table{
+			{Schema: "s", Name: "small", Engine: "InnoDB", RowFormat: "Dynamic", Columns: []wire.TableColumn{
+				{Name: "a", Type: "varchar(50)", Charset: "latin1"},
+				{Name: "b", Type: "varchar(50)", Charset: "latin1"},
+			}},
+		},
+	}
+	if findings := evaluateTables(req); len(findings) != 0 {
+		t.Errorf("expected 0 findings under budget, got %d", len(findings))
+	}
+}
+
+// TestEvaluateTables_MultipleOffendingTablesAggregateIntoOneFinding guards
+// against the state-collision bug: repman's state machine keys open states
+// as ErrKey@server and only keeps the first write per key for a monitoring
+// cycle (state.Map.Add), so multiple SCH0001 findings for the same server
+// would silently drop every table after the first. All offenses must be
+// folded into a single finding.
+func TestEvaluateTables_MultipleOffendingTablesAggregateIntoOneFinding(t *testing.T) {
+	wideCols := make([]wire.TableColumn, 0, 40)
+	for i := 0; i < 40; i++ {
+		wideCols = append(wideCols, wire.TableColumn{Name: "c", Type: "varchar(63)", Charset: "utf8mb4"})
+	}
+	req := wire.Request{
+		ServerVariables: map[string]string{"innodb_page_size": "16384"},
+		Tables: []wire.Table{
+			{Schema: "s", Name: "wide_a", Engine: "InnoDB", RowFormat: "Dynamic", Columns: wideCols},
+			{Schema: "s", Name: "wide_b", Engine: "InnoDB", RowFormat: "Dynamic", Columns: wideCols},
+		},
+	}
+	findings := evaluateTables(req)
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 aggregated finding for 2 offending tables (state-collision guard), got %d", len(findings))
+	}
+	if !strings.Contains(findings[0].Description, "wide_a") || !strings.Contains(findings[0].Description, "wide_b") {
+		t.Errorf("expected both offending tables named in the aggregated description, got: %s", findings[0].Description)
+	}
+	if !strings.Contains(findings[0].Description, "2 InnoDB table(s)") {
+		t.Errorf("expected offense count in description, got: %s", findings[0].Description)
+	}
+}

--- a/cluster/logplugin/plugins/plugin-schema-row-size/main_test.go
+++ b/cluster/logplugin/plugins/plugin-schema-row-size/main_test.go
@@ -190,3 +190,31 @@ func TestEvaluateTables_MultipleOffendingTablesAggregateIntoOneFinding(t *testin
 		t.Errorf("expected offense count in description, got: %s", findings[0].Description)
 	}
 }
+
+// TestEvaluateTables_MaskIdentifiers guards the PCI-DSS-style compliance
+// option: with mask-identifiers=true, the aggregated description must not
+// contain the real table or column names, only their masked form.
+func TestEvaluateTables_MaskIdentifiers(t *testing.T) {
+	cols := make([]wire.TableColumn, 0, 40)
+	for i := 0; i < 40; i++ {
+		cols = append(cols, wire.TableColumn{Name: "credit_card_number", Type: "varchar(63)", Charset: "utf8mb4"})
+	}
+	req := wire.Request{
+		ServerVariables: map[string]string{"innodb_page_size": "16384"},
+		Config:          map[string]string{"mask-identifiers": "true"},
+		Tables: []wire.Table{
+			{Schema: "payments", Name: "credit_cards", Engine: "InnoDB", RowFormat: "Dynamic", Columns: cols},
+		},
+	}
+	findings := evaluateTables(req)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	desc := findings[0].Description
+	if strings.Contains(desc, "credit_cards") || strings.Contains(desc, "credit_card_number") || strings.Contains(desc, "payments") {
+		t.Errorf("expected real identifiers masked out of description, got: %s", desc)
+	}
+	if !strings.Contains(desc, wire.MaskIdentifier("credit_cards")) {
+		t.Errorf("expected masked table name in description, got: %s", desc)
+	}
+}

--- a/cluster/logplugin/plugins/plugin-schema-row-size/plugin-schema-row-size.manifest.json
+++ b/cluster/logplugin/plugins/plugin-schema-row-size/plugin-schema-row-size.manifest.json
@@ -1,0 +1,21 @@
+{
+  "description": "Wide Variable Rows — SCH0001\n\nFlags InnoDB tables whose short, always-inline-stored VARCHAR columns (declared byte width under the inline threshold) already sum past the estimated InnoDB inline row budget. Rows past this budget either fail to insert with \"Row size too large\" or force additional columns off-page, hurting scan performance. Advisory and conservative — not a byte-exact replica of InnoDB's internal record format. All offending tables on a server are reported in a single SCH0001 finding (one finding per plugin run), not one finding per table.",
+  "prerequisites": [
+    {
+      "config_key": "monitoring-schema-columns",
+      "description": "Schema column metadata (types, charset) must be monitored (monitoring-schema-columns=true) — without it this check silently sees no columns and reports no findings"
+    }
+  ],
+  "config_keys": [
+    {
+      "key": "inline-varchar-max-bytes",
+      "label": "Inline VARCHAR byte threshold",
+      "type": "int",
+      "default": "256",
+      "min": 1,
+      "max": 8000,
+      "step": 1,
+      "help": "VARCHAR columns whose declared byte width (declared length × charset max-bytes-per-char) is under this value are treated as always inline-stored and summed against the InnoDB row budget."
+    }
+  ]
+}

--- a/cluster/logplugin/plugins/plugin-schema-row-size/plugin-schema-row-size.manifest.json
+++ b/cluster/logplugin/plugins/plugin-schema-row-size/plugin-schema-row-size.manifest.json
@@ -16,6 +16,13 @@
       "max": 8000,
       "step": 1,
       "help": "VARCHAR columns whose declared byte width (declared length × charset max-bytes-per-char) is under this value are treated as always inline-stored and summed against the InnoDB row budget."
+    },
+    {
+      "key": "mask-identifiers",
+      "label": "Mask table/column names",
+      "type": "bool",
+      "default": "false",
+      "help": "Partially obscure schema, table, and column names in the finding description (e.g. \"window\" -> \"wi???ow\") so the log entry is not directly useful to someone who only has log access. For PCI-DSS/compliance deployments where the findings log is more widely readable than the database schema itself."
     }
   ]
 }

--- a/cluster/logplugin/plugins/wire/wire.go
+++ b/cluster/logplugin/plugins/wire/wire.go
@@ -304,3 +304,31 @@ func EnvStr(envKey, def string) string {
 	}
 	return def
 }
+
+// MaskIdentifier partially obscures a table/column/schema name for compliance
+// logging (PCI-DSS §10.5.5 and similar: findings logs must not leak enough of
+// the schema to be useful to someone who only has log access). The masked
+// span is a fixed number of '?' rather than one that mirrors the real length,
+// so the identifier's length can't be inferred from the mask either — e.g.
+// "window" -> "wi???ow". Names of 4 chars or fewer are masked in full since
+// there is nothing safe left to reveal (and short names are often the most
+// sensitive: "ssn", "cc", "dob").
+func MaskIdentifier(s string) string {
+	if len(s) <= 4 {
+		return "????"
+	}
+	return s[:2] + "???" + s[len(s)-2:]
+}
+
+// MaskQualified masks every non-empty part of a dotted identifier path
+// (e.g. schema, table, column) and joins them back with ".".
+func MaskQualified(parts ...string) string {
+	masked := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		masked = append(masked, MaskIdentifier(p))
+	}
+	return strings.Join(masked, ".")
+}

--- a/cluster/logplugin/plugins/wire/wire.go
+++ b/cluster/logplugin/plugins/wire/wire.go
@@ -50,6 +50,12 @@ type TableColumn struct {
 	Nullable  bool   `json:"nullable"`
 	Charset   string `json:"charset,omitempty"`
 	Collation string `json:"collation,omitempty"`
+	// Compressed is true when the column declares MariaDB per-column
+	// COMPRESSED storage (BLOB/TEXT candidate columns only, MariaDB only).
+	Compressed bool `json:"compressed,omitempty"`
+	// AvgByteLength is a bounded-sample observed average byte length
+	// (BLOB/TEXT candidate columns only). Zero means not sampled.
+	AvgByteLength int64 `json:"avg_byte_length,omitempty"`
 }
 
 // Table is one table of the schema dictionary snapshot (wire v3).
@@ -57,13 +63,14 @@ type TableColumn struct {
 // plus boot and on-demand runs) and is populated ONLY on the master server's
 // request to keep per-tick payloads flat.
 type Table struct {
-	Schema     string        `json:"schema"`
-	Name       string        `json:"name"`
-	Engine     string        `json:"engine"`
-	RowFormat  string        `json:"row_format"`
-	Rows       int64         `json:"rows,omitempty"`
-	DataLength int64         `json:"data_length,omitempty"`
-	Columns    []TableColumn `json:"columns,omitempty"`
+	Schema       string        `json:"schema"`
+	Name         string        `json:"name"`
+	Engine       string        `json:"engine"`
+	RowFormat    string        `json:"row_format"`
+	Rows         int64         `json:"rows,omitempty"`
+	DataLength   int64         `json:"data_length,omitempty"`
+	AvgRowLength int64         `json:"avg_row_length,omitempty"` // observed average row length (information_schema.tables), corroborating signal only
+	Columns      []TableColumn `json:"columns,omitempty"`
 }
 
 // Request is written to the plugin's stdin as a single JSON object.

--- a/cluster/logplugin/plugins/wire/wire_test.go
+++ b/cluster/logplugin/plugins/wire/wire_test.go
@@ -1,0 +1,34 @@
+package wire
+
+import "testing"
+
+func TestMaskIdentifier(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"window", "wi???ow"},
+		{"customer_ssn", "cu???sn"},
+		{"cc", "????"},
+		{"ssn", "????"},
+		{"dob", "????"},
+		{"abcd", "????"},
+		{"abcde", "ab???de"},
+	}
+	for _, tc := range cases {
+		if got := MaskIdentifier(tc.in); got != tc.want {
+			t.Errorf("MaskIdentifier(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMaskQualified(t *testing.T) {
+	got := MaskQualified("payments", "credit_cards", "pan")
+	want := "pa???ts.cr???ds.????"
+	if got != want {
+		t.Errorf("MaskQualified(...) = %q, want %q", got, want)
+	}
+	if got := MaskQualified("s", "", "t"); got != "????.????" {
+		t.Errorf("MaskQualified with empty part = %q, want %q (empty parts skipped)", got, "????.????")
+	}
+}

--- a/cluster/srv_log_plugins.go
+++ b/cluster/srv_log_plugins.go
@@ -303,7 +303,7 @@ func (server *ServerMonitor) RunLogPlugins(spikeCache map[string]*logplugin.Spik
 				}
 			}
 			sm.AddState(compositeKey, st)
-			if !isSecurity && !isWorkload {
+			if !isSecurity && !isWorkload && !isSchema {
 				cluster.SetState(f.ErrKey, st)
 			}
 		}
@@ -405,15 +405,22 @@ func (cluster *Cluster) RefreshSchemaWireTables() {
 	tables := make([]logplugin.StdioTable, 0, len(dict))
 	for _, t := range dict {
 		wt := logplugin.StdioTable{
-			Schema:     t.TableSchema,
-			Name:       t.TableName,
-			Engine:     t.Engine,
-			RowFormat:  t.RowFormat,
-			Rows:       t.TableRows,
-			DataLength: t.DataLength,
+			Schema:       t.TableSchema,
+			Name:         t.TableName,
+			Engine:       t.Engine,
+			RowFormat:    t.RowFormat,
+			Rows:         t.TableRows,
+			DataLength:   t.DataLength,
+			AvgRowLength: t.AvgRowLength,
 		}
 		for _, c := range t.TableColumns {
-			col := logplugin.StdioTableColumn{Name: c.Name, Type: c.Type, Nullable: c.Nullable}
+			col := logplugin.StdioTableColumn{
+				Name:          c.Name,
+				Type:          c.Type,
+				Nullable:      c.Nullable,
+				Compressed:    c.Compressed,
+				AvgByteLength: c.AvgByteLength,
+			}
 			if c.Charset != nil {
 				col.Charset = *c.Charset
 			}
@@ -1081,6 +1088,7 @@ func buildMonitoringFlags(cluster *Cluster, server *ServerMonitor) map[string]bo
 		"monitoring-performance-schema":         cluster.Conf.MonitorPFS,
 		"monitoring-performance-schema-queries": cluster.Conf.MonitorPFSQueries,
 		"monitoring-processlist":                cluster.Conf.MonitorProcessList,
+		"monitoring-schema-columns":             cluster.Conf.MonitorSchemaColumns,
 
 		// Auto-detected per-server capability: true only when the MySQL
 		// METADATA_LOCK_INFO plugin is installed and active on this server.

--- a/cluster/srv_log_plugins.go
+++ b/cluster/srv_log_plugins.go
@@ -166,31 +166,36 @@ func (server *ServerMonitor) RunLogPlugins(spikeCache map[string]*logplugin.Spik
 		// SeveritySecurity findings but carry no ScoreChecks.
 		isSecurityPlugin := len(result.ScoreChecks) > 0
 		isWorkloadPlugin := false
+		isSchemaPlugin := false
 		for _, f := range result.Findings {
 			switch f.Severity {
 			case logplugin.SeveritySecurity:
 				isSecurityPlugin = true
 			case logplugin.SeverityWorkload:
 				isWorkloadPlugin = true
+			case logplugin.SeveritySchema:
+				isSchemaPlugin = true
 			}
 		}
 		// When the plugin is compliant (zero findings, no ScoreChecks), fall back
 		// to its declared default severity so debug messages still route to the
 		// correct dedicated log rather than the main cluster log.
-		if !isSecurityPlugin && !isWorkloadPlugin {
+		if !isSecurityPlugin && !isWorkloadPlugin && !isSchemaPlugin {
 			if ps, ok := p.(logplugin.LogPluginWithDefaultSeverity); ok {
 				switch ps.DefaultSeverity() {
 				case logplugin.SeveritySecurity:
 					isSecurityPlugin = true
 				case logplugin.SeverityWorkload:
 					isWorkloadPlugin = true
+				case logplugin.SeveritySchema:
+					isSchemaPlugin = true
 				}
 			}
 		}
 
-		// DBVersion debug: routed to the dedicated security/workload log only.
-		// Never falls back to the main cluster log — debug plugin diagnostics
-		// must not mix with HA operational logs.
+		// DBVersion debug: routed to the dedicated security/workload/schema log
+		// only. Never falls back to the main cluster log — debug plugin
+		// diagnostics must not mix with HA operational logs.
 		sv := src.ServerVersion
 		dbvMsg := fmt.Sprintf("[logplugin:%s] server=%s DBVersion flavor=%q major=%d minor=%d release=%d variables=%d",
 			p.Name(), server.URL, sv.Flavor, sv.Major, sv.Minor, sv.Release, len(src.ServerVariables))
@@ -198,6 +203,8 @@ func (server *ServerMonitor) RunLogPlugins(spikeCache map[string]*logplugin.Spik
 			cluster.logPluginDebugSec(p.Name(), dbvMsg)
 		} else if isWorkloadPlugin {
 			cluster.logPluginDebugWork(p.Name(), dbvMsg)
+		} else if isSchemaPlugin {
+			cluster.logPluginDebugSchema(p.Name(), dbvMsg)
 		}
 
 		// Send synthetic graphite metric if the plugin produced one.
@@ -215,6 +222,8 @@ func (server *ServerMonitor) RunLogPlugins(spikeCache map[string]*logplugin.Spik
 				cluster.logPluginDebugSec(p.Name(), gMsg)
 			} else if isWorkloadPlugin {
 				cluster.logPluginDebugWork(p.Name(), gMsg)
+			} else if isSchemaPlugin {
+				cluster.logPluginDebugSchema(p.Name(), gMsg)
 			}
 			// HA/operational plugins with graphite metrics keep their debug in the main log.
 		}

--- a/cluster/srv_log_plugins.go
+++ b/cluster/srv_log_plugins.go
@@ -286,6 +286,21 @@ func (server *ServerMonitor) RunLogPlugins(spikeCache map[string]*logplugin.Spik
 							config.LvlWarn, "[workload:%s] %s on server %s: %s",
 							p.Name(), f.ErrKey, server.URL, f.Description)
 					}
+				case isSchema:
+					// Schema advisory findings go exclusively to schema.log + LogSchema HTTP buffer.
+					cluster.LogSchema.Add(s18log.HttpMessage{
+						Group:     cluster.Name,
+						Level:     "WARN",
+						Timestamp: time.Now().Format("2006/01/02 15:04:05"),
+						Text:      fmt.Sprintf("[%s] %s %s: %s", p.Name(), f.ErrKey, server.URL, f.Description),
+					})
+					if cluster.SchemaLogrus != nil {
+						cluster.SchemaLogrus.WithFields(fields).Warn(f.Description)
+					} else {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPlugin,
+							config.LvlInfo, "[schema:%s] %s on server %s: %s",
+							p.Name(), f.ErrKey, server.URL, f.Description)
+					}
 				default:
 					// HA/operational findings stay in the main log.
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPlugin,
@@ -298,6 +313,8 @@ func (server *ServerMonitor) RunLogPlugins(spikeCache map[string]*logplugin.Spik
 					cluster.logPluginDebugSec(p.Name(), stillMsg)
 				} else if isWorkload {
 					cluster.logPluginDebugWork(p.Name(), stillMsg)
+				} else if isSchema {
+					cluster.logPluginDebugSchema(p.Name(), stillMsg)
 				} else {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModPlugin, config.LvlDbg, "%s", stillMsg)
 				}
@@ -1189,6 +1206,12 @@ func (cluster *Cluster) logPluginDebugSec(pluginName, msg string) {
 func (cluster *Cluster) logPluginDebugWork(pluginName, msg string) {
 	if cluster.WorkloadLogrus != nil {
 		cluster.WorkloadLogrus.WithField("plugin", pluginName).Debug(msg)
+	}
+}
+
+func (cluster *Cluster) logPluginDebugSchema(pluginName, msg string) {
+	if cluster.SchemaLogrus != nil {
+		cluster.SchemaLogrus.WithField("plugin", pluginName).Debug(msg)
 	}
 }
 

--- a/doc/implementation/cluster/LOG_PLUGINS.md
+++ b/doc/implementation/cluster/LOG_PLUGINS.md
@@ -280,7 +280,7 @@ type Response struct {
 
 type Finding struct {
     ErrKey       string        `json:"err_key"`
-    Severity     string        `json:"severity"`    // "WARNING", "ERROR", "SECURITY", or "WORKLOAD"
+    Severity     string        `json:"severity"`    // "WARNING", "ERROR", "SECURITY", "WORKLOAD", or "SCHEMA"
     Description  string        `json:"description"`
     Count        int64         `json:"count,omitempty"`   // wire v2 — occurrence count
     Total        int64         `json:"total,omitempty"`   // wire v2 — total for ratio computation
@@ -709,12 +709,29 @@ Wire version 3 adds two things:
    offending table/column into its description, rather than one finding per
    object (which would silently drop all but the first).
 
+   **Log routing.** Like `SECURITY`/`WORKLOAD`, `SCHEMA` findings go exclusively
+   to `cluster.LogSchema` (a rotating HTTP buffer, GUI "Schema Logs") and
+   `schema.log` on disk when configured — never the main cluster log. Same for
+   the existing core DDL/table-diff tracking (`cluster.LogDDL`, "DDL Change
+   Logs"): both live under the Schema section of the dashboard, separate from
+   the general/HA log.
+
 ### Shipped schema-advisory plugins
 
 | Plugin | Key | What it flags |
 |--------|-----|---------------|
-| `plugin-schema-row-size` | SCH0001 | InnoDB tables whose short (`< 256` byte, always-inline) VARCHAR columns sum past the InnoDB inline row budget (`page_size/2 − 66` ≈ 8126B for 16K, with a discount for `ROW_FORMAT=COMPRESSED`), risking "Row size too large" / forced off-page storage. Pure function over the snapshot — no extra query. Config: `inline-varchar-max-bytes` (default 256). |
-| `plugin-schema-lob-compression` | SCH0002 | MariaDB `BLOB`/`TEXT` columns whose sampled `avg_byte_length` exceeds a threshold and that are **not** `COMPRESSED`. MariaDB-only; requires `monitoring-schema-columns`. Config: `avg-length-threshold-bytes` (default 8192). |
+| `plugin-schema-row-size` | SCH0001 | InnoDB tables whose short (`< 256` byte, always-inline) VARCHAR columns sum past the InnoDB inline row budget (`page_size/2 − 66` ≈ 8126B for 16K, with a discount for `ROW_FORMAT=COMPRESSED`), risking "Row size too large" / forced off-page storage. Pure function over the snapshot — no extra query. Config: `inline-varchar-max-bytes` (default 256), `mask-identifiers` (default false). |
+| `plugin-schema-lob-compression` | SCH0002 | MariaDB `BLOB`/`TEXT` columns whose sampled `avg_byte_length` exceeds a threshold and that are **not** `COMPRESSED`. MariaDB-only; requires `monitoring-schema-columns`. Config: `avg-length-threshold-bytes` (default 8192), `mask-identifiers` (default false). |
+
+Both plugins support `mask-identifiers`: when true, schema/table/column names
+in the finding description are partially masked (`wire.MaskIdentifier`, e.g.
+`"window"` → `"wi???ow"`, with a fixed-length mask so the real length isn't
+inferable either; names of 4 chars or fewer mask to `"????"`). The
+lob-compression plugin also drops its suggested `ALTER TABLE` statement in
+this mode, since it would otherwise leak the exact names back into the log.
+Intended for PCI-DSS-style deployments where the findings log is readable by
+more people/systems than the database schema itself — an attacker who only
+gets log access shouldn't get a free schema map out of it.
 
 ---
 

--- a/doc/implementation/cluster/LOG_PLUGINS.md
+++ b/doc/implementation/cluster/LOG_PLUGINS.md
@@ -734,7 +734,7 @@ replication-manager-plugin-signer/
 ├── plugin-signing.pub          (public key deployed to repman servers)
 └── plugins/
     └── linux-amd64/
-        └── wire-v2/
+        └── wire-v3/
             ├── plugin-connection-storm
             ├── plugin-connection-storm.sig
             └── ...
@@ -744,7 +744,7 @@ The wire version is read directly from source:
 
 ```go
 // cluster/logplugin/plugins/wire/wire.go
-WireVersion = 2
+WireVersion = 3
 ```
 
 Makefile targets:

--- a/doc/implementation/cluster/LOG_PLUGINS.md
+++ b/doc/implementation/cluster/LOG_PLUGINS.md
@@ -667,7 +667,9 @@ Error keys follow the pattern `WARN<NNNN>` or a severity-specific prefix. The ra
 | WTAG0100–WTAG0199 | Workload optimizer path detection |
 | WTAG0200–WTAG0299 | PFS digest workload findings |
 
-| SCH0001+ | Schema advisories (errors/warnings, e.g. row-size risk) |
+| SCH0001 | Schema advisory: InnoDB wide-row risk — `plugin-schema-row-size` |
+| SCH0002 | Schema advisory: uncompressed large BLOB/TEXT (MariaDB) — `plugin-schema-lob-compression` |
+| SCH0003+ | Further schema advisories |
 | SCHTAG0001+ | Schema inventory tags (engine/row-format counts) |
 
 Choose a key in the WARN0400+ range for custom plugins to avoid collisions.
@@ -677,20 +679,42 @@ Choose a key in the WARN0400+ range for custom plugins to avoid collisions.
 Wire version 3 adds two things:
 
 1. **`tables` request field** — the schema dictionary snapshot: one entry per
-   table with `schema`, `name`, `engine`, `row_format`, `rows`, `data_length`
-   and `columns` (name, full type string, nullable, charset, collation).
-   Derive byte widths in the plugin from the type string and charset
-   (`varchar(255)` × utf8mb4 = 1020 bytes). The snapshot refreshes with the
-   schema monitor (daily cron `monitoring-schema-scheduler-cron` by default,
+   table with `schema`, `name`, `engine`, `row_format`, `rows`, `data_length`,
+   `avg_row_length`, and `columns` (name, full type string, nullable, charset,
+   collation). Derive VARCHAR byte widths in the plugin from the type string and
+   charset (`varchar(255)` × utf8mb4 = 1020 bytes). The snapshot refreshes with
+   the schema monitor (daily cron `monitoring-schema-scheduler-cron` by default,
    plus boot and on-demand runs) and is populated ONLY on the master server's
    request so per-tick payloads stay flat across replicas.
+
+   **Per-column enrichment (`monitoring-schema-columns`).** When
+   `monitoring-schema-columns` is enabled, BLOB/TEXT candidate columns also carry
+   `compressed` (MariaDB per-column `COMPRESSED` attribute, parsed from `SHOW
+   CREATE TABLE` — not exposed by `information_schema`) and `avg_byte_length` (a
+   **bounded** observed average: `LIMIT 1024` non-NULL rows, no `ORDER BY`, never
+   a full-table scan). The data source is `utils/dbhelper/schema_lob.go`; the
+   fields live on `wire.TableColumn` / `dbhelper.Column`. A schema plugin that
+   needs them declares `monitoring-schema-columns` as a manifest prerequisite so
+   the feed-off case routes an INFO state instead of silently seeing no columns.
 2. **`SCHEMA` finding severity** — findings with this severity are routed to
    the cluster `SchemaStateMachine` (exposed as `schemaStates` in the cluster
-   API payload). Use `SCHTAG0xxx` keys with `count` for inventory tags and
-   `SCH0xxx` for advisories. Planned first plugins: `plugin-schema-tags`
-   (engine/row-format inventory) and `plugin-schema-row-size` (InnoDB
-   Compact/Redundant tables whose short-varchar byte sum exceeds 8126B —
-   half a 16K page — risking "Row size too large" on DML).
+   API payload) and, unlike operational findings, are NOT mirrored into the main
+   HA `StateMachine`. Use `SCHTAG0xxx` keys with `count` for inventory tags and
+   `SCH0xxx` for advisories. `plugin-schema-*` binaries are inferred as
+   `SeveritySchema` by name (`external.go`).
+
+   **Aggregation note.** The state machine keys open states as `ErrKey@server`
+   and only the first state written for a key survives a cycle — so a schema
+   plugin emits **one** finding per run (fixed `ErrKey`) that aggregates every
+   offending table/column into its description, rather than one finding per
+   object (which would silently drop all but the first).
+
+### Shipped schema-advisory plugins
+
+| Plugin | Key | What it flags |
+|--------|-----|---------------|
+| `plugin-schema-row-size` | SCH0001 | InnoDB tables whose short (`< 256` byte, always-inline) VARCHAR columns sum past the InnoDB inline row budget (`page_size/2 − 66` ≈ 8126B for 16K, with a discount for `ROW_FORMAT=COMPRESSED`), risking "Row size too large" / forced off-page storage. Pure function over the snapshot — no extra query. Config: `inline-varchar-max-bytes` (default 256). |
+| `plugin-schema-lob-compression` | SCH0002 | MariaDB `BLOB`/`TEXT` columns whose sampled `avg_byte_length` exceeds a threshold and that are **not** `COMPRESSED`. MariaDB-only; requires `monitoring-schema-columns`. Config: `avg-length-threshold-bytes` (default 8192). |
 
 ---
 

--- a/regtest/regtest.go
+++ b/regtest/regtest.go
@@ -85,6 +85,7 @@ var tests = []string{
 	"testResticReseedXtrabackup",
 	"testResticReseedMariabackup",
 	"testOpenSVCUpgradeWarnRecovery",
+	"testSchemaPlugin",
 }
 
 const recoverTime = 8

--- a/regtest/test_schema_plugin.go
+++ b/regtest/test_schema_plugin.go
@@ -1,0 +1,173 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+
+package regtest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/signal18/replication-manager/cluster"
+	"github.com/signal18/replication-manager/config"
+)
+
+// schemaAdvisorPluginNames are the external plugins under test. Built via
+// `make plugins` into build/plugins/<name>, signed into share/plugins/<name>.sig.
+var schemaAdvisorPluginNames = []string{"plugin-schema-row-size", "plugin-schema-lob-compression"}
+
+// TestSchemaPlugin creates the schema conditions the schema-advisory plugins
+// are designed to flag:
+//   - an InnoDB table with enough short (< 256 byte), always-inline VARCHAR
+//     columns to exceed the InnoDB row-size budget (SCH0001);
+//   - on MariaDB, an uncompressed BLOB/TEXT column with a large observed
+//     average size (SCH0002).
+//
+// It then deploys the plugin binaries, synchronously refreshes the schema
+// snapshot and runs the plugin dispatch (no need to wait on the background
+// monitoring ticker), and asserts the expected findings land in
+// cluster.SchemaStates.
+func (regtest *RegTest) TestSchemaPlugin(cl *cluster.Cluster, conf string, test *cluster.Test) bool {
+	master := cl.GetMaster()
+	if master == nil || master.Conn == nil {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "TEST : SchemaPlugin: no master connection")
+		return false
+	}
+
+	// Feeds the plugins depend on.
+	cl.Conf.LogPlugin = true
+	cl.Conf.MonitorSchemaChange = true
+	cl.Conf.MonitorSchemaColumns = true
+
+	if !deploySchemaAdvisorPlugins(cl) {
+		return false
+	}
+
+	const testSchema = "test_schema_plugin"
+	const wideTable = "wide_row"
+	const lobTable = "lob_uncompressed"
+
+	if _, err := master.Conn.Exec("CREATE DATABASE IF NOT EXISTS " + testSchema); err != nil {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "TEST : SchemaPlugin: create database: %s", err)
+		return false
+	}
+	defer master.Conn.Exec("DROP DATABASE IF EXISTS " + testSchema)
+
+	// SCH0001 fixture: 40 VARCHAR(63) utf8mb4 columns. 63*4=252 declared bytes
+	// (under the 256-byte inline threshold) + 1-byte length prefix = 253 each.
+	// 40*253 = 10120 bytes, past the ~8126-byte 16K-page InnoDB budget.
+	cols := make([]string, 0, 40)
+	for i := 0; i < 40; i++ {
+		cols = append(cols, fmt.Sprintf("c%d VARCHAR(63)", i))
+	}
+	createWide := fmt.Sprintf(
+		"CREATE TABLE %s.%s (id INT PRIMARY KEY, %s) ENGINE=InnoDB ROW_FORMAT=DYNAMIC DEFAULT CHARSET=utf8mb4",
+		testSchema, wideTable, strings.Join(cols, ", "),
+	)
+	if _, err := master.Conn.Exec(createWide); err != nil {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "TEST : SchemaPlugin: create wide-row table: %s", err)
+		return false
+	}
+
+	isMariaDB := master.DBVersion != nil && master.DBVersion.IsMariaDB()
+	if isMariaDB {
+		// SCH0002 fixture: an uncompressed TEXT column populated with rows
+		// large enough that the bounded sample (LIMIT 1024 non-NULL rows)
+		// observes an average past the 8192-byte default threshold.
+		createLob := fmt.Sprintf(
+			"CREATE TABLE %s.%s (id INT PRIMARY KEY, payload TEXT) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+			testSchema, lobTable,
+		)
+		if _, err := master.Conn.Exec(createLob); err != nil {
+			cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "TEST : SchemaPlugin: create lob table: %s", err)
+			return false
+		}
+
+		payload := strings.Repeat("x", 9000)
+		insertLob := fmt.Sprintf("INSERT INTO %s.%s (id, payload) VALUES (?, ?)", testSchema, lobTable)
+		for i := 0; i < 5; i++ {
+			if _, err := master.Conn.Exec(insertLob, i, payload); err != nil {
+				cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "TEST : SchemaPlugin: insert lob rows: %s", err)
+				return false
+			}
+		}
+	}
+
+	// Synchronous refresh: schema scan (populates DictTables + per-column LOB
+	// enrichment), wire snapshot rebuild, then the plugin dispatch itself.
+	// Bypasses the async SetWaitMonitorSchema()/MonitorSchema() cooldown gate
+	// so the test is deterministic regardless of prior test execution order.
+	if err := cl.MonitorMasterTableSchema(); err != nil {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "TEST : SchemaPlugin: schema scan: %s", err)
+		return false
+	}
+	cl.RefreshSchemaWireTables()
+	cl.CheckLogPlugins()
+
+	foundSCH0001 := false
+	foundSCH0002 := false
+	for _, s := range cl.SchemaStates {
+		switch s.ErrKey {
+		case "SCH0001":
+			foundSCH0001 = true
+		case "SCH0002":
+			foundSCH0002 = true
+		}
+	}
+
+	if !foundSCH0001 {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
+			"TEST : SchemaPlugin: expected SCH0001 finding not found in SchemaStates: %v", cl.SchemaStates)
+		return false
+	}
+	if isMariaDB && !foundSCH0002 {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
+			"TEST : SchemaPlugin: expected SCH0002 finding not found in SchemaStates (MariaDB): %v", cl.SchemaStates)
+		return false
+	}
+
+	return true
+}
+
+// deploySchemaAdvisorPlugins copies the schema advisor plugin binaries (built
+// via `make plugins` into build/plugins/) into the cluster's plugin
+// directory and reloads the registry. Signature verification is satisfied by
+// the .sig files `make plugins` already wrote to share/plugins/ against the
+// same binaries.
+func deploySchemaAdvisorPlugins(cl *cluster.Cluster) bool {
+	repoRoot := filepath.Dir(cl.GetShareDir()) // share/ and build/ are siblings at repo root
+	buildDir := filepath.Join(repoRoot, "build", "plugins")
+
+	pluginDir := filepath.Join(cl.WorkingDir, "plugins")
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "TEST : SchemaPlugin: create plugin dir %s: %s", pluginDir, err)
+		return false
+	}
+
+	for _, name := range schemaAdvisorPluginNames {
+		src := filepath.Join(buildDir, name)
+		data, err := os.ReadFile(src)
+		if err != nil {
+			cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
+				"TEST : SchemaPlugin: plugin binary %s not found — run `make plugins` before this test: %s", src, err)
+			return false
+		}
+		if err := os.WriteFile(filepath.Join(pluginDir, name), data, 0755); err != nil {
+			cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "TEST : SchemaPlugin: copy %s: %s", name, err)
+			return false
+		}
+
+		// Manifest sidecar is best-effort: it only affects prerequisite
+		// declaration/UI metadata, not plugin execution, and this test
+		// enables monitoring-schema-columns directly regardless.
+		manifestSrc := filepath.Join(repoRoot, "cluster", "logplugin", "plugins", name, name+".manifest.json")
+		if manifestData, err := os.ReadFile(manifestSrc); err == nil {
+			os.WriteFile(filepath.Join(pluginDir, name+".manifest.json"), manifestData, 0644)
+		}
+	}
+
+	cl.ReloadLogPlugins()
+	return true
+}

--- a/regtest/test_schema_plugin.go
+++ b/regtest/test_schema_plugin.go
@@ -55,15 +55,28 @@ func (regtest *RegTest) TestSchemaPlugin(cl *cluster.Cluster, conf string, test 
 	}
 	defer master.Conn.Exec("DROP DATABASE IF EXISTS " + testSchema)
 
-	// SCH0001 fixture: 40 VARCHAR(63) utf8mb4 columns. 63*4=252 declared bytes
+	// SCH0001 fixture: 30 VARCHAR(63) utf8mb4 columns. 63*4=252 declared bytes
 	// (under the 256-byte inline threshold) + 1-byte length prefix = 253 each.
-	// 40*253 = 10120 bytes, past the ~8126-byte 16K-page InnoDB budget.
-	cols := make([]string, 0, 40)
-	for i := 0; i < 40; i++ {
+	// 30*253 = 7590 bytes.
+	//
+	// This must land in the narrow gap between the plugin's ROW_FORMAT=COMPRESSED
+	// budget (page_size/2 - 66, discounted 10% for the unknown KEY_BLOCK_SIZE:
+	// ~7313 bytes for a 16K page) and MariaDB's own hard DDL-time rejection
+	// (page_size/2 - 66 = 8126 bytes exactly — "Row size too large (> 8126)").
+	// A wider fixture (e.g. 40 columns / 10120 bytes) exceeds MariaDB's own hard
+	// limit and CREATE TABLE is rejected outright before the plugin ever runs —
+	// the plugin's uncompressed budget was deliberately built to match MariaDB's
+	// real enforcement, so it can never observe a table wider than that via a
+	// fresh CREATE TABLE. ROW_FORMAT=COMPRESSED is the one place the plugin's
+	// estimate is intentionally more conservative than MariaDB's own check
+	// (KEY_BLOCK_SIZE isn't in the schema snapshot), which is what creates a
+	// legitimate window: MariaDB accepts the table, the plugin still flags it.
+	cols := make([]string, 0, 30)
+	for i := 0; i < 30; i++ {
 		cols = append(cols, fmt.Sprintf("c%d VARCHAR(63)", i))
 	}
 	createWide := fmt.Sprintf(
-		"CREATE TABLE %s.%s (id INT PRIMARY KEY, %s) ENGINE=InnoDB ROW_FORMAT=DYNAMIC DEFAULT CHARSET=utf8mb4",
+		"CREATE TABLE %s.%s (id INT PRIMARY KEY, %s) ENGINE=InnoDB ROW_FORMAT=COMPRESSED DEFAULT CHARSET=utf8mb4",
 		testSchema, wideTable, strings.Join(cols, ", "),
 	)
 	if _, err := master.Conn.Exec(createWide); err != nil {

--- a/regtest/test_schema_plugin.go
+++ b/regtest/test_schema_plugin.go
@@ -45,15 +45,18 @@ func (regtest *RegTest) TestSchemaPlugin(cl *cluster.Cluster, conf string, test 
 		return false
 	}
 
-	const testSchema = "test_schema_plugin"
-	const wideTable = "wide_row"
-	const lobTable = "lob_uncompressed"
+	// Use repman's own existing operational schema (already created for
+	// checksums/slow-log/jobs tracking) instead of standing up a throwaway
+	// database — creating/dropping a whole database on a cluster a client may
+	// be actively using is unnecessarily invasive, and this schema is
+	// guaranteed to already exist. Only the two test tables are created and
+	// dropped, nothing schema-level.
+	const testSchema = "replication_manager_schema"
+	const wideTable = "test_schema_plugin_wide_row"
+	const lobTable = "test_schema_plugin_lob_uncompressed"
 
-	if _, err := master.Conn.Exec("CREATE DATABASE IF NOT EXISTS " + testSchema); err != nil {
-		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "TEST : SchemaPlugin: create database: %s", err)
-		return false
-	}
-	defer master.Conn.Exec("DROP DATABASE IF EXISTS " + testSchema)
+	defer master.Conn.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s.%s", testSchema, wideTable))
+	defer master.Conn.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s.%s", testSchema, lobTable))
 
 	// SCH0001 fixture: 30 VARCHAR(63) utf8mb4 columns. 63*4=252 declared bytes
 	// (under the 256-byte inline threshold) + 1-byte length prefix = 253 each.
@@ -98,9 +101,15 @@ func (regtest *RegTest) TestSchemaPlugin(cl *cluster.Cluster, conf string, test 
 			return false
 		}
 
+		// dbhelper.EnrichLobColumns (the step that populates AvgByteLength)
+		// only samples tables whose DataLength is at least 1MB
+		// (lobCandidateMinDataBytes) — a deliberate guard against wasting
+		// enrichment effort on trivially small tables. 150 rows * 9000 bytes
+		// ~= 1.35MB of payload alone clears that gate with margin, comfortably
+		// under the LIMIT 1024 sample cap so every row gets sampled.
 		payload := strings.Repeat("x", 9000)
 		insertLob := fmt.Sprintf("INSERT INTO %s.%s (id, payload) VALUES (?, ?)", testSchema, lobTable)
-		for i := 0; i < 5; i++ {
+		for i := 0; i < 150; i++ {
 			if _, err := master.Conn.Exec(insertLob, i, payload); err != nil {
 				cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "TEST : SchemaPlugin: insert lob rows: %s", err)
 				return false
@@ -119,13 +128,17 @@ func (regtest *RegTest) TestSchemaPlugin(cl *cluster.Cluster, conf string, test 
 	cl.RefreshSchemaWireTables()
 	cl.CheckLogPlugins()
 
+	// state.StateMachine.AddState overwrites State.ErrKey with the full
+	// composite key ("ErrKey@ServerUrl") it uses internally to dedup open
+	// states — the bare ErrKey the plugin emitted is not preserved as-is, so
+	// match by prefix rather than exact equality.
 	foundSCH0001 := false
 	foundSCH0002 := false
 	for _, s := range cl.SchemaStates {
-		switch s.ErrKey {
-		case "SCH0001":
+		if strings.HasPrefix(s.ErrKey, "SCH0001@") {
 			foundSCH0001 = true
-		case "SCH0002":
+		}
+		if strings.HasPrefix(s.ErrKey, "SCH0002@") {
 			foundSCH0002 = true
 		}
 	}

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -5192,12 +5192,12 @@ func (repman *ReplicationManager) handlerMuxLog(w http.ResponseWriter, r *http.R
 
 // handlerMuxWebLog handles the retrieval of cluster logs by type.
 // @Summary Retrieve cluster logs by type
-// @Description Returns cluster logs for the specified type. Available types: general, task, security, workload, ddl, variable-change, sysbench. Without logType returns all logs.
+// @Description Returns cluster logs for the specified type. Available types: general, task, security, workload, ddl, schema, variable-change, sysbench. Without logType returns all logs.
 // @Tags ClusterTopology
 // @Produce json
 // @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
 // @Param clusterName path string true "Cluster Name"
-// @Param logType path string false "Log type: general, task, security, workload, ddl, variable-change, sysbench"
+// @Param logType path string false "Log type: general, task, security, workload, ddl, schema, variable-change, sysbench"
 // @Success 200 {object} map[string]interface{} "Log data"
 // @Failure 403 {string} string "No valid ACL"
 // @Failure 500 {string} string "Cluster Not Found"

--- a/server/regtest.go
+++ b/server/regtest.go
@@ -254,6 +254,9 @@ func (repman *ReplicationManager) RunAllTests(cl *cluster.Cluster, testExp strin
 		if test.Name == "testOpenSVCUpgradeWarnRecovery" {
 			res = regtest.TestOpenSVCUpgradeWarnRecovery(cl, test.ConfigFile, &test)
 		}
+		if test.Name == "testSchemaPlugin" {
+			res = regtest.TestSchemaPlugin(cl, test.ConfigFile, &test)
+		}
 
 		test.Result = regtest.GetTestResultLabel(res)
 		if testExp == "SUITE" {

--- a/server/server.go
+++ b/server/server.go
@@ -209,6 +209,10 @@ type ReplicationManager struct {
 	// events to workload.log (path derived from log-file by inserting "-workload"
 	// before the extension). Nil when log-file is not configured.
 	WorkloadLogrus *log.Logger `json:"-"`
+	// SchemaLogrus is a dedicated logger that writes schema advisory events to
+	// schema.log (path derived from log-file by inserting "-schema" before
+	// the extension). Nil when log-file is not configured.
+	SchemaLogrus *log.Logger `json:"-"`
 	// MaintenanceLogrus is a dedicated logger that writes planned-operations events
 	// (backup, SST, task execution, purge, orchestrator) to maintenance.log.
 	// Nil when log-file is not configured.
@@ -2512,6 +2516,31 @@ func (repman *ReplicationManager) Run() error {
 			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Workload log to file: %s", wrkLogFile)
 		}
 
+		// Schema log — same rotation settings, separate file for schema advisory events.
+		schLogFile := schemaLogPath(repman.Conf.LogFile)
+		schLogger := log.New()
+		schLogger.SetLevel(log.InfoLevel)
+		schLogger.SetFormatter(&log.TextFormatter{DisableColors: true})
+		schHook, schErr := s18log.NewRotateFileHook(s18log.RotateFileConfig{
+			Filename:   schLogFile,
+			MaxSize:    repman.Conf.LogRotateMaxSize,
+			MaxBackups: repman.Conf.LogRotateMaxBackup,
+			MaxAge:     repman.Conf.LogRotateMaxAge,
+			Level:      log.InfoLevel,
+			Formatter: &log.TextFormatter{
+				DisableColors:   true,
+				TimestampFormat: "2006-01-02 15:04:05",
+				FullTimestamp:   true,
+			},
+		})
+		if schErr != nil {
+			repman.Logrus.WithError(schErr).Warn("Can't init schema log file, schema events will only appear in main log")
+		} else {
+			schLogger.AddHook(schHook)
+			repman.SchemaLogrus = schLogger
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Schema log to file: %s", schLogFile)
+		}
+
 		// Maintenance log — backup, SST, task execution, purge, orchestrator events.
 		mntLogFile := maintenanceLogPath(repman.Conf.LogFile)
 		mntLogger := log.New()
@@ -3043,6 +3072,7 @@ func (repman *ReplicationManager) initCluster(clusterName string) (*cluster.Clus
 	repman.currentCluster.Logrus = repman.Logrus
 	repman.currentCluster.SecurityLogrus = repman.SecurityLogrus
 	repman.currentCluster.WorkloadLogrus = repman.WorkloadLogrus
+	repman.currentCluster.SchemaLogrus = repman.SchemaLogrus
 	repman.currentCluster.MaintenanceLogrus = repman.MaintenanceLogrus
 	repman.currentCluster.Partner = &repman.Partner
 	repman.currentCluster.ServerGlobals = repman.serverGlobals
@@ -4019,6 +4049,14 @@ func workloadLogPath(logFile string) string {
 	ext := filepath.Ext(logFile)
 	base := strings.TrimSuffix(logFile, ext)
 	return base + "-workload" + ext
+}
+
+// schemaLogPath derives the schema log file path from the main log file path
+// by inserting "-schema" before the file extension.
+func schemaLogPath(logFile string) string {
+	ext := filepath.Ext(logFile)
+	base := strings.TrimSuffix(logFile, ext)
+	return base + "-schema" + ext
 }
 
 // maintenanceLogPath derives the maintenance log file path from the main log file path

--- a/share/dashboard_react/src/Pages/Dashboard/components/Logs/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/Logs/index.jsx
@@ -107,4 +107,9 @@ export const VariableChangeLogs = ({ className }) => {
   return <Logs key={"variable-change"} logs={varChangeLogs?.buffer} className={className} searchable={true} />
 }
 
+export const SchemaLogs = ({ className }) => {
+  const schemaLogs = useSelector((state) => state.cluster.clusterLogs.schema)
+  return <Logs key={"schema"} logs={schemaLogs?.buffer} className={className} searchable={true} />
+}
+
 export default Logs

--- a/share/dashboard_react/src/Pages/Dashboard/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/index.jsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux'
 import ClusterWorkload from './components/ClusterWorkload'
 import { Flex, HStack, Tooltip, Box, Text } from '@chakra-ui/react'
 import AccordionComponent from '../../components/AccordionComponent/index.jsx'
-import { GeneralLogs, TaskLogs, SecurityLogs, WorkloadLogs, DDLLogs, VariableChangeLogs } from './components/Logs'
+import { GeneralLogs, TaskLogs, SecurityLogs, WorkloadLogs, DDLLogs, SchemaLogs, VariableChangeLogs } from './components/Logs'
 import DBServers from './components/DBServers'
 import Proxies from './components/Proxies'
 import Apps from './components/Apps/index.jsx'
@@ -118,6 +118,16 @@ function Dashboard({ selectedCluster, user, openSettings = {} }) {
         }
         headerActions={gearButton(openSettings.monitoring, 'Monitoring Settings')}
         body={<DDLLogs />}
+      />
+      <AccordionComponent
+        heading={
+          <LogHeading
+            title='Schema Logs'
+            description='Schema advisory findings from schema plugins (SCH0xxx): row-size risks, LOB compression, engine/row-format tags. Does not appear in the main Cluster Logs.'
+          />
+        }
+        headerActions={gearButton(openSettings.plugins, 'Plugin Settings')}
+        body={<SchemaLogs />}
       />
       <AccordionComponent
         heading={

--- a/utils/dbhelper/schema_lob.go
+++ b/utils/dbhelper/schema_lob.go
@@ -1,0 +1,158 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+
+// This file enriches the schema dictionary with BLOB/TEXT LOB metadata
+// (MariaDB per-column COMPRESSED detection and bounded-sample observed
+// average byte length) consumed by the plugin-schema-lob-compression schema
+// advisor plugin (see issue #1592).
+
+package dbhelper
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/signal18/replication-manager/utils/version"
+)
+
+// Bounded sampling / gating constants. Average-length collection must never
+// become a full-table scan on the exact largest-LOB tables it is trying to
+// flag, so every query here is capped: a fixed row LIMIT with no ORDER BY
+// (keeps the read close to a clustered-index prefix scan) and a short
+// per-query timeout, with silent skip-on-failure.
+const (
+	lobSampleLimit           = 1024
+	lobSampleTimeout         = 2 * time.Second
+	lobCandidateMinDataBytes = 1 << 20 // 1MB — skip trivially small tables
+)
+
+var (
+	showCreateColumnRe = regexp.MustCompile("(?m)^\\s*`([^`]+)`\\s")
+	compressedAttrRe   = regexp.MustCompile(`(?i)\bCOMPRESSED\b`)
+)
+
+// IsLobColumnType reports whether colType (as stored by information_schema,
+// already lowercased) is a BLOB or TEXT family type (including the
+// tiny/medium/long variants, which all contain "blob" or "text").
+func IsLobColumnType(colType string) bool {
+	return strings.Contains(colType, "blob") || strings.Contains(colType, "text")
+}
+
+// EnrichLobColumns populates Compressed and AvgByteLength on BLOB/TEXT
+// candidate columns of MariaDB tables. No-op for non-MariaDB servers and for
+// tables under lobCandidateMinDataBytes.
+//
+// Per table with LOB candidates this issues at most one SHOW CREATE TABLE
+// (shared across all candidate columns, for compression detection) plus one
+// bounded sampled AVG(LENGTH()) query per column not already detected as
+// COMPRESSED. Every query is capped — see the constants above. Failures are
+// skipped silently: this must never break schema monitoring.
+func EnrichLobColumns(db *sqlx.DB, myver *version.Version, tables map[string]*Table) string {
+	if myver == nil || !myver.IsMariaDB() {
+		return ""
+	}
+
+	var logBuilder strings.Builder
+	for _, t := range tables {
+		if t.DataLength < lobCandidateMinDataBytes {
+			continue
+		}
+		var candidates []*Column
+		for i := range t.TableColumns {
+			c := &t.TableColumns[i]
+			if IsLobColumnType(c.Type) {
+				candidates = append(candidates, c)
+			}
+		}
+		if len(candidates) == 0 {
+			continue
+		}
+
+		appendLog(&logBuilder, applyCompressedFlags(db, t, candidates))
+
+		for _, c := range candidates {
+			if c.Compressed {
+				continue // already flagged compressed — no need to size it
+			}
+			avg, qlog, err := sampleAvgColumnLength(db, t.TableSchema, t.TableName, c.Name)
+			appendLog(&logBuilder, qlog)
+			if err != nil {
+				continue // skip silently — sampling failures must not break schema monitoring
+			}
+			c.AvgByteLength = avg
+		}
+	}
+	return logBuilder.String()
+}
+
+// applyCompressedFlags runs SHOW CREATE TABLE once and sets Compressed on any
+// candidate whose column definition line declares COMPRESSED. MariaDB's
+// per-column compression attribute is not exposed via information_schema —
+// SHOW CREATE TABLE parsing is the only way to detect it.
+func applyCompressedFlags(db *sqlx.DB, t *Table, candidates []*Column) string {
+	qtable, err := QuoteMySQLTableIdentifier(t.TableSchema + "." + t.TableName)
+	if err != nil {
+		return ""
+	}
+	query := "SHOW CREATE TABLE " + qtable
+	ctx, cancel := context.WithTimeout(context.Background(), lobSampleTimeout)
+	defer cancel()
+
+	var name, ddl string
+	if err := db.QueryRowxContext(ctx, query).Scan(&name, &ddl); err != nil {
+		return fmt.Sprintf("%s -- failed: %v", query, err)
+	}
+
+	byName := make(map[string]*Column, len(candidates))
+	for _, c := range candidates {
+		byName[c.Name] = c
+	}
+	for _, line := range strings.Split(ddl, "\n") {
+		m := showCreateColumnRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		col, ok := byName[m[1]]
+		if !ok {
+			continue
+		}
+		col.Compressed = compressedAttrRe.MatchString(line)
+	}
+	return query
+}
+
+// sampleAvgColumnLength computes a bounded-sample average byte length for one
+// column: at most lobSampleLimit non-NULL rows, no ORDER BY, short timeout.
+// Never scans the full table.
+func sampleAvgColumnLength(db *sqlx.DB, schema, table, column string) (int64, string, error) {
+	qtable, err := QuoteMySQLTableIdentifier(schema + "." + table)
+	if err != nil {
+		return 0, "", err
+	}
+	if verr := ValidateIdentifier(column); verr != nil {
+		return 0, "", verr
+	}
+	qcol := QuoteMySQLIdentifier(column)
+
+	query := fmt.Sprintf(
+		"SELECT AVG(LENGTH(%s)) FROM (SELECT %s FROM %s WHERE %s IS NOT NULL LIMIT %d) lob_sample",
+		qcol, qcol, qtable, qcol, lobSampleLimit,
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), lobSampleTimeout)
+	defer cancel()
+
+	var avg sql.NullFloat64
+	if err := db.QueryRowxContext(ctx, query).Scan(&avg); err != nil {
+		return 0, query, err
+	}
+	if !avg.Valid {
+		return 0, query, nil // all-NULL sample or empty table — nothing to report
+	}
+	return int64(avg.Float64), query, nil
+}

--- a/utils/dbhelper/schema_lob_test.go
+++ b/utils/dbhelper/schema_lob_test.go
@@ -1,0 +1,204 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+
+package dbhelper
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	"github.com/signal18/replication-manager/utils/version"
+)
+
+// ---- IsLobColumnType ---------------------------------------------------------
+
+func TestIsLobColumnType(t *testing.T) {
+	cases := []struct {
+		colType string
+		want    bool
+	}{
+		{"text", true},
+		{"tinytext", true},
+		{"mediumtext", true},
+		{"longtext", true},
+		{"blob", true},
+		{"tinyblob", true},
+		{"mediumblob", true},
+		{"longblob", true},
+		{"varchar(255)", false},
+		{"int(11)", false},
+		{"char(10)", false},
+	}
+	for _, tc := range cases {
+		if got := IsLobColumnType(tc.colType); got != tc.want {
+			t.Errorf("IsLobColumnType(%q) = %v, want %v", tc.colType, got, tc.want)
+		}
+	}
+}
+
+// ---- EnrichLobColumns ---------------------------------------------------------
+
+func newLobTestDB(t *testing.T) (*sqlx.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return sqlx.NewDb(db, "sqlmock"), mock
+}
+
+func TestEnrichLobColumns_NonMariaDBIsNoOp(t *testing.T) {
+	ver, _ := version.NewVersionFromString("MySQL", "8.0.34")
+	sqlxdb, mock := newLobTestDB(t)
+
+	tables := map[string]*Table{
+		"s.t": {TableSchema: "s", TableName: "t", DataLength: 10 << 20, TableColumns: []Column{
+			{Name: "c", Type: "text"},
+		}},
+	}
+
+	logs := EnrichLobColumns(sqlxdb, ver, tables)
+	if logs != "" {
+		t.Errorf("expected no queries logged for non-MariaDB, got %q", logs)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestEnrichLobColumns_SkipsSmallTables(t *testing.T) {
+	ver, _ := version.NewVersionFromString("MariaDB", "10.6.1-MariaDB")
+	sqlxdb, mock := newLobTestDB(t)
+
+	tables := map[string]*Table{
+		"s.t": {TableSchema: "s", TableName: "t", DataLength: 1024, TableColumns: []Column{
+			{Name: "c", Type: "text"},
+		}},
+	}
+
+	logs := EnrichLobColumns(sqlxdb, ver, tables)
+	if logs != "" {
+		t.Errorf("expected no queries logged for a table under the size gate, got %q", logs)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestEnrichLobColumns_SkipsTablesWithoutLobColumns(t *testing.T) {
+	ver, _ := version.NewVersionFromString("MariaDB", "10.6.1-MariaDB")
+	sqlxdb, mock := newLobTestDB(t)
+
+	tables := map[string]*Table{
+		"s.t": {TableSchema: "s", TableName: "t", DataLength: 10 << 20, TableColumns: []Column{
+			{Name: "c", Type: "varchar(255)"},
+		}},
+	}
+
+	logs := EnrichLobColumns(sqlxdb, ver, tables)
+	if logs != "" {
+		t.Errorf("expected no queries logged for a table with no LOB candidates, got %q", logs)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestEnrichLobColumns_DetectsCompressedAndSkipsSamplingIt(t *testing.T) {
+	ver, _ := version.NewVersionFromString("MariaDB", "10.6.1-MariaDB")
+	sqlxdb, mock := newLobTestDB(t)
+
+	tables := map[string]*Table{
+		"s.t": {TableSchema: "s", TableName: "t", DataLength: 10 << 20, TableColumns: []Column{
+			{Name: "payload", Type: "text"},
+		}},
+	}
+
+	ddl := "CREATE TABLE `t` (\n  `id` int(11) NOT NULL,\n  `payload` text COMPRESSED DEFAULT NULL\n) ENGINE=InnoDB"
+	mock.ExpectQuery(regexp.QuoteMeta("SHOW CREATE TABLE `s`.`t`")).
+		WillReturnRows(sqlmock.NewRows([]string{"Table", "Create Table"}).AddRow("t", ddl))
+	// No AVG(LENGTH()) query expected — a COMPRESSED column is skipped.
+
+	EnrichLobColumns(sqlxdb, ver, tables)
+
+	col := tables["s.t"].TableColumns[0]
+	if !col.Compressed {
+		t.Errorf("expected payload column to be detected as Compressed")
+	}
+	if col.AvgByteLength != 0 {
+		t.Errorf("expected AvgByteLength to stay 0 for a compressed column, got %d", col.AvgByteLength)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestEnrichLobColumns_SamplesUncompressedLobColumn(t *testing.T) {
+	ver, _ := version.NewVersionFromString("MariaDB", "10.6.1-MariaDB")
+	sqlxdb, mock := newLobTestDB(t)
+
+	tables := map[string]*Table{
+		"s.t": {TableSchema: "s", TableName: "t", DataLength: 10 << 20, TableColumns: []Column{
+			{Name: "payload", Type: "text"},
+		}},
+	}
+
+	ddl := "CREATE TABLE `t` (\n  `id` int(11) NOT NULL,\n  `payload` text DEFAULT NULL\n) ENGINE=InnoDB"
+	mock.ExpectQuery(regexp.QuoteMeta("SHOW CREATE TABLE `s`.`t`")).
+		WillReturnRows(sqlmock.NewRows([]string{"Table", "Create Table"}).AddRow("t", ddl))
+
+	// The sampling query must be bounded: LIMIT 1024, no ORDER BY.
+	sampleQuery := "SELECT AVG(LENGTH(`payload`)) FROM (SELECT `payload` FROM `s`.`t` WHERE `payload` IS NOT NULL LIMIT 1024) lob_sample"
+	if strings.Contains(strings.ToUpper(sampleQuery), "ORDER BY") {
+		t.Fatalf("test construction error: sample query must not contain ORDER BY")
+	}
+	mock.ExpectQuery(regexp.QuoteMeta(sampleQuery)).
+		WillReturnRows(sqlmock.NewRows([]string{"avg"}).AddRow(9500.0))
+
+	EnrichLobColumns(sqlxdb, ver, tables)
+
+	col := tables["s.t"].TableColumns[0]
+	if col.Compressed {
+		t.Errorf("expected payload column to not be Compressed")
+	}
+	if col.AvgByteLength != 9500 {
+		t.Errorf("expected AvgByteLength 9500, got %d", col.AvgByteLength)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestEnrichLobColumns_SkipsSilentlyOnSampleQueryError(t *testing.T) {
+	ver, _ := version.NewVersionFromString("MariaDB", "10.6.1-MariaDB")
+	sqlxdb, mock := newLobTestDB(t)
+
+	tables := map[string]*Table{
+		"s.t": {TableSchema: "s", TableName: "t", DataLength: 10 << 20, TableColumns: []Column{
+			{Name: "payload", Type: "text"},
+		}},
+	}
+
+	ddl := "CREATE TABLE `t` (\n  `payload` text DEFAULT NULL\n) ENGINE=InnoDB"
+	mock.ExpectQuery(regexp.QuoteMeta("SHOW CREATE TABLE `s`.`t`")).
+		WillReturnRows(sqlmock.NewRows([]string{"Table", "Create Table"}).AddRow("t", ddl))
+
+	sampleQuery := "SELECT AVG(LENGTH(`payload`)) FROM (SELECT `payload` FROM `s`.`t` WHERE `payload` IS NOT NULL LIMIT 1024) lob_sample"
+	mock.ExpectQuery(regexp.QuoteMeta(sampleQuery)).WillReturnError(sqlmock.ErrCancelled)
+
+	// Must not panic, must not propagate the error — schema monitoring must survive this.
+	EnrichLobColumns(sqlxdb, ver, tables)
+
+	col := tables["s.t"].TableColumns[0]
+	if col.AvgByteLength != 0 {
+		t.Errorf("expected AvgByteLength to stay 0 on query error, got %d", col.AvgByteLength)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}

--- a/utils/dbhelper/types.go
+++ b/utils/dbhelper/types.go
@@ -99,6 +99,16 @@ type Column struct {
 	Charset   *string `json:"charset,omitempty"`
 	Collation *string `json:"collation,omitempty"`
 	Crc64     uint64  `json:"crc64,omitempty"`
+	// Compressed is true when the column declares MariaDB per-column
+	// COMPRESSED storage. Detected via SHOW CREATE TABLE parsing (MariaDB
+	// only; not exposed by information_schema). Only populated for BLOB/TEXT
+	// candidate columns during schema monitoring.
+	Compressed bool `json:"compressed,omitempty"`
+	// AvgByteLength is a bounded-sample observed average byte length for
+	// BLOB/TEXT candidate columns (LIMIT 1024 non-NULL rows, no ORDER BY).
+	// Zero means not sampled (non-candidate column, sampling skipped/failed,
+	// or already known to be COMPRESSED).
+	AvgByteLength int64 `json:"avg_byte_length,omitempty"`
 }
 
 // IndexColumn represents a column in an index


### PR DESCRIPTION
## Summary
- add two schema advisor plugins for issue #1592: wide inline VARCHAR row risk and large uncompressed MariaDB BLOB/TEXT columns
- preserve external plugin SCHEMA severity and route schema findings through the existing schema state path
- extend the schema wire snapshot with row-size and LOB metadata used by schema advisors
- enrich MariaDB schema scans with bounded-sample LOB sizing and per-column COMPRESSED detection
- add unit tests for the new plugins, schema wire behavior, and LOB enrichment helpers

## Details
This PR implements the first schema advisor rules on top of the existing schema dictionary snapshot produced by schema monitoring.

### Rule 1: wide variable rows
Flags InnoDB tables whose short inline-stored VARCHAR columns collectively exceed the estimated inline row budget.

### Rule 2: large uncompressed LOBs
Flags MariaDB BLOB/TEXT columns whose observed average size is above the configured threshold and that are not using per-column COMPRESSED storage.

## Files of note
- cluster/logplugin/external.go
- cluster/srv_log_plugins.go
- cluster/logplugin/plugins/plugin-schema-row-size/*
- cluster/logplugin/plugins/plugin-schema-lob-compression/*
- utils/dbhelper/schema_lob.go
- cluster/logplugin/plugins/wire/wire.go

## Notes
- schema advisor results are surfaced through the existing schema domain / schema view path
- LOB sizing uses bounded sampling instead of full-table aggregation to avoid expensive scans on large tables

Closes #1592