### PR TITLE
fix(peer): health-poll scope + socket-leak, SSO-login root cause, marketplace/for-sale GUI

### DIFF
--- a/doc/implementation/peer/MARKETPLACE.md
+++ b/doc/implementation/peer/MARKETPLACE.md
@@ -335,13 +335,21 @@ that traffic — a single dark peer in your own fleet must not accumulate connec
    success (the claim is advanced up-front, before the call). Previously a failure
    left `LastUpdate` untouched and login wasn't even gated, so a dark peer was re-hit
    every dispatch.
-3. **Correct map locking, no single-flight** (`peer.go`) — because the claim, the
-   `PeerURL`/`Clients` access, and `GetHealthStatus`'s `PeerClusters` update all hold
-   `pm.mu` (released before network I/O), overlapping timer + reload dispatches can no
-   longer race the maps (`BatchUpdateClusters` mutates them under the same lock). So
-   no whole-poll serialization is needed: **different** peers still poll in parallel;
-   only the **same** peer is deduplicated. The earlier `peerHealthBusy` single-flight
-   guard was dropped in favour of this finer-grained, correct-by-construction claim.
+3. **Correct locking** (`peer.go`) — the claim, the `PeerURL`/`Clients` access, and
+   `GetHealthStatus`'s `PeerClusters` update all hold `pm.mu` (released before network
+   I/O), so a poll goroutine never races `BatchUpdateClusters` (which mutates the same
+   maps under the same lock). `pollPeerHealth` also writes `nodestat.Error` under the
+   lock (via `setNodeError`) because the status API (`GetPeerNodesJSON`) reads those
+   fields — and `GetPeerNodesJSON` now marshals a value-copy **snapshot** taken under
+   the lock, never the live pointers. Dedup is per-peer (different peers still poll in
+   parallel; only the **same** peer is skipped), so no whole-poll serialization is
+   needed for correctness.
+4. **Coarse busy signal, kept for operators** (`server_peer.go`) —
+   `dispatchPeerHealthPoll` still self-guards on `peerHealthBusy` and holds it for the
+   whole poll, purely so the flag reflects "a poll is running." The timer raises
+   `GWARN013@peerhealth` when it finds a poll that hasn't finished within a cycle (a
+   slow/stuck poll — the signal that would have surfaced the original incident). This
+   is complementary to, not a replacement for, the per-peer claim.
 
 **Timing (why Fix 1 costs no delay):** periodic backstop dispatch every ~2 min
 (`counter%60` × `monitoring-ticker` 2s); per-node staleness gate

--- a/doc/implementation/peer/MARKETPLACE.md
+++ b/doc/implementation/peer/MARKETPLACE.md
@@ -326,15 +326,22 @@ that traffic — a single dark peer in your own fleet must not accumulate connec
    plus `DialContext` (5s), `TLSHandshakeTimeout` (5s) and `ResponseHeaderTimeout`
    deadlines so a peer that accepts TCP but never answers is bounded. (`req.Close =
    true` and the 10s client `Timeout` were already present.)
-2. **Rate-limit + advance `LastUpdate` on failure** (`peer.go`, both pollers) — each
-   peer's whole attempt (login *and* health) is gated to once per `Interval`, and
-   `LastUpdate` is advanced **up-front** so a failed attempt is rate-limited the same
-   as a success. Previously a failure left `LastUpdate` untouched and login wasn't
-   even gated, so a dark peer was re-hit every dispatch.
-3. **Effective single-flight** (`server_peer.go`) — `dispatchPeerHealthPoll` now
-   self-guards on `peerHealthBusy` and holds it across the whole poll goroutine, so
-   the timer and the reload path can never run overlapping polls that race the shared
-   per-node `LastUpdate`.
+2. **First-in-wins atomic claim** (`peer.go`, `pollPeerHealth`) — both pollers route
+   each peer through one helper that, **under the lock**, checks `LastUpdate` and
+   advances it in the same critical section before releasing the lock and doing the
+   network call. The first dispatch to reach a peer claims the interval; any
+   overlapping dispatch sees a fresh timestamp and skips. This gives **exactly one
+   call per peer per `Interval`**, and rate-limits a failed attempt identically to a
+   success (the claim is advanced up-front, before the call). Previously a failure
+   left `LastUpdate` untouched and login wasn't even gated, so a dark peer was re-hit
+   every dispatch.
+3. **Correct map locking, no single-flight** (`peer.go`) — because the claim, the
+   `PeerURL`/`Clients` access, and `GetHealthStatus`'s `PeerClusters` update all hold
+   `pm.mu` (released before network I/O), overlapping timer + reload dispatches can no
+   longer race the maps (`BatchUpdateClusters` mutates them under the same lock). So
+   no whole-poll serialization is needed: **different** peers still poll in parallel;
+   only the **same** peer is deduplicated. The earlier `peerHealthBusy` single-flight
+   guard was dropped in favour of this finer-grained, correct-by-construction claim.
 
 **Timing (why Fix 1 costs no delay):** periodic backstop dispatch every ~2 min
 (`counter%60` × `monitoring-ticker` 2s); per-node staleness gate

--- a/doc/implementation/peer/MARKETPLACE.md
+++ b/doc/implementation/peer/MARKETPLACE.md
@@ -1,0 +1,372 @@
+# Peer Marketplace & Cross-Repman Health (Cloud18)
+
+How independent replication-manager instances ("peers") see each other: how a
+partner running *their own* repman can **manage a cluster you delegate to them**
+and see its status **live**, and how clusters **offered for sale** on the
+marketplace are advertised **asynchronously** (git-pull cadence, no live polling).
+
+> Scope: the `peer/` package (`PeerManager`, `PeerClient`) and its callers in
+> `server/` (`server_peer.go`, `server_git.go`, `api_register.go`). The Back
+> Office (BO) that aggregates and ships `peer.json` is a separate, private
+> service and is referenced here only by its contract (the shape of `peer.json`
+> and the git `.pull` cadence) — no BO internals.
+
+---
+
+## 1. Two relationships, two very different status paths (read this first)
+
+There are **two distinct ways** one repman relates to another peer's cluster, and
+they have **opposite** freshness requirements. Conflating them is the root of the
+scaling problem in §6.
+
+| Relationship | How it's declared | Who sees it | Status freshness |
+|--------------|-------------------|-------------|------------------|
+| **Delegated / shared** | You add the partner's **user email** to the cluster's ACL (`api-credentials-acl-allow-external`) | Only that partner (the user in the ACL) | **LIVE** — the partner's repman polls it directly |
+| **For sale (marketplace)** | You mark the cluster `cloud18-shared` (and no sponsor claims it yet) | **Every** registered repman that pulled the catalog | **Asynchronous** — refreshed on the BO's git-pull cadence via `peer.json`, staleness is fine |
+
+**Delegation is the live case.** You *delegate management* of one of your own
+fleet clusters to a partner by sharing a user email onto that cluster. The
+partner, from inside *their* repman, needs to see it as if it were their own:
+real-time status, and the ability to enter it and act. That legitimately warrants
+a direct, live connection to your repman.
+
+**For-sale is the async case.** A cluster on the marketplace only needs to
+advertise "here is a cluster, here is roughly its health, here is the plan" to
+prospective buyers. A buyer browsing the catalog does **not** need a live socket
+to the seller — the BO already collected that cluster's status once and shipped it
+in `peer.json`. Refresh happens when the catalog is next pulled. That is by design
+and entirely sufficient.
+
+Keeping these two paths separate is what keeps the system from fanning out into
+an O(N²) mesh (§6).
+
+---
+
+## 2. Data model (`peer/peer.go`)
+
+A peer cluster is one entry parsed from `peer.json`:
+
+```go
+type PeerCluster struct {
+    ApiPublicUrl                 string // reachable API of the hosting repman
+    ClusterName                  string
+    Cloud18Shared                bool   // offered on the marketplace
+    Cloud18SubscriptionPlan      string // "free" | "support" | "support-services" | "partner" | "developer"
+    ApiCredentialsAclAllow       string // local ACL grants  "user:pass:cluster:roles,..."
+    ApiCredentialsAclAllowExternal string // cross-repman ACL grants (the "shared user email")
+    RepmgrVersion                string
+    // ... status fields filled by the health poll ...
+}
+```
+
+`PeerManager` maintains the derived indexes:
+
+| Field | Meaning | Populated by |
+|-------|---------|--------------|
+| `PeerURL` | de-duplicated set of every peer API URL | `AddOrUpdatePeer` |
+| `PeerClusters` | all clusters keyed by hash id | reload |
+| `PeerUserClusters[email]` | **clusters a given user email may access** = the *delegated/live* set for that user | `ReloadUsers` |
+| `UserClusterAccess[email]` | same membership as a presence set (access check) | `ReloadUsers` |
+| `PeerForSale[hash]` | **clusters on the marketplace** = the *async* set | `ReloadUsers` |
+
+### How the split is computed — `ReloadUsers` (`peer.go:288`)
+
+For each cluster, `ReloadUsers` walks its ACL
+(`ApiCredentialsAclAllow + "," + ApiCredentialsAclAllowExternal`), and for every
+granted user:
+
+```go
+pm.UserClusterAccess[uname][hashID] = struct{}{}
+pm.PeerUserClusters[uname][hashID]  = pc      // this user can see/manage this cluster
+```
+
+The cluster starts as `forSale = pc.Cloud18Shared`, but it is **demoted out of the
+for-sale set** the moment a granted user carries a `sponsor` or `pending` role:
+
+```go
+if forSale {
+    if strings.Contains(roles, "sponsor") { forSale = false; continue }
+    if strings.Contains(roles, "pending") { forSale = false; continue }
+}
+...
+if forSale { pm.PeerForSale[hashID] = pc } else { delete(pm.PeerForSale, hashID) }
+```
+
+So a shared cluster that a partner has actually **claimed / been delegated**
+(sponsor) is no longer "for sale" — it is now *delegated*, and it lives in that
+partner's `PeerUserClusters`, not in `PeerForSale`. This is exactly the §1 split,
+expressed in code: **delegation ⇒ `PeerUserClusters` (live); pure marketplace ⇒
+`PeerForSale` (async).**
+
+### 2.1 Fleet identity and the `admin` ≡ SSO-user rule
+
+Three identity rules define what "my fleet" and "my cluster-peers" mean:
+
+1. **Fleet = same registering user.** Multiple repman instances that register with
+   the *same* `Cloud18GitUser` (the cloud18-gitlab / SSO user) are one fleet.
+2. **Local `admin` ≡ that instance's registering SSO user.** For marketplace/peer
+   identity, the built-in local `admin` API account stands in for the instance's
+   `Cloud18GitUser`.
+3. **My cluster-peers** (the live-pollable set) = my fleet (rule 1) **+** every
+   cluster a partner has delegated to me (my user email in *their*
+   `api-credentials-acl-allow-external`). This is `PeerUserClusters[Cloud18GitUser]`
+   unioned with the connected users' sets (§6).
+
+**The gap this exposes.** `SaveAcls` (`cluster_acl.go:143`) builds each cluster's
+external ACL from `api-credentials` + `api-credentials-external`, so the entry that
+ships in `peer.json` for an instance's *own* clusters is the literal local **`admin`**
+(default `admin:repman`, `server.go:655`) — never the SSO email. `ReloadUsers`
+(`peer.go:288`) then keys `PeerUserClusters["admin"][hash] = pc` verbatim, with no
+`admin` → `Cloud18GitUser` resolution. Two consequences:
+
+- **Own fleet is invisible to the SSO-keyed scope.** Your clusters sit under
+  `"admin"`, but the live scope looks them up under your `Cloud18GitUser` email →
+  no match (rule 1 unrealized).
+- **`admin` collides across fleets.** Every instance's local admin is the same
+  literal string, so `PeerUserClusters["admin"]` conflates unrelated fleets — an
+  over-scope that re-introduces the fan-out.
+
+`PeerCluster` carries `Cloud18Domain` but **not** the hosting instance's
+`Cloud18GitUser`, so the resolution cannot be done repman-side today — the
+identity has to travel with each peer cluster (BO stamps it into `peer.json`, or
+repman substitutes its own admin for its own `Cloud18GitUser`). This is a
+prerequisite for the §6 scope to be correct.
+
+---
+
+## 3. Where `peer.json` comes from (the async backbone)
+
+`peer.json` is produced by the **BO**, which aggregates the status of every
+`cloud18-shared` cluster across the fleet **once per collection cycle**, and ships
+the file to each registered repman through the git config channel (the `.pull`
+repo). On the repman side it lands at:
+
+```
+<datadir>/.pull/peer.json
+```
+
+`server_git.go` reloads it after each git pull and calls
+`PeerManager.BatchUpdateClusters(...)`. **This is the marketplace's normal,
+sufficient status path**: every for-sale cluster's health reaches every browsing
+repman here, at git-pull cadence, with zero cross-repman connections. The buyer
+sees "cluster X, healthy, partner plan" without anyone opening a socket to the
+seller.
+
+### Design goal: the sale must show *fast*
+
+The whole reason the marketplace is served from `peer.json` is speed of the **sale
+process**. When a prospective buyer opens the catalog, every for-sale cluster and
+its status is **already local** — the listing renders instantly, with **zero**
+live calls to sellers. Freshness is intentionally traded for speed: the status is
+as recent as the last BO collection / git pull, and that is fine for a sales
+listing (the operator explicitly does not need real-time health to browse what's
+for sale).
+
+Live-polling for-sale clusters would *defeat* this goal, not improve it: the
+listing would block on N remote `/api/health` calls and stall on any slow or dark
+seller (precisely the failure in §6). So **"show the sale quickly"** and **"never
+live-poll for-sale clusters"** are the *same* requirement — the async path is what
+makes the sale fast, and live polling is what made it hang. Live status is reserved
+for clusters you *own or were delegated* (§4–§5), where you actually operate them.
+
+---
+
+## 4. Health-poll modes (`cloud18-peer-health-mode`)
+
+Beyond the async `peer.json`, repman can *actively* poll peer `/api/health`
+endpoints. The mode selects **what gets polled live**:
+
+| Mode | What it polls live | Use |
+|------|--------------------|-----|
+| `pulling` **(default)** | nothing extra — trusts `peer.json`; only fills in peers whose `RepmgrVersion` is still unknown (`GetHealthStatusForUnknownVersions`) | ordinary registered clients browsing the marketplace |
+| `smart` | the caller's **own fleet + delegated clusters** (`PeerUserClusters` for the registered user + active users) — **not** the for-sale catalog | partners who host/delegate clusters and need live status |
+| `peering` | **every** peer URL (`GetAllHealthStatus`) | legacy full-mesh; heaviest |
+
+### Default and partner auto-promotion
+
+The shipped default is **`pulling`** (`server/server.go`, `cloud18-peer-health-mode`
+flag). A plain registered client that merely *reads* the marketplace must not open
+live connections to every seller — it just consumes `peer.json`.
+
+`partner`-plan instances *do* run their own fleet and benefit from live
+cross-repman status, so the default is **auto-promoted to `smart`** for them (an
+explicit non-default mode is always respected):
+
+- at config load — `server/server.go` `InitConfig`, before `NewPeerManager`;
+- at registration — `server/api_register.go` `persistInstanceSubscriptionPlan`,
+  when the plan is (re)confirmed as `partner`, also flipping the live
+  `PeerManager.HealthMode`.
+
+The point of the default: **the more repman clients register and receive the
+for-sale catalog, the more of them would otherwise start polling every seller.**
+Defaulting to `pulling` and promoting only partners bounds live polling to *within
+a partner fleet* instead of across the whole registered population.
+
+---
+
+## 5. Entering a delegated cluster (request forwarding)
+
+Live visibility is only half of delegation; the partner also needs to *act* on the
+cluster. `server_peer.go` forwards an authenticated request to the hosting repman:
+
+- `PeerLogin` — authenticates to the peer with the shared user's credentials
+  (`PeerUser`/`PeerPassword`) and caches the token per peer.
+- `PeerRequestForwarder` — proxies the API call to `ApiPublicUrl` and streams the
+  response back, so the partner drives the remote cluster from their own GUI.
+
+Both set `req.Close = true` and close response bodies — they are request-scoped and
+do **not** hold persistent connections (contrast §6).
+
+> Design note (Stephane): forwarding the hosting repman's URL to the client is
+> acceptable, but it should happen **at cluster-entry time**, not eagerly for every
+> advertised cluster. Live wiring belongs to *entering* a delegated cluster, not to
+> *listing* the marketplace.
+
+---
+
+## 6. The invariant, and the health-check leak that breaks it
+
+### The invariant
+
+The rule is **not** "never ping a for-sale cluster." It is:
+
+**A for-sale cluster is live-checked only by a repman whose connected user has a
+relationship to it — never by one merely browsing the catalog.**
+
+The subtlety is the **sale workflow**. A pure catalog listing must never be pinged.
+But the moment a user *enters the sale workflow* for a cluster — requests it (gains
+a `pending` role) or is granted it (`sponsor`) — that user needs to watch it live
+as it becomes theirs, so it *must* be pinged for them. That is not an exception to
+the scope; it is the scope working.
+
+The scope is the **union of `PeerUserClusters[u]` over the connected users** — the
+registering user (`Cloud18GitUser`) plus every user with an active dashboard
+session (`getActiveSessionUsers()`, i.e. a live `GitToken`). Poll what someone
+actually logged in has a relationship to; nothing else. This encodes the rule
+exactly, because `ReloadUsers` (`peer.go:304-315`) makes `pending`/`sponsor` flip
+`forSale = false` — **removing** the cluster from `PeerForSale` **and** keeping it
+in that user's `PeerUserClusters`:
+
+- **Catalog for-sale** (no connected user has pending/sponsor) → in `PeerForSale`,
+  in *no* connected user's set → **pinged by no one**.
+- **In sale workflow** (a connected user is `pending`/`sponsor`) → *out* of
+  `PeerForSale`, *in* that user's `PeerUserClusters` → **pinged live for them**.
+
+**Precisely, for a fresh instance:** zero seller connections while browsing. The
+moment a user here instantiates a sale workflow, it connects to **exactly that one
+seller** (the cluster in the workflow) — never the rest of the catalog. And *who*
+instantiated it decides whether it keeps polling while nobody is connected:
+
+- **the registering/SSO user** (`Cloud18GitUser`) → the cluster is in the
+  **always-on** set (`GetHealthStatusForActiveUsers` includes `registeredUser`
+  unconditionally, `peer.go:391`), so it's polled every cycle even with no dashboard
+  session — this is what lets you be **alerted on a master failure** of a cluster
+  you own or manage without being logged in;
+- **a session sub-user** → polled only while that user is connected.
+
+So the always-on scope is *own registering identity + everything delegated to it*
+(fleet + managed clusters), and active-session users' clusters are additive on top.
+No `PeerForSale` blocklist is needed — scoping to this set is both the exclusion
+(catalog) and the inclusion (sale workflow / delegation). `GetHealthStatusForActiveUsers`
+(`peer.go:385`) already builds exactly this set (`relevantURLs`); the bug was that
+it was the **only** poller that did.
+
+### Where the scope was (and wasn't) applied — before the fix
+
+Polling was kicked off from **two triggers**, each choosing a poller by mode. Only
+one cell of the matrix was correctly scoped:
+
+| Trigger | `pulling` | `smart` | `peering` |
+|---|---|---|---|
+| **Timer** — `dispatchPeerHealthPoll` (has session users) | `GetHealthStatusForUnknownVersions` — flat `PeerClusters` | `GetHealthStatusForActiveUsers` ✅ **scoped** | `GetAllHealthStatus` — flat `PeerURL` |
+| **Reload** — `BatchUpdateClusters` (on `peer.json` change) | `GetHealthStatusForUnknownVersions` — flat | `GetAllHealthStatus` — flat | `GetAllHealthStatus` — flat |
+
+Every other cell walked the flat `PeerURL`/`PeerClusters` maps — for-sale included.
+The default (`pulling`) reload path polled **every** unknown-version cluster, so a
+brand-new browsing repman broke the invariant the moment any for-sale cluster ran
+an older repman.
+
+### Symptom
+
+Observed in production: one repman went unresponsive with ~14,000 goroutines and
+~6,900 TCP connections wedged against a single peer's API (port 10001 behind
+HAProxy) — `net/http` `readLoop`/`writeLoop` pairs that never returned. Two
+independent defects combined: an **unscoped fan-out** (polling clusters nobody here
+owned) and a **poller that could not shed a dark peer** (re-hitting it every cycle
+with no connection ceiling).
+
+### Fix 1 — scope: never add traffic to peers you have no relationship to
+
+Route **all** live polling through the connected-users scope, from one server-driven
+entry point:
+
+1. **Deleted the internal poll from `BatchUpdateClusters`** — it now only updates
+   peer data, never polls (it had no session-user context, so it could only poll the
+   flat list).
+2. **The reload path calls `dispatchPeerHealthPoll()`** after `BatchUpdateClusters`
+   (`server_git.go`), mirroring the two "unchanged" branches. Instant-on-pull refresh
+   is preserved *and* scoped, because `dispatchPeerHealthPoll` runs server-side with
+   the session-user list.
+3. **`pulling` and `smart` both route to `GetHealthStatusForActiveUsers`**
+   (`relevantURLs`). `GetHealthStatusForUnknownVersions` — the unscoped version
+   back-fill — was **removed**. `peering` remains the one deliberate unscoped
+   full-mesh (opt-in, never default).
+
+Result: a fresh/browsing repman opens **zero** seller connections; polling arises
+only for your fleet + delegated + sale-workflow peers.
+
+### Fix 2 — leak: legitimate fleet polling must not strand connections
+
+Fleet polling *should* generate traffic (your own repmans + any repman sharing a
+cluster with you or a connected SSO user). So the leak had to be fixed for exactly
+that traffic — a single dark peer in your own fleet must not accumulate connections:
+
+1. **Bounded transport** (`client.go`) — `MaxConnsPerHost: 2` is the hard ceiling
+   that makes ~6900 connections to one peer impossible regardless of poll volume;
+   plus `DialContext` (5s), `TLSHandshakeTimeout` (5s) and `ResponseHeaderTimeout`
+   deadlines so a peer that accepts TCP but never answers is bounded. (`req.Close =
+   true` and the 10s client `Timeout` were already present.)
+2. **Rate-limit + advance `LastUpdate` on failure** (`peer.go`, both pollers) — each
+   peer's whole attempt (login *and* health) is gated to once per `Interval`, and
+   `LastUpdate` is advanced **up-front** so a failed attempt is rate-limited the same
+   as a success. Previously a failure left `LastUpdate` untouched and login wasn't
+   even gated, so a dark peer was re-hit every dispatch.
+3. **Effective single-flight** (`server_peer.go`) — `dispatchPeerHealthPoll` now
+   self-guards on `peerHealthBusy` and holds it across the whole poll goroutine, so
+   the timer and the reload path can never run overlapping polls that race the shared
+   per-node `LastUpdate`.
+
+**Timing (why Fix 1 costs no delay):** periodic backstop dispatch every ~2 min
+(`counter%60` × `monitoring-ticker` 2s); per-node staleness gate
+`cloud18-health-refresh-interval` = 30s. The reload path dispatches immediately on
+pull, so the 2-min timer is only a backstop.
+
+**Identity dependency (see §2.1):** the ownership scope is only fully correct once
+local `admin` resolves to the instance's registering `Cloud18GitUser`. Until then,
+own clusters keyed under the literal `admin` may not appear under
+`PeerUserClusters[Cloud18GitUser]`, so own-fleet 24/7 polling (the master-failed
+alerting case) is not guaranteed for clusters that carry only the local `admin` ACL
+entry. This is a BO/peer.json change, tracked separately.
+
+The default flip in §4 (`pulling`, partner-only promotion) further reduces the blast
+radius; Fix 1 removes the fan-out and Fix 2 removes the leak.
+
+---
+
+## 7. Configuration reference
+
+| Flag | Default | Effect |
+|------|---------|--------|
+| `cloud18-shared` | false | offer this cluster on the marketplace (`Cloud18Shared`) |
+| `cloud18-subscription-plan` | `free` | `free`/`support`/`support-services`/`partner`/`developer`; `partner` auto-promotes health mode to `smart` |
+| `cloud18-peer-health-mode` | `pulling` | `pulling` (async, BO `peer.json` only) / `smart` (delegated + own fleet, live) / `peering` (full mesh) |
+| `cloud18-health-refresh-interval` | `30` (s) | per-node staleness gate: a peer isn't re-polled within a dispatch unless its last check is older than this |
+| `monitoring-ticker` | `2` (s) | main loop period; peer-health dispatch is gated `counter%60`, so the periodic backstop fires every ~2 min |
+| `cloud18-disable-peers` | false | disables the peer-health dispatch entirely (`server.go:3006`) |
+| `api-credentials-acl-allow-external` | — | **share a user email onto a cluster** = delegate it; the email lands in that user's `PeerUserClusters` |
+
+---
+
+*Related: registration & subscription plans (`server/api_register.go`);
+config git channel that ships `peer.json` (`server/server_git.go`); arbitration &
+cross-DC authority (`doc/implementation/cluster/HEARTBEAT_AND_ARBITRATION.md`).*

