### PR TITLE
fix(dbhelper): detach InnoDB status submatches

### DIFF
--- a/utils/dbhelper/status.go
+++ b/utils/dbhelper/status.go
@@ -9,6 +9,7 @@
 package dbhelper
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"regexp"
@@ -250,13 +251,33 @@ func GetEngineInnoDBStatus(db *sqlx.DB) (string, string, error) {
 	defer rows.Close()
 	var typeCol, nameCol, statusCol string
 	// First row should contain the necessary info. If many rows returned then it's unknown case.
-	if rows.Next() {
-		if err := rows.Scan(&typeCol, &nameCol, &statusCol); err != nil {
-			return statusCol, query, nil
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return "", query, err
 		}
+		// SHOW ENGINE INNODB STATUS always returns exactly one row; zero rows means
+		// something is wrong (e.g. InnoDB disabled) and should not look like success.
+		return "", query, sql.ErrNoRows
 	}
-	return statusCol, query, err
+	if err := rows.Scan(&typeCol, &nameCol, &statusCol); err != nil {
+		return statusCol, query, err
+	}
+	// database/sql only reliably surfaces a stream/iteration error once Next() has been
+	// advanced past the last row, so advance the cursor before trusting rows.Err(). A true
+	// result here just means the server sent an (unexpected, but harmless) extra row; we
+	// already have the data we need from the first one.
+	rows.Next()
+	if err := rows.Err(); err != nil {
+		return statusCol, query, err
+	}
+	return statusCol, query, nil
 }
