### PR TITLE
fix(cloud18): first-claimant domain ownership + surface real GitLab errors

### DIFF
--- a/config/manager/manager.go
+++ b/config/manager/manager.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-git/v5"
+	gogitcfg "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	git_obj "github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport"
@@ -826,7 +827,47 @@ func (cm *ConfigManager) cloneRepositoryWithBootstrap(path string, conf *config.
 		repo, cloneErr = git.PlainClone(path, false, cloneopt)
 	}
 
+	// A freshly-created remote project has no commits: PlainClone returns
+	// ErrEmptyRemoteRepository and cannot establish a working tree. Clone can't
+	// bootstrap a bare remote, so initialize a local repository pointed at the
+	// same URL — the caller's add/commit/push then lands the first commit and
+	// creates the remote's default branch. Without this the repo stays empty
+	// forever and GWARN002 ("empty remote repository") re-fires every sync.
+	// (Regression: the pre-ConfigManager push path handled empty remotes;
+	// cloneRepositoryWithBootstrap only covered repository-not-found.)
+	if errors.Is(cloneErr, transport.ErrEmptyRemoteRepository) {
+		return cm.initRepositoryForEmptyRemote(path, cloneopt.URL)
+	}
+
 	return repo, cloneErr
+}
+
+// initRepositoryForEmptyRemote initializes a local git repository at path with
+// an "origin" remote at url, so a subsequent commit+push bootstraps the first
+// commit into an empty remote. The default branch is "master", matching the
+// branch the config-sync worker commits and pushes on (ResolveCurrentLocalBranch).
+func (cm *ConfigManager) initRepositoryForEmptyRemote(path, url string) (*git.Repository, error) {
+	cm.logger.Warnf("none", config.ConstLogModGit,
+		"Remote repository %s is empty; initializing local repository to bootstrap the first commit", url)
+
+	repo, err := git.PlainInit(path, false)
+	if err != nil {
+		if !errors.Is(err, git.ErrRepositoryAlreadyExists) {
+			return nil, fmt.Errorf("empty-remote bootstrap: cannot init repo at %s: %w", path, err)
+		}
+		if repo, err = git.PlainOpen(path); err != nil {
+			return nil, fmt.Errorf("empty-remote bootstrap: cannot open existing repo at %s: %w", path, err)
+		}
+	}
+
+	if _, err = repo.CreateRemote(&gogitcfg.RemoteConfig{
+		Name: "origin",
+		URLs: []string{url},
+	}); err != nil && !errors.Is(err, git.ErrRemoteExists) {
+		return nil, fmt.Errorf("empty-remote bootstrap: cannot set origin remote %s: %w", url, err)
+	}
+
+	return repo, nil
 }
 
 func (cm *ConfigManager) swapGitMetadata(workDir, stagedGitDir string) error {

--- a/config/manager/manager_test.go
+++ b/config/manager/manager_test.go
@@ -596,3 +596,49 @@ func TestIsRepositoryNotFoundError_MatchesWrappedError(t *testing.T) {
 		t.Fatalf("unexpected match for unrelated error")
 	}
 }
+
+// TestInitRepositoryForEmptyRemote_SetsOriginAndMasterHead verifies the
+// empty-remote bootstrap: when a freshly-created project has no commits (clone
+// returns ErrEmptyRemoteRepository), we init a local repo pointed at the same
+// URL on branch master so a subsequent commit+push lands the first commit.
+func TestInitRepositoryForEmptyRemote_SetsOriginAndMasterHead(t *testing.T) {
+	workDir := t.TempDir()
+	const url = "https://gitlab.example.com/example-domain/example-cluster.git"
+
+	logger := logrus.New()
+	logger.SetOutput(&bytes.Buffer{})
+	cm := NewConfigManager(config.NewLogrusWrapper(&config.Config{WorkingDir: workDir}, logger))
+	defer cm.Stop()
+
+	repo, err := cm.initRepositoryForEmptyRemote(workDir, url)
+	if err != nil {
+		t.Fatalf("initRepositoryForEmptyRemote failed: %v", err)
+	}
+
+	// origin remote points at the URL
+	rem, err := repo.Remote("origin")
+	if err != nil {
+		t.Fatalf("origin remote not created: %v", err)
+	}
+	if got := rem.Config().URLs; len(got) != 1 || got[0] != url {
+		t.Fatalf("origin URLs = %v, want [%s]", got, url)
+	}
+
+	// HEAD points at refs/heads/master (matches the config-sync push branch)
+	head, err := repo.Reference(plumbing.HEAD, false)
+	if err != nil {
+		t.Fatalf("cannot read HEAD: %v", err)
+	}
+	if want := plumbing.NewBranchReferenceName("master"); head.Target() != want {
+		t.Fatalf("HEAD target = %s, want %s", head.Target(), want)
+	}
+
+	// idempotent: calling again on the now-initialized dir must not error and
+	// must keep a single origin remote.
+	if _, err := cm.initRepositoryForEmptyRemote(workDir, url); err != nil {
+		t.Fatalf("second initRepositoryForEmptyRemote (existing repo) failed: %v", err)
+	}
+	if _, err := repo.Remote("origin"); err != nil {
+		t.Fatalf("origin remote lost after second init: %v", err)
+	}
+}

