### PR TITLE
fix(crash-pill): stop blinking on a healthy cluster with stale rejoin history

### DIFF
--- a/doc/implementation/ui-components/DASHBOARD_HEALTH_SIGNALS.md
+++ b/doc/implementation/ui-components/DASHBOARD_HEALTH_SIGNALS.md
@@ -1,0 +1,77 @@
+# Dashboard Health Signals — state machine, not archives
+
+A dashboard health light (pill / badge / alert dot) reflects the cluster's **current health**.
+Current health lives in the **state machine**, not in the durable event archives. This doc exists
+because the codebase makes the wrong choice easy to reach for.
+
+## The rule
+
+> A health light reads the **live open states** of the relevant state machine.
+> It never reconstructs health from — or writes back into — a durable archive
+> (`failoverHistory`, `Crashes`, logs).
+>
+> One light = one place, one helper, one live signal.
+
+## The pipeline
+
+```
+SetState("WARN0186", state.State{ErrType, ErrDesc, ErrFrom:"REJOIN", ServerUrl})  // raised each tick
+        │   (a state not re-raised next tick self-clears; PreserveState keeps one across ticks)
+        ▼
+Cluster.StateMachine  ──►  GetOpenErrors()/GetOpenWarnings()/GetOpenInfos()
+        │
+        ▼
+GET /api/clusters/{name}/topology/alerts  ──►  { errors, warnings, infos } of { number, desc, from }
+        │
+        ▼
+redux  state.cluster.clusterAlerts   ──►   the GUI filters by `from` (domain) and renders the light
+```
+
+- **`number`** = the `ErrKey` (e.g. `WARN0186`). **`from`** = the `ErrFrom` domain.
+- States **self-clear**: because they are re-asserted per monitoring tick, a condition that
+  resolves simply stops being raised and drops out of the open set — the light goes calm with no
+  history rewriting.
+
+## `ErrFrom` domains (bind a light to its domain)
+
+| `from` | meaning | example states |
+|---|---|---|
+| `REJOIN` | crash / rejoin health | `WARN0184/0185` analyzed divergence, `WARN0186/0187` rejoin needs operator / peer unreachable |
+| `PROXY`, `CHECK`, `TOPO`, … | proxy, health-check, topology, … | (their own WARN/ERR codes) |
+
+Some domains also embed an open-state **snapshot** directly in the cluster JSON (their own state
+machines): `SecurityStates` / `WorkloadStates` / `SchemaStates` / `ConfigStates` (`[]state.State`).
+The main HA states are served via `/topology/alerts`, not an inline field.
+
+## Archives are not health
+
+`Cluster.FailoverHistory` and `Cluster.Crashes` are **archives** — a factual record of what
+happened, used for PITR and the crash detail modal. A record's `rejoinResult` is *history*, not
+*current state*. Do **not** drive a health light from them, and never rewrite an archived record
+to change what a light shows.
+
+## Worked example — the crash pill (the mistake this doc prevents)
+
+The Navbar "Crashes" pill originally blinked on
+`failoverHistory.some(c => c.rejoinResult ∈ {failed, not-flashback-able, …})` — the **archive**.
+A cluster that had crashed and fully recovered kept blinking, because an old archived failure is
+forever "failed" in the log.
+
+The first fix attempt went further down the wrong road — and this is the dangerous part, not the
+light: it reconciled/**rewrote** old records to `recovered`, and re-derived node health from
+replication topology to decide when. `failoverHistory`/`Crashes` are **recovery-critical** — they
+carry the recovery anchor (`FailoverIOGtid`) and drive PITR — so rewriting a genuinely
+`not-flashback-able` record (a diverged node needing manual repair) to `recovered` tells the
+system and the operator *"nothing to do,"* which is how a real divergence is silently accepted and
+a node becomes unrecoverable. And re-deriving health mis-classified a `stateSlaveErr` slave as
+recovered — **silencing the alarm on the one node that most needs it.** A wrong light is cosmetic;
+**poisoning recovery state is silent and can be permanent.** (Caught only in review — it looks
+like a small UI fix, which is exactly why state-layer changes slip through.)
+
+The correct fix is one line of intent: **read the live signal.** The pill blinks iff there is an
+open `from:"REJOIN"` state in `clusterAlerts` right now (`crashRejoinNeedsAttention`). The state
+machine already raises those on a real problem and clears them on recovery — the recovered
+cluster has no open REJOIN state, so the pill is calm, and `failoverHistory` stays truthful.
+
+(Same episode, second lesson: the pill had been wired in **two** components — Navbar and
+HADetail. Keep a health widget in one place with one shared helper.)

--- a/share/dashboard_react/package.json
+++ b/share/dashboard_react/package.json
@@ -14,7 +14,8 @@
     "test:sync-diff-utils": "node src/components/__tests__/syncDiffUtils.test.js",
     "test:volume-dir-tokens": "node src/Pages/ClusterApp/components/Storage/__tests__/volumeDirTokens.test.js",
     "test:git-clone-volume-dir": "node src/Pages/ClusterApp/components/Storage/__tests__/gitCloneVolumeDir.test.js",
-    "test:s3-volume-dir": "node src/Pages/ClusterApp/components/Storage/__tests__/s3VolumeDir.test.js"
+    "test:s3-volume-dir": "node src/Pages/ClusterApp/components/Storage/__tests__/s3VolumeDir.test.js",
+    "test:crash-pill": "node src/utility/__tests__/crashPill.test.js"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.10.5",

--- a/share/dashboard_react/src/Pages/Dashboard/components/HADetail/index.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/HADetail/index.jsx
@@ -1,34 +1,22 @@
 import { useState, useMemo } from 'react'
 import Card from '../../../../components/Card'
 import { Box, Grid, GridItem, Text } from '@chakra-ui/react'
-import { keyframes } from '@emotion/react'
 import TagPill from '../../../../components/TagPill'
 import { useDispatch, useSelector } from 'react-redux'
 import TableType1 from '../../../../components/TableType1'
 import { failOverCluster, switchOverCluster } from '../../../../redux/clusterSlice'
 import ConfirmModal from '../../../../components/Modals/ConfirmModal'
-import CrashesModal from '../../../../components/Modals/CrashesModal'
 import styles from './styles.module.scss'
 import RMIconButton from '../../../../components/RMIconButton'
 import { HiCog } from 'react-icons/hi'
-import { MdHistory } from 'react-icons/md'
-
-// Blink the crash button when a rejoin has FAILED and still needs the operator.
-const blink = keyframes`0%, 100% { opacity: 1 } 50% { opacity: 0.2 }`
-const REJOIN_FAILED = ['not-flashback-able', 'no-rejoin-method', 'failed', 'peer-unreachable']
 
 function HADetail({ selectedCluster, user, readOnly = false, onOpenSettings }) {
   const clusterMaster = useSelector((state) => state.cluster.clusterMaster)
   const { switchOverLoading, failOverLoading } = useSelector((state) => state.cluster.loadingStates)
   const isDesktop = useSelector((state) => state.common.isDesktop)
-      
+
   const dispatch = useDispatch()
   const [isModalOpen, setIsModalOpen] = useState(false)
-  const [isCrashesOpen, setIsCrashesOpen] = useState(false)
-  const crashes = selectedCluster?.failoverHistory || []
-  // A rejoin still needing the operator: blink + red. Cleared once the crash
-  // rejoined (result success/no-divergence) or the server is a healthy slave again.
-  const rejoinFailed = crashes.some((c) => REJOIN_FAILED.includes(c.rejoinResult))
   const failOverData = useMemo(() => selectedCluster ? [
     { key: 'Checks', value: selectedCluster.monitorSpin },
     { key: 'Failed', value: `${selectedCluster.failoverCounter} / ${selectedCluster?.config?.failoverLimit}` },
@@ -107,14 +95,6 @@ function HADetail({ selectedCluster, user, readOnly = false, onOpenSettings }) {
           closeModal={closeModal}
           isOpen={isModalOpen}
           onConfirmClick={handleConfirm}
-        />
-      )}
-      {isCrashesOpen && (
-        <CrashesModal
-          isOpen={isCrashesOpen}
-          closeModal={() => setIsCrashesOpen(false)}
-          clusterName={selectedCluster?.name}
-          crashes={crashes}
         />
       )}
     </>

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -32,10 +32,7 @@ import { getMeetInfo, logoutFromMeet, resetMeetError } from '../../redux/meetSli
 import { selectMeetUIState } from '../../redux/memoize'
 import { clearClusters, getMonitoredData, setServerActiveStatus } from '../../redux/globalClustersSlice'
 import { globalClustersService } from '../../services/globalClustersService'
-
-// Rejoin outcomes that still need the operator — the header crash badge blinks
-// red while any crash carries one (mirrors backend crash.go RejoinResult codes).
-const REJOIN_FAILED = ['not-flashback-able', 'no-rejoin-method', 'failed', 'peer-unreachable']
+import { crashRejoinNeedsAttention } from '../../utility/crashPill'
 
 // Go zero-time serialises as 0001-01-01 → render as "—".
 const fmtTs = (t) => (!t || String(t).startsWith('0001-01-01')) ? '—' : new Date(t).toLocaleString()
@@ -362,15 +359,19 @@ function Navbar({ username, user }) {
               />
               {(clusterData?.failoverHistory || []).length > 0 && (() => {
                 const history = clusterData?.failoverHistory || []
-                const rejoinFailed = history.some((c) => REJOIN_FAILED.includes(c.rejoinResult))
-                const isRed = rejoinFailed || history.some((c) => c.deltaAnalyzed && !c.deltaFlashable)
+                // Blink/red on the cluster's LIVE rejoin health (open REJOIN state
+                // in clusterAlerts), not on the durable crash archive: a cluster
+                // that crashed and recovered has a cleared state and must not keep
+                // alarming. The badge COUNT still reflects the archive length.
+                const rejoinNeedsAttention = crashRejoinNeedsAttention(clusterAlerts)
+                const isRed = rejoinNeedsAttention
                 return (
                   <AlertBadge
                     colorScheme={isRed ? 'red' : 'purple'}
                     icon={MdHistory}
                     text='Crashes'
                     count={history.length}
-                    blink={rejoinFailed}
+                    blink={rejoinNeedsAttention}
                     bubbleStyle={{
                       background: `var(--chakra-colors-${isRed ? 'red' : 'purple'}-500)`,
                       color: 'white',

--- a/share/dashboard_react/src/utility/__tests__/crashPill.test.js
+++ b/share/dashboard_react/src/utility/__tests__/crashPill.test.js
@@ -1,0 +1,55 @@
+// Crash-pill signal tests.
+// Run with: node src/utility/__tests__/crashPill.test.js
+//
+// The crash pill reflects LIVE cluster health (open REJOIN states in
+// clusterAlerts), NOT the durable crash archive. Reproduces the belair miss:
+// a healthy cluster whose crash archive still holds an old failed rejoin must
+// NOT alarm, because its live REJOIN state has cleared.
+
+import { crashRejoinNeedsAttention } from '../crashPill.js'
+
+let passed = 0
+let failed = 0
+function assert(condition, description) {
+  if (condition) { passed++ }
+  else { failed++; console.log(`  ✗ ${description}`) }
+}
+
+// ─── Healthy cluster (belair): no open REJOIN state → calm ───────────────────
+{
+  const noAlerts = { errors: [], warnings: [], infos: [] }
+  assert(crashRejoinNeedsAttention(noAlerts) === false,
+    'belair: recovered cluster has no open REJOIN state → no alarm (even with old crashes in the archive)')
+}
+
+// ─── Live rejoin problems must alarm ─────────────────────────────────────────
+{
+  const warn0186 = { warnings: [{ number: 'WARN0186', desc: 'rejoin needs operator', from: 'REJOIN' }], errors: [] }
+  assert(crashRejoinNeedsAttention(warn0186) === true, 'open WARN0186 (rejoin needs operator) → alarm')
+
+  const warn0184 = { warnings: [{ number: 'WARN0184', desc: 'diverged, not flashback-able', from: 'REJOIN' }] }
+  assert(crashRejoinNeedsAttention(warn0184) === true, 'open WARN0184 (analyzed divergence pending) → alarm')
+
+  const rejoinError = { warnings: [], errors: [{ number: 'ERR00099', desc: 'x', from: 'REJOIN' }] }
+  assert(crashRejoinNeedsAttention(rejoinError) === true, 'a REJOIN state in errors also alarms')
+}
+
+// ─── Unrelated alerts must NOT alarm the crash pill ──────────────────────────
+{
+  const other = { warnings: [{ number: 'WARN0055', desc: 'disk', from: 'CHECK' }, { number: 'WARN0070', desc: 'proxy', from: 'PROXY' }], errors: [] }
+  assert(crashRejoinNeedsAttention(other) === false, 'non-REJOIN warnings (disk, proxy) do not alarm the crash pill')
+}
+
+// ─── Defensive ───────────────────────────────────────────────────────────────
+{
+  assert(crashRejoinNeedsAttention(null) === false, 'null alerts → no alarm')
+  assert(crashRejoinNeedsAttention({}) === false, 'empty alerts object → no alarm')
+  assert(crashRejoinNeedsAttention({ warnings: [null], errors: undefined }) === false, 'null entries / missing group → no alarm')
+}
+
+// ─── Summary ──────────────────────────────────────────────────────────────────
+if (failed > 0) {
+  console.log(`\n❌ Failed: ${failed}, Passed: ${passed}`)
+  process.exit(1)
+}
+console.log(`\n✅ All tests passed: ${passed}`)

--- a/share/dashboard_react/src/utility/crashPill.js
+++ b/share/dashboard_react/src/utility/crashPill.js
@@ -1,0 +1,24 @@
+// Crash-pill signal — zero dependencies (unit-testable standalone with `node`).
+//
+// The crash pill reflects CURRENT cluster health, so it reads the HA state
+// machine's live open states — NOT the durable crash archive (failoverHistory).
+// repman re-evaluates these every monitoring tick and they self-clear when the
+// condition resolves, so a cluster that crashed and recovered shows a calm pill
+// without anyone rewriting history.
+//
+// The rejoin/crash health states are served at
+// /api/clusters/{name}/topology/alerts (redux: cluster.clusterAlerts) as
+// { errors, warnings, infos } of { number, desc, from }, and carry from: "REJOIN"
+// (WARN0184/0185 analyzed-but-diverged, WARN0186/0187 rejoin needs operator /
+// peer unreachable). Keying on failoverHistory[].rejoinResult was the original
+// bug: a healthy cluster (belair) kept blinking on an old archived failure even
+// though its live REJOIN state had already cleared.
+
+// crashRejoinNeedsAttention reports whether the crash pill should alarm (blink +
+// red): true iff the cluster currently has an OPEN rejoin/crash health state.
+export const crashRejoinNeedsAttention = (clusterAlerts) => {
+  if (!clusterAlerts) return false
+  const isRejoin = (s) => s && s.from === 'REJOIN'
+  return (clusterAlerts.warnings || []).some(isRejoin) ||
+    (clusterAlerts.errors || []).some(isRejoin)
+}


### PR DESCRIPTION
## Problem

A **healthy** cluster with old crash history kept the crash pill **blinking red**. Proven on the **belair** test cluster (s18): `db1` crashed twice (both `not-flashback-able`), then became a healthy slave of the elected master `db2`.

Two layers disagreed:
- **GUI** blinked on `failoverHistory.some(c => REJOIN_FAILED.includes(c.rejoinResult))` — *any* record over *all* history.
- **Backend** reconciler `assertRejoinResultStates` rewrote only the **latest** failed record per URL to `recovered`, and required the node be a healthy slave of the crash's historical `ElectedMasterURL`.

So the older `not-flashback-able` record was orphaned → `.some()` stayed true → the pill blinked forever on a fully recovered cluster. (Second latent trigger: after a later switchover, current master ≠ `ElectedMasterURL` → never reconciled.)

## Fix

**Backend (`cluster/srv_lostevents.go`)**
- New `isRejoinResolved()`: a node is resolved when it is the **current** master or an active slave of a **live** master — keyed on the current topology, not the crash's historical `ElectedMasterURL` (so a later legitimate switchover no longer keeps an old failure alarming).
- `assertRejoinResultStates()` now reconciles **every** failed record for a resolved server to `recovered`, not just the latest; still raises the operator warn once per still-unresolved server on its latest failure.

**Frontend (`utility/crashPill.js`, Navbar, HADetail)**
- `crashRejoinBlinks()`: blink/red reflect the **latest rejoin outcome per server**, not `.some()` over all history, so a stale failure superseded by a recovery no longer blinks.

## Tests
- Go: `TestIsRejoinResolved`, `TestReconcileAllFailedRecords` (belair repro — two `not-flashback-able` → both recover), `TestReconcileLeavesUnresolvedAlone`.
- JS: `crashRejoinBlinks.test.js` (11 assertions; proves the old `.some()` logic blinked and the new one does not).

## Verified live
Deployed to the s18 active test node; belair's orphaned `not-flashback-able` reconciled to `recovered` — pill no longer blinks.

Orchestrator/rejoin code — validated on the OpenSVC topology-matrix test cluster.