### PR TITLE
docs: split-brain orchestration diagrams + material-procedure guides

### DIFF
--- a/doc/implementation/cluster/SPLIT_BRAIN_ORCHESTRATION.md
+++ b/doc/implementation/cluster/SPLIT_BRAIN_ORCHESTRATION.md
@@ -1,0 +1,106 @@
+# Split-Brain Orchestration Across Three Datacenters
+
+How replication-manager behaves when a dual-repman / arbitrator topology is cut
+in half, and how the **split-brain simulator** reproduces each case through the
+real fail-safe paths.
+
+## Topology
+
+Three clouds, one per datacenter:
+
+- **DC1** — master `db1` + the main repman (uid 1).
+- **DC2** — slaves `db2`/`db3` + the DR repman (uid 2).
+- **DC3** — the tie-breaker at signal18: a dedicated **arbitrator** (Support plan)
+  or a third repman standing in as arbitrator (Free plan).
+
+On a split, the isolated side becomes the **minority** and its master steps down;
+the side that keeps the arbitrator is the **majority** and promotes a slave to
+`NEW MASTER`. What differs between plans is the **recovery** — so the frames below
+start from the Free plan (where we come from), then the Support plan that removes
+the pain, then the symmetric split where repman must fence both sides.
+
+---
+
+## 1. Free plan — where we come from
+
+No dedicated arbitrator; a third repman stands in for DC3, so tie-breaking is
+weaker and the split lingers. Replication is cut, so the isolated old master keeps
+writing binlogs no slave consumes — a growing pile of delta transactions that
+**cannot be flashed back**. The only way home is a full **restore from backup**.
+
+![Free plan orchestration](img/sbs-free.svg)
+
+## 2. Support plan — the fix
+
+A dedicated arbitrator in DC3 is the strong tie-breaker: the minority is detected
+fast and yields cleanly (master read-only, `Active → Standby`). With
+[`arbitration-minority-freeze`](#the-ftwrl-minority-fence) the old master is
+**FTWRL-frozen** so the proxy cannot write to it. Its divergence is a single,
+flashback-able delta — **rejoin in place, in seconds**, never a restore.
+
+![Support plan orchestration](img/sbs-support.svg)
+
+## 3. Lose–Lose — the symmetric split
+
+Both DCs still reach the arbitrator, but not each other. Each side could naïvely
+read a 2-of-3 majority and promote — a real split-brain. To prevent it, repman
+does the safe thing and **grants neither**: both proxies are cut and both masters
+are FTWRL-frozen. The price is a full write outage until an operator (or a
+directional-failback policy) elects a survivor — but there is **zero divergence**,
+so recovery is a clean unfreeze rather than a restore.
+
+![Lose–Lose symmetric split](img/sbs-lose-lose.svg)
+
+---
+
+## The FTWRL minority fence
+
+`arbitration-minority-freeze` (`config.Config.ArbitrationMinorityFreeze`, default
+`false`):
+
+> Hold `FLUSH TABLES WITH READ LOCK` on a minority master during split brain
+> (blocks even `SUPER` writes; released when the split resolves) — true protection
+> `read_only` cannot give on MariaDB.
+
+This is the teal link cut on the minority side of the diagrams: repman actively
+blocks writes to the old master, on top of the network partition, so no client can
+diverge it while the majority promotes.
+
+## The split-brain simulator
+
+Each endpoint injects a **real** cut through the same code path a physical failure
+would trigger — nothing is faked at the state-machine level. All are per-cluster
+POSTs under:
+
+```
+/api/clusters/{clusterName}/test/split-brain-simulator/{action}
+```
+
+They require the `cluster-test` grant, are bounded by `?duration=<seconds>`
+(default 120), and auto-restore when the timer expires.
+
+| Action | Effect |
+|--------|--------|
+| `simulate-minority` | Marks **this** repman the minority side, instance-wide, on every cluster it drives. While armed the arbitrator link reads as severed, so this side cannot confirm authority and steps down through the real fail-safe path (master read-only, `Active → Standby` yield, peers `Suspect`). Aim it at the **active** instance — standby is the outcome you observe, never an input. |
+| `simulate-arbitrator-failure` | Cuts this repman's link to the arbitrator (DC3): it stops reporting and bails out of the election so its arbitrator row expires, exactly as if the DC3 link were physically severed. |
+| `simulate-heartbeat-failure` | Darkens this node's inbound `/api/heartbeat` handler so the peer's outbound heartbeat times out, producing a real peer-unreachable detection (`GWARN006`). Server-level and one-directional by design. |
+| `simulate-master-failure` | Cuts this repman's DB link to the master only, leaving the slaves reachable so the majority side can still promote. Used when the master is colocated on the isolated (minority) side. Also resets the failover counters so a prior test cycle cannot veto this failover. |
+| `restore` | Clears every simulated cut on this instance — the per-cluster arbitrator/database/master cuts and the server-level heartbeat. |
+
+**Reproducing each frame**
+
+- **Support / Free minority yield** — `simulate-minority` on the active (DC1)
+  instance; observe it go read-only and yield `Active → Standby` while the DR side
+  promotes.
+- **Master-colocated failover** — `simulate-master-failure` on the DC1 instance;
+  the majority (DC2) promotes a `NEW MASTER`.
+- **Lose–Lose** — arm the minority/heartbeat cut on **both** sides while leaving
+  each arbitrator link healthy: neither can prove a majority, and (with the freeze
+  enabled) both masters are held read-only.
+
+Always finish with `restore` (or let the `duration` expire) to release the cuts.
+
+---
+
+*Diagrams: `doc/implementation/cluster/img/sbs-{free,support,lose-lose}.svg`
+— self-contained, theme-aware SVG.*

--- a/doc/implementation/cluster/img/sbs-free.svg
+++ b/doc/implementation/cluster/img/sbs-free.svg
@@ -1,0 +1,155 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-18 -18 1156 596" role="img" aria-label="Free plan after failover, binlogs pile up"><style>
+  :root{
+    --bg:#eceef1;--panel:#ffffff;--ink:#12171d;--ink-soft:#4a5560;--ink-faint:#7b8794;
+    --line:#d7dbe0;--accent:#0a8f9c;--accent-ink:#06666f;--cloud:#f3f5f9;
+    --arb:#4b5cc4;--arb-bg:#eaecf9;--ok:#2f7fd1;
+    --majority:#1f8f52;--majority-bg:#e6f4ec;--minority:#c99613;--minority-bg:#f7efd8;
+    --cut:#cf4646;--cut-bg:#fbe9e9;
+    --mono:ui-monospace,"SF Mono","JetBrains Mono",Menlo,Consolas,monospace;
+    --sans:"Inter",ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#0d1014;--panel:#161b21;--ink:#eaeef2;--ink-soft:#a9b4bf;--ink-faint:#6b7681;
+    --line:#2a323b;--accent:#2bc0cd;--accent-ink:#7fe0e8;--cloud:#1a2027;
+    --arb:#8b98ec;--arb-bg:#1b1f36;--ok:#5aa6e6;
+    --majority:#4cc47f;--majority-bg:#142a1e;--minority:#e0b24a;--minority-bg:#2c2614;
+    --cut:#e26d6d;--cut-bg:#2c1717;
+  }}
+  :root[data-theme="light"]{--bg:#eceef1;--panel:#fff;--ink:#12171d;--ink-soft:#4a5560;--ink-faint:#7b8794;--line:#d7dbe0;--accent:#0a8f9c;--accent-ink:#06666f;--cloud:#f3f5f9;--arb:#4b5cc4;--arb-bg:#eaecf9;--ok:#2f7fd1;--majority:#1f8f52;--majority-bg:#e6f4ec;--minority:#c99613;--minority-bg:#f7efd8;--cut:#cf4646;--cut-bg:#fbe9e9;}
+  :root[data-theme="dark"]{--bg:#0d1014;--panel:#161b21;--ink:#eaeef2;--ink-soft:#a9b4bf;--ink-faint:#6b7681;--line:#2a323b;--accent:#2bc0cd;--accent-ink:#7fe0e8;--cloud:#1a2027;--arb:#8b98ec;--arb-bg:#1b1f36;--ok:#5aa6e6;--majority:#4cc47f;--majority-bg:#142a1e;--minority:#e0b24a;--minority-bg:#2c2614;--cut:#e26d6d;--cut-bg:#2c1717;}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.5;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1120px;margin:0 auto;padding:44px 24px 64px}
+  .eyebrow{font-size:12px;letter-spacing:.16em;text-transform:uppercase;color:var(--accent-ink);font-weight:600;margin:0 0 10px}
+  h1{font-size:clamp(25px,4vw,36px);line-height:1.1;margin:0 0 12px;letter-spacing:-.02em;text-wrap:balance;font-weight:700}
+  .lede{font-size:16.5px;color:var(--ink-soft);max-width:68ch;margin:0}
+  .lede b{color:var(--ink);font-weight:600}
+
+  .legend{display:flex;gap:22px;flex-wrap:wrap;margin:22px 0 4px;font-size:13px;color:var(--ink-soft)}
+  .legend span{display:inline-flex;align-items:center;gap:8px}
+  .swatch{width:34px;height:0;border-top:3px solid var(--ok)}
+  .swatch.cut{border-top:3px solid var(--cut);position:relative}
+  .swatch.cut::after{content:"||";position:absolute;left:11px;top:-11px;color:var(--cut);font-weight:800;font-size:14px;letter-spacing:-1px}
+  .swatch.ftwl{border-top:3px solid var(--accent)}
+  .pill{display:inline-flex;align-items:center;padding:2px 9px;border-radius:999px;font-size:11px;font-weight:700}
+  .pill.maj{background:var(--majority-bg);color:var(--majority)}
+  .pill.min{background:var(--minority-bg);color:var(--minority)}
+
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:20px 18px 8px;margin:24px 0}
+  .card h2{margin:0 6px 2px;font-size:19px;letter-spacing:-.01em}
+  .card .sub{margin:0 6px 6px;font-size:13.5px;color:var(--ink-faint)}
+  .card.support h2{color:var(--majority)}
+  .card.free h2{color:var(--minority)}
+  .card.lose h2{color:var(--cut)}
+  svg{display:block;width:100%;height:auto}
+  .note{margin:0 6px 14px;font-size:13.5px;color:var(--ink-soft)}
+  .note b{color:var(--ink);font-weight:600} .note .bad{color:var(--cut);font-weight:600}
+
+  .cloud-r{fill:var(--cloud);stroke:var(--line);stroke-width:1.5}
+  .cloud-dc1{stroke:color-mix(in srgb,var(--minority) 50%,var(--line))}
+  .cloud-dc2{stroke:color-mix(in srgb,var(--majority) 45%,var(--line))}
+  .cloud-dc3{fill:var(--arb-bg);stroke:color-mix(in srgb,var(--arb) 50%,var(--line))}
+  .cloud-lbl{fill:var(--ink);font:700 13px var(--sans)}
+  .cloud-loc{fill:var(--ink-faint);font:500 12px var(--mono)}
+  .tag-min{fill:var(--minority);font:800 11px var(--sans);letter-spacing:.5px}
+  .tag-maj{fill:var(--majority);font:800 11px var(--sans);letter-spacing:.5px}
+  .tag-fenced{fill:var(--cut);font:800 11px var(--sans);letter-spacing:.5px}
+  .box{fill:var(--panel);stroke:var(--line);stroke-width:2}
+  .box-old{stroke:color-mix(in srgb,var(--minority) 65%,var(--line));fill:var(--minority-bg)}
+  .box-new{stroke:color-mix(in srgb,var(--majority) 65%,var(--line));fill:var(--majority-bg)}
+  .box-repman{stroke:color-mix(in srgb,var(--accent) 60%,var(--line));fill:color-mix(in srgb,var(--accent) 14%,var(--panel))}
+  .box-arb{stroke:color-mix(in srgb,var(--arb) 60%,var(--line))}
+  .box-io{fill:var(--cut-bg);stroke:color-mix(in srgb,var(--cut) 45%,var(--line));stroke-width:1.5}
+  .t-name{fill:var(--ink);font:700 15px var(--mono)}
+  .t-name-s{fill:var(--ink);font:700 14px var(--sans)}
+  .t-badge-old{fill:var(--minority);font:800 10px var(--sans);letter-spacing:.5px}
+  .t-badge-new{fill:var(--majority);font:800 10px var(--sans);letter-spacing:.5px}
+  .t-badge-s{fill:var(--ink-faint);font:700 10px var(--sans);letter-spacing:.5px}
+  .t-io{fill:var(--cut);font:700 10px var(--mono)}
+  .t-arb{fill:var(--arb);font:700 15px var(--sans)}
+  .uid{fill:var(--accent-ink);font-weight:800}
+  .lnk-ok{stroke:var(--ok);stroke-width:3;fill:none}
+  .lnk-cut{stroke:var(--cut);stroke-width:3;fill:none;opacity:.85}
+  .cutbar{stroke:var(--cut);stroke-width:5;stroke-linecap:round}
+  .lnk-lbl{fill:var(--ink-faint);font:600 11.5px var(--sans)}
+  .lnk-lbl-cut{fill:var(--cut);font:700 11.5px var(--mono)}
+  .binlog{fill:var(--minority-bg);stroke:color-mix(in srgb,var(--minority) 55%,var(--line))}
+  .t-pile{fill:var(--cut);font:700 12px var(--sans)}
+  .yield-r{fill:var(--minority-bg);stroke:color-mix(in srgb,var(--minority) 45%,var(--line))}
+  .t-yield{fill:var(--minority);font:700 11.5px var(--sans)}
+  .box-proxy{fill:var(--panel);stroke:color-mix(in srgb,var(--accent) 45%,var(--line));stroke-width:2}
+  .t-proxy{fill:var(--accent-ink);font:700 13px var(--sans)}
+  .lnk-ftwl{stroke:var(--accent);stroke-width:3;fill:none}
+  .cutbar-ftwl{stroke:var(--accent);stroke-width:5;stroke-linecap:round}
+  .lnk-lbl-ftwl{fill:var(--accent-ink);font:700 11.5px var(--mono)}
+</style><rect x="-18" y="-18" width="1156" height="596" rx="18" fill="var(--panel)"/>
+      <!-- arbitrator links: DC1 cut (red), DC2 healthy (blue) -->
+      <path class="lnk-cut" d="M330,182 L470,116"/>
+      <path class="lnk-ok" d="M802,182 L650,116"/>
+      <text class="lnk-lbl-cut" x="300" y="152">✂ DC1 → repman-3: cut</text>
+      <text class="lnk-lbl" x="820" y="152" text-anchor="end" style="fill:var(--ok)">DC2 → repman-3: healthy</text>
+
+      <!-- horizontal DC1 <-> DC2 link, severed in the middle -->
+      <line class="cutbar" x1="336" y1="372" x2="796" y2="372" stroke-dasharray="10 8"/>
+      <rect x="448" y="322" width="224" height="100" rx="12" fill="var(--cut-bg)" stroke="var(--cut)" stroke-width="2"/>
+      <text x="560" y="350" text-anchor="middle" style="fill:var(--cut);font:800 14px var(--sans)">✕ NETWORK PARTITION</text>
+      <text x="560" y="373" text-anchor="middle" style="fill:var(--cut);font:600 12px var(--sans)">DC1 ↔ DC2 severed —</text>
+      <text x="560" y="392" text-anchor="middle" style="fill:var(--cut);font:600 12px var(--sans)">• peer heartbeat</text>
+      <text x="560" y="410" text-anchor="middle" style="fill:var(--cut);font:600 12px var(--sans)">• replication → slave IO</text>
+
+      <!-- DC3 = repman (MAJORITY) -->
+      <rect class="cloud-r cloud-dc3" x="400" y="20" width="320" height="104" rx="24"/>
+      <text class="cloud-lbl" x="424" y="46">☁ Cloud 3 · DC3 <tspan class="cloud-loc">— a REPMAN</tspan> <tspan class="tag-maj">· MAJORITY</tspan></text>
+      <rect class="box box-repman" x="432" y="56" width="256" height="54" rx="9"/>
+      <text class="t-name-s" x="560" y="80" text-anchor="middle">REPMAN · 3 (as arbitrator)</text>
+      <text class="t-sub" x="560" y="98" text-anchor="middle" style="fill:var(--ink-faint);font:500 11.5px var(--sans)">weaker quorum · no dedicated tie-breaker</text>
+
+      <!-- DC1 (MINORITY) -->
+      <rect class="cloud-r cloud-dc1" x="24" y="176" width="312" height="344" rx="22"/>
+      <text class="cloud-lbl" x="48" y="204">☁ Cloud 1 · DC1 <tspan class="tag-min">· MINORITY</tspan></text>
+      <rect class="box box-proxy" x="60" y="220" width="184" height="42" rx="9"/>
+      <text class="t-proxy" x="152" y="246" text-anchor="middle">PROXY</text>
+      <!-- minority link (repman color) but weak quorum: freeze never holds, writes flow -->
+      <line class="lnk-ftwl" x1="152" y1="262" x2="152" y2="288"/>
+      <text class="lnk-lbl-ftwl" x="172" y="279" style="fill:var(--cut)">no freeze — writes flow</text>
+      <rect class="box box-old" x="60" y="288" width="184" height="60" rx="9"/>
+      <text class="t-name" x="152" y="314" text-anchor="middle">db1</text>
+      <text class="t-badge-old" x="152" y="333" text-anchor="middle">MASTER → OLD MASTER</text>
+      <rect class="box box-repman" x="60" y="372" width="184" height="58" rx="9"/>
+      <text class="t-name-s" x="152" y="398" text-anchor="middle">REPMAN · main</text>
+      <text class="t-sub" x="152" y="416" text-anchor="middle" style="fill:var(--ink-faint);font:500 11.5px var(--sans)">Active → Standby · uid <tspan class="uid">1</tspan></text>
+      <rect x="44" y="456" width="250" height="42" rx="10" fill="var(--cut-bg)" stroke="var(--cut)" stroke-width="1.5"/>
+      <text x="169" y="473" text-anchor="middle" style="fill:var(--cut);font:800 11px var(--sans)">⛑ Only recovery:</text>
+      <text x="169" y="488" text-anchor="middle" style="fill:var(--cut);font:800 11px var(--sans)">RESTORE FROM BACKUP</text>
+      <!-- divergence: angry smiley on top of a piling binlog stack (same box size, more of them) -->
+      <text x="288" y="312" font-size="26" text-anchor="middle">😠</text>
+      <rect class="binlog" x="259" y="320" width="58" height="13" rx="2" style="fill:var(--cut-bg);stroke:color-mix(in srgb,var(--cut) 55%,var(--line))"/>
+      <rect class="binlog" x="259" y="336" width="58" height="13" rx="2" style="fill:var(--cut-bg);stroke:color-mix(in srgb,var(--cut) 55%,var(--line))"/>
+      <rect class="binlog" x="259" y="352" width="58" height="13" rx="2" style="fill:var(--cut-bg);stroke:color-mix(in srgb,var(--cut) 55%,var(--line))"/>
+      <rect class="binlog" x="259" y="368" width="58" height="13" rx="2" style="fill:var(--cut-bg);stroke:color-mix(in srgb,var(--cut) 55%,var(--line))"/>
+      <rect class="binlog" x="259" y="384" width="58" height="13" rx="2" style="fill:var(--cut-bg);stroke:color-mix(in srgb,var(--cut) 55%,var(--line))"/>
+      <rect class="binlog" x="259" y="400" width="58" height="13" rx="2" style="fill:var(--cut-bg);stroke:color-mix(in srgb,var(--cut) 55%,var(--line))"/>
+      <text x="288" y="430" text-anchor="middle" style="fill:var(--cut);font:800 10.5px var(--sans)">delta TRX ↑</text>
+      <text x="288" y="443" text-anchor="middle" style="fill:var(--cut);font:600 9.5px var(--sans)">no slave reads</text>
+
+      <!-- DC2 (MAJORITY) -->
+      <rect class="cloud-r cloud-dc2" x="796" y="176" width="300" height="364" rx="22"/>
+      <text class="cloud-lbl" x="820" y="204">☁ Cloud 2 · DC2 <tspan class="tag-maj">· MAJORITY</tspan></text>
+      <rect class="box box-proxy" x="836" y="220" width="220" height="42" rx="9"/>
+      <text class="t-proxy" x="946" y="246" text-anchor="middle">PROXY</text>
+      <!-- healthy (blue): proxy -> NEW MASTER -->
+      <line class="lnk-ok" x1="946" y1="262" x2="946" y2="288" stroke-width="3"/>
+      <rect class="box box-new" x="836" y="288" width="220" height="78" rx="9"/>
+      <text class="t-name" x="946" y="316" text-anchor="middle">db2</text>
+      <text class="t-badge-new" x="946" y="333" text-anchor="middle">SLAVE → NEW MASTER</text>
+      <rect class="box-io" x="852" y="338" width="72" height="24" rx="6"/>
+      <text class="t-io" x="888" y="354" text-anchor="middle">IO ✂</text>
+      <rect class="box" x="836" y="386" width="220" height="72" rx="9"/>
+      <text class="t-name" x="946" y="412" text-anchor="middle">db3</text>
+      <text class="t-badge-s" x="946" y="429" text-anchor="middle">SLAVE</text>
+      <rect class="box-io" x="852" y="432" width="72" height="24" rx="6"/>
+      <text class="t-io" x="888" y="448" text-anchor="middle">IO ✂</text>
+      <rect class="box box-repman" x="836" y="478" width="220" height="56" rx="9"/>
+      <text class="t-name-s" x="946" y="503" text-anchor="middle">REPMAN · DR</text>
+      <text class="t-sub" x="946" y="521" text-anchor="middle" style="fill:var(--ink-faint);font:500 11.5px var(--sans)">holds Active · uid <tspan class="uid">2</tspan></text>
+    </svg>

--- a/doc/implementation/cluster/img/sbs-lose-lose.svg
+++ b/doc/implementation/cluster/img/sbs-lose-lose.svg
@@ -1,0 +1,151 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-18 -18 1156 596" role="img" aria-label="Lose-lose symmetric split, both masters fenced"><style>
+  :root{
+    --bg:#eceef1;--panel:#ffffff;--ink:#12171d;--ink-soft:#4a5560;--ink-faint:#7b8794;
+    --line:#d7dbe0;--accent:#0a8f9c;--accent-ink:#06666f;--cloud:#f3f5f9;
+    --arb:#4b5cc4;--arb-bg:#eaecf9;--ok:#2f7fd1;
+    --majority:#1f8f52;--majority-bg:#e6f4ec;--minority:#c99613;--minority-bg:#f7efd8;
+    --cut:#cf4646;--cut-bg:#fbe9e9;
+    --mono:ui-monospace,"SF Mono","JetBrains Mono",Menlo,Consolas,monospace;
+    --sans:"Inter",ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#0d1014;--panel:#161b21;--ink:#eaeef2;--ink-soft:#a9b4bf;--ink-faint:#6b7681;
+    --line:#2a323b;--accent:#2bc0cd;--accent-ink:#7fe0e8;--cloud:#1a2027;
+    --arb:#8b98ec;--arb-bg:#1b1f36;--ok:#5aa6e6;
+    --majority:#4cc47f;--majority-bg:#142a1e;--minority:#e0b24a;--minority-bg:#2c2614;
+    --cut:#e26d6d;--cut-bg:#2c1717;
+  }}
+  :root[data-theme="light"]{--bg:#eceef1;--panel:#fff;--ink:#12171d;--ink-soft:#4a5560;--ink-faint:#7b8794;--line:#d7dbe0;--accent:#0a8f9c;--accent-ink:#06666f;--cloud:#f3f5f9;--arb:#4b5cc4;--arb-bg:#eaecf9;--ok:#2f7fd1;--majority:#1f8f52;--majority-bg:#e6f4ec;--minority:#c99613;--minority-bg:#f7efd8;--cut:#cf4646;--cut-bg:#fbe9e9;}
+  :root[data-theme="dark"]{--bg:#0d1014;--panel:#161b21;--ink:#eaeef2;--ink-soft:#a9b4bf;--ink-faint:#6b7681;--line:#2a323b;--accent:#2bc0cd;--accent-ink:#7fe0e8;--cloud:#1a2027;--arb:#8b98ec;--arb-bg:#1b1f36;--ok:#5aa6e6;--majority:#4cc47f;--majority-bg:#142a1e;--minority:#e0b24a;--minority-bg:#2c2614;--cut:#e26d6d;--cut-bg:#2c1717;}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.5;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1120px;margin:0 auto;padding:44px 24px 64px}
+  .eyebrow{font-size:12px;letter-spacing:.16em;text-transform:uppercase;color:var(--accent-ink);font-weight:600;margin:0 0 10px}
+  h1{font-size:clamp(25px,4vw,36px);line-height:1.1;margin:0 0 12px;letter-spacing:-.02em;text-wrap:balance;font-weight:700}
+  .lede{font-size:16.5px;color:var(--ink-soft);max-width:68ch;margin:0}
+  .lede b{color:var(--ink);font-weight:600}
+
+  .legend{display:flex;gap:22px;flex-wrap:wrap;margin:22px 0 4px;font-size:13px;color:var(--ink-soft)}
+  .legend span{display:inline-flex;align-items:center;gap:8px}
+  .swatch{width:34px;height:0;border-top:3px solid var(--ok)}
+  .swatch.cut{border-top:3px solid var(--cut);position:relative}
+  .swatch.cut::after{content:"||";position:absolute;left:11px;top:-11px;color:var(--cut);font-weight:800;font-size:14px;letter-spacing:-1px}
+  .swatch.ftwl{border-top:3px solid var(--accent)}
+  .pill{display:inline-flex;align-items:center;padding:2px 9px;border-radius:999px;font-size:11px;font-weight:700}
+  .pill.maj{background:var(--majority-bg);color:var(--majority)}
+  .pill.min{background:var(--minority-bg);color:var(--minority)}
+
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:20px 18px 8px;margin:24px 0}
+  .card h2{margin:0 6px 2px;font-size:19px;letter-spacing:-.01em}
+  .card .sub{margin:0 6px 6px;font-size:13.5px;color:var(--ink-faint)}
+  .card.support h2{color:var(--majority)}
+  .card.free h2{color:var(--minority)}
+  .card.lose h2{color:var(--cut)}
+  svg{display:block;width:100%;height:auto}
+  .note{margin:0 6px 14px;font-size:13.5px;color:var(--ink-soft)}
+  .note b{color:var(--ink);font-weight:600} .note .bad{color:var(--cut);font-weight:600}
+
+  .cloud-r{fill:var(--cloud);stroke:var(--line);stroke-width:1.5}
+  .cloud-dc1{stroke:color-mix(in srgb,var(--minority) 50%,var(--line))}
+  .cloud-dc2{stroke:color-mix(in srgb,var(--majority) 45%,var(--line))}
+  .cloud-dc3{fill:var(--arb-bg);stroke:color-mix(in srgb,var(--arb) 50%,var(--line))}
+  .cloud-lbl{fill:var(--ink);font:700 13px var(--sans)}
+  .cloud-loc{fill:var(--ink-faint);font:500 12px var(--mono)}
+  .tag-min{fill:var(--minority);font:800 11px var(--sans);letter-spacing:.5px}
+  .tag-maj{fill:var(--majority);font:800 11px var(--sans);letter-spacing:.5px}
+  .tag-fenced{fill:var(--cut);font:800 11px var(--sans);letter-spacing:.5px}
+  .box{fill:var(--panel);stroke:var(--line);stroke-width:2}
+  .box-old{stroke:color-mix(in srgb,var(--minority) 65%,var(--line));fill:var(--minority-bg)}
+  .box-new{stroke:color-mix(in srgb,var(--majority) 65%,var(--line));fill:var(--majority-bg)}
+  .box-repman{stroke:color-mix(in srgb,var(--accent) 60%,var(--line));fill:color-mix(in srgb,var(--accent) 14%,var(--panel))}
+  .box-arb{stroke:color-mix(in srgb,var(--arb) 60%,var(--line))}
+  .box-io{fill:var(--cut-bg);stroke:color-mix(in srgb,var(--cut) 45%,var(--line));stroke-width:1.5}
+  .t-name{fill:var(--ink);font:700 15px var(--mono)}
+  .t-name-s{fill:var(--ink);font:700 14px var(--sans)}
+  .t-badge-old{fill:var(--minority);font:800 10px var(--sans);letter-spacing:.5px}
+  .t-badge-new{fill:var(--majority);font:800 10px var(--sans);letter-spacing:.5px}
+  .t-badge-s{fill:var(--ink-faint);font:700 10px var(--sans);letter-spacing:.5px}
+  .t-io{fill:var(--cut);font:700 10px var(--mono)}
+  .t-arb{fill:var(--arb);font:700 15px var(--sans)}
+  .uid{fill:var(--accent-ink);font-weight:800}
+  .lnk-ok{stroke:var(--ok);stroke-width:3;fill:none}
+  .lnk-cut{stroke:var(--cut);stroke-width:3;fill:none;opacity:.85}
+  .cutbar{stroke:var(--cut);stroke-width:5;stroke-linecap:round}
+  .lnk-lbl{fill:var(--ink-faint);font:600 11.5px var(--sans)}
+  .lnk-lbl-cut{fill:var(--cut);font:700 11.5px var(--mono)}
+  .binlog{fill:var(--minority-bg);stroke:color-mix(in srgb,var(--minority) 55%,var(--line))}
+  .t-pile{fill:var(--cut);font:700 12px var(--sans)}
+  .yield-r{fill:var(--minority-bg);stroke:color-mix(in srgb,var(--minority) 45%,var(--line))}
+  .t-yield{fill:var(--minority);font:700 11.5px var(--sans)}
+  .box-proxy{fill:var(--panel);stroke:color-mix(in srgb,var(--accent) 45%,var(--line));stroke-width:2}
+  .t-proxy{fill:var(--accent-ink);font:700 13px var(--sans)}
+  .lnk-ftwl{stroke:var(--accent);stroke-width:3;fill:none}
+  .cutbar-ftwl{stroke:var(--accent);stroke-width:5;stroke-linecap:round}
+  .lnk-lbl-ftwl{fill:var(--accent-ink);font:700 11.5px var(--mono)}
+</style><rect x="-18" y="-18" width="1156" height="596" rx="18" fill="var(--panel)"/>
+      <!-- arbitrator links: BOTH healthy (blue) -->
+      <path class="lnk-ok" d="M330,182 L470,116"/>
+      <path class="lnk-ok" d="M802,182 L650,116"/>
+      <text class="lnk-lbl" x="300" y="152" style="fill:var(--ok)">DC1 → arbitrator: healthy</text>
+      <text class="lnk-lbl" x="820" y="152" text-anchor="end" style="fill:var(--ok)">DC2 → arbitrator: healthy</text>
+
+      <!-- horizontal DC1 <-> DC2 link severed: the split -->
+      <line class="cutbar" x1="336" y1="372" x2="796" y2="372" stroke-dasharray="10 8"/>
+      <rect x="436" y="316" width="248" height="112" rx="12" fill="var(--cut-bg)" stroke="var(--cut)" stroke-width="2"/>
+      <text x="560" y="342" text-anchor="middle" style="fill:var(--cut);font:800 14px var(--sans)">✕ SYMMETRIC SPLIT</text>
+      <text x="560" y="364" text-anchor="middle" style="fill:var(--cut);font:600 12px var(--sans)">DC1 ↔ DC2 severed —</text>
+      <text x="560" y="382" text-anchor="middle" style="fill:var(--cut);font:600 12px var(--sans)">each sees the arbitrator,</text>
+      <text x="560" y="400" text-anchor="middle" style="fill:var(--cut);font:600 12px var(--sans)">neither sees its peer</text>
+
+      <!-- DC3 arbitrator -->
+      <rect class="cloud-r cloud-dc3" x="400" y="20" width="320" height="104" rx="24"/>
+      <text class="cloud-lbl" x="424" y="46">☁ Cloud 3 · DC3 <tspan class="cloud-loc">@ signal18</tspan></text>
+      <rect class="box box-arb" x="432" y="56" width="256" height="54" rx="9"/>
+      <text class="t-arb" x="560" y="80" text-anchor="middle">ARBITRATOR</text>
+      <text class="t-sub" x="560" y="98" text-anchor="middle" style="fill:var(--ink-faint);font:500 11.5px var(--sans)">reachable by both — grants neither</text>
+
+      <!-- DC1 (FENCED) -->
+      <rect class="cloud-r cloud-dc1" x="24" y="176" width="312" height="344" rx="22"/>
+      <text class="cloud-lbl" x="48" y="204">☁ Cloud 1 · DC1 <tspan class="tag-fenced">· FENCED</tspan></text>
+      <rect class="box box-proxy" x="60" y="220" width="184" height="42" rx="9"/>
+      <text class="t-proxy" x="152" y="246" text-anchor="middle">PROXY</text>
+      <line class="lnk-ftwl" x1="152" y1="262" x2="152" y2="288"/>
+      <line class="cutbar-ftwl" x1="141" y1="270" x2="163" y2="280"/>
+      <line class="cutbar-ftwl" x1="141" y1="280" x2="163" y2="270"/>
+      <text class="lnk-lbl-ftwl" x="172" y="279">FTWRL — writes blocked</text>
+      <rect class="box box-old" x="60" y="288" width="184" height="60" rx="9"/>
+      <text class="t-name" x="152" y="314" text-anchor="middle">db1</text>
+      <text class="t-badge-old" x="152" y="333" text-anchor="middle">MASTER · FROZEN</text>
+      <rect class="box box-repman" x="60" y="372" width="184" height="58" rx="9"/>
+      <text class="t-name-s" x="152" y="398" text-anchor="middle">REPMAN · main</text>
+      <text class="t-sub" x="152" y="416" text-anchor="middle" style="fill:var(--ink-faint);font:500 11.5px var(--sans)">holds Active · uid <tspan class="uid">1</tspan></text>
+      <rect class="yield-r" x="44" y="456" width="256" height="26" rx="13" style="fill:var(--cut-bg);stroke:color-mix(in srgb,var(--cut) 45%,var(--line))"/>
+      <text class="t-yield" x="172" y="473" text-anchor="middle" style="fill:var(--cut)">no quorum → will not promote</text>
+      <text x="288" y="312" font-size="26" text-anchor="middle">😐</text>
+      <rect class="binlog" x="259" y="320" width="58" height="13" rx="2" style="fill:var(--panel);stroke:var(--line)"/>
+      <text x="288" y="352" text-anchor="middle" style="fill:var(--ink-soft);font:800 10.5px var(--sans)">delta ×0</text>
+      <text x="288" y="365" text-anchor="middle" style="fill:var(--ink-faint);font:600 9.5px var(--sans)">no writes</text>
+
+      <!-- DC2 (FENCED) -->
+      <rect class="cloud-r cloud-dc2" x="796" y="176" width="300" height="364" rx="22"/>
+      <text class="cloud-lbl" x="820" y="204">☁ Cloud 2 · DC2 <tspan class="tag-fenced">· FENCED</tspan></text>
+      <rect class="box box-proxy" x="836" y="220" width="220" height="42" rx="9"/>
+      <text class="t-proxy" x="946" y="246" text-anchor="middle">PROXY</text>
+      <line class="lnk-ftwl" x1="946" y1="262" x2="946" y2="288"/>
+      <line class="cutbar-ftwl" x1="935" y1="270" x2="957" y2="280"/>
+      <line class="cutbar-ftwl" x1="935" y1="280" x2="957" y2="270"/>
+      <text class="lnk-lbl-ftwl" x="966" y="279">held — no writes</text>
+      <rect class="box box-old" x="836" y="288" width="220" height="78" rx="9"/>
+      <text class="t-name" x="946" y="316" text-anchor="middle">db2</text>
+      <text class="t-badge-old" x="946" y="333" text-anchor="middle">SLAVE · NOT PROMOTED</text>
+      <rect class="box-io" x="852" y="338" width="72" height="24" rx="6"/>
+      <text class="t-io" x="888" y="354" text-anchor="middle">IO ✂</text>
+      <rect class="box" x="836" y="386" width="220" height="72" rx="9"/>
+      <text class="t-name" x="946" y="412" text-anchor="middle">db3</text>
+      <text class="t-badge-s" x="946" y="429" text-anchor="middle">SLAVE · FROZEN</text>
+      <rect class="box-io" x="852" y="432" width="72" height="24" rx="6"/>
+      <text class="t-io" x="888" y="448" text-anchor="middle">IO ✂</text>
+      <rect class="box box-repman" x="836" y="478" width="220" height="56" rx="9"/>
+      <text class="t-name-s" x="946" y="503" text-anchor="middle">REPMAN · DR</text>
+      <text class="t-sub" x="946" y="521" text-anchor="middle" style="fill:var(--ink-faint);font:500 11.5px var(--sans)">Standby · uid <tspan class="uid">2</tspan></text>
+    </svg>

--- a/doc/implementation/cluster/img/sbs-support.svg
+++ b/doc/implementation/cluster/img/sbs-support.svg
@@ -1,0 +1,151 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-18 -18 1156 596" role="img" aria-label="Support plan after failover"><style>
+  :root{
+    --bg:#eceef1;--panel:#ffffff;--ink:#12171d;--ink-soft:#4a5560;--ink-faint:#7b8794;
+    --line:#d7dbe0;--accent:#0a8f9c;--accent-ink:#06666f;--cloud:#f3f5f9;
+    --arb:#4b5cc4;--arb-bg:#eaecf9;--ok:#2f7fd1;
+    --majority:#1f8f52;--majority-bg:#e6f4ec;--minority:#c99613;--minority-bg:#f7efd8;
+    --cut:#cf4646;--cut-bg:#fbe9e9;
+    --mono:ui-monospace,"SF Mono","JetBrains Mono",Menlo,Consolas,monospace;
+    --sans:"Inter",ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#0d1014;--panel:#161b21;--ink:#eaeef2;--ink-soft:#a9b4bf;--ink-faint:#6b7681;
+    --line:#2a323b;--accent:#2bc0cd;--accent-ink:#7fe0e8;--cloud:#1a2027;
+    --arb:#8b98ec;--arb-bg:#1b1f36;--ok:#5aa6e6;
+    --majority:#4cc47f;--majority-bg:#142a1e;--minority:#e0b24a;--minority-bg:#2c2614;
+    --cut:#e26d6d;--cut-bg:#2c1717;
+  }}
+  :root[data-theme="light"]{--bg:#eceef1;--panel:#fff;--ink:#12171d;--ink-soft:#4a5560;--ink-faint:#7b8794;--line:#d7dbe0;--accent:#0a8f9c;--accent-ink:#06666f;--cloud:#f3f5f9;--arb:#4b5cc4;--arb-bg:#eaecf9;--ok:#2f7fd1;--majority:#1f8f52;--majority-bg:#e6f4ec;--minority:#c99613;--minority-bg:#f7efd8;--cut:#cf4646;--cut-bg:#fbe9e9;}
+  :root[data-theme="dark"]{--bg:#0d1014;--panel:#161b21;--ink:#eaeef2;--ink-soft:#a9b4bf;--ink-faint:#6b7681;--line:#2a323b;--accent:#2bc0cd;--accent-ink:#7fe0e8;--cloud:#1a2027;--arb:#8b98ec;--arb-bg:#1b1f36;--ok:#5aa6e6;--majority:#4cc47f;--majority-bg:#142a1e;--minority:#e0b24a;--minority-bg:#2c2614;--cut:#e26d6d;--cut-bg:#2c1717;}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.5;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1120px;margin:0 auto;padding:44px 24px 64px}
+  .eyebrow{font-size:12px;letter-spacing:.16em;text-transform:uppercase;color:var(--accent-ink);font-weight:600;margin:0 0 10px}
+  h1{font-size:clamp(25px,4vw,36px);line-height:1.1;margin:0 0 12px;letter-spacing:-.02em;text-wrap:balance;font-weight:700}
+  .lede{font-size:16.5px;color:var(--ink-soft);max-width:68ch;margin:0}
+  .lede b{color:var(--ink);font-weight:600}
+
+  .legend{display:flex;gap:22px;flex-wrap:wrap;margin:22px 0 4px;font-size:13px;color:var(--ink-soft)}
+  .legend span{display:inline-flex;align-items:center;gap:8px}
+  .swatch{width:34px;height:0;border-top:3px solid var(--ok)}
+  .swatch.cut{border-top:3px solid var(--cut);position:relative}
+  .swatch.cut::after{content:"||";position:absolute;left:11px;top:-11px;color:var(--cut);font-weight:800;font-size:14px;letter-spacing:-1px}
+  .swatch.ftwl{border-top:3px solid var(--accent)}
+  .pill{display:inline-flex;align-items:center;padding:2px 9px;border-radius:999px;font-size:11px;font-weight:700}
+  .pill.maj{background:var(--majority-bg);color:var(--majority)}
+  .pill.min{background:var(--minority-bg);color:var(--minority)}
+
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:20px 18px 8px;margin:24px 0}
+  .card h2{margin:0 6px 2px;font-size:19px;letter-spacing:-.01em}
+  .card .sub{margin:0 6px 6px;font-size:13.5px;color:var(--ink-faint)}
+  .card.support h2{color:var(--majority)}
+  .card.free h2{color:var(--minority)}
+  .card.lose h2{color:var(--cut)}
+  svg{display:block;width:100%;height:auto}
+  .note{margin:0 6px 14px;font-size:13.5px;color:var(--ink-soft)}
+  .note b{color:var(--ink);font-weight:600} .note .bad{color:var(--cut);font-weight:600}
+
+  .cloud-r{fill:var(--cloud);stroke:var(--line);stroke-width:1.5}
+  .cloud-dc1{stroke:color-mix(in srgb,var(--minority) 50%,var(--line))}
+  .cloud-dc2{stroke:color-mix(in srgb,var(--majority) 45%,var(--line))}
+  .cloud-dc3{fill:var(--arb-bg);stroke:color-mix(in srgb,var(--arb) 50%,var(--line))}
+  .cloud-lbl{fill:var(--ink);font:700 13px var(--sans)}
+  .cloud-loc{fill:var(--ink-faint);font:500 12px var(--mono)}
+  .tag-min{fill:var(--minority);font:800 11px var(--sans);letter-spacing:.5px}
+  .tag-maj{fill:var(--majority);font:800 11px var(--sans);letter-spacing:.5px}
+  .tag-fenced{fill:var(--cut);font:800 11px var(--sans);letter-spacing:.5px}
+  .box{fill:var(--panel);stroke:var(--line);stroke-width:2}
+  .box-old{stroke:color-mix(in srgb,var(--minority) 65%,var(--line));fill:var(--minority-bg)}
+  .box-new{stroke:color-mix(in srgb,var(--majority) 65%,var(--line));fill:var(--majority-bg)}
+  .box-repman{stroke:color-mix(in srgb,var(--accent) 60%,var(--line));fill:color-mix(in srgb,var(--accent) 14%,var(--panel))}
+  .box-arb{stroke:color-mix(in srgb,var(--arb) 60%,var(--line))}
+  .box-io{fill:var(--cut-bg);stroke:color-mix(in srgb,var(--cut) 45%,var(--line));stroke-width:1.5}
+  .t-name{fill:var(--ink);font:700 15px var(--mono)}
+  .t-name-s{fill:var(--ink);font:700 14px var(--sans)}
+  .t-badge-old{fill:var(--minority);font:800 10px var(--sans);letter-spacing:.5px}
+  .t-badge-new{fill:var(--majority);font:800 10px var(--sans);letter-spacing:.5px}
+  .t-badge-s{fill:var(--ink-faint);font:700 10px var(--sans);letter-spacing:.5px}
+  .t-io{fill:var(--cut);font:700 10px var(--mono)}
+  .t-arb{fill:var(--arb);font:700 15px var(--sans)}
+  .uid{fill:var(--accent-ink);font-weight:800}
+  .lnk-ok{stroke:var(--ok);stroke-width:3;fill:none}
+  .lnk-cut{stroke:var(--cut);stroke-width:3;fill:none;opacity:.85}
+  .cutbar{stroke:var(--cut);stroke-width:5;stroke-linecap:round}
+  .lnk-lbl{fill:var(--ink-faint);font:600 11.5px var(--sans)}
+  .lnk-lbl-cut{fill:var(--cut);font:700 11.5px var(--mono)}
+  .binlog{fill:var(--minority-bg);stroke:color-mix(in srgb,var(--minority) 55%,var(--line))}
+  .t-pile{fill:var(--cut);font:700 12px var(--sans)}
+  .yield-r{fill:var(--minority-bg);stroke:color-mix(in srgb,var(--minority) 45%,var(--line))}
+  .t-yield{fill:var(--minority);font:700 11.5px var(--sans)}
+  .box-proxy{fill:var(--panel);stroke:color-mix(in srgb,var(--accent) 45%,var(--line));stroke-width:2}
+  .t-proxy{fill:var(--accent-ink);font:700 13px var(--sans)}
+  .lnk-ftwl{stroke:var(--accent);stroke-width:3;fill:none}
+  .cutbar-ftwl{stroke:var(--accent);stroke-width:5;stroke-linecap:round}
+  .lnk-lbl-ftwl{fill:var(--accent-ink);font:700 11.5px var(--mono)}
+</style><rect x="-18" y="-18" width="1156" height="596" rx="18" fill="var(--panel)"/>
+      <!-- arbitrator links: DC1 cut (red), DC2 healthy (blue) -->
+      <path class="lnk-cut" d="M330,182 L470,116"/>
+      <path class="lnk-ok" d="M802,182 L650,116"/>
+      <text class="lnk-lbl-cut" x="300" y="152">✂ DC1 → arbitrator: cut</text>
+      <text class="lnk-lbl" x="820" y="152" text-anchor="end" style="fill:var(--ok)">DC2 → arbitrator: healthy</text>
+
+      <!-- horizontal DC1 <-> DC2 link, severed in the middle -->
+      <line class="cutbar" x1="336" y1="372" x2="796" y2="372" stroke-dasharray="10 8"/>
+      <rect x="448" y="322" width="224" height="100" rx="12" fill="var(--cut-bg)" stroke="var(--cut)" stroke-width="2"/>
+      <text x="560" y="350" text-anchor="middle" style="fill:var(--cut);font:800 14px var(--sans)">✕ NETWORK PARTITION</text>
+      <text x="560" y="373" text-anchor="middle" style="fill:var(--cut);font:600 12px var(--sans)">DC1 ↔ DC2 severed —</text>
+      <text x="560" y="392" text-anchor="middle" style="fill:var(--cut);font:600 12px var(--sans)">• peer heartbeat</text>
+      <text x="560" y="410" text-anchor="middle" style="fill:var(--cut);font:600 12px var(--sans)">• replication → slave IO</text>
+
+      <!-- DC3 arbitrator (MAJORITY) -->
+      <rect class="cloud-r cloud-dc3" x="400" y="20" width="320" height="104" rx="24"/>
+      <text class="cloud-lbl" x="424" y="46">☁ Cloud 3 · DC3 <tspan class="cloud-loc">@ signal18</tspan> <tspan class="tag-maj">· MAJORITY</tspan></text>
+      <rect class="box box-arb" x="432" y="56" width="256" height="54" rx="9"/>
+      <text class="t-arb" x="560" y="80" text-anchor="middle">ARBITRATOR</text>
+      <text class="t-sub" x="560" y="98" text-anchor="middle" style="fill:var(--ink-faint);font:500 11.5px var(--sans)">always reachable · breaks the tie</text>
+
+      <!-- DC1 (MINORITY) -->
+      <rect class="cloud-r cloud-dc1" x="24" y="176" width="312" height="344" rx="22"/>
+      <text class="cloud-lbl" x="48" y="204">☁ Cloud 1 · DC1 <tspan class="tag-min">· MINORITY</tspan></text>
+      <rect class="box box-proxy" x="60" y="220" width="184" height="42" rx="9"/>
+      <text class="t-proxy" x="152" y="246" text-anchor="middle">PROXY</text>
+      <!-- FTWRL fence (repman color, broken): proxy -> db1 -->
+      <line class="lnk-ftwl" x1="152" y1="262" x2="152" y2="288"/>
+      <line class="cutbar-ftwl" x1="141" y1="270" x2="163" y2="280"/>
+      <line class="cutbar-ftwl" x1="141" y1="280" x2="163" y2="270"/>
+      <text class="lnk-lbl-ftwl" x="172" y="279">FTWRL — writes blocked</text>
+      <rect class="box box-old" x="60" y="288" width="184" height="60" rx="9"/>
+      <text class="t-name" x="152" y="314" text-anchor="middle">db1</text>
+      <text class="t-badge-old" x="152" y="333" text-anchor="middle">MASTER → OLD MASTER</text>
+      <rect class="box box-repman" x="60" y="372" width="184" height="58" rx="9"/>
+      <text class="t-name-s" x="152" y="398" text-anchor="middle">REPMAN · main</text>
+      <text class="t-sub" x="152" y="416" text-anchor="middle" style="fill:var(--ink-faint);font:500 11.5px var(--sans)">Active → Standby · uid <tspan class="uid">1</tspan></text>
+      <rect class="yield-r" x="44" y="456" width="256" height="26" rx="13"/>
+      <text class="t-yield" x="172" y="473" text-anchor="middle">simulate-minority → read-only</text>
+      <!-- divergence: happy smiley on top of a single (flashback-able) delta -->
+      <text x="288" y="312" font-size="26" text-anchor="middle">😊</text>
+      <rect class="binlog" x="259" y="320" width="58" height="13" rx="2" style="fill:var(--majority-bg);stroke:color-mix(in srgb,var(--majority) 55%,var(--line))"/>
+      <text x="288" y="352" text-anchor="middle" style="fill:var(--majority);font:800 10.5px var(--sans)">delta ×1</text>
+      <text x="288" y="365" text-anchor="middle" style="fill:var(--majority);font:600 9.5px var(--sans)">flashback-able</text>
+
+      <!-- DC2 (MAJORITY) -->
+      <rect class="cloud-r cloud-dc2" x="796" y="176" width="300" height="364" rx="22"/>
+      <text class="cloud-lbl" x="820" y="204">☁ Cloud 2 · DC2 <tspan class="tag-maj">· MAJORITY</tspan></text>
+      <rect class="box box-proxy" x="836" y="220" width="220" height="42" rx="9"/>
+      <text class="t-proxy" x="946" y="246" text-anchor="middle">PROXY</text>
+      <!-- healthy (blue): proxy -> NEW MASTER -->
+      <line class="lnk-ok" x1="946" y1="262" x2="946" y2="288" stroke-width="3"/>
+      <rect class="box box-new" x="836" y="288" width="220" height="78" rx="9"/>
+      <text class="t-name" x="946" y="316" text-anchor="middle">db2</text>
+      <text class="t-badge-new" x="946" y="333" text-anchor="middle">SLAVE → NEW MASTER</text>
+      <rect class="box-io" x="852" y="338" width="72" height="24" rx="6"/>
+      <text class="t-io" x="888" y="354" text-anchor="middle">IO ✂</text>
+      <rect class="box" x="836" y="386" width="220" height="72" rx="9"/>
+      <text class="t-name" x="946" y="412" text-anchor="middle">db3</text>
+      <text class="t-badge-s" x="946" y="429" text-anchor="middle">SLAVE</text>
+      <rect class="box-io" x="852" y="432" width="72" height="24" rx="6"/>
+      <text class="t-io" x="888" y="448" text-anchor="middle">IO ✂</text>
+      <rect class="box box-repman" x="836" y="478" width="220" height="56" rx="9"/>
+      <text class="t-name-s" x="946" y="503" text-anchor="middle">REPMAN · DR</text>
+      <text class="t-sub" x="946" y="521" text-anchor="middle" style="fill:var(--ink-faint);font:500 11.5px var(--sans)">holds Active · uid <tspan class="uid">2</tspan></text>
+    </svg>

--- a/doc/implementation/cluster/split-brain-orchestration.html
+++ b/doc/implementation/cluster/split-brain-orchestration.html
@@ -1,0 +1,326 @@
+<title>Split-Brain Orchestration — Support vs Free plan</title>
+<style>
+  :root{
+    --bg:#eceef1;--panel:#ffffff;--ink:#12171d;--ink-soft:#4a5560;--ink-faint:#7b8794;
+    --line:#d7dbe0;--accent:#0a8f9c;--accent-ink:#06666f;--cloud:#f3f5f9;
+    --arb:#4b5cc4;--arb-bg:#eaecf9;--ok:#2f7fd1;
+    --majority:#1f8f52;--majority-bg:#e6f4ec;--minority:#c99613;--minority-bg:#f7efd8;
+    --cut:#cf4646;--cut-bg:#fbe9e9;
+    --mono:ui-monospace,"SF Mono","JetBrains Mono",Menlo,Consolas,monospace;
+    --sans:"Inter",ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#0d1014;--panel:#161b21;--ink:#eaeef2;--ink-soft:#a9b4bf;--ink-faint:#6b7681;
+    --line:#2a323b;--accent:#2bc0cd;--accent-ink:#7fe0e8;--cloud:#1a2027;
+    --arb:#8b98ec;--arb-bg:#1b1f36;--ok:#5aa6e6;
+    --majority:#4cc47f;--majority-bg:#142a1e;--minority:#e0b24a;--minority-bg:#2c2614;
+    --cut:#e26d6d;--cut-bg:#2c1717;
+  }}
+  :root[data-theme="light"]{--bg:#eceef1;--panel:#fff;--ink:#12171d;--ink-soft:#4a5560;--ink-faint:#7b8794;--line:#d7dbe0;--accent:#0a8f9c;--accent-ink:#06666f;--cloud:#f3f5f9;--arb:#4b5cc4;--arb-bg:#eaecf9;--ok:#2f7fd1;--majority:#1f8f52;--majority-bg:#e6f4ec;--minority:#c99613;--minority-bg:#f7efd8;--cut:#cf4646;--cut-bg:#fbe9e9;}
+  :root[data-theme="dark"]{--bg:#0d1014;--panel:#161b21;--ink:#eaeef2;--ink-soft:#a9b4bf;--ink-faint:#6b7681;--line:#2a323b;--accent:#2bc0cd;--accent-ink:#7fe0e8;--cloud:#1a2027;--arb:#8b98ec;--arb-bg:#1b1f36;--ok:#5aa6e6;--majority:#4cc47f;--majority-bg:#142a1e;--minority:#e0b24a;--minority-bg:#2c2614;--cut:#e26d6d;--cut-bg:#2c1717;}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.5;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1120px;margin:0 auto;padding:44px 24px 64px}
+  .eyebrow{font-size:12px;letter-spacing:.16em;text-transform:uppercase;color:var(--accent-ink);font-weight:600;margin:0 0 10px}
+  h1{font-size:clamp(25px,4vw,36px);line-height:1.1;margin:0 0 12px;letter-spacing:-.02em;text-wrap:balance;font-weight:700}
+  .lede{font-size:16.5px;color:var(--ink-soft);max-width:68ch;margin:0}
+  .lede b{color:var(--ink);font-weight:600}
+
+  .legend{display:flex;gap:22px;flex-wrap:wrap;margin:22px 0 4px;font-size:13px;color:var(--ink-soft)}
+  .legend span{display:inline-flex;align-items:center;gap:8px}
+  .swatch{width:34px;height:0;border-top:3px solid var(--ok)}
+  .swatch.cut{border-top:3px solid var(--cut);position:relative}
+  .swatch.cut::after{content:"||";position:absolute;left:11px;top:-11px;color:var(--cut);font-weight:800;font-size:14px;letter-spacing:-1px}
+  .swatch.ftwl{border-top:3px solid var(--accent)}
+  .pill{display:inline-flex;align-items:center;padding:2px 9px;border-radius:999px;font-size:11px;font-weight:700}
+  .pill.maj{background:var(--majority-bg);color:var(--majority)}
+  .pill.min{background:var(--minority-bg);color:var(--minority)}
+
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:20px 18px 8px;margin:24px 0}
+  .card h2{margin:0 6px 2px;font-size:19px;letter-spacing:-.01em}
+  .card .sub{margin:0 6px 6px;font-size:13.5px;color:var(--ink-faint)}
+  .card.support h2{color:var(--majority)}
+  .card.free h2{color:var(--minority)}
+  .card.lose h2{color:var(--cut)}
+  svg{display:block;width:100%;height:auto}
+  .note{margin:0 6px 14px;font-size:13.5px;color:var(--ink-soft)}
+  .note b{color:var(--ink);font-weight:600} .note .bad{color:var(--cut);font-weight:600}
+
+  .cloud-r{fill:var(--cloud);stroke:var(--line);stroke-width:1.5}
+  .cloud-dc1{stroke:color-mix(in srgb,var(--minority) 50%,var(--line))}
+  .cloud-dc2{stroke:color-mix(in srgb,var(--majority) 45%,var(--line))}
+  .cloud-dc3{fill:var(--arb-bg);stroke:color-mix(in srgb,var(--arb) 50%,var(--line))}
+  .cloud-lbl{fill:var(--ink);font:700 13px var(--sans)}
+  .cloud-loc{fill:var(--ink-faint);font:500 12px var(--mono)}
+  .tag-min{fill:var(--minority);font:800 11px var(--sans);letter-spacing:.5px}
+  .tag-maj{fill:var(--majority);font:800 11px var(--sans);letter-spacing:.5px}
+  .tag-fenced{fill:var(--cut);font:800 11px var(--sans);letter-spacing:.5px}
+  .box{fill:var(--panel);stroke:var(--line);stroke-width:2}
+  .box-old{stroke:color-mix(in srgb,var(--minority) 65%,var(--line));fill:var(--minority-bg)}
+  .box-new{stroke:color-mix(in srgb,var(--majority) 65%,var(--line));fill:var(--majority-bg)}
+  .box-repman{stroke:color-mix(in srgb,var(--accent) 60%,var(--line));fill:color-mix(in srgb,var(--accent) 14%,var(--panel))}
+  .box-arb{stroke:color-mix(in srgb,var(--arb) 60%,var(--line))}
+  .box-io{fill:var(--cut-bg);stroke:color-mix(in srgb,var(--cut) 45%,var(--line));stroke-width:1.5}
+  .t-name{fill:var(--ink);font:700 15px var(--mono)}
+  .t-name-s{fill:var(--ink);font:700 14px var(--sans)}
+  .t-badge-old{fill:var(--minority);font:800 10px var(--sans);letter-spacing:.5px}
+  .t-badge-new{fill:var(--majority);font:800 10px var(--sans);letter-spacing:.5px}
+  .t-badge-s{fill:var(--ink-faint);font:700 10px var(--sans);letter-spacing:.5px}
+  .t-io{fill:var(--cut);font:700 10px var(--mono)}
+  .t-arb{fill:var(--arb);font:700 15px var(--sans)}
+  .uid{fill:var(--accent-ink);font-weight:800}
+  .lnk-ok{stroke:var(--ok);stroke-width:3;fill:none}
+  .lnk-cut{stroke:var(--cut);stroke-width:3;fill:none;opacity:.85}
+  .cutbar{stroke:var(--cut);stroke-width:5;stroke-linecap:round}
+  .lnk-lbl{fill:var(--ink-faint);font:600 11.5px var(--sans)}
+  .lnk-lbl-cut{fill:var(--cut);font:700 11.5px var(--mono)}
+  .binlog{fill:var(--minority-bg);stroke:color-mix(in srgb,var(--minority) 55%,var(--line))}
+  .t-pile{fill:var(--cut);font:700 12px var(--sans)}
+  .yield-r{fill:var(--minority-bg);stroke:color-mix(in srgb,var(--minority) 45%,var(--line))}
+  .t-yield{fill:var(--minority);font:700 11.5px var(--sans)}
+  .box-proxy{fill:var(--panel);stroke:color-mix(in srgb,var(--accent) 45%,var(--line));stroke-width:2}
+  .t-proxy{fill:var(--accent-ink);font:700 13px var(--sans)}
+  .lnk-ftwl{stroke:var(--accent);stroke-width:3;fill:none}
+  .cutbar-ftwl{stroke:var(--accent);stroke-width:5;stroke-linecap:round}
+  .lnk-lbl-ftwl{fill:var(--accent-ink);font:700 11.5px var(--mono)}
+</style>
+
+<div class="wrap">
+  <p class="eyebrow">replication-manager · arbitration</p>
+  <h1>Split-brain orchestration across three datacenters</h1>
+  <p class="lede">Three clouds, one per DC. On a split, DC1 is cut off from its peer <b>and the arbitrator</b>, so it becomes the <span class="pill min">MINORITY</span> — its master steps down. DC2 + DC3 keep the <span class="pill maj">MAJORITY</span> and promote a slave to NEW MASTER. What differs is the <b>recovery</b> — so we <b>start from the Free plan</b> to see where we come from, then the Support plan that removes the pain, then the symmetric split where repman must fence both sides.</p>
+
+  <div class="legend">
+    <span><span class="swatch"></span> healthy network link</span>
+    <span><span class="swatch cut"></span> cut link (a <code style="font-family:var(--mono)">simulate-*</code> operation)</span>
+    <span><span class="swatch ftwl"></span> repman FTWRL fence — minority master</span>
+  </div>
+
+  <!-- ============ FREE PLAN ============ -->
+  <div class="card free">
+    <h2>Free Plan Orchestration</h2>
+    <p class="sub">No dedicated arbitrator — a third <b>repman</b> stands in for DC3.</p>
+    <svg viewBox="0 0 1120 560" role="img" aria-label="Free plan after failover, binlogs pile up">
+      <!-- arbitrator links: DC1 cut (red), DC2 healthy (blue) -->
+      <path class="lnk-cut" d="M330,182 L470,116"/>
+      <path class="lnk-ok" d="M802,182 L650,116"/>
+      <text class="lnk-lbl-cut" x="300" y="152">✂ DC1 → repman-3: cut</text>
+      <text class="lnk-lbl" x="820" y="152" text-anchor="end" style="fill:var(--ok)">DC2 → repman-3: healthy</text>
+
+      <!-- horizontal DC1 <-> DC2 link, severed in the middle -->
+      <line class="cutbar" x1="336" y1="372" x2="796" y2="372" stroke-dasharray="10 8"/>
+      <rect x="448" y="322" width="224" height="100" rx="12" fill="var(--cut-bg)" stroke="var(--cut)" stroke-width="2"/>
+      <text x="560" y="350" text-anchor="middle" style="fill:var(--cut);font:800 14px var(--sans)">✕ NETWORK PARTITION</text>
+      <text x="560" y="373" text-anchor="middle" style="fill:var(--cut);font:600 12px var(--sans)">DC1 ↔ DC2 severed —</text>
+      <text x="560" y="392" text-anchor="middle" style="fill:var(--cut);font:600 12px var(--sans)">• peer heartbeat</text>
+      <text x="560" y="410" text-anchor="middle" style="fill:var(--cut);font:600 12px var(--sans)">• replication → slave IO</text>
+
+      <!-- DC3 = repman (MAJORITY) -->
+      <rect class="cloud-r cloud-dc3" x="400" y="20" width="320" height="104" rx="24"/>
+      <text class="cloud-lbl" x="424" y="46">☁ Cloud 3 · DC3 <tspan class="cloud-loc">— a REPMAN</tspan> <tspan class="tag-maj">· MAJORITY</tspan></text>
+      <rect class="box box-repman" x="432" y="56" width="256" height="54" rx="9"/>
+      <text class="t-name-s" x="560" y="80" text-anchor="middle">REPMAN · 3 (as arbitrator)</text>
+      <text class="t-sub" x="560" y="98" text-anchor="middle" style="fill:var(--ink-faint);font:500 11.5px var(--sans)">weaker quorum · no dedicated tie-breaker</text>
+
+      <!-- DC1 (MINORITY) -->
+      <rect class="cloud-r cloud-dc1" x="24" y="176" width="312" height="344" rx="22"/>
+      <text class="cloud-lbl" x="48" y="204">☁ Cloud 1 · DC1 <tspan class="tag-min">· MINORITY</tspan></text>
+      <rect class="box box-proxy" x="60" y="220" width="184" height="42" rx="9"/>
+      <text class="t-proxy" x="152" y="246" text-anchor="middle">PROXY</text>
+      <!-- minority link (repman color) but weak quorum: freeze never holds, writes flow -->
+      <line class="lnk-ftwl" x1="152" y1="262" x2="152" y2="288"/>
+      <text class="lnk-lbl-ftwl" x="172" y="279" style="fill:var(--cut)">no freeze — writes flow</text>
+      <rect class="box box-old" x="60" y="288" width="184" height="60" rx="9"/>
+      <text class="t-name" x="152" y="314" text-anchor="middle">db1</text>
+      <text class="t-badge-old" x="152" y="333" text-anchor="middle">MASTER → OLD MASTER</text>
+      <rect class="box box-repman" x="60" y="372" width="184" height="58" rx="9"/>
+      <text class="t-name-s" x="152" y="398" text-anchor="middle">REPMAN · main</text>
+      <text class="t-sub" x="152" y="416" text-anchor="middle" style="fill:var(--ink-faint);font:500 11.5px var(--sans)">Active → Standby · uid <tspan class="uid">1</tspan></text>
+      <rect x="44" y="456" width="250" height="42" rx="10" fill="var(--cut-bg)" stroke="var(--cut)" stroke-width="1.5"/>
+      <text x="169" y="473" text-anchor="middle" style="fill:var(--cut);font:800 11px var(--sans)">⛑ Only recovery:</text>
+      <text x="169" y="488" text-anchor="middle" style="fill:var(--cut);font:800 11px var(--sans)">RESTORE FROM BACKUP</text>
+      <!-- divergence: angry smiley on top of a piling binlog stack (same box size, more of them) -->
+      <text x="288" y="312" font-size="26" text-anchor="middle">😠</text>
+      <rect class="binlog" x="259" y="320" width="58" height="13" rx="2" style="fill:var(--cut-bg);stroke:color-mix(in srgb,var(--cut) 55%,var(--line))"/>
+      <rect class="binlog" x="259" y="336" width="58" height="13" rx="2" style="fill:var(--cut-bg);stroke:color-mix(in srgb,var(--cut) 55%,var(--line))"/>
+      <rect class="binlog" x="259" y="352" width="58" height="13" rx="2" style="fill:var(--cut-bg);stroke:color-mix(in srgb,var(--cut) 55%,var(--line))"/>
+      <rect class="binlog" x="259" y="368" width="58" height="13" rx="2" style="fill:var(--cut-bg);stroke:color-mix(in srgb,var(--cut) 55%,var(--line))"/>
+      <rect class="binlog" x="259" y="384" width="58" height="13" rx="2" style="fill:var(--cut-bg);stroke:color-mix(in srgb,var(--cut) 55%,var(--line))"/>
+      <rect class="binlog" x="259" y="400" width="58" height="13" rx="2" style="fill:var(--cut-bg);stroke:color-mix(in srgb,var(--cut) 55%,var(--line))"/>
+      <text x="288" y="430" text-anchor="middle" style="fill:var(--cut);font:800 10.5px var(--sans)">delta TRX ↑</text>
+      <text x="288" y="443" text-anchor="middle" style="fill:var(--cut);font:600 9.5px var(--sans)">no slave reads</text>
+
+      <!-- DC2 (MAJORITY) -->
+      <rect class="cloud-r cloud-dc2" x="796" y="176" width="300" height="364" rx="22"/>
+      <text class="cloud-lbl" x="820" y="204">☁ Cloud 2 · DC2 <tspan class="tag-maj">· MAJORITY</tspan></text>
+      <rect class="box box-proxy" x="836" y="220" width="220" height="42" rx="9"/>
+      <text class="t-proxy" x="946" y="246" text-anchor="middle">PROXY</text>
+      <!-- healthy (blue): proxy -> NEW MASTER -->
+      <line class="lnk-ok" x1="946" y1="262" x2="946" y2="288" stroke-width="3"/>
+      <rect class="box box-new" x="836" y="288" width="220" height="78" rx="9"/>
+      <text class="t-name" x="946" y="316" text-anchor="middle">db2</text>
+      <text class="t-badge-new" x="946" y="333" text-anchor="middle">SLAVE → NEW MASTER</text>
+      <rect class="box-io" x="852" y="338" width="72" height="24" rx="6"/>
+      <text class="t-io" x="888" y="354" text-anchor="middle">IO ✂</text>
+      <rect class="box" x="836" y="386" width="220" height="72" rx="9"/>
+      <text class="t-name" x="946" y="412" text-anchor="middle">db3</text>
+      <text class="t-badge-s" x="946" y="429" text-anchor="middle">SLAVE</text>
+      <rect class="box-io" x="852" y="432" width="72" height="24" rx="6"/>
+      <text class="t-io" x="888" y="448" text-anchor="middle">IO ✂</text>
+      <rect class="box box-repman" x="836" y="478" width="220" height="56" rx="9"/>
+      <text class="t-name-s" x="946" y="503" text-anchor="middle">REPMAN · DR</text>
+      <text class="t-sub" x="946" y="521" text-anchor="middle" style="fill:var(--ink-faint);font:500 11.5px var(--sans)">holds Active · uid <tspan class="uid">2</tspan></text>
+    </svg>
+    <p class="note"><span class="bad">The catch:</span> tie-breaking is weaker, so the split lingers. Replication is cut, so the isolated <b>OLD MASTER keeps writing binlogs no slave consumes</b> — a growing <span class="bad">pile of delta transactions</span> that can't be flashed back. The <span class="bad">only way home is a full RESTORE FROM BACKUP</span> — slow and heavy. The Support plan avoids it entirely: the dedicated arbitrator resolves fast, and flashback / mariabackup rejoin recover the old master in place.</p>
+  </div>
+
+  <!-- ============ SUPPORT PLAN ============ -->
+  <div class="card support">
+    <h2>Support Plan Orchestration</h2>
+    <p class="sub">Dedicated arbitrator in DC3 (signal18) — the strong tie-breaker.</p>
+    <svg viewBox="0 0 1120 560" role="img" aria-label="Support plan after failover">
+      <!-- arbitrator links: DC1 cut (red), DC2 healthy (blue) -->
+      <path class="lnk-cut" d="M330,182 L470,116"/>
+      <path class="lnk-ok" d="M802,182 L650,116"/>
+      <text class="lnk-lbl-cut" x="300" y="152">✂ DC1 → arbitrator: cut</text>
+      <text class="lnk-lbl" x="820" y="152" text-anchor="end" style="fill:var(--ok)">DC2 → arbitrator: healthy</text>
+
+      <!-- horizontal DC1 <-> DC2 link, severed in the middle -->
+      <line class="cutbar" x1="336" y1="372" x2="796" y2="372" stroke-dasharray="10 8"/>
+      <rect x="448" y="322" width="224" height="100" rx="12" fill="var(--cut-bg)" stroke="var(--cut)" stroke-width="2"/>
+      <text x="560" y="350" text-anchor="middle" style="fill:var(--cut);font:800 14px var(--sans)">✕ NETWORK PARTITION</text>
+      <text x="560" y="373" text-anchor="middle" style="fill:var(--cut);font:600 12px var(--sans)">DC1 ↔ DC2 severed —</text>
+      <text x="560" y="392" text-anchor="middle" style="fill:var(--cut);font:600 12px var(--sans)">• peer heartbeat</text>
+      <text x="560" y="410" text-anchor="middle" style="fill:var(--cut);font:600 12px var(--sans)">• replication → slave IO</text>
+
+      <!-- DC3 arbitrator (MAJORITY) -->
+      <rect class="cloud-r cloud-dc3" x="400" y="20" width="320" height="104" rx="24"/>
+      <text class="cloud-lbl" x="424" y="46">☁ Cloud 3 · DC3 <tspan class="cloud-loc">@ signal18</tspan> <tspan class="tag-maj">· MAJORITY</tspan></text>
+      <rect class="box box-arb" x="432" y="56" width="256" height="54" rx="9"/>
+      <text class="t-arb" x="560" y="80" text-anchor="middle">ARBITRATOR</text>
+      <text class="t-sub" x="560" y="98" text-anchor="middle" style="fill:var(--ink-faint);font:500 11.5px var(--sans)">always reachable · breaks the tie</text>
+
+      <!-- DC1 (MINORITY) -->
+      <rect class="cloud-r cloud-dc1" x="24" y="176" width="312" height="344" rx="22"/>
+      <text class="cloud-lbl" x="48" y="204">☁ Cloud 1 · DC1 <tspan class="tag-min">· MINORITY</tspan></text>
+      <rect class="box box-proxy" x="60" y="220" width="184" height="42" rx="9"/>
+      <text class="t-proxy" x="152" y="246" text-anchor="middle">PROXY</text>
+      <!-- FTWRL fence (repman color, broken): proxy -> db1 -->
+      <line class="lnk-ftwl" x1="152" y1="262" x2="152" y2="288"/>
+      <line class="cutbar-ftwl" x1="141" y1="270" x2="163" y2="280"/>
+      <line class="cutbar-ftwl" x1="141" y1="280" x2="163" y2="270"/>
+      <text class="lnk-lbl-ftwl" x="172" y="279">FTWRL — writes blocked</text>
+      <rect class="box box-old" x="60" y="288" width="184" height="60" rx="9"/>
+      <text class="t-name" x="152" y="314" text-anchor="middle">db1</text>
+      <text class="t-badge-old" x="152" y="333" text-anchor="middle">MASTER → OLD MASTER</text>
+      <rect class="box box-repman" x="60" y="372" width="184" height="58" rx="9"/>
+      <text class="t-name-s" x="152" y="398" text-anchor="middle">REPMAN · main</text>
+      <text class="t-sub" x="152" y="416" text-anchor="middle" style="fill:var(--ink-faint);font:500 11.5px var(--sans)">Active → Standby · uid <tspan class="uid">1</tspan></text>
+      <rect class="yield-r" x="44" y="456" width="256" height="26" rx="13"/>
+      <text class="t-yield" x="172" y="473" text-anchor="middle">simulate-minority → read-only</text>
+      <!-- divergence: happy smiley on top of a single (flashback-able) delta -->
+      <text x="288" y="312" font-size="26" text-anchor="middle">😊</text>
+      <rect class="binlog" x="259" y="320" width="58" height="13" rx="2" style="fill:var(--majority-bg);stroke:color-mix(in srgb,var(--majority) 55%,var(--line))"/>
+      <text x="288" y="352" text-anchor="middle" style="fill:var(--majority);font:800 10.5px var(--sans)">delta ×1</text>
+      <text x="288" y="365" text-anchor="middle" style="fill:var(--majority);font:600 9.5px var(--sans)">flashback-able</text>
+
+      <!-- DC2 (MAJORITY) -->
+      <rect class="cloud-r cloud-dc2" x="796" y="176" width="300" height="364" rx="22"/>
+      <text class="cloud-lbl" x="820" y="204">☁ Cloud 2 · DC2 <tspan class="tag-maj">· MAJORITY</tspan></text>
+      <rect class="box box-proxy" x="836" y="220" width="220" height="42" rx="9"/>
+      <text class="t-proxy" x="946" y="246" text-anchor="middle">PROXY</text>
+      <!-- healthy (blue): proxy -> NEW MASTER -->
+      <line class="lnk-ok" x1="946" y1="262" x2="946" y2="288" stroke-width="3"/>
+      <rect class="box box-new" x="836" y="288" width="220" height="78" rx="9"/>
+      <text class="t-name" x="946" y="316" text-anchor="middle">db2</text>
+      <text class="t-badge-new" x="946" y="333" text-anchor="middle">SLAVE → NEW MASTER</text>
+      <rect class="box-io" x="852" y="338" width="72" height="24" rx="6"/>
+      <text class="t-io" x="888" y="354" text-anchor="middle">IO ✂</text>
+      <rect class="box" x="836" y="386" width="220" height="72" rx="9"/>
+      <text class="t-name" x="946" y="412" text-anchor="middle">db3</text>
+      <text class="t-badge-s" x="946" y="429" text-anchor="middle">SLAVE</text>
+      <rect class="box-io" x="852" y="432" width="72" height="24" rx="6"/>
+      <text class="t-io" x="888" y="448" text-anchor="middle">IO ✂</text>
+      <rect class="box box-repman" x="836" y="478" width="220" height="56" rx="9"/>
+      <text class="t-name-s" x="946" y="503" text-anchor="middle">REPMAN · DR</text>
+      <text class="t-sub" x="946" y="521" text-anchor="middle" style="fill:var(--ink-faint);font:500 11.5px var(--sans)">holds Active · uid <tspan class="uid">2</tspan></text>
+    </svg>
+    <p class="note"><b>Outcome:</b> DC2 + DC3 are the <b style="color:var(--majority)">majority</b> — db2 is promoted to <b style="color:var(--majority)">NEW MASTER</b>. DC1 is the <b style="color:var(--minority)">minority</b>; db1 steps down to <b style="color:var(--minority)">OLD MASTER</b>, read-only. Its divergence is a single flashback-able delta — <b>rejoin in place, seconds</b>.</p>
+  </div>
+
+  <!-- ============ LOSE–LOSE (SYMMETRIC SPLIT) ============ -->
+  <div class="card lose">
+    <h2>Lose–Lose Orchestration · Symmetric Split</h2>
+    <p class="sub">Both DCs still reach the arbitrator — but not each other. Neither can prove a safe majority, so repman fences <b>both</b> masters.</p>
+    <svg viewBox="0 0 1120 560" role="img" aria-label="Lose-lose symmetric split, both masters fenced">
+      <!-- arbitrator links: BOTH healthy (blue) -->
+      <path class="lnk-ok" d="M330,182 L470,116"/>
+      <path class="lnk-ok" d="M802,182 L650,116"/>
+      <text class="lnk-lbl" x="300" y="152" style="fill:var(--ok)">DC1 → arbitrator: healthy</text>
+      <text class="lnk-lbl" x="820" y="152" text-anchor="end" style="fill:var(--ok)">DC2 → arbitrator: healthy</text>
+
+      <!-- horizontal DC1 <-> DC2 link severed: the split -->
+      <line class="cutbar" x1="336" y1="372" x2="796" y2="372" stroke-dasharray="10 8"/>
+      <rect x="436" y="316" width="248" height="112" rx="12" fill="var(--cut-bg)" stroke="var(--cut)" stroke-width="2"/>
+      <text x="560" y="342" text-anchor="middle" style="fill:var(--cut);font:800 14px var(--sans)">✕ SYMMETRIC SPLIT</text>
+      <text x="560" y="364" text-anchor="middle" style="fill:var(--cut);font:600 12px var(--sans)">DC1 ↔ DC2 severed —</text>
+      <text x="560" y="382" text-anchor="middle" style="fill:var(--cut);font:600 12px var(--sans)">each sees the arbitrator,</text>
+      <text x="560" y="400" text-anchor="middle" style="fill:var(--cut);font:600 12px var(--sans)">neither sees its peer</text>
+
+      <!-- DC3 arbitrator -->
+      <rect class="cloud-r cloud-dc3" x="400" y="20" width="320" height="104" rx="24"/>
+      <text class="cloud-lbl" x="424" y="46">☁ Cloud 3 · DC3 <tspan class="cloud-loc">@ signal18</tspan></text>
+      <rect class="box box-arb" x="432" y="56" width="256" height="54" rx="9"/>
+      <text class="t-arb" x="560" y="80" text-anchor="middle">ARBITRATOR</text>
+      <text class="t-sub" x="560" y="98" text-anchor="middle" style="fill:var(--ink-faint);font:500 11.5px var(--sans)">reachable by both — grants neither</text>
+
+      <!-- DC1 (FENCED) -->
+      <rect class="cloud-r cloud-dc1" x="24" y="176" width="312" height="344" rx="22"/>
+      <text class="cloud-lbl" x="48" y="204">☁ Cloud 1 · DC1 <tspan class="tag-fenced">· FENCED</tspan></text>
+      <rect class="box box-proxy" x="60" y="220" width="184" height="42" rx="9"/>
+      <text class="t-proxy" x="152" y="246" text-anchor="middle">PROXY</text>
+      <line class="lnk-ftwl" x1="152" y1="262" x2="152" y2="288"/>
+      <line class="cutbar-ftwl" x1="141" y1="270" x2="163" y2="280"/>
+      <line class="cutbar-ftwl" x1="141" y1="280" x2="163" y2="270"/>
+      <text class="lnk-lbl-ftwl" x="172" y="279">FTWRL — writes blocked</text>
+      <rect class="box box-old" x="60" y="288" width="184" height="60" rx="9"/>
+      <text class="t-name" x="152" y="314" text-anchor="middle">db1</text>
+      <text class="t-badge-old" x="152" y="333" text-anchor="middle">MASTER · FROZEN</text>
+      <rect class="box box-repman" x="60" y="372" width="184" height="58" rx="9"/>
+      <text class="t-name-s" x="152" y="398" text-anchor="middle">REPMAN · main</text>
+      <text class="t-sub" x="152" y="416" text-anchor="middle" style="fill:var(--ink-faint);font:500 11.5px var(--sans)">holds Active · uid <tspan class="uid">1</tspan></text>
+      <rect class="yield-r" x="44" y="456" width="256" height="26" rx="13" style="fill:var(--cut-bg);stroke:color-mix(in srgb,var(--cut) 45%,var(--line))"/>
+      <text class="t-yield" x="172" y="473" text-anchor="middle" style="fill:var(--cut)">no quorum → will not promote</text>
+      <text x="288" y="312" font-size="26" text-anchor="middle">😐</text>
+      <rect class="binlog" x="259" y="320" width="58" height="13" rx="2" style="fill:var(--panel);stroke:var(--line)"/>
+      <text x="288" y="352" text-anchor="middle" style="fill:var(--ink-soft);font:800 10.5px var(--sans)">delta ×0</text>
+      <text x="288" y="365" text-anchor="middle" style="fill:var(--ink-faint);font:600 9.5px var(--sans)">no writes</text>
+
+      <!-- DC2 (FENCED) -->
+      <rect class="cloud-r cloud-dc2" x="796" y="176" width="300" height="364" rx="22"/>
+      <text class="cloud-lbl" x="820" y="204">☁ Cloud 2 · DC2 <tspan class="tag-fenced">· FENCED</tspan></text>
+      <rect class="box box-proxy" x="836" y="220" width="220" height="42" rx="9"/>
+      <text class="t-proxy" x="946" y="246" text-anchor="middle">PROXY</text>
+      <line class="lnk-ftwl" x1="946" y1="262" x2="946" y2="288"/>
+      <line class="cutbar-ftwl" x1="935" y1="270" x2="957" y2="280"/>
+      <line class="cutbar-ftwl" x1="935" y1="280" x2="957" y2="270"/>
+      <text class="lnk-lbl-ftwl" x="966" y="279">held — no writes</text>
+      <rect class="box box-old" x="836" y="288" width="220" height="78" rx="9"/>
+      <text class="t-name" x="946" y="316" text-anchor="middle">db2</text>
+      <text class="t-badge-old" x="946" y="333" text-anchor="middle">SLAVE · NOT PROMOTED</text>
+      <rect class="box-io" x="852" y="338" width="72" height="24" rx="6"/>
+      <text class="t-io" x="888" y="354" text-anchor="middle">IO ✂</text>
+      <rect class="box" x="836" y="386" width="220" height="72" rx="9"/>
+      <text class="t-name" x="946" y="412" text-anchor="middle">db3</text>
+      <text class="t-badge-s" x="946" y="429" text-anchor="middle">SLAVE · FROZEN</text>
+      <rect class="box-io" x="852" y="432" width="72" height="24" rx="6"/>
+      <text class="t-io" x="888" y="448" text-anchor="middle">IO ✂</text>
+      <rect class="box box-repman" x="836" y="478" width="220" height="56" rx="9"/>
+      <text class="t-name-s" x="946" y="503" text-anchor="middle">REPMAN · DR</text>
+      <text class="t-sub" x="946" y="521" text-anchor="middle" style="fill:var(--ink-faint);font:500 11.5px var(--sans)">Standby · uid <tspan class="uid">2</tspan></text>
+    </svg>
+    <p class="note"><b>Outcome:</b> the split is <b>symmetric</b> — each side still reaches the arbitrator, so each could naïvely read a 2-of-3 majority and promote. To stop a real split-brain, repman does the safe thing and <b style="color:var(--cut)">grants neither</b>: both proxies are cut and both masters are <b>FTWRL-frozen</b>. The price is a <b>full write outage</b> until an operator (or a directional-failback policy) elects a survivor — but there is <b>zero divergence</b>, so recovery is a clean unfreeze, never a restore.</p>
+  </div>
+
+  <p style="margin-top:22px;font-size:12.5px;color:var(--ink-faint);font-family:var(--mono)">signal18/replication-manager · /api/clusters/{cluster}/test/split-brain-simulator/*</p>
+</div>

--- a/doc/material-procedure/INCRUST_DEMO_VIDEO.md
+++ b/doc/material-procedure/INCRUST_DEMO_VIDEO.md
@@ -1,0 +1,188 @@
+# Producing an "Incrust" Demo Video
+
+Procedure for building a narrated marketing video of the replication-manager GUI,
+where live demo footage plays full-screen and a small **inset ("incrust")** panel
+in the bottom-right shows the current topic, section labels, and (optionally) a
+countdown — with a synthetic mouse cursor and a human voiceover.
+
+> The intro / explainer slides reuse the split-brain orchestration diagrams —
+> see [ORCHESTRATION_DIAGRAMS.md](./ORCHESTRATION_DIAGRAMS.md). When those diagrams
+> change, the video's slides must be re-exported from them.
+
+> **Secrets stay out of this repo.** The GUI URL, login, and cluster names are
+> environment-specific and are **not** committed here — supply them at runtime via
+> env vars / a local token file. Keep credentials in a private local note, never in
+> `doc/`.
+
+---
+
+## 1. Why it's built this way (constraints that shaped the method)
+
+- **Headless Chromium cannot decode/paint a `<video>` element** — it renders black.
+  So we never composite the demo footage *inside* a browser. Instead the demo is
+  recorded as its own video, and any animated overlay (inset, labels, countdown) is
+  a **separate HTML page** recorded on a solid **chroma-key** background, then keyed
+  over the footage with ffmpeg.
+- **Headless has no real mouse pointer** — recordings show no cursor. We inject a
+  **synthetic cursor** (a styled `div`) and animate it to each target.
+- **Playwright synthetic clicks (`el.click()`) don't drive some Chakra components**
+  (accordion headers). Use **trusted input** (`page.mouse.click(x,y)` /
+  `locator.click()`) for those; tab navigation may still need a `scrollIntoView` +
+  synthetic click helper.
+- **ffmpeg from a static build**, not Homebrew — on older macOS there is no bottle
+  and `brew install ffmpeg` compiles from source (~1h). Download a prebuilt static
+  binary instead.
+- **CPU contention ruins voice takes.** Recording footage or encoding while the
+  narrator records their microphone causes audio dropouts. **Never run
+  Playwright/ffmpeg while the mic is live** — record voice on an idle machine, then
+  process.
+
+---
+
+## 2. Tooling setup
+
+**Static ffmpeg** (no compile):
+```bash
+mkdir -p ./bin
+curl -sL -o ff.zip "https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip"
+unzip -o ff.zip -d ./bin && chmod +x ./bin/ffmpeg
+```
+
+**Playwright** — run recording scripts from a directory that has
+`node_modules/playwright` installed.
+
+**Auth** — obtain a session token from the GUI's login API and inject it as
+`localStorage.user_token` via `addInitScript`. Tokens are short-lived; re-mint per
+session. Provide `BASE` (GUI URL) and the token file as env vars — do not hard-code.
+
+---
+
+## 3. Record the demo footage (Playwright + synthetic cursor)
+
+Key building blocks (see the working scripts kept in the local
+`REPMAN/video/scripts/` cheatsheet):
+
+- Launch headless, `viewport 1600x900`, `recordVideo` on the context.
+- `addInitScript` #1: `localStorage.setItem('user_token', <token>)`.
+- `addInitScript` #2: inject the cursor — a fixed `#fakecursor` div with a CSS
+  `transition` on `left/top`, plus a keyframed `.rip` click-ripple element.
+- Helpers:
+  - `rectOf(text, role)` → scrolls the element into view, returns its center.
+  - `move(x,y)` → sets the cursor div's position, waits for the ~0.6s glide.
+  - `moveClick(x,y)` → glide, spawn a ripple, then **`page.mouse.click(x,y)`**
+    (trusted).
+- Pace it **relaxed** — dwell 10–15s per screen with natural pauses; this reads as
+  human, and gives room for narration.
+- Optional top **caption banner** (a fixed dark bar) to label each phase; matches
+  the pre-recorded arbitration footage which already carries banners.
+
+Gotchas learned:
+- Tab (e.g. "Maintenance") — use the scrollIntoView + synthetic-click helper.
+- Accordion section headers (backups snapshots, database jobs) — use
+  `page.mouse.click` on the header row, not the text node.
+- A card's settings **gear** (far-right of a section header) can deep-link to the
+  relevant Settings section — good for "jump to the config" beats.
+- Pages can load slowly; **sync on real elements** (`waitForSelector('text=…')`)
+  rather than fixed sleeps, and expect the final clip to run longer than scripted.
+
+---
+
+## 4. Build the overlay (inset + labels + countdown)
+
+An HTML page on a **magenta `#FF00FF`** background (a color absent from the GUI):
+
+- A full-screen **intro** slide that zooms in from the inset corner, then shrinks
+  to the inset (CSS `opacity`+`transform`, `transform-origin` bottom-right).
+- A **bottom-right inset** card: logo, section label, and either a static line or
+  a few **slowly cycling** points. With a voiceover, keep it **minimal** — the
+  voice carries the detail; on-screen text competing with narration reads as "too
+  much, too fast."
+- Optional footer **countdown** to the next section.
+
+Record it with Playwright `recordVideo` for the section's duration.
+
+---
+
+## 5. Composite (chroma-key overlay over footage) + mux voice
+
+```bash
+./bin/ffmpeg -i FOOTAGE.webm -i OVERLAY.webm -i VOICE.m4a -filter_complex \
+ "[0:v]scale=1600:900,setsar=1[bg];\
+  [1:v]colorkey=0xFF00FF:0.32:0.14[o];\
+  [bg][o]overlay=shortest=1,format=yuv420p[v]" \
+ -map "[v]" -map 2:a -c:v libx264 -pix_fmt yuv420p -c:a aac -shortest -r 25 out.mp4
+```
+
+To **sync footage to the narration**, split the footage into segments and re-time
+them (`trim` + `setpts`) so key reveals land on the narrator's cues (e.g. "the
+snapshot list appears when I say *snapshots*"). Slow static screens gently — heavy
+slowdown looks sluggish.
+
+---
+
+## 6. Voiceover workflow (voice-first)
+
+1. Narrator records **freely** over a silent reference cut (talk naturally; do not
+   race any countdown).
+2. **Trim** dead air with ffmpeg — cut the leading/trailing silence and any
+   genuinely long pauses, but **keep the calm mid-phrase pauses** (they're
+   delivery, not silence):
+   ```bash
+   ./bin/ffmpeg -i VOICE.m4a -filter_complex \
+    "[0:a]atrim=start=S1:end=E1,asetpts=PTS-STARTPTS[a1];\
+     [0:a]atrim=start=S2,asetpts=PTS-STARTPTS[a2];[a1][a2]concat=n=2:v=0:a=1[a]" \
+    -map "[a]" -c:a aac voice-trim.m4a
+   ```
+3. **Gentle** de-breath only — a downward expander, never a hard gate (a hard gate
+   *pumps* and destroys the voice on a regular period):
+   ```bash
+   ./bin/ffmpeg -i voice-trim.m4a \
+    -af "highpass=f=80,agate=threshold=0.04:ratio=1.6:range=0.4:attack=30:release=420:knee=6" \
+    voice-soft.m4a
+   ```
+4. Retime the **video** to the final narration length and mux.
+
+---
+
+## 7. Messaging guardrails (technical audience will scrutinize)
+
+- **Do not** claim "backups make rejoin fast." **Flashback** is the fast path
+  (rewind the divergent delta, seconds). **Backups** are the safety-net / reseed
+  fallback used when flashback isn't possible.
+- Backup value, stated accurately: repman **auto-selects** the right backup+method
+  → faster than a **manual** restore (never "faster than flashback"); binlogs +
+  backups archived to a **remote S3** store (restic, deduplicated) → offsite DR and
+  long-retention point-in-time recovery; **single-table physical restore into a
+  live server** (no restart, no downtime, consistent PITR); **concurrent** restore;
+  **pigz** parallel decompression.
+- A visible **failed job** is a **feature, not a demo-effect blemish** — narrate it
+  as proof that repman **tracks every job's state and flags failures** (silent
+  backup/restore failures are the real nightmare). The narration turns an on-camera
+  failure into a deliberate proof point.
+
+---
+
+## 8. Section map / status (update as it progresses)
+
+The video follows the arbitration story:
+
+| # | Section | State |
+|---|---------|-------|
+| 1 | Registration & arbitration settings | TODO (re-record with cursor) |
+| 2 | Backups & restore | **DONE** — footage + synced VO + gentle de-breath |
+| 2b | Scheduled jobs & monitoring → scheduler settings | footage recorded, awaiting VO |
+| 3 | Network split — minority isolated | TODO |
+| 4 | Failover — arbitration promotes new master | TODO |
+| 5 | Partition healed — old master diverged | TODO |
+| 6 | Rejoin (flashback fast-path / mariabackup reseed fallback) | TODO |
+| 7 | Recovered — old master healthy slave | TODO |
+
+Sections 1 and 3–7 come from the **master demo take**, to be re-recorded with the
+synthetic cursor (safe on a test cluster, since it re-fires the split→failover→
+rejoin scenario).
+
+---
+
+*Working assets (footage, voice, finals, and the runnable scripts + a private
+command cheatsheet with the environment-specific URL/auth) are kept locally under
+the operator's `REPMAN/video/` working folder — not in this repo.*

--- a/doc/material-procedure/ORCHESTRATION_DIAGRAMS.md
+++ b/doc/material-procedure/ORCHESTRATION_DIAGRAMS.md
@@ -1,0 +1,99 @@
+# Split-Brain Orchestration Diagrams
+
+Procedure for the three arbitration diagrams — **Free**, **Support**, and
+**Lose–Lose (symmetric split)** — that illustrate how replication-manager handles a
+two-datacenter partition.
+
+These diagrams are used in **two** places, so keep them in sync:
+- the arbitration documentation (docs.signal18.io → Architecture → Arbitration
+  §4.7.1.6), and
+- the demo video, as the explainer / intro slides — see
+  [INCRUST_DEMO_VIDEO.md](./INCRUST_DEMO_VIDEO.md).
+
+---
+
+## 1. Single source of truth
+
+Everything is generated from one **self-contained HTML generator**:
+
+```
+doc/implementation/cluster/split-brain-orchestration.html
+```
+
+It contains the three `<svg viewBox="0 0 1120 560">` diagrams plus an inline
+`<style>` with the whole design system. No external assets, no build step —
+open it in a browser to view/edit. A companion reference lives at
+`doc/implementation/cluster/SPLIT_BRAIN_ORCHESTRATION.md`.
+
+### Design system (CSS custom properties, theme-aware light/dark)
+- `--accent` teal = **repman / proxy / FTWRL fence** color
+- `--majority` green = the winning side (NEW MASTER)
+- `--minority` amber = the yielding side (OLD MASTER, read-only)
+- `--cut` red = severed links / NETWORK PARTITION
+- `--arb` indigo = the arbitrator
+- `--ok` blue = healthy link
+
+### What the three frames show
+- **Free** — weak arbiter (a 3rd repman): the isolated old master piles
+  unrecoverable binlogs → restore from backup.
+- **Support** — dedicated arbitrator: old master **FTWRL-fenced** (teal broken
+  link), single flashback-able delta → rejoin in seconds.
+- **Lose–Lose** — symmetric split, both sides still reach the arbitrator → repman
+  fences **both** masters (write outage, but zero divergence).
+
+Shared elements: three DC "clouds", per-DC **proxy** boxes, **repman** boxes (teal),
+the arbitrator, the **FTWRL** fence (teal cut on the minority side, blue healthy on
+the majority side), and a single horizontal **NETWORK PARTITION** cross between
+DC1↔DC2.
+
+---
+
+## 2. Edit → verify
+
+1. Edit the SVG(s) in `split-brain-orchestration.html`.
+2. Render-check with Playwright (headless is fine — these are pure HTML/SVG, no
+   `<video>`): `page.goto('file://…/split-brain-orchestration.html')` →
+   `page.screenshot({fullPage:true})`, and eyeball the PNG.
+3. Iterate. Keep both light and dark tokens working.
+
+---
+
+## 3. Export — two targets
+
+### a) Standalone theme-aware SVGs (for the repman docs)
+Each `<svg>` in the generator relies on the page-level `<style>`, so to stand alone
+each needs its **own** embedded style + a panel background. Extract each `<svg>`,
+inject the full `<style>` and a background `<rect>`, add the SVG namespace, and pad
+the viewBox:
+
+```py
+# pseudo: for each <svg> block in the generator html
+svg = svg.replace('<svg ', '<svg xmlns="http://www.w3.org/2000/svg" ', 1)
+svg = svg.replace('viewBox="0 0 1120 560"', 'viewBox="-18 -18 1156 596"', 1)
+inject = f'<style>{css}</style><rect x="-18" y="-18" width="1156" height="596" rx="18" fill="var(--panel)"/>'
+svg = re.sub(r'(<svg[^>]*>)', lambda m: m.group(1)+inject, svg, count=1)
+```
+→ write to `doc/implementation/cluster/img/sbs-{free,support,lose-lose}.svg`.
+
+### b) PNGs (for the Grav docs site + the video slides)
+Grav uses PNG (`/images/*.png`) and PNG is safest for slides/PDF. Render each
+standalone SVG via Playwright at 1600×900 (`deviceScaleFactor:2`) and screenshot:
+→ `docs.signal18.io/pages/images/arbitration{free,support,loselose}.png`,
+referenced from the arbitration overview as `![...](/images/arbitration*.png)`.
+
+> Caveat: an SVG embedded via `<img>` follows the *OS* color scheme, not a site's
+> light/dark toggle — so on GitHub/Grav it renders in the viewer's OS theme.
+
+---
+
+## 4. Where each output lives
+
+| Output | Location | Consumed by |
+|--------|----------|-------------|
+| Generator HTML | `doc/implementation/cluster/split-brain-orchestration.html` | source of truth |
+| Standalone SVGs | `doc/implementation/cluster/img/sbs-*.svg` | repman implementation doc |
+| PNGs | `docs.signal18.io/pages/images/arbitration*.png` | arbitration docs §4.7.1.6 |
+| Slide frames | rendered into the demo video | see [INCRUST_DEMO_VIDEO.md](./INCRUST_DEMO_VIDEO.md) |
+
+**When the diagram changes, re-export all three targets** so the docs and the video
+stay consistent.


### PR DESCRIPTION
**Docs only — no code changes.**

Moves the split-brain orchestration diagrams (previously stranded on the already-merged \`feat/gui-inject-traffic-mode\` branch) onto develop, and adds reproducible material-production procedures.

### What's here
- \`doc/implementation/cluster/\` — the three arbitration diagrams (\`img/sbs-{free,support,lose-lose}.svg\`), the self-contained HTML **generator** (\`split-brain-orchestration.html\`), and \`SPLIT_BRAIN_ORCHESTRATION.md\` (diagram narrative + split-brain-simulator API reference).
- \`doc/material-procedure/\` — two cross-linked guides:
  - **INCRUST_DEMO_VIDEO.md** — how the narrated demo video is produced (Playwright footage + synthetic cursor, chroma-key overlay compositing, voice-first audio workflow, messaging guardrails).
  - **ORCHESTRATION_DIAGRAMS.md** — how the diagrams are authored/rendered and exported to the repman docs (SVG) and the docs.signal18.io site (PNG). The diagrams are the video's explainer slides, so the two are linked.

### Notes
- No secrets: GUI URL/auth are placeholders (public repo).
- The diagrams are already live in the arbitration docs on docs.signal18.io §4.7.1.6.