--- a/utils/githelper/errors_test.go
+++ b/utils/githelper/errors_test.go
@@ -1,0 +1,58 @@
+package githelper
+
+import "testing"
+
+func TestGitlabErrorMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "oauth error/description",
+			body: `{"error":"invalid_grant","error_description":"Invalid credentials"}`,
+			want: "invalid_grant Invalid credentials",
+		},
+		{
+			name: "message as plain string",
+			body: `{"message":"403 Forbidden"}`,
+			want: "403 Forbidden",
+		},
+		{
+			name: "message as field->reasons object (path taken)",
+			body: `{"message":{"path":["has already been taken"]}}`,
+			want: "path has already been taken",
+		},
+		{
+			name: "non-json body falls back to raw",
+			body: `Bad Gateway`,
+			want: "Bad Gateway",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := gitlabErrorMessage([]byte(tc.body)); got != tc.want {
+				t.Fatalf("gitlabErrorMessage(%q) = %q, want %q", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGitlabErrorMessage_TakenDetectable guards the substring the create path
+// relies on to raise ErrDomainAlreadyOwned.
+func TestGitlabErrorMessage_TakenDetectable(t *testing.T) {
+	msg := gitlabErrorMessage([]byte(`{"message":{"path":["has already been taken"]}}`))
+	if want := "has already been taken"; !contains(msg, want) {
+		t.Fatalf("message %q does not contain %q — ownership detection would break", msg, want)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/utils/githelper/githelper.go
+++ b/utils/githelper/githelper.go
@@ -9,6 +9,7 @@ package githelper
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,6 +22,55 @@ import (
 )
 
 var Logrus = logrus.New()
+
+// ErrDomainAlreadyOwned is returned when creating a Cloud18 domain group fails
+// because the group path is already taken — i.e. the domain exists but the
+// requesting user is not a member (GitLab returns 404 on GET for a private
+// group the user can't see, then 400 "has already been taken" on create).
+// This is the ownership boundary: the first registrant owns the domain group,
+// and later users must be invited by that owner rather than auto-joined.
+var ErrDomainAlreadyOwned = errors.New("cloud18 domain already exists and is owned by another account")
+
+// gitlabErrorMessage extracts a human-readable message from a GitLab API error
+// body. GitLab is inconsistent: OAuth endpoints use {"error","error_description"},
+// while REST validation errors use "message" as either a string
+// ({"message":"403 Forbidden"}) or an object keyed by field
+// ({"message":{"path":["has already been taken"]}}). Return the best available
+// text, falling back to the raw body so nothing is ever silently dropped.
+func gitlabErrorMessage(body []byte) string {
+	var probe struct {
+		Error            string          `json:"error"`
+		ErrorDescription string          `json:"error_description"`
+		Message          json.RawMessage `json:"message"`
+	}
+	if err := json.Unmarshal(body, &probe); err != nil {
+		return strings.TrimSpace(string(body))
+	}
+
+	if probe.ErrorDescription != "" || probe.Error != "" {
+		return strings.TrimSpace(probe.Error + " " + probe.ErrorDescription)
+	}
+
+	if len(probe.Message) > 0 {
+		// message may be a plain string...
+		var s string
+		if err := json.Unmarshal(probe.Message, &s); err == nil {
+			return s
+		}
+		// ...or an object mapping field -> []reasons.
+		var fields map[string][]string
+		if err := json.Unmarshal(probe.Message, &fields); err == nil {
+			var parts []string
+			for field, reasons := range fields {
+				parts = append(parts, field+" "+strings.Join(reasons, ", "))
+			}
+			return strings.Join(parts, "; ")
+		}
+		return strings.TrimSpace(string(probe.Message))
+	}
+
+	return strings.TrimSpace(string(body))
+}
 
 type TokenInfo struct {
 	ID     int    `json:"id"`
@@ -466,13 +516,21 @@ func InitGroupAccessLevel(acces_token, domain string, user_id int, log_git bool)
 	}
 	defer resp.Body.Close()
 
-	// If 404 error, create the group
+	// A 404 is ambiguous: the group truly does not exist, OR it exists but is
+	// private and this user is not a member. Attempt to create it — the group
+	// becomes owned by the creating user (first-claimant ownership, enforced by
+	// GitLab). If the create is rejected because the path is already taken, the
+	// group exists and belongs to someone else: stop with an actionable error
+	// (do NOT recurse — that would loop forever on a group the user can't see).
 	if resp.StatusCode == http.StatusNotFound {
 		_, createErr := CreateCloud18Domain(acces_token, domain, log_git)
 		if createErr != nil {
+			if errors.Is(createErr, ErrDomainAlreadyOwned) {
+				return 0, fmt.Errorf("cloud18 domain %q is already registered to another account; ask its owner to grant you access in GitLab", domain)
+			}
 			return 0, fmt.Errorf("Error creating GitLab domain %s: %s", domain, createErr.Error())
 		}
-		// Try to get the access level again
+		// Group created and owned by this user — resolve the access level.
 		return InitGroupAccessLevel(acces_token, domain, user_id, log_git)
 	}
 
@@ -513,12 +571,14 @@ func CreateCloud18Domain(acces_token, domain string, log_git bool) (int, error) 
 	}
 
 	if resp.StatusCode != http.StatusCreated {
-		// Parse the error response into Main struct
-		var apiError ErrorResponse
-		if err := json.Unmarshal(body, &apiError); err != nil {
-			return 0, fmt.Errorf("received non-OK HTTP status %d and failed to parse error response: %w", resp.StatusCode, err)
+		msg := gitlabErrorMessage(body)
+		// A taken path means the group already exists but this user can't see
+		// it (not a member) — surface the ownership sentinel so the caller can
+		// tell the user to request access instead of looping on create.
+		if strings.Contains(strings.ToLower(msg), "has already been taken") {
+			return 0, fmt.Errorf("%w (domain %q): %s", ErrDomainAlreadyOwned, domain, msg)
 		}
-		return 0, fmt.Errorf("API error: %d - %s - %s", resp.StatusCode, apiError.Error, apiError.ErrorDescription)
+		return 0, fmt.Errorf("gitlab group create failed for domain %q: HTTP %d - %s", domain, resp.StatusCode, msg)
 	}
 
 	var groupId GroupId


### PR DESCRIPTION
## Context

Follow-up to a Cloud18 partner registration failure and the BO-side removal of the email→domain auto-membership pipeline (Mechanism B). This is the **repman side** of the same model: a Cloud18 domain group is owned by the **first repman that registers it**, and everyone else is invited by that owner — never auto-joined from an email string. Under the shared GitLab SSO (Mattermost + repman), a GitLab account is the trust boundary; email must carry no authorization.

## The bug

`InitGroupAccessLevel` GETs the group with the **user's** token. GitLab returns **404 for two different reasons** — the group doesn't exist, *or* it's private and the user isn't a member. The code then tried to create it and, on failure, emitted an opaque `API error: 400 - -` — blank because it parsed only `error`/`error_description`, while GitLab returns validation errors under `message` (a string **or** a `field→[reasons]` object). That masked the real cause (`path has already been taken`) and it recursed on a group it could never see.

## The fix

- **`gitlabErrorMessage()`** extracts a human message from all three GitLab error shapes, falling back to the raw body so nothing is silently dropped.
- **`CreateCloud18Domain`** classifies `has already been taken` → returns the `ErrDomainAlreadyOwned` sentinel.
- **`InitGroupAccessLevel`** on that sentinel stops with an actionable error — *"domain already registered to another account; ask its owner to grant you access"* — instead of looping. A genuinely-new domain is still created and **owned by the registering user** (first-claimant, enforced by GitLab).

## Also: empty-remote config-repo bootstrap regression

The config-sync refactor into `ConfigManager` replaced the old empty-remote push handling with `cloneRepositoryWithBootstrap`, which only retried on repository-not-found — not `ErrEmptyRemoteRepository`. A freshly-created (empty) config project therefore never received its first commit: `git.PlainClone` returns `ErrEmptyRemoteRepository`, the push is skipped, and GWARN002 re-fires every sync. Restored the behavior: on an empty remote, init a local repo pointed at the same URL on branch `master` so the subsequent commit+push lands the first commit.

## Tests

`utils/githelper/errors_test.go` (error-shape parsing) and `config/manager/manager_test.go` (empty-remote bootstrap: origin remote + master HEAD, idempotent). `go build`/`go vet`/`go test` green for both packages.