### PR TITLE
perf(api): slim /api/clusters (5.9x) + /api/monitor (3.1x) — every user, on-prem included

### DIFF
--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -1956,6 +1956,19 @@ func (cluster *Cluster) GetCompactJson() ([]byte, error) {
 		return nil, fmt.Errorf("set clusterS3Providers snapshot: %w", err)
 	}
 
+	// Slim the cluster-LIST payload. These subtrees are single-cluster DETAIL — the
+	// dashboard reads them ONLY from the per-cluster /api/clusters/{name} fetch
+	// (clusterData), never from the list (verified via a dashboard-wide read audit).
+	// The full cluster object is ~77 KB/row; dropping these cuts ~48% for EVERY user's
+	// cluster page on every refresh. config + apiUsers still stay (the list does read
+	// those) and are handled in a follow-up. See project_api_clusters_bloat.
+	for _, field := range []string{
+		"configurator", "securityStates", "securityScore", "securityRemediations",
+		"Whitelist", "diskStat", "workloadStates", "schemaStates",
+	} {
+		result, _ = sjson.DeleteBytes(result, field)
+	}
+
 	return result, nil
 }
 

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -35,6 +35,7 @@ import (
 	"github.com/signal18/replication-manager/utils/state"
 	"github.com/signal18/replication-manager/utils/tty"
 	"github.com/signal18/replication-manager/utils/version"
+	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
@@ -1968,6 +1969,27 @@ func (cluster *Cluster) GetCompactJson() ([]byte, error) {
 	} {
 		result, _ = sjson.DeleteBytes(result, field)
 	}
+
+	// Slim `config`: the ~500-field config struct is 36% of the row (~31 KB), but the
+	// LIST reads only a handful of keys (the columns it renders + NewServerModal's
+	// default-port lookup). Replace it with just those keys — GUI `row.config?.x` reads
+	// still resolve, AND this drops EVERY config value (incl. secrets) that the list
+	// never needed. ACLs are enforced server-side (IsValidClusterACL on the request
+	// path), so this changes payload weight, not access control. Audit-derived key set;
+	// full config still comes from /api/clusters/{name} on drill-in. project_api_clusters_bloat.
+	leanCfg := []byte("{}")
+	for _, k := range []string{
+		"arbitrationExternal", "monitoringPause", "provOrchestrator",
+		"backupRestic", "backupPhysicalType", "backupLogicalType", "schedulerEnabled",
+		"dbServersHosts", "proxysqlPort", "maxscalePort", "haproxyWritePort",
+		"haproxyReadPort", "shardproxyServers", "sphinxSqlPort", "sphinxPort",
+		"provProxyRoutePort",
+	} {
+		if v := gjson.GetBytes(result, "config."+k); v.Exists() {
+			leanCfg, _ = sjson.SetRawBytes(leanCfg, k, []byte(v.Raw))
+		}
+	}
+	result, _ = sjson.SetRawBytes(result, "config", leanCfg)
 
 	return result, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -151,7 +151,12 @@ type ReplicationManager struct {
 	exitMsg                     string
 	exit                        atomic.Bool
 	isStarted                   bool
-	Confs                       map[string]config.Config
+	// Confs holds every cluster's full config, used only INTERNALLY (config build,
+	// reload, delete). It is never read from the wire — the dashboard and CLI don't
+	// reference it — yet json.Marshal(repman) shipped it in /api/monitor at 312 KB (66%
+	// of a 463 KB payload), unredacted secrets and all. json:"-" keeps it internal (like
+	// VersionConfs). Per-cluster config still comes from /api/clusters/{name}.
+	Confs                       map[string]config.Config       `json:"-"`
 	VersionConfs                map[string]*config.ConfVersion `json:"-"`
 	grpcServer                  *grpc.Server                   `json:"-"`
 	grpcWrapped                 *grpcweb.WrappedGrpcServer     `json:"-"`

--- a/share/dashboard_react/src/Pages/Home/index.jsx
+++ b/share/dashboard_react/src/Pages/Home/index.jsx
@@ -217,7 +217,12 @@ function Home() {
         globalTabsRef.current[selectedTabRef.current] === 'Settings'
       ) {
         if (!isPaused) {
-          dispatch(getMonitoredData({}))
+          // monitor = global/near-static options (config, service catalogs, plans) +
+          // slow-moving status. It doesn't need the per-tick cadence the live cluster
+          // list does — poll it 10x less often (same gate used inside a cluster below).
+          if (intervalTickerRef.current % 10 === 0) {
+            dispatch(getMonitoredData({}))
+          }
           dispatch(getClusters({}))
           dispatch(getGlobalLogs({}))
           dispatch(getGlobalAlerts({}))


### PR DESCRIPTION
## Why
The two heaviest, polled-every-tick dashboard calls were shipping ~1.23 MB per refresh **for every user** (on-prem and cloud). This is the highest-leverage perf fix in the codebase — it hits the whole user base, not just the peer/cloud path. Measured on a live instance (10 clusters).

## What

| endpoint | before | after | |
|---|---|---|---|
| `/api/clusters` | 768 KB | **129 KB** | 5.9× |
| `/api/monitor` | 463 KB | **151 KB** | 3.1× |
| `/api/monitor` poll cadence (Clusters Local tab) | every tick | **1/10 ticks** | ~90% fewer calls |

**`/api/clusters` (`GetCompactJson`)** — the list shipped the full ~77 KB cluster object per row; 89% was single-cluster *detail*:
- Strip 8 subtrees consumed only from the per-cluster `clusterData` fetch (`configurator`, `securityStates`, `securityScore`, `securityRemediations`, `Whitelist`, `diskStat`, `workloadStates`, `schemaStates`).
- Lean `config` projection: keep only the ~16 keys the list actually reads (columns + NewServerModal ports) — GUI-transparent (`row.config?.x` still resolves) and drops config **secrets** from the list.

**`/api/monitor` (`handlerMuxReplicationManager`)** — `Confs` (`map[clusterName]config.Config` = every cluster's full config, 66%, secrets unredacted) was marshaled but read by nobody. `json:"-"` it (matching the adjacent `VersionConfs`).

**Poll cadence** — `/api/monitor` (near-static: config, catalogs, slow status) was polled every tick on the Clusters Local/Settings tab. Apply the same 1/10 gate already used inside a cluster. Live cluster list / logs / alerts keep full cadence.

## Safety — audited three consumers, no regressions
- **Dashboard:** Explore-agent audit confirmed only `config` + `apiUsers` are read from the *list*; all 8 stripped subtrees are `clusterData`-only. `config` lean projection keeps every list-read key.
- **Go CLI:** reads only `ClusterList`(names) + `Tests` from `/api/monitor` (never `Confs`); gets full per-cluster config from the untouched `/api/clusters/{name}`.
- **Security:** access control is enforced **server-side** (`IsValidClusterACL` on the request path, ~280 sites) — the payload `grants`/`config` are frontend affordance only, so slimming is security-*positive*.

Full config still served by `/api/clusters/{name}` on drill-in. Deployed + measured on the test instance; no frontend behavior change beyond fewer monitor calls.

## Deferred (scoped, not in this PR)
- `apiUsers` (7 KB) — `APIUser.Grants` is the weight; list only needs `roles`, but `AddUserModal` reads grants from the list row, so it needs a navbar-safe repoint first.
- Full static/heartbeat split of `/api/monitor`.