### PR TITLE
harden(auth): bind API auth method to password presence

### DIFF
--- a/cluster/cluster_acl.go
+++ b/cluster/cluster_acl.go
@@ -7,6 +7,7 @@
 package cluster
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"slices"
 	"sort"
@@ -107,6 +108,21 @@ func (u *APIUser) Granted(grant string) error {
 //   - no password        => SSO identity. Authenticated by OIDC only; local
 //     password auth is refused — an empty stored or submitted password must
 //     never authenticate, closing the blank-password bypass.
+// IsLocalOnlyAccount reports whether strUser is a local (password-protected)
+// account that must authenticate by password only — SSO must never bind or
+// authenticate it, or a same-named GitLab identity would ride its ACL. The
+// registering owner (Cloud18GitUser) is exempt: it authenticates via SSO despite
+// carrying a GitLab password. Single source of truth for the auth-model
+// invariant, used by IsValidACL's OIDC branch and the OIDC callback's collision
+// guard in server/api.go.
+func (cluster *Cluster) IsLocalOnlyAccount(strUser string) bool {
+	user, ok := cluster.APIUsers[strUser]
+	if !ok {
+		return false
+	}
+	return user.Password != "" && strUser != cluster.Conf.Cloud18GitUser
+}
+
 func (cluster *Cluster) IsValidACL(strUser string, strPassword string, URL string, AuthMethod string) bool {
 	user, ok := cluster.APIUsers[strUser]
 	if !ok {
@@ -115,8 +131,8 @@ func (cluster *Cluster) IsValidACL(strUser string, strPassword string, URL strin
 
 	if AuthMethod == "oidc" {
 		// A password-protected account is local; SSO cannot authenticate it
-		// (except the registering owner, whose credential is a GitLab password).
-		if user.Password != "" && strUser != cluster.Conf.Cloud18GitUser {
+		// (except the registering owner). Same rule the collision guard uses.
+		if cluster.IsLocalOnlyAccount(strUser) {
 			return false
 		}
 		return cluster.IsURLPassACL(strUser, URL, true)
@@ -127,7 +143,7 @@ func (cluster *Cluster) IsValidACL(strUser string, strPassword string, URL strin
 	if user.Password == "" || strPassword == "" {
 		return false
 	}
-	if user.Password == cluster.Conf.GetDecryptedPassword("api-credentials", strPassword) {
+	if subtle.ConstantTimeCompare([]byte(user.Password), []byte(cluster.Conf.GetDecryptedPassword("api-credentials", strPassword))) == 1 {
 		return cluster.IsURLPassACL(strUser, URL, true)
 	}
 	return false
@@ -140,7 +156,7 @@ func (cluster *Cluster) GetAPIUser(strUser string, strPassword string) (APIUser,
 		if user.Password == "" || strPassword == "" {
 			return APIUser{}, fmt.Errorf("incorrect password")
 		}
-		if user.Password == strPassword {
+		if subtle.ConstantTimeCompare([]byte(user.Password), []byte(strPassword)) == 1 {
 			return user, nil
 		}
 		return APIUser{}, fmt.Errorf("incorrect password")

--- a/cluster/cluster_acl.go
+++ b/cluster/cluster_acl.go
@@ -97,21 +97,49 @@ func (u *APIUser) Granted(grant string) error {
 	return v3.NewErrorResource(codes.PermissionDenied, v3.ErrGrantNotFound, "grant not found", "").Err()
 }
 
+// IsValidACL authenticates strUser for URL. The auth model is keyed on whether
+// the account carries a local password:
+//
+//   - password present  => LOCAL account. Authenticated by password only; SSO is
+//     refused (a same-named GitLab identity must never ride a local account's
+//     ACL). The registering owner (Cloud18GitUser) is the one SSO account that
+//     legitimately carries a credential, so it is exempt.
+//   - no password        => SSO identity. Authenticated by OIDC only; local
+//     password auth is refused — an empty stored or submitted password must
+//     never authenticate, closing the blank-password bypass.
 func (cluster *Cluster) IsValidACL(strUser string, strPassword string, URL string, AuthMethod string) bool {
-	if user, ok := cluster.APIUsers[strUser]; ok {
-		if user.Password == cluster.Conf.GetDecryptedPassword("api-credentials", strPassword) || AuthMethod == "oidc" {
-			// cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "ACL URL check for user %s ", strUser)
-			return cluster.IsURLPassACL(strUser, URL, true)
-		}
+	user, ok := cluster.APIUsers[strUser]
+	if !ok {
 		return false
 	}
 
-	// cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "ACL failed, user not found %s ", strUser)
+	if AuthMethod == "oidc" {
+		// A password-protected account is local; SSO cannot authenticate it
+		// (except the registering owner, whose credential is a GitLab password).
+		if user.Password != "" && strUser != cluster.Conf.Cloud18GitUser {
+			return false
+		}
+		return cluster.IsURLPassACL(strUser, URL, true)
+	}
+
+	// Local password auth: passwordless accounts are SSO-only, and a blank
+	// submitted password never authenticates.
+	if user.Password == "" || strPassword == "" {
+		return false
+	}
+	if user.Password == cluster.Conf.GetDecryptedPassword("api-credentials", strPassword) {
+		return cluster.IsURLPassACL(strUser, URL, true)
+	}
 	return false
 }
 
 func (cluster *Cluster) GetAPIUser(strUser string, strPassword string) (APIUser, error) {
 	if user, ok := cluster.APIUsers[strUser]; ok {
+		// A passwordless (SSO-provisioned) account must never authenticate by a
+		// blank local password (blank-password bypass).
+		if user.Password == "" || strPassword == "" {
+			return APIUser{}, fmt.Errorf("incorrect password")
+		}
 		if user.Password == strPassword {
 			return user, nil
 		}

--- a/cluster/cluster_acl_auth_guard_test.go
+++ b/cluster/cluster_acl_auth_guard_test.go
@@ -95,3 +95,24 @@ func TestIsValidACL_AuthGuards(t *testing.T) {
 		}
 	})
 }
+
+// TestIsLocalOnlyAccount checks the single-source-of-truth helper shared by
+// IsValidACL's OIDC branch and the OIDC-callback collision guard.
+func TestIsLocalOnlyAccount(t *testing.T) {
+	c := newAuthGuardCluster() // Cloud18GitUser = "owner"
+	c.APIUsers["dba"] = APIUser{User: "dba", Password: "secret"}       // local
+	c.APIUsers["peer@corp.com"] = APIUser{User: "peer@corp.com"}       // SSO (no password)
+	c.APIUsers["owner"] = APIUser{User: "owner", Password: "gitlabpw"} // owner, exempt
+
+	cases := map[string]bool{
+		"dba":           true,  // password-protected -> local only
+		"peer@corp.com": false, // passwordless -> SSO
+		"owner":         false, // Cloud18GitUser exempt despite password
+		"ghost":         false, // unknown
+	}
+	for user, want := range cases {
+		if got := c.IsLocalOnlyAccount(user); got != want {
+			t.Errorf("IsLocalOnlyAccount(%q) = %v, want %v", user, got, want)
+		}
+	}
+}

--- a/cluster/cluster_acl_auth_guard_test.go
+++ b/cluster/cluster_acl_auth_guard_test.go
@@ -1,0 +1,97 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// Authors: Guillaume Lefranc <guillaume@signal18.io>
+//          Stephane Varoqui  <svaroqui@gmail.com>
+// This source code is licensed under the GNU General Public License, version 3.
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+)
+
+func newAuthGuardCluster() *Cluster {
+	return &Cluster{
+		Name:     "test",
+		Conf:     &config.Config{Verbose: false, Cloud18GitUser: "owner"},
+		APIUsers: make(map[string]APIUser),
+	}
+}
+
+// TestIsValidACL_AuthGuards covers the password/SSO auth model:
+// password present => local-only; no password => SSO-only. /api/monitor is a
+// public endpoint so IsURLPassACL is always true and only the auth guards decide.
+func TestIsValidACL_AuthGuards(t *testing.T) {
+	const pubURL = "/api/monitor"
+
+	t.Run("local account: correct password authenticates", func(t *testing.T) {
+		c := newAuthGuardCluster()
+		c.APIUsers["dba"] = APIUser{User: "dba", Password: "secret"}
+		if !c.IsValidACL("dba", "secret", pubURL, "password") {
+			t.Fatal("local account with correct password must authenticate")
+		}
+	})
+
+	t.Run("local account: wrong password rejected", func(t *testing.T) {
+		c := newAuthGuardCluster()
+		c.APIUsers["dba"] = APIUser{User: "dba", Password: "secret"}
+		if c.IsValidACL("dba", "nope", pubURL, "password") {
+			t.Fatal("wrong password must be rejected")
+		}
+	})
+
+	t.Run("local account: empty submitted password rejected", func(t *testing.T) {
+		c := newAuthGuardCluster()
+		c.APIUsers["dba"] = APIUser{User: "dba", Password: "secret"}
+		if c.IsValidACL("dba", "", pubURL, "password") {
+			t.Fatal("empty submitted password must be rejected")
+		}
+	})
+
+	// THE bypass: a passwordless (SSO-provisioned) account must NOT authenticate
+	// via the local password path with a blank password.
+	t.Run("passwordless account: blank-password local auth rejected", func(t *testing.T) {
+		c := newAuthGuardCluster()
+		c.APIUsers["peer@corp.com"] = APIUser{User: "peer@corp.com", Password: ""}
+		if c.IsValidACL("peer@corp.com", "", pubURL, "password") {
+			t.Fatal("blank-password bypass: passwordless account authenticated via local password path")
+		}
+	})
+
+	t.Run("passwordless account: SSO authenticates", func(t *testing.T) {
+		c := newAuthGuardCluster()
+		c.APIUsers["peer@corp.com"] = APIUser{User: "peer@corp.com", Password: ""}
+		if !c.IsValidACL("peer@corp.com", "", pubURL, "oidc") {
+			t.Fatal("passwordless SSO account must authenticate via oidc")
+		}
+	})
+
+	// Collision protection: a password-protected local account must NOT be
+	// authenticated via SSO (a same-named GitLab identity can't ride its ACL).
+	t.Run("local account: SSO refused (collision protection)", func(t *testing.T) {
+		c := newAuthGuardCluster()
+		c.APIUsers["dba"] = APIUser{User: "dba", Password: "secret"}
+		if c.IsValidACL("dba", "", pubURL, "oidc") {
+			t.Fatal("password-protected local account must not authenticate via SSO")
+		}
+	})
+
+	// Owner exemption: the registering Cloud18GitUser carries a GitLab password
+	// yet must still be allowed to SSO.
+	t.Run("owner: SSO allowed despite password", func(t *testing.T) {
+		c := newAuthGuardCluster()
+		c.APIUsers["owner"] = APIUser{User: "owner", Password: "gitlabpass"}
+		if !c.IsValidACL("owner", "", pubURL, "oidc") {
+			t.Fatal("Cloud18GitUser must be allowed to SSO despite carrying a password")
+		}
+	})
+
+	t.Run("unknown user rejected", func(t *testing.T) {
+		c := newAuthGuardCluster()
+		if c.IsValidACL("ghost", "x", pubURL, "password") {
+			t.Fatal("unknown user must be rejected")
+		}
+	})
+}

--- a/doc/implementation/security/API_CREDENTIAL_AUTH_MODEL.md
+++ b/doc/implementation/security/API_CREDENTIAL_AUTH_MODEL.md
@@ -1,0 +1,60 @@
+# API credential authentication model
+
+The API auth model is keyed on **whether an account carries a local password**.
+This makes local vs SSO identity explicit and prevents a same-named SSO identity
+from taking over a local account.
+
+## The invariant
+
+| Account | Declared by | Authenticates via | Other path |
+|---------|-------------|-------------------|------------|
+| **Local** | a **non-empty** password in `api-credentials` | local password only | SSO refused |
+| **SSO**   | **no** password (email-only entry) | OIDC/SSO only | local password refused |
+| **Owner** | `Cloud18GitUser` (registering user) | OIDC/SSO (its credential is a GitLab password) | — |
+
+So: *a password means the account is local; no password means it is SSO; the
+registering owner is the single exception.*
+
+## Enforcement (`cluster.IsValidACL`, `cluster/cluster_acl.go`)
+
+- **OIDC path:** if the matched account has a non-empty password it is refused —
+  a password-protected name is local, and SSO must not authenticate (or bind to)
+  it. Exempt: `Cloud18GitUser`.
+- **Password path:** if the stored **or** submitted password is empty, auth is
+  refused — a passwordless (SSO) account never authenticates by a blank local
+  password. `GetAPIUser` (gRPC auth) carries the same guard.
+
+## Collision handling (`server/api.go`, OIDC callback)
+
+When an SSO login's identity matches a **password-protected local account**, the
+login is denied and a security event is logged
+(`api_sso_local_collision`, see [SECURITY_LOGGING.md](SECURITY_LOGGING.md)) —
+loud by design, so a real attempt to authenticate against a reserved local name
+(`admin`, `system`, `dba`, …) is visible rather than silently ignored. The owner
+(`Cloud18GitUser`) is exempt.
+
+## Why
+
+Two API auth doors share one `APIUsers` map: the local password login and the
+OIDC callback. Without this model, an empty-password entry (any SSO-provisioned
+peer, or a hand-written passwordless `api-credentials` line) could be
+authenticated on the **local** door with a blank password, and an SSO identity
+could ride a same-named local account's ACL. Binding auth method to password
+presence closes both.
+
+## Operational / migration note
+
+- **A local API account must have a password.** Any account intended for local
+  password login needs a non-empty password in `api-credentials` — a passwordless
+  entry is now treated as SSO-only and will not accept a local password.
+- **An SSO peer must be passwordless.** Grant partners by **email only** (no
+  `:password`), so they authenticate through the identity manager.
+- The default `admin:repman` and normal password-protected accounts are
+  unaffected.
+
+## Tests
+
+`cluster/cluster_acl_auth_guard_test.go`: correct/blank/wrong password on the
+local path, blank-password rejected for a passwordless account, SSO allowed for
+passwordless, SSO refused for a password-protected local account, and the owner
+exemption.

--- a/doc/implementation/security/SECURITY_LOGGING.md
+++ b/doc/implementation/security/SECURITY_LOGGING.md
@@ -115,6 +115,24 @@ These events are logged by the `server` package via `repman.logSecurityEvent()`.
 {"event":"api_secret_login_success","user":"system","remote_addr":"127.0.0.1:12345","msg":"API secret login successful (dbjobs/service account)"}
 ```
 
+### SSO/local account collision — `api_sso_local_collision`
+
+**Trigger:** An OIDC/SSO login (`/api/auth/callback`) whose identity matches a
+**password-protected local account** (see
+[API_CREDENTIAL_AUTH_MODEL.md](API_CREDENTIAL_AUTH_MODEL.md)). SSO is denied and
+the attempt is logged — a same-named GitLab identity must never authenticate
+against a local account (`admin`, `system`, `dba`, …). The registering owner
+(`Cloud18GitUser`) is exempt. Always logged.
+
+```json
+{"event":"api_sso_local_collision","user":"dba","remote_addr":"10.0.0.1:54321","msg":"SSO denied: dba is a password-protected local account; refusing to bind a GitLab identity to it"}
+```
+
+> Do not confuse with **`api_login_local_sso_mismatch`** (`api_login_upgrade.go`),
+> a different scenario: a *local* login succeeded but its background SSO upgrade
+> was explicitly rejected. `api_sso_local_collision` is an SSO login being
+> refused because the name belongs to a local account.
+
 ---
 
 ## Configuration

--- a/server/api.go
+++ b/server/api.go
@@ -1097,6 +1097,15 @@ func (repman *ReplicationManager) handlerMuxAuthCallback(w http.ResponseWriter, 
 	r.Header.Get("Accept")
 
 	for _, cluster := range repman.Clusters {
+		// A password-protected account is a LOCAL account; SSO must never bind to
+		// it. If a GitLab identity matches a local account name, deny loudly so a
+		// real attempt to ride a reserved local name is visible in the security
+		// log. The registering owner (Cloud18GitUser) is the one exception.
+		if existing, ok := cluster.APIUsers[userInfo.Email]; ok && existing.Password != "" && userInfo.Email != cluster.Conf.Cloud18GitUser {
+			repman.logSecurityEvent("api_sso_local_collision", userInfo.Email, r.RemoteAddr,
+				"SSO denied: "+userInfo.Email+" is a password-protected local account; refusing to bind a GitLab identity to it")
+			continue
+		}
 		//validate user credentials
 		if cluster.IsValidACL(userInfo.Email, cluster.APIUsers[userInfo.Email].Password, r.URL.Path, "oidc") {
 			repman.ensureCRMSessionBootstrappedAsync(oauth2Token.AccessToken)

--- a/server/api.go
+++ b/server/api.go
@@ -1100,8 +1100,11 @@ func (repman *ReplicationManager) handlerMuxAuthCallback(w http.ResponseWriter, 
 		// A password-protected account is a LOCAL account; SSO must never bind to
 		// it. If a GitLab identity matches a local account name, deny loudly so a
 		// real attempt to ride a reserved local name is visible in the security
-		// log. The registering owner (Cloud18GitUser) is the one exception.
-		if existing, ok := cluster.APIUsers[userInfo.Email]; ok && existing.Password != "" && userInfo.Email != cluster.Conf.Cloud18GitUser {
+		// log. Uses cluster.IsLocalOnlyAccount — the single source of truth also
+		// enforced by IsValidACL's OIDC branch, so the two can't drift.
+		// NB: distinct from api_login_local_sso_mismatch (api_login_upgrade.go),
+		// which is "local login succeeded but the SSO upgrade was refused".
+		if cluster.IsLocalOnlyAccount(userInfo.Email) {
 			repman.logSecurityEvent("api_sso_local_collision", userInfo.Email, r.RemoteAddr,
 				"SSO denied: "+userInfo.Email+" is a password-protected local account; refusing to bind a GitLab identity to it")
 			continue


### PR DESCRIPTION
Makes the API authentication model explicit and consistent across the local-password and OIDC paths, which share one `APIUsers` map.

## Model
- **Password present → local account:** authenticated by password only; SSO refused.
- **No password → SSO identity:** authenticated by OIDC only; local password refused.
- **Owner (`Cloud18GitUser`):** the one SSO account that legitimately carries a credential — exempt.

## Changes
- `cluster.IsValidACL`: OIDC refuses a password-protected account (except the owner); the password path refuses an empty stored or submitted password. `GetAPIUser` (gRPC) gets the same empty-password guard.
- OIDC callback (`server/api.go`): an SSO identity matching a password-protected local account is denied and logged (`api_sso_local_collision`) — loud, so an attempt to authenticate against a reserved local name (`admin`/`system`/`dba`) is visible in the security log rather than silently ignored.

## Why
Binding the auth method to password presence keeps a same-named SSO identity from riding a local account's ACL, and stops a passwordless entry (an SSO-provisioned peer, or a hand-written passwordless `api-credentials` line) from being accepted on the local password door.

## Migration
- A local API account **must** have a password (a passwordless entry is now SSO-only).
- Grant SSO peers by **email only** (no `:password`).
- Default `admin:repman` and normal password-protected accounts are unaffected.

## Tests
`cluster/cluster_acl_auth_guard_test.go` — correct/blank/wrong password locally, blank-password rejected for a passwordless account, SSO allowed for passwordless, SSO refused for a password-protected local account, owner exemption. Build/vet/existing ACL+auth suites green.

Model doc: `doc/implementation/security/API_CREDENTIAL_AUTH_MODEL.md`.