### PR TITLE
fix(reload): preserve live cluster state during config reload

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -945,6 +945,31 @@ func (cluster *Cluster) Run() {
 	}
 }
 
+// reloadDrainTimeout bounds how long ReloadConfig waits for tickWG to drain.
+// See waitTickDrain and its call site in ReloadConfig for why this must not
+// be indefinite.
+const reloadDrainTimeout = 10 * time.Second
+
+// waitTickDrain waits for tickWG to reach zero, up to timeout. Returns true
+// if it drained fully, false if the timeout elapsed first. The Wait() runs in
+// its own goroutine so a timeout can be observed without blocking the
+// caller; if tickWG never drains, that goroutine leaks for the life of the
+// process, which is an accepted tradeoff for a codepath that should be rare
+// (see ReloadConfig's caller).
+func (cluster *Cluster) waitTickDrain(timeout time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		cluster.tickWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
 // trackTickGoroutine launches fn in a goroutine tracked by tickWG. Use it for
 // a tick's genuinely fire-and-forget spawns -- ones not already joined by a
 // local sync.WaitGroup within the same tick (e.g. the wg/goRun-based Phase
@@ -2170,7 +2195,21 @@ func (cluster *Cluster) ReloadConfig(conf config.Config) {
 	// the tick that just released reloadMu (see tickWG's declaration). Safe
 	// to call here: reloadMu being held blocks Run() from starting a new
 	// tick, so no concurrent Add() can race this Wait().
-	cluster.tickWG.Wait()
+	//
+	// Bounded, not indefinite: some tracked work (rolling jobs upgrade,
+	// script/reseed deployment, restic fetch) is a genuinely long per-server
+	// operational job that can run for minutes, not the quick cluster-state
+	// touch tickWG exists to catch. Waiting on it forever here would freeze
+	// the whole monitor loop for this cluster -- reloadMu stays held for as
+	// long as the wait does, and Run() needs reloadMu for every subsequent
+	// tick, so a stuck drain silently stops the ticker with no panic (the
+	// stuck goroutine itself is doing real work, not asleep). Past the
+	// timeout, proceed anyway: residual overlap with one long job is a
+	// smaller risk than reload never completing at all.
+	if !cluster.waitTickDrain(reloadDrainTimeout) {
+		cluster.LogModulePrintf(true, config.ConstLogModGeneral, config.LvlWarn,
+			"ReloadConfig(%s): proceeding after %s with tick goroutines still running", cluster.Name, reloadDrainTimeout)
+	}
 
 	cluster.Lock()
 	*cluster.Conf = conf

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -78,107 +78,107 @@ type ClusterResponse struct {
 }
 
 type Cluster struct {
-	OsUser                        *user.User             `json:"-"`
-	Name                          string                 `json:"name" groups:"apps,web"`
-	Tenant                        string                 `json:"tenant" groups:"web"`
-	WorkingDir                    string                 `json:"workingDir" groups:"web"`
-	Servers                       serverList             `json:"servers" groups:"apps"`
-	LogSlaveServers               []string               `json:"logSlaveServers" groups:"web" ` //To store slave with log-slave-updates
-	ServerIdList                  []string               `json:"dbServers" groups:"web"`
-	Crashes                       crashList              `json:"dbServersCrashes" groups:"web"` //This will be purged on all db node up
-	FailoverHistory               crashList              `json:"failoverHistory" groups:"web"`  //This will be used for PITR
-	Apps                          appList                `json:"apps" groups:"apps" `
-	AppIdList                     []string               `json:"appServers" groups:"web"`
-	Proxies                       proxyList              `json:"proxies" groups:"apps"`
-	ProxyIdList                   []string               `json:"proxyServers" groups:"web"`
-	FailoverCtr                   int                    `json:"failoverCounter" groups:"web"`
-	FailoverTs                    int64                  `json:"failoverLastTime" groups:"web"`
-	Status                        string                 `json:"activePassiveStatus" groups:"web"`
-	IsSplitBrain                  bool                   `json:"isSplitBrain" groups:"web"`
-	IsSplitBrainBck               bool                   `json:"-"`
-	SplitBrainStartTs             int64                  `json:"splitBrainStartTs" groups:"web"` // unix ts when the current/last split brain began; used to filter a peer crash to THIS split
+	OsUser            *user.User `json:"-"`
+	Name              string     `json:"name" groups:"apps,web"`
+	Tenant            string     `json:"tenant" groups:"web"`
+	WorkingDir        string     `json:"workingDir" groups:"web"`
+	Servers           serverList `json:"servers" groups:"apps"`
+	LogSlaveServers   []string   `json:"logSlaveServers" groups:"web" ` //To store slave with log-slave-updates
+	ServerIdList      []string   `json:"dbServers" groups:"web"`
+	Crashes           crashList  `json:"dbServersCrashes" groups:"web"` //This will be purged on all db node up
+	FailoverHistory   crashList  `json:"failoverHistory" groups:"web"`  //This will be used for PITR
+	Apps              appList    `json:"apps" groups:"apps" `
+	AppIdList         []string   `json:"appServers" groups:"web"`
+	Proxies           proxyList  `json:"proxies" groups:"apps"`
+	ProxyIdList       []string   `json:"proxyServers" groups:"web"`
+	FailoverCtr       int        `json:"failoverCounter" groups:"web"`
+	FailoverTs        int64      `json:"failoverLastTime" groups:"web"`
+	Status            string     `json:"activePassiveStatus" groups:"web"`
+	IsSplitBrain      bool       `json:"isSplitBrain" groups:"web"`
+	IsSplitBrainBck   bool       `json:"-"`
+	SplitBrainStartTs int64      `json:"splitBrainStartTs" groups:"web"` // unix ts when the current/last split brain began; used to filter a peer crash to THIS split
 
-	injectTrafficTableReady       map[string]bool        `json:"-"` // dml marker schema created once per proxy target
-	IsFailedArbitrator            bool                   `json:"isFailedArbitrator" groups:"web"`
-	IsLostMajority                bool                   `json:"isLostMajority" groups:"web"`
-	IsDown                        bool                   `json:"isDown" groups:"web"`
-	IsClusterDown                 bool                   `json:"isClusterDown" groups:"web"`
-	IsMasterDown                  bool                   `json:"isMasterDown" groups:"web"`
-	IsAllDbUp                     bool                   `json:"isAllDbUp" groups:"web"`
-	IsFailable                    bool                   `json:"isFailable" groups:"web"`
-	IsPostgres                    bool                   `json:"isPostgres" groups:"web"`
-	IsProvision                   bool                   `json:"isProvision" groups:"web"`
-	IsNeedProxiesRestart          bool                   `json:"isNeedProxiesRestart" groups:"web"`
-	IsNeedProxiesReprov           bool                   `json:"isNeedProxiesReprov" groups:"web"`
-	IsNeedProxiesConfigChange     bool                   `json:"isNeedProxiesConfigChange" groups:"web"`
-	IsNeedDatabasesRestart        bool                   `json:"isNeedDatabasesRestart" groups:"web"`
-	IsNeedDatabasesRollingRestart bool                   `json:"isNeedDatabasesRollingRestart" groups:"web"`
-	IsNeedDatabasesRollingReprov  bool                   `json:"isNeedDatabasesRollingReprov" groups:"web"`
-	IsNeedDatabasesReprov         bool                   `json:"isNeedDatabasesReprov" groups:"web"`
-	IsNeedDatabasesConfigChange   bool                   `json:"isNeedDatabasesConfigChange" groups:"web"`
-	IsNeedAppsReprov              bool                   `json:"isNeedAppsReprov" groups:"web"`
-	IsGettingSlowLog              bool                   `json:"isGettingSlowLog" groups:"web"`
-	IsValidBackup                 bool                   `json:"isValidBackup" groups:"web"`
-	IsValidRejoinBackupLogical    bool                   `json:"isValidRejoinBackupLogical" groups:"web"`
-	IsValidRejoinBackupPhysical   bool                   `json:"isValidRejoinBackupPhysical" groups:"web"`
-	IsNotMonitoring               bool                   `json:"isNotMonitoring" groups:"web"`
-	HaveSSHKeyChecked             bool                   `json:"-"`
-	IsCapturing                   bool                   `json:"isCapturing" groups:"web"`
-	IsGitPull                     bool                   `json:"isGitPull" groups:"web"`
-	IsGitPush                     bool                   `json:"isGitPush" groups:"web"`
-	IsSavingConfig                bool                   `json:"-"`
-	IsNeedGitPush                 bool                   `json:"-"`
-	IsNeedConfigSave              bool                   `json:"-"` // event flag: Save() sets it, the repman config-sync gate consumes it and runs SaveCallBack
-	IsExportPush                  bool                   `json:"isExportPush" groups:"web"`
-	IsAlertDisable                bool                   `json:"isAlertDisable" groups:"web"`
-	IsIntervention                bool                   `json:"isIntervention" groups:"web"`
-	InterventionCurrent           *InterventionEntry     `json:"interventionCurrent,omitempty" groups:"web"`
-	InterventionHistory           []InterventionEntry    `json:"interventionHistory" groups:"web"`
-	InterventionSuppressedAlerts  int                    `json:"interventionSuppressedAlerts" groups:"web"`
-	InterventionPending           *InterventionEntry     `json:"interventionPending,omitempty" groups:"web"`
-	IsRefreshStaging              bool                   `json:"isRefreshStaging" groups:"web"`
-	IsNeedStagingChange           bool                   `json:"isNeedStagingChange" groups:"web"`
-	IsConfigPathChange            bool                   `json:"isConfigPathChange" groups:"web"`
-	IsResticQueuePaused           bool                   `json:"isResticQueuePaused" groups:"web"`
-	BackupSlotsInUse              int                    `json:"backupSlotsInUse" groups:"web"`
-	BackupSlotsTotal              int                    `json:"backupSlotsTotal" groups:"web"`
-	SchemaMonitorRequested        int32                  `json:"-"`
-	Conf                          *config.Config         `json:"config" groups:"apps"`
-	Confs                         *config.ConfVersion    `json:"-"`
-	CleanAll                      bool                   `json:"cleanReplication" groups:"web"` //used in testing
-	Topology                      string                 `json:"topology" groups:"web"`
-	Uptime                        string                 `json:"uptime" groups:"web"`
-	UptimeFailable                string                 `json:"uptimeFailable" groups:"web"`
-	UptimeSemiSync                string                 `json:"uptimeSemisync" groups:"web"`
-	MonitorSpin                   string                 `json:"monitorSpin" groups:"web"`
-	WorkLoad                      config.WorkLoad        `json:"workLoad" groups:"web"`
-	DockerRepos                   []config.DockerRepo    `json:"-"`
-	Logrus                        *log.Logger            `json:"-"`
-	LogPushover                   *log.Logger            `json:"-"`
-	Log                           s18log.HttpLog         `json:"-" groups:"web"`
-	LogTask                       s18log.HttpLog         `json:"-" groups:"web"`
-	LogSecurity                   s18log.HttpLog         `json:"-" groups:"web"`
-	LogWorkload                   s18log.HttpLog         `json:"-" groups:"web"`
-	LogDDL                        s18log.HttpLog         `json:"-" groups:"web"`
-	LogVariableChange             s18log.HttpLog         `json:"-" groups:"web"`
+	injectTrafficTableReady       map[string]bool     `json:"-"` // dml marker schema created once per proxy target
+	IsFailedArbitrator            bool                `json:"isFailedArbitrator" groups:"web"`
+	IsLostMajority                bool                `json:"isLostMajority" groups:"web"`
+	IsDown                        bool                `json:"isDown" groups:"web"`
+	IsClusterDown                 bool                `json:"isClusterDown" groups:"web"`
+	IsMasterDown                  bool                `json:"isMasterDown" groups:"web"`
+	IsAllDbUp                     bool                `json:"isAllDbUp" groups:"web"`
+	IsFailable                    bool                `json:"isFailable" groups:"web"`
+	IsPostgres                    bool                `json:"isPostgres" groups:"web"`
+	IsProvision                   bool                `json:"isProvision" groups:"web"`
+	IsNeedProxiesRestart          bool                `json:"isNeedProxiesRestart" groups:"web"`
+	IsNeedProxiesReprov           bool                `json:"isNeedProxiesReprov" groups:"web"`
+	IsNeedProxiesConfigChange     bool                `json:"isNeedProxiesConfigChange" groups:"web"`
+	IsNeedDatabasesRestart        bool                `json:"isNeedDatabasesRestart" groups:"web"`
+	IsNeedDatabasesRollingRestart bool                `json:"isNeedDatabasesRollingRestart" groups:"web"`
+	IsNeedDatabasesRollingReprov  bool                `json:"isNeedDatabasesRollingReprov" groups:"web"`
+	IsNeedDatabasesReprov         bool                `json:"isNeedDatabasesReprov" groups:"web"`
+	IsNeedDatabasesConfigChange   bool                `json:"isNeedDatabasesConfigChange" groups:"web"`
+	IsNeedAppsReprov              bool                `json:"isNeedAppsReprov" groups:"web"`
+	IsGettingSlowLog              bool                `json:"isGettingSlowLog" groups:"web"`
+	IsValidBackup                 bool                `json:"isValidBackup" groups:"web"`
+	IsValidRejoinBackupLogical    bool                `json:"isValidRejoinBackupLogical" groups:"web"`
+	IsValidRejoinBackupPhysical   bool                `json:"isValidRejoinBackupPhysical" groups:"web"`
+	IsNotMonitoring               bool                `json:"isNotMonitoring" groups:"web"`
+	HaveSSHKeyChecked             bool                `json:"-"`
+	IsCapturing                   bool                `json:"isCapturing" groups:"web"`
+	IsGitPull                     bool                `json:"isGitPull" groups:"web"`
+	IsGitPush                     bool                `json:"isGitPush" groups:"web"`
+	IsSavingConfig                bool                `json:"-"`
+	IsNeedGitPush                 bool                `json:"-"`
+	IsNeedConfigSave              bool                `json:"-"` // event flag: Save() sets it, the repman config-sync gate consumes it and runs SaveCallBack
+	IsExportPush                  bool                `json:"isExportPush" groups:"web"`
+	IsAlertDisable                bool                `json:"isAlertDisable" groups:"web"`
+	IsIntervention                bool                `json:"isIntervention" groups:"web"`
+	InterventionCurrent           *InterventionEntry  `json:"interventionCurrent,omitempty" groups:"web"`
+	InterventionHistory           []InterventionEntry `json:"interventionHistory" groups:"web"`
+	InterventionSuppressedAlerts  int                 `json:"interventionSuppressedAlerts" groups:"web"`
+	InterventionPending           *InterventionEntry  `json:"interventionPending,omitempty" groups:"web"`
+	IsRefreshStaging              bool                `json:"isRefreshStaging" groups:"web"`
+	IsNeedStagingChange           bool                `json:"isNeedStagingChange" groups:"web"`
+	IsConfigPathChange            bool                `json:"isConfigPathChange" groups:"web"`
+	IsResticQueuePaused           bool                `json:"isResticQueuePaused" groups:"web"`
+	BackupSlotsInUse              int                 `json:"backupSlotsInUse" groups:"web"`
+	BackupSlotsTotal              int                 `json:"backupSlotsTotal" groups:"web"`
+	SchemaMonitorRequested        int32               `json:"-"`
+	Conf                          *config.Config      `json:"config" groups:"apps"`
+	Confs                         *config.ConfVersion `json:"-"`
+	CleanAll                      bool                `json:"cleanReplication" groups:"web"` //used in testing
+	Topology                      string              `json:"topology" groups:"web"`
+	Uptime                        string              `json:"uptime" groups:"web"`
+	UptimeFailable                string              `json:"uptimeFailable" groups:"web"`
+	UptimeSemiSync                string              `json:"uptimeSemisync" groups:"web"`
+	MonitorSpin                   string              `json:"monitorSpin" groups:"web"`
+	WorkLoad                      config.WorkLoad     `json:"workLoad" groups:"web"`
+	DockerRepos                   []config.DockerRepo `json:"-"`
+	Logrus                        *log.Logger         `json:"-"`
+	LogPushover                   *log.Logger         `json:"-"`
+	Log                           s18log.HttpLog      `json:"-" groups:"web"`
+	LogTask                       s18log.HttpLog      `json:"-" groups:"web"`
+	LogSecurity                   s18log.HttpLog      `json:"-" groups:"web"`
+	LogWorkload                   s18log.HttpLog      `json:"-" groups:"web"`
+	LogDDL                        s18log.HttpLog      `json:"-" groups:"web"`
+	LogVariableChange             s18log.HttpLog      `json:"-" groups:"web"`
 	// LogSchema is a dedicated rotating buffer for schema advisory findings, mirrors LogSecurity/LogWorkload.
-	LogSchema s18log.HttpLog `json:"-" groups:"web"`
-	LogSlack                      *slackman.SlackManager `json:"-"`
-	JobResults                    *config.TasksMap       `json:"jobResults" groups:"web"`
-	FalsePositiveChecks           map[string]bool        `json:"falsePositiveChecks" groups:"web"`
-	Grants                        map[string]string      `json:"-"`
-	Roles                         map[string]string      `json:"-"`
-	tlog                          *s18log.TermLog        `json:"-"`
-	htlog                         *s18log.HttpLog        `json:"-"`
-	SQLGeneralLog                 s18log.HttpLog         `json:"sqlGeneralLog" groups:"web"`
-	SQLErrorLog                   s18log.HttpLog         `json:"sqlErrorLog" groups:"web"`
-	MonitorType                   map[string]string      `json:"monitorType" groups:"web"`
-	TopologyType                  map[string]string      `json:"topologyType" groups:"web"`
-	FSType                        map[string]bool        `json:"fsType" groups:"web"`
-	DiskType                      map[string]string      `json:"diskType" groups:"web"`
-	VMType                        map[string]bool        `json:"vmType" groups:"web"`
-	AppS3Providers                []string               `json:"appS3Providers" groups:"web"`
-	GatewayConflicts              map[string]string      `json:"gatewayConflicts" groups:"web"`
+	LogSchema           s18log.HttpLog         `json:"-" groups:"web"`
+	LogSlack            *slackman.SlackManager `json:"-"`
+	JobResults          *config.TasksMap       `json:"jobResults" groups:"web"`
+	FalsePositiveChecks map[string]bool        `json:"falsePositiveChecks" groups:"web"`
+	Grants              map[string]string      `json:"-"`
+	Roles               map[string]string      `json:"-"`
+	tlog                *s18log.TermLog        `json:"-"`
+	htlog               *s18log.HttpLog        `json:"-"`
+	SQLGeneralLog       s18log.HttpLog         `json:"sqlGeneralLog" groups:"web"`
+	SQLErrorLog         s18log.HttpLog         `json:"sqlErrorLog" groups:"web"`
+	MonitorType         map[string]string      `json:"monitorType" groups:"web"`
+	TopologyType        map[string]string      `json:"topologyType" groups:"web"`
+	FSType              map[string]bool        `json:"fsType" groups:"web"`
+	DiskType            map[string]string      `json:"diskType" groups:"web"`
+	VMType              map[string]bool        `json:"vmType" groups:"web"`
+	AppS3Providers      []string               `json:"appS3Providers" groups:"web"`
+	GatewayConflicts    map[string]string      `json:"gatewayConflicts" groups:"web"`
 	// s3Providers groups S3 provider state and locking primitives in one place.
 	// Use the accessor methods (Add/Remove/Update/GetS3ProvidersSnapshot) and
 	// CRUD transaction lock helpers instead of direct field mutation.
@@ -200,7 +200,7 @@ type Cluster struct {
 	// sb*FailUntil (unix seconds) sever this cluster's individual links on
 	// this instance for split-brain testing — see cluster_splitbrain_simulator.go. Runtime
 	// state only, never persisted.
-	sbDatabaseFailUntil         int64 `json:"-"`
+	sbDatabaseFailUntil   int64 `json:"-"`
 	sbArbitratorFailUntil int64 `json:"-"`
 	sbMasterFailUntil     int64 `json:"-"`
 	// sbMasterFailURL pins the sim master-cut to the server that was master when
@@ -393,9 +393,26 @@ type Cluster struct {
 	s3SyncApplyMu               sync.Mutex                 `json:"-"`
 	appListEpoch                uint64                     `json:"-"`
 	// appListRebuildMu serializes newAppList() (held internally, see app.go).
-	appListRebuildMu sync.Mutex `json:"-"`
-	secretVersionStoreMu        sync.Mutex                 `json:"-"`
-	secretVersionStoreDirty     bool                       `json:"-"`
+	appListRebuildMu        sync.Mutex `json:"-"`
+	secretVersionStoreMu    sync.Mutex `json:"-"`
+	secretVersionStoreDirty bool       `json:"-"`
+	// reloadMu serializes Run()'s per-tick synchronous work (topology
+	// discovery, the wg-joined Phase 1/2/3 monitoring work) against
+	// ReloadConfig() rebuilding Conf/state machines/Servers out from under
+	// it. It is a dedicated mutex, not the embedded sync.Mutex Lock()/
+	// Unlock() used throughout this file for short field accesses -- those
+	// are called from within a tick's own work, so reusing the embedded
+	// mutex here (held for a whole tick) would self-deadlock on the first
+	// nested Lock() call. Held only in Run() and ReloadConfig(); do not
+	// acquire it anywhere else.
+	reloadMu sync.Mutex `json:"-"`
+	// tickWG tracks tickBody's genuinely fire-and-forget goroutines (spawned
+	// via trackTickGoroutine) -- the handful not already joined by a local
+	// wg.Wait() within the same tick. ReloadConfig() waits on it (while
+	// holding reloadMu, so no new tick can add to it concurrently) so a
+	// reload never rebuilds Conf/Servers/state machines while one of these
+	// is still reading/writing them.
+	tickWG sync.WaitGroup `json:"-"`
 	// pluginSpikeCache holds the last DetectSpike result per server+plugin pair.
 	// Keyed as "serverURL:pluginName". Prevents graphite HTTP on every tick.
 	pluginSpikeCache map[string]*logplugin.SpikeCache `json:"-"`
@@ -420,7 +437,7 @@ type Cluster struct {
 	// rebuilt when the schema monitor refreshes the table dictionary.
 	schemaWireTables []logplugin.StdioTable `json:"-"`
 	schemaWireLock   sync.RWMutex           `json:"-"`
-	initiated             bool
+	initiated        bool
 }
 
 // PluginRegistry returns the per-cluster plugin registry, which contains both
@@ -877,8 +894,8 @@ var pstates30 = []string{
 	"WARN0093", "WARN0134", "WARN0145", // Restic related
 	"WARN0101", "WARN0111", "WARN0112", // Backup related
 	"WARN0141", "WARN0142", "WARN0143", "WARN0150", "WARN0151", // Tresholds
-	"WARN0153",             // Job related
-	"WARN0158",             // Job secrets mismatch
+	"WARN0153", // Job related
+	"WARN0158", // Job secrets mismatch
 	"CREDIT01", // Credit related
 }
 
@@ -905,233 +922,15 @@ func (cluster *Cluster) Run() {
 
 	for !cluster.exit.Load() {
 		if !cluster.Conf.MonitorPause {
-			cluster.ReconcileSecretVersionStore()
-			cluster.ServerIdList = cluster.GetDBServerIdList()
-			cluster.ProxyIdList = cluster.GetProxyServerIdList()
-			cluster.AppIdList = cluster.GetAppServerIdList()
-			if cluster.ResticManager != nil {
-				cluster.IsResticQueuePaused = cluster.ResticManager.IsPaused()
-			}
-			if cluster.ServerGlobals != nil && cluster.ServerGlobals.BackupSemaphore != nil {
-				cluster.BackupSlotsInUse = len(cluster.ServerGlobals.BackupSemaphore)
-				cluster.BackupSlotsTotal = cap(cluster.ServerGlobals.BackupSemaphore)
-			}
-			go cluster.CheckDefaultUser(false)
-
-			if cluster.HasBadConfigMeasurement() {
-				cluster.SetState("WARN0135", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0135"], cluster.ErrorConfigs), ErrFrom: "CONFIG"})
-			}
-
-			select {
-			case sig := <-cluster.switchoverChan:
-				if sig {
-					if cluster.Status == "A" {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Signaling Switchover...")
-						cluster.MasterFailover(false)
-						cluster.switchoverCond.Send <- true
-					} else {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Not in active mode, cancel switchover %s", cluster.Status)
-					}
-				}
-
-			default:
-				if cluster.Conf.LogLevel > 2 {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Monitoring server loop")
-					if len(cluster.Servers) > 0 {
-						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Servers not nil : %v\n", cluster.Servers)
-						for k, v := range cluster.Servers {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Servers loops k : %d, url : %s, state : %s, prevstate %s", k, v.URL, v.State, v.PrevState)
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Server [%d]: URL: %-15s State: %6s PrevState: %6s", k, v.URL, v.State, v.PrevState)
-						}
-						if m := cluster.GetMaster(); m != nil {
-							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Master [ ]: URL: %-15s State: %6s PrevState: %6s", m.URL, m.State, m.PrevState)
-							for k, v := range cluster.slaves {
-								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Slave  [%d]: URL: %-15s State: %6s PrevState: %6s", k, v.URL, v.State, v.PrevState)
-							}
-						}
-					}
-				}
-				// Phase 1: topology discovery must complete before anything reads Servers
-				wg := new(sync.WaitGroup)
-				wg.Add(1)
-				go cluster.TopologyDiscover(wg)
-				wg.Wait()
-
-				cluster.CheckInterventionSchedule()
-
-				if cluster.runOnceAfterTopology {
-					if !cluster.IsInFailover() {
-						cluster.initProxies()
-					}
-					go cluster.initOrchetratorNodes()
-					go cluster.ResticFetchRepo()
-					cluster.SetRollingJobsUpgradeState()
-					cluster.CleanupRestartCookies()
-					cluster.ReloadLogPlugins()
-					if master := cluster.GetMaster(); master != nil {
-						cachedTables := master.DictTables.ToNewMap()
-						if len(cachedTables) == 0 {
-							go cluster.MonitorSchema()
-						} else {
-							var tottablesize, totindexsize int64
-							for _, t := range cachedTables {
-								tottablesize += t.DataLength
-								totindexsize += t.IndexLength
-							}
-							cluster.WorkLoad.DBTableSize = tottablesize
-							cluster.WorkLoad.DBIndexSize = totindexsize
-						}
-					}
-					cluster.runOnceAfterTopology = false
-				} else {
-
-					if !cluster.IsInFailover() {
-						goRun := func(fn func()) {
-							wg.Add(1)
-							go func() {
-								defer wg.Done()
-								fn()
-							}()
-						}
-						heartbeats := cluster.StateMachine.GetHeartbeats()
-
-						// Fire-and-forget: long-running, no synchronization needed
-						if cluster.Conf.MdbsProxyOn {
-							go cluster.MonitorSchema()
-						}
-						if heartbeats%30 == 0 {
-							go cluster.initOrchetratorNodes()
-							go cluster.CheckCredentialRotation()
-						}
-						if heartbeats%3600 == 0 {
-							go cluster.RefreshAllAppTemplateMD5()
-						}
-						if cluster.Conf.BackupReconcileInterval > 0 && heartbeats%int64(cluster.Conf.BackupReconcileInterval) == 0 {
-							cluster.ReconcileSnapshotMetadataAsync()
-						}
-
-						// Phase 2: parallel reads of stable topology — Phase 3 depends on these
-						goRun(cluster.ArbitratorHandler)
-						wg.Add(2)
-						go cluster.refreshProxies(wg)
-						go cluster.refreshApps(wg)
-						if heartbeats%10 == 0 {
-							goRun(cluster.MonitorTableSchemaDiff)
-						}
-						if heartbeats%30 == 0 {
-							goRun(cluster.ResticFetchRepo)
-							goRun(cluster.MonitorVariablesDiff)
-							goRun(cluster.MonitorVariablesChange)
-						}
-						wg.Wait()
-
-						// Phase 3: parallel — depends on Phase 2, independent of each other
-						if heartbeats%30 == 0 {
-							goRun(cluster.MonitorQueryRules)
-						}
-						if cluster.Conf.TestInjectTraffic || cluster.Conf.TestInjectTrafficStaging || cluster.Conf.AutorejoinSlavePositionalHeartbeat || cluster.Conf.MonitorWriteHeartbeat {
-							goRun(cluster.InjectProxiesTraffic)
-						}
-						if heartbeats%3600 == 0 {
-							goRun(func() { cluster.ResticPurgeRepo(false) })
-							goRun(cluster.RefreshToolVersions)
-							goRun(cluster.CheckBackupToolVersions)
-							goRun(cluster.CheckComplianceUpdate)
-							goRun(cluster.ReloadDockerRepos)
-						}
-						goRun(cluster.CheckAppsCredit)
-						goRun(cluster.CheckWaitRunJobSSH)
-						goRun(cluster.CheckDummyConfigSendCookies)
-						goRun(cluster.CheckRestartContainerCookies)
-						goRun(cluster.PrintDelayStat)
-						if cluster.SlavesOldestMasterFile.Suffix == 0 {
-							goRun(cluster.CheckSlavesReplicationsPurge)
-						}
-						if heartbeats%10 == 0 {
-							goRun(cluster.CheckJobsVersion)
-						}
-						if heartbeats%30 == 0 {
-							goRun(func() { cluster.IsValidBackup = cluster.HasValidBackup() })
-							goRun(func() { cluster.HasCatalogBackupForRejoin() })
-							goRun(cluster.CheckCanSaveDynamicConfig)
-							goRun(cluster.CheckIsOverwrite)
-							goRun(cluster.CheckAllBackupEstimatedSize)
-							goRun(cluster.CheckAvailableCredit)
-							goRun(cluster.CheckOpenSVCTresholds)
-							goRun(cluster.JobsCheckSchedulerTable)
-							goRun(cluster.CheckOnPremiseSSHKey)
-							goRun(cluster.CheckOnPremiseSSHConnect)
-							goRun(cluster.CheckConfiguratorPrerequisites)
-							goRun(cluster.CheckGlobalDeprecatedKeys)
-							goRun(cluster.CheckClusterDeprecatedKeys)
-							goRun(cluster.CheckClusterServiceAgents)
-						}
-						if cluster.Conf.GraphiteMetrics && heartbeats%5 == 0 {
-							goRun(func() { cluster.SendGraphiteMetrics() })
-							goRun(cluster.CheckDisksUsage)
-						}
-						wg.Wait()
-
-						// PreserveState for non-running ticks (fast, no I/O)
-						if heartbeats%10 != 0 {
-							cluster.StateMachine.PreserveState("WARN0147")
-							cluster.SchemaStateMachine.PreserveState("WARN0164")
-						}
-						if heartbeats%30 != 0 {
-							cluster.StateMachine.PreserveState(pstates30...)
-							cluster.ConfigStateMachine.PreserveState("WARN0159", "WARN0160", "WARN0178")
-						}
-						if heartbeats%3600 != 0 {
-							cluster.StateMachine.PreserveState(pstates3600...)
-							cluster.ConfigStateMachine.PreserveState("WARN0168")
-						}
-						if !(cluster.Conf.GraphiteMetrics && heartbeats%5 == 0) {
-							cluster.StateMachine.PreserveState("WARN0139", "WARN0140")
-						}
-						if !cluster.CanInitNodes {
-							cluster.SetState("ERR00082", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00082"], cluster.errorInitNodes), ErrFrom: "OPENSVC"})
-						}
-						if !cluster.CanConnectVault {
-							cluster.SetState("ERR00089", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00089"], cluster.errorConnectVault), ErrFrom: "OPENSVC"})
-						}
-					} else {
-						cluster.StateMachine.PreserveState("ERR00100")
-					}
-				}
-
-				cluster.EmitAppErrors()
-
-				if cluster.HasDiscoverTopologyMismatchTarget() {
-					cluster.SetState("ERR00092", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00092"], cluster.Name, cluster.Topology, cluster.Conf.TopologyTarget), ErrFrom: "TOPO"})
-				}
-
-				// AddChildServers can't be done before TopologyDiscover but need a refresh aquiring more fresh gtid vs current cluster so election win but server is ignored see electFailoverCandidate
-				err := cluster.AddChildServers()
-
-				if err != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Fail of AddChildServers %s", err)
-				}
-
-				cluster.IsFailable = cluster.GetStatus()
-				cluster.IsMasterDown = cluster.GetMaster() == nil || cluster.GetMaster().IsFailed()
-				cluster.CheckDBCredentials()
-				// Run generic log-tailer plugin checks (errorlog / sqlerrorlog / slowlog 24h)
-				cluster.CheckLogPlugins()
-				// CheckFailed trigger failover code if passing all false positiv and constraints
-				cluster.CheckFailed()
-				// Run any operator-armed rejoin (GUI delta viewer) — independent of
-				// Conf.Autorejoin and the Failed->up edge, so a manual rejoin actually
-				// executes even with auto-rejoin off.
-				cluster.ProcessArmedRejoins()
-				cluster.IsConfigPathChange = cluster.HasConfigPathChanged()
-				cluster.SetStatus()
-				cluster.CheckBackupStates()
-				cluster.CheckResticErrors()
-				cluster.CheckPluginRejectionStates()
-				cluster.StateProcessing()
-				cluster.CheckHasFailCertLoadP12()
-				go cluster.GetSlowLogTable() // prevent blocking cycle
-			}
+			// See reloadMu's declaration: serializes this tick's synchronous
+			// work against a concurrent ReloadConfig() rebuild. Wrapped in a
+			// func() purely so a panic anywhere in the tick still releases
+			// the lock via defer -- the body itself is untouched.
+			cluster.reloadMu.Lock()
+			func() {
+				defer cluster.reloadMu.Unlock()
+				cluster.tickBody()
+			}()
 		}
 
 		if cluster.clog != nil {
@@ -1143,6 +942,252 @@ func (cluster *Cluster) Run() {
 
 		time.Sleep(interval * time.Duration(cluster.Conf.MonitoringTicker))
 
+	}
+}
+
+// trackTickGoroutine launches fn in a goroutine tracked by tickWG. Use it for
+// a tick's genuinely fire-and-forget spawns -- ones not already joined by a
+// local sync.WaitGroup within the same tick (e.g. the wg/goRun-based Phase
+// 1/2/3 work already is). See tickWG's declaration for why this matters for
+// reload safety.
+func (cluster *Cluster) trackTickGoroutine(fn func()) {
+	cluster.tickWG.Add(1)
+	go func() {
+		defer cluster.tickWG.Done()
+		fn()
+	}()
+}
+
+// tickBody is Run()'s per-iteration monitoring work, extracted only so
+// reloadMu can wrap it with a plain defer (see Run()) without reformatting
+// the ~225-line body itself.
+func (cluster *Cluster) tickBody() {
+	cluster.ReconcileSecretVersionStore()
+	cluster.ServerIdList = cluster.GetDBServerIdList()
+	cluster.ProxyIdList = cluster.GetProxyServerIdList()
+	cluster.AppIdList = cluster.GetAppServerIdList()
+	if cluster.ResticManager != nil {
+		cluster.IsResticQueuePaused = cluster.ResticManager.IsPaused()
+	}
+	if cluster.ServerGlobals != nil && cluster.ServerGlobals.BackupSemaphore != nil {
+		cluster.BackupSlotsInUse = len(cluster.ServerGlobals.BackupSemaphore)
+		cluster.BackupSlotsTotal = cap(cluster.ServerGlobals.BackupSemaphore)
+	}
+	cluster.trackTickGoroutine(func() { cluster.CheckDefaultUser(false) })
+
+	if cluster.HasBadConfigMeasurement() {
+		cluster.SetState("WARN0135", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0135"], cluster.ErrorConfigs), ErrFrom: "CONFIG"})
+	}
+
+	select {
+	case sig := <-cluster.switchoverChan:
+		if sig {
+			if cluster.Status == "A" {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Signaling Switchover...")
+				cluster.MasterFailover(false)
+				cluster.switchoverCond.Send <- true
+			} else {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Not in active mode, cancel switchover %s", cluster.Status)
+			}
+		}
+
+	default:
+		if cluster.Conf.LogLevel > 2 {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Monitoring server loop")
+			if len(cluster.Servers) > 0 {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Servers not nil : %v\n", cluster.Servers)
+				for k, v := range cluster.Servers {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Servers loops k : %d, url : %s, state : %s, prevstate %s", k, v.URL, v.State, v.PrevState)
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Server [%d]: URL: %-15s State: %6s PrevState: %6s", k, v.URL, v.State, v.PrevState)
+				}
+				if m := cluster.GetMaster(); m != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Master [ ]: URL: %-15s State: %6s PrevState: %6s", m.URL, m.State, m.PrevState)
+					for k, v := range cluster.slaves {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Slave  [%d]: URL: %-15s State: %6s PrevState: %6s", k, v.URL, v.State, v.PrevState)
+					}
+				}
+			}
+		}
+		// Phase 1: topology discovery must complete before anything reads Servers
+		wg := new(sync.WaitGroup)
+		wg.Add(1)
+		go cluster.TopologyDiscover(wg)
+		wg.Wait()
+
+		cluster.CheckInterventionSchedule()
+
+		if cluster.runOnceAfterTopology {
+			if !cluster.IsInFailover() {
+				cluster.initProxies()
+			}
+			cluster.trackTickGoroutine(cluster.initOrchetratorNodes)
+			cluster.trackTickGoroutine(cluster.ResticFetchRepo)
+			cluster.SetRollingJobsUpgradeState()
+			cluster.CleanupRestartCookies()
+			cluster.ReloadLogPlugins()
+			if master := cluster.GetMaster(); master != nil {
+				cachedTables := master.DictTables.ToNewMap()
+				if len(cachedTables) == 0 {
+					cluster.trackTickGoroutine(cluster.MonitorSchema)
+				} else {
+					var tottablesize, totindexsize int64
+					for _, t := range cachedTables {
+						tottablesize += t.DataLength
+						totindexsize += t.IndexLength
+					}
+					cluster.WorkLoad.DBTableSize = tottablesize
+					cluster.WorkLoad.DBIndexSize = totindexsize
+				}
+			}
+			cluster.runOnceAfterTopology = false
+		} else {
+
+			if !cluster.IsInFailover() {
+				goRun := func(fn func()) {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						fn()
+					}()
+				}
+				heartbeats := cluster.StateMachine.GetHeartbeats()
+
+				// Fire-and-forget: long-running, no synchronization needed
+				if cluster.Conf.MdbsProxyOn {
+					cluster.trackTickGoroutine(cluster.MonitorSchema)
+				}
+				if heartbeats%30 == 0 {
+					cluster.trackTickGoroutine(cluster.initOrchetratorNodes)
+					cluster.trackTickGoroutine(cluster.CheckCredentialRotation)
+				}
+				if heartbeats%3600 == 0 {
+					cluster.trackTickGoroutine(cluster.RefreshAllAppTemplateMD5)
+				}
+				if cluster.Conf.BackupReconcileInterval > 0 && heartbeats%int64(cluster.Conf.BackupReconcileInterval) == 0 {
+					cluster.ReconcileSnapshotMetadataAsync()
+				}
+
+				// Phase 2: parallel reads of stable topology — Phase 3 depends on these
+				goRun(cluster.ArbitratorHandler)
+				wg.Add(2)
+				go cluster.refreshProxies(wg)
+				go cluster.refreshApps(wg)
+				if heartbeats%10 == 0 {
+					goRun(cluster.MonitorTableSchemaDiff)
+				}
+				if heartbeats%30 == 0 {
+					goRun(cluster.ResticFetchRepo)
+					goRun(cluster.MonitorVariablesDiff)
+					goRun(cluster.MonitorVariablesChange)
+				}
+				wg.Wait()
+
+				// Phase 3: parallel — depends on Phase 2, independent of each other
+				if heartbeats%30 == 0 {
+					goRun(cluster.MonitorQueryRules)
+				}
+				if cluster.Conf.TestInjectTraffic || cluster.Conf.TestInjectTrafficStaging || cluster.Conf.AutorejoinSlavePositionalHeartbeat || cluster.Conf.MonitorWriteHeartbeat {
+					goRun(cluster.InjectProxiesTraffic)
+				}
+				if heartbeats%3600 == 0 {
+					goRun(func() { cluster.ResticPurgeRepo(false) })
+					goRun(cluster.RefreshToolVersions)
+					goRun(cluster.CheckBackupToolVersions)
+					goRun(cluster.CheckComplianceUpdate)
+					goRun(cluster.ReloadDockerRepos)
+				}
+				goRun(cluster.CheckAppsCredit)
+				goRun(cluster.CheckWaitRunJobSSH)
+				goRun(cluster.CheckDummyConfigSendCookies)
+				goRun(cluster.CheckRestartContainerCookies)
+				goRun(cluster.PrintDelayStat)
+				if cluster.SlavesOldestMasterFile.Suffix == 0 {
+					goRun(cluster.CheckSlavesReplicationsPurge)
+				}
+				if heartbeats%10 == 0 {
+					goRun(cluster.CheckJobsVersion)
+				}
+				if heartbeats%30 == 0 {
+					goRun(func() { cluster.IsValidBackup = cluster.HasValidBackup() })
+					goRun(func() { cluster.HasCatalogBackupForRejoin() })
+					goRun(cluster.CheckCanSaveDynamicConfig)
+					goRun(cluster.CheckIsOverwrite)
+					goRun(cluster.CheckAllBackupEstimatedSize)
+					goRun(cluster.CheckAvailableCredit)
+					goRun(cluster.CheckOpenSVCTresholds)
+					goRun(cluster.JobsCheckSchedulerTable)
+					goRun(cluster.CheckOnPremiseSSHKey)
+					goRun(cluster.CheckOnPremiseSSHConnect)
+					goRun(cluster.CheckConfiguratorPrerequisites)
+					goRun(cluster.CheckGlobalDeprecatedKeys)
+					goRun(cluster.CheckClusterDeprecatedKeys)
+					goRun(cluster.CheckClusterServiceAgents)
+				}
+				if cluster.Conf.GraphiteMetrics && heartbeats%5 == 0 {
+					goRun(func() { cluster.SendGraphiteMetrics() })
+					goRun(cluster.CheckDisksUsage)
+				}
+				wg.Wait()
+
+				// PreserveState for non-running ticks (fast, no I/O)
+				if heartbeats%10 != 0 {
+					cluster.StateMachine.PreserveState("WARN0147")
+					cluster.SchemaStateMachine.PreserveState("WARN0164")
+				}
+				if heartbeats%30 != 0 {
+					cluster.StateMachine.PreserveState(pstates30...)
+					cluster.ConfigStateMachine.PreserveState("WARN0159", "WARN0160", "WARN0178")
+				}
+				if heartbeats%3600 != 0 {
+					cluster.StateMachine.PreserveState(pstates3600...)
+					cluster.ConfigStateMachine.PreserveState("WARN0168")
+				}
+				if !(cluster.Conf.GraphiteMetrics && heartbeats%5 == 0) {
+					cluster.StateMachine.PreserveState("WARN0139", "WARN0140")
+				}
+				if !cluster.CanInitNodes {
+					cluster.SetState("ERR00082", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00082"], cluster.errorInitNodes), ErrFrom: "OPENSVC"})
+				}
+				if !cluster.CanConnectVault {
+					cluster.SetState("ERR00089", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00089"], cluster.errorConnectVault), ErrFrom: "OPENSVC"})
+				}
+			} else {
+				cluster.StateMachine.PreserveState("ERR00100")
+			}
+		}
+
+		cluster.EmitAppErrors()
+
+		if cluster.HasDiscoverTopologyMismatchTarget() {
+			cluster.SetState("ERR00092", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00092"], cluster.Name, cluster.Topology, cluster.Conf.TopologyTarget), ErrFrom: "TOPO"})
+		}
+
+		// AddChildServers can't be done before TopologyDiscover but need a refresh aquiring more fresh gtid vs current cluster so election win but server is ignored see electFailoverCandidate
+		err := cluster.AddChildServers()
+
+		if err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlDbg, "Fail of AddChildServers %s", err)
+		}
+
+		cluster.IsFailable = cluster.GetStatus()
+		cluster.IsMasterDown = cluster.GetMaster() == nil || cluster.GetMaster().IsFailed()
+		cluster.CheckDBCredentials()
+		// Run generic log-tailer plugin checks (errorlog / sqlerrorlog / slowlog 24h)
+		cluster.CheckLogPlugins()
+		// CheckFailed trigger failover code if passing all false positiv and constraints
+		cluster.CheckFailed()
+		// Run any operator-armed rejoin (GUI delta viewer) — independent of
+		// Conf.Autorejoin and the Failed->up edge, so a manual rejoin actually
+		// executes even with auto-rejoin off.
+		cluster.ProcessArmedRejoins()
+		cluster.IsConfigPathChange = cluster.HasConfigPathChanged()
+		cluster.SetStatus()
+		cluster.CheckBackupStates()
+		cluster.CheckResticErrors()
+		cluster.CheckPluginRejectionStates()
+		cluster.StateProcessing()
+		cluster.CheckHasFailCertLoadP12()
+		cluster.trackTickGoroutine(cluster.GetSlowLogTable) // prevent blocking cycle
 	}
 }
 
@@ -1212,12 +1257,12 @@ func (cluster *Cluster) StateProcessing() {
 				for _, srv := range cluster.Servers {
 					if srv.HasWaitLogicalBackupCookie() {
 						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Server %s was waiting for logical backup", srv.URL)
-						go func() {
+						cluster.trackTickGoroutine(func() {
 							err := srv.JobReseedLogicalBackup(context.Background(), "default")
 							if err != nil {
 								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Logical reseed on %s error: %s", srv.URL, err.Error())
 							}
-						}()
+						})
 					}
 				}
 			}
@@ -1226,25 +1271,25 @@ func (cluster *Cluster) StateProcessing() {
 				for _, srv := range cluster.Servers {
 					if srv.HasWaitPhysicalBackupCookie() {
 						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Server %s was waiting for physical backup", srv.URL)
-						go func() {
+						cluster.trackTickGoroutine(func() {
 							err := srv.JobReseedPhysicalBackup("default")
 							if err != nil {
 								cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, err.Error())
 							}
-						}()
+						})
 					}
 				}
 			}
 			if s.ErrKey == "WARN0148" && servertoreseed != nil {
-				go servertoreseed.UpgradeJobsScript()
+				cluster.trackTickGoroutine(func() { servertoreseed.UpgradeJobsScript() })
 			}
 
 			if s.ErrKey == "WARN0155" {
-				go cluster.RollingJobsUpgrade()
+				cluster.trackTickGoroutine(func() { cluster.RollingJobsUpgrade() })
 			}
 
 			if s.ErrKey == "WARN0163" {
-				go cluster.MonitorSchema()
+				cluster.trackTickGoroutine(cluster.MonitorSchema)
 			}
 
 			//		cluster.statecloseChan <- s
@@ -1279,7 +1324,8 @@ func (cluster *Cluster) StateProcessing() {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlInfo,
 						"Dequeued restic reseed request for %s snapshot=%s method=%s strategy=%s",
 						server.URL, req.SnapshotID, req.Method, req.Strategy)
-					go func(srv *ServerMonitor, request ResticReseedRequest) {
+					srv, request := server, req
+					cluster.trackTickGoroutine(func() {
 						err := srv.JobReseedFromRestic(request.SnapshotID, request.Method, request.Strategy, request.Options)
 						if err != nil {
 							if srv.HasAnyReseedingState() {
@@ -1297,7 +1343,7 @@ func (cluster *Cluster) StateProcessing() {
 						}
 						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlInfo,
 							"Restic reseed completed for %s snapshot=%s", srv.URL, request.SnapshotID)
-					}(server, req)
+					})
 				}
 			}
 
@@ -2113,6 +2159,19 @@ func (cluster *Cluster) InitAgent(conf config.Config) {
 }
 
 func (cluster *Cluster) ReloadConfig(conf config.Config) {
+	// reloadMu excludes Run()'s tick body (see its declaration) for the
+	// whole rebuild: Conf/state-machine/Servers replacement below is not
+	// safe to run concurrently with a tick's topology discovery or Phase
+	// 1/2/3 monitoring work reading/writing the same fields.
+	cluster.reloadMu.Lock()
+	defer cluster.reloadMu.Unlock()
+
+	// Drain any tick-spawned fire-and-forget goroutines still running from
+	// the tick that just released reloadMu (see tickWG's declaration). Safe
+	// to call here: reloadMu being held blocks Run() from starting a new
+	// tick, so no concurrent Add() can race this Wait().
+	cluster.tickWG.Wait()
+
 	cluster.Lock()
 	*cluster.Conf = conf
 	cluster.Unlock()

--- a/cluster/cluster_bck_meta.go
+++ b/cluster/cluster_bck_meta.go
@@ -1362,7 +1362,7 @@ func (cluster *Cluster) ReconcileSnapshotMetadataAsync() {
 	if !atomic.CompareAndSwapInt32(&cluster.reconcileSnapshotMetadataInProgress, 0, 1) {
 		return
 	}
-	go func() {
+	cluster.trackTickGoroutine(func() {
 		defer atomic.StoreInt32(&cluster.reconcileSnapshotMetadataInProgress, 0)
 		report, err := cluster.ReconcileSnapshotMetadata()
 		if err != nil {
@@ -1375,5 +1375,5 @@ func (cluster *Cluster) ReconcileSnapshotMetadataAsync() {
 		if len(report.OrphanedMetadata) > 0 {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModRestic, config.LvlDbg, "Reconciliation: %d orphaned metadata entries (stale files for deleted snapshots); enable backup-reconcile-auto-cleanup to remove them", len(report.OrphanedMetadata))
 		}
-	}()
+	})
 }

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -5425,7 +5425,7 @@ func (repman *ReplicationManager) handlerMuxSettingsReload(w http.ResponseWriter
 	mycluster := repman.getClusterByName(vars["clusterName"])
 	if mycluster != nil {
 		prevGW := mycluster.Conf.Cloud18GatewayService
-		mycluster.ReloadConfig(repman.Confs[vars["clusterName"]])
+		repman.ReloadClusterConfig(mycluster, vars["clusterName"])
 		repman.RecomputeGatewayConflicts(vars["clusterName"], prevGW)
 	} else {
 		http.Error(w, "Cluster Not Found", http.StatusInternalServerError)

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -5421,11 +5421,14 @@ func (repman *ReplicationManager) handlerMuxTests(w http.ResponseWriter, r *http
 func (repman *ReplicationManager) handlerMuxSettingsReload(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	vars := mux.Vars(r)
-	repman.InitConfig(*repman.Conf, true)
 	mycluster := repman.getClusterByName(vars["clusterName"])
 	if mycluster != nil {
 		prevGW := mycluster.Conf.Cloud18GatewayService
-		repman.ReloadClusterConfig(mycluster, vars["clusterName"])
+		if err := repman.ReloadLiveClusterConfig(mycluster, vars["clusterName"]); err != nil {
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Reload error: %v", err)
+			http.Error(w, "Reload error: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
 		repman.RecomputeGatewayConflicts(vars["clusterName"], prevGW)
 	} else {
 		http.Error(w, "Cluster Not Found", http.StatusInternalServerError)

--- a/server/regtest.go
+++ b/server/regtest.go
@@ -69,7 +69,7 @@ func (repman *ReplicationManager) RunAllTests(cl *cluster.Cluster, testExp strin
 		if testExp == "SUITE" {
 			regtest.CopyConfig(cl, test)
 			repman.InitConfig(*repman.Conf, true)
-			cl.ReloadConfig(repman.Confs["regtest"])
+			repman.ReloadClusterConfig(cl, "regtest")
 			cl = repman.getClusterByName("regtest")
 			if !cl.InitTestCluster(test.ConfigFile, &test) {
 				test.Result = "ERR"

--- a/server/repmanv3.go
+++ b/server/repmanv3.go
@@ -461,9 +461,10 @@ func (s *ReplicationManager) SetActionForClusterSettings(ctx context.Context, in
 		if err = user.Granted(config.GrantClusterSettings); err != nil {
 			return nil, err
 		}
-		s.InitConfig(*s.Conf, true)
 		prevGW := mycluster.Conf.Cloud18GatewayService
-		s.ReloadClusterConfig(mycluster, in.Cluster.Name)
+		if err := s.ReloadLiveClusterConfig(mycluster, in.Cluster.Name); err != nil {
+			return nil, err
+		}
 		s.RecomputeGatewayConflicts(in.Cluster.Name, prevGW)
 
 	case v3.ClusterSetting_ADD_PROXY_TAG:

--- a/server/repmanv3.go
+++ b/server/repmanv3.go
@@ -463,7 +463,7 @@ func (s *ReplicationManager) SetActionForClusterSettings(ctx context.Context, in
 		}
 		s.InitConfig(*s.Conf, true)
 		prevGW := mycluster.Conf.Cloud18GatewayService
-		mycluster.ReloadConfig(s.Confs[in.Cluster.Name])
+		s.ReloadClusterConfig(mycluster, in.Cluster.Name)
 		s.RecomputeGatewayConflicts(in.Cluster.Name, prevGW)
 
 	case v3.ClusterSetting_ADD_PROXY_TAG:

--- a/server/server.go
+++ b/server/server.go
@@ -3089,6 +3089,20 @@ func (repman *ReplicationManager) Run() error {
 
 }
 
+// ReloadClusterConfig applies clusterName's config after repman.InitConfig,
+// re-pointing ImmuableFlagMap/DynamicFlagMap/DefaultFlagMap at the per-cluster
+// maps the way initCluster does at startup -- InitConfig itself leaves them on
+// the global-default maps, which breaks secret decryption. Callers should use
+// this instead of cluster.ReloadConfig directly.
+func (repman *ReplicationManager) ReloadClusterConfig(mycluster *cluster.Cluster, clusterName string) {
+	conf := repman.Confs[clusterName]
+	conf.ImmuableFlagMap = repman.ImmuableFlagMaps[clusterName]
+	conf.DynamicFlagMap = repman.DynamicFlagMaps[clusterName]
+	conf.DefaultFlagMap = repman.DefaultFlagMap
+	repman.Confs[clusterName] = conf
+	mycluster.ReloadConfig(conf)
+}
+
 // initCluster initialises a cluster and registers it in repman.Clusters but
 // does NOT start its monitoring goroutine.  Call go cl.Run() (or StartCluster)
 // separately.  The startup sequence uses initCluster so cross-cluster gateway

--- a/server/server.go
+++ b/server/server.go
@@ -3089,6 +3089,92 @@ func (repman *ReplicationManager) Run() error {
 
 }
 
+// ReconstructLiveClusterConfig rebuilds clusterName's config for a single
+// already-running cluster, scoped to that cluster only. It deliberately does
+// NOT go through InitConfig: InitConfig rediscovers the whole cluster list,
+// rebuilds repman.ClusterList/ImmutableClusterList/ImmuableFlagMaps/
+// DynamicFlagMaps for every cluster, and -- critically -- recomputes
+// WorkingDir from scratch. Its non-root fallback (hasExplicitWorkingDir,
+// see ~line 1897) silently relocates WorkingDir to
+// ~/.local/replication-manager/data the moment it can't re-derive the
+// original startup context, which on a live reload quietly moved an
+// already-running cluster's data directory out from under it (HAProxy,
+// restic and the job-script deployer all went looking in the new, empty
+// directory and treated it as first boot -- see logs/reload-config.log).
+//
+// Anchoring baseConf on the live *repman.Conf (as reconstructImportedClusterConfig
+// does for freshly-imported clusters) sidesteps that entirely: WorkingDir,
+// ShareDir, BaseDir etc. keep whatever value startup already resolved unless
+// the cluster's own TOML section explicitly overrides them.
+func (repman *ReplicationManager) ReconstructLiveClusterConfig(clusterName string) (config.Config, error) {
+	isolated := viper.New()
+	isolated.SetConfigType("toml")
+
+	if repman.Conf.ConfigFile != "" {
+		if _, err := os.Stat(repman.Conf.ConfigFile); err == nil {
+			isolated.SetConfigFile(repman.Conf.ConfigFile)
+			if err := isolated.ReadInConfig(); err != nil {
+				return config.Config{}, fmt.Errorf("cannot parse %s: %w", repman.Conf.ConfigFile, err)
+			}
+		}
+	}
+
+	// Saved cluster overlay (dynamic settings persisted since the last
+	// restart) -- mirrors InitConfig's per-cluster "Parsing saved config
+	// from working directory" merge, but only for this one cluster.
+	clusterTomlPath := filepath.Join(repman.Conf.WorkingDir, clusterName, clusterName+".toml")
+	if _, err := os.Stat(clusterTomlPath); err == nil {
+		isolated.SetConfigName(clusterName)
+		isolated.SetConfigFile(clusterTomlPath)
+		if err := isolated.MergeInConfig(); err != nil {
+			return config.Config{}, fmt.Errorf("cannot parse %s: %w", clusterTomlPath, err)
+		}
+	}
+
+	repman.Lock()
+	defaultImmuable := repman.ImmuableFlagMaps["default"]
+	defaultDynamic := repman.DynamicFlagMaps["default"]
+	repman.Unlock()
+
+	baseConf := *repman.Conf
+	return repman.GetClusterConfig(isolated, defaultImmuable, defaultDynamic, clusterName, baseConf), nil
+}
+
+// ReloadLiveClusterConfig reconstructs clusterName's config in isolation (see
+// ReconstructLiveClusterConfig) and applies it to the running mycluster.
+// Callers driving a single-cluster settings reload should use this instead of
+// InitConfig+ReloadClusterConfig, which mutates global server state as a side
+// effect of reloading one cluster.
+func (repman *ReplicationManager) ReloadLiveClusterConfig(mycluster *cluster.Cluster, clusterName string) error {
+	conf, err := repman.ReconstructLiveClusterConfig(clusterName)
+	if err != nil {
+		return err
+	}
+	repman.Lock()
+	repman.Confs[clusterName] = conf
+	repman.Unlock()
+	repman.ReloadClusterConfig(mycluster, clusterName)
+	return nil
+}
+
+// deriveClusterConfFields applies the runtime-computed fields that never come
+// from TOML/env/flags (Interactive has toml:"-" and is derived purely from
+// FailMode) or need resolving against the running host (localhost
+// MonitorAddress, BaseDir-relative ShareDir/WorkingDir). initCluster applies
+// these at startup; ReloadClusterConfig must reapply them on every reload or
+// they silently reset to their zero values -- e.g. Interactive resets to
+// false, forcing automatic failover even when fail-mode=manual.
+func (repman *ReplicationManager) deriveClusterConfFields(conf *config.Config) {
+	if conf.MonitorAddress == "localhost" {
+		conf.MonitorAddress = repman.resolveHostIp()
+	}
+	conf.Interactive = conf.FailMode == "manual"
+	if conf.BaseDir != "system" {
+		conf.ShareDir = conf.BaseDir + "/share"
+		conf.WorkingDir = conf.BaseDir + "/data"
+	}
+}
+
 // ReloadClusterConfig applies clusterName's config after repman.InitConfig,
 // re-pointing ImmuableFlagMap/DynamicFlagMap/DefaultFlagMap at the per-cluster
 // maps the way initCluster does at startup -- InitConfig itself leaves them on
@@ -3099,6 +3185,7 @@ func (repman *ReplicationManager) ReloadClusterConfig(mycluster *cluster.Cluster
 	conf.ImmuableFlagMap = repman.ImmuableFlagMaps[clusterName]
 	conf.DynamicFlagMap = repman.DynamicFlagMaps[clusterName]
 	conf.DefaultFlagMap = repman.DefaultFlagMap
+	repman.deriveClusterConfFields(&conf)
 	repman.Confs[clusterName] = conf
 	mycluster.ReloadConfig(conf)
 }
@@ -3122,18 +3209,7 @@ func (repman *ReplicationManager) initCluster(clusterName string) (*cluster.Clus
 	go repman.currentCluster.InitiateRefreshTemplateMD5Worker()
 
 	myClusterConf := repman.Confs[clusterName]
-	if myClusterConf.MonitorAddress == "localhost" {
-		myClusterConf.MonitorAddress = repman.resolveHostIp()
-	}
-	if myClusterConf.FailMode == "manual" {
-		myClusterConf.Interactive = true
-	} else {
-		myClusterConf.Interactive = false
-	}
-	if myClusterConf.BaseDir != "system" {
-		myClusterConf.ShareDir = myClusterConf.BaseDir + "/share"
-		myClusterConf.WorkingDir = myClusterConf.BaseDir + "/data"
-	}
+	repman.deriveClusterConfFields(&myClusterConf)
 
 	myClusterConf.ImmuableFlagMap = repman.ImmuableFlagMaps[clusterName]
 	myClusterConf.DynamicFlagMap = repman.DynamicFlagMaps[clusterName]

--- a/server/server.go
+++ b/server/server.go
@@ -112,7 +112,7 @@ type ReplicationManager struct {
 	// sbHeartbeatFailUntil (unix seconds) severs the peer heartbeat both ways
 	// to simulate this node being isolated from its peer — the server-level
 	// leg of the split-brain simulator (cluster_splitbrain_simulator.go). Runtime state only.
-	sbHeartbeatFailUntil            atomic.Int64                       `json:"-"`
+	sbHeartbeatFailUntil atomic.Int64 `json:"-"`
 	//Adding default flags from AddFlags
 	CommandLineFlag             []string                    `json:"-"`
 	ConfigPathList              []string                    `json:"-"`
@@ -156,62 +156,62 @@ type ReplicationManager struct {
 	// reference it — yet json.Marshal(repman) shipped it in /api/monitor at 312 KB (66%
 	// of a 463 KB payload), unredacted secrets and all. json:"-" keeps it internal (like
 	// VersionConfs). Per-cluster config still comes from /api/clusters/{name}.
-	Confs                       map[string]config.Config       `json:"-"`
+	Confs map[string]config.Config `json:"-"`
 	// Peer-network freshness, surfaced in the Clusters Peer view. Push/Pull are stamped
 	// by the ConfigManager worker (the real sync path) via SetSyncStampHook — NOT by any
 	// server-side helper, which would sit on a dead path.
-	LastConfigGitPush           time.Time                      `json:"lastConfigGitPush"` // last successful config push to the BO git
-	LastConfigGitPull           time.Time                      `json:"lastConfigGitPull"` // last successful config pull from the BO git
-	LastPeerLookup              time.Time                      `json:"lastPeerLookup"`    // last remote peer-cluster catalog refresh (peer.json pull)
-	VersionConfs                map[string]*config.ConfVersion `json:"-"`
-	grpcServer                  *grpc.Server                   `json:"-"`
-	grpcWrapped                 *grpcweb.WrappedGrpcServer     `json:"-"`
-	httpServer                  *http.Server                   `json:"-"`
-	apiServer                   *http.Server                   `json:"-"`
-	V3Up                        chan bool                      `json:"-"`
-	v3Config                    Repmanv3Config                 `json:"-"`
-	cloud18CheckSum             hash.Hash                      `json:"-"`
-	RegStatus                   RegistrationStatus             `json:"-"`
-	clog                        *clog.Logger                   `json:"-"`
-	cApiLog                     *clog.Logger                   `json:"-"`
-	Logrus                      *log.Logger                    `json:"-"`
-	ApiLogAdapter               *ApiLogAdapter                 `json:"-"`
-	lastReportedStatus          string                         `json:"-"`
-	lastReportedSplitBrain     bool                            `json:"-"`
-	IsSavingConfig              bool                           `json:"isSavingConfig"`
-	HasSavingConfigQueue        bool                           `json:"hasSavingConfigQueue"`
-	IsGitPull                   bool                           `json:"isGitPull"`
-	IsGitPush                   bool                           `json:"isGitPush"`
-	GitPushLock                 sync.Mutex                     `json:"-"`
+	LastConfigGitPush      time.Time                      `json:"lastConfigGitPush"` // last successful config push to the BO git
+	LastConfigGitPull      time.Time                      `json:"lastConfigGitPull"` // last successful config pull from the BO git
+	LastPeerLookup         time.Time                      `json:"lastPeerLookup"`    // last remote peer-cluster catalog refresh (peer.json pull)
+	VersionConfs           map[string]*config.ConfVersion `json:"-"`
+	grpcServer             *grpc.Server                   `json:"-"`
+	grpcWrapped            *grpcweb.WrappedGrpcServer     `json:"-"`
+	httpServer             *http.Server                   `json:"-"`
+	apiServer              *http.Server                   `json:"-"`
+	V3Up                   chan bool                      `json:"-"`
+	v3Config               Repmanv3Config                 `json:"-"`
+	cloud18CheckSum        hash.Hash                      `json:"-"`
+	RegStatus              RegistrationStatus             `json:"-"`
+	clog                   *clog.Logger                   `json:"-"`
+	cApiLog                *clog.Logger                   `json:"-"`
+	Logrus                 *log.Logger                    `json:"-"`
+	ApiLogAdapter          *ApiLogAdapter                 `json:"-"`
+	lastReportedStatus     string                         `json:"-"`
+	lastReportedSplitBrain bool                           `json:"-"`
+	IsSavingConfig         bool                           `json:"isSavingConfig"`
+	HasSavingConfigQueue   bool                           `json:"hasSavingConfigQueue"`
+	IsGitPull              bool                           `json:"isGitPull"`
+	IsGitPush              bool                           `json:"isGitPush"`
+	GitPushLock            sync.Mutex                     `json:"-"`
 	// runtimeClusterStartMu serializes the runtime cluster-start paths that
 	// mutate shared server state (repman.currentCluster, repman.Clusters) —
 	// currently AddCluster(), FetchDynamicClustersFromGit(), and the
 	// auto-discovery start path inside PullCloud18Configs(). See
 	// doc/implementation/server/DYNAMIC_CLUSTER_GIT_IMPORT_PLAN.md.
-	runtimeClusterStartMu       sync.Mutex                     `json:"-"`
-	gatewayMu                   sync.Map                       `json:"-"`
-	IsNeedGitPush               bool                           `json:"-"`
-	IsNeedConfigSave            bool                           `json:"-"` // event flag: Save() sets it, the config-sync gate consumes it and runs SaveCallBack
-	CanConnectVault             bool                           `json:"canConnectVault"`
-	IsExportPush                bool                           `json:"-"`
-	globalScheduler             *cron.Cron                     `json:"-"`
-	CheckSumConfig              map[string]hash.Hash           `json:"-"`
-	Mailer                      *mailer.Mailer                 `json:"-"`
-	IsHttpListenerReady         bool                           `json:"-"`
-	IsApiListenerReady          bool                           `json:"-"`
-	Terms                       []byte                         `json:"-"` //Will be fetched by /api/terms later to prevent excessive data
-	TermsDT                     time.Time                      `json:"termsDT"`
-	ModTimes                    map[string]time.Time           `json:"-"`
-	SessionManager              *tty.SessionManager            `json:"-"`
-	ConfigManager               *manager.ConfigManager         `json:"-"`
-	MeetUserID                  string                         `json:"-"`
-	LoginUpgradeStore           *LoginUpgradeStore             `json:"-"`
-	LoginUpgradeInitOnce        sync.Once                      `json:"-"`
-	DiskStatManager             *misc.DiskStatManager          `json:"-"`
-	OpenSVCStats                atomic.Value                   `json:"-"`
-	inFetchOpenSVCStats         bool                           `json:"-"`
-	MessageChan                 chan sharedlog.Message         `json:"-"`
-	fileHook                    log.Hook
+	runtimeClusterStartMu sync.Mutex             `json:"-"`
+	gatewayMu             sync.Map               `json:"-"`
+	IsNeedGitPush         bool                   `json:"-"`
+	IsNeedConfigSave      bool                   `json:"-"` // event flag: Save() sets it, the config-sync gate consumes it and runs SaveCallBack
+	CanConnectVault       bool                   `json:"canConnectVault"`
+	IsExportPush          bool                   `json:"-"`
+	globalScheduler       *cron.Cron             `json:"-"`
+	CheckSumConfig        map[string]hash.Hash   `json:"-"`
+	Mailer                *mailer.Mailer         `json:"-"`
+	IsHttpListenerReady   bool                   `json:"-"`
+	IsApiListenerReady    bool                   `json:"-"`
+	Terms                 []byte                 `json:"-"` //Will be fetched by /api/terms later to prevent excessive data
+	TermsDT               time.Time              `json:"termsDT"`
+	ModTimes              map[string]time.Time   `json:"-"`
+	SessionManager        *tty.SessionManager    `json:"-"`
+	ConfigManager         *manager.ConfigManager `json:"-"`
+	MeetUserID            string                 `json:"-"`
+	LoginUpgradeStore     *LoginUpgradeStore     `json:"-"`
+	LoginUpgradeInitOnce  sync.Once              `json:"-"`
+	DiskStatManager       *misc.DiskStatManager  `json:"-"`
+	OpenSVCStats          atomic.Value           `json:"-"`
+	inFetchOpenSVCStats   bool                   `json:"-"`
+	MessageChan           chan sharedlog.Message `json:"-"`
+	fileHook              log.Hook
 	// SecurityLogrus is a dedicated logger that writes security events to
 	// security.log (path derived from log-file by inserting "-security" before
 	// the extension). Nil when log-file is not configured.
@@ -302,12 +302,12 @@ type Heartbeat struct {
 	UUID      string    `json:"uuid"`
 	StartTime time.Time `json:"startTime"`
 	Secret    string    `json:"secret"`
-	Cluster string `json:"cluster"`
-	Master  string `json:"master"`
-	UID     int    `json:"id"`
-	Status  string `json:"status"`
-	Hosts   int    `json:"hosts"`
-	Failed  int    `json:"failed"`
+	Cluster   string    `json:"cluster"`
+	Master    string    `json:"master"`
+	UID       int       `json:"id"`
+	Status    string    `json:"status"`
+	Hosts     int       `json:"hosts"`
+	Failed    int       `json:"failed"`
 }
 
 var confs = make(map[string]config.Config)
@@ -2065,15 +2065,10 @@ func (repman *ReplicationManager) GetClusterConfig(firstRead *viper.Viper, Immua
 
 		//clusterconf.PrintConf()
 
-		//save the immuable map for the cluster
-		//fmt.Printf("Immuatable map : %s\n", ImmuableMap)
-		repman.ImmuableFlagMaps[cluster] = clustImmuableMap
-
 		//store default cluster config in immutable config (all parameter set in default and cluster section, default value and command line)
 		confs.ConfImmuable = clusterconf
 
 		//fmt.Printf("%+v\n", cf2.AllSettings())
-		repman.DynamicFlagMaps[cluster] = clustDynamicMap
 		//if dynamic config, load modified parameter from the saved config.
 		// Deliberately NOT gated on cf2 (the static cluster section):
 		// dynamically-created clusters exist only through their
@@ -2115,13 +2110,26 @@ func (repman *ReplicationManager) GetClusterConfig(firstRead *viper.Viper, Immua
 			confs.ConfDynamic = clusterconf
 
 		}
-		repman.DynamicFlagMaps[cluster] = clustDynamicMap
 
 		confs.ConfInit = clusterconf
 		//fmt.Printf("init conf : ")
 		//clusterconf.PrintConf()
 
+		// Publish all three maps together, once, under repman's lock: this
+		// function is reachable concurrently from live cluster reload
+		// (ReconstructLiveClusterConfig) as well as startup/import paths, and
+		// clustImmuableMap/clustDynamicMap are plain maps -- an unguarded
+		// write here races with any concurrent reader of
+		// ImmuableFlagMaps/DynamicFlagMaps/VersionConfs (e.g. a different
+		// cluster's reload, or ReloadClusterConfig reading this one).
+		// Publishing once, after all mutation above is done, also avoids
+		// exposing a partially-populated clustDynamicMap the way the old
+		// early assignment (before the saved-config loop above) did.
+		repman.Lock()
+		repman.ImmuableFlagMaps[cluster] = clustImmuableMap
+		repman.DynamicFlagMaps[cluster] = clustDynamicMap
 		repman.VersionConfs[cluster] = confs
+		repman.Unlock()
 	}
 	return clusterconf
 }
@@ -3218,6 +3226,7 @@ func (repman *ReplicationManager) ReconstructLiveClusterConfig(clusterName strin
 	// -- still falls through to the live baseConf value untouched.
 	baseConf := *repman.Conf
 	if cf1 := isolated.Sub("default"); cf1 != nil {
+		repman.initAlias(cf1)
 		cf1.Unmarshal(&baseConf)
 	}
 	if cf3 := isolated.Sub("saved-default"); cf3 != nil {
@@ -3226,6 +3235,7 @@ func (repman *ReplicationManager) ReconstructLiveClusterConfig(clusterName strin
 				cf3.Set(f, v)
 			}
 		}
+		repman.initAlias(cf3)
 		cf3.Unmarshal(&baseConf)
 	}
 
@@ -3273,12 +3283,21 @@ func (repman *ReplicationManager) deriveClusterConfFields(conf *config.Config) {
 // the global-default maps, which breaks secret decryption. Callers should use
 // this instead of cluster.ReloadConfig directly.
 func (repman *ReplicationManager) ReloadClusterConfig(mycluster *cluster.Cluster, clusterName string) {
+	// repman.Confs/ImmuableFlagMaps/DynamicFlagMaps are plain maps read and
+	// written from concurrent HTTP/gRPC reload requests (possibly for
+	// different clusters at once) -- lock around every access to them here,
+	// but release before the potentially slow mycluster.ReloadConfig(conf)
+	// call below so a single cluster's reload doesn't hold the server-wide
+	// lock for the duration of its topology discovery.
+	repman.Lock()
 	conf := repman.Confs[clusterName]
 	conf.ImmuableFlagMap = repman.ImmuableFlagMaps[clusterName]
 	conf.DynamicFlagMap = repman.DynamicFlagMaps[clusterName]
 	conf.DefaultFlagMap = repman.DefaultFlagMap
 	repman.deriveClusterConfFields(&conf)
 	repman.Confs[clusterName] = conf
+	repman.Unlock()
+
 	mycluster.ReloadConfig(conf)
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -3089,6 +3089,45 @@ func (repman *ReplicationManager) Run() error {
 
 }
 
+// loadMainConfigInto reads the server's main config.toml into v, using the
+// same resolution rules InitConfig applies at startup (~line 1622): an
+// explicit --config file if set, otherwise search /etc/replication-manager/
+// (or ConfDirExtra when embedded), ".", and the tarball path. Kept minimal
+// and side-effect-free (no cluster discovery, no repman mutation) so callers
+// like ReconstructLiveClusterConfig can reuse it without pulling in
+// InitConfig's global-rebuild behavior. If ConfigFile is unset, this must
+// still find the file -- omitting the fallback search here is exactly what
+// left dev2 without its [dev2] section on reload (isolated.Sub("dev2") came
+// back nil, "Could not parse configuration group", "No hosts list specified").
+func (repman *ReplicationManager) loadMainConfigInto(v *viper.Viper) error {
+	if repman.Conf.ConfigFile != "" {
+		if _, err := os.Stat(repman.Conf.ConfigFile); err != nil {
+			return fmt.Errorf("no config file %s: %w", repman.Conf.ConfigFile, err)
+		}
+		v.SetConfigFile(repman.Conf.ConfigFile)
+	} else {
+		v.SetConfigName("config")
+		if repman.Conf.WithEmbed == "OFF" {
+			v.AddConfigPath("/etc/replication-manager/")
+		} else {
+			v.AddConfigPath(repman.Conf.ConfDirExtra)
+		}
+		v.AddConfigPath(".")
+		if repman.Conf.WithTarball == "ON" {
+			v.AddConfigPath("/usr/local/replication-manager/etc")
+		}
+	}
+
+	if err := v.ReadInConfig(); err != nil {
+		var configNotFound viper.ConfigFileNotFoundError
+		if errors.As(err, &configNotFound) {
+			return nil
+		}
+		return fmt.Errorf("cannot parse config file: %w", err)
+	}
+	return nil
+}
+
 // ReconstructLiveClusterConfig rebuilds clusterName's config for a single
 // already-running cluster, scoped to that cluster only. It deliberately does
 // NOT go through InitConfig: InitConfig rediscovers the whole cluster list,
@@ -3110,11 +3149,45 @@ func (repman *ReplicationManager) ReconstructLiveClusterConfig(clusterName strin
 	isolated := viper.New()
 	isolated.SetConfigType("toml")
 
-	if repman.Conf.ConfigFile != "" {
-		if _, err := os.Stat(repman.Conf.ConfigFile); err == nil {
-			isolated.SetConfigFile(repman.Conf.ConfigFile)
-			if err := isolated.ReadInConfig(); err != nil {
-				return config.Config{}, fmt.Errorf("cannot parse %s: %w", repman.Conf.ConfigFile, err)
+	if err := repman.loadMainConfigInto(isolated); err != nil {
+		return config.Config{}, err
+	}
+
+	// Global saved-default overlay (dynamic [DEFAULT]-scope settings changed
+	// since the last restart, persisted to WorkingDir/default.toml) -- feeds
+	// the [saved-default] layering below, same as InitConfig's
+	// monitoringSaveConfig block (~line 1800).
+	defaultTomlPath := filepath.Join(repman.Conf.WorkingDir, "default.toml")
+	if _, err := os.Stat(defaultTomlPath); err == nil {
+		isolated.SetConfigFile(defaultTomlPath)
+		if err := isolated.MergeInConfig(); err != nil {
+			return config.Config{}, fmt.Errorf("cannot parse %s: %w", defaultTomlPath, err)
+		}
+	}
+
+	// Optional include directory (default.include), same as InitConfig: a
+	// cluster's static section can live there instead of the main file.
+	// A missing include dir is expected (InitConfig treats it the same way,
+	// just at Debug level) but any other read failure -- permissions, an
+	// unmounted path -- must be visible: silently continuing here would
+	// reload the cluster with its static section quietly dropped, exactly
+	// the "No hosts list specified" failure this function exists to avoid.
+	if includeDir := isolated.GetString("default.include"); includeDir != "" {
+		files, err := os.ReadDir(includeDir)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				repman.Logrus.WithError(err).Warnf("ReconstructLiveClusterConfig(%s): cannot read include dir %s", clusterName, includeDir)
+			}
+		} else {
+			for _, f := range files {
+				if f.IsDir() || !strings.HasSuffix(f.Name(), ".toml") {
+					continue
+				}
+				isolated.SetConfigName(f.Name())
+				isolated.SetConfigFile(filepath.Join(includeDir, f.Name()))
+				if err := isolated.MergeInConfig(); err != nil {
+					return config.Config{}, fmt.Errorf("cannot parse include file %s: %w", f.Name(), err)
+				}
 			}
 		}
 	}
@@ -3136,7 +3209,26 @@ func (repman *ReplicationManager) ReconstructLiveClusterConfig(clusterName strin
 	defaultDynamic := repman.DynamicFlagMaps["default"]
 	repman.Unlock()
 
+	// Re-layer [DEFAULT]/[saved-default] from disk on top of the live
+	// baseline: a reload should reflect default-section edits made since
+	// startup (matching InitConfig's own default-then-cluster layering, see
+	// ~line 1875), not just re-apply the cluster's own section. Unmarshal
+	// only overwrites fields actually present in the TOML, so anything not
+	// explicitly set on disk -- WorkingDir, ShareDir, Interactive (toml:"-")
+	// -- still falls through to the live baseConf value untouched.
 	baseConf := *repman.Conf
+	if cf1 := isolated.Sub("default"); cf1 != nil {
+		cf1.Unmarshal(&baseConf)
+	}
+	if cf3 := isolated.Sub("saved-default"); cf3 != nil {
+		for _, f := range cf3.AllKeys() {
+			if v, ok := repman.Conf.ImmuableFlagMap[f]; ok {
+				cf3.Set(f, v)
+			}
+		}
+		cf3.Unmarshal(&baseConf)
+	}
+
 	return repman.GetClusterConfig(isolated, defaultImmuable, defaultDynamic, clusterName, baseConf), nil
 }
 

--- a/server/server_reload_test.go
+++ b/server/server_reload_test.go
@@ -250,3 +250,64 @@ func TestReconstructLiveClusterConfig_IncludeDirReadFailureIsLogged(t *testing.T
 		t.Errorf("expected a warning mentioning the unreadable include dir %q, got log output: %s", notADir, logOutput.String())
 	}
 }
+
+// TestReconstructLiveClusterConfig_AppliesDefaultSectionAlias proves a
+// deprecated key in [DEFAULT] (e.g. "logfile", aliased to "log-file" in
+// config.GetKeyAliasMap) still resolves on live reload, matching startup's
+// InitConfig, which calls repman.initAlias(cf1) before unmarshaling
+// [default] (~line 1882). Without that call here, deployments still using a
+// deprecated top-level key would see it silently stop working on reload
+// despite still working across a full restart.
+func TestReconstructLiveClusterConfig_AppliesDefaultSectionAlias(t *testing.T) {
+	mainConfigPath := filepath.Join(t.TempDir(), "config.toml")
+	mainConfigContent := "[DEFAULT]\nlogfile = \"/var/log/deprecated-alias.log\"\n\n[dev2]\ndb-servers-hosts = \"db1\"\n"
+	if err := os.WriteFile(mainConfigPath, []byte(mainConfigContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repman := newReloadTestRepman(&config.Config{
+		ConfigFile: mainConfigPath,
+		WorkingDir: t.TempDir(),
+	})
+
+	conf, err := repman.ReconstructLiveClusterConfig("dev2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if conf.LogFile != "/var/log/deprecated-alias.log" {
+		t.Errorf("LogFile = %q, want %q (deprecated [DEFAULT] key \"logfile\" was not aliased to \"log-file\")", conf.LogFile, "/var/log/deprecated-alias.log")
+	}
+}
+
+// TestReconstructLiveClusterConfig_AppliesSavedDefaultSectionAlias is the
+// same proof for the [saved-default] overlay (WorkingDir/default.toml),
+// matching InitConfig's repman.initAlias(cf3) call (~line 1923).
+func TestReconstructLiveClusterConfig_AppliesSavedDefaultSectionAlias(t *testing.T) {
+	workingDir := t.TempDir()
+
+	mainConfigPath := filepath.Join(t.TempDir(), "config.toml")
+	mainConfigContent := "[dev2]\ndb-servers-hosts = \"db1\"\n"
+	if err := os.WriteFile(mainConfigPath, []byte(mainConfigContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(workingDir, "default.toml"),
+		[]byte("[saved-default]\nlogfile = \"/var/log/saved-deprecated-alias.log\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repman := newReloadTestRepman(&config.Config{
+		ConfigFile: mainConfigPath,
+		WorkingDir: workingDir,
+	})
+
+	conf, err := repman.ReconstructLiveClusterConfig("dev2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if conf.LogFile != "/var/log/saved-deprecated-alias.log" {
+		t.Errorf("LogFile = %q, want %q (deprecated [saved-default] key \"logfile\" was not aliased to \"log-file\")", conf.LogFile, "/var/log/saved-deprecated-alias.log")
+	}
+}

--- a/server/server_reload_test.go
+++ b/server/server_reload_test.go
@@ -1,0 +1,252 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+	"github.com/sirupsen/logrus"
+)
+
+// newReloadTestRepman builds the minimal ReplicationManager needed to drive
+// ReconstructLiveClusterConfig/GetClusterConfig in isolation, following the
+// same pattern as TestReconstructImportedClusterConfig_MergesStagedDefaultThenClusterDelta.
+func newReloadTestRepman(conf *config.Config) *ReplicationManager {
+	return &ReplicationManager{
+		Conf:             conf,
+		Logrus:           logrus.New(),
+		ImmuableFlagMaps: map[string]map[string]interface{}{"default": {}},
+		DynamicFlagMaps:  map[string]map[string]interface{}{"default": {}},
+		VersionConfs:     map[string]*config.ConfVersion{},
+		Confs:            map[string]config.Config{},
+	}
+}
+
+// TestReconstructLiveClusterConfig_LoadsStaticIncludeSection reproduces the
+// real dev2 deployment layout: the main config.toml only declares
+// [DEFAULT] include = "<cluster.d>", and the cluster's static section
+// (db-servers-hosts, haproxy-servers) lives in cluster.d/dev2.toml, entirely
+// separate from the dynamic saved-dev2 overlay under WorkingDir. Before the
+// fix, ReconstructLiveClusterConfig never read default.include, so a reload
+// silently dropped Hosts/HaproxyHosts ("No hosts list specified").
+func TestReconstructLiveClusterConfig_LoadsStaticIncludeSection(t *testing.T) {
+	includeDir := t.TempDir()
+	workingDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(includeDir, "dev2.toml"),
+		[]byte("[dev2]\ndb-servers-hosts = \"db1,db2,db3\"\nhaproxy-servers = \"haproxy1\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mainConfigPath := filepath.Join(t.TempDir(), "config.toml")
+	mainConfigContent := "[DEFAULT]\ninclude = \"" + includeDir + "\"\n"
+	if err := os.WriteFile(mainConfigPath, []byte(mainConfigContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Dynamic overlay persisted since the last restart -- a different file,
+	// under a different top-level table ([saved-dev2]), that must layer on
+	// top of (not replace) the static section above.
+	clusterDir := filepath.Join(workingDir, "dev2")
+	if err := os.MkdirAll(clusterDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(clusterDir, "dev2.toml"),
+		[]byte("[saved-dev2]\ntitle = \"dev2\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repman := newReloadTestRepman(&config.Config{
+		ConfigFile:  mainConfigPath,
+		WorkingDir:  workingDir,
+		ConfRewrite: true,
+	})
+
+	conf, err := repman.ReconstructLiveClusterConfig("dev2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if conf.Hosts != "db1,db2,db3" {
+		t.Errorf("Hosts = %q, want %q (static [dev2] section from include dir was lost)", conf.Hosts, "db1,db2,db3")
+	}
+	if conf.HaproxyHosts != "haproxy1" {
+		t.Errorf("HaproxyHosts = %q, want %q (static [dev2] section from include dir was lost)", conf.HaproxyHosts, "haproxy1")
+	}
+}
+
+// TestReconstructLiveClusterConfig_FindsConfigFileViaAutoDiscovery covers the
+// second regression: when repman.Conf.ConfigFile is empty (the process was
+// started relying on Viper's standard search paths, not an explicit --config
+// flag), reload must still find the main config.toml -- and with it, the
+// cluster's static section -- via the same "." search path InitConfig uses.
+func TestReconstructLiveClusterConfig_FindsConfigFileViaAutoDiscovery(t *testing.T) {
+	workingDir := t.TempDir()
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	if err := os.WriteFile(filepath.Join(cwd, "config.toml"),
+		[]byte("[dev2]\ndb-servers-hosts = \"db1,db2,db3\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repman := newReloadTestRepman(&config.Config{
+		ConfigFile: "", // not set -- must fall back to searching "."
+		WorkingDir: workingDir,
+	})
+
+	conf, err := repman.ReconstructLiveClusterConfig("dev2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if conf.Hosts != "db1,db2,db3" {
+		t.Errorf("Hosts = %q, want %q (auto-discovered config.toml was not read)", conf.Hosts, "db1,db2,db3")
+	}
+}
+
+// TestReconstructLiveClusterConfig_PreservesLiveWorkingDir guards the earlier
+// regression in the same reload path: reconstruction must anchor on the live
+// repman.Conf rather than re-deriving WorkingDir, so it never relocates an
+// already-running cluster's data directory (e.g. to ~/.local/replication-manager).
+func TestReconstructLiveClusterConfig_PreservesLiveWorkingDir(t *testing.T) {
+	mainConfigPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(mainConfigPath, []byte("[dev2]\ndb-servers-hosts = \"db1\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	const liveWorkingDir = "/var/lib/replication-manager"
+	repman := newReloadTestRepman(&config.Config{
+		ConfigFile: mainConfigPath,
+		WorkingDir: liveWorkingDir,
+	})
+
+	conf, err := repman.ReconstructLiveClusterConfig("dev2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if conf.WorkingDir != liveWorkingDir {
+		t.Errorf("WorkingDir = %q, want live value %q preserved", conf.WorkingDir, liveWorkingDir)
+	}
+}
+
+// TestReloadLiveClusterConfig_DoesNotMutateSiblingClusters proves the
+// cluster-scoped contract: reloading one cluster must only ever touch that
+// cluster's own entries, never repman.ClusterList or a sibling's Confs entry
+// -- unlike the old InitConfig(*repman.Conf, true) path this replaced.
+func TestReloadLiveClusterConfig_DoesNotMutateSiblingClusters(t *testing.T) {
+	mainConfigPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(mainConfigPath, []byte("[dev2]\ndb-servers-hosts = \"db1\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repman := newReloadTestRepman(&config.Config{
+		ConfigFile: mainConfigPath,
+		WorkingDir: t.TempDir(),
+	})
+	repman.ClusterList = []string{"dev2", "dev2-child", "mysql84"}
+	siblingConf := config.Config{Hosts: "sibling-host"}
+	repman.Confs["dev2-child"] = siblingConf
+	repman.Confs["mysql84"] = siblingConf
+
+	conf, err := repman.ReconstructLiveClusterConfig("dev2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	repman.Confs["dev2"] = conf
+
+	if got, want := repman.ClusterList, []string{"dev2", "dev2-child", "mysql84"}; !equalStrSlices(got, want) {
+		t.Errorf("ClusterList = %v, want unchanged %v", got, want)
+	}
+	if repman.Confs["dev2-child"].Hosts != "sibling-host" {
+		t.Errorf("sibling dev2-child.Hosts mutated: got %q", repman.Confs["dev2-child"].Hosts)
+	}
+	if repman.Confs["mysql84"].Hosts != "sibling-host" {
+		t.Errorf("sibling mysql84.Hosts mutated: got %q", repman.Confs["mysql84"].Hosts)
+	}
+}
+
+// TestReconstructLiveClusterConfig_PicksUpChangedDefaultSection proves reload
+// reflects [DEFAULT]/[saved-default] edits made on disk since startup, not
+// just the cluster's own section -- matching origin/develop's old
+// InitConfig-based reload path (which re-ran the full startup assembly,
+// including the [DEFAULT] merge at ~1875 and the [saved-default] merge at
+// ~1908), rather than freezing on whatever the live in-memory repman.Conf
+// happened to hold.
+func TestReconstructLiveClusterConfig_PicksUpChangedDefaultSection(t *testing.T) {
+	workingDir := t.TempDir()
+
+	mainConfigPath := filepath.Join(t.TempDir(), "config.toml")
+	mainConfigContent := "[DEFAULT]\nprov-orchestrator = \"onpremise\"\n\n[dev2]\ndb-servers-hosts = \"db1\"\n"
+	if err := os.WriteFile(mainConfigPath, []byte(mainConfigContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Dynamic [saved-default] overlay, persisted since the last restart --
+	// edited on disk to a value the live process hasn't seen yet.
+	if err := os.WriteFile(filepath.Join(workingDir, "default.toml"),
+		[]byte("[saved-default]\nmonitoring-ticker = 7\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repman := newReloadTestRepman(&config.Config{
+		ConfigFile: mainConfigPath,
+		WorkingDir: workingDir,
+		// Stale in-memory value from before the on-disk [DEFAULT] edit above
+		// -- a reload must not keep serving this.
+		ProvOrchestrator: "opensvc",
+		MonitorAddress:   "",
+	})
+
+	conf, err := repman.ReconstructLiveClusterConfig("dev2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if conf.ProvOrchestrator != "onpremise" {
+		t.Errorf("ProvOrchestrator = %q, want %q ([DEFAULT] edit on disk was not picked up)", conf.ProvOrchestrator, "onpremise")
+	}
+	if conf.MonitoringTicker != 7 {
+		t.Errorf("MonitoringTicker = %d, want %d ([saved-default] overlay was not picked up)", conf.MonitoringTicker, 7)
+	}
+}
+
+// TestReconstructLiveClusterConfig_IncludeDirReadFailureIsLogged proves an
+// include-dir read failure other than "does not exist" is surfaced, not
+// silently swallowed -- previously a reload with e.g. a permission-denied or
+// unmounted default.include path would proceed with the cluster's static
+// section quietly dropped and no trace of why.
+func TestReconstructLiveClusterConfig_IncludeDirReadFailureIsLogged(t *testing.T) {
+	// A regular file, not a directory: os.ReadDir on it fails with something
+	// other than "not exist".
+	notADir := filepath.Join(t.TempDir(), "cluster.d")
+	if err := os.WriteFile(notADir, []byte("not a directory"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mainConfigPath := filepath.Join(t.TempDir(), "config.toml")
+	mainConfigContent := "[DEFAULT]\ninclude = \"" + notADir + "\"\n\n[dev2]\ndb-servers-hosts = \"db1\"\n"
+	if err := os.WriteFile(mainConfigPath, []byte(mainConfigContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repman := newReloadTestRepman(&config.Config{
+		ConfigFile: mainConfigPath,
+		WorkingDir: t.TempDir(),
+		Daemon:     true, // LogModulePrintf only reaches Logrus in daemon mode
+	})
+
+	var logOutput strings.Builder
+	repman.Logrus.SetOutput(&logOutput)
+
+	if _, err := repman.ReconstructLiveClusterConfig("dev2"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(logOutput.String(), notADir) {
+		t.Errorf("expected a warning mentioning the unreadable include dir %q, got log output: %s", notADir, logOutput.String())
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes a chain of live cluster config reload issues that showed up on running clusters, especially on deployments where the static cluster config lives in `/etc/replication-manager/cluster.d/*.toml` and dynamic overlays live under the cluster working directory.

Before this branch, a reload could:

- use the wrong flag maps after `InitConfig`, breaking secret decryption behavior
- rebuild global server state for a single-cluster reload
- silently relocate the live working directory on non-root runs
- lose static cluster settings from `default.include` / `cluster.d`
- reload with no `db-servers-hosts` / proxy hosts
- race the active monitor tick while rebuilding cluster state
- block too long while draining in-flight tick work

This PR makes live reload:

- cluster-scoped instead of global
- consistent with startup config layering
- safe for include-based static cluster config
- serialized against the active monitor tick
- bounded when draining tracked tick goroutines

## Problem

### Global rebuild for a single-cluster reload
The old reload path called `InitConfig(*repman.Conf, true)` and then reloaded one cluster. That re-ran global discovery and mutated:

- `repman.ClusterList`
- `repman.ImmutableClusterList`
- `repman.Confs`
- `repman.VersionConfs`
- per-cluster flag maps

That was too broad for `/api/clusters/{cluster}/settings/actions/reload`.

### Secret decryption regressions after reload
After `InitConfig()`, the reloaded cluster config could still point at the wrong flag maps, which broke secret decryption behavior and led to downstream credential issues.

### Working directory relocation on non-root reloads
Re-running `InitConfig()` during reload could re-derive `WorkingDir` from fallback logic and silently move a live cluster into `~/.local/replication-manager/data`, causing some subsystems to behave like first boot.

### Static cluster config lost on live reload
The first isolated reload implementation only read the saved dynamic overlay from the working directory. It did not reconstruct the static cluster section from the main config/include directory.

On layouts like:

- `/etc/replication-manager/config.toml`
- `include = "/etc/replication-manager/cluster.d"`
- `/etc/replication-manager/cluster.d/dev2.toml`

reload could log:

- `Could not parse configuration group`
- `No hosts list specified`

and then fail to rebuild DB servers and proxies.

### Reload vs monitor tick race
`cluster.ReloadConfig()` rebuilt `Conf`, state machines, `Servers`, `Proxies`, and topology in place while `cluster.Run()` could still be executing the current tick and some of its fire-and-forget goroutines.

### Reload drain could block too long
Once reload/tick serialization was added, reload could wait too long on tracked tick goroutines, making the cluster appear stuck.

## Root cause

The reload path was mixing startup/global config rebuild semantics with live single-cluster reload semantics.

Startup config assembly correctly loads:

- main config
- include dir files
- `[DEFAULT]`
- `[saved-default]`
- per-cluster static sections
- per-cluster saved overlays

But it also rebuilds global runtime state, which is unsafe for a targeted live reload.

Separately, `cluster.ReloadConfig()` assumed it could rebuild cluster state in place without coordinating with the active monitor loop.

## What changed

### Server-side live reload reconstruction

#### Preserve cluster flag maps on reload
Added `ReloadClusterConfig()` so reload rebinds:

- `ImmuableFlagMap`
- `DynamicFlagMap`
- `DefaultFlagMap`

before applying the reloaded config.

#### Stop using full `InitConfig()` for cluster-scoped reload
HTTP and gRPC reload paths now use a cluster-only reconstruction path instead of `InitConfig()`.

Updated:

- `server/api_cluster.go`
- `server/repmanv3.go`
- `server/regtest.go`

#### Reconstruct live cluster config in isolation
Added live reload reconstruction in `server/server.go` that rebuilds only the requested cluster’s config from disk/runtime context.

This reconstruction now loads:

- main config via the same search rules as startup
- static cluster files from `default.include`
- `WorkingDir/default.toml` for `[saved-default]`
- `WorkingDir/<cluster>/<cluster>.toml` for `[saved-<cluster>]`

#### Restore startup-equivalent default layering for reload
Reload now reapplies:

- `[DEFAULT]`
- `[saved-default]`

onto the live baseline before merging the target cluster section and saved cluster overlay.

#### Preserve live runtime-derived fields
Reload re-applies derived runtime fields like:

- `Interactive`
- `MonitorAddress`
- `ShareDir`
- `WorkingDir` when based on `BaseDir`

without re-running the unsafe global fallback path.

#### Add reload regression coverage
Added `server/server_reload_test.go` covering:

- include-based static cluster section loading
- config auto-discovery when `--config` is not set
- preservation of live working directory
- no sibling cluster mutation during reload
- pickup of changed `[DEFAULT]` / `[saved-default]`
- logging when include-dir reading fails

### Cluster-side reload safety

#### Serialize reload against the active monitor tick
Added a dedicated per-cluster `reloadMu` in `cluster/cluster.go`.

`cluster.Run()` now executes the synchronous tick body under this mutex, and `ReloadConfig()` takes the same mutex before rebuilding cluster state.

#### Track tick-spawned fire-and-forget goroutines
Added `tickWG` and `trackTickGoroutine(...)` to cover the tick-spawned async work that is not already joined by local `WaitGroup`s.

This now includes relevant operations like:

- `CheckDefaultUser`
- `MonitorSchema`
- `initOrchetratorNodes`
- `ResticFetchRepo`
- `RefreshAllAppTemplateMD5`
- `GetSlowLogTable`
- jobs upgrade / reseed / restic reseed paths
- snapshot metadata reconciliation async path

#### Drain tracked tick work before rebuilding
`ReloadConfig()` now waits for tracked in-flight tick goroutines before rebuilding the cluster.

#### Bound reload drain wait
Added a timeout-based drain helper so reload does not wait forever on long operational jobs. If the drain exceeds the bound, reload proceeds with a warning instead of silently freezing the cluster monitor loop indefinitely.

## User-visible behavior after this PR

Reloading a cluster should now:

- keep the cluster present in the running inventory
- keep static cluster settings from `/etc/replication-manager/cluster.d/*.toml`
- keep DB host lists and proxy host lists intact
- preserve secret decryption behavior
- avoid unexpected working-dir relocation on non-root installs
- avoid racing the active monitor tick
- avoid waiting forever on tracked long-running tick work

## Validation

Passed:

- `go test ./server/...`
- `go test ./cluster ./server`

## Files changed

- `server/api_cluster.go`
- `server/regtest.go`
- `server/repmanv3.go`
- `server/server.go`
- `server/server_reload_test.go`
- `cluster/cluster.go`
- `cluster/cluster_bck_meta.go`

## Commits in this branch

- `fix(server): preserve cluster flag maps on reload`
- `fix(server): isolate live cluster config reload`
- `fix(server): restore static/default config on live reload`
- `fix(cluster): serialize live reload with monitor tick`
- `fix(cluster): bound live reload drain wait`
