### PR TITLE
CI: document GitHub Actions pipeline, harden packaging against bad tags, fix dispatch publish mismatch

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -21,7 +21,9 @@ jobs:
     name: Build Linux Packages and Publish Repos
     runs-on: [self-hosted, linux, x64]
 
-    timeout-minutes: 20
+    # Full run (amd64 + arm64 build + both repo publishes) takes ~20-21 min;
+    # the previous 20 min limit killed the RPM publish mid-run on 2026-07-21.
+    timeout-minutes: 35
 
     steps:
       - name: Checkout
@@ -39,6 +41,13 @@ jobs:
           fi
           echo "Checking out $tag"
           git checkout "$tag"
+
+      # On workflow_dispatch GITHUB_REF_NAME is 'develop' while the publish
+      # steps read /builds/v<tag> — resolve the checked-out tag once and use
+      # it everywhere so built artifacts and published artifacts always match.
+      - name: Resolve build tag
+        id: buildtag
+        run: echo "tag=$(git describe --tags --exact-match 2>/dev/null || echo "${GITHUB_REF_NAME}")" >> "$GITHUB_OUTPUT"
 
       - name: Set up Go 1.25
         uses: actions/setup-go@v5
@@ -77,7 +86,7 @@ jobs:
           PLUGIN_PUSH: "ON"
         run: |
           echo "::add-mask::${PLUGIN_SIGNER_USER}:${PLUGIN_SIGNER_TOKEN}"
