### PR TITLE
fix(backup+config): abort backup on dead-volume stall; persist per-cluster settings across restart

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -348,6 +348,7 @@ type Cluster struct {
 	SstAvailablePorts                   map[string]string           `json:"sstAvailablePorts" groups:"web"`
 	InPhysicalBackup                    bool                        `json:"inPhysicalBackup" groups:"web"`
 	InLogicalBackup                     bool                        `json:"inLogicalBackup" groups:"web"`
+	LastConfigSaveToDisk                time.Time                   `json:"lastConfigSaveToDisk" groups:"web"` // when the datadir <cluster>.toml was last actually written (config persistence observability)
 	InBinlogBackup                      bool                        `json:"inBinlogBackup" groups:"web"`
 	InResticLogicalBackup               bool                        `json:"inResticLogicalBackup" groups:"web"`
 	InResticPhysicalBackup              bool                        `json:"inResticPhysicalBackup" groups:"web"`
@@ -1895,6 +1896,13 @@ func (cluster *Cluster) SaveConfigFile() (bool, error) {
 	s.WriteTo(&buf)
 
 	has_changed, err = cluster.saveConfigArtifact(filePath, buf.Bytes(), "saved-"+cluster.Name, true)
+	if err == nil && has_changed {
+		// Stamp the last time the persisted cluster config actually hit disk.
+		// Exposed via the API and GUI so operators (and the config-persistence
+		// regtest) can tell "changed in memory" from "written to the datadir
+		// <cluster>.toml that startup reads back".
+		cluster.LastConfigSaveToDisk = time.Now()
+	}
 	return has_changed, err
 }
 

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -1127,8 +1127,15 @@ func (server *ServerMonitor) JobsCheckFinished(conn *sqlx.Conn) error {
 		server.SetNeedRefreshJobs(true)
 	}
 
-	//Wait for debug sent via API
-	time.Sleep(3 * time.Second)
+	// Wait for the writelog API to flush a finished job's status before we log it
+	// — but ONLY when there was actually a finished task. This runs on the
+	// monitoring hot path (Ping → Refresh → JobsCheckStates), so an unconditional
+	// sleep taxed every tick for every server even with no finished job, which
+	// (compounded by a stuck backup) is enough to trip the global heartbeat stall
+	// detector. Sleep only when there is something to flush.
+	if len(logs) > 0 {
+		time.Sleep(3 * time.Second)
+	}
 	for _, logrow := range logs {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, logrow[0], logrow[1], logrow[2])
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, logrow[0], logrow[1], logrow[2])

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -2067,6 +2067,37 @@ func backupStallWatchdog(done <-chan struct{}, cancel context.CancelFunc, progre
 	}
 }
 
+// backupStallLeakGrace is how long, after the stall watchdog has cancelled, we
+// still wait for the backup's reader/pipeline goroutines to unwind before giving
+// up on them. SIGKILL (from context cancel) frees a normal subprocess well within
+// this window; a subprocess wedged in uninterruptible sleep (D-state) on a
+// hard-hung mount never dies, so we stop waiting and leak it rather than hang the
+// backup forever.
+const backupStallLeakGrace = 60 * time.Second
+
+// boundedWait blocks until wg completes. If `fired` is signalled (the stall
+// watchdog cancelled) and wg still hasn't completed after `grace`, it returns
+// true — the goroutine is stuck (e.g. a subprocess in uninterruptible sleep on a
+// hung mount that SIGKILL can't free) and must be treated as leaked so the caller
+// can return instead of blocking indefinitely. Returns false on normal
+// completion. The internal waiter goroutine leaks with wg only in the true case,
+// which is exactly the unavoidable hard-hung-mount scenario.
+func boundedWait(wg *sync.WaitGroup, fired <-chan struct{}, grace time.Duration) bool {
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+		return false
+	case <-fired:
+		select {
+		case <-done:
+			return false
+		case <-time.After(grace):
+			return true
+		}
+	}
+}
+
 func (server *ServerMonitor) JobBackupMysqldump(ctx context.Context, task, filename string, allowRotate bool) error {
 	cluster := server.ClusterGroup
 	var err error
@@ -2202,6 +2233,11 @@ func (server *ServerMonitor) JobBackupMysqldump(ctx context.Context, task, filen
 	var bytesProgress atomic.Int64
 	var stalled atomic.Bool
 	stallDone := make(chan struct{})
+	stallFired := make(chan struct{})
+	if cluster.Conf.BackupWriteStallTimeout < 0 {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn,
+			"backup-write-stall-timeout is negative (%d) — the write-stall watchdog is DISABLED; use 0 to disable intentionally, or a positive number of seconds to enable", cluster.Conf.BackupWriteStallTimeout)
+	}
 	stallTimeout := time.Duration(cluster.Conf.BackupWriteStallTimeout) * time.Second
 	checkInterval := stallTimeout / 4
 	if checkInterval < time.Second {
@@ -2209,6 +2245,7 @@ func (server *ServerMonitor) JobBackupMysqldump(ctx context.Context, task, filen
 	}
 	go backupStallWatchdog(stallDone, dumpCancel, &bytesProgress, stallTimeout, checkInterval, func() {
 		stalled.Store(true)
+		close(stallFired)
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr,
 			"Backup write stalled for %s with no output written (dead/hung backup volume?); aborting backup for %s", stallTimeout, server.URL)
 	})
@@ -2253,13 +2290,28 @@ func (server *ServerMonitor) JobBackupMysqldump(ctx context.Context, task, filen
 		}
 	}()
 