+
+var (
+	reInnoDBQueries = regexp.MustCompile(`(\d+) queries inside InnoDB, (\d+) queries in queue`)
+	reInnoDBViews   = regexp.MustCompile(`(\d+) read views open inside InnoDB`)
+	reInnoDBHistory = regexp.MustCompile(`History list length (\d+)`)
+)
 
 // GetEngineInnoDBVariables parses InnoDB status and returns key metrics
 func GetEngineInnoDBVariables(db *sqlx.DB) (map[string]string, string, error) {
@@ -268,18 +289,18 @@ func GetEngineInnoDBVariables(db *sqlx.DB) (map[string]string, string, error) {
 	vars := make(map[string]string)
 	// 0 queries inside InnoDB, 0 queries in queue
 	// 0 read views open inside InnoDB
-	rQueries, _ := regexp.Compile(`(\d+) queries inside InnoDB, (\d+) queries in queue`)
-	rViews, _ := regexp.Compile(`(\d+) read views open inside InnoDB`)
-	rHistory, _ := regexp.Compile(`History list length (\d+)`)
+	// regexp submatches and strings.Split lines alias statusCol's backing array, so every
+	// extracted value must be cloned before storing it: otherwise a few retained digits keep
+	// the entire (up to ~1MB) SHOW ENGINE INNODB STATUS output alive.
 	for _, line := range strings.Split(statusCol, "\n") {
-		if data := rQueries.FindStringSubmatch(line); data != nil {
-			vars["queries_inside_innodb"] = data[1]
-			vars["queries_in_queue"] = data[2]
-		} else if data := rViews.FindStringSubmatch(line); data != nil {
-			vars["read_views_open_inside_innodb"] = data[1]
+		if data := reInnoDBQueries.FindStringSubmatch(line); data != nil {
+			vars["queries_inside_innodb"] = strings.Clone(data[1])
+			vars["queries_in_queue"] = strings.Clone(data[2])
+		} else if data := reInnoDBViews.FindStringSubmatch(line); data != nil {
+			vars["read_views_open_inside_innodb"] = strings.Clone(data[1])
 
-		} else if data := rHistory.FindStringSubmatch(line); data != nil {
-			vars["history_list_lenght_inside_innodb"] = data[1]
+		} else if data := reInnoDBHistory.FindStringSubmatch(line); data != nil {
+			vars["history_list_lenght_inside_innodb"] = strings.Clone(data[1])
 		}
 	}
 	return vars, logs, nil

--- a/utils/dbhelper/status_test.go
+++ b/utils/dbhelper/status_test.go
@@ -7,9 +7,13 @@
 package dbhelper
 
 import (
+	"database/sql"
+	"errors"
 	"strings"
 	"testing"
+	"unsafe"
 
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/signal18/replication-manager/utils/version"
 )
 
@@ -570,4 +574,158 @@ func TestGetMaxscaleVersion_Integration(t *testing.T) {
 	}
 
 	t.Logf("MaxScale version: %s", value)
+}
+
+// stringDataAddr returns the address of s's backing array, for aliasing checks.
+//
+// This relies on unsafe.StringData exposing the Go runtime's actual string representation
+// (pointer + length), which is an implementation detail rather than a language guarantee.
+// It holds for the standard gc toolchain used by this project; a different Go implementation
+// (e.g. gccgo/TinyGo) or a future runtime change to string representation could invalidate
+// this check. If this test ever needs to be dropped for portability, the underlying fix
+// (cloning submatches in GetEngineInnoDBVariables) still stands on its own.
+func stringDataAddr(s string) uintptr {
+	if len(s) == 0 {
+		return 0
+	}
+	return uintptr(unsafe.Pointer(unsafe.StringData(s)))
+}
+
+// aliasesBacking reports whether s's backing array overlaps big's, i.e. s was produced by
+// slicing big (via strings.Split / regexp submatches) rather than being copied out of it.
+func aliasesBacking(s, big string) bool {
+	if len(s) == 0 || len(big) == 0 {
+		return false
+	}
+	start := stringDataAddr(big)
+	end := start + uintptr(len(big))
+	sp := stringDataAddr(s)
+	return sp >= start && sp < end
+}
+
+// TestGetEngineInnoDBVariables_DetachesFromLargeStatus is a regression test for the memory
+// growth reported in issue #1633: SHOW ENGINE INNODB STATUS output can reach ~1MB on busy
+// servers, and both strings.Split lines and regexp.FindStringSubmatch results alias the
+// original string's backing array. Storing an un-cloned submatch into the returned map keeps
+// the entire large status string reachable (and un-collectable) for as long as the map lives.
+func TestGetEngineInnoDBVariables_DetachesFromLargeStatus(t *testing.T) {
+	db, mock := mockDB(t, "mysql")
+
+	// Pad the status blob well past any driver/runtime buffer reuse thresholds so a real
+	// aliasing bug would be unambiguous.
+	padding := strings.Repeat("X", 2*1024*1024)
+	status := padding + "\n" +
+		"5 queries inside InnoDB, 2 queries in queue\n" +
+		"3 read views open inside InnoDB\n" +
+		"History list length 42\n" +
+		padding
+
+	rows := sqlmock.NewRows([]string{"Type", "Name", "Status"}).AddRow("InnoDB", "", status)
+	mock.ExpectQuery("SHOW ENGINE INNODB STATUS").WillReturnRows(rows)
+
+	vars, _, err := GetEngineInnoDBVariables(db)
+	if err != nil {
+		t.Fatalf("GetEngineInnoDBVariables() failed: %v", err)
+	}
+
+	want := map[string]string{
+		"queries_inside_innodb":             "5",
+		"queries_in_queue":                  "2",
+		"read_views_open_inside_innodb":     "3",
+		"history_list_lenght_inside_innodb": "42",
+	}
+	for k, v := range want {
+		if vars[k] != v {
+			t.Errorf("vars[%q] = %q, want %q", k, vars[k], v)
+		}
+		if aliasesBacking(vars[k], status) {
+			t.Errorf("vars[%q] aliases the large status string's backing array; expected a detached copy", k)
+		}
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+// TestGetEngineInnoDBStatus_ScanError verifies that a rows.Scan failure is surfaced to the
+// caller instead of being swallowed as a nil error (issue #1633 follow-up finding).
+func TestGetEngineInnoDBStatus_ScanError(t *testing.T) {
+	db, mock := mockDB(t, "mysql")
+
+	// Two columns instead of the expected three makes rows.Scan(&typeCol, &nameCol, &statusCol)
+	// fail with a destination-argument-count error. The exact wording is a database/sql
+	// implementation detail, so only assert that an error comes back at all.
+	rows := sqlmock.NewRows([]string{"Type", "Status"}).AddRow("InnoDB", "some status")
+	mock.ExpectQuery("SHOW ENGINE INNODB STATUS").WillReturnRows(rows)
+
+	_, _, err := GetEngineInnoDBStatus(db)
+	if err == nil {
+		t.Fatal("expected an error from rows.Scan(), got nil")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+// TestGetEngineInnoDBStatus_NoRows verifies that a zero-row result set (SHOW ENGINE INNODB
+// STATUS should always return exactly one row) is treated as an error rather than silently
+// returning an empty status string as if it were a successful call.
+func TestGetEngineInnoDBStatus_NoRows(t *testing.T) {
+	db, mock := mockDB(t, "mysql")
+
+	rows := sqlmock.NewRows([]string{"Type", "Name", "Status"})
+	mock.ExpectQuery("SHOW ENGINE INNODB STATUS").WillReturnRows(rows)
+
+	status, _, err := GetEngineInnoDBStatus(db)
+	if err == nil {
+		t.Fatal("expected an error for a zero-row result, got nil")
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("expected sql.ErrNoRows, got: %v", err)
+	}
+	if status != "" {
+		t.Errorf("expected empty status on error, got %q", status)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+// TestGetEngineInnoDBStatus_RowIterationError verifies that an error surfaced only once the
+// cursor is advanced past the first row (e.g. a mid-stream network error while reading the
+// terminating EOF packet) is not silently discarded. sqlmock ties a RowError to the row index
+// it's attached to, and that row's data is populated on the very same Next() call as the
+// error, so the only way to simulate "row 0 scans cleanly, then the next cursor advance
+// fails" is to give the mock a second row and attach the error there: GetEngineInnoDBStatus
+// calls rows.Next() a second time purely to reach that point in the stream, discarding
+// whatever data it would have carried.
+func TestGetEngineInnoDBStatus_RowIterationError(t *testing.T) {
+	db, mock := mockDB(t, "mysql")
+
+	wantErr := errors.New("simulated row iteration error")
+	rows := sqlmock.NewRows([]string{"Type", "Name", "Status"}).
+		AddRow("InnoDB", "", "some status").
+		AddRow("InnoDB", "", "unreachable: error fires before this row's data is used").
+		RowError(1, wantErr)
+	mock.ExpectQuery("SHOW ENGINE INNODB STATUS").WillReturnRows(rows)
+
+	status, _, err := GetEngineInnoDBStatus(db)
+	if err == nil {
+		t.Fatal("expected a row iteration error, got nil")
+	}
+	if !strings.Contains(err.Error(), wantErr.Error()) {
+		t.Errorf("expected error to wrap %q, got: %v", wantErr, err)
+	}
+	// The first row was scanned successfully before the second Next() surfaced the error;
+	// that data should still be returned rather than discarded.
+	if status != "some status" {
+		t.Errorf("expected the successfully scanned first row to be preserved, got %q", status)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary
This PR fixes the memory-retention path behind `monitoring-innodb-status` by detaching parsed values extracted from `SHOW ENGINE INNODB STATUS` before they are stored in Replication Manager state.

## Why this change
Issue #1633 reported unbounded memory growth when `monitoring-innodb-status` is enabled. Heap profiles pointed at `database/sql.convertAssignRows` through this call path:

- `utils/dbhelper.GetEngineInnoDBStatus`
- `utils/dbhelper.GetEngineInnoDBVariables`
- `cluster.(*ServerMonitor).Refresh`

`SHOW ENGINE INNODB STATUS` can return a very large status blob. The previous implementation parsed values with `regexp.FindStringSubmatch` and stored those submatches directly in the returned map. In Go, those submatch strings alias the original backing string, so retaining a tiny value like `"42"` could keep the full InnoDB status payload alive in memory.

## What this fixes
- clones extracted InnoDB metric submatches before storing them so the large status blob can be garbage-collected
- precompiles the InnoDB status regexes used by the parser
- fixes `GetEngineInnoDBStatus` so `rows.Scan` errors are returned instead of being swallowed
- treats a zero-row `SHOW ENGINE INNODB STATUS` result as an error instead of silently succeeding with an empty string
- advances the cursor before trusting `rows.Err()` so post-row iteration failures are surfaced instead of ignored

## Behavior impact
This PR keeps the existing monitoring cadence intact. It does **not** slow down InnoDB status collection; it fixes the retention bug while preserving current behavior and metric keys.

## Tests
Added focused regression coverage in `utils/dbhelper/status_test.go` for:

- detached parsed values from a large synthetic InnoDB status payload
- `rows.Scan` failure propagation
- zero-row result handling
- row-iteration/stream error handling after the first scanned row

Validation run:

```bash
go test ./utils/dbhelper -run 'TestGetEngineInnoDB(Status_(ScanError|NoRows|RowIterationError)|Variables_DetachesFromLargeStatus)$'
```
