### PR TITLE
feat(gui): expose logical dump/restore thread counts in Backup settings

### DIFF
--- a/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
+++ b/share/dashboard_react/src/Pages/Settings/BackupSettings.jsx
@@ -127,6 +127,8 @@ function BackupSettings({ selectedCluster, user }) {
   const hMydumperOptions = `**Mydumper Options**\n\nAdditional command-line flags passed to mydumper.\n\nConfig: \`backup-mydumper-options\``
   const hMydumperRegex = `**Mydumper Regex**\n\nRegular expression to filter which tables mydumper includes in the backup.\n\nConfig: \`backup-mydumper-regex\``
   const hMyloaderOptions = `**Myloader Options**\n\nAdditional command-line flags passed to myloader during restore.\n\nConfig: \`backup-myloader-options\``
+  const hLoadThreads = `**Logical Restore Threads**\n\nNumber of parallel threads used when restoring a logical/splitdump backup (passed as \`--threads\` to myloader/splitdump).\nHigher values speed up restore at the cost of more CPU and I/O on the target. Default: 2.\n\nConfig: \`backup-logical-load-threads\``
+  const hDumpThreads = `**Logical Dump Threads**\n\nNumber of parallel threads used when taking a logical/splitdump backup.\nHigher values speed up the dump at the cost of more load on the source. Default: 2.\n\nConfig: \`backup-logical-dump-threads\``
   const hSplitUser = `**Split Logical Dump with DB Credentials**\n\nWhen enabled, the logical dump is split into per-database files using the database credentials for each.\n\nConfig: \`backup-split-mysql-user\``
   const hRestoreUser = `**Restore User When Reseed**\n\nWhen enabled, MySQL user accounts and grants are restored as part of the reseed process.\n\nConfig: \`backup-restore-mysql-user\``
   const hPhysicalBackup = `**Physical Backup**\n\nSelects the tool used for physical backups (xtrabackup, mariabackup, etc.).\nPhysical backups copy raw data files and are faster to restore for large datasets.\n\nConfig: \`backup-physical-type\``
@@ -301,6 +303,24 @@ function BackupSettings({ selectedCluster, user }) {
         <TextForm value={selectedCluster?.config?.backupMyLoaderOptions} confirmTitle={`Confirm backup-myloader-options to `}
           maxLength={1024} className={styles.textbox}
           onSave={(value) => dispatch(setSetting({ clusterName: selectedCluster?.name, setting: 'backup-myloader-options', value: btoa(value) }))} />
+      )
+    },
+    {
+      key: 'Logical Restore Threads',
+      help: h(hLoadThreads, 'Logical Restore Threads'),
+      value: (
+        <NumberInput min={1} max={64} value={selectedCluster?.config?.backupLogicalLoadThreads}
+          showEditButton={true} showConfirmModal={true} confirmTitle={`Confirm change logical restore threads to: `}
+          onConfirm={(value) => dispatch(setSetting({ clusterName: selectedCluster?.name, setting: 'backup-logical-load-threads', value }))} />
+      )
+    },
+    {
+      key: 'Logical Dump Threads',
+      help: h(hDumpThreads, 'Logical Dump Threads'),
+      value: (
+        <NumberInput min={1} max={64} value={selectedCluster?.config?.backupLogicalDumpThreads}
+          showEditButton={true} showConfirmModal={true} confirmTitle={`Confirm change logical dump threads to: `}
+          onConfirm={(value) => dispatch(setSetting({ clusterName: selectedCluster?.name, setting: 'backup-logical-dump-threads', value }))} />
       )
     },
     {


### PR DESCRIPTION
Closes #1619.

## What

Adds GUI controls for the two logical/splitdump backup concurrency flags that existed in the backend and could only be set via TOML/CLI:

- **Logical Restore Threads** → `backup-logical-load-threads` (passed as `--threads` to the myloader/splitdump **restore** path — `cluster/srv_job_backup.go:1285,1569,1610`)
- **Logical Dump Threads** → `backup-logical-dump-threads` (dump side — `cluster/srv_job_backup.go:2367`)

Both are `NumberInput` rows in `share/dashboard_react/src/Pages/Settings/BackupSettings.jsx`, placed next to the Myloader/Mydumper options and mirroring the existing **Parallel Blocks** row exactly (grant-gated on `cluster-settings`, `setSetting` dispatch, confirm modal).

## Why

The operator went looking for the splitdump restore thread count in the GUI and it wasn't there — the flags (default 2) were only reachable via config file. This is a frontend-only gap: the config fields, JSON (`backupLogicalLoadThreads` / `backupLogicalDumpThreads`), and `setSetting` plumbing already existed.

## Verification

- Real `npm run build` (vite) passes — not esbuild-external, so bad imports would surface.
- `NumberInput` already imported (used by Parallel Blocks). No backend change.