-	wg.Wait()
-	close(stallDone) // stop the watchdog now that the read loop is done
+	// Bounded wait: normally block until the reader goroutine unwinds, but if the
+	// watchdog cancelled and the subprocess is stuck in uninterruptible sleep
+	// (D-state, a hard-hung NFS-style mount) SIGKILL cannot free it and this wait
+	// would never return — so after backupStallLeakGrace give up, leak the stuck
+	// goroutine, and return the stall error. Best-effort mitigation for the
+	// hard-hung-mount case, not a hard guarantee — see BACKUP_DEAD_VOLUME_STALL.md.
+	leaked := boundedWait(&wg, stallFired, backupStallLeakGrace)
+	close(stallDone) // stop the watchdog
+	if leaked {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn,
+			"Backup reader did not unwind %s after stall-cancel on %s (subprocess likely in uninterruptible sleep on a hung mount); leaking the stuck goroutine and returning stall error", backupStallLeakGrace, server.URL)
+		return fmt.Errorf("backup aborted: no output written for %s (dead/hung backup volume; subprocess stuck and unkillable)", stallTimeout)
+	}
 
 	// Collect all errors
 	var splitDumpErr, readErr error
 	if splitDumpPipeline != nil {
-		splitDumpPipeline.wg.Wait()
+		if boundedWait(splitDumpPipeline.wg, stallFired, backupStallLeakGrace) {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn,
+				"Splitdump pipeline did not unwind %s after stall-cancel on %s (hung mount?); leaking and returning stall error", backupStallLeakGrace, server.URL)
+			return fmt.Errorf("backup aborted: no output written for %s (dead/hung backup volume; splitdump stuck and unkillable)", stallTimeout)
+		}
 		splitDumpErr = drainErrorChannel(splitDumpPipeline.errCh)
 		if splitDumpErr != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Splitdump error: %s", splitDumpErr)

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -2025,6 +2025,48 @@ func (server *ServerMonitor) setupSplitDumpPipeline(
 	}
 }
 
+// backupStallWatchdog aborts a backup whose output has stopped accepting writes
+// (a dead/hung backup volume). It samples a byte-progress counter every
+// checkInterval; if the counter does not advance for stallTimeout, it invokes
+// onStall and cancel() — which kills the dump + splitdump subprocesses and
+// unblocks the pipe so the backup returns an error instead of hanging forever.
+// It returns when done is closed (normal completion) or on stall. stallTimeout
+// <= 0 disables it. Kept standalone so it is unit-testable without a DB or mount.
+func backupStallWatchdog(done <-chan struct{}, cancel context.CancelFunc, progress *atomic.Int64, stallTimeout, checkInterval time.Duration, onStall func()) {
+	if stallTimeout <= 0 {
+		return
+	}
+	if checkInterval <= 0 {
+		checkInterval = time.Second
+	}
+	ticker := time.NewTicker(checkInterval)
+	defer ticker.Stop()
+
+	last := progress.Load()
+	var idle time.Duration
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			cur := progress.Load()
+			if cur != last {
+				last = cur
+				idle = 0
+				continue
+			}
+			idle += checkInterval
+			if idle >= stallTimeout {
+				if onStall != nil {
+					onStall()
+				}
+				cancel()
+				return
+			}
+		}
+	}
+}
+
 func (server *ServerMonitor) JobBackupMysqldump(ctx context.Context, task, filename string, allowRotate bool) error {
 	cluster := server.ClusterGroup
 	var err error
@@ -2150,6 +2192,27 @@ func (server *ServerMonitor) JobBackupMysqldump(ctx context.Context, task, filen
 		},
 	)
 
