### PR TITLE
fix(monitor): run logical reseed off the tick (unblock monitor during restore)

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1239,6 +1239,12 @@ func (cluster *Cluster) StateProcessing() {
 					}
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Fail of processing reseed for %s: %s", servertoreseed.URL, err)
 				}
+				// Reconcile a rejoin-armed reseed with the real outcome (deferred at
+				// arm time). See the WARN0075 handler below for the ordering rationale.
+				if servertoreseed.reseedFromRejoin.Load() {
+					cluster.finishRejoin(servertoreseed.URL, rejoinResultOf(err))
+					servertoreseed.reseedFromRejoin.Store(false)
+				}
 			}
 
 			if s.ErrKey == "WARN0075" && servertoreseed != nil {
@@ -1267,12 +1273,21 @@ func (cluster *Cluster) StateProcessing() {
 				srvReseed := servertoreseed
 				reseedTask := task
 				cluster.trackTickGoroutine(func() {
-					if err := srvReseed.ProcessReseedLogical(reseedTask); err != nil {
+					err := srvReseed.ProcessReseedLogical(reseedTask)
+					if err != nil {
 						srvReseed.JobsUpdateState(reseedTask, err.Error(), 5, 1)
 						if srvReseed.HasReseedingState(reseedTask) {
 							srvReseed.SetInReseedBackup("")
 						}
 						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Fail of processing logical reseed for %s: %s", srvReseed.URL, err)
+					}
+					// If this reseed was armed by a rejoin, reconcile the rejoin record
+					// with the REAL restore outcome (finishRejoin was deferred at arm
+					// time). finishRejoin first (→ rejoinAlreadyAttempted true), then
+					// clear the marker, so the one-shot never has an open gap.
+					if srvReseed.reseedFromRejoin.Load() {
+						cluster.finishRejoin(srvReseed.URL, rejoinResultOf(err))
+						srvReseed.reseedFromRejoin.Store(false)
 					}
 				})
 			}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1255,14 +1255,26 @@ func (cluster *Cluster) StateProcessing() {
 					})
 				}
 
-				err := servertoreseed.ProcessReseedLogical(task)
-				if err != nil {
-					servertoreseed.JobsUpdateState(task, err.Error(), 5, 1)
-					if servertoreseed.HasReseedingState(task) {
-						servertoreseed.SetInReseedBackup("")
+				// Run the logical reseed OFF the monitor tick. A splitdump /
+				// mysqldump restore takes minutes; running it inline here froze
+				// the whole cluster monitor loop (no health checks, no failover —
+				// not even if the master died) for the entire restore, and
+				// serialized concurrent slave reseeds. ProcessReseedLogical claims
+				// the per-server IsReseeding flag atomically (TrySetInReseedBackup),
+				// and rejoin/switchover already refuse a reseeding server, so a
+				// later tick that still sees WARN0075 cannot start a second reseed.
+				// Mirrors the WARN0111 async reseed path below.
+				srvReseed := servertoreseed
+				reseedTask := task
+				cluster.trackTickGoroutine(func() {
+					if err := srvReseed.ProcessReseedLogical(reseedTask); err != nil {
+						srvReseed.JobsUpdateState(reseedTask, err.Error(), 5, 1)
+						if srvReseed.HasReseedingState(reseedTask) {
+							srvReseed.SetInReseedBackup("")
+						}
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Fail of processing logical reseed for %s: %s", srvReseed.URL, err)
 					}
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Fail of processing logical reseed for %s: %s", servertoreseed.URL, err)
-				}
+				})
 			}
 
 			if s.ErrKey == "WARN0076" && servertoreseed != nil {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1239,12 +1239,10 @@ func (cluster *Cluster) StateProcessing() {
 					}
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Fail of processing reseed for %s: %s", servertoreseed.URL, err)
 				}
-				// Reconcile a rejoin-armed reseed with the real outcome (deferred at
-				// arm time). See the WARN0075 handler below for the ordering rationale.
-				if servertoreseed.reseedFromRejoin.Load() {
-					cluster.finishRejoin(servertoreseed.URL, rejoinResultOf(err))
-					servertoreseed.reseedFromRejoin.Store(false)
-				}
+				// NOTE: a rejoin-armed reseed is NOT reconciled here — ProcessReseedPhysical
+				// only arms a detached WaitAndSendSST/SSTRunSender goroutine and returns nil,
+				// so err is not the real outcome. Reconciliation happens at true completion
+				// (IsReseeding clear) via reconcileDeferredRejoinReseeds.
 			}
 
 			if s.ErrKey == "WARN0075" && servertoreseed != nil {
@@ -1281,14 +1279,9 @@ func (cluster *Cluster) StateProcessing() {
 						}
 						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Fail of processing logical reseed for %s: %s", srvReseed.URL, err)
 					}
-					// If this reseed was armed by a rejoin, reconcile the rejoin record
-					// with the REAL restore outcome (finishRejoin was deferred at arm
-					// time). finishRejoin first (→ rejoinAlreadyAttempted true), then
-					// clear the marker, so the one-shot never has an open gap.
-					if srvReseed.reseedFromRejoin.Load() {
-						cluster.finishRejoin(srvReseed.URL, rejoinResultOf(err))
-						srvReseed.reseedFromRejoin.Store(false)
-					}
+					// Rejoin-armed reseed outcome is reconciled uniformly at true
+					// completion (IsReseeding clear) by reconcileDeferredRejoinReseeds,
+					// not here — see that function and the WARN0074 note above.
 				})
 			}
 

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -317,7 +317,11 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 					if m := cluster.GetMaster(); m != nil && extra.URL != m.URL && !extra.IsFailed() &&
 						!cluster.IsSplitBrain && !cluster.StateMachine.IsInFailover() && cluster.Conf.Autorejoin {
 						cluster.SetState("ERR00063", state.State{ErrType: "ERROR", ErrDesc: clusterError["ERR00063"], ErrFrom: "TOPO"})
-						extra.RejoinMaster()
+						// Spawn async like every other rejoin edge (srv.go, crash.go): a
+						// rejoin may run a multi-hour reseed and must never block the monitor
+						// tick. rejoinInProgress makes the per-tick spawn safe; finishRejoin
+						// makes it one-shot. This was the last synchronous rejoin caller.
+						go extra.RejoinMaster()
 					}
 				} else if !cluster.IsFailedArbitrator {
 					// Minority fail-safe: a node that cannot confirm authority via the

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -154,6 +154,7 @@ func (cluster *Cluster) TopologyDiscover(wcg *sync.WaitGroup) error {
 		}
 	}
 	cluster.assertLostEventsStates()