-          branch="${GITHUB_REF_NAME}"
+          branch="${{ steps.buildtag.outputs.tag }}"
           mkdir -p /builds/"$branch"
           bash -x ./package_linux.sh
           mv build/release/* /builds/"$branch"/
@@ -94,14 +103,14 @@ jobs:
           PLUGIN_PUSH: "ON"
         run: |
           echo "::add-mask::${PLUGIN_SIGNER_USER}:${PLUGIN_SIGNER_TOKEN}"
-          branch="${GITHUB_REF_NAME}"
+          branch="${{ steps.buildtag.outputs.tag }}"
           export architecture=arm64
           bash -x ./package_linux.sh
           mv build/release/* /builds/"$branch"/
 
       - name: Publish DEB repo
         run: |
-          tag="${{ github.event.inputs.tag || github.ref_name }}"
+          tag="${{ steps.buildtag.outputs.tag }}"
           cleantag="${tag#v}"
           docker run --rm \
             -v /root/.gnupg:/root/.gnupg \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,12 +76,16 @@ The project provides multiple Docker image variants for different deployment sce
 - `Dockerfile.slim_rootless` - Slim rootless
 - `Dockerfile.dev_rootless` - Dev rootless
 
-**Jenkins CI/CD Pipeline**:
+**CI/CD Pipeline (GitHub Actions — Jenkins is retired)**:
 
-Automated builds create tagged images:
-- Standard tags: `latest`, `pro`, `slim`, `dev`, `{TAG_NAME}`
-- Rootless tags: `latest-rootless`, `pro-rootless`, `{TAG_NAME}-rootless`
-- Nightly builds: `nightly`, `nightly-rootless`
+All builds run from `.github/workflows/` (the root `Jenkinsfile` is dead code). See
+`doc/implementation/CI_RELEASE_PIPELINE.md` for the full map. Docker images built by
+`docker-build-push.yml`:
+- Release tags (on `v*` tag push): `{TAG_NAME}`, `latest`, `{TAG_NAME}-pro`, `{TAG_NAME}-slim`, `{TAG_NAME}-arb`, `arb` + `-rootless` variants
+- Branch builds (push to `develop`): `nightly`, `nightly-rootless`, `nightly-arb`, `dev`, `dev-rootless`
+
+Packages (DEB/RPM) and signed plugins are published by `build-packages.yml` on tag push;
+release binaries, SBOM, and changelog run on GitHub release publication.
 
 **Local Development**:
 ```bash

--- a/doc/implementation/BUILD_PLUGIN_PUBLISHING.md
+++ b/doc/implementation/BUILD_PLUGIN_PUBLISHING.md
@@ -5,6 +5,10 @@ distributed to servers at runtime through the signed-plugin store. This note def
 publishes to that store, and when** — the rule that keeps the store consistent with what
 servers actually run.
 
+The publisher lives inside the release pipeline; for the full CI map (workflows, triggers,
+package/repo publication, tag naming rules) see
+[CI_RELEASE_PIPELINE.md](CI_RELEASE_PIPELINE.md).
+
 ## The rule
 
 > **Publishing is opt-in and single-owner.** A build publishes plugins **only** when it is

--- a/doc/implementation/CI_RELEASE_PIPELINE.md
+++ b/doc/implementation/CI_RELEASE_PIPELINE.md
@@ -1,0 +1,100 @@
+# CI / Release pipeline — GitHub Actions
+
+**Jenkins is retired.** The `Jenkinsfile` at the repo root is a leftover and is no longer
+wired to any build server; everything it did (and more) now runs as GitHub Actions under
+`.github/workflows/`. This doc is the map of what runs, when, and where artifacts land.
+
+## Workflow map
+
+| Workflow | Trigger | Produces |
+|---|---|---|
+| `build-packages.yml` | tag push `v*`, or manual dispatch with a `tag` input | DEB + RPM packages (amd64 + arm64), published to the apt/yum repos; **sole publisher of the signed log-plugin set** |
+| `docker-build-push.yml` | push to `develop`, tag push `v*`, or manual dispatch | All Docker Hub images (release, nightly, dev, arb, slim + rootless variants) |
+| `release-binaries.yml` | GitHub **release published**, or manual dispatch | Standalone linux amd64/arm64 binaries attached to the release (darwin/windows currently disabled) |
+| `generate-sbom.yml` | GitHub release published | CycloneDX SBOM attached to the release |
+| `update-changelog.yml` → `update-changelog-claude.yml` | GitHub release published | Claude-authored `CHANGELOG.md` entry committed to `develop` |
+| `claude.yml` / `claude-code-review.yml` | PR opened, or `@claude` PR comment | Automated PR review |
+
+Note the trigger split: **pushing a tag** builds packages and docker images; the
+**release-published** event (creating the GitHub release from that tag) drives binaries,
+SBOM, and changelog. A tag without a GitHub release ships packages/images but no release
+assets.
+
+## Package build & repo publication (`build-packages.yml`)
+
+Runs on a **self-hosted linux x64 runner** (the packaging host — it holds the GPG key and
+the repo trees):
+
+1. Checkout (full history + submodules). Manual dispatch checks out the given `tag`
+   (defaults to the latest tag).
+2. `package_linux.sh` runs **twice, sequentially, in the same job**: amd64 then
+   `architecture=arm64`. Each run does `make`, then builds `deb`+`rpm` for the four nfpm
+   configs (`client`, `osc`, `prov`, `arbitrator`) into `build/release/`, moved to
+   `/builds/<tag>/` on the runner.
+3. **DEB repo publish**: `signal18/reprepro:latest` container, mounting `/root/.gnupg`,
+   `/home/repo` (the served repo tree) and `/builds`, invoked with the tag **stripped of
+   its leading `v`** (`${tag#v}`).
+4. **RPM repo publish**: `/usr/local/bin/rpmrepo.sh` on the runner host.
+5. Mattermost notification (success/cancelled/failure).
+
+Both arch builds run with `PLUGIN_PUSH=ON` — this workflow is the **single owner** of
+signed-plugin publication. Do not set `PLUGIN_PUSH` anywhere else; rationale and the
+wire-version coupling are in [BUILD_PLUGIN_PUBLISHING.md](BUILD_PLUGIN_PUBLISHING.md).
+
+### Version derivation — tags must be `v<digit>…`
+
+`package_linux.sh` derives the package version as:
+
+```sh
+version=$(git describe --tag --abbrev=4 | sed 's/^v//')
+```
+
+The `sed` strips only a **lowercase** `v`. Debian versions must start with a digit, so a
+mis-cased tag flows straight through nfpm into an invalid `.deb`:
+
+> **Incident 2026-07-20:** tag `V3.1.35` (capital V) produced
+> `replication-manager-osc_V3.1.35-1_amd64.deb`; dpkg rejected it on every client
+> (`'Version' field value 'V3.1.35-1': version number does not start with digit`) and the
+> published apt repo was poisoned until the bad packages were removed.
+
+Rules:
+- Release tags are always `v` + digits (`v3.1.35`). Never capital `V`, never a bare
+  version.
+- Recovery from a bad tag: delete/replace the tag with the correct lowercase form, remove
+  the bad packages from the repo tree on the packaging host (reprepro remove + clean
+  `/builds/<badtag>/`), then re-run `build-packages.yml` via manual dispatch with the
+  corrected tag.
+
+## Docker images (`docker-build-push.yml`)
+
+One job per image; concurrency-grouped per ref, never cancelled. A `paths-filter` gate
+(`detect-changes`) skips the branch-triggered (nightly/dev) jobs when no relevant files
+changed; the arbitrator nightly has its own narrower filter.
+
+**Tag-only jobs** (run on `v*` tags, or forced via dispatch):
+
+| Image tags | Dockerfile |
+|---|---|
+| `{tag}`, `latest` | `docker/Dockerfile` (OSC) |
+| `{tag}-rootless`, `latest-rootless` | `docker/Dockerfile.rootless` |
+| `{tag}-pro` | `docker/Dockerfile.pro` |
+| `{tag}-pro-rootless` | `docker/Dockerfile.pro_rootless` |
+| `{tag}-slim` / `{tag}-slim-rootless` | slim variants |
+| `{tag}-arb`, `arb` / `{tag}-arb-rootless`, `arb-rootless` | arbitrator |
+
+**Branch jobs** (push to `develop`): `nightly`, `nightly-rootless`, `nightly-arb`, `dev`,
+`dev-rootless` (dev images also get `{tag}-dev*` on tag builds).
+
+Docker builds do **not** publish plugins (`PLUGIN_PUSH` unset) — nightly images therefore
+depend on the last tag build having published a plugin set for the current wire version
+(see the nightly-plugins gap discussion in BUILD_PLUGIN_PUBLISHING.md).
+
+## Operational notes
+
+- The packaging host state lives outside CI: `/home/repo` (served repo tree),
+  `/builds/<tag>/` (raw artifacts), `/root/.gnupg` (signing key). Repo surgery
+  (removing a bad package) happens there, not in a workflow.
+- `build-packages.yml` uses a non-cancelling concurrency group — re-dispatching while a
+  build runs queues, matching the old Jenkins `concurrentBuild: false`.
+- The root `Jenkinsfile` and its Mattermost plumbing are dead code and can be removed once
+  nobody references the old Jenkins job.

--- a/doc/implementation/README.md
+++ b/doc/implementation/README.md
@@ -2,6 +2,11 @@
 
 This directory contains detailed implementation documentation for various features and components of replication-manager.
 
+## Build & Release
+
+- **CI_RELEASE_PIPELINE.md** - GitHub Actions CI/release pipeline map (Jenkins is retired): package/repo publication, docker images, release assets, tag naming rules
+- **BUILD_PLUGIN_PUBLISHING.md** - Log-plugin publishing ownership (single publisher, `PLUGIN_PUSH` gate)
+
 ## Directory Structure
 
 ### `/restart-cookie/`

--- a/package_linux.sh
+++ b/package_linux.sh
@@ -16,7 +16,14 @@ git status -bs
 builddir="$(pwd)"/build
 mkdir -p "$builddir"/binaries "$builddir"/package "$builddir"/tar "$builddir"/release
 
-version=$(git describe --tag --abbrev=4 | sed 's/^v//')
+version=$(git describe --tag --abbrev=4 | sed 's/^[vV]//')
+case "$version" in
+  [0-9]*) ;;
+  *)
+    echo "ERROR: version '$version' does not start with a digit (bad tag name?); refusing to package" >&2
+    exit 1
+    ;;
+esac
 head=$(git rev-parse --short HEAD)
 epoch=$(date +%s)
 release=1


### PR DESCRIPTION
## Context

The `V3.1.35` tag incident (2026-07-20/21): a capital-V tag produced dpkg-invalid debs that poisoned repo.signal18.io, and a manual workflow re-run silently republished the stale bad packages. This PR fixes the two repo-side causes and documents the (post-Jenkins) release pipeline.

## Changes

- **`package_linux.sh`**: strip `v`/`V` from `git describe` and refuse to package when the derived version does not start with a digit — a mis-cased tag now fails the build instead of poisoning the apt repo (dpkg rejects such versions, and `V` sorts above digits so apt keeps preferring the broken package).
- **`.github/workflows/build-packages.yml`**:
  - On `workflow_dispatch`, artifacts went to `/builds/$GITHUB_REF_NAME` (= `develop`) while the publish steps read `/builds/v<tag>` — a manual re-run of a tag republished whatever stale files sat there. The checked-out tag is now resolved once (`git describe --tags --exact-match`) and used for both the artifact dir and the publish steps.
  - `timeout-minutes` 20 → 35: a full run takes ~20-21 min; the old limit killed the RPM publish mid-run, leaving the centos tree half-built.
- **`doc/implementation/CI_RELEASE_PIPELINE.md`** (new): map of the GitHub Actions release pipeline (Jenkins is retired) — workflow triggers, package/repo publication on the CI host, docker image matrix, release-event assets, tag naming rules, and the incident recovery procedure.
- **`CLAUDE.md` / doc index**: stale Jenkins references replaced, docs cross-linked with `BUILD_PLUGIN_PUBLISHING.md`.

## Not in this PR (follow-up)

- `reprepro_tag.sh` in the `signal18/reprepro` docker image has a quoted-glob `rm` that never cleans `incoming/`, so stale debs get re-included on every publish — that fix belongs in the image's repo.
- `utils/githelper/githelper.go` swallows GitLab error bodies (`message` field not parsed → "API error: 400 - -").