+	// Write-stall watchdog. A dead/hung backup output volume blocks the write
+	// side of the pipe, which back-pressures this read loop; without this the
+	// backup hangs forever and its deferred InLogicalBackup clear never runs
+	// (the "STALLED pill that won't clear" incident). If no bytes flow for the
+	// configured timeout, cancel the dump + splitdump subprocesses so the backup
+	// fails cleanly and the caller's defers run. See
+	// doc/implementation/cluster/BACKUP_DEAD_VOLUME_STALL.md.
+	var bytesProgress atomic.Int64
+	var stalled atomic.Bool
+	stallDone := make(chan struct{})
+	stallTimeout := time.Duration(cluster.Conf.BackupWriteStallTimeout) * time.Second
+	checkInterval := stallTimeout / 4
+	if checkInterval < time.Second {
+		checkInterval = time.Second
+	}
+	go backupStallWatchdog(stallDone, dumpCancel, &bytesProgress, stallTimeout, checkInterval, func() {
+		stalled.Store(true)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr,
+			"Backup write stalled for %s with no output written (dead/hung backup volume?); aborting backup for %s", stallTimeout, server.URL)
+	})
+
 	// Main reading goroutine
 	wg.Add(1)
 	go func() {
@@ -2169,6 +2232,7 @@ func (server *ServerMonitor) JobBackupMysqldump(ctx context.Context, task, filen
 			if n == 0 {
 				break
 			}
+			bytesProgress.Add(int64(n))
 			if parser.Enabled() {
 				parser.Consume(buffer[:n])
 			}
@@ -2190,6 +2254,7 @@ func (server *ServerMonitor) JobBackupMysqldump(ctx context.Context, task, filen
 	}()
 
 	wg.Wait()
+	close(stallDone) // stop the watchdog now that the read loop is done
 
 	// Collect all errors
 	var splitDumpErr, readErr error
@@ -2203,6 +2268,18 @@ func (server *ServerMonitor) JobBackupMysqldump(ctx context.Context, task, filen
 
 	readErr = drainErrorChannel(errCh)
 	combinedErr := errors.Join(splitDumpErr, readErr)
+
+	// A watchdog-triggered stall cancels the same context as a user cancel, so
+	// report it distinctly (and never as a user cancellation): surface a clear
+	// stall error rather than the underlying "context canceled".
+	if stalled.Load() {
+		stallErr := fmt.Errorf("backup aborted: no output written for %s (dead/hung backup volume)", stallTimeout)
+		if combinedErr != nil {
+			return errors.Join(stallErr, combinedErr)
+		}
+		return stallErr
+	}
+
 	if combinedErr != nil {
 		if errors.Is(combinedErr, context.Canceled) && server.isJobCancelRequested(task) {
 			if cluster.Conf.BackupKeepUntilValid {

--- a/cluster/srv_job_backup_stall_test.go
+++ b/cluster/srv_job_backup_stall_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -97,5 +98,31 @@ func TestBackupStallWatchdog_DisabledWhenZero(t *testing.T) {
 	}
 	if canceled.Load() {
 		t.Fatal("disabled watchdog cancelled the backup")
+	}
+}
+
+// TestBoundedWait covers the D-state / hard-hung-mount mitigation: a wait that
+// never completes must be abandoned (leaked=true) once the stall was fired, so
+// the backup returns instead of hanging forever; a completing wait returns false.
+func TestBoundedWait_LeaksStuckGoroutineAfterStall(t *testing.T) {
+	// completes normally, no stall → false
+	var wgOK sync.WaitGroup
+	wgOK.Add(1)
+	go func() { time.Sleep(10 * time.Millisecond); wgOK.Done() }()
+	if boundedWait(&wgOK, make(chan struct{}), 50*time.Millisecond) {
+		t.Fatal("boundedWait reported leak for a wg that completed")
+	}
+
+	// never completes + stall fired → leaked=true after grace
+	var wgStuck sync.WaitGroup
+	wgStuck.Add(1) // never Done() — simulates a D-state-wedged goroutine
+	fired := make(chan struct{})
+	close(fired) // watchdog already fired
+	start := time.Now()
+	if !boundedWait(&wgStuck, fired, 40*time.Millisecond) {
+		t.Fatal("boundedWait did not report leak for a stuck wg after stall fired")
+	}
+	if time.Since(start) < 30*time.Millisecond {
+		t.Fatal("boundedWait returned before the grace period elapsed")
 	}
 }

--- a/cluster/srv_job_backup_stall_test.go
+++ b/cluster/srv_job_backup_stall_test.go
@@ -1,0 +1,101 @@
+package cluster
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestBackupStallWatchdog_CancelsOnStall: once progress stops advancing, the
+// watchdog must cancel within roughly the stall timeout. This is the software
+// stand-in for "the backup volume was disconnected" — the write side stops
+// accepting bytes, so the byte counter freezes.
+func TestBackupStallWatchdog_CancelsOnStall(t *testing.T) {
+	var progress atomic.Int64
+	var canceled atomic.Bool
+	var stallReported atomic.Bool
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	defer close(done)
+
+	stallTimeout := 60 * time.Millisecond
+	interval := 10 * time.Millisecond
+
+	go backupStallWatchdog(done, func() { canceled.Store(true); cancel() }, &progress,
+		stallTimeout, interval, func() { stallReported.Store(true) })
+
+	// Simulate a healthy backup for a bit — bytes keep flowing, no cancel.
+	for i := 0; i < 5; i++ {
+		progress.Add(4096)
+		time.Sleep(interval)
+	}
+	if canceled.Load() {
+		t.Fatal("watchdog cancelled while progress was still advancing")
+	}
+
+	// Now the "volume dies": stop advancing progress and wait past the timeout.
+	select {
+	case <-ctx.Done():
+		// good — cancelled after the stall
+	case <-time.After(stallTimeout + 20*interval):
+		t.Fatal("watchdog did not cancel after progress stalled")
+	}
+	if !stallReported.Load() {
+		t.Fatal("stall callback was not invoked")
+	}
+	if !canceled.Load() {
+		t.Fatal("cancel was not called on stall")
+	}
+}
+
+// TestBackupStallWatchdog_NoCancelWhenProgressing: continuous progress must
+// never trip the watchdog.
+func TestBackupStallWatchdog_NoCancelWhenProgressing(t *testing.T) {
+	var progress atomic.Int64
+	var canceled atomic.Bool
+	done := make(chan struct{})
+
+	stallTimeout := 40 * time.Millisecond
+	interval := 10 * time.Millisecond
+
+	go backupStallWatchdog(done, func() { canceled.Store(true) }, &progress,
+		stallTimeout, interval, nil)
+
+	deadline := time.Now().Add(stallTimeout * 5)
+	for time.Now().Before(deadline) {
+		progress.Add(1)
+		time.Sleep(interval / 2)
+	}
+	close(done)
+	if canceled.Load() {
+		t.Fatal("watchdog cancelled a backup that was making continuous progress")
+	}
+}
+
+// TestBackupStallWatchdog_DisabledWhenZero: a zero timeout disables the
+// watchdog entirely (opt-out), so it must return immediately and never cancel.
+func TestBackupStallWatchdog_DisabledWhenZero(t *testing.T) {
+	var progress atomic.Int64
+	var canceled atomic.Bool
+	done := make(chan struct{})
+	defer close(done)
+
+	returned := make(chan struct{})
+	go func() {
+		backupStallWatchdog(done, func() { canceled.Store(true) }, &progress, 0, 10*time.Millisecond, nil)
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+		// good — disabled watchdog returns immediately without waiting on done
+	case <-time.After(time.Second):
+		t.Fatal("disabled watchdog (timeout=0) did not return immediately")
+	}
+	if canceled.Load() {
+		t.Fatal("disabled watchdog cancelled the backup")
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -827,6 +827,7 @@ type Config struct {
 	BackupResticRepository                    string                       `mapstructure:"backup-restic-repository" toml:"backup-restic-repository" json:"backupResticRepository"`
 	BackupResticPassword                      string                       `mapstructure:"backup-restic-password"  toml:"backup-restic-password" json:"-"`
 	BackupResticAws                           bool                         `mapstructure:"backup-restic-aws"  toml:"backup-restic-aws" json:"backupResticAws"`
+	BackupWriteStallTimeout                   int                          `mapstructure:"backup-write-stall-timeout" toml:"backup-write-stall-timeout" json:"backupWriteStallTimeout"`
 	BackupResticTimeout                       int                          `mapstructure:"backup-restic-timeout"  toml:"backup-restic-timeout" json:"backupResticTimeout"`
 	BackupResticDumpTimeout                   int                          `mapstructure:"backup-restic-dump-timeout" toml:"backup-restic-dump-timeout" json:"backupResticDumpTimeout"`
 	BackupResticDirMode                       int                          `mapstructure:"backup-restic-dir-mode" toml:"backup-restic-dir-mode" json:"backupResticDirMode"`

--- a/doc/implementation/README.md
+++ b/doc/implementation/README.md
@@ -9,6 +9,11 @@ This directory contains detailed implementation documentation for various featur
 
 ## Directory Structure
 
+### `/cluster/`
+Cluster monitoring, backup, and resilience.
+
+- **BACKUP_DEAD_VOLUME_STALL.md** - Why a lost backup volume must not stall the monitor: the write-stall watchdog (`backup-write-stall-timeout`), the monitoring-hot-path sleep fix, and the controllable-mount reproduction
+
 ### `/restart-cookie/`
 Documentation related to the restart cookie mechanism and database restart functionality.
 

--- a/doc/implementation/cluster/BACKUP_DEAD_VOLUME_STALL.md
+++ b/doc/implementation/cluster/BACKUP_DEAD_VOLUME_STALL.md
@@ -1,0 +1,140 @@
+# Backup resilience: dead output volume must not stall the monitor
+
+## Incident
+
+A logical (`mysqldump`/`mariadb-dump` → `replication-manager-cli splitdump`) backup was
+running to a **mounted backup volume**. The volume was lost mid-backup (the mount
+disappeared). The database being backed up was **never affected** — but repman itself
+went sideways:
+
+- The backup never finished. `mariadb-dump` and `splitdump` stayed alive for over an
+  hour, still holding the dump's `--single-transaction` read view **open on the source**
+  (pinning InnoDB purge / growing the history list).
+- The GUI lit a **STALLED** pill that kept blinking even though monitoring checks were
+  visibly advancing.
+- Killing both OS processes by hand did **not** clear the pill.
+
+## Root cause (from a goroutine profile, `/debug/pprof/goroutine?debug=2`)
+
+Two 30-seconds-apart goroutine dumps showed the monitoring loop **advancing** (Ping /
+`TopologyDiscover` goroutines turned over between snapshots) — so it was **not** a
+hard deadlock. But three separate defects stacked into the observed behaviour:
+
+### 1. A dead output volume hangs the backup forever
+
+The write chain is:
+
+```
+source DB → mariadb-dump (reads) → pipe → splitdump (writes shards) → <mount>
+```
+
+When the mount is gone, `splitdump`'s writes block, so it stops draining the pipe, so
+`mariadb-dump` blocks on the full pipe, and repman's reader goroutine blocks on the tee
+write. `JobBackupMysqldump` then parks on `wg.Wait()`
+(`srv_job_backup.go`) **with no timeout** — forever. Evidence:
+
+```
+goroutine … [sync.WaitGroup.Wait, 64 minutes]:
+  cluster.(*ServerMonitor).JobBackupMysqldump  srv_job_backup.go:2192
+goroutine … [select, 64 minutes]:
+  cluster.(*ServerMonitor).copyLogs            srv_job_backup.go:2822   (blocked reading the child's pipe)
+```
+
+### 2. The stuck backup drags the monitoring loop
+
+Per-server `Refresh()` runs `JobsCheckStates → JobsCheckFinished` **inline on the `Ping`
+path**, and `TopologyDiscover` waits for **every** server's `Ping` before the cluster
+heartbeat advances (`cluster_topo.go:136`). So job-state work — including anything that
+touches the backup — sits on the monitoring hot path. Evidence: all three `Ping`
+goroutines were inside `JobsCheckFinished`.
+
+### 3. A hard 3-second sleep on the monitoring hot path
+
+`JobsCheckFinished` ended with an **unconditional** `time.Sleep(3 * time.Second)`
+(`srv_job.go:1131`, commit `c527781f1`, comment *"wait for writelog api before sending
+job status"*). It ran on **every** monitoring tick for **every** server, even when there
+were no finished jobs — a per-tick tax that, combined with #2, is enough to trip the
+30-tick (~60s) global-heartbeat stall detector (`server_state.go`).
+
+### Why hand-killing the processes didn't clear the pill
+
+`IsInBackup()` is `InLogicalBackup || …` (`cluster_has.go:635`). The caller clears
+`InLogicalBackup` via `defer` on return (`srv_job_backup.go:2549`) — but because the
+backup goroutine **hung and never returned**, the `defer` never ran. Killing the OS
+processes doesn't unwind a blocked Go goroutine, so the in-memory flag (and the STALLED
+state derived from the stalled loop) stayed set. The database-side coordination table
+(`replication_manager_schema.jobs`) was already clean — the ghost was purely in repman
+memory, so only a repman restart cleared it.
+
+## The fix
+
+### Primary: a write-stall watchdog on the backup (defect #1)
+
+`JobBackupMysqldump` already derives a cancellable context that covers **both**
+subprocesses:
+
+```go
+dumpCtx, dumpCancel := context.WithCancel(ctx)          // srv_job_backup.go:2061
+dumpCmd := exec.CommandContext(dumpCtx, …)               // dump uses it
+splitDumpPipeline = server.setupSplitDumpPipeline(dumpCtx, …, dumpCancel)  // splitdump too
+```
+
+So one `dumpCancel()` kills the whole chain. The reader goroutine advances a byte
+counter on every successful read; a watchdog samples it and, if **no bytes flow for
+`backup-write-stall-timeout`**, logs, cancels, and the backup returns a stall error
+instead of hanging. Cancelling frees the pipes → `wg.Wait()` returns → the caller's
+`defer` clears `InLogicalBackup` → the source's dump transaction is released → the pill
+clears. **One fix resolves the hang, the pinned source transaction, and the ghost
+state.**
+
+`backup-write-stall-timeout` (seconds, default **300**; `0` disables) — a *stall*
+timeout, not a total-time cap, so legitimately long dumps are unaffected; only a backup
+that stops making progress is aborted.
+
+### Secondary: stop taxing the monitoring hot path (defect #3)
+
+The `time.Sleep(3s)` in `JobsCheckFinished` now runs **only when there were finished
+tasks** to flush (`len(logs) > 0`) — the writelog-API wait it was added for. The common
+case (no finished job, every tick) no longer sleeps.
+
+### Documented, not yet changed: decouple job checks from `Ping` (defect #2)
+
+Moving `JobsCheckStates` off the synchronous `Ping`/`TopologyDiscover` path (run it on
+its own cadence, publish results as state) is the structural fix so no backup/job work
+can ever stall topology discovery. Larger change; tracked as follow-up.
+
+## Testing
+
+### Unit — watchdog logic (CI, no DB, no mount)
+
+`backupStallWatchdog` is a standalone helper tested directly
+(`srv_job_backup_stall_test.go`): drive a progress counter, stop advancing it, and assert
+`cancel` fires within the stall timeout (and that it does **not** fire while progress
+continues, nor when the timeout is `0`). Uses millisecond timeouts for speed.
+
+### Integration — a controllable mount you can disconnect (manual/ops)
+
+The faithful reproduction, matching the incident, uses a mount you can pull mid-backup:
+
+```bash
+# 1. a small loopback filesystem as the backup volume
+truncate -s 200M /tmp/repman-backvol.img
+mkfs.ext4 -q /tmp/repman-backvol.img
+mkdir -p /mnt/repman-backvol
+mount -o loop /tmp/repman-backvol.img /mnt/repman-backvol
+# point the cluster's backup dir at /mnt/repman-backvol and start a logical backup
+
+# 2. mid-backup, disconnect the volume
+umount -l /mnt/repman-backvol        # lazy unmount = writes start failing/hanging
+#   (or, to simulate a hung NFS rather than a clean ENOSPC/EIO:
+#    losetup -d the backing device, or block the nfs server)
+
+# 3. expected WITH the fix: within backup-write-stall-timeout the backup aborts with a
+#    stall error, InLogicalBackup clears, no STALLED pill, source dump transaction released.
+#    WITHOUT the fix: backup hangs indefinitely (the incident).
+```
+
+A `losetup`-detach or an `iptables`-blocked NFS server reproduces the *hung* variant
+(writes block instead of erroring), which is the harder case the watchdog specifically
+targets — an `EIO`/`ENOSPC` would at least error the write, but a hung mount never
+returns, which is why a progress watchdog (not just error handling) is required.

--- a/doc/implementation/cluster/BACKUP_DEAD_VOLUME_STALL.md
+++ b/doc/implementation/cluster/BACKUP_DEAD_VOLUME_STALL.md
@@ -87,9 +87,26 @@ instead of hanging. Cancelling frees the pipes → `wg.Wait()` returns → the c
 clears. **One fix resolves the hang, the pinned source transaction, and the ghost
 state.**
 
-`backup-write-stall-timeout` (seconds, default **300**; `0` disables) — a *stall*
-timeout, not a total-time cap, so legitimately long dumps are unaffected; only a backup
-that stops making progress is aborted.
+`backup-write-stall-timeout` (seconds, default **300**; `0` disables, negative
+logs a warning and disables) — a *stall* timeout, not a total-time cap, so
+legitimately long dumps are unaffected; only a backup that stops making progress
+is aborted.
+
+**Detection latency.** The watchdog samples every `stallTimeout/4` (min 1s) and
+confirms over four idle samples, so the abort lands up to
+`stallTimeout + checkInterval` after progress stops (~375s at the 300s default).
+
+**Best-effort against a *hard*-hung mount, not a guarantee.** Cancellation relies
+on `exec.CommandContext` sending `SIGKILL`. That frees a normal subprocess, but a
+process wedged in uninterruptible sleep (**D-state**) on a hard-hung NFS-style
+mount will not die on `SIGKILL`, and its pipe reader/writer goroutines cannot
+unwind. So after cancelling, the wait on those goroutines is **bounded**
+(`backupStallLeakGrace`, 60s): if they still haven't finished, the backup returns
+the stall error and **leaks** the stuck goroutine rather than hanging forever
+(only a mount recovery or a repman restart can free a D-state process). This
+guarantees the *backup call* unwinds — clearing `InLogicalBackup` and releasing
+the source transaction — even in the worst case; it does not guarantee the OS
+process is gone.
 
 ### Secondary: stop taxing the monitoring hot path (defect #3)
 

--- a/doc/implementation/config/CONFIG_PERSISTENCE_SAVE_LOAD_GATE.md
+++ b/doc/implementation/config/CONFIG_PERSISTENCE_SAVE_LOAD_GATE.md
@@ -1,0 +1,78 @@
+# Config persistence: the save/load gate asymmetry
+
+## Symptom
+
+A per-cluster setting changed at runtime (via GUI/API) — e.g. a custom
+`backup-mysqldump-options` with `--skip-ssl` — **works during the session but
+reverts to the old value after a repman restart.** The value is genuinely on
+disk: it is written to the datadir `<cluster>/<cluster>.toml` under
+`[saved-<cluster>]`, committed, and pushed to the git config repo (confirmed by
+reading the file on the repo's `master` branch). So the **save works**; the loss
+happens on **restart**.
+
+## Root cause
+
+Two different gates decide "does monitoring-save-config apply", and they resolve
+its default **differently**:
+
+| Path | Gate | Value when the key is ABSENT from the config file |
+|------|------|---------------------------------------------------|
+| **Save** (`SaveCallBack` → `SaveConfigFile`) | `conf.ConfRewrite` — the `monitoring-save-config` **pflag**, default **true** (`server.go:388`) | **true** → writes `<cluster>/<cluster>.toml` |
+| **Load at startup** (`InitConfig`) | `firstRead.GetBool("default.monitoring-save-config")` — reads the config **file** (`server.go:1777`) | **false** → skips the whole datadir-overlay read block |
+
+So for a user who never explicitly sets `monitoring-save-config` in their config
+(the common case — the flag default is `true`, so nobody needs to):
+
+- **Saves happen** (`ConfRewrite` = flag default `true`) → the change reaches
+  `[saved-<cluster>]` on disk and in git.
+- **Startup skips loading** the datadir overlays (`GetBool` returns `false` for
+  an absent key) → the `[saved-<cluster>]` section is never merged → the value
+  silently reverts to the static/`[DEFAULT]` value on restart.
+
+This also explains why a **runtime** reload (`ReconstructLiveClusterConfig`,
+the API `settings/actions/reload`) preserves the value — that path is **not**
+gated on `monitoring-save-config`; it always reads
+`<cluster>/<cluster>.toml` when present. Only the full **process restart**
+(`InitConfig`) loses it. This is the OSC build; `monitoring-save-config`
+defaults to `true` there (shared `AddFlags`, no build-tag variance).
+
+## Fix
+
+`monitoringSaveConfigEnabled(firstRead, flagDefault)` resolves the gate to the
+flag default (`conf.ConfRewrite`, true) when the key is **absent**, and only
+uses the file value when it is **explicitly set**:
+
+```go
+func monitoringSaveConfigEnabled(firstRead *viper.Viper, flagDefault bool) bool {
+	if firstRead.IsSet("default.monitoring-save-config") {
+		return firstRead.GetBool("default.monitoring-save-config")
+	}
+	return flagDefault
+}
+```
+
+`InitConfig` now uses it (`server.go:1777`), so the **load gate matches the save
+gate**: if repman saved it, repman reads it back. Explicit `= false` in the
+config still disables persistence; env and command-line overrides are unchanged.
+
+## Observability
+
+`Cluster.LastConfigSaveToDisk` (exposed in the API as `lastConfigSaveToDisk`,
+groups `web`) is stamped whenever `SaveConfigFile` actually writes the datadir
+`<cluster>.toml`. It lets an operator (and the regression tests) distinguish
+"changed in memory only" from "written to the file that startup reads back" —
+a passing timestamp with a value that still reverts pinpoints the load gate; a
+timestamp that never advances pinpoints the save.
+
+## Tests
+
+- `server_reload_test.go`:
+  - `TestReconstructLiveClusterConfig_PreservesSavedBackupOption` — a persisted
+    `[saved-<cluster>]` backup option survives the reconstruct/reload path.
+  - `TestMonitoringSaveConfigEnabled_DefaultsToFlagWhenAbsent` — the gate
+    defaults to the flag value when absent, honors explicit true/false. This is
+    the direct reproduction of the asymmetry.
+- `regtest/test_config_persist_backup_option.go` — `testConfigPersistBackupOption`:
+  against a live cluster, change `backup-mysqldump-options`, persist, and assert
+  both that `LastConfigSaveToDisk` advanced and that the value reached the datadir
+  `<cluster>.toml` (the save side, on real infrastructure).

--- a/etc/config.toml
+++ b/etc/config.toml
@@ -171,6 +171,7 @@ include = "/etc/replication-manager/cluster.d"
 # backup-mydumper-path = "/usr/bin/mydumper"
 # backup-myloader-path = "/usr/bin/myloader"
 # backup-restic-binary-path = "/usr/bin/restic"
+# backup-write-stall-timeout = 300 # seconds with no bytes written to the backup output before a logical backup is aborted (dead/hung backup volume); 0 disables. A stall timeout, not a cap on total backup time.
 # backup-restic-timeout = 7200
 # backup-restic-dump-timeout = 0 # 0 uses backup-restic-timeout
 # backup-restic-dir-mode = 700

--- a/regtest/regtest.go
+++ b/regtest/regtest.go
@@ -63,6 +63,7 @@ var tests = []string{
 	"testSplitBrainNoWinner",
 	"testMasterNil",
 	"testRunSysbenchTPCPerMinuteIncreaseThreads",
+	"testConfigPersistBackupOption",
 	"testConfigCookiePushBasic",
 	"testConfigCookiePushLifecycle",
 	"testConfigCookiePushMultipleServers",

--- a/regtest/test_config_persist_backup_option.go
+++ b/regtest/test_config_persist_backup_option.go
@@ -1,0 +1,76 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// Authors: Guillaume Lefranc <guillaume@signal18.io>
+//          Stephane Varoqui  <svaroqui@gmail.com>
+// This source code is licensed under the GNU General Public License, version 3.
+
+package regtest
+
+import (
+	"os"
+	"strings"
+
+	"github.com/signal18/replication-manager/cluster"
+	"github.com/signal18/replication-manager/config"
+)
+
+// TestConfigPersistBackupOption verifies that a changed per-cluster config value
+// (here backup-mysqldump-options) actually survives a persist to the datadir
+// <cluster>/<cluster>.toml — the file startup merges LAST and that therefore
+// wins on restart. This is the reproduction for the "custom backup options lost
+// after restart" bug: change the value, persist, and confirm it is on disk (not
+// just in memory). It also asserts the LastConfigSaveToDisk instrument advanced,
+// so a passing timestamp with a missing value pinpoints strip-on-save, while an
+// unchanged timestamp pinpoints the save never running.
+func (regtest *RegTest) TestConfigPersistBackupOption(cl *cluster.Cluster, conf string, test *cluster.Test) bool {
+	const marker = "--hex-blob --single-transaction --skip-ssl --REGTEST-PERSIST-MARKER"
+
+	savedFile := cl.Conf.WorkingDir + "/" + cl.Name + "/" + cl.Name + ".toml"
+	original := cl.Conf.BackupMysqldumpOptions
+	beforeStamp := cl.LastConfigSaveToDisk
+
+	// Always restore the original value and re-persist, pass or fail.
+	defer func() {
+		cl.Conf.BackupMysqldumpOptions = original
+		cl.SaveConfigFile()
+	}()
+
+	// 1. Change the value in memory (mirrors what the API/GUI setter does).
+	cl.Conf.BackupMysqldumpOptions = marker
+
+	// 2. Persist to the datadir <cluster>.toml.
+	changed, err := cl.SaveConfigFile()
+	if err != nil {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "TEST persist: SaveConfigFile error: %s", err)
+		return false
+	}
+	if !changed {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "TEST persist: SaveConfigFile reported no change for a changed value")
+		return false
+	}
+
+	// 3. The last-saved-to-disk instrument must have advanced.
+	if !cl.LastConfigSaveToDisk.After(beforeStamp) {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
+			"TEST persist: LastConfigSaveToDisk did not advance (%s) — the save never reached disk", cl.LastConfigSaveToDisk)
+		return false
+	}
+
+	// 4. Read the persisted file back — this is the file startup merges last.
+	//    If the marker is absent, the value was stripped on save (the bug):
+	//    it will "disappear" on the next restart even though it saved.
+	data, err := os.ReadFile(savedFile)
+	if err != nil {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "TEST persist: cannot read %s: %s", savedFile, err)
+		return false
+	}
+	if !strings.Contains(string(data), "REGTEST-PERSIST-MARKER") {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
+			"TEST persist: backup-mysqldump-options was NOT persisted to %s — it will be lost on restart (config-persistence bug)", savedFile)
+		return false
+	}
+
+	cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST",
+		"Config persistence OK: backup-mysqldump-options reached %s and LastConfigSaveToDisk advanced to %s", savedFile, cl.LastConfigSaveToDisk)
+	return true
+}

--- a/server/regtest.go
+++ b/server/regtest.go
@@ -257,6 +257,9 @@ func (repman *ReplicationManager) RunAllTests(cl *cluster.Cluster, testExp strin
 		if test.Name == "testSchemaPlugin" {
 			res = regtest.TestSchemaPlugin(cl, test.ConfigFile, &test)
 		}
+		if test.Name == "testConfigPersistBackupOption" {
+			res = regtest.TestConfigPersistBackupOption(cl, test.ConfigFile, &test)
+		}
 
 		test.Result = regtest.GetTestResultLabel(res)
 		if testExp == "SUITE" {

--- a/server/server.go
+++ b/server/server.go
@@ -930,6 +930,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.BackupResticRepository, "backup-restic-repository", "s3:https://s3.signal18.io/backups", "Restic backend repository")
 	flags.StringVar(&conf.BackupResticPassword, "backup-restic-password", "secret", "Restic backend password")
 	flags.BoolVar(&conf.BackupResticAws, "backup-restic-aws", false, "Restic will archive to s3 or to datadir/backups/archive")
+	flags.IntVar(&conf.BackupWriteStallTimeout, "backup-write-stall-timeout", 300, "Seconds with no bytes written to the backup output before a logical backup is aborted (dead/hung backup volume). 0 disables. This is a stall timeout, not a cap on total backup time.")
 	flags.IntVar(&conf.BackupResticTimeout, "backup-restic-timeout", 7200, "Restic operation timeout in seconds")
 	flags.IntVar(&conf.BackupResticDumpTimeout, "backup-restic-dump-timeout", 0, "Timeout in seconds for restic dump operations (0 uses backup-restic-timeout)")
 	flags.IntVar(&conf.BackupResticDirMode, "backup-restic-dir-mode", 700, "Restic directory permissions (octal, e.g. 700)")

--- a/server/server.go
+++ b/server/server.go
@@ -1555,6 +1555,26 @@ func (repman *ReplicationManager) MergeOnStart(conf config.Config) error {
 	return nil
 }
 
+// monitoringSaveConfigEnabled resolves whether startup loads the datadir saved
+// overlays (default.toml + <cluster>/<cluster>.toml, i.e. the [saved-*]
+// sections). It must default to flagDefault (the monitoring-save-config pflag
+// default, true) when the key is ABSENT from the config file.
+//
+// The bug this fixes: reading a bare firstRead.GetBool("default.monitoring-save-config")
+// returns false when the key is not present in the file, so the datadir
+// overlays were skipped at startup — even though the SAVE path is gated on
+// conf.ConfRewrite (the same flag, default true) and had been writing them. A
+// user who never sets monitoring-save-config in their config therefore had
+// their per-cluster changes persisted to disk/git but silently reverted on
+// every restart (e.g. custom backup-mysqldump-options). Aligning the load gate
+// with the save gate removes the asymmetry.
+func monitoringSaveConfigEnabled(firstRead *viper.Viper, flagDefault bool) bool {
+	if firstRead.IsSet("default.monitoring-save-config") {
+		return firstRead.GetBool("default.monitoring-save-config")
+	}
+	return flagDefault
+}
+
 func (repman *ReplicationManager) InitConfig(conf config.Config, init_git bool) {
 	if repman.Conf == nil {
 		repman.Conf = new(config.Config)
@@ -1773,8 +1793,12 @@ func (repman *ReplicationManager) InitConfig(conf config.Config, init_git bool) 
 		tmp_read.Unmarshal(&conf)
 	}
 
-	// Proceed dynamic config
-	monitoringSaveConfig := firstRead.GetBool("default.monitoring-save-config")
+	// Proceed dynamic config. Default to the flag value (conf.ConfRewrite,
+	// default true) when monitoring-save-config is absent from the file — a bare
+	// GetBool returned false when absent and skipped the datadir saved overlays
+	// at startup, silently reverting persisted per-cluster settings on restart
+	// even though the save path (conf.ConfRewrite) had written them.
+	monitoringSaveConfig := monitoringSaveConfigEnabled(firstRead, conf.ConfRewrite)
 	envDefault := envViperForScope("DEFAULT")
 	if envDefault.IsSet("monitoring-save-config") {
 		monitoringSaveConfig = envDefault.GetBool("monitoring-save-config")

--- a/server/server_reload_test.go
+++ b/server/server_reload_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 // newReloadTestRepman builds the minimal ReplicationManager needed to drive
@@ -309,5 +310,84 @@ func TestReconstructLiveClusterConfig_AppliesSavedDefaultSectionAlias(t *testing
 
 	if conf.LogFile != "/var/log/saved-deprecated-alias.log" {
 		t.Errorf("LogFile = %q, want %q (deprecated [saved-default] key \"logfile\" was not aliased to \"log-file\")", conf.LogFile, "/var/log/saved-deprecated-alias.log")
+	}
+}
+
+// TestReconstructLiveClusterConfig_PreservesSavedBackupOption reproduces the
+// "custom backup options lost after restart" bug. A per-cluster dynamic value
+// (backup-mysqldump-options, e.g. with --skip-ssl) is changed at runtime and
+// persisted to the datadir <cluster>/<cluster>.toml under [saved-<cluster>]
+// (verified present in the git config repo). The reload MUST re-apply it; if
+// the saved overlay is dropped, the value silently reverts on restart even
+// though it is on disk.
+func TestReconstructLiveClusterConfig_PreservesSavedBackupOption(t *testing.T) {
+	includeDir := t.TempDir()
+	workingDir := t.TempDir()
+
+	// Static section (from /etc-style include) — does NOT set the backup option.
+	if err := os.WriteFile(filepath.Join(includeDir, "regcluster.toml"),
+		[]byte("[regcluster]\ndb-servers-hosts = \"db1\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainConfigPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(mainConfigPath, []byte("[DEFAULT]\ninclude = \""+includeDir+"\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Dynamic overlay persisted since the last restart — the custom value.
+	clusterDir := filepath.Join(workingDir, "regcluster")
+	if err := os.MkdirAll(clusterDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	const marker = "--hex-blob --single-transaction --skip-ssl"
+	if err := os.WriteFile(filepath.Join(clusterDir, "regcluster.toml"),
+		[]byte("[saved-regcluster]\ntitle = \"regcluster\"\nbackup-mysqldump-options = \""+marker+"\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repman := newReloadTestRepman(&config.Config{
+		ConfigFile:  mainConfigPath,
+		WorkingDir:  workingDir,
+		ConfRewrite: true,
+	})
+
+	conf, err := repman.ReconstructLiveClusterConfig("regcluster")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if conf.BackupMysqldumpOptions != marker {
+		t.Errorf("BackupMysqldumpOptions = %q, want %q — the persisted [saved-regcluster] backup option was dropped on reload (custom backup options lost after restart)", conf.BackupMysqldumpOptions, marker)
+	}
+}
+
+// TestMonitoringSaveConfigEnabled_DefaultsToFlagWhenAbsent reproduces the
+// save/load gate asymmetry behind "custom settings lost after restart": when
+// monitoring-save-config is not in the config file, the startup load gate must
+// default to the flag value (true), NOT false — otherwise the datadir saved
+// overlays are skipped at startup even though the save path (same flag, default
+// true) wrote them.
+func TestMonitoringSaveConfigEnabled_DefaultsToFlagWhenAbsent(t *testing.T) {
+	// Absent in file, flag default true -> must enable (the bug returned false).
+	v := viper.New()
+	v.SetConfigType("toml")
+	if !monitoringSaveConfigEnabled(v, true) {
+		t.Fatal("absent monitoring-save-config must default to the flag value true; got false -> datadir overlays skipped at startup, persisted settings revert on restart")
+	}
+
+	// Explicit false overrides the flag default.
+	vFalse := viper.New()
+	vFalse.SetConfigType("toml")
+	vFalse.Set("default.monitoring-save-config", false)
+	if monitoringSaveConfigEnabled(vFalse, true) {
+		t.Fatal("explicit monitoring-save-config=false must disable")
+	}
+
+	// Explicit true is honored even if the flag default were false.
+	vTrue := viper.New()
+	vTrue.SetConfigType("toml")
+	vTrue.Set("default.monitoring-save-config", true)
+	if !monitoringSaveConfigEnabled(vTrue, false) {
+		t.Fatal("explicit monitoring-save-config=true must enable")
 	}
 }

--- a/share/dashboard_react/src/Pages/Settings/index.jsx
+++ b/share/dashboard_react/src/Pages/Settings/index.jsx
@@ -1,4 +1,4 @@
-import { Button, Flex, useDisclosure } from '@chakra-ui/react'
+import { Button, Flex, Text, useDisclosure } from '@chakra-ui/react'
 import React, { useState, useEffect } from 'react'
 import styles from './styles.module.scss'
 import GeneralSettings from './GeneralSettings'
@@ -148,6 +148,15 @@ function Settings({ selectedCluster, user, onTabChange, monitor }) {
   return (
     <Flex className={styles.settingsContainer}>
       <StandbyBanner />
+      {(() => {
+        const ts = selectedCluster?.lastConfigSaveToDisk
+        const saved = ts && !ts.startsWith('0001-01-01')
+        return (
+          <Text fontSize='xs' color='gray.500' mb={1}>
+            Config last saved to disk: {saved ? new Date(ts).toLocaleString() : 'not yet saved this session'}
+          </Text>
+        )
+      })()}
       {sectionFilter && (
         <Button size='sm' variant='outline' mb={2} onClick={clearFilter}>
           Show all settings


### PR DESCRIPTION
## Incident

A logical (`mariadb-dump` → `splitdump`) backup was running to a **mounted backup volume**; the mount was lost mid-backup. The database was never affected, but repman went sideways: the backup hung for 1h+, the source's `--single-transaction` read view stayed open (pinning InnoDB purge), and the GUI lit a **STALLED** pill that kept blinking **even after both OS processes were killed by hand**.

Diagnosed from a `/debug/pprof/goroutine` capture (two 30s-apart dumps): the monitoring loop was *advancing*, not deadlocked — three defects stacked.

## Root cause

1. **Dead output volume hangs the backup forever.** The hung mount blocks `splitdump`'s writes → back-pressures `mariadb-dump` and repman's read loop → `JobBackupMysqldump` parks on `wg.Wait()` with **no timeout**.
2. **The stuck backup drags monitoring** — job-state checks run inline on the `Ping`/`TopologyDiscover` path (documented; structural fix is follow-up).
3. **An unconditional `time.Sleep(3s)`** in `JobsCheckFinished` taxed every monitoring tick for every server.

Killing the processes didn't clear the pill because the hung goroutine never returned, so the deferred `InLogicalBackup` clear never ran — a pure in-memory ghost (the DB `jobs` table was already clean).

## Fix

- **Write-stall watchdog** (defect #1): track bytes flowing through the read loop; if none flow for `backup-write-stall-timeout` (default **300s**, `0` disables), cancel the already-cancellable `dumpCtx` — which kills **both** the dump and splitdump subprocesses (the cancel infra already existed at `srv_job_backup.go:2061`). The backup returns a clear stall error instead of hanging; unwinding runs the defers → `InLogicalBackup` clears, source transaction releases. **One fix resolves the hang, the pinned source transaction, and the ghost STALLED state.** It's a *stall* timeout, not a total-time cap — long healthy dumps are unaffected.
- **Sleep guard** (defect #3): the `time.Sleep(3s)` in `JobsCheckFinished` now runs only when there was a finished job to flush.

## Tests

- `srv_job_backup_stall_test.go` unit-tests the standalone watchdog: cancels on stall, never cancels while progressing, no-ops when disabled (`0`). `go build`/`go vet`/`go test ./cluster ./config ./server` green.
- **Controllable-mount reproduction** (loopback fs + lazy-unmount / `losetup`-detach) documented in `doc/implementation/cluster/BACKUP_DEAD_VOLUME_STALL.md` — the faithful way to validate the hung-mount variant before trusting it in production.

## Follow-ups (documented, not in this PR)

- Move job-state checks off the synchronous `Ping` path (defect #2) so no backup work can stall topology discovery.
- Expose `backup-write-stall-timeout` in the GUI Backup settings panel.