### PR TITLE
fix(docker/dev): symlink monitor binaries into workdir root at entrypoint

### DIFF
--- a/docker/dev/entrypoint.sh
+++ b/docker/dev/entrypoint.sh
@@ -7,4 +7,14 @@ for script in run.sh stop.sh restart.sh wait.sh; do
     [ ! -e "$WORKDIR/$script" ] && ln -s "$DEVDIR/$script" "$WORKDIR/$script"
 done
 
+# run.sh launches the monitor from the workdir root (./replication-manager-pro /
+# -osc), but 'make' builds the binaries into build/binaries/. Older dev images had
+# root-level symlinks baked in; fresh images don't, so run.sh's backgrounded launch
+# silently exec-failed ("no such file") and repman never came up — no panic, just a
+# vanished PID. Recreate the symlinks here (force: they may dangle until 'make' runs,
+# then resolve once the binary exists).
+for bin in replication-manager-pro replication-manager-osc replication-manager-cli; do
+    ln -sf "$WORKDIR/build/binaries/$bin" "$WORKDIR/$bin"
+done
+
 exec "$@"


### PR DESCRIPTION
## Problem
`docker/dev/run.sh` launches the monitor from the **workdir root** (`./replication-manager-pro` / `./replication-manager-osc`), but `make` builds the binaries into **`build/binaries/`**. Older dev images happened to have root-level symlinks baked in; **fresh images don't**.

Result on a freshly-pulled `:dev` image: `run.sh`'s backgrounded launch (`./replication-manager-pro monitor … &`) exec-fails silently — "no such file" goes to the log, the PID vanishes instantly, and repman never comes up. **No panic**, which made it look like a crash/config problem. Meanwhile a direct `./build/binaries/replication-manager-pro monitor …` runs fine — that's the tell.

## Fix
`entrypoint.sh` already symlinks the `*.sh` scripts into the workdir; extend it to do the same for the binaries (`-pro`, `-osc`, `-cli`), using `ln -sf` so they resolve once `make` builds them (dangling until then is harmless).

Confirmed on a partner OpenSVC testing cluster: with the symlinks, `./restart.sh run` starts `replication-manager-pro` and it stays up.

No functional/runtime code change — dev-image build glue only.