+	cluster.reconcileDeferredRejoinReseeds()
 	cluster.assertRejoinResultStates()
 	cluster.assertReseedProgressStates()
 	if cluster.Conf.Arbitration {

--- a/cluster/restore_progress.go
+++ b/cluster/restore_progress.go
@@ -102,6 +102,66 @@ func (server *ServerMonitor) reseedProgressLine() (string, *ReseedProgress) {
 	return line, info
 }
 
+// ReseedProgressView is the JSON-friendly snapshot of an in-flight restore for the
+// dashboard: enough to render a progress bar (bytes/total/percent) or a generic
+// "started T (elapsed)" timer when the method has no byte instrumentation.
+type ReseedProgressView struct {
+	InProgress   bool   `json:"inProgress"`
+	FromRejoin   bool   `json:"fromRejoin"`   // armed by a rejoin (reseedFromRejoin)
+	Task         string `json:"task"`         // reseed task: "reseedmysqldump", "reseedmariabackup", "direct", …
+	Backup       string `json:"backup"`       // backup file/dir being restored ("" if generic)
+	Tool         string `json:"tool"`         // restore tool
+	Bytes        int64  `json:"bytes"`        // streamed (compressed) so far
+	Total        int64  `json:"total"`        // total compressed size (0 = unknown)
+	Percent      int    `json:"percent"`      // 0..100, or -1 when total is unknown
+	StartedUnix  int64  `json:"startedUnix"`  // restore start (byte path) or rejoin-arm time (generic)
+	ElapsedSecs  int64  `json:"elapsedSecs"`
+	RateBytesSec int64  `json:"rateBytesSec"` // average over elapsed (0 when no bytes)
+	Line         string `json:"line"`         // the human progress line
+}
+
+// GetReseedProgress returns a snapshot of the server's in-flight restore, or nil
+// when idle. It merges the byte-instrumented progress (reseedInfo + counters) with
+// the generic rejoin timer (rejoinReseedStart) so a rejoin is always reportable
+// even for methods that do not count bytes.
+func (server *ServerMonitor) GetReseedProgress() *ReseedProgressView {
+	task := server.IsReseeding
+	fromRejoin := server.reseedFromRejoin.Load()
+	if task == "" && !fromRejoin {
+		return nil
+	}
+	v := &ReseedProgressView{InProgress: task != "", FromRejoin: fromRejoin, Task: task, Percent: -1}
+	info, _ := server.reseedInfo.Load().(*ReseedProgress)
+	startNanos := server.reseedStart.Load()
+	if info != nil {
+		v.Backup = info.Backup
+		v.Tool = info.Tool
+		v.Bytes = server.reseedBytes.Load()
+		v.Total = server.reseedTotal.Load()
+		if v.Total > 0 {
+			v.Percent = int(v.Bytes * 100 / v.Total)
+		}
+	} else if startNanos == 0 {
+		startNanos = server.rejoinReseedStart.Load() // generic rejoin timer, no byte instrumentation
+	}
+	if startNanos > 0 {
+		v.StartedUnix = startNanos / int64(time.Second)
+		elapsed := time.Since(time.Unix(0, startNanos))
+		v.ElapsedSecs = int64(elapsed / time.Second)
+		if v.ElapsedSecs > 0 && v.Bytes > 0 {
+			v.RateBytesSec = v.Bytes / v.ElapsedSecs
+		}
+	}
+	if line, _ := server.reseedProgressLine(); line != "" {
+		v.Line = line
+	} else if v.StartedUnix > 0 {
+		v.Line = fmt.Sprintf("rejoin reseed in progress, started %s (%s)",
+			time.Unix(v.StartedUnix, 0).Format("15:04:05"),
+			(time.Duration(v.ElapsedSecs) * time.Second).String())
+	}
+	return v
+}
+
 // humanBytes formats a byte count like "223M" / "100G".
 func humanBytes(b int64) string {
 	const unit = 1024

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -251,7 +251,8 @@ type ServerMonitor struct {
 	configGenMutex              sync.Mutex // protects config generation operations
 	backupMetaMutex             sync.Mutex  // protects LastBackupMeta from concurrent Restic callback updates
 	rejoinInProgress            atomic.Bool  // guards RejoinMaster re-entrancy so it runs async (a reseed can take hours/days; it must never block the monitor loop)
-	reseedFromRejoin            atomic.Bool  // set when a rejoin armed an ASYNC reseed; the reseed completion handler (WARN0074/WARN0075) reconciles finishRejoin with the real outcome, and RejoinMaster holds the one-shot while it is set
+	reseedFromRejoin            atomic.Bool  // set when a rejoin armed an ASYNC reseed; reconcileDeferredRejoinReseeds records finishRejoin from observed health once the reseed completes (IsReseeding clears), and RejoinMaster holds the one-shot while it is set
+	rejoinReseedStart           atomic.Int64 // unix-nanos when the rejoin armed its reseed; drives the generic "rejoin reseed in progress, started T" state (WARN0189) for methods without byte instrumentation
 	reseedInfo                  atomic.Value // *ReseedProgress: the in-flight restore's backup (nil when idle) — for the progress state
 	reseedBytes                 atomic.Int64 // raw bytes streamed so far (compressed input; no decompression accounting yet)
 	reseedTotal                 atomic.Int64 // total compressed backup file size (0 = unknown)

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -251,6 +251,7 @@ type ServerMonitor struct {
 	configGenMutex              sync.Mutex // protects config generation operations
 	backupMetaMutex             sync.Mutex  // protects LastBackupMeta from concurrent Restic callback updates
 	rejoinInProgress            atomic.Bool  // guards RejoinMaster re-entrancy so it runs async (a reseed can take hours/days; it must never block the monitor loop)
+	reseedFromRejoin            atomic.Bool  // set when a rejoin armed an ASYNC reseed; the reseed completion handler (WARN0074/WARN0075) reconciles finishRejoin with the real outcome, and RejoinMaster holds the one-shot while it is set
 	reseedInfo                  atomic.Value // *ReseedProgress: the in-flight restore's backup (nil when idle) — for the progress state
 	reseedBytes                 atomic.Int64 // raw bytes streamed so far (compressed input; no decompression accounting yet)
 	reseedTotal                 atomic.Int64 // total compressed backup file size (0 = unknown)

--- a/cluster/srv_lostevents.go
+++ b/cluster/srv_lostevents.go
@@ -182,6 +182,68 @@ func (cluster *Cluster) assertLostEventsStates() {
 	}
 }
 
+// reconcileDeferredRejoinReseeds records the outcome of a rejoin-armed reseed once
+// it actually completes, and surfaces a generic in-flight progress state meanwhile.
+//
+// recordOrDeferRejoin defers finishRejoin for a reseed still in flight (it sets
+// reseedFromRejoin) because EVERY reseed method — physical SST (ProcessReseedPhysical),
+// direct mysqldump (RejoinDirectDump), and the off-tick logical restore
+// (ProcessReseedLogical) — arms a DETACHED goroutine and returns before the restore
+// finishes. The one signal they all share is clearing IsReseeding (SetInReseedBackup(""))
+// on completion; none carries a uniform success/fail return. So the outcome is read
+// from OBSERVED health, not from any arming call's return value.
+//
+//   - in flight (IsReseeding still set): raise a generic "rejoin reseed in progress,
+//     started T" state (WARN0189) for methods WITHOUT byte instrumentation — the ones
+//     that DO instrument bytes are already surfaced by assertReseedProgressStates.
+//   - completed (IsReseeding cleared): record from observed health — a healthy slave of
+//     the current master is success, otherwise failed. A node still establishing
+//     replication right after the reseed self-corrects: assertRejoinResultStates
+//     rewrites a stale "failed" to "recovered" once it becomes a healthy slave.
+//
+// Called per tick, before assertRejoinResultStates.
+func (cluster *Cluster) reconcileDeferredRejoinReseeds() {
+	for _, sv := range cluster.Servers {
+		if sv == nil || !sv.reseedFromRejoin.Load() {
+			continue
+		}
+		if sv.HasAnyReseedingState() {
+			// Reseed still running — RejoinMaster stays held. Show generic progress
+			// only when there is no byte progress (assertReseedProgressStates covers
+			// the instrumented methods).
+			if _, info := sv.reseedProgressLine(); info == nil {
+				if startNanos := sv.rejoinReseedStart.Load(); startNanos > 0 {
+					start := time.Unix(0, startNanos)
+					generic := fmt.Sprintf("rejoin reseed in progress, started %s (%s)",
+						start.Format("15:04:05"), time.Since(start).Round(time.Second))
+					cluster.SetState("WARN0189", state.State{
+						ErrType:   "WARNING",
+						ErrKey:    "WARN0189",
+						ErrDesc:   fmt.Sprintf(cluster.GetErrorList()["WARN0189"], sv.URL, generic, sv.IsReseeding),
+						ErrFrom:   "REJOIN",
+						ServerUrl: sv.URL,
+					})
+				}
+			}
+			continue
+		}
+		// Reseed completed (IsReseeding cleared) → record from observed health.
+		result := RejoinResultFailed
+		if sv.IsSlave && !sv.IsFailed() && cluster.master != nil {
+			if m, _ := cluster.GetMasterFromReplication(sv); m != nil && m.URL == cluster.master.URL {
+				result = RejoinResultSuccess
+			}
+		}
+		// finishRejoin first (→ rejoinAlreadyAttempted true), then clear the marker,
+		// so RejoinMaster's one-shot has no open gap.
+		cluster.finishRejoin(sv.URL, result)
+		sv.reseedFromRejoin.Store(false)
+		sv.rejoinReseedStart.Store(0)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+			"Rejoin of %s reseed completed → %s", sv.URL, result)
+	}
+}
+
 // assertRejoinResultStates makes a FINISHED rejoin outcome visible per tick,
 // read from durable history (finishRejoin moved the crash there). Only outcomes
 // that need the operator are raised, and only while the server is not yet a

--- a/cluster/srv_rejoin.go
+++ b/cluster/srv_rejoin.go
@@ -79,6 +79,15 @@ func (server *ServerMonitor) RejoinMaster() error {
 	// Strange here add comment for why
 	cluster.canFlashBack = true
 
+	// A reseed armed by a previous rejoin tick is still in flight: the rejoin is
+	// NOT finished — its outcome is recorded by the reseed completion handler
+	// (WARN0074/WARN0075 → recordOrDeferRejoin), not here. Do not re-enter or
+	// record; hold the one-shot until completion. reseedFromRejoin covers the tiny
+	// window after the reseed clears IsReseeding but before finishRejoin lands.
+	if server.HasAnyReseedingState() || server.reseedFromRejoin.Load() {
+		return nil
+	}
+
 	// ONE-SHOT terminator: this event already ended with a recorded result (in
 	// crash history). Do nothing until an explicit re-arm (rearmRejoin) copies it
 	// back. Makes the Failed->up edge AND the per-tick topology extra-master call
@@ -157,7 +166,7 @@ func (server *ServerMonitor) RejoinMaster() error {
 					}
 					if cluster.Conf.Autoseed {
 						err := server.ReseedMasterSST()
-						cluster.finishRejoin(server.URL, rejoinResultOf(err))
+						cluster.recordOrDeferRejoin(server, err)
 						return nil
 					}
 					// PEER-UNREACHABLE (real-world transient split): arbitration is on and
@@ -603,6 +612,27 @@ func rejoinResultOf(err error) string {
 		return RejoinResultNoMethod
 	}
 	return RejoinResultSuccess
+}
+
+// recordOrDeferRejoin records the rejoin outcome NOW, or defers it to the reseed
+// completion handler when an async reseed is still in flight.
+//
+// A synchronous reseed (RejoinDirectDump) has already run and cleared its
+// reseeding state by the time it returns, so err is the real result → record it.
+// An async reseed (JobReseedLogicalBackup/JobReseedPhysicalBackup) only ARMS
+// WARN0075/WARN0074 and returns nil while the restore runs off-tick; recording
+// success here would stamp the rejoin done before the restore even ran. Instead we
+// set reseedFromRejoin and let the WARN0074/WARN0075 completion call finishRejoin
+// with the REAL result (rejoinResultOf(err) from ProcessReseed*). Never a retry —
+// one-shot either way; RejoinMaster holds the one-shot while reseedFromRejoin is set.
+func (cluster *Cluster) recordOrDeferRejoin(server *ServerMonitor, err error) {
+	if err == nil && server.HasAnyReseedingState() {
+		server.reseedFromRejoin.Store(true)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+			"Rejoin of %s: async reseed in flight — outcome recorded at reseed completion", server.URL)
+		return
+	}
+	cluster.finishRejoin(server.URL, rejoinResultOf(err))
 }
 
 // rejoinWithMethod runs the OPERATOR-CHOSEN recovery method for a re-armed crash,

--- a/cluster/srv_rejoin.go
+++ b/cluster/srv_rejoin.go
@@ -628,6 +628,7 @@ func rejoinResultOf(err error) string {
 func (cluster *Cluster) recordOrDeferRejoin(server *ServerMonitor, err error) {
 	if err == nil && server.HasAnyReseedingState() {
 		server.reseedFromRejoin.Store(true)
+		server.rejoinReseedStart.Store(time.Now().UnixNano())
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
 			"Rejoin of %s: async reseed in flight — outcome recorded at reseed completion", server.URL)
 		return

--- a/cluster/srv_rejoin.go
+++ b/cluster/srv_rejoin.go
@@ -80,8 +80,8 @@ func (server *ServerMonitor) RejoinMaster() error {
 	cluster.canFlashBack = true
 
 	// A reseed armed by a previous rejoin tick is still in flight: the rejoin is
-	// NOT finished — its outcome is recorded by the reseed completion handler
-	// (WARN0074/WARN0075 → recordOrDeferRejoin), not here. Do not re-enter or
+	// NOT finished — its outcome is recorded by reconcileDeferredRejoinReseeds
+	// (from observed health, once IsReseeding clears), not here. Do not re-enter or
 	// record; hold the one-shot until completion. reseedFromRejoin covers the tiny
 	// window after the reseed clears IsReseeding but before finishRejoin lands.
 	if server.HasAnyReseedingState() || server.reseedFromRejoin.Load() {
@@ -614,17 +614,18 @@ func rejoinResultOf(err error) string {
 	return RejoinResultSuccess
 }
 
-// recordOrDeferRejoin records the rejoin outcome NOW, or defers it to the reseed
-// completion handler when an async reseed is still in flight.
+// recordOrDeferRejoin records the rejoin outcome NOW, or defers it when an async
+// reseed is still in flight.
 //
-// A synchronous reseed (RejoinDirectDump) has already run and cleared its
-// reseeding state by the time it returns, so err is the real result → record it.
-// An async reseed (JobReseedLogicalBackup/JobReseedPhysicalBackup) only ARMS
-// WARN0075/WARN0074 and returns nil while the restore runs off-tick; recording
-// success here would stamp the rejoin done before the restore even ran. Instead we
-// set reseedFromRejoin and let the WARN0074/WARN0075 completion call finishRejoin
-// with the REAL result (rejoinResultOf(err) from ProcessReseed*). Never a retry —
-// one-shot either way; RejoinMaster holds the one-shot while reseedFromRejoin is set.
+// EVERY rejoin reseed method (RejoinDirectDump → JobRejoinMysqldumpFromSource,
+// ProcessReseedPhysical → WaitAndSendSST/SSTRunSender, ProcessReseedLogical) arms a
+// DETACHED goroutine and returns nil before the restore finishes — so err here is
+// NOT the outcome. If a reseed is in flight (HasAnyReseedingState), we set
+// reseedFromRejoin and defer: reconcileDeferredRejoinReseeds records finishRejoin
+// from OBSERVED health once the reseed completes (IsReseeding clears). Only when the
+// arm itself failed (err != nil, no reseed in flight) do we record here immediately.
+// Never a retry — one-shot either way; RejoinMaster holds the one-shot while
+// reseedFromRejoin is set.
 func (cluster *Cluster) recordOrDeferRejoin(server *ServerMonitor, err error) {
 	if err == nil && server.HasAnyReseedingState() {
 		server.reseedFromRejoin.Store(true)

--- a/doc/implementation/cluster/UNIFIED_REJOIN_DESIGN.md
+++ b/doc/implementation/cluster/UNIFIED_REJOIN_DESIGN.md
@@ -75,6 +75,163 @@ set ONLY if that event is not already in our history with a result. Same event =
 same (loser URL, elected URL, peer failover ts). Already-attempted => leave it in
 history with its state, do nothing.
 
+## Execution model — RejoinMaster runs in a goroutine (async by design)
+
+*(Added 2026-07-23 — this was implicit in the code but never written down, and its
+absence led the topology caller to run synchronously.)*
+
+A rejoin can run a logical/physical reseed that takes minutes, hours, or days. It
+MUST NOT run on the monitor tick, or the entire cluster loop — health checks,
+failover, everything — freezes for the whole restore.
+
+So `RejoinMaster` is **always spawned asynchronously**, and is safe to fire per tick:
+
+- `go server.RejoinMaster()` at every edge that detects a server needing rejoin:
+  the Failed→up edge (`srv.go`), the armed/operator path (`crash.go`), and the
+  topology extra-master path (`cluster_topo.go`).
+- **Re-entrancy** is guarded by `server.rejoinInProgress` (atomic CompareAndSwap):
+  a second spawn while one is running returns immediately, so per-tick spawning
+  never stacks duplicates.
+- **One-shot** is guarded by `rejoinAlreadyAttempted` (crash-history result): once
+  the first attempt records a result, later spawns are no-ops until an explicit
+  re-arm. (This is the "Retry is EXPLICIT, never automatic" law above.)
+
+### The reseed stays async; the RECORD is what gets reconciled
+The reseed does NOT need to be synchronous. Whether it runs inside the rejoin
+goroutine or off-tick via the `WARN0074`/`WARN0075` handlers, the monitor loop is
+never blocked (rejoin is a goroutine; the logical handler is `trackTickGoroutine`;
+both are one-shot). The one thing the async restore broke was the **record**:
+`finishRejoin` fired at ARM time and stamped `success` before the restore had run,
+so the rejoin/crash-history outcome disagreed with the actual reseed job result.
+
+**Fix (implemented 2026-07-23) — defer the record to reseed completion:**
+
+- **`recordOrDeferRejoin(server, err)`** (`srv_rejoin.go`) replaces the arm-time
+  `finishRejoin` on the auto-rejoin reseed path (`Autoseed` → `ReseedMasterSST`).
+  - Synchronous reseed (`RejoinDirectDump`): its reseeding state is already
+    cleared on return, so `err` is real → record now.
+  - Async reseed in flight (`HasAnyReseedingState()` true — logical/physical
+    backup only armed `WARN0075`/`WARN0074`): set `server.reseedFromRejoin`,
+    return **without** recording.
+- **Reconcile at completion:** the `WARN0075` (logical, off-tick) and `WARN0074`
+  (physical) handlers, after `ProcessReseed*` returns the real `err`, call
+  `finishRejoin(url, rejoinResultOf(err))` when `reseedFromRejoin` is set, then
+  clear the marker. Order is finishRejoin → clear, so the one-shot has no open gap.
+- **One-shot hold:** `RejoinMaster` early-returns while a reseed is pending —
+  `if HasAnyReseedingState() || reseedFromRejoin.Load() { return nil }`. The
+  `reseedFromRejoin` half covers the tiny window after `IsReseeding` clears but
+  before `finishRejoin` lands, so no per-tick re-entry can re-arm or record early.
+- **Never a retry:** the record is one-shot either way; `finishRejoin` runs exactly
+  once, with the true outcome. Retry stays EXPLICIT (operator re-arm) as always.
+
+The `WARN0074`/`WARN0075` handlers stay the reseed executors for NON-rejoin
+triggers too (manual, GUI, staging); the reconcile is a no-op there (marker unset).
+
+### Status
+- ✅ All rejoin call sites are `go`-spawned (topology caller fixed 2026-07-23).
+- ✅ Async-reseed rejoin record reconciled at completion (2026-07-23): rejoin
+  history records the real restore outcome, not arm-time success. Scope: the
+  `Autoseed` → `ReseedMasterSST` path (logical + physical). Flashback and
+  operator-method paths are unchanged — their restores are synchronous or
+  operator-observed, so their arm-time record is already the real result.
+
+## Rejoin workflow — triggers, gates, and the state each path emits
+
+*(Added 2026-07-23. Map of `RejoinMaster` in `srv_rejoin.go` as built.)*
+
+### Triggers — every one is async (`go`-spawned)
+| Edge | Site | When |
+|---|---|---|
+| Failed→up | `srv.go:759` | a monitored server that was Failed comes back standalone |
+| Armed / operator | `crash.go:511` | a re-armed crash (operator chose a method in the delta viewer) |
+| Topology extra-master | `cluster_topo.go:320` | a 2nd node still acts as master (colocated old master after split-brain; never got a Failed→up edge) |
+
+### Entry gates — each returns WITHOUT acting (top of `RejoinMaster`)
+| Gate | Condition | Why |
+|---|---|---|
+| re-entrancy | `rejoinInProgress` CAS fails | one rejoin goroutine per server |
+| active-passive | `Conf.ActivePassive` | a passive node never rejoins |
+| wsrep | `TopoMultiMasterWsrep` | Galera self-heals |
+| in failover | `StateMachine.IsInFailover()` | never rejoin mid-failover |
+| **reseed in flight** | `HasAnyReseedingState() \|\| reseedFromRejoin` | rejoin not finished — its record lands at reseed completion; hold the one-shot *(2026-07-23)* |
+| **one-shot** | `rejoinAlreadyAttempted(url)` | a result already sits in crash history → done until explicit re-arm |
+
+### Role resolution (before the rejoin paths)
+- No local crash + `Conf.Arbitration` → `fetchMasterFromPeer()` materializes the peer verdict as a normal crash (the crash SOURCE).
+- **Winner** (`getCrashFromMaster` names this server) → **crown it master**, `return` (it is the elected master, not a rejoiner — no result recorded).
+- `cluster.master == nil` + crash names `ElectedMasterURL` → adopt that master, then converge with the paths below.
+
+### The paths (server ≠ master → a returning replica / old master)
+Prelude for all: `WARN0022` (server ≠ master) + `RejoinScript`. If `MultiMasterGrouprep` → `StartGroupReplication` and stop.
+
+**A. `crash == nil` (no divergence record) → raises `ERR00066`, then:**
+
+| Sub-path | Gate | Restore action | Result recorded |
+|---|---|---|---|
+| old master | `oldMaster.URL == server.URL` | `RejoinMasterSST` (flashback/SST) | `success` / `no-rejoin-method` |
+| **fresh-provision seed** | `Conf.Autoseed` | `ReseedMasterSST` → logical (`WARN0075`) or physical (`WARN0074`) backup | **deferred** → real `ProcessReseed*` outcome (`success` / `no-rejoin-method`) |
+| peer unreachable | `Conf.Arbitration && peerFetchTried && peerFetchErr` | fence read-only, NO re-slave | `peer-unreachable` (RETRYABLE — not terminal) |
+| default | — | `attachAsReadOnlySlave` on current GTID | `no-divergence` |
+
+**B. `crash != nil` (divergence record) →**
+- if `AutorejoinBackupBinlog` → capture the lost tail first (`freezeThenCaptureLostEvents`).
+- if `crash.RejoinMethod != ""` (operator chose) → `rejoinWithMethod`: flashback / logical-dump / logical-bkp / physical-bkp / ignore-force / reset-master-reslave / bootstrap-ftwrl / script → `success` / `no-divergence` / `not-flashback-able` / `no-rejoin-method`.
+- else automatic → `rejoinMasterIncremental` (flashback):
+  - success → `success` (or `no-divergence` if the delta was empty),
+  - fail → `RejoinMasterSST`; on its failure → `not-flashback-able` (diverged + DDL) or `no-rejoin-method`, and **always** `attachAsReadOnlySlave` (fenced RO — never a floating writable standalone; strict mode then guards a divergent tail as SlaveErr).
+
+If no master is discovered at all, RejoinMaster falls through to rediscover from `lastmaster` (no rejoin/record).
+
+### Result states (`finishRejoin` → crash history, one-shot)
+`success` · `no-divergence` · `not-flashback-able` · `no-rejoin-method` · `peer-unreachable` · `failed` · `recovered`
+(`recovered` = a previously-`failed` rejoin whose node later became a healthy slave by other means — reconciled so history stops showing a stale failure.)
+
+### Dashboard states raised during the workflow
+`WARN0022` (server ≠ master) · `ERR00066` (no-crash SST/reseed) · `ERR00063` (extra master) · `WARN0074`/`WARN0075` (physical/logical reseed armed) · `WARN0114` (super-read-only blocks the reseed).
+
+### Reseed record timing (the async-reseed reconcile)
+- **Synchronous** restore (`RejoinDirectDump`): `finishRejoin` records the real result inline.
+- **Async** reseed (`ReseedMasterSST` → `WARN0074`/`WARN0075`): `recordOrDeferRejoin` defers; the WARN handler reconciles `finishRejoin` with the real `ProcessReseed*` outcome; `RejoinMaster` holds the one-shot via `reseedFromRejoin` in between. See "Execution model" above.
+
+## Reseed progress instrumentation (WARN0189)
+
+*(Added 2026-07-23.)*
+
+A reseed can run for hours; without progress it shows only a silent "processing".
+The mechanism (`restore_progress.go`):
+
+- **`startReseedProgress(info, reader, total)`** stamps the server (`reseedInfo`,
+  `reseedBytes`, `reseedTotal`, `reseedStart`) and returns a `countingReader` that
+  tallies bytes streamed through it. `total` is the compressed backup size (0 =
+  unknown). `defer stopReseedProgress()` clears it.
+- **`assertReseedProgressStates()`** runs **per tick** (`cluster_topo.go:158`) and,
+  for any server with a live `reseedInfo`, raises **`WARN0189`** with a human line:
+  `"<streamed> streamed out of <total> compressed backup, started 14:32:01 (1h23m, avg 45M/s)"`.
+  Rate is the average over elapsed (per-table speed varies too much for instantaneous).
+
+### Coverage — what is and isn't instrumented
+| Reseed path | Instrumented? |
+|---|---|
+| `JobReseedMysqldump` (monolithic `mysqldump.sql.gz`) | ✅ yes — the only wired path |
+| **splitdump** (`restoreSplitdumpWithMysql` / per-table shards) | ❌ **no** — silent "processing" |
+| native-Go splitdump loader (`fix/splitdump-skip-first-shard`) | ❌ no |
+| physical / restic | ❌ no (not via WARN0189) |
+
+This is why a rejoin/reseed **from a splitdump backup shows no progress**.
+
+### To instrument splitdump (the multi-file shape)
+`countingReader` accumulates into a single `reseedBytes` atomic, so the multi-file
+restore fits with a small change to the reset semantics:
+1. **Once**, before the restore: set `reseedTotal = Σ shard sizes`, `reseedBytes = 0`,
+   `reseedStart = now`, `reseedInfo = {Backup: dir}` (a start-without-reset variant,
+   since the current `startReseedProgress` resets bytes on every call).
+2. Wrap **each shard's file reader** with a plain `countingReader` (adds to the
+   shared `reseedBytes`), so bytes accumulate across all shards.
+3. `stopReseedProgress()` at the end.
+
+Then WARN0189 reports the same live line for a splitdump reload. Same hook applies to
+the native-Go loader (wrap each shard's `os.Open` reader before pgzip).
+
 ## What this deletes (the night's fragmentation)
 
 - `rejoinFromElection` (srv_rejoin.go) — was a SECOND rejoin. Delete.
@@ -180,13 +337,17 @@ What each code change DOES (documented before coding, per Stephane's process rul
 - DELETE `rejoinFromElection` (folded into the above).
 
 ### cluster_topo.go — reach the ONE path, don't reimplement it
-- Extra-master branch: keep `SetState(ERR00063)`, and call `extra.RejoinMaster()`
-  (like 3.0) — NO getFreshCrashForLoser, NO age gate. RejoinMaster is now one-shot
-  via finishRejoin, so the per-tick topology call is harmless after the first
-  attempt (crash in history-with-result → rejoinAlreadyAttempted true → returns).
-  This is how the COLOCATED old master (never gets a Failed->up edge on the
-  minority) reaches the unified rejoin.
+- Extra-master branch: keep `SetState(ERR00063)`, and call `go extra.RejoinMaster()`
+  (async — see "Execution model" below) — NO getFreshCrashForLoser, NO age gate.
+  RejoinMaster is one-shot via finishRejoin, so the per-tick topology call is
+  harmless after the first attempt (crash in history-with-result →
+  rejoinAlreadyAttempted true → returns). This is how the COLOCATED old master
+  (never gets a Failed->up edge on the minority) reaches the unified rejoin.
 - REMOVE the `consumeServedCrashes()` call.
+- NOTE (2026-07-23): this branch historically called `extra.RejoinMaster()`
+  **synchronously** — the one rejoin caller that ran on the monitor tick. That is
+  why the reseed had to be decoupled (arm WARN0075 and return). It is now
+  `go`-spawned like the others; see "Execution model".
 
 ### States (config/error.go) — the visible outcomes
 - Reuse WARN0184 (flashback-able) / WARN0185 (not flashback-able) where they fit;

--- a/doc/implementation/cluster/UNIFIED_REJOIN_DESIGN.md
+++ b/doc/implementation/cluster/UNIFIED_REJOIN_DESIGN.md
@@ -96,36 +96,51 @@ So `RejoinMaster` is **always spawned asynchronously**, and is safe to fire per 
   the first attempt records a result, later spawns are no-ops until an explicit
   re-arm. (This is the "Retry is EXPLICIT, never automatic" law above.)
 
-### The reseed stays async; the RECORD is what gets reconciled
-The reseed does NOT need to be synchronous. Whether it runs inside the rejoin
-goroutine or off-tick via the `WARN0074`/`WARN0075` handlers, the monitor loop is
-never blocked (rejoin is a goroutine; the logical handler is `trackTickGoroutine`;
-both are one-shot). The one thing the async restore broke was the **record**:
-`finishRejoin` fired at ARM time and stamped `success` before the restore had run,
-so the rejoin/crash-history outcome disagreed with the actual reseed job result.
+### The reseed stays async; the RECORD is reconciled at TRUE completion
 
-**Fix (implemented 2026-07-23) — defer the record to reseed completion:**
+The reseed does NOT need to be synchronous — the monitor loop is never blocked
+(rejoin is a goroutine; the logical handler is `trackTickGoroutine`). The one thing
+the async restore broke was the **record**: `finishRejoin` fired at ARM time and
+stamped `success` before the restore had run.
 
-- **`recordOrDeferRejoin(server, err)`** (`srv_rejoin.go`) replaces the arm-time
-  `finishRejoin` on the auto-rejoin reseed path (`Autoseed` → `ReseedMasterSST`).
-  - Synchronous reseed (`RejoinDirectDump`): its reseeding state is already
-    cleared on return, so `err` is real → record now.
-  - Async reseed in flight (`HasAnyReseedingState()` true — logical/physical
-    backup only armed `WARN0075`/`WARN0074`): set `server.reseedFromRejoin`,
-    return **without** recording.
-- **Reconcile at completion:** the `WARN0075` (logical, off-tick) and `WARN0074`
-  (physical) handlers, after `ProcessReseed*` returns the real `err`, call
-  `finishRejoin(url, rejoinResultOf(err))` when `reseedFromRejoin` is set, then
-  clear the marker. Order is finishRejoin → clear, so the one-shot has no open gap.
-- **One-shot hold:** `RejoinMaster` early-returns while a reseed is pending —
-  `if HasAnyReseedingState() || reseedFromRejoin.Load() { return nil }`. The
-  `reseedFromRejoin` half covers the tiny window after `IsReseeding` clears but
-  before `finishRejoin` lands, so no per-tick re-entry can re-arm or record early.
-- **Never a retry:** the record is one-shot either way; `finishRejoin` runs exactly
-  once, with the true outcome. Retry stays EXPLICIT (operator re-arm) as always.
+**The trap I fell into first (and the review caught):** there is no reliable
+"the reseed returned" signal to hook. **Every** reseed method arms a DETACHED
+goroutine and returns before the restore runs:
 
-The `WARN0074`/`WARN0075` handlers stay the reseed executors for NON-rejoin
-triggers too (manual, GUI, staging); the reconcile is a no-op there (marker unset).
+| Reseed method | Arming call | What it does | Completion signal |
+|---|---|---|---|
+| logical backup | `ProcessReseedLogical` (WARN0075, off-tick) | runs the restore in the tick goroutine, `StartSlave`, clears `IsReseeding` | `IsReseeding` clear |
+| physical SST | `ProcessReseedPhysical` (WARN0074) | `go WaitAndSendSST → go SSTRunSender`, **returns `nil` immediately** | `IsReseeding` clear (in the goroutine) |
+| direct mysqldump | `RejoinDirectDump` | `go JobRejoinMysqldumpFromSource`, **returns `nil` immediately**, no WARN state | `IsReseeding` clear (`defer`) |
+
+So reconciling in the WARN0074/WARN0075 handlers on their return value was wrong:
+physical would stamp success at *arm* time, and direct-mysqldump (no WARN state)
+would never reconcile at all — leaving `reseedFromRejoin` set forever and
+permanently blocking `RejoinMaster` for that server.
+
+**Fix (2026-07-23) — reconcile from OBSERVED health at the ONE shared completion
+signal (`IsReseeding` clears):**
+
+- **`recordOrDeferRejoin(server, err)`** (`srv_rejoin.go`): arm failed → record now;
+  else (reseed in flight, `HasAnyReseedingState()`) set `reseedFromRejoin` +
+  `rejoinReseedStart`, return **without** recording.
+- **`reconcileDeferredRejoinReseeds()`** (`srv_lostevents.go`, per tick, before
+  `assertRejoinResultStates`): for each server with `reseedFromRejoin` set —
+  - still reseeding → hold; surface a generic `WARN0189` "rejoin reseed in progress,
+    started T" for methods without byte instrumentation (instrumented ones are shown
+    by `assertReseedProgressStates`);
+  - `IsReseeding` cleared (completed) → record from observed health: a **healthy
+    slave of the current master** is `success`, otherwise `failed`. finishRejoin
+    first, then clear the marker (one-shot has no gap).
+- **Self-correcting:** a node still establishing replication right after the reseed
+  is rewritten `failed → recovered` by `assertRejoinResultStates` once it becomes a
+  healthy slave — so a transient `failed` never sticks.
+- **One-shot hold:** `RejoinMaster` early-returns while pending
+  (`HasAnyReseedingState() || reseedFromRejoin.Load()`).
+- **Never a retry:** one record, one-shot; retry stays EXPLICIT (operator re-arm).
+
+The WARN0074/WARN0075 handlers no longer reconcile — they only *execute* the reseed
+(for rejoin and non-rejoin triggers alike).
 
 ### Status
 - ✅ All rejoin call sites are `go`-spawned (topology caller fixed 2026-07-23).
@@ -169,7 +184,7 @@ Prelude for all: `WARN0022` (server ≠ master) + `RejoinScript`. If `MultiMaste
 | Sub-path | Gate | Restore action | Result recorded |
 |---|---|---|---|
 | old master | `oldMaster.URL == server.URL` | `RejoinMasterSST` (flashback/SST) | `success` / `no-rejoin-method` |
-| **fresh-provision seed** | `Conf.Autoseed` | `ReseedMasterSST` → logical (`WARN0075`) or physical (`WARN0074`) backup | **deferred** → real `ProcessReseed*` outcome (`success` / `no-rejoin-method`) |
+| **fresh-provision seed** | `Conf.Autoseed` | `ReseedMasterSST` → logical/physical backup or direct mysqldump (all async) | **deferred** → observed-health outcome at reseed completion (`success` / `failed`, self-corrects to `recovered`) |
 | peer unreachable | `Conf.Arbitration && peerFetchTried && peerFetchErr` | fence read-only, NO re-slave | `peer-unreachable` (RETRYABLE — not terminal) |
 | default | — | `attachAsReadOnlySlave` on current GTID | `no-divergence` |
 
@@ -187,11 +202,15 @@ If no master is discovered at all, RejoinMaster falls through to rediscover from
 (`recovered` = a previously-`failed` rejoin whose node later became a healthy slave by other means — reconciled so history stops showing a stale failure.)
 
 ### Dashboard states raised during the workflow
-`WARN0022` (server ≠ master) · `ERR00066` (no-crash SST/reseed) · `ERR00063` (extra master) · `WARN0074`/`WARN0075` (physical/logical reseed armed) · `WARN0114` (super-read-only blocks the reseed).
+`WARN0022` (server ≠ master) · `ERR00066` (no-crash SST/reseed) · `ERR00063` (extra master) · `WARN0074`/`WARN0075` (physical/logical reseed armed) · `WARN0114` (super-read-only blocks the reseed) · `WARN0189` (reseed in progress — byte progress or generic "started T").
 
 ### Reseed record timing (the async-reseed reconcile)
-- **Synchronous** restore (`RejoinDirectDump`): `finishRejoin` records the real result inline.
-- **Async** reseed (`ReseedMasterSST` → `WARN0074`/`WARN0075`): `recordOrDeferRejoin` defers; the WARN handler reconciles `finishRejoin` with the real `ProcessReseed*` outcome; `RejoinMaster` holds the one-shot via `reseedFromRejoin` in between. See "Execution model" above.
+- **All** rejoin reseeds are async (each arms a detached goroutine and returns nil).
+  `recordOrDeferRejoin` sets `reseedFromRejoin` + `rejoinReseedStart`.
+- `reconcileDeferredRejoinReseeds` (per tick) records `finishRejoin` from **observed
+  health** at the ONE shared completion signal — `IsReseeding` clearing — not from any
+  arming call's return. `RejoinMaster` holds the one-shot via `reseedFromRejoin`
+  meanwhile. See "The reseed stays async; the RECORD is reconciled at TRUE completion".
 
 ## Reseed progress instrumentation (WARN0189)
 
@@ -209,15 +228,22 @@ The mechanism (`restore_progress.go`):
   `"<streamed> streamed out of <total> compressed backup, started 14:32:01 (1h23m, avg 45M/s)"`.
   Rate is the average over elapsed (per-table speed varies too much for instantaneous).
 
-### Coverage — what is and isn't instrumented
-| Reseed path | Instrumented? |
+### Coverage — what is and isn't byte-instrumented
+| Reseed path | Byte progress? |
 |---|---|
-| `JobReseedMysqldump` (monolithic `mysqldump.sql.gz`) | ✅ yes — the only wired path |
-| **splitdump** (`restoreSplitdumpWithMysql` / per-table shards) | ❌ **no** — silent "processing" |
-| native-Go splitdump loader (`fix/splitdump-skip-first-shard`) | ❌ no |
-| physical / restic | ❌ no (not via WARN0189) |
+| `JobReseedMysqldump` (monolithic `mysqldump.sql.gz`) | ✅ yes |
+| native-Go splitdump loader (`fix/splitdump-native-restore` PR #1627) | ✅ yes (per-shard accumulating counter) |
+| splitdump via mysql CLI (this branch) | ❌ no |
+| physical / restic | ❌ no |
 
-This is why a rejoin/reseed **from a splitdump backup shows no progress**.
+### Generic fallback so a rejoin ALWAYS shows progress (proof-of-work)
+Independent of byte instrumentation, `reconcileDeferredRejoinReseeds` raises a
+**generic `WARN0189`** — `"rejoin reseed in progress, started 14:32:01 (3m12s)"` —
+from `rejoinReseedStart` for any rejoin-armed reseed whose method has no byte
+counter (physical SST, direct mysqldump, CLI splitdump). So the GUI always shows a
+running rejoin (generic timer), and upgrades to `<streamed> out of <total>` when the
+method instruments bytes. The progress line landing its true outcome at completion
+is the visible proof that the reconciliation works.
 
 ### To instrument splitdump (the multi-file shape)
 `countingReader` accumulates into a single `reseedBytes` atomic, so the multi-file

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -944,6 +944,15 @@ func (repman *ReplicationManager) handlerMuxServers(w http.ResponseWriter, r *ht
 				http.Error(w, "Encoding error: "+err.Error(), http.StatusInternalServerError)
 				return
 			}
+			// Live restore progress (nil when idle) so the dashboard can render a
+			// progress bar / "rejoin reseed in progress, started T" panel per server.
+			if rp := srv.GetReseedProgress(); rp != nil {
+				data, err = sjson.SetBytes(data, "reseedProgress", rp)
+				if err != nil {
+					http.Error(w, "Encoding error: "+err.Error(), http.StatusInternalServerError)
+					return
+				}
+			}
 			err = json.Unmarshal(data, &cont)
 			if err != nil {
 				http.Error(w, "Encoding error: "+err.Error(), http.StatusInternalServerError)

--- a/share/dashboard_react/package.json
+++ b/share/dashboard_react/package.json
@@ -15,7 +15,8 @@
     "test:volume-dir-tokens": "node src/Pages/ClusterApp/components/Storage/__tests__/volumeDirTokens.test.js",
     "test:git-clone-volume-dir": "node src/Pages/ClusterApp/components/Storage/__tests__/gitCloneVolumeDir.test.js",
     "test:s3-volume-dir": "node src/Pages/ClusterApp/components/Storage/__tests__/s3VolumeDir.test.js",
-    "test:crash-pill": "node src/utility/__tests__/crashPill.test.js"
+    "test:crash-pill": "node src/utility/__tests__/crashPill.test.js",
+    "test:reseed-progress": "node src/utility/__tests__/reseedProgress.test.js"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.10.5",

--- a/share/dashboard_react/src/components/Modals/ReseedProgressModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/ReseedProgressModal/index.jsx
@@ -1,0 +1,80 @@
+import { Badge, Box, Flex, Progress, Text } from '@chakra-ui/react'
+import React from 'react'
+import CommonModal from '../CommonModal'
+import {
+  getActiveReseeds,
+  reseedHasBar,
+  formatBytes,
+  formatElapsed,
+} from '../../../utility/reseedProgress'
+
+// ReseedProgressModal shows every server currently being reseeded/rejoined with a
+// live progress bar (byte-instrumented methods) or an indeterminate timer + the
+// generic "started T" line (methods without byte counting). The panel landing each
+// reseed's true outcome at completion is the visible proof the rejoin reconcile works.
+function ReseedProgressModal({ isOpen, closeModal, servers }) {
+  const active = getActiveReseeds(servers)
+
+  const body = (
+    <Flex direction='column' gap={4}>
+      {active.length === 0 && <Text>No reseed in progress.</Text>}
+      {active.map((rp) => {
+        const hasBar = reseedHasBar(rp)
+        return (
+          <Box key={rp.url} borderWidth='1px' borderRadius='md' p={3}>
+            <Flex justify='space-between' align='center' mb={2}>
+              <Text fontWeight='bold'>{rp.url}</Text>
+              <Flex gap={2}>
+                {rp.fromRejoin && <Badge colorScheme='purple'>rejoin</Badge>}
+                {rp.task && <Badge colorScheme='blue'>{rp.task}</Badge>}
+              </Flex>
+            </Flex>
+
+            {hasBar ? (
+              <>
+                <Progress
+                  value={rp.percent}
+                  size='sm'
+                  colorScheme='blue'
+                  hasStripe
+                  isAnimated
+                  borderRadius='md'
+                />
+                <Text fontSize='sm' mt={1}>
+                  {formatBytes(rp.bytes)} / {formatBytes(rp.total)} ({rp.percent}%)
+                  {rp.rateBytesSec > 0 ? ` · ${formatBytes(rp.rateBytesSec)}/s` : ''}
+                  {` · ${formatElapsed(rp.elapsedSecs)}`}
+                </Text>
+              </>
+            ) : (
+              <>
+                <Progress size='sm' colorScheme='blue' isIndeterminate borderRadius='md' />
+                <Text fontSize='sm' mt={1}>
+                  {rp.line || `in progress · ${formatElapsed(rp.elapsedSecs)}`}
+                </Text>
+              </>
+            )}
+
+            {rp.backup && (
+              <Text fontSize='xs' opacity={0.7} mt={1}>
+                backup: {rp.backup}
+              </Text>
+            )}
+          </Box>
+        )
+      })}
+    </Flex>
+  )
+
+  return (
+    <CommonModal
+      isOpen={isOpen}
+      closeModal={closeModal}
+      title='Reseed / rejoin in progress'
+      size='lg'
+      body={body}
+    />
+  )
+}
+
+export default ReseedProgressModal

--- a/share/dashboard_react/src/components/Navbar/index.jsx
+++ b/share/dashboard_react/src/components/Navbar/index.jsx
@@ -13,6 +13,7 @@ import WorkloadModal from '../Modals/WorkloadModal'
 import SchemaModal from '../Modals/SchemaModal'
 import ConfigModal from '../Modals/ConfigModal'
 import CrashesModal from '../Modals/CrashesModal'
+import ReseedProgressModal from '../Modals/ReseedProgressModal'
 import { FaUserPlus, FaUserCircle } from 'react-icons/fa'
 import { MdSecurity, MdNotificationsOff, MdSchema, MdSettings, MdHistory } from 'react-icons/md'
 import { HiRefresh } from 'react-icons/hi'
@@ -33,6 +34,7 @@ import { selectMeetUIState } from '../../redux/memoize'
 import { clearClusters, getMonitoredData, setServerActiveStatus } from '../../redux/globalClustersSlice'
 import { globalClustersService } from '../../services/globalClustersService'
 import { crashRejoinNeedsAttention } from '../../utility/crashPill'
+import { hasActiveReseed, getActiveReseeds } from '../../utility/reseedProgress'
 
 // Go zero-time serialises as 0001-01-01 → render as "—".
 const fmtTs = (t) => (!t || String(t).startsWith('0001-01-01')) ? '—' : new Date(t).toLocaleString()
@@ -47,6 +49,7 @@ function Navbar({ username, user }) {
   const [isSchemaModalOpen, setIsSchemaModalOpen] = useState(false)
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false)
   const [isCrashesModalOpen, setIsCrashesModalOpen] = useState(false)
+  const [isReseedModalOpen, setIsReseedModalOpen] = useState(false)
   const [isAddUserModalOpen, setIsAddUserModalOpen] = useState(false)
   const [isInterventionPanelOpen, setIsInterventionPanelOpen] = useState(false)
   const [isUserInfoPanelOpen, setIsUserInfoPanelOpen] = useState(false)
@@ -59,6 +62,7 @@ function Navbar({ username, user }) {
   const { isMobile, isDesktop } = useSelector((state) => state.common)
   const clusterAlerts = useSelector((state) => state?.cluster?.clusterAlerts)
   const clusterData = useSelector((state) => state?.cluster?.clusterData)
+  const clusterServers = useSelector((state) => state?.cluster?.clusterServers)
   // Which header renders — instance (monitor) vs cluster — must follow the
   // SAME signal as the tab bar (which is always correct): Home's cluster-open
   // state, mirrored into redux as isClusterView. clusterData is NOT that
@@ -381,6 +385,21 @@ function Navbar({ username, user }) {
                   />
                 )
               })()}
+              {hasActiveReseed(clusterServers) && (
+                <AlertBadge
+                  colorScheme={'blue'}
+                  icon={HiRefresh}
+                  text='Reseed'
+                  count={getActiveReseeds(clusterServers).length}
+                  blink={true}
+                  bubbleStyle={{
+                    background: 'var(--chakra-colors-blue-500)',
+                    color: 'white',
+                  }}
+                  onClick={() => setIsReseedModalOpen(true)}
+                  showText={!isMobile}
+                />
+              )}
             </Flex>
           )}
 
@@ -459,6 +478,13 @@ function Navbar({ username, user }) {
           closeModal={() => setIsCrashesModalOpen(false)}
           clusterName={clusterData?.name}
           crashes={clusterData?.failoverHistory}
+        />
+      )}
+      {isReseedModalOpen && (
+        <ReseedProgressModal
+          isOpen={isReseedModalOpen}
+          closeModal={() => setIsReseedModalOpen(false)}
+          servers={clusterServers}
         />
       )}
       {isSchemaModalOpen && (

--- a/share/dashboard_react/src/utility/__tests__/crashPill.test.js
+++ b/share/dashboard_react/src/utility/__tests__/crashPill.test.js
@@ -40,6 +40,20 @@ function assert(condition, description) {
   assert(crashRejoinNeedsAttention(other) === false, 'non-REJOIN warnings (disk, proxy) do not alarm the crash pill')
 }
 
+// ─── WARN0189 (reseed in progress) is informational, NOT a crash-pill alarm ──
+{
+  const inProgress = { warnings: [{ number: 'WARN0189', desc: 'Restore in progress on db1', from: 'REJOIN' }], errors: [] }
+  assert(crashRejoinNeedsAttention(inProgress) === false,
+    'WARN0189 (reseed in progress) does NOT alarm the crash pill (the Reseed pill shows it)')
+
+  const mixed = { warnings: [
+    { number: 'WARN0189', desc: 'Restore in progress on db1', from: 'REJOIN' },
+    { number: 'WARN0186', desc: 'rejoin needs operator', from: 'REJOIN' },
+  ], errors: [] }
+  assert(crashRejoinNeedsAttention(mixed) === true,
+    'a real needs-attention state (WARN0186) still alarms even alongside an in-progress reseed')
+}
+
 // ─── Defensive ───────────────────────────────────────────────────────────────
 {
   assert(crashRejoinNeedsAttention(null) === false, 'null alerts → no alarm')

--- a/share/dashboard_react/src/utility/__tests__/reseedProgress.test.js
+++ b/share/dashboard_react/src/utility/__tests__/reseedProgress.test.js
@@ -1,0 +1,71 @@
+// Reseed-progress signal tests.
+// Run with: node src/utility/__tests__/reseedProgress.test.js
+//
+// Reads the structured per-server field server.reseedProgress (not a parsed alert
+// string), so the "in progress" set, the bar-vs-timer decision, and the byte/elapsed
+// formatting are all exact.
+
+import {
+  getActiveReseeds,
+  hasActiveReseed,
+  reseedHasBar,
+  formatBytes,
+  formatElapsed,
+} from '../reseedProgress.js'
+
+let passed = 0
+let failed = 0
+function assert(condition, description) {
+  if (condition) {
+    passed++
+  } else {
+    failed++
+    console.log(`  ✗ ${description}`)
+  }
+}
+
+// ─── getActiveReseeds / hasActiveReseed ──────────────────────────────────────
+{
+  assert(getActiveReseeds(null).length === 0, 'null servers → no active reseeds')
+  assert(getActiveReseeds([]).length === 0, 'empty servers → no active reseeds')
+  assert(hasActiveReseed(undefined) === false, 'undefined servers → hasActiveReseed false')
+
+  const servers = [
+    { url: 'db1:3306', state: 'Slave' }, // no reseedProgress
+    { url: 'db2:3306', reseedProgress: { inProgress: false } }, // idle marker
+    { url: 'db3:3306', reseedProgress: { inProgress: true, percent: 42, total: 100, bytes: 42 } },
+    { url: 'db4:3306', reseedProgress: { inProgress: true, percent: -1, fromRejoin: true } },
+    null,
+  ]
+  const active = getActiveReseeds(servers)
+  assert(active.length === 2, 'only servers with reseedProgress.inProgress are active')
+  assert(active[0].url === 'db3:3306' && active[1].url === 'db4:3306', 'active rows carry the server url')
+  assert(hasActiveReseed(servers) === true, 'a running reseed → hasActiveReseed true')
+}
+
+// ─── reseedHasBar (byte-instrumented vs generic timer) ───────────────────────
+{
+  assert(reseedHasBar({ percent: 42, total: 100 }) === true, 'byte-instrumented (percent>=0, total>0) → bar')
+  assert(reseedHasBar({ percent: -1, total: 0, fromRejoin: true }) === false, 'generic timer (percent -1) → no bar')
+  assert(reseedHasBar({ percent: 0, total: 100 }) === true, '0% with a known total still shows a bar')
+  assert(reseedHasBar(null) === false, 'null → no bar')
+}
+
+// ─── formatBytes (mirrors backend humanBytes) ────────────────────────────────
+{
+  assert(formatBytes(0) === '0B', '0 → 0B')
+  assert(formatBytes(512) === '512B', '512 → 512B')
+  assert(formatBytes(1024) === '1K', '1024 → 1K')
+  assert(formatBytes(100 * 1024 * 1024 * 1024) === '100G', '100 GiB → 100G')
+}
+
+// ─── formatElapsed ───────────────────────────────────────────────────────────
+{
+  assert(formatElapsed(45) === '45s', '45s')
+  assert(formatElapsed(192) === '3m12s', '3m12s')
+  assert(formatElapsed(3600 + 23 * 60 + 10) === '1h23m', '1h23m (drops seconds at hour scale)')
+  assert(formatElapsed(-5) === '0s', 'negative clamps to 0s')
+}
+
+console.log(`\nreseedProgress: ${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/share/dashboard_react/src/utility/crashPill.js
+++ b/share/dashboard_react/src/utility/crashPill.js
@@ -15,10 +15,14 @@
 // though its live REJOIN state had already cleared.
 
 // crashRejoinNeedsAttention reports whether the crash pill should alarm (blink +
-// red): true iff the cluster currently has an OPEN rejoin/crash health state.
+// red): true iff the cluster currently has an OPEN rejoin/crash health state that
+// NEEDS THE OPERATOR. WARN0189 ("reseed in progress") is a live, self-resolving
+// restore — informational, surfaced by the dedicated Reseed pill/panel — so it is
+// excluded here; otherwise every normal reseed made the crash pill blink red as if
+// something were broken.
 export const crashRejoinNeedsAttention = (clusterAlerts) => {
   if (!clusterAlerts) return false
-  const isRejoin = (s) => s && s.from === 'REJOIN'
-  return (clusterAlerts.warnings || []).some(isRejoin) ||
-    (clusterAlerts.errors || []).some(isRejoin)
+  const needsAttention = (s) => s && s.from === 'REJOIN' && s.number !== 'WARN0189'
+  return (clusterAlerts.warnings || []).some(needsAttention) ||
+    (clusterAlerts.errors || []).some(needsAttention)
 }

--- a/share/dashboard_react/src/utility/reseedProgress.js
+++ b/share/dashboard_react/src/utility/reseedProgress.js
@@ -1,0 +1,54 @@
+// Reseed / rejoin progress signal — zero dependencies (unit-testable with `node`).
+//
+// The dashboard shows a live "reseed in progress" panel driven by the per-server
+// structured progress the backend attaches to /api/clusters/{name}/topology/servers
+// as `server.reseedProgress` (absent when idle). Shape:
+//   { inProgress, fromRejoin, task, backup, tool, bytes, total, percent,
+//     startedUnix, elapsedSecs, rateBytesSec, line }
+// `percent` is -1 when the reseed method has no byte instrumentation — those show a
+// generic "rejoin reseed in progress, started T" timer instead of a filled bar.
+//
+// This is a state-machine signal, NOT a parsed alert string: it reads the structured
+// per-server field, so the URL and the numbers are exact (the WARN0189 alert only
+// carries a human string with the url baked in).
+
+// getActiveReseeds returns one row per server currently restoring, each shaped
+// { url, ...reseedProgress }.
+export const getActiveReseeds = (clusterServers) => {
+  if (!Array.isArray(clusterServers)) return []
+  return clusterServers
+    .filter((s) => s && s.reseedProgress && s.reseedProgress.inProgress)
+    .map((s) => ({ url: s.url, ...s.reseedProgress }))
+}
+
+// hasActiveReseed reports whether any server is currently being reseeded.
+export const hasActiveReseed = (clusterServers) => getActiveReseeds(clusterServers).length > 0
+
+// reseedHasBar reports whether a row can show a real progress bar (byte-instrumented)
+// rather than only an indeterminate timer.
+export const reseedHasBar = (rp) =>
+  !!rp && typeof rp.percent === 'number' && rp.percent >= 0 && rp.total > 0
+
+// formatBytes → "223M" / "100G" (mirror of the backend humanBytes).
+export const formatBytes = (b) => {
+  if (!b || b < 1024) return `${b || 0}B`
+  const units = ['K', 'M', 'G', 'T', 'P', 'E']
+  let n = b / 1024
+  let i = 0
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024
+    i++
+  }
+  return `${Math.round(n)}${units[i]}`
+}
+
+// formatElapsed(seconds) → "1h23m" / "3m12s" / "45s".
+export const formatElapsed = (secs) => {
+  secs = Math.max(0, Math.floor(secs || 0))
+  const h = Math.floor(secs / 3600)
+  const m = Math.floor((secs % 3600) / 60)
+  const s = secs % 60
+  if (h > 0) return `${h}h${m}m`
+  if (m > 0) return `${m}m${s}s`
+  return `${s}s`
+}


### PR DESCRIPTION
## Problem (confirmed from a live goroutine profile during a restore)

A splitdump/mysqldump **reseed runs on the cluster monitor tick goroutine**: `Run → tickBody → StateProcessing (cluster.go:1258) → ProcessReseedLogical → splitdump.Restore`. So for the entire multi-minute restore the cluster monitor loop is **frozen** — no health checks, **no failover even if the master dies mid-reseed** — and two concurrent slave reseeds **serialize** on the one tick goroutine (so "restore 2 slaves at once" isn't actually concurrent, and freezes monitoring the whole time).

## Fix

Dispatch the reseed via `cluster.trackTickGoroutine(...)` — **off the tick** — mirroring the WARN0111 async reseed path immediately below it. Dedup is already safe:
- `ProcessReseedLogical` claims the per-server `IsReseeding` flag atomically (`TrySetInReseedBackup`), so a later tick that still sees WARN0075 can't start a second reseed for the same server.
- **rejoin** (`srv_rejoin.go:482`) and **switchover staging** (`cluster_staging.go:449`) already refuse a reseeding server.
- Failover is master-triggered, so a slave reseed can't trip it.

## Why this is a net safety gain

Today the frozen monitor can't fail over even if the **master** dies during a slave reseed. After the fix the monitor keeps running, so that failover works — and the two slaves genuinely reseed in **parallel**. The only new exposure is cosmetic WARN states on the reseeding slave (its replication is stopped mid-restore); the structural re-actions are already `IsReseeding`-guarded.

## Testing

Builds/vets clean; cluster reseed/tick/state tests pass. **This is an orchestrator hot-path change — please run it on the OpenSVC topology matrix before merge** (concurrent 2-slave reseed + master-failover-during-reseed are the key scenarios).