### PR TITLE
fix(peer): live /api/clusters enrichment must reach the peer/for-sale views

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -164,6 +164,13 @@ func (pm *PeerManager) BatchUpdateClusters(clusterUpdates []*PeerCluster, remove
 	for _, pc := range clusterUpdates {
 		hashID := GetPeerHashID(pc)
 
+		// stored is the canonical object kept in PeerClusters — the one the live
+		// /api/clusters poll (GetClusterDetails) enriches. We wire the user/for-sale maps
+		// to THIS object below (not the transient catalog pc), so the post-reload poll's
+		// live data prevails in the peer/for-sale views; catalog data remains only when
+		// the live fetch can't reach the peer. Before this, ReloadUsers(pc) pointed the
+		// views at a sibling object the poll never wrote to, so live info never showed.
+		var stored *PeerCluster
 		if cl, exists := pm.PeerClusters[hashID]; exists {
 			// Preserve the direct-connection enrichment (auto-connect to fleet) — these
 			// fields are never in the peer.json catalog, so a catalog refresh must not
@@ -195,14 +202,16 @@ func (pm *PeerManager) BatchUpdateClusters(clusterUpdates []*PeerCluster, remove
 				pc.LastUpdate = cl.LastUpdate
 			}
 			*cl = *pc
+			stored = cl
 		} else {
 			if pm.HealthMode == "pulling" && pc.RepmgrVersion != "" {
 				pc.LastUpdate = time.Now()
 			}
 			pm.PeerClusters[hashID] = pc
+			stored = pc
 		}
 
-		pm.ReloadUsers(pc)
+		pm.ReloadUsers(stored)
 		updatedNames[hashID] = true
 
 		if _, exists := pm.PeerURL[pc.ApiPublicUrl]; !exists {

--- a/peer/peer_scope_test.go
+++ b/peer/peer_scope_test.go
@@ -3,6 +3,7 @@ package peer
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // The marketplace invariant (MARKETPLACE.md §6): live polling is scoped to
@@ -193,5 +194,52 @@ func TestDRSharedApiUrlDoesNotHideClusters(t *testing.T) {
 	got := pm.GetUserClusters("me@sig", map[string]bool{}) // DR has no live local clusters
 	if len(got) != 1 || got[0].ClusterName != "goodlands" {
 		t.Fatalf("a cluster sharing the DR api-url but not run locally must stay visible; got %+v", got)
+	}
+}
+
+// TestReloadPreservesLiveEnrichmentInViews locks the fix: after a peer.json RELOAD
+// (a second BatchUpdateClusters over an existing cluster), the peer view
+// (PeerUserClusters) and the marketplace (PeerForSale) must share the SAME object
+// that the live /api/clusters poll enriches (PeerClusters[hashID]). Before the fix,
+// ReloadUsers was wired to the transient catalog object, so a post-reload live poll
+// updated PeerClusters but the views showed a stale sibling → for-sale clusters
+// stayed gray/not-provisioned even when the peer reported them live.
+func TestReloadPreservesLiveEnrichmentInViews(t *testing.T) {
+	pm := NewPeerManager(30)
+	mk := func() *PeerCluster {
+		return &PeerCluster{
+			ApiPublicUrl:                   "https://seller.example.com",
+			ClusterName:                    "cl-sale",
+			Cloud18Shared:                  true,
+			ApiCredentialsAclAllowExternal: "me@sig:x:cl-sale",
+		}
+	}
+	pm.BatchUpdateClusters([]*PeerCluster{mk()}, false) // initial catalog load
+	pm.BatchUpdateClusters([]*PeerCluster{mk()}, false) // reload -> existing-cluster path
+
+	hashID := GetHashID("https://seller.example.com", "cl-sale")
+	stored, ok := pm.PeerClusters[hashID]
+	if !ok {
+		t.Fatalf("cluster missing from PeerClusters under %s", hashID)
+	}
+
+	// Simulate the live /api/clusters enrichment (GetClusterDetails writes here).
+	stored.DirectUpdate = time.Now()
+	stored.IsProvisioned = true
+
+	uv, ok := pm.PeerUserClusters["me@sig"][hashID]
+	if !ok {
+		t.Fatalf("cluster missing from PeerUserClusters[me@sig]")
+	}
+	if uv.DirectUpdate.IsZero() || !uv.IsProvisioned {
+		t.Errorf("peer view did NOT reflect live enrichment after reload: directUpdate=%v isProvisioned=%v (view points at a stale sibling object)", uv.DirectUpdate, uv.IsProvisioned)
+	}
+
+	fs, ok := pm.PeerForSale[hashID]
+	if !ok {
+		t.Fatalf("cluster missing from PeerForSale")
+	}
+	if fs.DirectUpdate.IsZero() || !fs.IsProvisioned {
+		t.Errorf("for-sale view did NOT reflect live enrichment after reload")
 	}
 }


### PR DESCRIPTION
## Problem (found live against BSO)
For-sale peer clusters showed **gray / `isProvisioned=false`** even though the peer reported them **live-provisioned**. Verified end-to-end:
- BSO's live `/api/clusters` (auth'd as our registered user) → `isProvision=true` for **all 7** clusters.
- BO catalog / `peer.json` → `isProvisioned=null` (BSO publishes null from a standby node).
- Our peer view → showed the stale catalog value, never the live one.

## Root cause
`BatchUpdateClusters` keeps the enriched object in `PeerClusters[hashID]` (`*cl = *pc`), but then calls **`ReloadUsers(pc)`** — wiring `PeerUserClusters` (peer view) and `PeerForSale` (marketplace) to the **transient catalog `pc`, a *sibling* object**. The post-reload live poll (`GetClusterDetails`) writes to `PeerClusters` (`cl`), so the views keep reading a stale sibling that live data never touches.

`cgr` looked fine only incidentally; shared/for-sale clusters never picked up live data — and a **standby that never pulls/reloads** made it permanent.

## Fix (checkpoint model)
Reload + live poll should form **one checkpoint**: wire the user/for-sale maps to the **same object the poll enriches**, so **live prevails where reachable, catalog remains only where it isn't**. One line:
```go
*cl = *pc
pm.ReloadUsers(cl)   // was ReloadUsers(pc) — a sibling the poll never wrote to
```
(implemented via a `stored` var: `cl` on the existing-cluster path, `pc` on insert).

## Test
`TestReloadPreservesLiveEnrichmentInViews` — reloads a for-sale cluster twice, simulates the live enrichment on `PeerClusters`, asserts the peer + for-sale views reflect it. **Fails without the fix** ("view points at a stale sibling object"), passes with it.

## Blast radius / rollback
One line of behavior + one comment + one test. No API/schema change. Fully revertable — just don't merge, or revert the commit.