--- a/peer/client.go
+++ b/peer/client.go
@@ -140,7 +140,7 @@ func (pc *PeerClient) PeerLogin(username, password string) error {
 	}
 
 	if status != http.StatusOK {
-		return err
+		return fmt.Errorf("peer login failed with status %d: %s", status, string(body))
 	}
 
 	var AuthToken struct {

--- a/peer/client.go
+++ b/peer/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -31,6 +32,27 @@ func NewPeerClient(baseURL string, timeout time.Duration) *PeerClient {
 	return &PeerClient{
 		client: &http.Client{
 			Timeout: timeout,
+			// Bounded transport so a single unresponsive peer can never
+			// accumulate connections. The marketplace fan-out once stranded
+			// ~6900 sockets against one dark peer; MaxConnsPerHost is the hard
+			// ceiling that makes that impossible regardless of how many polls
+			// fire. DialContext/handshake/response deadlines bound a peer that
+			// accepts TCP (e.g. behind HAProxy) but never answers.
+			// See doc/implementation/peer/MARKETPLACE.md §6.
+			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				DialContext: (&net.Dialer{
+					Timeout:   5 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).DialContext,
+				MaxConnsPerHost:       2,
+				MaxIdleConns:          10,
+				MaxIdleConnsPerHost:   1,
+				IdleConnTimeout:       30 * time.Second,
+				TLSHandshakeTimeout:   5 * time.Second,
+				ResponseHeaderTimeout: timeout,
+				ExpectContinueTimeout: 1 * time.Second,
+			},
 		},
 		baseURL: urlparse.String(),
 		headers: make(map[string]string),

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -346,6 +346,10 @@ func (pm *PeerManager) GetHealthStatus(pclient *PeerClient) error {
 			return fmt.Errorf("failed to parse health status: %s", err)
 		}
 
+		// Lock the map mutation: this runs off-lock (called from pollPeerHealth
+		// after the network I/O) and BatchUpdateClusters writes PeerClusters under
+		// the same lock.
+		pm.mu.Lock()
 		for clustername, status := range healths {
 			hashID := GetHashID(pclient.baseURL, clustername)
 			if pc, exists := pm.PeerClusters[hashID]; exists {
@@ -356,6 +360,7 @@ func (pm *PeerManager) GetHealthStatus(pclient *PeerClient) error {
 				pc.LastUpdate = update
 			}
 		}
+		pm.mu.Unlock()
 	}
 
 	return nil
@@ -418,87 +423,70 @@ func (pm *PeerManager) GetHealthStatusForActiveUsers(registeredUser string, acti
 	}
 
 	for url := range relevantURLs {
-		nodestat, ok := pm.PeerURL[url]
-		if !ok {
-			continue
-		}
-
-		// Rate-limit ALL work for this peer (login + health) to once per Interval,
-		// and advance LastUpdate up-front — success OR failure. Previously a failed
-		// login/health left LastUpdate untouched, so the gate stayed open and a
-		// dark peer was re-hit on every dispatch, stranding connections. Advancing
-		// here bounds a dead peer to one attempt per Interval.
-		// See doc/implementation/peer/MARKETPLACE.md §6.
-		if time.Since(nodestat.LastUpdate) <= time.Duration(pm.Interval)*time.Second {
-			continue
-		}
-		nodestat.LastUpdate = time.Now()
-
-		if !misc.IsValidPublicURL(url) {
-			nodestat.Error = "not a valid public URL"
-			continue
-		}
-
-		pclient, ok := pm.Clients[url]
-		if !ok {
-			pclient = pm.NewClient(url)
-			pm.Clients[url] = pclient
-		}
-
-		if token, ok := pclient.headers["Authorization"]; !ok || token == "" {
-			if err := pclient.PeerLogin(pm.PeerUser, pm.PeerPassword); err != nil {
-				nodestat.Error = fmt.Sprintf("failed to login: %s", err)
-				continue
-			}
-		}
-
-		if err := pm.GetHealthStatus(pclient); err != nil {
-			nodestat.Error = fmt.Sprintf("failed to get health status: %s", err)
-			continue
-		}
-		nodestat.Error = ""
+		pm.pollPeerHealth(url)
 	}
 }
 
+// pollPeerHealth checks one peer's /api/health, but only if it has not been polled
+// within Interval. It "claims" the peer atomically under the lock — FIRST IN WINS:
+// the first dispatch to reach a peer advances LastUpdate and does the call, while
+// any overlapping dispatch sees a fresh timestamp and skips it. So each peer is
+// called at most once per Interval regardless of how many dispatches overlap, and a
+// failed attempt is rate-limited exactly like a success (LastUpdate is advanced
+// up-front, before the call). All shared-map access (PeerURL / Clients) happens
+// under the lock; the network I/O runs AFTER the lock is released, so a slow peer
+// never blocks other peers or the BatchUpdateClusters mutator, and there is no
+// concurrent-map race. This makes whole-poll serialization (single-flight)
+// unnecessary: different peers can still be polled in parallel — only the SAME peer
+// is deduplicated. See doc/implementation/peer/MARKETPLACE.md §6.
+func (pm *PeerManager) pollPeerHealth(url string) {
+	pm.mu.Lock()
+	nodestat, ok := pm.PeerURL[url]
+	if !ok || url == pm.ApiURL || time.Since(nodestat.LastUpdate) <= time.Duration(pm.Interval)*time.Second {
+		pm.mu.Unlock()
+		return
+	}
+	if !misc.IsValidPublicURL(url) {
+		nodestat.Error = "not a valid public URL"
+		pm.mu.Unlock()
+		return
+	}
+	nodestat.LastUpdate = time.Now() // claim: no other dispatch polls this peer this Interval
+	pclient, ok := pm.Clients[url]
+	if !ok {
+		pclient = pm.NewClient(url)
+	}
+	pm.mu.Unlock()
+
+	// Network I/O outside the lock. Only this goroutine owns nodestat this Interval.
+	if token, ok := pclient.headers["Authorization"]; !ok || token == "" {
+		if err := pclient.PeerLogin(pm.PeerUser, pm.PeerPassword); err != nil {
+			nodestat.Error = fmt.Sprintf("failed to login: %s", err)
+			return
+		}
+	}
+	if err := pm.GetHealthStatus(pclient); err != nil {
+		nodestat.Error = fmt.Sprintf("failed to get health status: %s", err)
+		return
+	}
+	nodestat.Error = ""
+}
+
 func (pm *PeerManager) GetAllHealthStatus() {
-	for url, nodestat := range pm.PeerURL {
-		if url == pm.ApiURL {
-			continue
+	// Snapshot the URL set under the lock, then poll each through the atomic-claim
+	// helper (network I/O off-lock). Never iterate pm.PeerURL directly during the
+	// calls — BatchUpdateClusters mutates it under the same lock.
+	pm.mu.RLock()
+	urls := make([]string, 0, len(pm.PeerURL))
+	for url := range pm.PeerURL {
+		if url != pm.ApiURL {
+			urls = append(urls, url)
 		}
+	}
+	pm.mu.RUnlock()
 
-		// Rate-limit to once per Interval and advance LastUpdate up-front (success
-		// OR failure) so a dark peer cannot be re-hit every dispatch. See the
-		// matching note in GetHealthStatusForActiveUsers and MARKETPLACE.md §6.
-		if time.Since(nodestat.LastUpdate) <= time.Duration(pm.Interval)*time.Second {
-			continue
-		}
-		nodestat.LastUpdate = time.Now()
-
-		// Skip if the URL is not valid.
-		if !misc.IsValidPublicURL(url) {
-			nodestat.Error = fmt.Sprintf("not a valid public URL")
-			continue
-		}
-
-		pclient, ok := pm.Clients[url]
-		if !ok {
-			pclient = pm.NewClient(url)
-			pm.Clients[url] = pclient
-		}
-
-		// Login if no token is set in the client.
-		if token, ok := pclient.headers["Authorization"]; !ok || token == "" {
-			if err := pclient.PeerLogin(pm.PeerUser, pm.PeerPassword); err != nil {
-				nodestat.Error = fmt.Sprintf("failed to login: %s", err)
-				continue
-			}
-		}
-
-		if err := pm.GetHealthStatus(pclient); err != nil {
-			nodestat.Error = fmt.Sprintf("failed to get health status: %s", err)
-			continue
-		}
-		nodestat.Error = ""
+	for _, url := range urls {
+		pm.pollPeerHealth(url)
 	}
 }
 

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -119,6 +119,15 @@ func (pm *PeerManager) SetApiPublicURL(apiURL string) {
 	pm.ApiURL = apiURL
 }
 
+// SetHealthMode safely updates HealthMode. It can be changed at runtime from HTTP
+// handlers (registration, global settings) while BatchUpdateClusters reads it under
+// pm.mu, so the write must take the same lock to avoid a data race.
+func (pm *PeerManager) SetHealthMode(mode string) {
+	pm.mu.Lock()
+	pm.HealthMode = mode
+	pm.mu.Unlock()
+}
+
 func (pm *PeerManager) NewClient(baseURL string) *PeerClient {
 	pclient := NewPeerClient(baseURL, 10*time.Second)
 	pm.Clients[baseURL] = pclient
@@ -383,46 +392,47 @@ func (pm *PeerManager) UpdateHealthStatus(healths map[string]PeerHealth) {
 	}
 }
 
+// relevantPeerURLs returns the set of peer API URLs this instance may live-poll:
+// the registering user's peers (own fleet — always) plus each active-session user's
+// peers. These come only from PeerUserClusters (own fleet + delegated + sale
+// workflows via ReloadUsers' pending/sponsor demotion), so a for-sale catalog
+// cluster nobody here is related to — keyed under the seller's user, in PeerForSale —
+// never appears. A fresh/browsing instance returns an empty set. Own ApiURL is
+// excluded. See doc/implementation/peer/MARKETPLACE.md §6.
+func (pm *PeerManager) relevantPeerURLs(registeredUser string, activeUsers []string) map[string]bool {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	urls := make(map[string]bool)
+	addUserPeers := func(user string) {
+		clusters, ok := pm.PeerUserClusters[user]
+		if !ok {
+			return
+		}
+		for _, pc := range clusters {
+			if pc.ApiPublicUrl != "" && pc.ApiPublicUrl != pm.ApiURL {
+				urls[pc.ApiPublicUrl] = true
+			}
+		}
+	}
+
+	if registeredUser != "" {
+		addUserPeers(registeredUser)
+	}
+	for _, user := range activeUsers {
+		if user != registeredUser {
+			addUserPeers(user)
+		}
+	}
+	return urls
+}
+
 // GetHealthStatusForActiveUsers polls only the peer URLs that the registered
 // user or active session users can access. The registeredUser (cloud18-gitlab-user)
 // is always included — own fleet peers are always polled. Other users' peers
 // are only polled when they have an active session (non-empty GitToken).
 func (pm *PeerManager) GetHealthStatusForActiveUsers(registeredUser string, activeUsers []string) {
-	// Collect unique peer URLs: registered user always + active session users.
-	pm.mu.RLock()
-	relevantURLs := make(map[string]bool)
-
-	// Always include registered user's peers (own fleet)
-	if registeredUser != "" {
-		if clusters, ok := pm.PeerUserClusters[registeredUser]; ok {
-			for _, pc := range clusters {
-				if pc.ApiPublicUrl != "" && pc.ApiPublicUrl != pm.ApiURL {
-					relevantURLs[pc.ApiPublicUrl] = true
-				}
-			}
-		}
-	}
-
-	// Add active session users' peers
-	for _, user := range activeUsers {
-		if user == registeredUser {
-			continue
-		}
-		if clusters, ok := pm.PeerUserClusters[user]; ok {
-			for _, pc := range clusters {
-				if pc.ApiPublicUrl != "" && pc.ApiPublicUrl != pm.ApiURL {
-					relevantURLs[pc.ApiPublicUrl] = true
-				}
-			}
-		}
-	}
-	pm.mu.RUnlock()
-
-	if len(relevantURLs) == 0 {
-		return
-	}
-
-	for url := range relevantURLs {
+	for url := range pm.relevantPeerURLs(registeredUser, activeUsers) {
 		pm.pollPeerHealth(url)
 	}
 }

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -180,14 +180,14 @@ func (pm *PeerManager) BatchUpdateClusters(clusterUpdates []*PeerCluster, remove
 		}
 	}
 
-	// Update health status based on configured mode.
-	if len(pm.PeerURL) > 0 {
-		if pm.HealthMode == "pulling" {
-			go pm.GetHealthStatusForUnknownVersions()
-		} else {
-			go pm.GetAllHealthStatus()
-		}
-	}
+	// NOTE: health polling is intentionally NOT started here. This runs inside
+	// the peer package with no session-user context, so it can only poll the
+	// flat, unscoped PeerURL list — which includes for-sale clusters this
+	// instance has no relationship to (O(N^2) fan-out, dark-peer connection
+	// leak). The caller (server_git.go, after this returns) invokes the
+	// server-driven, session-scoped dispatchPeerHealthPoll instead, so live
+	// polling is always restricted to PeerUserClusters for connected users.
+	// See doc/implementation/peer/MARKETPLACE.md §6.
 }
 
 // removeCluster (internal function, assumes lock is held).
@@ -423,6 +423,17 @@ func (pm *PeerManager) GetHealthStatusForActiveUsers(registeredUser string, acti
 			continue
 		}
 
+		// Rate-limit ALL work for this peer (login + health) to once per Interval,
+		// and advance LastUpdate up-front — success OR failure. Previously a failed
+		// login/health left LastUpdate untouched, so the gate stayed open and a
+		// dark peer was re-hit on every dispatch, stranding connections. Advancing
+		// here bounds a dead peer to one attempt per Interval.
+		// See doc/implementation/peer/MARKETPLACE.md §6.
+		if time.Since(nodestat.LastUpdate) <= time.Duration(pm.Interval)*time.Second {
+			continue
+		}
+		nodestat.LastUpdate = time.Now()
+
 		if !misc.IsValidPublicURL(url) {
 			nodestat.Error = "not a valid public URL"
 			continue
@@ -441,14 +452,11 @@ func (pm *PeerManager) GetHealthStatusForActiveUsers(registeredUser string, acti
 			}
 		}
 
-		if time.Since(nodestat.LastUpdate) > time.Duration(pm.Interval)*time.Second {
-			if err := pm.GetHealthStatus(pclient); err != nil {
-				nodestat.Error = fmt.Sprintf("failed to get health status: %s", err)
-				continue
-			}
-			nodestat.Error = ""
-			nodestat.LastUpdate = time.Now()
+		if err := pm.GetHealthStatus(pclient); err != nil {
+			nodestat.Error = fmt.Sprintf("failed to get health status: %s", err)
+			continue
 		}
+		nodestat.Error = ""
 	}
 }
 
@@ -457,6 +465,14 @@ func (pm *PeerManager) GetAllHealthStatus() {
 		if url == pm.ApiURL {
 			continue
 		}
+
+		// Rate-limit to once per Interval and advance LastUpdate up-front (success
+		// OR failure) so a dark peer cannot be re-hit every dispatch. See the
+		// matching note in GetHealthStatusForActiveUsers and MARKETPLACE.md §6.
+		if time.Since(nodestat.LastUpdate) <= time.Duration(pm.Interval)*time.Second {
+			continue
+		}
+		nodestat.LastUpdate = time.Now()
 
 		// Skip if the URL is not valid.
 		if !misc.IsValidPublicURL(url) {
@@ -478,78 +494,22 @@ func (pm *PeerManager) GetAllHealthStatus() {
 			}
 		}
 
-		if time.Since(nodestat.LastUpdate) > time.Duration(pm.Interval)*time.Second {
-			if err := pm.GetHealthStatus(pclient); err != nil {
-				nodestat.Error = fmt.Sprintf("failed to get health status: %s", err)
-				continue
-			}
-			nodestat.Error = ""
-			nodestat.LastUpdate = time.Now()
+		if err := pm.GetHealthStatus(pclient); err != nil {
+			nodestat.Error = fmt.Sprintf("failed to get health status: %s", err)
+			continue
 		}
+		nodestat.Error = ""
 	}
 }
 
-// GetHealthStatusForUnknownVersions polls only peers whose RepmgrVersion is
-// empty — meaning they are running an old repman that doesn't push health
-// fields to clusterstate.json. Peers with a known version get their health
-// from peer.json (populated by the BO from clusters_state) and don't need
-// direct HTTP polling.
-func (pm *PeerManager) GetHealthStatusForUnknownVersions() {
-	pm.mu.RLock()
-	// Collect URLs of peers with unknown version
-	var unknownURLs []string
-	for _, pc := range pm.PeerClusters {
-		if pc.RepmgrVersion == "" && pc.ApiPublicUrl != "" && pc.ApiPublicUrl != pm.ApiURL {
-			unknownURLs = append(unknownURLs, pc.ApiPublicUrl)
-		}
-	}
-	pm.mu.RUnlock()
-
-	if len(unknownURLs) == 0 {
-		return
-	}
-
-	// Deduplicate URLs (multiple clusters on same instance)
-	seen := make(map[string]bool)
-	for _, url := range unknownURLs {
-		if seen[url] {
-			continue
-		}
-		seen[url] = true
-
-		nodestat, ok := pm.PeerURL[url]
-		if !ok {
-			continue
-		}
-
-		if !misc.IsValidPublicURL(url) {
-			nodestat.Error = "not a valid public URL"
-			continue
-		}
-
-		pclient, ok := pm.Clients[url]
-		if !ok {
-			pclient = pm.NewClient(url)
-			pm.Clients[url] = pclient
-		}
-
-		if token, ok := pclient.headers["Authorization"]; !ok || token == "" {
-			if err := pclient.PeerLogin(pm.PeerUser, pm.PeerPassword); err != nil {
-				nodestat.Error = fmt.Sprintf("failed to login: %s", err)
-				continue
-			}
-		}
-
-		if time.Since(nodestat.LastUpdate) > time.Duration(pm.Interval)*time.Second {
-			if err := pm.GetHealthStatus(pclient); err != nil {
-				nodestat.Error = fmt.Sprintf("failed to get health status: %s", err)
-				continue
-			}
-			nodestat.Error = ""
-			nodestat.LastUpdate = time.Now()
-		}
-	}
-}
+// GetHealthStatusForUnknownVersions was removed: it polled every peer with an
+// empty RepmgrVersion across the whole catalog (for-sale clusters included),
+// with no ownership/relationship scope — an unscoped fan-out that broke the
+// marketplace invariant. All live polling now goes through
+// GetHealthStatusForActiveUsers (scoped to PeerUserClusters for connected
+// users). Version back-fill for peers you have a relationship to happens there;
+// for-sale catalog versions come from peer.json (BO), not direct polling.
+// See doc/implementation/peer/MARKETPLACE.md §6.
 
 func GetPeerHashID(pc *PeerCluster) string {
 	md5Hash := md5.New()

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -481,10 +481,12 @@ func (pm *PeerManager) pollPeerHealth(url string) {
 	// also read by GetPeerNodesJSON (status API), so its fields are written under the
 	// lock via setNodeError, not raw.
 	if token, ok := pclient.headers["Authorization"]; !ok || token == "" {
-		if err := pclient.PeerLogin(pm.PeerUser, pm.PeerPassword); err != nil {
-			pm.setNodeError(nodestat, fmt.Sprintf("failed to login: %s", err))
-			return
-		}
+		// Best-effort login: /api/health is PUBLIC (curl of any dbaas-*.signal18.io
+		// /api/health returns 200 with no auth). A login failure — the SSO user not
+		// being provisioned on the peer, a wrong password, etc. — must NOT block the
+		// health/connectivity check, which needs no token. Login only matters for
+		// richer authenticated calls (e.g. /api/clusters).
+		_ = pclient.PeerLogin(pm.PeerUser, pm.PeerPassword)
 	}
 	if err := pm.GetHealthStatus(pclient); err != nil {
 		pm.setNodeError(nodestat, fmt.Sprintf("failed to get health status: %s", err))

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -238,34 +238,27 @@ func (pm *PeerManager) GetCluster(hashID string) (*PeerCluster, bool) {
 	return cluster, exists
 }
 
-// normPublicURL normalizes an api-public-url for identity comparison: lowercased,
-// scheme-stripped, no trailing slash. So "https://Host/" and "host" compare equal.
-func normPublicURL(u string) string {
-	u = strings.TrimSpace(strings.ToLower(u))
-	u = strings.TrimPrefix(u, "https://")
-	u = strings.TrimPrefix(u, "http://")
-	return strings.TrimRight(u, "/")
-}
-
-// isOwnCluster reports whether a peer cluster is hosted by THIS repman instance
-// (its api-public-url matches ours). Own clusters already appear in the LOCAL
-// cluster list, so they must be excluded from the peer / for-sale views — otherwise
-// they show up twice. Assumes the caller holds pm.mu (read or write); pm.ApiURL is
-// set once at startup and never mutated afterwards.
-func (pm *PeerManager) isOwnCluster(pc *PeerCluster) bool {
-	return pc != nil && pm.ApiURL != "" && normPublicURL(pc.ApiPublicUrl) == normPublicURL(pm.ApiURL)
+// isOwnCluster reports whether a peer cluster is one THIS instance manages locally —
+// its name is in localNames, the live local cluster list. Such clusters already appear
+// in the LOCAL cluster view, so they are excluded from the peer / for-sale views to
+// avoid showing them twice. Keying on the local cluster NAME (not api-public-url) is
+// deliberate: a DR standby shares its primary's api-public-url but runs a different
+// (often empty) local cluster set, so a url match would wrongly hide the primary's
+// clusters from the DR. An empty/nil localNames set excludes nothing.
+func isOwnCluster(pc *PeerCluster, localNames map[string]bool) bool {
+	return pc != nil && localNames[pc.ClusterName]
 }
 
 // GetUserClusters retrieves all clusters a user has access to, excluding clusters
-// this instance hosts itself (they are already in the local cluster list).
-func (pm *PeerManager) GetUserClusters(username string) []*PeerCluster {
+// this instance manages locally (localNames) — they are already in the local list.
+func (pm *PeerManager) GetUserClusters(username string, localNames map[string]bool) []*PeerCluster {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
 
 	clusters := []*PeerCluster{}
 	if pcs, ok := pm.PeerUserClusters[username]; ok {
 		for _, pc := range pcs {
-			if pm.isOwnCluster(pc) {
+			if isOwnCluster(pc, localNames) {
 				continue
 			}
 			clusters = append(clusters, pc)
@@ -297,22 +290,22 @@ func (pm *PeerManager) GetPeerNodesJSON() ([]byte, error) {
 	return json.MarshalIndent(snapshot, "", "\t")
 }
 
-// GetUserClustersJSON returns a JSON string of all clusters assigned to a user.
-func (pm *PeerManager) GetUserClustersJSON(username string) ([]byte, error) {
-	clusters := pm.GetUserClusters(username)
+// GetUserClustersJSON returns a JSON string of all clusters assigned to a user,
+// excluding this instance's own local clusters (localNames).
+func (pm *PeerManager) GetUserClustersJSON(username string, localNames map[string]bool) ([]byte, error) {
+	clusters := pm.GetUserClusters(username, localNames)
 	return json.MarshalIndent(clusters, "", "\t")
 }
 
-// GetSaleClustersJSON returns a JSON string of all clusters available for sale.
+// GetSaleClustersJSON returns a JSON string of all clusters available for sale. Unlike
+// the peer view, the for-sale marketplace is NOT filtered by local ownership — a seller
+// browses the full catalog, including any of their own offers.
 func (pm *PeerManager) GetSaleClustersJSON() ([]byte, error) {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
 
 	clusters := make([]*PeerCluster, 0, len(pm.PeerForSale))
 	for _, pc := range pm.PeerForSale {
-		if pm.isOwnCluster(pc) {
-			continue
-		}
 		clusters = append(clusters, pc)
 	}
 

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -238,7 +238,26 @@ func (pm *PeerManager) GetCluster(hashID string) (*PeerCluster, bool) {
 	return cluster, exists
 }
 
-// GetUserClusters retrieves all clusters a user has access to.
+// normPublicURL normalizes an api-public-url for identity comparison: lowercased,
+// scheme-stripped, no trailing slash. So "https://Host/" and "host" compare equal.
+func normPublicURL(u string) string {
+	u = strings.TrimSpace(strings.ToLower(u))
+	u = strings.TrimPrefix(u, "https://")
+	u = strings.TrimPrefix(u, "http://")
+	return strings.TrimRight(u, "/")
+}
+
+// isOwnCluster reports whether a peer cluster is hosted by THIS repman instance
+// (its api-public-url matches ours). Own clusters already appear in the LOCAL
+// cluster list, so they must be excluded from the peer / for-sale views — otherwise
+// they show up twice. Assumes the caller holds pm.mu (read or write); pm.ApiURL is
+// set once at startup and never mutated afterwards.
+func (pm *PeerManager) isOwnCluster(pc *PeerCluster) bool {
+	return pc != nil && pm.ApiURL != "" && normPublicURL(pc.ApiPublicUrl) == normPublicURL(pm.ApiURL)
+}
+
+// GetUserClusters retrieves all clusters a user has access to, excluding clusters
+// this instance hosts itself (they are already in the local cluster list).
 func (pm *PeerManager) GetUserClusters(username string) []*PeerCluster {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
@@ -246,6 +265,9 @@ func (pm *PeerManager) GetUserClusters(username string) []*PeerCluster {
 	clusters := []*PeerCluster{}
 	if pcs, ok := pm.PeerUserClusters[username]; ok {
 		for _, pc := range pcs {
+			if pm.isOwnCluster(pc) {
+				continue
+			}
 			clusters = append(clusters, pc)
 		}
 	}
@@ -288,6 +310,9 @@ func (pm *PeerManager) GetSaleClustersJSON() ([]byte, error) {
 
 	clusters := make([]*PeerCluster, 0, len(pm.PeerForSale))
 	for _, pc := range pm.PeerForSale {
+		if pm.isOwnCluster(pc) {
+			continue
+		}
 		clusters = append(clusters, pc)
 	}
 

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -260,10 +260,19 @@ func (pm *PeerManager) GetPeerNodeStatus() map[string]*PeerNodeStatus {
 	return pm.PeerURL
 }
 
-// GetUserClustersJSON returns a JSON string of all clusters assigned to a user.
+// GetPeerNodesJSON returns the peer node statuses as JSON. It marshals a value-copy
+// snapshot taken under the lock — never the live *PeerNodeStatus pointers — because
+// pollPeerHealth mutates Error/LastUpdate concurrently off the status-API path.
 func (pm *PeerManager) GetPeerNodesJSON() ([]byte, error) {
-	nodes := pm.GetPeerNodeStatus()
-	return json.MarshalIndent(nodes, "", "\t")
+	pm.mu.RLock()
+	snapshot := make(map[string]PeerNodeStatus, len(pm.PeerURL))
+	for url, ns := range pm.PeerURL {
+		if ns != nil {
+			snapshot[url] = *ns
+		}
+	}
+	pm.mu.RUnlock()
+	return json.MarshalIndent(snapshot, "", "\t")
 }
 
 // GetUserClustersJSON returns a JSON string of all clusters assigned to a user.
@@ -468,18 +477,28 @@ func (pm *PeerManager) pollPeerHealth(url string) {
 	}
 	pm.mu.Unlock()
 
-	// Network I/O outside the lock. Only this goroutine owns nodestat this Interval.
+	// Network I/O outside the lock. This goroutine owns the claim, but nodestat is
+	// also read by GetPeerNodesJSON (status API), so its fields are written under the
+	// lock via setNodeError, not raw.
 	if token, ok := pclient.headers["Authorization"]; !ok || token == "" {
 		if err := pclient.PeerLogin(pm.PeerUser, pm.PeerPassword); err != nil {
-			nodestat.Error = fmt.Sprintf("failed to login: %s", err)
+			pm.setNodeError(nodestat, fmt.Sprintf("failed to login: %s", err))
 			return
 		}
 	}
 	if err := pm.GetHealthStatus(pclient); err != nil {
-		nodestat.Error = fmt.Sprintf("failed to get health status: %s", err)
+		pm.setNodeError(nodestat, fmt.Sprintf("failed to get health status: %s", err))
 		return
 	}
-	nodestat.Error = ""
+	pm.setNodeError(nodestat, "")
+}
+
+// setNodeError writes ns.Error under the lock. PeerNodeStatus pointers are read by
+// the status API (GetPeerNodesJSON), so field writes must be synchronized.
+func (pm *PeerManager) setNodeError(ns *PeerNodeStatus, errMsg string) {
+	pm.mu.Lock()
+	ns.Error = errMsg
+	pm.mu.Unlock()
 }
 
 func (pm *PeerManager) GetAllHealthStatus() {

--- a/peer/peer_scope_test.go
+++ b/peer/peer_scope_test.go
@@ -1,6 +1,9 @@
 package peer
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // The marketplace invariant (MARKETPLACE.md §6): live polling is scoped to
 // PeerUserClusters for the registering user + active-session users. A for-sale
@@ -131,5 +134,39 @@ func TestReloadUsersPendingSaleWorkflowBecomesPollable(t *testing.T) {
 	// ...and into my pollable set (I'm watching it become mine).
 	if urls := pm.relevantPeerURLs("me@sig", nil); !urls["https://seller.example.com"] {
 		t.Fatalf("a cluster I have a pending role on must be pollable, got %v", urls)
+	}
+}
+
+// Own/local clusters (hosted by THIS instance: api-public-url == ours) already
+// appear in the LOCAL cluster list, so they must be filtered out of BOTH the peer
+// (GetUserClusters) and the for-sale (GetSaleClustersJSON) views to avoid duplicates.
+// URL comparison is normalized (scheme/case/trailing-slash insensitive).
+func TestPeerViewsExcludeOwnClusters(t *testing.T) {
+	pm := NewPeerManager(30)
+	pm.SetApiPublicURL("https://me.example.com")
+
+	// Mine: same public URL as this instance (note trailing slash + scheme differ).
+	mine := &PeerCluster{ApiPublicUrl: "http://ME.example.com/", ClusterName: "cl-local"}
+	// A partner's cluster delegated to me.
+	partner := &PeerCluster{ApiPublicUrl: "https://partner.example.com", ClusterName: "cl-deleg"}
+	pm.PeerUserClusters["me@sig"] = map[string]*PeerCluster{
+		"h-mine":    mine,
+		"h-partner": partner,
+	}
+
+	got := pm.GetUserClusters("me@sig")
+	if len(got) != 1 || got[0].ClusterName != "cl-deleg" {
+		t.Fatalf("peer view must exclude own cluster, keep partner's; got %+v", got)
+	}
+
+	// For-sale: my own shared cluster must not be listed to myself.
+	pm.PeerForSale["h-mine"] = mine
+	pm.PeerForSale["h-sale"] = &PeerCluster{ApiPublicUrl: "https://seller.example.com", ClusterName: "cl-sale"}
+	saleJSON, err := pm.GetSaleClustersJSON()
+	if err != nil {
+		t.Fatalf("GetSaleClustersJSON: %v", err)
+	}
+	if s := string(saleJSON); strings.Contains(s, "cl-local") || !strings.Contains(s, "cl-sale") {
+		t.Fatalf("for-sale view must exclude own cluster, keep seller's; got %s", s)
 	}
 }

--- a/peer/peer_scope_test.go
+++ b/peer/peer_scope_test.go
@@ -137,36 +137,61 @@ func TestReloadUsersPendingSaleWorkflowBecomesPollable(t *testing.T) {
 	}
 }
 
-// Own/local clusters (hosted by THIS instance: api-public-url == ours) already
-// appear in the LOCAL cluster list, so they must be filtered out of BOTH the peer
-// (GetUserClusters) and the for-sale (GetSaleClustersJSON) views to avoid duplicates.
-// URL comparison is normalized (scheme/case/trailing-slash insensitive).
-func TestPeerViewsExcludeOwnClusters(t *testing.T) {
+// Local clusters — those THIS instance manages locally (name in localNames) — are
+// excluded from the PEER view for the admin, who already sees them in the local
+// dashboard. Exclusion keys on the local cluster NAME, not api-public-url. The
+// for-sale view is NEVER filtered this way. A nil/empty localNames excludes nothing.
+func TestPeerViewExcludesLocalForAdmin(t *testing.T) {
 	pm := NewPeerManager(30)
 	pm.SetApiPublicURL("https://me.example.com")
 
-	// Mine: same public URL as this instance (note trailing slash + scheme differ).
-	mine := &PeerCluster{ApiPublicUrl: "http://ME.example.com/", ClusterName: "cl-local"}
-	// A partner's cluster delegated to me.
+	// cl-local is one I run locally; cl-deleg is a partner's cluster delegated to me.
+	mine := &PeerCluster{ApiPublicUrl: "https://me.example.com", ClusterName: "cl-local"}
 	partner := &PeerCluster{ApiPublicUrl: "https://partner.example.com", ClusterName: "cl-deleg"}
 	pm.PeerUserClusters["me@sig"] = map[string]*PeerCluster{
 		"h-mine":    mine,
 		"h-partner": partner,
 	}
+	local := map[string]bool{"cl-local": true}
 
-	got := pm.GetUserClusters("me@sig")
+	// Admin: local clusters are excluded (localNames set).
+	got := pm.GetUserClusters("me@sig", local)
 	if len(got) != 1 || got[0].ClusterName != "cl-deleg" {
-		t.Fatalf("peer view must exclude own cluster, keep partner's; got %+v", got)
+		t.Fatalf("admin peer view must exclude own local cluster, keep partner's; got %+v", got)
 	}
 
-	// For-sale: my own shared cluster must not be listed to myself.
+	// Non-admin SSO user: no exclusion (nil set) — a shared local cluster stays visible.
+	got = pm.GetUserClusters("me@sig", nil)
+	if len(got) != 2 {
+		t.Fatalf("non-admin peer view must exclude nothing; got %+v", got)
+	}
+
+	// For-sale is never ownership-filtered — every offer is listed.
 	pm.PeerForSale["h-mine"] = mine
 	pm.PeerForSale["h-sale"] = &PeerCluster{ApiPublicUrl: "https://seller.example.com", ClusterName: "cl-sale"}
 	saleJSON, err := pm.GetSaleClustersJSON()
 	if err != nil {
 		t.Fatalf("GetSaleClustersJSON: %v", err)
 	}
-	if s := string(saleJSON); strings.Contains(s, "cl-local") || !strings.Contains(s, "cl-sale") {
-		t.Fatalf("for-sale view must exclude own cluster, keep seller's; got %s", s)
+	if s := string(saleJSON); !strings.Contains(s, "cl-local") || !strings.Contains(s, "cl-sale") {
+		t.Fatalf("for-sale view must list ALL offers incl. own; got %s", s)
+	}
+}
+
+// A DR standby shares its primary's api-public-url but runs a different (often empty)
+// local cluster set. Exclusion keys on the local NAME set — with no local clusters,
+// a cluster carrying our api-public-url must STILL be visible in the admin peer view
+// (regression: the down clusters vanished on the DR because they shared its api-url).
+func TestDRSharedApiUrlDoesNotHideClusters(t *testing.T) {
+	pm := NewPeerManager(30)
+	pm.SetApiPublicURL("https://dbaas-fr-2.signal18.io") // DR configured with primary's url
+
+	// Published by the primary, same api-public-url as the DR, but NOT run locally here.
+	down := &PeerCluster{ApiPublicUrl: "https://dbaas-fr-2.signal18.io", ClusterName: "goodlands", IsDown: true}
+	pm.PeerUserClusters["me@sig"] = map[string]*PeerCluster{"h1": down}
+
+	got := pm.GetUserClusters("me@sig", map[string]bool{}) // DR has no live local clusters
+	if len(got) != 1 || got[0].ClusterName != "goodlands" {
+		t.Fatalf("a cluster sharing the DR api-url but not run locally must stay visible; got %+v", got)
 	}
 }

--- a/peer/peer_scope_test.go
+++ b/peer/peer_scope_test.go
@@ -1,0 +1,135 @@
+package peer
+
+import "testing"
+
+// The marketplace invariant (MARKETPLACE.md §6): live polling is scoped to
+// PeerUserClusters for the registering user + active-session users. A for-sale
+// catalog cluster nobody here is related to must never be in the pollable set;
+// a fresh/browsing instance must poll zero sellers; a cluster enters the set only
+// via a real relationship (delegation, or a pending/sponsor sale workflow).
+
+func TestRelevantPeerURLsExcludesForSaleIncludesDelegated(t *testing.T) {
+	pm := NewPeerManager(30)
+	pm.SetApiPublicURL("https://me.example.com")
+
+	// Delegated to me → in my user set → pollable.
+	delegated := &PeerCluster{ApiPublicUrl: "https://partner.example.com", ClusterName: "cl-deleg"}
+	pm.PeerUserClusters["me@sig"] = map[string]*PeerCluster{"h1": delegated}
+
+	// For-sale catalog cluster: present in the catalog (PeerForSale/PeerClusters)
+	// but keyed under the seller, NOT in my user set.
+	forsale := &PeerCluster{ApiPublicUrl: "https://seller.example.com", ClusterName: "cl-sale"}
+	pm.PeerForSale["h2"] = forsale
+	pm.PeerClusters["h2"] = forsale
+
+	urls := pm.relevantPeerURLs("me@sig", nil)
+
+	if !urls["https://partner.example.com"] {
+		t.Fatalf("delegated peer should be pollable, got %v", urls)
+	}
+	if urls["https://seller.example.com"] {
+		t.Fatalf("for-sale catalog peer must NOT be pollable, got %v", urls)
+	}
+	if len(urls) != 1 {
+		t.Fatalf("expected exactly 1 relevant url, got %d: %v", len(urls), urls)
+	}
+}
+
+func TestRelevantPeerURLsFreshBrowserPollsNothing(t *testing.T) {
+	pm := NewPeerManager(30)
+	pm.SetApiPublicURL("https://fresh.example.com")
+
+	// A catalog full of for-sale clusters, none related to me.
+	for i, u := range []string{"https://s1.example.com", "https://s2.example.com"} {
+		pc := &PeerCluster{ApiPublicUrl: u}
+		key := string(rune('a' + i))
+		pm.PeerForSale[key] = pc
+		pm.PeerClusters[key] = pc
+	}
+
+	if urls := pm.relevantPeerURLs("me@sig", nil); len(urls) != 0 {
+		t.Fatalf("fresh browser must poll zero sellers, got %v", urls)
+	}
+}
+
+func TestRelevantPeerURLsIncludesActiveSessionUsers(t *testing.T) {
+	pm := NewPeerManager(30)
+	pm.SetApiPublicURL("https://me.example.com")
+
+	// Delegated to a sub-user who is in an active session; registering user owns nothing.
+	sub := &PeerCluster{ApiPublicUrl: "https://subdeleg.example.com"}
+	pm.PeerUserClusters["sub@sig"] = map[string]*PeerCluster{"h3": sub}
+
+	urls := pm.relevantPeerURLs("me@sig", []string{"sub@sig"})
+	if !urls["https://subdeleg.example.com"] {
+		t.Fatalf("active-session user's delegated peer should be pollable, got %v", urls)
+	}
+}
+
+func TestRelevantPeerURLsExcludesOwnApiURL(t *testing.T) {
+	pm := NewPeerManager(30)
+	pm.SetApiPublicURL("https://me.example.com")
+
+	// My own instance appears in my user set — must not poll myself.
+	own := &PeerCluster{ApiPublicUrl: "https://me.example.com"}
+	remote := &PeerCluster{ApiPublicUrl: "https://other.example.com"}
+	pm.PeerUserClusters["me@sig"] = map[string]*PeerCluster{"h4": own, "h5": remote}
+
+	urls := pm.relevantPeerURLs("me@sig", nil)
+	if urls["https://me.example.com"] {
+		t.Fatalf("own ApiURL must be excluded, got %v", urls)
+	}
+	if !urls["https://other.example.com"] {
+		t.Fatalf("remote peer should be pollable, got %v", urls)
+	}
+}
+
+// ReloadUsers is what wires a cluster into the pollable set. A pure catalog for-sale
+// cluster (only the seller's local admin in its ACL) lands in PeerForSale and is not
+// pollable by me; a cluster where I hold a pending/sponsor role is demoted OUT of
+// PeerForSale and INTO my pollable set — the sale workflow.
+
+func TestReloadUsersCatalogForSaleNotPollableByBrowser(t *testing.T) {
+	pm := NewPeerManager(30)
+	pm.SetApiPublicURL("https://me.example.com")
+
+	pc := &PeerCluster{
+		ApiPublicUrl:                   "https://seller.example.com",
+		ClusterName:                    "cl-sale",
+		Cloud18Shared:                  true,
+		ApiCredentialsAclAllowExternal: "admin:x:cl-sale", // only the seller's local admin
+	}
+	pm.PeerClusters[GetPeerHashID(pc)] = pc
+	pm.ReloadUsers(pc)
+
+	if _, ok := pm.PeerForSale[GetPeerHashID(pc)]; !ok {
+		t.Fatalf("catalog for-sale cluster should be in PeerForSale")
+	}
+	if urls := pm.relevantPeerURLs("me@sig", nil); len(urls) != 0 {
+		t.Fatalf("a browser (me@sig) must not be able to poll a catalog for-sale cluster, got %v", urls)
+	}
+}
+
+func TestReloadUsersPendingSaleWorkflowBecomesPollable(t *testing.T) {
+	pm := NewPeerManager(30)
+	pm.SetApiPublicURL("https://me.example.com")
+
+	// I (me@sig) requested this for-sale cluster → I hold a pending role on it.
+	pc := &PeerCluster{
+		ApiPublicUrl:                   "https://seller.example.com",
+		ClusterName:                    "cl-sale",
+		Cloud18Shared:                  true,
+		ApiCredentialsAclAllowExternal: "me@sig:x:cl-sale:pending",
+	}
+	pm.PeerClusters[GetPeerHashID(pc)] = pc
+	pm.ReloadUsers(pc)
+
+	// pending demotes it out of the for-sale catalog...
+	if _, ok := pm.PeerForSale[GetPeerHashID(pc)]; ok {
+		t.Fatalf("a cluster with a pending user must be demoted OUT of PeerForSale")
+	}
+	// ...and into my pollable set (I'm watching it become mine).
+	if urls := pm.relevantPeerURLs("me@sig", nil); !urls["https://seller.example.com"] {
+		t.Fatalf("a cluster I have a pending role on must be pollable, got %v", urls)
+	}
+}

--- a/server/api.go
+++ b/server/api.go
@@ -807,8 +807,13 @@ func (repman *ReplicationManager) loginHandler(w http.ResponseWriter, r *http.Re
 
 	// ── Cloud18 ───────────────────────────────────────────────────────────────
 
-	// Admin users always authenticate via local credentials only; no SSO.
-	if repman.isAdminUser(user.Username) {
+	// Admin users always authenticate via local credentials only; no SSO. EXCEPTION:
+	// the registering SSO user (Cloud18GitUser) is granted global-admin-show (it's the
+	// owner), but its credential is a GitLab/SSO password, NOT a local one — so forcing
+	// it down the local-only path makes it fail local auth and 401, breaking SSO login
+	// for the registering user (and every peer connection that uses it). Let it fall
+	// through to the SSO path below.
+	if repman.isAdminUser(user.Username) && user.Username != repman.Conf.Cloud18GitUser {
 		userInfo, ok := tryLocalAuth()
 		if !ok {
 			authFail()

--- a/server/api.go
+++ b/server/api.go
@@ -1555,6 +1555,22 @@ func (repman *ReplicationManager) handlerMuxPeerNodes(w http.ResponseWriter, r *
 	w.Write(cl)
 }
 
+// localClusterNames returns the set of cluster names this instance manages locally
+// (its live ClusterList). Used to exclude own clusters from the peer / for-sale views
+// so they are not listed twice (they already appear in the local cluster list). On a
+// DR standby with no active local clusters this is empty, so nothing is excluded —
+// which is correct: a DR shares its primary's api-public-url but does not run its
+// clusters, so those must still be visible as peers.
+func (repman *ReplicationManager) localClusterNames() map[string]bool {
+	names := make(map[string]bool, len(repman.ClusterList))
+	for _, n := range repman.ClusterList {
+		if n != "" {
+			names[n] = true
+		}
+	}
+	return names
+}
+
 // handlerMuxPeerClusters handles the request to retrieve peer clusters for a user.
 // @Summary Retrieve peer clusters for a user
 // @Description This endpoint retrieves the peer clusters that a user has access to.
@@ -1584,12 +1600,22 @@ func (repman *ReplicationManager) handlerMuxPeerClusters(w http.ResponseWriter, 
 		return
 	}
 
-	peerUser := uinfo["User"]
+	requester := uinfo["User"]
+	peerUser := requester
 	if peerUser == "admin" {
 		peerUser = repman.Conf.Cloud18GitUser
 	}
 
-	cl, err := repman.PeerManager.GetUserClustersJSON(peerUser)
+	// Exclude this instance's own local clusters ONLY for the admin / registering user,
+	// who already sees them in the local cluster dashboard (so they'd be duplicated).
+	// Any other SSO user has no local dashboard, so a local cluster the admin shared
+	// with them must stay visible here — pass a nil set (excludes nothing).
+	var localNames map[string]bool
+	if requester == "admin" || requester == repman.Conf.Cloud18GitUser {
+		localNames = repman.localClusterNames()
+	}
+
+	cl, err := repman.PeerManager.GetUserClustersJSON(peerUser, localNames)
 	if err != nil {
 		http.Error(w, "Error Marshal", http.StatusInternalServerError)
 		return

--- a/server/api_global_settings.go
+++ b/server/api_global_settings.go
@@ -487,7 +487,9 @@ func (repman *ReplicationManager) setRepmanSetting(name string, value string) er
 	case "cloud18-peer-health-mode":
 		if value == "peering" || value == "smart" || value == "pulling" {
 			repman.Conf.Cloud18PeerHealthMode = value
-			repman.PeerManager.HealthMode = value
+			if repman.PeerManager != nil {
+				repman.PeerManager.SetHealthMode(value)
+			}
 		}
 	case "mail-max-pool":
 		v, _ = strconv.Atoi(value)

--- a/server/api_register.go
+++ b/server/api_register.go
@@ -949,7 +949,7 @@ func (repman *ReplicationManager) persistInstanceSubscriptionPlan(plan, uri stri
 	if plan == "partner" && repman.Conf.Cloud18PeerHealthMode == "pulling" {
 		repman.Conf.Cloud18PeerHealthMode = "smart"
 		if repman.PeerManager != nil {
-			repman.PeerManager.HealthMode = "smart"
+			repman.PeerManager.SetHealthMode("smart")
 		}
 	}
 	if repman.ConfigManager != nil {

--- a/server/api_register.go
+++ b/server/api_register.go
@@ -943,6 +943,15 @@ func isAllowedOfflineInstancePlan(plan string) bool {
 
 func (repman *ReplicationManager) persistInstanceSubscriptionPlan(plan, uri string) {
 	repman.Conf.Cloud18SubscriptionPlan = plan
+	// Keep peer-health mode aligned with the plan when the CRM validates it at
+	// runtime: partner fleets poll (smart), everyone else pulls the BO aggregate.
+	// Only the "pulling" default is promoted, so an explicit operator choice stays.
+	if plan == "partner" && repman.Conf.Cloud18PeerHealthMode == "pulling" {
+		repman.Conf.Cloud18PeerHealthMode = "smart"
+		if repman.PeerManager != nil {
+			repman.PeerManager.HealthMode = "smart"
+		}
+	}
 	if repman.ConfigManager != nil {
 		repman.ConfigManager.SaveConfig(repman, true)
 	} else {

--- a/server/server.go
+++ b/server/server.go
@@ -3004,13 +3004,11 @@ func (repman *ReplicationManager) Run() error {
 			}
 
 			if repman.Conf.Cloud18 && !repman.Conf.Cloud18DisablePeers {
-				if repman.peerHealthBusy.CompareAndSwap(false, true) {
-					go func() {
-						defer repman.peerHealthBusy.Store(false)
-						repman.dispatchPeerHealthPoll()
-						repman.UpdateLocalPeer()
-					}()
-				} else {
+				// dispatchPeerHealthPoll self-guards on peerHealthBusy and runs the
+				// poll + UpdateLocalPeer in its own goroutine, holding the flag for the
+				// whole poll. A false return means a prior poll is still running (didn't
+				// finish within this cycle) — surface the slow/stuck-poll warning.
+				if !repman.dispatchPeerHealthPoll() {
 					repman.SetState("GWARN013@peerhealth", state.State{ErrType: "WARNING", ErrKey: "GWARN013", ErrDesc: fmt.Sprintf(config.GlobalError["GWARN013"], "peer health poll"), ErrFrom: "REPMAN"})
 				}
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -1159,7 +1159,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.Cloud18AlertSlackURL, "cloud18-alert-slack-url", "https://meet.signal18.io/hooks/1wuk8e5sttd89epqoaff3y9t6y", "Slack webhook URL for cloud18")
 	flags.StringVar(&conf.Cloud18AlertSlackUser, "cloud18-alert-slack-user", "repman", "Slack user for cloud18")
 	flags.IntVar(&conf.Cloud18HealthRefreshInterval, "cloud18-health-refresh-interval", 30, "Health refresh interval in seconds")
-	flags.StringVar(&conf.Cloud18PeerHealthMode, "cloud18-peer-health-mode", "pulling", "Peer health source. DEFAULT pulling: read shared-cluster health from the BO-aggregated peer.json (git-pull cadence) — no per-peer HTTP polling; correct for regular/client instances. The direct-polling modes fan out to every shared cluster on each peer.json reload (O(N^2), and a dark peer strands connections) — reserve them for partner fleets: smart (own fleet + active-session users), peering (poll all).")
+	flags.StringVar(&conf.Cloud18PeerHealthMode, "cloud18-peer-health-mode", "pulling", "Peer health polling scope. pulling (DEFAULT) and smart both serve the for-sale catalog from the BO-aggregated peer.json and live-poll ONLY clusters this instance has a relationship to — own fleet (registering user) + delegated + active-session users' clusters + sale workflows. An instance with no such relationship (a fresh/browsing client) opens no peer connections. peering is a legacy full-mesh that live-polls EVERY peer incl. the for-sale catalog (O(N^2); opt-in only, never for clients). partner plan auto-promotes pulling->smart.")
 	flags.BoolVar(&conf.Cloud18DisablePeers, "cloud18-disable-peers", false, "Hide peer clusters from dashboard")
 	flags.BoolVar(&conf.Cloud18DisableForSale, "cloud18-disable-for-sale", false, "Hide clusters for sale from marketplace (paid plans only)")
 	flags.StringVar(&conf.Cloud18GatewayDomainName, "cloud18-gateway-domain-name", "", "Cloud18 janitor gateway DNS ")
@@ -1568,7 +1568,7 @@ func (repman *ReplicationManager) InitConfig(conf config.Config, init_git bool) 
 		repman.Conf.Cloud18PeerHealthMode = "smart"
 	}
 	repman.PeerManager = peer.NewPeerManager(repman.Conf.Cloud18HealthRefreshInterval)
-	repman.PeerManager.HealthMode = repman.Conf.Cloud18PeerHealthMode
+	repman.PeerManager.SetHealthMode(repman.Conf.Cloud18PeerHealthMode)
 	conf.ParseJobsExecOverrides()
 	repman.ModTimes = make(map[string]time.Time)
 	repman.ServerScopeList = make(map[string]bool)

--- a/server/server.go
+++ b/server/server.go
@@ -3004,10 +3004,13 @@ func (repman *ReplicationManager) Run() error {
 			}
 
 			if repman.Conf.Cloud18 && !repman.Conf.Cloud18DisablePeers {
-				// dispatchPeerHealthPoll self-guards (single-flight) and runs the
-				// poll + UpdateLocalPeer in its own goroutine; it returns false if a
-				// poll was already in flight.
-				if !repman.dispatchPeerHealthPoll() {
+				if repman.peerHealthBusy.CompareAndSwap(false, true) {
+					go func() {
+						defer repman.peerHealthBusy.Store(false)
+						repman.dispatchPeerHealthPoll()
+						repman.UpdateLocalPeer()
+					}()
+				} else {
 					repman.SetState("GWARN013@peerhealth", state.State{ErrType: "WARNING", ErrKey: "GWARN013", ErrDesc: fmt.Sprintf(config.GlobalError["GWARN013"], "peer health poll"), ErrFrom: "REPMAN"})
 				}
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -1159,7 +1159,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.Cloud18AlertSlackURL, "cloud18-alert-slack-url", "https://meet.signal18.io/hooks/1wuk8e5sttd89epqoaff3y9t6y", "Slack webhook URL for cloud18")
 	flags.StringVar(&conf.Cloud18AlertSlackUser, "cloud18-alert-slack-user", "repman", "Slack user for cloud18")
 	flags.IntVar(&conf.Cloud18HealthRefreshInterval, "cloud18-health-refresh-interval", 30, "Health refresh interval in seconds")
-	flags.StringVar(&conf.Cloud18PeerHealthMode, "cloud18-peer-health-mode", "smart", "Peer health mode: peering (poll all), smart (own fleet + active users), pulling (BO via peer.json)")
+	flags.StringVar(&conf.Cloud18PeerHealthMode, "cloud18-peer-health-mode", "pulling", "Peer health source. DEFAULT pulling: read shared-cluster health from the BO-aggregated peer.json (git-pull cadence) — no per-peer HTTP polling; correct for regular/client instances. The direct-polling modes fan out to every shared cluster on each peer.json reload (O(N^2), and a dark peer strands connections) — reserve them for partner fleets: smart (own fleet + active-session users), peering (poll all).")
 	flags.BoolVar(&conf.Cloud18DisablePeers, "cloud18-disable-peers", false, "Hide peer clusters from dashboard")
 	flags.BoolVar(&conf.Cloud18DisableForSale, "cloud18-disable-for-sale", false, "Hide clusters for sale from marketplace (paid plans only)")
 	flags.StringVar(&conf.Cloud18GatewayDomainName, "cloud18-gateway-domain-name", "", "Cloud18 janitor gateway DNS ")
@@ -1559,6 +1559,14 @@ func (repman *ReplicationManager) InitConfig(conf config.Config, init_git bool) 
 		repman.DeprecatedKeys = make(map[string]map[string]bool)
 	}
 
+	// Partner-plan instances run their own fleet and benefit from direct
+	// cross-repman polling, so promote the "pulling" default to "smart" for them.
+	// Every other plan stays on the BO-aggregated "pulling" default so hundreds of
+	// registered clients never fan out (O(N^2) polling of shared clusters). An
+	// explicit non-default mode is always respected.
+	if repman.Conf.Cloud18PeerHealthMode == "pulling" && repman.Conf.Cloud18SubscriptionPlan == "partner" {
+		repman.Conf.Cloud18PeerHealthMode = "smart"
+	}
 	repman.PeerManager = peer.NewPeerManager(repman.Conf.Cloud18HealthRefreshInterval)
 	repman.PeerManager.HealthMode = repman.Conf.Cloud18PeerHealthMode
 	conf.ParseJobsExecOverrides()

--- a/server/server.go
+++ b/server/server.go
@@ -3004,13 +3004,10 @@ func (repman *ReplicationManager) Run() error {
 			}
 
 			if repman.Conf.Cloud18 && !repman.Conf.Cloud18DisablePeers {
-				if repman.peerHealthBusy.CompareAndSwap(false, true) {
-					go func() {
-						defer repman.peerHealthBusy.Store(false)
-						repman.dispatchPeerHealthPoll()
-						repman.UpdateLocalPeer()
-					}()
-				} else {
+				// dispatchPeerHealthPoll self-guards (single-flight) and runs the
+				// poll + UpdateLocalPeer in its own goroutine; it returns false if a
+				// poll was already in flight.
+				if !repman.dispatchPeerHealthPoll() {
 					repman.SetState("GWARN013@peerhealth", state.State{ErrType: "WARNING", ErrKey: "GWARN013", ErrDesc: fmt.Sprintf(config.GlobalError["GWARN013"], "peer health poll"), ErrFrom: "REPMAN"})
 				}
 			}

--- a/server/server_git.go
+++ b/server/server_git.go
@@ -1127,6 +1127,13 @@ func (repman *ReplicationManager) LoadPeerJson() error {
 		repman.PeerManager.BatchUpdateClusters(PeerList, true)
 	}
 
+	// peer.json content changed: refresh health immediately, but through the
+	// server-driven, session-scoped dispatch (same call the two unchanged
+	// branches above make). This keeps instant-on-pull refresh while ensuring
+	// only PeerUserClusters for connected users are polled — never the for-sale
+	// catalog. See doc/implementation/peer/MARKETPLACE.md §6.
+	repman.dispatchPeerHealthPoll()
+
 	// Update state
 	repman.CheckSumConfig["peer"] = newHash
 

--- a/server/server_peer.go
+++ b/server/server_peer.go
@@ -130,39 +130,30 @@ func (repman *ReplicationManager) UpdateLocalPeer() {
 	repman.PeerManager.UpdateHealthStatus(repman.GetLocalHealth())
 }
 
-// dispatchPeerHealthPoll starts a single scoped health poll and returns false if it
-// skipped because one was already in flight (single-flight via peerHealthBusy). The
-// guard is held for the whole poll, so the timer and the peer.json reload path can
-// never run overlapping polls that race the shared per-node LastUpdate — a dark peer
-// is attempted at most once per Interval. The poll runs in a goroutine so callers
-// (reload path included) never block.
+// dispatchPeerHealthPoll starts a scoped health poll (in a goroutine, so callers —
+// the reload path included — never block). It needs no single-flight guard: the
+// pollers claim each peer atomically (first-in-wins on LastUpdate under the lock),
+// so overlapping timer + reload dispatches deduplicate per peer and never race the
+// shared maps. See PeerManager.pollPeerHealth and MARKETPLACE.md §6.
 //
 // pulling (default) and smart both scope live polling to the connected-users set
 // (own registering identity + active-session users) via GetHealthStatusForActiveUsers.
 // This is the invariant: a for-sale cluster is polled only once a user here has a
 // relationship to it (delegation, or a pending/sponsor sale workflow) — never while
 // merely browsing the catalog. A fresh instance with no such relationship polls zero
-// sellers. See doc/implementation/peer/MARKETPLACE.md §6.
+// sellers.
 //
 // peering is the only unscoped mode: a deliberate full-mesh that polls every peer
 // URL, for-sale included. It ignores the invariant on purpose and must stay opt-in
 // (never the default), reserved for legacy/debug full-mesh fleets.
-func (repman *ReplicationManager) dispatchPeerHealthPoll() bool {
-	if !repman.peerHealthBusy.CompareAndSwap(false, true) {
-		return false
+func (repman *ReplicationManager) dispatchPeerHealthPoll() {
+	switch repman.Conf.Cloud18PeerHealthMode {
+	case "peering":
+		go repman.PeerManager.GetAllHealthStatus()
+	case "smart", "pulling":
+		activeUsers := repman.getActiveSessionUsers()
+		go repman.PeerManager.GetHealthStatusForActiveUsers(repman.Conf.Cloud18GitUser, activeUsers)
 	}
-	go func() {
-		defer repman.peerHealthBusy.Store(false)
-		switch repman.Conf.Cloud18PeerHealthMode {
-		case "peering":
-			repman.PeerManager.GetAllHealthStatus()
-		case "smart", "pulling":
-			activeUsers := repman.getActiveSessionUsers()
-			repman.PeerManager.GetHealthStatusForActiveUsers(repman.Conf.Cloud18GitUser, activeUsers)
-		}
-		repman.UpdateLocalPeer()
-	}()
-	return true
 }
 
 // getActiveSessionUsers returns usernames of users with an active session

--- a/server/server_peer.go
+++ b/server/server_peer.go
@@ -130,11 +130,14 @@ func (repman *ReplicationManager) UpdateLocalPeer() {
 	repman.PeerManager.UpdateHealthStatus(repman.GetLocalHealth())
 }
 
-// dispatchPeerHealthPoll starts a scoped health poll (in a goroutine, so callers —
-// the reload path included — never block). It needs no single-flight guard: the
-// pollers claim each peer atomically (first-in-wins on LastUpdate under the lock),
-// so overlapping timer + reload dispatches deduplicate per peer and never race the
-// shared maps. See PeerManager.pollPeerHealth and MARKETPLACE.md §6.
+// dispatchPeerHealthPoll runs a scoped health poll in a goroutine (callers — the
+// reload path included — never block) and returns false if one was already in
+// flight. It holds peerHealthBusy for the WHOLE poll, so the flag genuinely reflects
+// "a poll is running": the timer raises GWARN013@peerhealth when it finds a poll
+// that hasn't finished within a cycle (a slow/stuck poll — the operator signal that
+// would have flagged the original incident). This coarse guard is complementary to
+// pollPeerHealth's per-peer first-in-wins claim, which handles fine-grained dedup and
+// map safety against BatchUpdateClusters. See MARKETPLACE.md §6.
 //
 // pulling (default) and smart both scope live polling to the connected-users set
 // (own registering identity + active-session users) via GetHealthStatusForActiveUsers.
@@ -146,14 +149,22 @@ func (repman *ReplicationManager) UpdateLocalPeer() {
 // peering is the only unscoped mode: a deliberate full-mesh that polls every peer
 // URL, for-sale included. It ignores the invariant on purpose and must stay opt-in
 // (never the default), reserved for legacy/debug full-mesh fleets.
-func (repman *ReplicationManager) dispatchPeerHealthPoll() {
-	switch repman.Conf.Cloud18PeerHealthMode {
-	case "peering":
-		go repman.PeerManager.GetAllHealthStatus()
-	case "smart", "pulling":
-		activeUsers := repman.getActiveSessionUsers()
-		go repman.PeerManager.GetHealthStatusForActiveUsers(repman.Conf.Cloud18GitUser, activeUsers)
+func (repman *ReplicationManager) dispatchPeerHealthPoll() bool {
+	if !repman.peerHealthBusy.CompareAndSwap(false, true) {
+		return false
 	}
+	go func() {
+		defer repman.peerHealthBusy.Store(false)
+		switch repman.Conf.Cloud18PeerHealthMode {
+		case "peering":
+			repman.PeerManager.GetAllHealthStatus()
+		case "smart", "pulling":
+			activeUsers := repman.getActiveSessionUsers()
+			repman.PeerManager.GetHealthStatusForActiveUsers(repman.Conf.Cloud18GitUser, activeUsers)
+		}
+		repman.UpdateLocalPeer()
+	}()
+	return true
 }
 
 // getActiveSessionUsers returns usernames of users with an active session

--- a/server/server_peer.go
+++ b/server/server_peer.go
@@ -130,17 +130,39 @@ func (repman *ReplicationManager) UpdateLocalPeer() {
 	repman.PeerManager.UpdateHealthStatus(repman.GetLocalHealth())
 }
 
-// dispatchPeerHealthPoll runs the appropriate health poll based on the configured mode.
-func (repman *ReplicationManager) dispatchPeerHealthPoll() {
-	switch repman.Conf.Cloud18PeerHealthMode {
-	case "peering":
-		go repman.PeerManager.GetAllHealthStatus()
-	case "smart":
-		activeUsers := repman.getActiveSessionUsers()
-		go repman.PeerManager.GetHealthStatusForActiveUsers(repman.Conf.Cloud18GitUser, activeUsers)
-	case "pulling":
-		go repman.PeerManager.GetHealthStatusForUnknownVersions()
+// dispatchPeerHealthPoll starts a single scoped health poll and returns false if it
+// skipped because one was already in flight (single-flight via peerHealthBusy). The
+// guard is held for the whole poll, so the timer and the peer.json reload path can
+// never run overlapping polls that race the shared per-node LastUpdate — a dark peer
+// is attempted at most once per Interval. The poll runs in a goroutine so callers
+// (reload path included) never block.
+//
+// pulling (default) and smart both scope live polling to the connected-users set
+// (own registering identity + active-session users) via GetHealthStatusForActiveUsers.
+// This is the invariant: a for-sale cluster is polled only once a user here has a
+// relationship to it (delegation, or a pending/sponsor sale workflow) — never while
+// merely browsing the catalog. A fresh instance with no such relationship polls zero
+// sellers. See doc/implementation/peer/MARKETPLACE.md §6.
+//
+// peering is the only unscoped mode: a deliberate full-mesh that polls every peer
+// URL, for-sale included. It ignores the invariant on purpose and must stay opt-in
+// (never the default), reserved for legacy/debug full-mesh fleets.
+func (repman *ReplicationManager) dispatchPeerHealthPoll() bool {
+	if !repman.peerHealthBusy.CompareAndSwap(false, true) {
+		return false
 	}
+	go func() {
+		defer repman.peerHealthBusy.Store(false)
+		switch repman.Conf.Cloud18PeerHealthMode {
+		case "peering":
+			repman.PeerManager.GetAllHealthStatus()
+		case "smart", "pulling":
+			activeUsers := repman.getActiveSessionUsers()
+			repman.PeerManager.GetHealthStatusForActiveUsers(repman.Conf.Cloud18GitUser, activeUsers)
+		}
+		repman.UpdateLocalPeer()
+	}()
+	return true
 }
 
 // getActiveSessionUsers returns usernames of users with an active session

--- a/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
@@ -463,11 +463,23 @@ function PeerClusterList({ onLogin, mode }) {
       return (<Tooltip label={uri} placement='top'><Text isTruncated maxW='300px' fontFamily='mono' fontSize='sm'>{uri}</Text></Tooltip>)
     }
   })
-  const activeCol = columnHelper.accessor((row) => row['api-public-url'], {
-    id: 'active', header: 'Active', enableSorting: false,
+  // The two data paths, side by side:
+  //  - peerJsonCol: health the BO catalog reports (peer.json, async / git-pull cadence)
+  //  - directCol:   what the local repman got by actually connecting to the peer
+  //                 (/api/peers PeerNodeStatus — connected + last-seen, or never/error)
+  const peerJsonCol = columnHelper.accessor((row) => row, {
+    id: 'peerjson', header: 'peer.json', enableSorting: false,
+    cell: (info) => (
+      <Tooltip label='Health as reported by the BO catalog (peer.json — async, git-pull cadence)' placement='top'>
+        <Box display='inline-block'>{healthCell(info.row.original)}</Box>
+      </Tooltip>
+    )
+  })
+  const directCol = columnHelper.accessor((row) => row['api-public-url'], {
+    id: 'direct', header: 'Direct', enableSorting: false,
     cell: (info) => {
       const cs = getConnState(info.getValue())
-      return (<Tooltip label={cs.tooltip} placement='top'><Badge colorScheme={cs.colorScheme}>{cs.label}</Badge></Tooltip>)
+      return (<Tooltip label={`Direct connection to the peer — ${cs.tooltip}`} placement='top'><Badge colorScheme={cs.colorScheme}>{cs.label}</Badge></Tooltip>)
     }
   })
   const actionCol = columnHelper.display({
@@ -482,9 +494,8 @@ function PeerClusterList({ onLogin, mode }) {
   // Operational view — mirrors the local cluster table (as far as catalog data
   // allows); everything degrades to "—" for an out-of-cloud18 shared cluster.
   const operationalColumns = useMemo(() => [
-    clusterCol, uriCol, activeCol,
+    clusterCol, uriCol, peerJsonCol, directCol,
     columnHelper.accessor((row) => row['prov-orchestrator'], { id: 'orchestrator', header: 'Orchestrator', cell: (info) => info.getValue() || '—' }),
-    columnHelper.accessor((row) => row, { id: 'healthy', header: 'Healthy', enableSorting: false, cell: (info) => healthCell(info.row.original) }),
     columnHelper.accessor((row) => row, { id: 'provisioned', header: 'Provisioned', enableSorting: false, cell: (info) => isUnknown(info.row.original) ? <Text>—</Text> : <CheckOrCrossIcon isValid={!!info.row.original.isProvisioned} /> }),
     actionCol,
   ], [peerNodes, mode])
@@ -516,7 +527,7 @@ function PeerClusterList({ onLogin, mode }) {
 
   // Offer view — infra + commercial together: what you get for the price.
   const offerColumns = useMemo(() => [
-    clusterCol, uriCol, activeCol,
+    clusterCol, uriCol, directCol,
     columnHelper.accessor((row) => row['prov-service-plan'], { id: 'plan', header: 'Plan', cell: (info) => info.getValue() || '—' }),
     columnHelper.accessor((row) => row, { id: 'price', header: 'Price', enableSorting: false, cell: (info) => priceCell(info.row.original) }),
     columnHelper.accessor((row) => infraSummary(row).join(' · '), {

--- a/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
@@ -621,8 +621,10 @@ function PeerClusterList({ onLogin, mode }) {
 
   // Offer view — a buyer's spec sheet: what you acquire and what it costs. Order:
   // Cluster · Plan · Price · Partner · Zone · Infra (multi-line) · Service (multi-line)
-  // · Healthy (de-emphasised — an unprovisioned offer is still buyable). No Peer/URL
-  // column: a sales listing shouldn't expose the peer instance's connectivity.
+  // · Pre Provision (is the offer already provisioned? — an unprovisioned one is still
+  // buyable, the buyer provisions it). No Peer/URL column: a sales listing shouldn't
+  // expose the peer instance's connectivity. Health is not shown here — a for-sale
+  // offer's health is irrelevant to the buyer; only its provisioning state matters.
   const offerColumns = useMemo(() => [
     clusterCol,
     columnHelper.accessor((row) => row['prov-service-plan'], { id: 'plan', header: 'Plan', cell: (info) => info.getValue() || '—' }),
@@ -631,7 +633,10 @@ function PeerClusterList({ onLogin, mode }) {
     columnHelper.accessor((row) => row['cloud18-infra-geo-localizations'], { id: 'zone', header: 'Zone', cell: (info) => info.getValue() || '—' }),
     columnHelper.accessor((row) => infraLines(row).join(' · '), { id: 'infra', header: 'Infra', enableSorting: false, cell: (info) => multiLineCell(infraLines(info.row.original)) }),
     columnHelper.accessor((row) => serviceLines(row).join(' · '), { id: 'service', header: 'Service', enableSorting: false, cell: (info) => multiLineCell(serviceLines(info.row.original)) }),
-    healthyCol,
+    columnHelper.accessor((row) => row.isProvisioned, {
+      id: 'preprovision', header: 'Pre Provision', enableSorting: false,
+      cell: (info) => isUnknown(info.row.original) ? <Text>—</Text> : <CheckOrCrossIcon isValid={!!info.row.original.isProvisioned} />
+    }),
   ], [peerNodes, mode])
 
   // Merge the direct /api/clusters data (peerDetails) over the peer.json catalog rows.

--- a/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useReducer, useState, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { getClusterPeers, getClusterForSale, getClusterPeerNodes, getTermsData } from '../../redux/globalClustersSlice'
-import { Badge, Box, Flex, HStack, Link, Text, Wrap, IconButton, useColorModeValue, Collapse, Divider, Tooltip, ButtonGroup, Button } from '@chakra-ui/react'
+import { Badge, Box, Flex, HStack, VStack, Link, Text, Wrap, IconButton, useColorModeValue, Collapse, Divider, Tooltip, ButtonGroup, Button } from '@chakra-ui/react'
 import { FaCloud } from 'react-icons/fa'
 import NotFound from '../../components/NotFound'
 import { AiOutlineCluster } from 'react-icons/ai'
@@ -139,7 +139,9 @@ function PeerClusterList({ onLogin, mode }) {
   // Two table views, one visible via toggle: 'operational' (local-like) and
   // 'offer' (infra + commercial — what you get for the price). URI + Active columns
   // appear in both as the transparency anchor.
-  const [contentType, setContentType] = useState('monitor') // 'monitor' (operational) | 'sale' (offer)
+  // Default to the Sale view: this page is primarily a marketplace — buyers come to
+  // see what hardware they can acquire, not to monitor. Monitor is one toggle away.
+  const [contentType, setContentType] = useState('sale') // 'sale' (offer) | 'monitor' (operational)
   const [displayMode, setDisplayMode] = useState('table')    // 'table' | 'grid' (cards)
   // Option (a): full cluster data pulled directly from each reachable peer's
   // /api/clusters (using the per-peer SSO token the login-upgrade stored), keyed
@@ -562,45 +564,62 @@ function PeerClusterList({ onLogin, mode }) {
     uriCol,
   ], [peerNodes, mode])
 
-  // Compact infra: a short inline summary, full spec sheet on hover — keeps the
-  // Offer table narrow instead of a dozen spec columns.
-  const infraSummary = (row) => {
-    const parts = []
-    if (row['prov-db-cpu-cores']) parts.push(`${row['prov-db-cpu-cores']} core${row['prov-db-cpu-cores'] * 1 === 1 ? '' : 's'}`)
-    if (row['prov-db-memory']) parts.push(`${row['prov-db-memory'] / 1024}GB`)
-    if (row['prov-db-disk-size']) parts.push(`${row['prov-db-disk-size']}GB disk`)
-    if (row['cloud18-infra-cpu-model']) parts.push(row['cloud18-infra-cpu-model'])
-    return parts
+  // has(): a peer.json numeric/string field is present and meaningful (not undefined,
+  // empty, or "0"). The BO encodes these as strings, so guard both.
+  const has = (v) => v !== undefined && v !== null && v !== '' && v * 1 !== 0
+  // Infra spec packed into ONE column, one spec per line, so a buyer reads exactly
+  // what the hardware is: "16 cores AMD EPYC 7702 3.4GHz / 128GB RAM / 600GB disk
+  // 330 iops / 10Gbps public / <data centers, geo>". Left-aligned (see cellValueAlign).
+  const infraLines = (row) => {
+    const lines = []
+    const cpu = [
+      has(row['prov-db-cpu-cores']) ? `${row['prov-db-cpu-cores']} core${row['prov-db-cpu-cores'] * 1 === 1 ? '' : 's'}` : '',
+      row['cloud18-infra-cpu-model'],
+      row['cloud18-infra-cpu-freq'],
+    ].filter(Boolean).join(' ')
+    if (cpu) lines.push(cpu)
+    if (has(row['prov-db-memory'])) lines.push(`${row['prov-db-memory'] / 1024}GB RAM`)
+    const disk = [
+      has(row['prov-db-disk-size']) ? `${row['prov-db-disk-size']}GB disk` : '',
+      has(row['prov-db-disk-iops']) ? `${row['prov-db-disk-iops']} iops` : '',
+    ].filter(Boolean).join(' ')
+    if (disk) lines.push(disk)
+    if (has(row['cloud18-infra-public-bandwidth'])) lines.push(`${row['cloud18-infra-public-bandwidth'] / 1024}Gbps public`)
+    const loc = [row['cloud18-infra-data-centers'], row['cloud18-infra-geo-localizations']].filter(Boolean).join(' · ')
+    if (loc) lines.push(loc)
+    return lines
   }
-  const infraDetail = (row) => (
-    [
-      ['CPU cores', row['prov-db-cpu-cores']],
-      ['Memory', row['prov-db-memory'] ? `${row['prov-db-memory'] / 1024}GB` : ''],
-      ['Disk', row['prov-db-disk-size'] ? `${row['prov-db-disk-size']}GB` : ''],
-      ['Disk IOPS', row['prov-db-disk-iops']],
-      ['CPU model', row['cloud18-infra-cpu-model']],
-      ['CPU freq', row['cloud18-infra-cpu-freq']],
-      ['Data centers', row['cloud18-infra-data-centers']],
-      ['Geo', row['cloud18-infra-geo-localizations']],
-      ['Bandwidth', row['cloud18-infra-public-bandwidth'] ? `${row['cloud18-infra-public-bandwidth'] / 1024}Gbps` : ''],
-      ['Certifications', row['cloud18-infra-certifications']],
-    ].filter(([, v]) => v !== undefined && v !== '' && v !== null).map(([k, v]) => `${k}: ${v}`).join('\n')
-  )
+  // Service-level commitments (hours), one per line.
+  const serviceLines = (row) => {
+    const lines = []
+    if (has(row['cloud18-sla-response-time'])) lines.push(`Response ${row['cloud18-sla-response-time']}h`)
+    if (has(row['cloud18-sla-repair-time'])) lines.push(`Repair ${row['cloud18-sla-repair-time']}h`)
+    if (has(row['cloud18-sla-provision-time'])) lines.push(`Provision ${row['cloud18-sla-provision-time']}h`)
+    return lines
+  }
+  const multiLineCell = (lines) => {
+    if (!lines || lines.length === 0) return <Text>—</Text>
+    return (
+      <VStack align='start' spacing='0.5'>
+        {lines.map((l, i) => <Text key={i} fontSize='sm'>{l}</Text>)}
+      </VStack>
+    )
+  }
+  // Partner = the selling org (cloud18 domain / sub-domain hierarchy).
+  const partnerOf = (row) => [row['cloud18-domain'], row['cloud18-sub-domain']].filter(Boolean).join(' / ')
 
-  // Offer view — infra + commercial together: what you get for the price.
+  // Offer view — a buyer's spec sheet: what you acquire and what it costs. Order:
+  // Cluster · Plan · Price · Partner · Zone · Infra (multi-line) · Service (multi-line)
+  // · Healthy (de-emphasised — an unprovisioned offer is still buyable) · Peer.
   const offerColumns = useMemo(() => [
-    clusterCol, healthyCol,
+    clusterCol,
     columnHelper.accessor((row) => row['prov-service-plan'], { id: 'plan', header: 'Plan', cell: (info) => info.getValue() || '—' }),
     columnHelper.accessor((row) => row, { id: 'price', header: 'Price', enableSorting: false, cell: (info) => priceCell(info.row.original) }),
-    columnHelper.accessor((row) => infraSummary(row).join(' · '), {
-      id: 'infra', header: 'Infra',
-      cell: (info) => {
-        const row = info.row.original
-        const parts = infraSummary(row)
-        if (parts.length === 0) return <Text>—</Text>
-        return (<Tooltip label={infraDetail(row)} placement='top' whiteSpace='pre-line'><Text fontSize='sm'>{parts.join(' · ')}</Text></Tooltip>)
-      }
-    }),
+    columnHelper.accessor((row) => partnerOf(row), { id: 'partner', header: 'Partner', cell: (info) => info.getValue() || '—' }),
+    columnHelper.accessor((row) => row['cloud18-sub-domain-zone'], { id: 'zone', header: 'Zone', cell: (info) => info.getValue() || '—' }),
+    columnHelper.accessor((row) => infraLines(row).join(' · '), { id: 'infra', header: 'Infra', enableSorting: false, cell: (info) => multiLineCell(infraLines(info.row.original)) }),
+    columnHelper.accessor((row) => serviceLines(row).join(' · '), { id: 'service', header: 'Service', enableSorting: false, cell: (info) => multiLineCell(serviceLines(info.row.original)) }),
+    healthyCol,
     uriCol,
   ], [peerNodes, mode])
 
@@ -913,7 +932,7 @@ function PeerClusterList({ onLogin, mode }) {
               })}
             </Flex>
             ) : (
-              <DataTable data={enrichedClusters} columns={contentType === 'sale' ? offerColumns : operationalColumns} />
+              <DataTable data={enrichedClusters} columns={contentType === 'sale' ? offerColumns : operationalColumns} cellValueAlign={contentType === 'sale' ? 'left' : 'center'} />
             )
             }
           />

--- a/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
@@ -476,10 +476,10 @@ function PeerClusterList({ onLogin, mode }) {
     const amount = promo > 0 ? (cost * (100 - promo)) / 100 : cost
     if (promo > 0) {
       return (
-        <HStack spacing='1'>
-          <Text as='span' textColor='red.500' textDecoration='line-through'>{cost.toFixed(2)}</Text>
+        <VStack align='start' spacing='0'>
+          <Text as='span' textColor='red.500' textDecoration='line-through' fontSize='sm'>{cost.toFixed(2)} {currency}/mo</Text>
           <Text as='span' fontWeight='bold'>{amount.toFixed(2)} {currency}/mo</Text>
-        </HStack>
+        </VStack>
       )
     }
     return <Text>{cost.toFixed(2)} {currency}/mo</Text>
@@ -585,9 +585,19 @@ function PeerClusterList({ onLogin, mode }) {
     ].filter(Boolean).join(' ')
     if (disk) lines.push(disk)
     if (has(row['cloud18-infra-public-bandwidth'])) lines.push(`${row['cloud18-infra-public-bandwidth'] / 1024}Gbps public`)
-    const loc = [row['cloud18-infra-data-centers'], row['cloud18-infra-geo-localizations']].filter(Boolean).join(' · ')
-    if (loc) lines.push(loc)
+    // Data center(s); geo-localization ("FR") lives in the Zone column, not here.
+    if (row['cloud18-infra-data-centers']) lines.push(row['cloud18-infra-data-centers'])
+    // Infrastructure: orchestrator + platform (e.g. "opensvc <platform>").
+    const infra = [row['prov-orchestrator'], row['cloud18-platform-description']].filter(Boolean).join(' ')
+    if (infra) lines.push(infra)
     return lines
+  }
+  // A for-sale offer is "qualified" when it carries what a buyer needs to decide: a
+  // price and the core hardware spec (cores + memory + disk). Offers missing those are
+  // still shown, but grouped into a separate "Unqualified" card below the catalog.
+  const isQualified = (row) => {
+    const cost = (row['cloud18-monthly-infra-cost'] * 1) + (row['cloud18-monthly-license-cost'] * 1) + (row['cloud18-monthly-sysops-cost'] * 1) + (row['cloud18-monthly-dbops-cost'] * 1)
+    return cost > 0 && has(row['prov-db-cpu-cores']) && has(row['prov-db-memory']) && has(row['prov-db-disk-size'])
   }
   // Service-level commitments (hours), one per line.
   const serviceLines = (row) => {
@@ -616,7 +626,7 @@ function PeerClusterList({ onLogin, mode }) {
     columnHelper.accessor((row) => row['prov-service-plan'], { id: 'plan', header: 'Plan', cell: (info) => info.getValue() || '—' }),
     columnHelper.accessor((row) => row, { id: 'price', header: 'Price', enableSorting: false, cell: (info) => priceCell(info.row.original) }),
     columnHelper.accessor((row) => partnerOf(row), { id: 'partner', header: 'Partner', cell: (info) => info.getValue() || '—' }),
-    columnHelper.accessor((row) => row['cloud18-sub-domain-zone'], { id: 'zone', header: 'Zone', cell: (info) => info.getValue() || '—' }),
+    columnHelper.accessor((row) => row['cloud18-infra-geo-localizations'], { id: 'zone', header: 'Zone', cell: (info) => info.getValue() || '—' }),
     columnHelper.accessor((row) => infraLines(row).join(' · '), { id: 'infra', header: 'Infra', enableSorting: false, cell: (info) => multiLineCell(infraLines(info.row.original)) }),
     columnHelper.accessor((row) => serviceLines(row).join(' · '), { id: 'service', header: 'Service', enableSorting: false, cell: (info) => multiLineCell(serviceLines(info.row.original)) }),
     healthyCol,
@@ -643,6 +653,19 @@ function PeerClusterList({ onLogin, mode }) {
       isProvisioned: fc.isProvision,
     }
   }), [clusters, peerDetails])
+
+  // In the Sale view, split the catalog into qualified offers (a buyer can act on)
+  // and unqualified ones (missing price or hardware spec) — the latter go on a
+  // separate card so they don't pollute the marketplace. Monitor view is not split.
+  const qualifiedClusters = contentType === 'sale' ? (enrichedClusters || []).filter(isQualified) : enrichedClusters
+  const unqualifiedClusters = contentType === 'sale' ? (enrichedClusters || []).filter((c) => !isQualified(c)) : []
+  const primaryHeading = `${mode === 'shared' ? 'Clusters For Sale' : 'Clusters Peer'} — ${qualifiedClusters?.length || 0} cluster${(qualifiedClusters?.length || 0) !== 1 ? 's' : ''}`
+  const saleSections = [
+    { key: 'primary', heading: primaryHeading, list: qualifiedClusters },
+    ...(unqualifiedClusters.length > 0
+      ? [{ key: 'unqualified', heading: `Unqualified — ${unqualifiedClusters.length} cluster${unqualifiedClusters.length !== 1 ? 's' : ''} (missing price or hardware spec)`, list: unqualifiedClusters }]
+      : []),
+  ]
 
   // Colors for the filter panel based on color mode
   const filterPanelBg = useColorModeValue('gray.50', 'gray.800')
@@ -785,9 +808,11 @@ function PeerClusterList({ onLogin, mode }) {
         {!loading && clusters?.length === 0 ? (
           <NotFound text={mode === 'shared' ? 'No shared peer cluster found!' : 'No peer cluster found!'} />
         ) : (
+          saleSections.map((section, si) => (
           <AccordionComponent
-            heading={`${mode === 'shared' ? 'Clusters For Sale' : 'Clusters Peer'} — ${clusters.length} cluster${clusters.length !== 1 ? 's' : ''}`}
-            headerActions={
+            key={section.key}
+            heading={section.heading}
+            headerActions={si !== 0 ? null : (
               <HStack spacing="2">
                 {/* Content: Monitor (operational) vs Sale (offer) */}
                 <ButtonGroup size='sm' isAttached variant='outline'>
@@ -813,11 +838,11 @@ function PeerClusterList({ onLogin, mode }) {
                   />
                 )}
               </HStack>
-            }
+            )}
             body={
             displayMode === 'grid' ? (
             <Flex className={styles.clusterList}>
-              {enrichedClusters?.map((clusterItem) => {
+              {section.list?.map((clusterItem) => {
                 const headerText = `${clusterItem['cluster-name']}`
                 const domain = `${clusterItem['cloud18-domain']}`
                 const subDomain = `${clusterItem['cloud18-sub-domain']}`
@@ -932,10 +957,11 @@ function PeerClusterList({ onLogin, mode }) {
               })}
             </Flex>
             ) : (
-              <DataTable data={enrichedClusters} columns={contentType === 'sale' ? offerColumns : operationalColumns} cellValueAlign={contentType === 'sale' ? 'left' : 'center'} />
+              <DataTable data={section.list} columns={contentType === 'sale' ? offerColumns : operationalColumns} cellValueAlign={contentType === 'sale' ? 'left' : 'center'} />
             )
             }
           />
+          ))
         )}
       </Box>
       {isTermsModalOpen && <TermsModal cluster={item} terms={finalTerms} isOpen={isTermsModalOpen} closeModal={closeTermsModal} onAgreeTerms={handleSubscribeModal} />}

--- a/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
@@ -810,8 +810,8 @@ function PeerClusterList({ onLogin, mode }) {
           <NotFound text={mode === 'shared' ? 'No shared peer cluster found!' : 'No peer cluster found!'} />
         ) : (
           saleSections.map((section, si) => (
+          <Box key={section.key} mt={si === 0 ? 0 : 8}>
           <AccordionComponent
-            key={section.key}
             heading={section.heading}
             headerActions={si !== 0 ? null : (
               <HStack spacing="2">
@@ -962,6 +962,7 @@ function PeerClusterList({ onLogin, mode }) {
             )
             }
           />
+          </Box>
           ))
         )}
       </Box>

--- a/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
@@ -393,7 +393,10 @@ function PeerClusterList({ onLogin, mode }) {
     const lastDate = new Date(last)
     const lastStr = lastDate.toLocaleString()
     if (node?.Error) {
-      return { label: 'Error', colorScheme: 'red', tooltip: `Direct connection failed — last try ${lastStr}: ${node.Error}` }
+      // We can't reach the peer directly (firewall / IPv4-vs-IPv6 / NAT / network) —
+      // this is NOT a cluster failure. Health falls back to the peer.json catalog
+      // value (the BO can reach peers this instance can't). Orange, not red.
+      return { label: 'Unreachable', colorScheme: 'orange', tooltip: `This instance can't reach the peer directly (firewall / IPv4-IPv6 / network) — showing the peer.json catalog value. Last try ${lastStr}: ${node.Error}` }
     }
     // Health dispatch cadence is ~2 min; treat a connection within 5 min as fresh.
     const isRecent = Date.now() - lastDate.getTime() < 5 * 60 * 1000

--- a/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
@@ -18,6 +18,7 @@ import { getClusterData, clusterSubscribe } from '../../redux/clusterSlice'
 import TermsModal from '../../components/Modals/TermsModal'
 import { showErrorToast } from '../../redux/toastSlice'
 import CheckOrCrossIcon from '../../components/Icons/CheckOrCrossIcon'
+import RMIconButton from '../../components/RMIconButton'
 import SearchBox from '../../components/SearchBox'
 import Dropdown from '../../components/Dropdown'
 import { getApi, getTokenByBaseURL } from '../../services/apiHelper'
@@ -825,14 +826,12 @@ function PeerClusterList({ onLogin, mode }) {
                   <Button variant={contentType === 'monitor' ? 'solid' : 'outline'} colorScheme={contentType === 'monitor' ? 'blue' : 'gray'} onClick={() => setContentType('monitor')}>Monitor</Button>
                   <Button variant={contentType === 'sale' ? 'solid' : 'outline'} colorScheme={contentType === 'sale' ? 'blue' : 'gray'} onClick={() => setContentType('sale')}>Sale</Button>
                 </ButtonGroup>
-                {/* Display: table vs grid (cards) — like the local cluster list */}
-                <IconButton
-                  size='sm'
-                  aria-label={displayMode === 'table' ? 'Show grid view' : 'Show table view'}
-                  title={displayMode === 'table' ? 'Grid view' : 'Table view'}
-                  icon={displayMode === 'table' ? <HiViewGrid /> : <HiTable />}
-                  onClick={() => setDisplayMode(displayMode === 'table' ? 'grid' : 'table')}
-                />
+                {/* Display: table vs grid (cards) — same RMIconButton as the local list */}
+                {displayMode === 'table' ? (
+                  <RMIconButton icon={HiViewGrid} tooltip='Show grid view' onClick={() => setDisplayMode('grid')} />
+                ) : (
+                  <RMIconButton icon={HiTable} tooltip='Show table view' onClick={() => setDisplayMode('table')} />
+                )}
                 {/* Only show this on mobile views when panel is collapsed */}
                 {!isFilterPanelOpen && (
                   <IconButton

--- a/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
@@ -1,11 +1,13 @@
-import React, { useCallback, useEffect, useReducer, useState, useRef } from 'react'
+import React, { useCallback, useEffect, useMemo, useReducer, useState, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { getClusterPeers, getClusterForSale, getTermsData } from '../../redux/globalClustersSlice'
-import { Box, Flex, HStack, Text, Wrap, IconButton, useColorModeValue, Collapse, Divider, Tooltip, ButtonGroup, Button } from '@chakra-ui/react'
+import { getClusterPeers, getClusterForSale, getClusterPeerNodes, getTermsData } from '../../redux/globalClustersSlice'
+import { Badge, Box, Flex, HStack, Text, Wrap, IconButton, useColorModeValue, Collapse, Divider, Tooltip, ButtonGroup, Button } from '@chakra-ui/react'
 import NotFound from '../../components/NotFound'
 import { AiOutlineCluster } from 'react-icons/ai'
 import Card from '../../components/Card'
 import TableType2 from '../../components/TableType2'
+import { DataTable } from '../../components/DataTable'
+import { createColumnHelper } from '@tanstack/react-table'
 import styles from './styles.module.scss'
 import CustomIcon from '../../components/Icons/CustomIcon'
 import TagPill from '../../components/TagPill'
@@ -17,6 +19,8 @@ import { showErrorToast } from '../../redux/toastSlice'
 import CheckOrCrossIcon from '../../components/Icons/CheckOrCrossIcon'
 import SearchBox from '../../components/SearchBox'
 import Dropdown from '../../components/Dropdown'
+
+const columnHelper = createColumnHelper()
 
 const defaultFilter = {
   domain: "",
@@ -129,7 +133,13 @@ function PeerClusterList({ onLogin, mode }) {
   const [finalTerms, setFinalTerms] = useState(``)
   const [isTermsModalOpen, setIsTermsModalOpen] = useState(false)
   const [item, setItem] = useState({})
-  const [isFilterPanelOpen, setIsFilterPanelOpen] = useState(true)
+  // Two table views, one visible via toggle: 'operational' (local-like) and
+  // 'offer' (infra + commercial — what you get for the price). URI + Active columns
+  // appear in both as the transparency anchor.
+  const [viewType, setViewType] = useState('operational')
+  // Keep the search/filter panel retracted by default so the URI/Active columns
+  // lead; the operator can expand it manually.
+  const [isFilterPanelOpen, setIsFilterPanelOpen] = useState(false)
   const mainContentRef = useRef(null)
 
   // Auto-close filter panel when mouse moves to cluster list
@@ -142,7 +152,7 @@ function PeerClusterList({ onLogin, mode }) {
   const { domain, subdomain, zone, plan, search, domainOptions, subdomainOptions, zoneOptions, planOptions, sortBy, sortOrder } = filter
 
   const {
-    globalClusters: { loading, clusterPeers, clusterForSale, monitor, terms },
+    globalClusters: { loading, clusterPeers, clusterForSale, peerNodes, monitor, terms },
     auth: {
       user
     },
@@ -151,6 +161,7 @@ function PeerClusterList({ onLogin, mode }) {
   useEffect(() => {
     dispatch(getClusterPeers({}))
     dispatch(getClusterForSale({}))
+    dispatch(getClusterPeerNodes({}))
     dispatch(getTermsData({}))
   }, [])
 
@@ -381,6 +392,157 @@ function PeerClusterList({ onLogin, mode }) {
     />
   )
 
+  // getConnState reflects the GROUND TRUTH of whether this instance has actually
+  // opened an HTTPS connection to a peer URI, from /api/peers (PeerNodeStatus:
+  // LastUpdate is advanced only when we really poll). A for-sale catalog entry we
+  // never call has a zero LastUpdate -> "None": a beta tester can match their
+  // firewall log against the "Active" rows and confirm the "None" rows generate no
+  // outbound traffic. See doc/implementation/peer/MARKETPLACE.md.
+  const getConnState = (uri) => {
+    const node = peerNodes?.[uri]
+    const last = node?.LastUpdate
+    const never = !last || last === '0001-01-01T00:00:00Z'
+    if (never) {
+      return { label: 'None', colorScheme: 'gray', tooltip: 'Never connected — catalog listing only, no HTTPS call made from this instance' }
+    }
+    const lastDate = new Date(last)
+    const lastStr = lastDate.toLocaleString()
+    if (node?.Error) {
+      return { label: 'Error', colorScheme: 'red', tooltip: `Last connection: ${lastStr} — ${node.Error}` }
+    }
+    // Health dispatch cadence is ~2 min; treat a connection within 5 min as active.
+    const isRecent = Date.now() - lastDate.getTime() < 5 * 60 * 1000
+    return isRecent
+      ? { label: 'Active', colorScheme: 'green', tooltip: `Last connection: ${lastStr}` }
+      : { label: 'Idle', colorScheme: 'orange', tooltip: `Last connection: ${lastStr}` }
+  }
+
+  // Status/hardware fields are only present when advertised (for-sale listing) or
+  // once we've actually polled a delegated peer — a plain shared cluster may carry
+  // none of them, so every cell degrades to "—".
+  const isUnknown = (row) => !row?.lastUpdate || row?.lastUpdate === '0001-01-01T00:00:00Z'
+
+  const healthCell = (row) => {
+    if (isUnknown(row)) return <Text>—</Text>
+    if (row.isDown || row.isMasterDown) {
+      return <HStack spacing='2'><CheckOrCrossIcon isValid={false} /><Text>No</Text></HStack>
+    }
+    if (!row.isFailable) {
+      return <HStack spacing='2'><CustomIcon icon={HiExclamation} color='red' /><Text>Blocker</Text></HStack>
+    }
+    return <HStack spacing='2'><CheckOrCrossIcon isValid={true} /><Text>Yes</Text></HStack>
+  }
+
+  const num = (v) => (v === undefined || v === null || v === '' ? '—' : v)
+
+  const priceCell = (row) => {
+    const cost = (row['cloud18-monthly-infra-cost'] * 1) + (row['cloud18-monthly-license-cost'] * 1) + (row['cloud18-monthly-sysops-cost'] * 1) + (row['cloud18-monthly-dbops-cost'] * 1)
+    if (!cost) return <Text>—</Text>
+    const promo = row['cloud18-promotion-pct'] * 1
+    const currency = row['cloud18-cost-currency'] || ''
+    const amount = promo > 0 ? (cost * (100 - promo)) / 100 : cost
+    if (promo > 0) {
+      return (
+        <HStack spacing='1'>
+          <Text as='span' textColor='red.500' textDecoration='line-through'>{cost.toFixed(2)}</Text>
+          <Text as='span' fontWeight='bold'>{amount.toFixed(2)} {currency}/mo</Text>
+        </HStack>
+      )
+    }
+    return <Text>{cost.toFixed(2)} {currency}/mo</Text>
+  }
+
+  // Columns common to both views — the transparency anchor (name + URI + live
+  // connection state) is present whatever metadata a peer carries.
+  const clusterCol = columnHelper.accessor((row) => row['cluster-name'], {
+    id: 'cluster', header: 'Cluster',
+    cell: (info) => {
+      const row = info.row.original
+      const isPending = row?.['api-credentials-acl-allow']?.includes('pending')
+      const isSponsor = row?.['api-credentials-acl-allow']?.includes('sponsor')
+      return (
+        <HStack cursor='pointer' onClick={() => handlePeerCluster(row)}>
+          <CustomIcon icon={isSponsor || isPending ? HiCreditCard : AiOutlineCluster} fill={isSponsor ? 'green' : isPending ? 'orange' : 'gray'} />
+          <Text fontWeight='semibold'>{info.getValue()}</Text>
+        </HStack>
+      )
+    }
+  })
+  const uriCol = columnHelper.accessor((row) => row['api-public-url'], {
+    id: 'uri', header: 'URI',
+    cell: (info) => {
+      const uri = info.getValue() || '—'
+      return (<Tooltip label={uri} placement='top'><Text isTruncated maxW='300px' fontFamily='mono' fontSize='sm'>{uri}</Text></Tooltip>)
+    }
+  })
+  const activeCol = columnHelper.accessor((row) => row['api-public-url'], {
+    id: 'active', header: 'Active', enableSorting: false,
+    cell: (info) => {
+      const cs = getConnState(info.getValue())
+      return (<Tooltip label={cs.tooltip} placement='top'><Badge colorScheme={cs.colorScheme}>{cs.label}</Badge></Tooltip>)
+    }
+  })
+  const actionCol = columnHelper.display({
+    id: 'action', header: '',
+    cell: (info) => (
+      <Button size='xs' colorScheme='blue' variant='outline' onClick={() => handlePeerCluster(info.row.original)}>
+        {mode === 'shared' ? 'Subscribe' : 'Enter'}
+      </Button>
+    )
+  })
+
+  // Operational view — mirrors the local cluster table (as far as catalog data
+  // allows); everything degrades to "—" for an out-of-cloud18 shared cluster.
+  const operationalColumns = useMemo(() => [
+    clusterCol, uriCol, activeCol,
+    columnHelper.accessor((row) => row['prov-orchestrator'], { id: 'orchestrator', header: 'Orchestrator', cell: (info) => info.getValue() || '—' }),
+    columnHelper.accessor((row) => row, { id: 'healthy', header: 'Healthy', enableSorting: false, cell: (info) => healthCell(info.row.original) }),
+    columnHelper.accessor((row) => row, { id: 'provisioned', header: 'Provisioned', enableSorting: false, cell: (info) => isUnknown(info.row.original) ? <Text>—</Text> : <CheckOrCrossIcon isValid={!!info.row.original.isProvisioned} /> }),
+    actionCol,
+  ], [peerNodes, mode])
+
+  // Compact infra: a short inline summary, full spec sheet on hover — keeps the
+  // Offer table narrow instead of a dozen spec columns.
+  const infraSummary = (row) => {
+    const parts = []
+    if (row['prov-db-cpu-cores']) parts.push(`${row['prov-db-cpu-cores']} core${row['prov-db-cpu-cores'] * 1 === 1 ? '' : 's'}`)
+    if (row['prov-db-memory']) parts.push(`${row['prov-db-memory'] / 1024}GB`)
+    if (row['prov-db-disk-size']) parts.push(`${row['prov-db-disk-size']}GB disk`)
+    if (row['cloud18-infra-cpu-model']) parts.push(row['cloud18-infra-cpu-model'])
+    return parts
+  }
+  const infraDetail = (row) => (
+    [
+      ['CPU cores', row['prov-db-cpu-cores']],
+      ['Memory', row['prov-db-memory'] ? `${row['prov-db-memory'] / 1024}GB` : ''],
+      ['Disk', row['prov-db-disk-size'] ? `${row['prov-db-disk-size']}GB` : ''],
+      ['Disk IOPS', row['prov-db-disk-iops']],
+      ['CPU model', row['cloud18-infra-cpu-model']],
+      ['CPU freq', row['cloud18-infra-cpu-freq']],
+      ['Data centers', row['cloud18-infra-data-centers']],
+      ['Geo', row['cloud18-infra-geo-localizations']],
+      ['Bandwidth', row['cloud18-infra-public-bandwidth'] ? `${row['cloud18-infra-public-bandwidth'] / 1024}Gbps` : ''],
+      ['Certifications', row['cloud18-infra-certifications']],
+    ].filter(([, v]) => v !== undefined && v !== '' && v !== null).map(([k, v]) => `${k}: ${v}`).join('\n')
+  )
+
+  // Offer view — infra + commercial together: what you get for the price.
+  const offerColumns = useMemo(() => [
+    clusterCol, uriCol, activeCol,
+    columnHelper.accessor((row) => row['prov-service-plan'], { id: 'plan', header: 'Plan', cell: (info) => info.getValue() || '—' }),
+    columnHelper.accessor((row) => row, { id: 'price', header: 'Price', enableSorting: false, cell: (info) => priceCell(info.row.original) }),
+    columnHelper.accessor((row) => infraSummary(row).join(' · '), {
+      id: 'infra', header: 'Infra',
+      cell: (info) => {
+        const row = info.row.original
+        const parts = infraSummary(row)
+        if (parts.length === 0) return <Text>—</Text>
+        return (<Tooltip label={infraDetail(row)} placement='top' whiteSpace='pre-line'><Text fontSize='sm'>{parts.join(' · ')}</Text></Tooltip>)
+      }
+    }),
+    actionCol,
+  ], [peerNodes, mode])
+
   // Colors for the filter panel based on color mode
   const filterPanelBg = useColorModeValue('gray.50', 'gray.800')
   const filterPanelBorder = useColorModeValue('gray.200', 'gray.700')
@@ -528,17 +690,25 @@ function PeerClusterList({ onLogin, mode }) {
                 Showing {clusters.length} cluster{clusters.length !== 1 ? 's' : ''}
               </Text>
 
-              {/* Only show this on mobile views when panel is collapsed */}
-              {!isFilterPanelOpen && (
-                <IconButton
-                  display={{ base: 'flex', lg: 'none' }}
-                  aria-label="Open filters"
-                  icon={<HiSearch />}
-                  onClick={() => setIsFilterPanelOpen(true)}
-                />
-              )}
+              <HStack spacing="2">
+                <ButtonGroup size='sm' isAttached variant='outline'>
+                  <Button variant={viewType === 'operational' ? 'solid' : 'outline'} colorScheme={viewType === 'operational' ? 'blue' : 'gray'} onClick={() => setViewType('operational')}>Operational</Button>
+                  <Button variant={viewType === 'offer' ? 'solid' : 'outline'} colorScheme={viewType === 'offer' ? 'blue' : 'gray'} onClick={() => setViewType('offer')}>Offer</Button>
+                  <Button variant={viewType === 'cards' ? 'solid' : 'outline'} colorScheme={viewType === 'cards' ? 'blue' : 'gray'} onClick={() => setViewType('cards')}>Cards</Button>
+                </ButtonGroup>
+                {/* Only show this on mobile views when panel is collapsed */}
+                {!isFilterPanelOpen && (
+                  <IconButton
+                    display={{ base: 'flex', lg: 'none' }}
+                    aria-label="Open filters"
+                    icon={<HiSearch />}
+                    onClick={() => setIsFilterPanelOpen(true)}
+                  />
+                )}
+              </HStack>
             </Flex>
 
+            {viewType === 'cards' ? (
             <Flex className={styles.clusterList}>
               {clusters?.map((clusterItem) => {
                 const headerText = `${clusterItem['cluster-name']}`
@@ -656,6 +826,9 @@ function PeerClusterList({ onLogin, mode }) {
                 )
               })}
             </Flex>
+            ) : (
+              <DataTable data={clusters} columns={viewType === 'offer' ? offerColumns : operationalColumns} />
+            )}
           </>
         )}
       </Box>

--- a/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
@@ -887,13 +887,11 @@ function PeerClusterList({ onLogin, mode }) {
                       className={styles.card}
                       width={'400px'}
                       header={
-                        <HStack as="div" className={styles.btnHeading} cursor={'pointer'} onClick={() => { handlePeerCluster(clusterItem) }} justifyContent="space-between">
-                          <HStack>
-                            <CustomIcon icon={isSponsor || isPending ? (HiCreditCard) : (AiOutlineCluster)} fill={isSponsor ? "green" : isPending ? "orange" : "gray"} />
-                            <span className={styles.cardHeaderText}>{headerText}</span>
-                          </HStack>
+                        <HStack as="div" cursor={'pointer'} className={styles.btnHeading} onClick={() => { handlePeerCluster(clusterItem) }}>
+                          <CustomIcon icon={isSponsor || isPending ? (HiCreditCard) : (AiOutlineCluster)} fill={isSponsor ? "green" : isPending ? "orange" : "gray"} />
+                          <span className={styles.cardHeaderText}>{headerText}</span>
                           <Tooltip label={statusInfo.tooltip} placement="top">
-                            <Box>
+                            <Box marginLeft="auto">
                               {statusInfo.icon === HiQuestionMarkCircle ? (
                                 <CustomIcon icon={HiQuestionMarkCircle} color={statusInfo.color} />
                               ) : (

--- a/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
@@ -139,9 +139,10 @@ function PeerClusterList({ onLogin, mode }) {
   // Two table views, one visible via toggle: 'operational' (local-like) and
   // 'offer' (infra + commercial — what you get for the price). URI + Active columns
   // appear in both as the transparency anchor.
-  // Default to the Sale view: this page is primarily a marketplace — buyers come to
-  // see what hardware they can acquire, not to monitor. Monitor is one toggle away.
-  const [contentType, setContentType] = useState('sale') // 'sale' (offer) | 'monitor' (operational)
+  // Default tab depends on the page: the For-Sale marketplace (mode 'shared') opens on
+  // the Sale spec-sheet — buyers come to see what they can acquire. The Peer page opens
+  // on Monitor (operational) — peers are watched, not bought. Either toggle is one click.
+  const [contentType, setContentType] = useState(mode === 'shared' ? 'sale' : 'monitor') // 'sale' | 'monitor'
   const [displayMode, setDisplayMode] = useState('table')    // 'table' | 'grid' (cards)
   // Option (a): full cluster data pulled directly from each reachable peer's
   // /api/clusters (using the per-peer SSO token the login-upgrade stored), keyed

--- a/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
@@ -12,7 +12,7 @@ import { createColumnHelper } from '@tanstack/react-table'
 import styles from './styles.module.scss'
 import CustomIcon from '../../components/Icons/CustomIcon'
 import TagPill from '../../components/TagPill'
-import { HiCreditCard, HiExclamation, HiQuestionMarkCircle, HiTag, HiSortAscending, HiSortDescending, HiSearch, HiChevronLeft, HiChevronRight } from 'react-icons/hi'
+import { HiCreditCard, HiExclamation, HiQuestionMarkCircle, HiTag, HiSortAscending, HiSortDescending, HiSearch, HiChevronLeft, HiChevronRight, HiViewGrid, HiTable } from 'react-icons/hi'
 import { peerLogin, setBaseURL } from '../../redux/authSlice'
 import { getClusterData, clusterSubscribe } from '../../redux/clusterSlice'
 import TermsModal from '../../components/Modals/TermsModal'
@@ -137,7 +137,8 @@ function PeerClusterList({ onLogin, mode }) {
   // Two table views, one visible via toggle: 'operational' (local-like) and
   // 'offer' (infra + commercial — what you get for the price). URI + Active columns
   // appear in both as the transparency anchor.
-  const [viewType, setViewType] = useState('operational')
+  const [contentType, setContentType] = useState('monitor') // 'monitor' (operational) | 'sale' (offer)
+  const [displayMode, setDisplayMode] = useState('table')    // 'table' | 'grid' (cards)
   // Keep the search/filter panel retracted by default so the URI/Active columns
   // lead; the operator can expand it manually.
   const [isFilterPanelOpen, setIsFilterPanelOpen] = useState(false)
@@ -473,12 +474,18 @@ function PeerClusterList({ onLogin, mode }) {
   // Connectivity cloud: green = we have a working direct connection to the peer,
   // red = none / can't reach it (health then comes from the peer.json catalog).
   const connCloud = (uri) => {
+    if (!uri) return { color: 'gray', tooltip: 'No peer URL' }
+    // Our own instance is always reachable — it's us.
+    if (monitor?.config?.apiPublicUrl && uri === monitor.config.apiPublicUrl) {
+      return { color: 'green', tooltip: 'This is your own instance' }
+    }
     const node = peerNodes?.[uri]
     const last = node?.LastUpdate
-    const ok = last && last !== '0001-01-01T00:00:00Z' && !node?.Error
-    return ok
-      ? { color: 'green', tooltip: `Direct connection OK — last ${new Date(last).toLocaleString()}` }
-      : { color: 'red', tooltip: node?.Error ? `Cannot reach peer directly: ${node.Error}` : 'No direct connection — health comes from the peer.json catalog' }
+    const connected = last && last !== '0001-01-01T00:00:00Z'
+    if (node?.Error) return { color: 'red', tooltip: `Direct connection failed: ${node.Error}` }
+    if (connected) return { color: 'green', tooltip: `Direct connection OK — last ${new Date(last).toLocaleString()}` }
+    // Not polled directly (catalog only) — unknown, not a failure. Grey, not red.
+    return { color: 'gray', tooltip: 'No direct connection attempted — health from the peer.json catalog (click the cluster to connect on demand)' }
   }
   const uriCol = columnHelper.accessor((row) => row['api-public-url'], {
     id: 'uri', header: 'Peer', enableSorting: false,
@@ -717,14 +724,23 @@ function PeerClusterList({ onLogin, mode }) {
               </Text>
 
               <HStack spacing="2">
+                {/* Content: Monitor (operational) vs Sale (offer) */}
                 <ButtonGroup size='sm' isAttached variant='outline'>
-                  <Button variant={viewType === 'operational' ? 'solid' : 'outline'} colorScheme={viewType === 'operational' ? 'blue' : 'gray'} onClick={() => setViewType('operational')}>Operational</Button>
-                  <Button variant={viewType === 'offer' ? 'solid' : 'outline'} colorScheme={viewType === 'offer' ? 'blue' : 'gray'} onClick={() => setViewType('offer')}>Offer</Button>
-                  <Button variant={viewType === 'cards' ? 'solid' : 'outline'} colorScheme={viewType === 'cards' ? 'blue' : 'gray'} onClick={() => setViewType('cards')}>Cards</Button>
+                  <Button variant={contentType === 'monitor' ? 'solid' : 'outline'} colorScheme={contentType === 'monitor' ? 'blue' : 'gray'} onClick={() => setContentType('monitor')}>Monitor</Button>
+                  <Button variant={contentType === 'sale' ? 'solid' : 'outline'} colorScheme={contentType === 'sale' ? 'blue' : 'gray'} onClick={() => setContentType('sale')}>Sale</Button>
                 </ButtonGroup>
+                {/* Display: table vs grid (cards) — like the local cluster list */}
+                <IconButton
+                  size='sm'
+                  aria-label={displayMode === 'table' ? 'Show grid view' : 'Show table view'}
+                  title={displayMode === 'table' ? 'Grid view' : 'Table view'}
+                  icon={displayMode === 'table' ? <HiViewGrid /> : <HiTable />}
+                  onClick={() => setDisplayMode(displayMode === 'table' ? 'grid' : 'table')}
+                />
                 {/* Only show this on mobile views when panel is collapsed */}
                 {!isFilterPanelOpen && (
                   <IconButton
+                    size='sm'
                     display={{ base: 'flex', lg: 'none' }}
                     aria-label="Open filters"
                     icon={<HiSearch />}
@@ -734,7 +750,7 @@ function PeerClusterList({ onLogin, mode }) {
               </HStack>
             </Flex>
 
-            {viewType === 'cards' ? (
+            {displayMode === 'grid' ? (
             <Flex className={styles.clusterList}>
               {clusters?.map((clusterItem) => {
                 const headerText = `${clusterItem['cluster-name']}`
@@ -853,7 +869,7 @@ function PeerClusterList({ onLogin, mode }) {
               })}
             </Flex>
             ) : (
-              <DataTable data={clusters} columns={viewType === 'offer' ? offerColumns : operationalColumns} />
+              <DataTable data={clusters} columns={contentType === 'sale' ? offerColumns : operationalColumns} />
             )}
           </>
         )}

--- a/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
@@ -387,18 +387,19 @@ function PeerClusterList({ onLogin, mode }) {
     const last = node?.LastUpdate
     const never = !last || last === '0001-01-01T00:00:00Z'
     if (never) {
-      return { label: 'None', colorScheme: 'gray', tooltip: 'Never connected — catalog listing only, no HTTPS call made from this instance' }
+      // No direct connection -> the health shown is the peer.json catalog default.
+      return { label: 'Catalog', colorScheme: 'gray', tooltip: 'Not directly connected — health is the peer.json catalog default (async, git-pull cadence). No HTTPS call is made from this instance.' }
     }
     const lastDate = new Date(last)
     const lastStr = lastDate.toLocaleString()
     if (node?.Error) {
-      return { label: 'Error', colorScheme: 'red', tooltip: `Last connection: ${lastStr} — ${node.Error}` }
+      return { label: 'Error', colorScheme: 'red', tooltip: `Direct connection failed — last try ${lastStr}: ${node.Error}` }
     }
-    // Health dispatch cadence is ~2 min; treat a connection within 5 min as active.
+    // Health dispatch cadence is ~2 min; treat a connection within 5 min as fresh.
     const isRecent = Date.now() - lastDate.getTime() < 5 * 60 * 1000
     return isRecent
-      ? { label: 'Active', colorScheme: 'green', tooltip: `Last connection: ${lastStr}` }
-      : { label: 'Idle', colorScheme: 'orange', tooltip: `Last connection: ${lastStr}` }
+      ? { label: 'Live', colorScheme: 'green', tooltip: `Direct connection — health is live-verified (last ${lastStr})` }
+      : { label: 'Stale', colorScheme: 'orange', tooltip: `Direct connection went stale — last ${lastStr}` }
   }
 
   // Health is "unknown" only when the peer carries NO health fields at all (e.g. an
@@ -463,14 +464,13 @@ function PeerClusterList({ onLogin, mode }) {
       return (<Tooltip label={uri} placement='top'><Text isTruncated maxW='300px' fontFamily='mono' fontSize='sm'>{uri}</Text></Tooltip>)
     }
   })
-  // The two data paths, side by side:
-  //  - peerJsonCol: health the BO catalog reports (peer.json, async / git-pull cadence)
-  //  - directCol:   what the local repman got by actually connecting to the peer
-  //                 (/api/peers PeerNodeStatus — connected + last-seen, or never/error)
-  const peerJsonCol = columnHelper.accessor((row) => row, {
-    id: 'peerjson', header: 'peer.json', enableSorting: false,
+  // Effective health + its source (the "peer.json default, overwritten by a direct
+  // connection" model). healthyCol shows the effective value; directCol shows whether
+  // that value is Live (direct-verified) or Catalog (peer.json default).
+  const healthyCol = columnHelper.accessor((row) => row, {
+    id: 'healthy', header: 'Healthy', enableSorting: false,
     cell: (info) => (
-      <Tooltip label='Health as reported by the BO catalog (peer.json — async, git-pull cadence)' placement='top'>
+      <Tooltip label='Effective health: peer.json catalog default, overwritten by a direct connection for clusters in your fleet (see the Direct column for the source).' placement='top'>
         <Box display='inline-block'>{healthCell(info.row.original)}</Box>
       </Tooltip>
     )
@@ -479,7 +479,7 @@ function PeerClusterList({ onLogin, mode }) {
     id: 'direct', header: 'Direct', enableSorting: false,
     cell: (info) => {
       const cs = getConnState(info.getValue())
-      return (<Tooltip label={`Direct connection to the peer — ${cs.tooltip}`} placement='top'><Badge colorScheme={cs.colorScheme}>{cs.label}</Badge></Tooltip>)
+      return (<Tooltip label={cs.tooltip} placement='top'><Badge colorScheme={cs.colorScheme}>{cs.label}</Badge></Tooltip>)
     }
   })
   const actionCol = columnHelper.display({
@@ -494,7 +494,7 @@ function PeerClusterList({ onLogin, mode }) {
   // Operational view — mirrors the local cluster table (as far as catalog data
   // allows); everything degrades to "—" for an out-of-cloud18 shared cluster.
   const operationalColumns = useMemo(() => [
-    clusterCol, uriCol, peerJsonCol, directCol,
+    clusterCol, uriCol, healthyCol, directCol,
     columnHelper.accessor((row) => row['prov-orchestrator'], { id: 'orchestrator', header: 'Orchestrator', cell: (info) => info.getValue() || '—' }),
     columnHelper.accessor((row) => row, { id: 'provisioned', header: 'Provisioned', enableSorting: false, cell: (info) => isUnknown(info.row.original) ? <Text>—</Text> : <CheckOrCrossIcon isValid={!!info.row.original.isProvisioned} /> }),
     actionCol,
@@ -527,7 +527,7 @@ function PeerClusterList({ onLogin, mode }) {
 
   // Offer view — infra + commercial together: what you get for the price.
   const offerColumns = useMemo(() => [
-    clusterCol, uriCol, directCol,
+    clusterCol, uriCol, healthyCol, directCol,
     columnHelper.accessor((row) => row['prov-service-plan'], { id: 'plan', header: 'Plan', cell: (info) => info.getValue() || '—' }),
     columnHelper.accessor((row) => row, { id: 'price', header: 'Price', enableSorting: false, cell: (info) => priceCell(info.row.original) }),
     columnHelper.accessor((row) => infraSummary(row).join(' · '), {

--- a/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
@@ -621,7 +621,8 @@ function PeerClusterList({ onLogin, mode }) {
 
   // Offer view — a buyer's spec sheet: what you acquire and what it costs. Order:
   // Cluster · Plan · Price · Partner · Zone · Infra (multi-line) · Service (multi-line)
-  // · Healthy (de-emphasised — an unprovisioned offer is still buyable) · Peer.
+  // · Healthy (de-emphasised — an unprovisioned offer is still buyable). No Peer/URL
+  // column: a sales listing shouldn't expose the peer instance's connectivity.
   const offerColumns = useMemo(() => [
     clusterCol,
     columnHelper.accessor((row) => row['prov-service-plan'], { id: 'plan', header: 'Plan', cell: (info) => info.getValue() || '—' }),
@@ -631,7 +632,6 @@ function PeerClusterList({ onLogin, mode }) {
     columnHelper.accessor((row) => infraLines(row).join(' · '), { id: 'infra', header: 'Infra', enableSorting: false, cell: (info) => multiLineCell(infraLines(info.row.original)) }),
     columnHelper.accessor((row) => serviceLines(row).join(' · '), { id: 'service', header: 'Service', enableSorting: false, cell: (info) => multiLineCell(serviceLines(info.row.original)) }),
     healthyCol,
-    uriCol,
   ], [peerNodes, mode])
 
   // Merge the direct /api/clusters data (peerDetails) over the peer.json catalog rows.

--- a/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
@@ -329,40 +329,24 @@ function PeerClusterList({ onLogin, mode }) {
     })
   };
 
-  // Function to get status icon and tooltip text
+  // Status icon for the card header. Health-first: a cluster is green when it's up
+  // and failable, regardless of isProvisioned (the BO peer.json often reports
+  // isProvisioned=false for shared clusters even when they're running). Only
+  // "unknown" when the peer carries no health fields at all. Mirrors healthCell.
   const getStatusIcon = (clusterItem) => {
-    const isUnknown = clusterItem?.lastUpdate === "0001-01-01T00:00:00Z"
-    const isHealthy = !clusterItem?.isDown && !clusterItem?.isMasterDown && clusterItem?.isFailable
-    const isProvisioned = clusterItem?.isProvisioned
-
-    if (isUnknown) {
-      return {
-        icon: HiQuestionMarkCircle,
-        color: 'gray.400',
-        tooltip: 'Unknown - Status cannot be determined'
-      }
+    if (isUnknown(clusterItem)) {
+      return { icon: HiQuestionMarkCircle, color: 'gray.400', tooltip: 'Unknown — no health reported by peer' }
     }
-
-    if (!isProvisioned || !isHealthy) {
-      return {
-        icon: 'circle',
-        color: 'red.500',
-        tooltip: `${!isProvisioned ? 'Not Provisioned' : ''}${!isProvisioned && !isHealthy ? ' & ' : ''}${!isHealthy ? 'Not Healthy' : ''}`
-      }
+    if (clusterItem?.isDown || clusterItem?.isMasterDown) {
+      return { icon: 'circle', color: 'red.500', tooltip: clusterItem?.isMasterDown ? 'Master down' : 'Down' }
     }
-
-    if (isProvisioned && !isHealthy) {
-      return {
-        icon: 'circle',
-        color: 'orange.500',
-        tooltip: 'Provisioned but Not Healthy'
-      }
+    if (!clusterItem?.isFailable) {
+      return { icon: 'circle', color: 'orange.500', tooltip: 'Not failable (blocker)' }
     }
-
     return {
       icon: 'circle',
       color: 'green.500',
-      tooltip: 'Healthy & Provisioned'
+      tooltip: clusterItem?.isProvisioned ? 'Healthy & provisioned' : 'Healthy (provisioning not reported by peer)'
     }
   }
 
@@ -417,10 +401,14 @@ function PeerClusterList({ onLogin, mode }) {
       : { label: 'Idle', colorScheme: 'orange', tooltip: `Last connection: ${lastStr}` }
   }
 
-  // Status/hardware fields are only present when advertised (for-sale listing) or
-  // once we've actually polled a delegated peer — a plain shared cluster may carry
-  // none of them, so every cell degrades to "—".
-  const isUnknown = (row) => !row?.lastUpdate || row?.lastUpdate === '0001-01-01T00:00:00Z'
+  // Health is "unknown" only when the peer carries NO health fields at all (e.g. an
+  // out-of-cloud18 shared cluster with no metadata). Do NOT gate on lastUpdate: the
+  // BO peer.json reports isDown/isMasterDown/isFailable/isProvisioned but NOT
+  // lastUpdate, so gating on it wrongly blanks every peer to "—". lastUpdate is only
+  // set by a direct poll; the live "Active" column uses /api/peers for that instead.
+  const isUnknown = (row) =>
+    row?.isFailable === undefined && row?.isDown === undefined &&
+    row?.isMasterDown === undefined && row?.isProvisioned === undefined
 
   const healthCell = (row) => {
     if (isUnknown(row)) return <Text>—</Text>

--- a/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
@@ -21,6 +21,7 @@ import CheckOrCrossIcon from '../../components/Icons/CheckOrCrossIcon'
 import SearchBox from '../../components/SearchBox'
 import Dropdown from '../../components/Dropdown'
 import { getApi, getTokenByBaseURL } from '../../services/apiHelper'
+import AccordionComponent from '../../components/AccordionComponent'
 
 const columnHelper = createColumnHelper()
 
@@ -765,12 +766,9 @@ function PeerClusterList({ onLogin, mode }) {
         {!loading && clusters?.length === 0 ? (
           <NotFound text={mode === 'shared' ? 'No shared peer cluster found!' : 'No peer cluster found!'} />
         ) : (
-          <>
-            <Flex justifyContent="space-between" alignItems="center" mb={4}>
-              <Text fontSize="lg" fontWeight="bold">
-                Showing {clusters.length} cluster{clusters.length !== 1 ? 's' : ''}
-              </Text>
-
+          <AccordionComponent
+            heading={`${mode === 'shared' ? 'Clusters For Sale' : 'Clusters Peer'} — ${clusters.length} cluster${clusters.length !== 1 ? 's' : ''}`}
+            headerActions={
               <HStack spacing="2">
                 {/* Content: Monitor (operational) vs Sale (offer) */}
                 <ButtonGroup size='sm' isAttached variant='outline'>
@@ -796,9 +794,9 @@ function PeerClusterList({ onLogin, mode }) {
                   />
                 )}
               </HStack>
-            </Flex>
-
-            {displayMode === 'grid' ? (
+            }
+            body={
+            displayMode === 'grid' ? (
             <Flex className={styles.clusterList}>
               {enrichedClusters?.map((clusterItem) => {
                 const headerText = `${clusterItem['cluster-name']}`
@@ -916,8 +914,9 @@ function PeerClusterList({ onLogin, mode }) {
             </Flex>
             ) : (
               <DataTable data={enrichedClusters} columns={contentType === 'sale' ? offerColumns : operationalColumns} />
-            )}
-          </>
+            )
+            }
+          />
         )}
       </Box>
       {isTermsModalOpen && <TermsModal cluster={item} terms={finalTerms} isOpen={isTermsModalOpen} closeModal={closeTermsModal} onAgreeTerms={handleSubscribeModal} />}

--- a/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useReducer, useState, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { getClusterPeers, getClusterForSale, getClusterPeerNodes, getTermsData } from '../../redux/globalClustersSlice'
-import { Badge, Box, Flex, HStack, Text, Wrap, IconButton, useColorModeValue, Collapse, Divider, Tooltip, ButtonGroup, Button } from '@chakra-ui/react'
+import { Badge, Box, Flex, HStack, Link, Text, Wrap, IconButton, useColorModeValue, Collapse, Divider, Tooltip, ButtonGroup, Button } from '@chakra-ui/react'
+import { FaCloud } from 'react-icons/fa'
 import NotFound from '../../components/NotFound'
 import { AiOutlineCluster } from 'react-icons/ai'
 import Card from '../../components/Card'
@@ -387,8 +388,8 @@ function PeerClusterList({ onLogin, mode }) {
     const last = node?.LastUpdate
     const never = !last || last === '0001-01-01T00:00:00Z'
     if (never) {
-      // No direct connection -> the health shown is the peer.json catalog default.
-      return { label: 'Catalog', colorScheme: 'gray', tooltip: 'Not directly connected — health is the peer.json catalog default (async, git-pull cadence). No HTTPS call is made from this instance.' }
+      // No direct connection -> the health shown comes from peer.json (the BO catalog).
+      return { label: 'peer.json', colorScheme: 'gray', tooltip: 'No direct connection — health comes from peer.json (the BO catalog: async, git-pull cadence). No HTTPS call is made from this instance.' }
     }
     const lastDate = new Date(last)
     const lastStr = lastDate.toLocaleString()
@@ -425,6 +426,15 @@ function PeerClusterList({ onLogin, mode }) {
     return <HStack spacing='2'><CheckOrCrossIcon isValid={true} /><Text>Yes</Text></HStack>
   }
 
+  // Local-cluster-parity cells; "—" until the BO adds these to peer.json.
+  const arbCell = (row) => {
+    if (row.activePassiveStatus === 'A') return <TagPill colorScheme='green' text='Active' />
+    if (row.activePassiveStatus === 'S') return <TagPill colorScheme='orange' text='Standby' />
+    return <Text>—</Text>
+  }
+  const monCell = (row) => (row.monitoringPause === undefined ? <Text>—</Text> : <CheckOrCrossIcon isValid={!row.monitoringPause} />)
+  const countOf = (v) => (Array.isArray(v) ? v.length : v)
+
   const num = (v) => (v === undefined || v === null || v === '' ? '—' : v)
 
   const priceCell = (row) => {
@@ -460,11 +470,29 @@ function PeerClusterList({ onLogin, mode }) {
       )
     }
   })
+  // Connectivity cloud: green = we have a working direct connection to the peer,
+  // red = none / can't reach it (health then comes from the peer.json catalog).
+  const connCloud = (uri) => {
+    const node = peerNodes?.[uri]
+    const last = node?.LastUpdate
+    const ok = last && last !== '0001-01-01T00:00:00Z' && !node?.Error
+    return ok
+      ? { color: 'green', tooltip: `Direct connection OK — last ${new Date(last).toLocaleString()}` }
+      : { color: 'red', tooltip: node?.Error ? `Cannot reach peer directly: ${node.Error}` : 'No direct connection — health comes from the peer.json catalog' }
+  }
   const uriCol = columnHelper.accessor((row) => row['api-public-url'], {
-    id: 'uri', header: 'URI',
+    id: 'uri', header: 'Peer', enableSorting: false,
     cell: (info) => {
-      const uri = info.getValue() || '—'
-      return (<Tooltip label={uri} placement='top'><Text isTruncated maxW='300px' fontFamily='mono' fontSize='sm'>{uri}</Text></Tooltip>)
+      const uri = info.getValue()
+      if (!uri) return <Text>—</Text>
+      const host = uri.replace(/^https?:\/\//, '').replace(/\/+$/, '')
+      const cc = connCloud(uri)
+      return (
+        <HStack spacing='2'>
+          <Tooltip label={cc.tooltip} placement='top'><Box as='span' display='inline-flex'><CustomIcon icon={FaCloud} color={cc.color} /></Box></Tooltip>
+          <Link href={uri} isExternal fontFamily='mono' fontSize='sm'>{host}</Link>
+        </HStack>
+      )
     }
   })
   // Effective health + its source (the "peer.json default, overwritten by a direct
@@ -473,34 +501,30 @@ function PeerClusterList({ onLogin, mode }) {
   const healthyCol = columnHelper.accessor((row) => row, {
     id: 'healthy', header: 'Healthy', enableSorting: false,
     cell: (info) => (
-      <Tooltip label='Effective health: peer.json catalog default, overwritten by a direct connection for clusters in your fleet (see the Direct column for the source).' placement='top'>
+      <Tooltip label='Effective health: peer.json catalog default, overwritten by a direct connection for reachable fleet clusters (the cloud icon on the Peer column shows whether a direct connection is up).' placement='top'>
         <Box display='inline-block'>{healthCell(info.row.original)}</Box>
       </Tooltip>
     )
   })
-  const directCol = columnHelper.accessor((row) => row['api-public-url'], {
-    id: 'direct', header: 'Direct', enableSorting: false,
-    cell: (info) => {
-      const cs = getConnState(info.getValue())
-      return (<Tooltip label={cs.tooltip} placement='top'><Badge colorScheme={cs.colorScheme}>{cs.label}</Badge></Tooltip>)
-    }
-  })
-  const actionCol = columnHelper.display({
-    id: 'action', header: '',
-    cell: (info) => (
-      <Button size='xs' colorScheme='blue' variant='outline' onClick={() => handlePeerCluster(info.row.original)}>
-        {mode === 'shared' ? 'Subscribe' : 'Enter'}
-      </Button>
-    )
-  })
+  // No action column — clicking the cluster name enters/subscribes (the Enter button
+  // was redundant).
 
-  // Operational view — mirrors the local cluster table (as far as catalog data
-  // allows); everything degrades to "—" for an out-of-cloud18 shared cluster.
+  // Operational view — same columns and SAME ORDER as the local cluster table
+  // (ClusterList), so the two views are consistent. Fields the BO peer.json doesn't
+  // carry yet render "—" and fill in once enriched. The Peer column (last) shows the
+  // hostname as a link + a green/red cloud for direct connectivity.
   const operationalColumns = useMemo(() => [
-    clusterCol, uriCol, healthyCol, directCol,
+    clusterCol,
+    columnHelper.accessor((row) => row.activePassiveStatus, { id: 'arbitration', header: 'Arbitration', enableSorting: false, cell: (info) => arbCell(info.row.original) }),
+    columnHelper.accessor((row) => row.monitoringPause, { id: 'monitoring', header: 'Monitoring', enableSorting: false, cell: (info) => monCell(info.row.original) }),
+    columnHelper.accessor((row) => row.topology, { id: 'topology', header: 'Topology', cell: (info) => info.getValue() || '—' }),
     columnHelper.accessor((row) => row['prov-orchestrator'], { id: 'orchestrator', header: 'Orchestrator', cell: (info) => info.getValue() || '—' }),
+    columnHelper.accessor((row) => countOf(row.dbServers), { id: 'databases', header: 'Databases', cell: (info) => num(info.getValue()) }),
+    columnHelper.accessor((row) => countOf(row.proxyServers), { id: 'proxies', header: 'Proxies', cell: (info) => num(info.getValue()) }),
+    healthyCol,
     columnHelper.accessor((row) => row, { id: 'provisioned', header: 'Provisioned', enableSorting: false, cell: (info) => isUnknown(info.row.original) ? <Text>—</Text> : <CheckOrCrossIcon isValid={!!info.row.original.isProvisioned} /> }),
-    actionCol,
+    columnHelper.accessor((row) => row.uptime, { id: 'sla', header: 'SLA', cell: (info) => info.getValue() || '—' }),
+    uriCol,
   ], [peerNodes, mode])
 
   // Compact infra: a short inline summary, full spec sheet on hover — keeps the
@@ -530,7 +554,7 @@ function PeerClusterList({ onLogin, mode }) {
 
   // Offer view — infra + commercial together: what you get for the price.
   const offerColumns = useMemo(() => [
-    clusterCol, uriCol, healthyCol, directCol,
+    clusterCol, healthyCol,
     columnHelper.accessor((row) => row['prov-service-plan'], { id: 'plan', header: 'Plan', cell: (info) => info.getValue() || '—' }),
     columnHelper.accessor((row) => row, { id: 'price', header: 'Price', enableSorting: false, cell: (info) => priceCell(info.row.original) }),
     columnHelper.accessor((row) => infraSummary(row).join(' · '), {
@@ -542,7 +566,7 @@ function PeerClusterList({ onLogin, mode }) {
         return (<Tooltip label={infraDetail(row)} placement='top' whiteSpace='pre-line'><Text fontSize='sm'>{parts.join(' · ')}</Text></Tooltip>)
       }
     }),
-    actionCol,
+    uriCol,
   ], [peerNodes, mode])
 
   // Colors for the filter panel based on color mode

--- a/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
+++ b/share/dashboard_react/src/Pages/PeerClusterList/index.jsx
@@ -20,6 +20,7 @@ import { showErrorToast } from '../../redux/toastSlice'
 import CheckOrCrossIcon from '../../components/Icons/CheckOrCrossIcon'
 import SearchBox from '../../components/SearchBox'
 import Dropdown from '../../components/Dropdown'
+import { getApi, getTokenByBaseURL } from '../../services/apiHelper'
 
 const columnHelper = createColumnHelper()
 
@@ -139,6 +140,10 @@ function PeerClusterList({ onLogin, mode }) {
   // appear in both as the transparency anchor.
   const [contentType, setContentType] = useState('monitor') // 'monitor' (operational) | 'sale' (offer)
   const [displayMode, setDisplayMode] = useState('table')    // 'table' | 'grid' (cards)
+  // Option (a): full cluster data pulled directly from each reachable peer's
+  // /api/clusters (using the per-peer SSO token the login-upgrade stored), keyed
+  // baseURL -> { clusterName -> full cluster }. Overwrites the thin peer.json catalog.
+  const [peerDetails, setPeerDetails] = useState({})
   // Keep the search/filter panel retracted by default so the URI/Active columns
   // lead; the operator can expand it manually.
   const [isFilterPanelOpen, setIsFilterPanelOpen] = useState(false)
@@ -166,6 +171,28 @@ function PeerClusterList({ onLogin, mode }) {
     dispatch(getClusterPeerNodes({}))
     dispatch(getTermsData({}))
   }, [])
+
+  // Option (a): for each reachable peer, pull its real /api/clusters directly (with
+  // the per-peer SSO token from the login-upgrade). This is what "Enter" does, applied
+  // to the whole list — the full local-cluster data overwrites the thin peer.json
+  // catalog for peers we can actually reach/authenticate to. Unreachable or
+  // unauthenticated peers just 401/fail and stay on the catalog ("—").
+  useEffect(() => {
+    const all = [...(clusterPeers || []), ...(clusterForSale || [])]
+    if (all.length === 0) return
+    const ownUrl = monitor?.config?.apiPublicUrl
+    const urls = [...new Set(all.map((c) => c['api-public-url']).filter((u) => u && u !== ownUrl))]
+    let cancelled = false
+    urls.forEach((baseURL) => {
+      getApi(baseURL).get('clusters').then((resp) => {
+        if (cancelled || resp?.status !== 200 || !Array.isArray(resp.data)) return
+        const byName = {}
+        resp.data.forEach((fc) => { if (fc?.name) byName[fc.name] = fc })
+        setPeerDetails((prev) => ({ ...prev, [baseURL]: byName }))
+      }).catch(() => { /* unreachable / unauthorized -> keep peer.json catalog */ })
+    })
+    return () => { cancelled = true }
+  }, [clusterPeers, clusterForSale, monitor])
 
   useEffect(() => {
     let filteredClusters = []
@@ -576,6 +603,27 @@ function PeerClusterList({ onLogin, mode }) {
     uriCol,
   ], [peerNodes, mode])
 
+  // Merge the direct /api/clusters data (peerDetails) over the peer.json catalog rows.
+  // Where we have the peer's real cluster, its fields overwrite the catalog defaults
+  // (topology, db/proxy counts, uptime/SLA, monitoring, arbitration, live health).
+  const enrichedClusters = useMemo(() => (clusters || []).map((item) => {
+    const fc = peerDetails[item['api-public-url']]?.[item['cluster-name']]
+    if (!fc) return item
+    return {
+      ...item,
+      topology: fc.topology,
+      dbServers: fc.dbServers,
+      proxyServers: fc.proxyServers,
+      uptime: fc.uptime,
+      monitoringPause: fc.config?.monitoringPause,
+      activePassiveStatus: fc.activePassiveStatus,
+      isDown: fc.isDown,
+      isMasterDown: fc.isMasterDown,
+      isFailable: fc.isFailable,
+      isProvisioned: fc.isProvision,
+    }
+  }), [clusters, peerDetails])
+
   // Colors for the filter panel based on color mode
   const filterPanelBg = useColorModeValue('gray.50', 'gray.800')
   const filterPanelBorder = useColorModeValue('gray.200', 'gray.700')
@@ -752,7 +800,7 @@ function PeerClusterList({ onLogin, mode }) {
 
             {displayMode === 'grid' ? (
             <Flex className={styles.clusterList}>
-              {clusters?.map((clusterItem) => {
+              {enrichedClusters?.map((clusterItem) => {
                 const headerText = `${clusterItem['cluster-name']}`
                 const domain = `${clusterItem['cloud18-domain']}`
                 const subDomain = `${clusterItem['cloud18-sub-domain']}`
@@ -869,7 +917,7 @@ function PeerClusterList({ onLogin, mode }) {
               })}
             </Flex>
             ) : (
-              <DataTable data={clusters} columns={contentType === 'sale' ? offerColumns : operationalColumns} />
+              <DataTable data={enrichedClusters} columns={contentType === 'sale' ? offerColumns : operationalColumns} />
             )}
           </>
         )}

--- a/share/dashboard_react/src/Pages/PeerClusterList/styles.module.scss
+++ b/share/dashboard_react/src/Pages/PeerClusterList/styles.module.scss
@@ -34,9 +34,9 @@
 
 // Cluster list styles
 .clusterList {
+  height: 100%;
   flex-wrap: wrap;
-  gap: 20px;
-  margin-top: 10px;
+  gap: rem(16);
 }
 
 .cardWrapper {
@@ -64,14 +64,17 @@
   }
 }*/
 
+// Identical to the local cluster list (ClusterList/styles.module.scss): set only
+// width and let the shared Card component supply the rounded border. Do NOT override
+// border/border-radius/box-shadow here — that's what broke the shape.
 .card {
-  height: 100%;
-  // Force the rounded shape like every other card in the app, and clip the inner
-  // table so its square corners don't poke over the radius.
-  border: rem(1) solid var(--tertiary-color);
-  border-radius: rem(10);
-  overflow: hidden;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  width: rem(400);
+
+  .btnHeading {
+    padding: rem(4) 0;
+    width: 100%;
+    font-weight: bold;
+  }
 }
 
 .btnHeading {

--- a/share/dashboard_react/src/Pages/PeerClusterList/styles.module.scss
+++ b/share/dashboard_react/src/Pages/PeerClusterList/styles.module.scss
@@ -77,22 +77,9 @@
   }
 }
 
-.btnHeading {
-  width: 100%;
-  padding: 10px;
-  //transition: background-color 0.2s ease;
-  border-bottom: none;
-  /*&:hover {
-    background-color: rgba(0, 0, 0, 0.05);
-  }*/
-}
-
-.cardHeaderText {
-  font-weight: bold;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
+// (Removed the top-level .btnHeading and .cardHeaderText overrides — local
+// (ClusterList) has neither; the .card-nested .btnHeading is the only one, so the
+// peer cards now match local exactly.)
 
 // Filter component styles
 .dropdownButton {

--- a/share/dashboard_react/src/Pages/PeerClusterList/styles.module.scss
+++ b/share/dashboard_react/src/Pages/PeerClusterList/styles.module.scss
@@ -66,8 +66,11 @@
 
 .card {
   height: 100%;
-  // keep the Card component's rounded 1px border (do not set `border: none`) so
-  // these cards match every other card in the app
+  // Force the rounded shape like every other card in the app, and clip the inner
+  // table so its square corners don't poke over the radius.
+  border: rem(1) solid var(--tertiary-color);
+  border-radius: rem(10);
+  overflow: hidden;
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
 }
 

--- a/share/dashboard_react/src/Pages/PeerClusterList/styles.module.scss
+++ b/share/dashboard_react/src/Pages/PeerClusterList/styles.module.scss
@@ -66,7 +66,8 @@
 
 .card {
   height: 100%;
-  border: none;
+  // keep the Card component's rounded 1px border (do not set `border: none`) so
+  // these cards match every other card in the app
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
 }
 

--- a/share/dashboard_react/src/redux/globalClustersSlice.js
+++ b/share/dashboard_react/src/redux/globalClustersSlice.js
@@ -169,6 +169,15 @@ export const getClusterForSale = createGuardedAsyncThunk('globalClusters/getClus
   }
 });
 
+export const getClusterPeerNodes = createGuardedAsyncThunk('globalClusters/getClusterPeerNodes', async ({ }, thunkAPI) => {
+  try {
+    const { data, status } = await globalClustersService.getClusterPeerNodes()
+    return { data, status }
+  } catch (error) {
+    return handleError(error, thunkAPI)
+  }
+});
+
 export const getMonitoredData = createGuardedAsyncThunk('globalClusters/getMonitoredData', async ({ }, thunkAPI) => {
   try {
     const { data, status } = await globalClustersService.getMonitoredData()
@@ -464,6 +473,7 @@ const initialState = {
   isFailableList: {},
   clusterPeers: null,
   clusterForSale: null,
+  peerNodes: null,
   monitor: null,
   appTemplatesByCluster: {},
   // requestId of the latest dispatched refreshAppTemplateRepo per cluster, so
@@ -528,6 +538,12 @@ export const globalClustersSlice = createSlice({
         state.clusterForSale = action.payload.data
       })
       .addCase(getClusterForSale.rejected, (state, action) => {
+        state.error = action.error
+      })
+      .addCase(getClusterPeerNodes.fulfilled, (state, action) => {
+        state.peerNodes = action.payload.data
+      })
+      .addCase(getClusterPeerNodes.rejected, (state, action) => {
         state.error = action.error
       })
       .addCase(refreshAppTemplateRepo.pending, (state, action) => {

--- a/share/dashboard_react/src/services/globalClustersService.js
+++ b/share/dashboard_react/src/services/globalClustersService.js
@@ -62,6 +62,10 @@ function getClusterForSale() {
   return getApi().get('clusters/for-sale')
 }
 
+function getClusterPeerNodes() {
+  return getApi().get('peers')
+}
+
 function switchGlobalSetting(setting) {
   return getApi().get(`clusters/settings/actions/switch/${setting}`)
 }


### PR DESCRIPTION
## Summary

Fixes the peer-health / marketplace polling so a repman never adds load to
partners it has no relationship to, and so legitimate fleet polling can't strand
connections on a dark peer. Two independent problems, two fixes, plus a new
technical doc.

Production symptom this addresses: one repman went unresponsive with ~14k
goroutines and ~6.9k TCP connections wedged against a single peer.

## Fix 1 — scope: no traffic on partners from registrants

A fresh/browsing repman now opens **zero** seller connections. All live polling
routes through the connected-users scope (`GetHealthStatusForActiveUsers`):

- `BatchUpdateClusters` no longer polls (it has no session-user context, so it
  could only walk the flat, unscoped list — for-sale included).
- The `peer.json` reload path calls `dispatchPeerHealthPoll()` after updating
  data, so refresh stays instant-on-pull **and** scoped.
- `pulling` and `smart` both route to the scoped poller; the unscoped
  `GetHealthStatusForUnknownVersions` is removed.
- `peering` remains the single opt-in unscoped full-mesh (never the default).

A for-sale cluster is polled only once a connected user enters its **sale
workflow** (`pending`/`sponsor` role) or is delegated it — and then only that one
seller, never the rest of the catalog. Catalog status comes from the
BO-aggregated `peer.json` (git-pull cadence), which is what keeps the sale view
fast.

## Fix 2 — leak: legitimate fleet polling must not strand connections

Fleet polling (your own repmans + any repman sharing a cluster with you or a
connected SSO user) *should* generate traffic, so the leak is fixed for that path:

- **Bounded transport** — `MaxConnsPerHost: 2` hard ceiling (thousands of sockets
  to one peer is now impossible), plus dial/handshake/response deadlines for a
  peer that accepts TCP but never answers.
- **Rate-limit + advance `LastUpdate` on failure** — each peer's login+health is
  gated to once per `Interval`, advanced up-front so a failed attempt is
  rate-limited like a success. (The core bug: failures never advanced the gate and
  login wasn't gated at all, so a dark peer was re-hit every dispatch.)
- **Effective single-flight** — `dispatchPeerHealthPoll` self-guards on
  `peerHealthBusy` and holds it across the whole poll, so timer + reload can't
  overlap and race the shared `LastUpdate`.

## Docs

New `doc/implementation/peer/MARKETPLACE.md`: the delegation-vs-for-sale model,
the fleet/identity rules, the invariant (with the sale-workflow and
always-on-vs-session precision), the sale-workflow timing, and both fixes.

## Known follow-up (not in this PR)

- **Identity `admin` → `Cloud18GitUser` (§2.1).** Own clusters that carry only the
  local `admin` ACL entry may not land under `PeerUserClusters[Cloud18GitUser]`,
  so 24/7 own-fleet polling for master-failed alerting isn't yet guaranteed for
  them. This is a BO/`peer.json` change.
- Alerting design: whether "in charge" can be a sub-user, and whether the alert is
  raised locally from peer `IsMasterDown` or by the hosting repman.

## Testing

`go build ./peer/` and `go build -tags server ./server/` pass. Behavioural
verification (fresh instance = zero seller connections; fleet polling survives a
dark peer) to be exercised on the OpenSVC test cluster.
