### PR TITLE
fix(dbhelper): correctly match mysql.user hosts in privilege checks

### DIFF
--- a/utils/dbhelper/replication.go
+++ b/utils/dbhelper/replication.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"hash/crc64"
 	"log"
+	"net"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -155,68 +157,219 @@ func ChangeMaster(db *sqlx.DB, opt ChangeMasterOpt, myver *version.Version) (str
 	return cm, nil
 }
 
+// hostAccountMatch reports whether a mysql.user account host pattern matches
+// a connecting client identified by hostname and/or IP, following MariaDB/MySQL
+// account host syntax: literal hostname/IP, the "%" wildcard, SQL LIKE-style
+// wildcards ('%' and '_', escapable with '\'), and IPv4 "network/netmask"
+// notation. MariaDB/MySQL only support netmasks for IPv4 addresses.
+func hostAccountMatch(accountHost, clientHost, clientIP string) bool {
+	if accountHost == "" {
+		return false
+	}
+	if accountHost == "%" {
+		return true
+	}
+	if (clientHost != "" && strings.EqualFold(accountHost, clientHost)) ||
+		(clientIP != "" && strings.EqualFold(accountHost, clientIP)) {
+		return true
+	}
+	if strings.Contains(accountHost, "/") {
+		return hostMatchesNetmask(accountHost, clientIP)
+	}
+	// Route through the LIKE-pattern matcher whenever the pattern contains a
+	// wildcard OR a backslash: a pattern that only contains escaped
+	// characters (e.g. "db1\_host") has no unescaped wildcard per
+	// firstWildcardIndex, but still needs sqlLikeToRegexp to unescape it
+	// before comparing -- the raw string still has the backslash in it, so
+	// the exact-match check above never fires for it.
+	if strings.ContainsAny(accountHost, "%_\\") {
+		return hostMatchesWildcard(accountHost, clientHost) || hostMatchesWildcard(accountHost, clientIP)
+	}
+	return false
+}
+
+// hostMatchesNetmask evaluates MariaDB/MySQL IPv4 "network/netmask" account
+// host notation (e.g. "10.0.0.0/255.0.0.0") against the connecting client IP.
+func hostMatchesNetmask(accountHost, clientIP string) bool {
+	if clientIP == "" {
+		return false
+	}
+	parts := strings.SplitN(accountHost, "/", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	network := parseIPv4(parts[0])
+	mask := parseIPv4(parts[1])
+	ip := parseIPv4(clientIP)
+	if network == nil || mask == nil || ip == nil {
+		return false
+	}
+	netmask := net.IPMask(mask)
+	return ip.Mask(netmask).Equal(network.Mask(netmask))
+}
+
+// parseIPv4 parses s as an IPv4 address, returning nil if s is empty,
+// malformed, or an IPv6 address.
+func parseIPv4(s string) net.IP {
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return nil
+	}
+	return ip.To4()
+}
+
+// hostMatchesWildcard evaluates a mysql.user account host pattern containing
+// SQL LIKE-style wildcards ('%' matches any sequence, '_' matches a single
+// character, '\' escapes the following character) against a client hostname
+// or IP.
+func hostMatchesWildcard(pattern, value string) bool {
+	if value == "" {
+		return false
+	}
+	re, err := sqlLikeToRegexp(pattern)
+	if err != nil {
+		return false
+	}
+	return re.MatchString(value)
+}
+
+func sqlLikeToRegexp(pattern string) (*regexp.Regexp, error) {
+	var b strings.Builder
+	b.WriteString("(?i)^")
+	runes := []rune(pattern)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		switch r {
+		case '\\':
+			if i+1 < len(runes) {
+				i++
+				b.WriteString(regexp.QuoteMeta(string(runes[i])))
+			} else {
+				b.WriteString(regexp.QuoteMeta(string(r)))
+			}
+		case '%':
+			b.WriteString(".*")
+		case '_':
+			b.WriteString(".")
+		default:
+			b.WriteString(regexp.QuoteMeta(string(r)))
+		}
+	}
+	b.WriteString("$")
+	return regexp.Compile(b.String())
+}
+
+// firstWildcardIndex returns the byte index of the first unescaped SQL
+// LIKE-style wildcard ('%' or '_') in pattern, or -1 if there is none.
+// A backslash escapes the character that follows it.
+func firstWildcardIndex(pattern string) int {
+	for i := 0; i < len(pattern); i++ {
+		switch pattern[i] {
+		case '\\':
+			i++
+		case '%', '_':
+			return i
+		}
+	}
+	return -1
+}
+
+// hostAccountSpecificity ranks a mysql.user account host pattern by how
+// specific it is, so that when several account rows match a connecting
+// client, GetPrivileges can pick the single most specific one -- mirroring
+// how MariaDB/MySQL resolve which account row applies to a connection --
+// instead of taking the union (MAX) of privileges across every matching row.
+// Higher return values are more specific; "%" is the least specific (0).
+func hostAccountSpecificity(accountHost string) int {
+	const (
+		tierWildcard = 1 << 20
+		tierNetmask  = 2 << 20
+		tierExact    = 3 << 20
+	)
+	if accountHost == "%" {
+		return 0
+	}
+	if strings.Contains(accountHost, "/") {
+		score := tierNetmask
+		parts := strings.SplitN(accountHost, "/", 2)
+		if len(parts) == 2 {
+			if mask := parseIPv4(parts[1]); mask != nil {
+				ones, _ := net.IPMask(mask).Size()
+				score += ones
+			}
+		}
+		return score
+	}
+	if idx := firstWildcardIndex(accountHost); idx >= 0 {
+		return tierWildcard + idx
+	}
+	return tierExact
+}
+
 func GetPrivileges(db *sqlx.DB, user string, host string, ip string, myver *version.Version) (Privileges, string, error) {
 	db.MapperFunc(strings.Title)
-	stmt := ""
-	var err error
 	priv := Privileges{}
 	if ip == "" {
 		return priv, "", errors.New("Error getting privileges for non-existent IP address")
 	}
 
-	if strings.Contains(ip, ":") {
-		splitip := strings.Split(ip, ":")
-		iprange1 := splitip[0] + ":%:%:%"
-		iprange2 := splitip[0] + ":" + splitip[1] + ":%:%"
-		iprange3 := splitip[0] + ":" + splitip[1] + ":" + splitip[2] + ":%"
-
-		if myver.IsPostgreSQL() {
-			stmt = `SELECT 'Y' as "Select_priv" ,'Y'  as "Process_priv",  CASE WHEN u.usesuper THEN 'Y' ELSE 'N' END  as "Super_priv",  CASE WHEN  u.userepl THEN 'Y' ELSE 'N' END as "Repl_slave_priv", CASE WHEN  u.userepl THEN 'Y' ELSE 'N' END as "Repl_client_priv" ,CASE WHEN u.usesuper THEN 'Y' ELSE 'N' END as "Reload_priv" FROM pg_catalog.pg_user u WHERE u.usename = $1`
-			row := db.QueryRowx(stmt, user)
-			err = row.StructScan(&priv)
-			if err != nil && strings.Contains(err.Error(), "unsupported Scan") {
-				return priv, stmt, errors.New("No replication user defined. Please check the replication user is created with the required privileges")
-			}
-
-		} else {
-			stmt = "SELECT COALESCE(MAX(Select_priv),'N') as Select_priv, COALESCE(MAX(Process_priv),'N') as Process_priv, COALESCE(MAX(Super_priv),'N') as Super_priv, COALESCE(MAX(Repl_slave_priv),'N') as Repl_slave_priv, COALESCE(MAX(Repl_client_priv),'N') as Repl_client_priv, COALESCE(MAX(Reload_priv),'N') as Reload_priv FROM mysql.user WHERE user = ? AND host IN(?,?,?,?,?,?,?,?,?)"
-			row := db.QueryRowx(stmt, user, host, ip, "::", ip+"/255.0.0.0", ip+"/255.255.0.0", ip+"/255:255.255.0", iprange1, iprange2, iprange3)
-			err = row.StructScan(&priv)
-
-			if err != nil && strings.Contains(err.Error(), "unsupported Scan") {
-				return priv, stmt, errors.New("No replication user defined. Please check the replication user is created with the required privileges")
-			}
+	if myver.IsPostgreSQL() {
+		stmt := `SELECT 'Y' as "Select_priv" ,'Y'  as "Process_priv",  CASE WHEN u.usesuper THEN 'Y' ELSE 'N' END  as "Super_priv",  CASE WHEN  u.userepl THEN 'Y' ELSE 'N' END as "Repl_slave_priv", CASE WHEN  u.userepl THEN 'Y' ELSE 'N' END as "Repl_client_priv" ,CASE WHEN u.usesuper THEN 'Y' ELSE 'N' END as "Reload_priv" FROM pg_catalog.pg_user u WHERE u.usename = $1`
+		row := db.QueryRowx(stmt, user)
+		err := row.StructScan(&priv)
+		if err != nil && strings.Contains(err.Error(), "unsupported Scan") {
+			return priv, stmt, errors.New("No replication user defined. Please check the replication user is created with the required privileges")
 		}
 		return priv, stmt, err
 	}
-	splitip := strings.Split(ip, ".")
 
-	iprange1 := splitip[0] + ".%.%.%"
-	iprange4 := splitip[0] + ".%"
+	// Fetch every account row for this user and pick the single row that
+	// MariaDB/MySQL would select for this client, rather than approximating
+	// it with a host IN(...) list and unioning privileges across matches.
+	// ORDER BY makes row order (and thus tie-breaking between equally
+	// specific matches) deterministic across calls.
+	stmt := "SELECT Host, Select_priv, Process_priv, Super_priv, Repl_slave_priv, Repl_client_priv, Reload_priv FROM mysql.user WHERE user = ? ORDER BY Host"
+	rows, err := db.Query(stmt, user)
+	if err != nil {
+		return priv, stmt, err
+	}
+	defer rows.Close()
 
-	iprange2 := splitip[0] + "." + splitip[1] + ".%.%"
-	iprange5 := splitip[0] + "." + splitip[1] + ".%"
-
-	iprange3 := splitip[0] + "." + splitip[1] + "." + splitip[2] + ".%"
-
-	if myver.IsPostgreSQL() {
-		stmt = `SELECT 'Y' as "Select_priv" ,'Y'  as "Process_priv",  CASE WHEN u.usesuper THEN 'Y' ELSE 'N' END  as "Super_priv",  CASE WHEN  u.userepl THEN 'Y' ELSE 'N' END as "Repl_slave_priv", CASE WHEN  u.userepl THEN 'Y' ELSE 'N' END as "Repl_client_priv" ,CASE WHEN u.usesuper THEN 'Y' ELSE 'N' END as "Reload_priv" FROM pg_catalog.pg_user u WHERE u.usename = $1`
-		row := db.QueryRowx(stmt, user)
-		err = row.StructScan(&priv)
-		if err != nil && strings.Contains(err.Error(), "unsupported Scan") {
-			return priv, stmt, errors.New("No replication user defined. Please check the replication user is created with the required privileges")
+	found := false
+	bestScore := 0
+	for rows.Next() {
+		var acctHost string
+		var p Privileges
+		if err := rows.Scan(&acctHost, &p.Select_priv, &p.Process_priv, &p.Super_priv, &p.Repl_slave_priv, &p.Repl_client_priv, &p.Reload_priv); err != nil {
+			return priv, stmt, err
 		}
-
-	} else {
-		stmt := "SELECT COALESCE(MAX(Select_priv),'N') as Select_priv, COALESCE(MAX(Process_priv),'N') as Process_priv, COALESCE(MAX(Super_priv),'N') as Super_priv, COALESCE(MAX(Repl_slave_priv),'N') as Repl_slave_priv, COALESCE(MAX(Repl_client_priv),'N') as Repl_client_priv, COALESCE(MAX(Reload_priv),'N') as Reload_priv FROM mysql.user WHERE user = ? AND host IN(?,?,?,?,?,?,?,?,?,?,?)"
-		row := db.QueryRowx(stmt, user, host, ip, "%", ip+"/255.0.0.0", ip+"/255.255.0.0", ip+"/255.255.255.0", iprange1, iprange2, iprange3, iprange4, iprange5)
-		err = row.StructScan(&priv)
-		if err != nil && strings.Contains(err.Error(), "unsupported Scan") {
-			return priv, stmt, errors.New("No replication user defined. Please check the replication user is created with the required privileges")
+		if !hostAccountMatch(acctHost, host, ip) {
+			continue
+		}
+		if score := hostAccountSpecificity(acctHost); !found || score > bestScore {
+			found = true
+			bestScore = score
+			priv = p
 		}
 	}
-	return priv, stmt, err
-
+	if err := rows.Err(); err != nil {
+		return priv, stmt, err
+	}
+	if !found {
+		// No account row matches this client: report "N" for every privilege
+		// (not an error) so callers evaluating individual priv.*_priv fields,
+		// e.g. cluster.CheckPrivileges, keep raising their usual per-privilege
+		// alerts instead of a generic connection/query error.
+		priv = Privileges{
+			Select_priv:      "N",
+			Process_priv:     "N",
+			Super_priv:       "N",
+			Repl_slave_priv:  "N",
+			Repl_client_priv: "N",
+			Reload_priv:      "N",
+		}
+	}
+	return priv, stmt, nil
 }
 
 func CheckReplicationAccount(db *sqlx.DB, pass string, user string, host string, ip string, myver *version.Version) (bool, string, error) {

--- a/utils/dbhelper/replication.go
+++ b/utils/dbhelper/replication.go
@@ -294,6 +294,11 @@ func hostAccountSpecificity(accountHost string) int {
 		parts := strings.SplitN(accountHost, "/", 2)
 		if len(parts) == 2 {
 			if mask := parseIPv4(parts[1]); mask != nil {
+				// Size() returns (0, 0) for a non-contiguous mask (e.g. a
+				// hypothetical 255.0.255.0), which silently ranks it as the
+				// least specific netmask (same as /0). MySQL/MariaDB netmask
+				// accounts are effectively always contiguous CIDR-style
+				// masks in practice, so this is left unhandled.
 				ones, _ := net.IPMask(mask).Size()
 				score += ones
 			}
@@ -307,13 +312,15 @@ func hostAccountSpecificity(accountHost string) int {
 }
 
 func GetPrivileges(db *sqlx.DB, user string, host string, ip string, myver *version.Version) (Privileges, string, error) {
-	db.MapperFunc(strings.Title)
 	priv := Privileges{}
 	if ip == "" {
 		return priv, "", errors.New("Error getting privileges for non-existent IP address")
 	}
 
 	if myver.IsPostgreSQL() {
+		// MapperFunc controls how StructScan maps column names to struct
+		// fields; only the StructScan call below needs it.
+		db.MapperFunc(strings.Title)
 		stmt := `SELECT 'Y' as "Select_priv" ,'Y'  as "Process_priv",  CASE WHEN u.usesuper THEN 'Y' ELSE 'N' END  as "Super_priv",  CASE WHEN  u.userepl THEN 'Y' ELSE 'N' END as "Repl_slave_priv", CASE WHEN  u.userepl THEN 'Y' ELSE 'N' END as "Repl_client_priv" ,CASE WHEN u.usesuper THEN 'Y' ELSE 'N' END as "Reload_priv" FROM pg_catalog.pg_user u WHERE u.usename = $1`
 		row := db.QueryRowx(stmt, user)
 		err := row.StructScan(&priv)

--- a/utils/dbhelper/replication_test.go
+++ b/utils/dbhelper/replication_test.go
@@ -9,8 +9,13 @@ package dbhelper
 
 import (
 	"math"
+	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	"github.com/signal18/replication-manager/utils/version"
 )
 
 func TestCheckSlavePrerequisites(t *testing.T) {
@@ -579,6 +584,352 @@ func TestSkipBinlogEvent_CommandGeneration(t *testing.T) {
 
 			if !strings.Contains(cmd, tt.wantCmd) {
 				t.Errorf("Generated command %q doesn't contain expected %q", cmd, tt.wantCmd)
+			}
+		})
+	}
+}
+
+func TestHostAccountMatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		accountHost string
+		clientHost  string
+		clientIP    string
+		want        bool
+	}{
+		{"bare percent matches anything", "%", "db1.example.com", "10.2.3.4", true},
+		{"exact ip match", "10.2.3.4", "db1.example.com", "10.2.3.4", true},
+		{"exact hostname match", "db1.example.com", "db1.example.com", "10.2.3.4", true},
+		{"exact match is case-insensitive", "DB1.EXAMPLE.COM", "db1.example.com", "10.2.3.4", true},
+		{"unrelated exact host does not match", "otherhost", "db1.example.com", "10.2.3.4", false},
+		{"netmask /8 matches", "10.0.0.0/255.0.0.0", "db1.example.com", "10.2.3.4", true},
+		{"netmask /8 rejects out of range ip", "10.0.0.0/255.0.0.0", "db1.example.com", "11.2.3.4", false},
+		{"netmask /16 matches", "10.2.0.0/255.255.0.0", "db1.example.com", "10.2.3.4", true},
+		{"netmask /16 rejects out of range ip", "10.2.0.0/255.255.0.0", "db1.example.com", "10.9.3.4", false},
+		{"wildcard ip prefix matches", "10.2.%", "db1.example.com", "10.2.3.4", true},
+		{"wildcard ip prefix rejects mismatch", "10.9.%", "db1.example.com", "10.2.3.4", false},
+		{"wildcard hostname matches", "db%.example.com", "db1.example.com", "10.2.3.4", true},
+		{"wildcard underscore matches single char", "db_.example.com", "db1.example.com", "10.2.3.4", true},
+		{"empty account host never matches", "", "db1.example.com", "10.2.3.4", false},
+		{"escaped underscore is literal", `db1\_host`, "db1_host", "10.2.3.4", true},
+		{"escaped underscore rejects substitution", `db1\_host`, "db1Xhost", "10.2.3.4", false},
+		{"IPv6 netmask notation never matches (IPv4-only feature)", "::/ffff::", "db1.example.com", "::1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hostAccountMatch(tt.accountHost, tt.clientHost, tt.clientIP)
+			if got != tt.want {
+				t.Errorf("hostAccountMatch(%q, %q, %q) = %v, want %v", tt.accountHost, tt.clientHost, tt.clientIP, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHostAccountSpecificity(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+	}{
+		{"exact beats netmask", "10.2.3.4", "10.2.0.0/255.255.0.0"},
+		{"exact beats wildcard", "10.2.3.4", "10.2.%"},
+		{"exact beats percent", "10.2.3.4", "%"},
+		{"narrower netmask beats broader netmask", "10.2.0.0/255.255.0.0", "10.0.0.0/255.0.0.0"},
+		{"netmask beats percent", "10.0.0.0/255.0.0.0", "%"},
+		{"more specific wildcard beats less specific wildcard", "10.2.%", "10.%"},
+		{"wildcard beats percent", "10.%", "%"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sa := hostAccountSpecificity(tt.a)
+			sb := hostAccountSpecificity(tt.b)
+			if sa <= sb {
+				t.Errorf("hostAccountSpecificity(%q)=%d, hostAccountSpecificity(%q)=%d; want %q strictly more specific", tt.a, sa, tt.b, sb, tt.a)
+			}
+		})
+	}
+}
+
+func mariaDBVersionForTest() *version.Version {
+	v, _ := version.NewVersionFromString("MariaDB", "10.6.12-MariaDB")
+	return v
+}
+
+const getPrivilegesQuery = "SELECT Host, Select_priv, Process_priv, Super_priv, Repl_slave_priv, Repl_client_priv, Reload_priv FROM mysql.user WHERE user = ? ORDER BY Host"
+
+func TestGetPrivileges_NetmaskMatch(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+	sqlxdb := sqlx.NewDb(db, "sqlmock")
+
+	mock.ExpectQuery(regexp.QuoteMeta(getPrivilegesQuery)).
+		WithArgs("repl").
+		WillReturnRows(sqlmock.NewRows([]string{"Host", "Select_priv", "Process_priv", "Super_priv", "Repl_slave_priv", "Repl_client_priv", "Reload_priv"}).
+			AddRow("10.0.0.0/255.0.0.0", "Y", "Y", "Y", "Y", "Y", "Y"))
+
+	priv, _, err := GetPrivileges(sqlxdb, "repl", "db1.example.com", "10.2.3.4", mariaDBVersionForTest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if priv.Repl_slave_priv != "Y" {
+		t.Errorf("expected netmask account to match, got privileges %+v", priv)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestGetPrivileges_MoreSpecificNetmaskWins(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+	sqlxdb := sqlx.NewDb(db, "sqlmock")
+
+	mock.ExpectQuery(regexp.QuoteMeta(getPrivilegesQuery)).
+		WithArgs("repl").
+		WillReturnRows(sqlmock.NewRows([]string{"Host", "Select_priv", "Process_priv", "Super_priv", "Repl_slave_priv", "Repl_client_priv", "Reload_priv"}).
+			AddRow("10.0.0.0/255.0.0.0", "N", "N", "N", "N", "N", "N").
+			AddRow("10.2.0.0/255.255.0.0", "Y", "Y", "Y", "Y", "Y", "Y"))
+
+	priv, _, err := GetPrivileges(sqlxdb, "repl", "db1.example.com", "10.2.3.4", mariaDBVersionForTest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if priv.Repl_slave_priv != "Y" {
+		t.Errorf("expected the /16 netmask row to win over the /8 row, got privileges %+v", priv)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+// TestGetPrivileges_MixedExactHostAndIP documents a known, deliberately
+// unresolved ambiguity: hostAccountSpecificity ranks an exact hostname row
+// and an exact IP row identically (both "tierExact"), so when a user has
+// both and a client's hostname and IP each exactly match one of them,
+// GetPrivileges breaks the tie using the ORDER BY Host row order rather than
+// replicating MariaDB/MySQL's internal ACL sort. This is a narrower
+// approximation than the wildcard/netmask specificity ranking, called out as
+// an accepted risk rather than implemented, because a byte-for-byte clone of
+// MariaDB's ACL sort was judged out of scope for this fix. If a deployment
+// relies on this exact combination for privilege differentiation, this test
+// is the place to add real precedence logic.
+func TestGetPrivileges_MixedExactHostAndIP(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+	sqlxdb := sqlx.NewDb(db, "sqlmock")
+
+	// ORDER BY Host sorts "10.2.3.4" before "db1.example.com" (ASCII '1' <
+	// 'd'), so with the tie-break in GetPrivileges (first row seen wins ties
+	// via strict '>'), the IP row currently wins.
+	mock.ExpectQuery(regexp.QuoteMeta(getPrivilegesQuery)).
+		WithArgs("repl").
+		WillReturnRows(sqlmock.NewRows([]string{"Host", "Select_priv", "Process_priv", "Super_priv", "Repl_slave_priv", "Repl_client_priv", "Reload_priv"}).
+			AddRow("10.2.3.4", "Y", "N", "N", "N", "N", "N").
+			AddRow("db1.example.com", "N", "Y", "N", "N", "N", "N"))
+
+	priv, _, err := GetPrivileges(sqlxdb, "repl", "db1.example.com", "10.2.3.4", mariaDBVersionForTest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if priv.Select_priv != "Y" || priv.Process_priv != "N" {
+		t.Errorf("tie-break behavior changed: expected the IP row (Select_priv=Y) to win via ORDER BY Host, got %+v", priv)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestGetPrivileges_ExactBeatsWildcard(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+	sqlxdb := sqlx.NewDb(db, "sqlmock")
+
+	mock.ExpectQuery(regexp.QuoteMeta(getPrivilegesQuery)).
+		WithArgs("repl").
+		WillReturnRows(sqlmock.NewRows([]string{"Host", "Select_priv", "Process_priv", "Super_priv", "Repl_slave_priv", "Repl_client_priv", "Reload_priv"}).
+			AddRow("%", "N", "N", "N", "N", "N", "N").
+			AddRow("10.2.%", "N", "N", "N", "N", "N", "N").
+			AddRow("10.2.3.4", "Y", "Y", "Y", "Y", "Y", "Y"))
+
+	priv, _, err := GetPrivileges(sqlxdb, "repl", "db1.example.com", "10.2.3.4", mariaDBVersionForTest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if priv.Repl_slave_priv != "Y" {
+		t.Errorf("expected the exact-host row to win, got privileges %+v", priv)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestGetPrivileges_WildcardSpecificity(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+	sqlxdb := sqlx.NewDb(db, "sqlmock")
+
+	mock.ExpectQuery(regexp.QuoteMeta(getPrivilegesQuery)).
+		WithArgs("repl").
+		WillReturnRows(sqlmock.NewRows([]string{"Host", "Select_priv", "Process_priv", "Super_priv", "Repl_slave_priv", "Repl_client_priv", "Reload_priv"}).
+			AddRow("10.%", "N", "N", "N", "N", "N", "N").
+			AddRow("10.2.%", "Y", "Y", "Y", "Y", "Y", "Y"))
+
+	priv, _, err := GetPrivileges(sqlxdb, "repl", "db1.example.com", "10.2.3.4", mariaDBVersionForTest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if priv.Repl_slave_priv != "Y" {
+		t.Errorf("expected the more specific '10.2.%%' row to win, got privileges %+v", priv)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestGetPrivileges_HostnameExactMatch(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+	sqlxdb := sqlx.NewDb(db, "sqlmock")
+
+	mock.ExpectQuery(regexp.QuoteMeta(getPrivilegesQuery)).
+		WithArgs("repl").
+		WillReturnRows(sqlmock.NewRows([]string{"Host", "Select_priv", "Process_priv", "Super_priv", "Repl_slave_priv", "Repl_client_priv", "Reload_priv"}).
+			AddRow("%", "N", "N", "N", "N", "N", "N").
+			AddRow("db1.example.com", "Y", "Y", "Y", "Y", "Y", "Y"))
+
+	priv, _, err := GetPrivileges(sqlxdb, "repl", "db1.example.com", "10.2.3.4", mariaDBVersionForTest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if priv.Repl_slave_priv != "Y" {
+		t.Errorf("expected the exact hostname row to win over '%%', got privileges %+v", priv)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+// TestGetPrivileges_NoMatch pins the pre-existing caller contract: when no
+// account row matches the client, GetPrivileges must return a "N"-filled
+// Privileges struct with a nil error (not a synthetic error), because
+// cluster.CheckPrivileges (cluster/srv_chk.go) only inspects individual
+// priv.*_priv fields to raise its ERR00006/ERR00007/ERR00008/ERR00009
+// alerts and treats a non-nil error as a separate ERR00005 condition.
+// Returning an error here would silently stop those specific alerts from
+// firing.
+func TestGetPrivileges_NoMatch(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+	sqlxdb := sqlx.NewDb(db, "sqlmock")
+
+	mock.ExpectQuery(regexp.QuoteMeta(getPrivilegesQuery)).
+		WithArgs("repl").
+		WillReturnRows(sqlmock.NewRows([]string{"Host", "Select_priv", "Process_priv", "Super_priv", "Repl_slave_priv", "Repl_client_priv", "Reload_priv"}).
+			AddRow("192.168.0.0/255.255.0.0", "Y", "Y", "Y", "Y", "Y", "Y"))
+
+	priv, _, err := GetPrivileges(sqlxdb, "repl", "db1.example.com", "10.2.3.4", mariaDBVersionForTest())
+	if err != nil {
+		t.Fatalf("expected nil error when no account row matches (old MAX(...) query never errored either), got: %v", err)
+	}
+	want := Privileges{
+		Select_priv:      "N",
+		Process_priv:     "N",
+		Super_priv:       "N",
+		Repl_slave_priv:  "N",
+		Repl_client_priv: "N",
+		Reload_priv:      "N",
+	}
+	if priv != want {
+		t.Errorf("expected all-N privileges on no match, got %+v", priv)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestGetPrivileges_NetmaskIsIPv4Only(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+	sqlxdb := sqlx.NewDb(db, "sqlmock")
+
+	mock.ExpectQuery(regexp.QuoteMeta(getPrivilegesQuery)).
+		WithArgs("repl").
+		WillReturnRows(sqlmock.NewRows([]string{"Host", "Select_priv", "Process_priv", "Super_priv", "Repl_slave_priv", "Repl_client_priv", "Reload_priv"}).
+			AddRow("::/ffff::", "Y", "Y", "Y", "Y", "Y", "Y"))
+
+	priv, _, err := GetPrivileges(sqlxdb, "repl", "db1.example.com", "::1", mariaDBVersionForTest())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if priv.Repl_slave_priv != "N" {
+		t.Errorf("expected an IPv6 network/netmask account host to never match (MariaDB/MySQL netmasks are IPv4-only), got privileges %+v", priv)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestGetPrivileges_EscapedWildcardIsLiteral(t *testing.T) {
+	// "db1\_host" (escaped underscore) must match only the literal
+	// "db1_host", not an arbitrary substitution like "db1Xhost".
+	tests := []struct {
+		name       string
+		clientHost string
+		want       string
+	}{
+		{"substituted char does not match", "db1Xhost", "N"},
+		{"literal escaped char matches", "db1_host", "Y"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("failed to create sqlmock: %v", err)
+			}
+			defer db.Close()
+			sqlxdb := sqlx.NewDb(db, "sqlmock")
+
+			mock.ExpectQuery(regexp.QuoteMeta(getPrivilegesQuery)).
+				WithArgs("repl").
+				WillReturnRows(sqlmock.NewRows([]string{"Host", "Select_priv", "Process_priv", "Super_priv", "Repl_slave_priv", "Repl_client_priv", "Reload_priv"}).
+					AddRow(`db1\_host`, "Y", "Y", "Y", "Y", "Y", "Y"))
+
+			priv, _, err := GetPrivileges(sqlxdb, "repl", tt.clientHost, "10.2.3.4", mariaDBVersionForTest())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if priv.Repl_slave_priv != tt.want {
+				t.Errorf("clientHost %q: got Repl_slave_priv %q, want %q", tt.clientHost, priv.Repl_slave_priv, tt.want)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unmet sqlmock expectations: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Why this PR exists

This PR fixes false privilege warnings reported in #1637 when database accounts use MariaDB/MySQL IPv4 netmask host notation, for example:

```sql
'dba'@'10.0.0.0/255.0.0.0'
```

Before this change, `utils/dbhelper.GetPrivileges()` approximated host matching with a fixed `host IN (...)` query. For a client IP like `10.2.3.4`, that logic generated candidates such as `10.2.3.4/255.0.0.0`, which does not match how MariaDB/MySQL stores netmask accounts. The server stores the network base plus netmask (for example `10.0.0.0/255.0.0.0`), so valid grants could be missed and replication-manager would incorrectly warn that required privileges were absent.

## What changed

This PR replaces the `host IN (...)` approximation with explicit matching against `mysql.user.Host` semantics for:

- exact hostname matches
- exact IP matches
- SQL wildcard hosts (`%`, `_`)
- escaped wildcard literals
- IPv4 `network/netmask` notation

Instead of unioning privileges across multiple candidate rows via `MAX(...)`, the code now selects a single best-matching host row using deterministic specificity rules.

## Compatibility / regression safety

A key requirement for this change was preserving current alert behavior.

When no `mysql.user` row matches the client, `GetPrivileges()` now returns an all-`"N"` `Privileges` struct with a `nil` error. This preserves the existing caller contract used by `cluster.CheckPrivileges()` so the usual per-privilege alerts still fire:

- `ERR00006`
- `ERR00007`
- `ERR00008`
- `ERR00009`

instead of turning the condition into a generic privilege-fetch error.

## Tests added

Regression coverage was added for:

- IPv4 netmask matching
- more-specific netmask precedence
- exact host vs wildcard precedence
- escaped wildcard literals
- IPv4-only enforcement for `network/netmask`
- no-match compatibility behavior
- documented exact hostname vs exact IP tie-break behavior

## Known limitation

This PR does not implement a byte-for-byte clone of MariaDB/MySQL internal ACL resolution.

In particular, when the same user has both an exact hostname row and an exact IP row that both match, tie-breaking remains a deterministic approximation. This is documented in tests and was kept out of scope for this fix to keep the change focused on the false-negative netmask bug.

## Validation

Passed targeted tests:

```bash
go test ./utils/dbhelper -run 'TestHostAccount|TestGetPrivileges'
```

A broader `go test ./utils/dbhelper` run still shows an existing unrelated failure in `TestGetTablesQueryAlignment`.