### PR TITLE
fix(app): harden async refresh snapshots and observability

### DIFF
--- a/cluster/app.go
+++ b/cluster/app.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/misc"
@@ -50,6 +51,19 @@ type App struct {
 	Agent         string `json:"agent"`
 	Weight        string `json:"weight"`
 	FailCount     int    `json:"failCount"`
+	// Per-app refresh freshness (cluster-level AppRefreshLast* on Cluster
+	// only shows batch-wide timing, not which app is actually slow). Set
+	// via SetRefreshInProgress/SetRefreshResult under app.Mutex -- read
+	// them the same way (App.Lock()/Unlock()) rather than directly, for
+	// the same reason State/PrevState should be but historically aren't
+	// (see KNOWN ISSUE notes elsewhere in this package): these are read
+	// from a different goroutine than the one that writes them
+	// (maybeRefreshAppsAsync's worker vs. any status/API reader).
+	LastRefreshStart      time.Time `json:"lastRefreshStart"`
+	LastRefreshEnd        time.Time `json:"lastRefreshEnd"`
+	LastRefreshDurationMs int64     `json:"lastRefreshDurationMs"`
+	LastRefreshError      string    `json:"lastRefreshError"`
+	RefreshInProgress     bool      `json:"refreshInProgress"`
 	// Route-scoped debounce counters are the single source of truth.
 	AppErrConsecutiveMap map[string]int         `json:"-"`
 	ErrState             map[string]state.State `json:"-"`
@@ -269,12 +283,22 @@ func (app *App) AddFlags(flags *pflag.FlagSet, conf *config.AppConfig) {
 
 func (app *App) Refresh() error {
 	cluster := app.ClusterGroup
+
+	start := time.Now()
+	app.SetRefreshInProgress(true)
+	var refreshErr error
+	defer func() {
+		app.SetRefreshResult(start, time.Now(), refreshErr)
+		app.SetRefreshInProgress(false)
+	}()
+
 	app.CheckPrimaryRoute()
 	appState := app.GetMonitoringStatus()
 	sub, err := cluster.GetAppsSubstitutionJSon(app)
 	if err == nil {
 		app.AppClusterSubstitute = sub
 	}
+	refreshErr = err
 
 	switch appState {
 	case stateMaintenance:

--- a/cluster/app.go
+++ b/cluster/app.go
@@ -54,11 +54,10 @@ type App struct {
 	// Per-app refresh freshness (cluster-level AppRefreshLast* on Cluster
 	// only shows batch-wide timing, not which app is actually slow). Set
 	// via SetRefreshInProgress/SetRefreshResult under app.Mutex -- read
-	// them the same way (App.Lock()/Unlock()) rather than directly, for
-	// the same reason State/PrevState should be but historically aren't
-	// (see KNOWN ISSUE notes elsewhere in this package): these are read
-	// from a different goroutine than the one that writes them
-	// (maybeRefreshAppsAsync's worker vs. any status/API reader).
+	// them the same way (App.Lock()/Unlock(), or GetAppAPIView) rather than
+	// directly: these are read from a different goroutine than the one
+	// that writes them (maybeRefreshAppsAsync's worker vs. any status/API
+	// reader).
 	LastRefreshStart      time.Time `json:"lastRefreshStart"`
 	LastRefreshEnd        time.Time `json:"lastRefreshEnd"`
 	LastRefreshDurationMs int64     `json:"lastRefreshDurationMs"`
@@ -305,13 +304,13 @@ func (app *App) Refresh() error {
 		app.SetState(stateMaintenance)
 	case stateAppRunning:
 		app.SetState(stateAppRunning)
-		app.FailCount = 0
+		app.SetFailCount(0)
 	case stateFailed:
-		if app.FailCount >= cluster.Conf.MaxFail {
+		if app.GetFailCount() >= cluster.Conf.MaxFail {
 			app.SetState(stateFailed)
 		} else {
 			app.SetState(stateSuspect)
-			app.FailCount++
+			app.SetFailCount(app.GetFailCount() + 1)
 		}
 	case stateAppWarning:
 		app.SetState(stateAppWarning)

--- a/cluster/app_chk.go
+++ b/cluster/app_chk.go
@@ -441,8 +441,13 @@ func (app *App) GetAppTCPStatus(route config.Route) error {
 	return nil
 }
 
+// CheckPrimaryRoute mutates app.AppConfig.Deployment.Routes/PrimaryRoute, so
+// it must take app.Mutex: buildAppSubstitutionView (app_get.go) clones these
+// same fields under the same lock to build a race-free copy for template
+// substitution, and that only works if every writer shares the lock.
 func (app *App) CheckPrimaryRoute() {
 	cluster := app.ClusterGroup
+	app.Lock()
 	hasPrimaryRoute := false
 	for _, route := range app.AppConfig.Deployment.Routes {
 		if route.Primary {
@@ -451,9 +456,15 @@ func (app *App) CheckPrimaryRoute() {
 			break
 		}
 	}
+	assignedFirstAsPrimary := false
 	if !hasPrimaryRoute && len(app.AppConfig.Deployment.Routes) > 0 {
 		app.AppConfig.Deployment.Routes[0].Primary = true
 		app.AppConfig.Deployment.PrimaryRoute = app.AppConfig.Deployment.Routes[0]
+		assignedFirstAsPrimary = true
+	}
+	app.Unlock()
+
+	if assignedFirstAsPrimary {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlInfo, "No primary route defined for app %s, setting first route as primary", app.Name)
 	}
 }

--- a/cluster/app_error_test.go
+++ b/cluster/app_error_test.go
@@ -660,3 +660,60 @@ func TestAppRefreshTracksTimingAndInProgress(t *testing.T) {
 		t.Fatalf("expected non-negative LastRefreshDurationMs, got %d", lastDurationMs)
 	}
 }
+
+// TestAppStateAccessorsThreadSafe verifies SetState/GetState (and
+// SetPrevState) are race-free under concurrent access. Run with `go test
+// -race`: before SetState/GetState took app.Lock(), this raced against
+// GetAppAPIView()/IsDown() reading app.State directly.
+func TestAppStateAccessorsThreadSafe(t *testing.T) {
+	app := newTestApp()
+
+	const total = 100
+	var wg sync.WaitGroup
+	wg.Add(total * 3)
+
+	for i := 0; i < total; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			app.SetState(fmt.Sprintf("state-%d", i))
+		}()
+		go func() {
+			defer wg.Done()
+			app.SetPrevState(fmt.Sprintf("prev-%d", i))
+		}()
+	}
+	for i := 0; i < total; i++ {
+		go func() {
+			defer wg.Done()
+			_ = app.GetState()
+			_ = app.GetPrevState()
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestAppFailCountAccessorsThreadSafe verifies SetFailCount/GetFailCount are
+// race-free under concurrent access, mirroring the increment pattern used in
+// Refresh() (app.SetFailCount(app.GetFailCount() + 1)).
+func TestAppFailCountAccessorsThreadSafe(t *testing.T) {
+	app := newTestApp()
+
+	const total = 100
+	var wg sync.WaitGroup
+	wg.Add(total)
+
+	for i := 0; i < total; i++ {
+		go func() {
+			defer wg.Done()
+			app.SetFailCount(app.GetFailCount() + 1)
+		}()
+	}
+
+	wg.Wait()
+
+	if got := app.GetFailCount(); got <= 0 || got > total {
+		t.Fatalf("expected FailCount in (0, %d], got %d", total, got)
+	}
+}

--- a/cluster/app_error_test.go
+++ b/cluster/app_error_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/state"
@@ -619,5 +620,43 @@ func TestGetMonitoringStatusRefreshTotalOutageBecomesFailedAfterMaxFail(t *testi
 	}
 	if app.State != stateFailed {
 		t.Fatalf("expected %s after max-fail threshold, got %s", stateFailed, app.State)
+	}
+}
+
+// TestAppRefreshTracksTimingAndInProgress guards the per-app freshness
+// fields (app.go) added so operators can tell which specific app is slow,
+// not just that the batch as a whole is -- the cluster-level
+// AppRefreshLast* fields only cover the batch, not any one app within it.
+func TestAppRefreshTracksTimingAndInProgress(t *testing.T) {
+	app := newMonitoringTestApp([]config.Route{{Protocol: "tcp", CName: "127.0.0.1", Port: "1", Primary: true}})
+
+	if app.RefreshInProgress {
+		t.Fatalf("expected RefreshInProgress=false before any Refresh() call")
+	}
+
+	before := time.Now()
+	if err := app.Refresh(); err != nil {
+		t.Fatalf("Refresh returned error: %v", err)
+	}
+	after := time.Now()
+
+	app.Lock()
+	inProgress := app.RefreshInProgress
+	lastStart := app.LastRefreshStart
+	lastEnd := app.LastRefreshEnd
+	lastDurationMs := app.LastRefreshDurationMs
+	app.Unlock()
+
+	if inProgress {
+		t.Fatalf("expected RefreshInProgress=false after Refresh() returns")
+	}
+	if lastStart.Before(before) || lastStart.After(after) {
+		t.Fatalf("LastRefreshStart %s not within [%s, %s]", lastStart, before, after)
+	}
+	if lastEnd.Before(lastStart) {
+		t.Fatalf("LastRefreshEnd %s before LastRefreshStart %s", lastEnd, lastStart)
+	}
+	if lastDurationMs < 0 {
+		t.Fatalf("expected non-negative LastRefreshDurationMs, got %d", lastDurationMs)
 	}
 }

--- a/cluster/app_get.go
+++ b/cluster/app_get.go
@@ -23,6 +23,14 @@ import (
 	"github.com/signal18/replication-manager/config"
 )
 
+// KNOWN ISSUE: this does an unlocked sheriff.Marshal reflection walk over the
+// whole Cluster, including every *App in cluster.Apps. When app refresh runs
+// multiple apps concurrently (see maybeRefreshAppsAsync), other workers can
+// be mutating their own app's fields (SetRouteStatuses, SetState) under only
+// app.Mutex at the same time, which -race flags as a data race against this
+// read. Predates the app-refresh async decoupling change; needs its own fix
+// (e.g. locking per app during marshal, or building the substitution JSON
+// from a locked snapshot) rather than a quick patch here.
 func (cluster *Cluster) GetAppsSubstitutionJSon(app *App) (string, error) {
 
 	o := &sheriff.Options{Groups: []string{"apps"}}

--- a/cluster/app_get.go
+++ b/cluster/app_get.go
@@ -13,8 +13,10 @@ package cluster
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/liip/sheriff/v2"
 	"github.com/tidwall/sjson"
@@ -78,6 +80,108 @@ func cloneAppConfigForSubstitution(cnf *config.AppConfig) *config.AppConfig {
 		}
 	}
 	return &clone
+}
+
+// appConfigAPIView wraps a cloned *config.AppConfig for the wire API and
+// suppresses "deployment" from the output entirely, matching what
+// handlerMuxApps has always stripped. A same-named shadow field at a
+// shallower embedding depth wins encoding/json's field conflict resolution
+// (see AppAPIView's package doc for why json:"-" does NOT achieve this --
+// it drops out of the conflict instead of winning it, so the embedded field
+// would still be marshaled); tagging the shadow field "omitempty" then
+// means the key is omitted entirely (nil pointer) rather than emitted as
+// "deployment":null.
+type appConfigAPIView struct {
+	*config.AppConfig
+	Deployment *struct{} `json:"deployment,omitempty"`
+}
+
+// AppAPIView mirrors every field of App that the wire API
+// (handlerMuxApps, server/api_cluster.go) exposes, built as an independent
+// copy so the API layer never marshals a live *App -- encoding/json
+// reflects over live struct memory the same way sheriff does (see
+// appSubstitutionView's comment), so it races against
+// maybeRefreshAppsAsync's workers exactly the same way GetAppsSubstitutionJSon
+// did before that was fixed. AppClusterSubstitute is intentionally absent:
+// the handler has always stripped it from its response, so the view simply
+// never has it, rather than adding it and deleting it after marshal.
+type AppAPIView struct {
+	Id                    string               `json:"id"`
+	Name                  string               `json:"name"`
+	Type                  string               `json:"type"`
+	Host                  string               `json:"host"`
+	HostIPV6              string               `json:"hostIPV6"`
+	Port                  string               `json:"port"`
+	Version               string               `json:"version"`
+	Datadir               string               `json:"datadir"`
+	State                 string               `json:"state"`
+	PrevState             string               `json:"prevState"`
+	SlapOSDatadir         string               `json:"slaposDatadir"`
+	ServiceName           string               `json:"serviceName"`
+	Agent                 string               `json:"agent"`
+	Weight                string               `json:"weight"`
+	FailCount             int                  `json:"failCount"`
+	LastRefreshStart      time.Time            `json:"lastRefreshStart"`
+	LastRefreshEnd        time.Time            `json:"lastRefreshEnd"`
+	LastRefreshDurationMs int64                `json:"lastRefreshDurationMs"`
+	LastRefreshError      string               `json:"lastRefreshError"`
+	RefreshInProgress     bool                 `json:"refreshInProgress"`
+	Process               *os.Process          `json:"process" swaggerignore:"true"`
+	RouteStatus           []config.RouteStatus `json:"routeStatus"`
+	AppConfig             *appConfigAPIView    `json:"config"`
+	TemplateMD5Prov       string               `json:"templateMD5Prov"`
+	TemplateMD5           string               `json:"templateMD5"`
+	IsHashingTemplate     bool                 `json:"isHashingTemplate"`
+}
+
+// GetAppAPIView builds an independent, race-free snapshot of app for the
+// wire API, taken entirely under app.Lock() (App has no other embedded
+// lock -- *sync.Mutex is a pointer field -- so this is the one place it's
+// safe to read every field in one pass). AppConfig is cloned via
+// cloneAppConfigForSubstitution (already race-free, already used by
+// GetAppsSubstitutionJSon), then Deployment is cleared and AppDbPass is
+// masked to match what handlerMuxApps has always stripped/redacted from
+// its response -- baked in here instead of patched into the JSON bytes
+// after the fact.
+func (app *App) GetAppAPIView() *AppAPIView {
+	app.Lock()
+	defer app.Unlock()
+
+	view := &AppAPIView{
+		Id:                    app.Id,
+		Name:                  app.Name,
+		Type:                  app.Type,
+		Host:                  app.Host,
+		HostIPV6:              app.HostIPV6,
+		Port:                  app.Port,
+		Version:               app.Version,
+		Datadir:               app.Datadir,
+		State:                 app.State,
+		PrevState:             app.PrevState,
+		SlapOSDatadir:         app.SlapOSDatadir,
+		ServiceName:           app.ServiceName,
+		Agent:                 app.Agent,
+		Weight:                app.Weight,
+		FailCount:             app.FailCount,
+		LastRefreshStart:      app.LastRefreshStart,
+		LastRefreshEnd:        app.LastRefreshEnd,
+		LastRefreshDurationMs: app.LastRefreshDurationMs,
+		LastRefreshError:      app.LastRefreshError,
+		RefreshInProgress:     app.RefreshInProgress,
+		Process:               app.Process,
+		TemplateMD5Prov:       app.TemplateMD5Prov,
+		TemplateMD5:           app.TemplateMD5,
+		IsHashingTemplate:     app.IsHashingTemplate,
+	}
+	if app.RouteStatus != nil {
+		view.RouteStatus = append([]config.RouteStatus(nil), app.RouteStatus...)
+	}
+	if app.AppConfig != nil {
+		cfg := cloneAppConfigForSubstitution(app.AppConfig)
+		cfg.AppDbPass = "*****"
+		view.AppConfig = &appConfigAPIView{AppConfig: cfg}
+	}
+	return view
 }
 
 // buildAppSubstitutionView builds an independent, race-free copy of the
@@ -482,7 +586,10 @@ func (p *App) GetId() string {
 	return p.Id
 }
 
+// GetState is locked (app.Lock()) -- see App.SetState (app_set.go).
 func (p *App) GetState() string {
+	p.Lock()
+	defer p.Unlock()
 	return p.State
 }
 
@@ -494,11 +601,17 @@ func (p *App) GetPass() string {
 	return p.Pass
 }
 
+// GetFailCount is locked (app.Lock()) -- see App.SetFailCount (app_set.go).
 func (p *App) GetFailCount() int {
+	p.Lock()
+	defer p.Unlock()
 	return p.FailCount
 }
 
+// GetPrevState is locked (app.Lock()) -- see App.SetPrevState (app_set.go).
 func (p *App) GetPrevState() string {
+	p.Lock()
+	defer p.Unlock()
 	return p.PrevState
 }
 

--- a/cluster/app_get.go
+++ b/cluster/app_get.go
@@ -23,18 +23,311 @@ import (
 	"github.com/signal18/replication-manager/config"
 )
 
-// KNOWN ISSUE: this does an unlocked sheriff.Marshal reflection walk over the
-// whole Cluster, including every *App in cluster.Apps. When app refresh runs
-// multiple apps concurrently (see maybeRefreshAppsAsync), other workers can
-// be mutating their own app's fields (SetRouteStatuses, SetState) under only
-// app.Mutex at the same time, which -race flags as a data race against this
-// read. Predates the app-refresh async decoupling change; needs its own fix
-// (e.g. locking per app during marshal, or building the substitution JSON
-// from a locked snapshot) rather than a quick patch here.
-func (cluster *Cluster) GetAppsSubstitutionJSon(app *App) (string, error) {
+// appSubstitutionView mirrors the groups:"apps" subset of App
+// (cluster/app.go). It exists so GetAppsSubstitutionJSon never hands sheriff
+// a live *App: sheriff's reflection boxes each struct element via
+// reflect.Value.Interface() to recurse into it, which bulk-copies the whole
+// struct's memory *before* its own group-tag filtering runs -- so handing it
+// a live App races against any concurrent app-refresh worker mutating that
+// same app, regardless of whether the racing field is itself group-tagged.
+// buildAppSubstitutionView instead produces an independent copy up front.
+type appSubstitutionView struct {
+	Id        string            `json:"id" groups:"apps"`
+	Name      string            `json:"name" groups:"apps"`
+	Type      string            `json:"type" groups:"apps"`
+	Host      string            `json:"host" groups:"apps"`
+	Port      string            `json:"port" groups:"apps"`
+	Version   string            `json:"version" groups:"apps"`
+	AppConfig *config.AppConfig `json:"config" groups:"apps"`
+}
 
+// cloneAppConfigForSubstitution returns an independent copy of cnf, safe to
+// hand to sheriff even while cnf (or the App owning it) is concurrently
+// mutated elsewhere. config.AppConfig has no embedded lock, so a shallow
+// value copy is safe; config.Deployment does embed a sync.RWMutex
+// (config/deployment.go), so it's rebuilt fresh rather than copied by
+// value, with Routes/PrimaryRoute deep-cloned via config.Route.Clone() (the
+// only Deployment fields the refresh loop -- CheckPrimaryRoute -- mutates)
+// and Storages/Paths/Variables passed through by reference (only touched by
+// config/API flows, not the refresh loop).
+//
+// Callers owning an *App that shares this AppConfig (via app.AppConfig)
+// must call this under app.Lock(), since CheckPrimaryRoute mutates
+// Routes/PrimaryRoute under that same lock. cluster.Conf.Apps entries with
+// no matching App (e.g. skipped by newAppList for an invalid host) are
+// never touched by the refresh loop, so cloning them lock-free is safe.
+func cloneAppConfigForSubstitution(cnf *config.AppConfig) *config.AppConfig {
+	if cnf == nil {
+		return nil
+	}
+	clone := *cnf
+	if d := cnf.Deployment; d != nil {
+		var routes config.Routes
+		if d.Routes != nil {
+			routes = make(config.Routes, len(d.Routes))
+			for i, r := range d.Routes {
+				routes[i] = r.Clone()
+			}
+		}
+		clone.Deployment = &config.Deployment{
+			PrimaryRoute: d.PrimaryRoute.Clone(),
+			Routes:       routes,
+			Storages:     d.Storages,
+			Paths:        d.Paths,
+			Variables:    d.Variables,
+		}
+	}
+	return &clone
+}
+
+// buildAppSubstitutionView builds an independent, race-free copy of the
+// groups:"apps" subset of app's fields, safe to hand to sheriff even while
+// other app-refresh workers concurrently mutate this same app.
+//
+// Id/Name/Type/Host/Port/Version are set once at construction/config-load
+// and never mutated by the refresh loop, so they're read lock-free here --
+// the same trust already given to GetHost()/GetPort(), called lock-free
+// elsewhere in this exact refresh path. AppConfig is cloned under
+// app.Lock() (see cloneAppConfigForSubstitution).
+func (app *App) buildAppSubstitutionView() *appSubstitutionView {
+	view := &appSubstitutionView{
+		Id:      app.Id,
+		Name:    app.Name,
+		Type:    app.Type,
+		Host:    app.Host,
+		Port:    app.Port,
+		Version: app.Version,
+	}
+	if app.AppConfig == nil {
+		return view
+	}
+	app.Lock()
+	view.AppConfig = cloneAppConfigForSubstitution(app.AppConfig)
+	app.Unlock()
+	return view
+}
+
+// proxySubstitutionView mirrors the groups:"apps" subset of Proxy
+// (cluster/prx.go). Every concrete proxy type (HaproxyProxy, ProxySQLProxy,
+// MaxscaleProxy, etc.) embeds Proxy by value with no fields of its own, so
+// this one view type covers all of them. Built for the same reason as
+// appSubstitutionView: sheriff's reflect.Value.Interface() bulk-copies the
+// whole struct to box it for recursion, before its own group-tag filtering
+// runs, so handing it a live DatabaseProxy races against refreshProxies
+// (cluster/prx.go) regardless of which field is racing -- refreshProxies
+// runs as its own goroutine, concurrently with app-refresh workers building
+// this same substitution JSON, since app refresh was decoupled from the
+// tick's waited phase. Proven under -race, not assumed.
+type proxySubstitutionView struct {
+	Id            string `json:"id" groups:"apps"`
+	Name          string `json:"name" groups:"apps"`
+	Type          string `json:"type" groups:"apps"`
+	Host          string `json:"host" groups:"apps"`
+	Port          string `json:"port" groups:"apps"`
+	WritePort     int    `json:"writePort" groups:"apps"`
+	ReadPort      int    `json:"readPort" groups:"apps"`
+	ReadWritePort int    `json:"readWritePort" groups:"apps"`
+	Version       string `json:"version" groups:"apps"`
+}
+
+// buildProxySubstitutionView builds an independent, race-free copy of the
+// groups:"apps" subset of pr's fields, safe to hand to sheriff even while
+// refreshProxies concurrently mutates this same proxy.
+//
+// Id/Name/Type/Host/Port/WritePort/ReadPort/ReadWritePort are set once at
+// proxy construction/config-load and never mutated by the refresh loop, so
+// they're read lock-free here. Version IS reassigned on every Refresh() by
+// several proxy types (ExternalProxy, MariadbShardProxy, ProxySQLProxy,
+// HaproxyProxy, ProxyJanitor, SphinxProxy); GetVersion() takes p.Lock
+// internally (see prx_get.go), matching SetVersion() on the write side, so
+// no manual lock pairing is needed (or exposed) here.
+func buildProxySubstitutionView(pr DatabaseProxy) *proxySubstitutionView {
+	if pr == nil {
+		return nil
+	}
+	return &proxySubstitutionView{
+		Id:            pr.GetId(),
+		Name:          pr.GetName(),
+		Type:          pr.GetType(),
+		Host:          pr.GetHost(),
+		Port:          pr.GetPort(),
+		WritePort:     pr.GetWritePort(),
+		ReadPort:      pr.GetReadPort(),
+		ReadWritePort: pr.GetReadWritePort(),
+		Version:       pr.GetVersion(),
+	}
+}
+
+// serverSubstitutionView mirrors the groups:"apps" subset of ServerMonitor
+// (cluster/srv.go). ServerMonitor embeds several sync.Mutex/sync.RWMutex
+// fields by value (freezeMu, workingAgentMu, jobMutex, etc.), so it can
+// never be copied by value -- this view exists precisely to avoid that,
+// same as appSubstitutionView/proxySubstitutionView. Proven under -race:
+// ServerMonitor.SetState (cluster/srv_set.go) is unlocked and runs
+// continuously as part of normal DB topology monitoring, a goroutine
+// independent of app-refresh workers; sheriff's whole-struct bulk copy
+// races against it exactly like App/Proxy, regardless of State itself not
+// being groups:"apps"-tagged.
+type serverSubstitutionView struct {
+	Id                string `json:"id" groups:"apps"`
+	Name              string `json:"name" groups:"apps"`
+	Domain            string `json:"domain" groups:"apps"`
+	SourceClusterName string `json:"sourceClusterName" groups:"apps"`
+	URL               string `json:"url" groups:"apps"`
+	Host              string `json:"host" groups:"apps"`
+	Port              string `json:"port" groups:"apps"`
+}
+
+// buildServerSubstitutionView builds an independent, race-free copy of the
+// groups:"apps" subset of srv's fields, safe to hand to sheriff even while
+// the DB monitoring loop concurrently mutates this same server.
+//
+// All 7 fields are set once at server construction/config-load and never
+// reassigned by ServerMonitor.Refresh() (grepped; no hits) -- same
+// write-once trust already given to App/Proxy identity fields -- so they're
+// read lock-free here. No lock is needed because, unlike Deployment.Routes
+// or Proxy.Version, nothing in the refresh loop mutates these specific
+// fields; the race is purely sheriff's whole-struct bulk copy racing
+// against *other* ServerMonitor fields, which this view sidesteps by never
+// handing sheriff the live struct at all.
+func buildServerSubstitutionView(srv *ServerMonitor) *serverSubstitutionView {
+	if srv == nil {
+		return nil
+	}
+	return &serverSubstitutionView{
+		Id:                srv.Id,
+		Name:              srv.Name,
+		Domain:            srv.Domain,
+		SourceClusterName: srv.SourceClusterName,
+		URL:               srv.URL,
+		Host:              srv.Host,
+		Port:              srv.Port,
+	}
+}
+
+func (cluster *Cluster) GetAppsSubstitutionJSon(app *App) (string, error) {
 	o := &sheriff.Options{Groups: []string{"apps"}}
-	data, err := sheriff.Marshal(o, cluster)
+
+	// Snapshot cluster.Apps, cluster.Proxies, cluster.Servers, cluster.Conf
+	// and cluster.Conf.Apps under cluster.Lock(): all are reassigned
+	// wholesale under this lock elsewhere (see newAppList, cluster_del.go,
+	// and GetAppConfig's own "Conf.Apps is mutated under cluster.Lock()
+	// elsewhere" note) -- reading any of them without it races on the
+	// slice/pointer header itself, separately from the per-object races
+	// fixed below. confCopy is taken here (not later) so the whole-Config
+	// value copy is covered by the same lock as Conf.Apps. nil is preserved
+	// (not made into an empty-but-non-nil slice) so a cluster with nothing
+	// in a given collection still marshals e.g. "apps": null, matching
+	// sheriff's original behavior for a nil slice -- templates rely on that
+	// to leave {{apps...}}/{{proxies...}} placeholders unresolved rather
+	// than "".
+	cluster.Lock()
+	var apps []*App
+	if cluster.Apps != nil {
+		apps = make([]*App, len(cluster.Apps))
+		copy(apps, cluster.Apps)
+	}
+	var proxies []DatabaseProxy
+	if cluster.Proxies != nil {
+		proxies = make([]DatabaseProxy, len(cluster.Proxies))
+		copy(proxies, cluster.Proxies)
+	}
+	var servers []*ServerMonitor
+	if cluster.Servers != nil {
+		servers = make([]*ServerMonitor, len(cluster.Servers))
+		copy(servers, cluster.Servers)
+	}
+	var liveConfApps []*config.AppConfig
+	var confCopy config.Config
+	haveConf := cluster.Conf != nil
+	if haveConf {
+		confCopy = *cluster.Conf
+		if cluster.Conf.Apps != nil {
+			liveConfApps = make([]*config.AppConfig, len(cluster.Conf.Apps))
+			copy(liveConfApps, cluster.Conf.Apps)
+		}
+	}
+	cluster.Unlock()
+
+	var proxyViews []*proxySubstitutionView
+	if proxies != nil {
+		proxyViews = make([]*proxySubstitutionView, 0, len(proxies))
+		for _, pr := range proxies {
+			if pr != nil {
+				proxyViews = append(proxyViews, buildProxySubstitutionView(pr))
+			}
+		}
+	}
+
+	var serverViews []*serverSubstitutionView
+	if servers != nil {
+		serverViews = make([]*serverSubstitutionView, 0, len(servers))
+		for _, srv := range servers {
+			if srv != nil {
+				serverViews = append(serverViews, buildServerSubstitutionView(srv))
+			}
+		}
+	}
+
+	// Build each app's substitution view (clones AppConfig/Deployment under
+	// that app's own lock) and remember which cloned AppConfig corresponds
+	// to which live one, so cluster.Conf.Apps below can reuse it instead of
+	// reflecting the exact same live object a second, unsynchronized way:
+	// cluster.Conf.Apps[i] and app.AppConfig are literally the same
+	// *config.AppConfig pointer (see GetAppConfig), so leaving Conf's copy
+	// live would still race against CheckPrimaryRoute even after fixing the
+	// App-list path above.
+	var appViews []*appSubstitutionView
+	cloneByLiveConfig := make(map[*config.AppConfig]*config.AppConfig, len(apps))
+	if apps != nil {
+		appViews = make([]*appSubstitutionView, 0, len(apps))
+		for _, a := range apps {
+			if a == nil {
+				continue
+			}
+			view := a.buildAppSubstitutionView()
+			appViews = append(appViews, view)
+			if a.AppConfig != nil {
+				cloneByLiveConfig[a.AppConfig] = view.AppConfig
+			}
+		}
+	}
+
+	var confAppClones []*config.AppConfig
+	if liveConfApps != nil {
+		confAppClones = make([]*config.AppConfig, 0, len(liveConfApps))
+		for _, cnf := range liveConfApps {
+			if cnf == nil {
+				continue
+			}
+			if clone, ok := cloneByLiveConfig[cnf]; ok {
+				confAppClones = append(confAppClones, clone)
+				continue
+			}
+			confAppClones = append(confAppClones, cloneAppConfigForSubstitution(cnf))
+		}
+	}
+
+	// config.Config itself has no embedded lock, so the value copy taken
+	// under cluster.Lock() above is safe; it also means the rest of
+	// Config's ~500 other fields are read from a single point-in-time
+	// snapshot rather than reflected live for the whole marshal walk. Only
+	// Apps needed replacing here.
+	var confView *config.Config
+	if haveConf {
+		confCopy.Apps = confAppClones
+		confView = &confCopy
+	}
+
+	clusterView := struct {
+		Name    string                    `json:"name" groups:"apps,web"`
+		Servers []*serverSubstitutionView `json:"servers" groups:"apps"`
+		Apps    []*appSubstitutionView    `json:"apps" groups:"apps"`
+		Proxies []*proxySubstitutionView  `json:"proxies" groups:"apps"`
+		Conf    *config.Config            `json:"config" groups:"apps"`
+	}{cluster.Name, serverViews, appViews, proxyViews, confView}
+
+	data, err := sheriff.Marshal(o, &clusterView)
 	if err != nil {
 		return "", err
 	}
@@ -44,7 +337,7 @@ func (cluster *Cluster) GetAppsSubstitutionJSon(app *App) (string, error) {
 	}
 
 	// Add app specific data
-	child, err3 := sheriff.Marshal(o, app)
+	child, err3 := sheriff.Marshal(o, app.buildAppSubstitutionView())
 	if err3 != nil {
 		return string(result), err3
 	}

--- a/cluster/app_get_test.go
+++ b/cluster/app_get_test.go
@@ -1,0 +1,302 @@
+package cluster
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/signal18/replication-manager/config"
+	"github.com/tidwall/gjson"
+)
+
+// newSubstitutionTestCluster builds a minimal cluster with one server and two
+// apps: one with a normal route deployment, one with a nil Routes slice (to
+// verify buildAppSubstitutionView preserves the nil-vs-empty-slice
+// distinction that config.Routes(nil) has in the original sheriff-driven
+// output).
+func newSubstitutionTestCluster(t *testing.T) (cluster *Cluster, appWithRoutes *App, appNoRoutes *App) {
+	t.Helper()
+	cluster = &Cluster{
+		Name: "pfx-cluster",
+		Conf: &config.Config{Timeout: 5},
+	}
+	cluster.Servers = serverList{
+		&ServerMonitor{Id: "1", Host: "10.0.0.1", Port: "3306", ClusterGroup: cluster},
+	}
+	cluster.Proxies = []DatabaseProxy{
+		&HaproxyProxy{Proxy: Proxy{Id: "prx1", Name: "prx1", Type: "haproxy", Host: "10.0.0.5", Port: "3307", Version: "1.0.0", ClusterGroup: cluster}},
+	}
+
+	appWithRoutes = &App{
+		Id: "app1", Name: "app1", Type: "web", Host: "app1.internal", Port: "80", Version: "1.2.3",
+		Mutex: &sync.Mutex{},
+		AppConfig: &config.AppConfig{
+			AppDbUser:   "dbuser",
+			AppDbPass:   "dbpass",
+			AppDbSchema: "dbschema",
+			Deployment: &config.Deployment{
+				Routes: config.Routes{
+					{CName: "app1.example.com", Protocol: "https", Primary: true},
+					{CName: "app1-admin.example.com", Protocol: "https"},
+				},
+			},
+		},
+		ClusterGroup: cluster,
+	}
+	appWithRoutes.CheckPrimaryRoute()
+
+	appNoRoutes = &App{
+		Id: "app2", Name: "app2", Type: "web", Host: "app2.internal", Port: "8080", Version: "0.1.0",
+		Mutex: &sync.Mutex{},
+		AppConfig: &config.AppConfig{
+			Deployment: &config.Deployment{}, // Routes intentionally left nil
+		},
+		ClusterGroup: cluster,
+	}
+
+	cluster.Apps = []*App{appWithRoutes, appNoRoutes}
+	return cluster, appWithRoutes, appNoRoutes
+}
+
+// TestGetAppsSubstitutionJSon_ShapePreserved locks down the JSON shape that
+// GetAppsSubstitutionJSon must keep producing after replacing the
+// sheriff-over-live-App marshal with buildAppSubstitutionView's independent
+// copies -- templates reference these paths (e.g. {{app.name}},
+// {{proxies.#.host}}) and must keep resolving identically.
+func TestGetAppsSubstitutionJSon_ShapePreserved(t *testing.T) {
+	cluster, appWithRoutes, _ := newSubstitutionTestCluster(t)
+
+	result, err := cluster.GetAppsSubstitutionJSon(appWithRoutes)
+	if err != nil {
+		t.Fatalf("GetAppsSubstitutionJSon failed: %v", err)
+	}
+
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"name", "pfx-cluster"},
+		{"servers.0.host", "10.0.0.1"},
+		{"proxies.0.host", "10.0.0.5"},
+		{"proxies.0.version", "1.0.0"},
+		{"apps.0.name", "app1"},
+		{"apps.0.host", "app1.internal"},
+		{"apps.0.config.appDbUser", "dbuser"},
+		{"apps.0.config.appDbSchema", "dbschema"},
+		{"apps.0.config.deployment.routes.0.cname", "app1.example.com"},
+		{"apps.0.config.deployment.primaryRoute.cname", "app1.example.com"},
+		{"apps.1.name", "app2"},
+		{"app.name", "app1"},
+		{"app.config.deployment.routes.0.cname", "app1.example.com"},
+	}
+	for _, tc := range cases {
+		got := gjson.Get(result, tc.path)
+		if !got.Exists() {
+			t.Fatalf("path %q: not found in %s", tc.path, result)
+		}
+		if got.String() != tc.want {
+			t.Fatalf("path %q: got %q, want %q", tc.path, got.String(), tc.want)
+		}
+	}
+}
+
+// TestGetAppsSubstitutionJSon_NilRoutesStayNull guards the specific detail
+// buildAppSubstitutionView has to get right by hand (sheriff did this
+// automatically): a nil config.Routes must still render as JSON null, not
+// an empty array, both in the "apps" list and the singular "app" key.
+func TestGetAppsSubstitutionJSon_NilRoutesStayNull(t *testing.T) {
+	cluster, _, appNoRoutes := newSubstitutionTestCluster(t)
+
+	result, err := cluster.GetAppsSubstitutionJSon(appNoRoutes)
+	if err != nil {
+		t.Fatalf("GetAppsSubstitutionJSon failed: %v", err)
+	}
+
+	routesVal := gjson.Get(result, "apps.1.config.deployment.routes")
+	if routesVal.Type != gjson.Null {
+		t.Fatalf("expected nil Routes to render as JSON null in apps list, got %s (type %v)", routesVal.Raw, routesVal.Type)
+	}
+
+	singularRoutes := gjson.Get(result, "app.config.deployment.routes")
+	if singularRoutes.Type != gjson.Null {
+		t.Fatalf("expected nil Routes on singular app to render as JSON null, got %s (type %v)", singularRoutes.Raw, singularRoutes.Type)
+	}
+}
+
+// TestGetAppsSubstitutionJSon_ConcurrentRefreshAndListRebuildNoRace exercises
+// three concurrent-mutation classes GetAppsSubstitutionJSon must survive
+// under -race:
+//
+//   - CheckPrimaryRoute() mutating Deployment.Routes/PrimaryRoute on the app
+//     being marshaled -- fixed by cloning AppConfig under app.Lock().
+//   - cluster.Conf.Apps holding the *same* *config.AppConfig pointer as
+//     app.AppConfig (see GetAppConfig): a second live path to the exact
+//     data just cloned, which has to be closed too, not just the App-list
+//     path.
+//   - cluster.Apps / cluster.Conf.Apps being reassigned wholesale, as
+//     newAppList does under cluster.Lock(), while a marshal is in flight.
+//
+// Run with -race; a regression here reproduces immediately rather than
+// needing a specific timing window.
+func TestGetAppsSubstitutionJSon_ConcurrentRefreshAndListRebuildNoRace(t *testing.T) {
+	cluster, appWithRoutes, appNoRoutes := newSubstitutionTestCluster(t)
+	cluster.Conf.Apps = []*config.AppConfig{appWithRoutes.AppConfig, appNoRoutes.AppConfig}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Mutator 1: repeatedly runs CheckPrimaryRoute on the live app, exactly
+	// as the refresh loop does every tick.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				appWithRoutes.CheckPrimaryRoute()
+			}
+		}
+	}()
+
+	// Mutator 2: repeatedly rebuilds cluster.Apps / cluster.Conf.Apps under
+	// cluster.Lock(), mirroring newAppList's atomic swap.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				cluster.Lock()
+				cluster.Apps = []*App{appWithRoutes, appNoRoutes}
+				cluster.Conf.Apps = []*config.AppConfig{appWithRoutes.AppConfig, appNoRoutes.AppConfig}
+				cluster.Unlock()
+			}
+		}
+	}()
+
+	// Reader: repeatedly builds the substitution JSON, as every app refresh does.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, err := cluster.GetAppsSubstitutionJSon(appWithRoutes); err != nil {
+			close(stop)
+			wg.Wait()
+			t.Fatalf("GetAppsSubstitutionJSon failed: %v", err)
+		}
+	}
+
+	close(stop)
+	wg.Wait()
+}
+
+// TestGetAppsSubstitutionJSon_NilAppsStayNull guards the regression this fix
+// introduced and then fixed: cluster.Apps/cluster.Conf.Apps being nil must
+// still produce "apps": null (and cluster.Conf's "apps": null), not an
+// empty array. ParseAppTemplate distinguishes "no value" (leaves a
+// placeholder like {{apps.#.host}} unresolved) from "empty array" (resolves
+// to ""), so collapsing nil into [] silently changes template behavior --
+// see TestResolveEnvVariableValue_NoSubstitutionData_KeepsRaw.
+func TestGetAppsSubstitutionJSon_NilAppsStayNull(t *testing.T) {
+	cluster := &Cluster{
+		Name: "empty-cluster",
+		Conf: &config.Config{Timeout: 5},
+	}
+	app := &App{Id: "solo", Name: "solo", Mutex: &sync.Mutex{}, ClusterGroup: cluster}
+	cluster.Apps = []*App{app}
+
+	result, err := cluster.GetAppsSubstitutionJSon(app)
+	if err != nil {
+		t.Fatalf("GetAppsSubstitutionJSon failed: %v", err)
+	}
+
+	if v := gjson.Get(result, "config.apps"); v.Type != gjson.Null {
+		t.Fatalf(`expected nil cluster.Conf.Apps to render as "config.apps": null, got %s (type %v)`, v.Raw, v.Type)
+	}
+}
+
+// TestGetAppsSubstitutionJSon_ConcurrentServerRefreshNoRace guards the
+// proven Servers race: ServerMonitor.SetState (cluster/srv_set.go:76) is
+// unlocked, exactly like App.SetState and Proxy.SetState were, and runs
+// continuously as part of normal DB topology monitoring -- a goroutine
+// independent of app-refresh workers. Before serverSubstitutionView
+// existed, this test failed under -race (confirmed): sheriff's
+// reflect.Value.Interface() bulk-copies the whole live ServerMonitor
+// struct before its own tag filtering runs, so mutating State raced
+// against GetAppsSubstitutionJSon reflecting live cluster.Servers, even
+// though State itself isn't groups:"apps"-tagged.
+func TestGetAppsSubstitutionJSon_ConcurrentServerRefreshNoRace(t *testing.T) {
+	cluster, appWithRoutes, _ := newSubstitutionTestCluster(t)
+	server := cluster.Servers[0]
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				server.SetState(stateSuspect)
+			}
+		}
+	}()
+
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, err := cluster.GetAppsSubstitutionJSon(appWithRoutes); err != nil {
+			close(stop)
+			wg.Wait()
+			t.Fatalf("GetAppsSubstitutionJSon failed: %v", err)
+		}
+	}
+
+	close(stop)
+	wg.Wait()
+}
+
+// TestGetAppsSubstitutionJSon_ConcurrentProxyRefreshNoRace guards the
+// proven Proxies race: refreshProxies (cluster/prx.go:457-502) runs as its
+// own goroutine, concurrently with app-refresh workers building this same
+// substitution JSON. Version is the one groups:"apps"-tagged Proxy field
+// the refresh loop actively mutates (see e.g. HaproxyProxy/ProxySQLProxy
+// Refresh()), so this mimics that write pattern -- SetVersion(), exactly as
+// the real Refresh() methods now do -- against a concurrent
+// GetAppsSubstitutionJSon reader.
+func TestGetAppsSubstitutionJSon_ConcurrentProxyRefreshNoRace(t *testing.T) {
+	cluster, appWithRoutes, _ := newSubstitutionTestCluster(t)
+	proxy := cluster.Proxies[0].(*HaproxyProxy)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				proxy.SetVersion("1.2.3")
+			}
+		}
+	}()
+
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, err := cluster.GetAppsSubstitutionJSon(appWithRoutes); err != nil {
+			close(stop)
+			wg.Wait()
+			t.Fatalf("GetAppsSubstitutionJSon failed: %v", err)
+		}
+	}
+
+	close(stop)
+	wg.Wait()
+}

--- a/cluster/app_has.go
+++ b/cluster/app_has.go
@@ -70,7 +70,8 @@ func (app *App) IsIgnored() bool {
 }
 
 func (app *App) IsDown() bool {
-	if app.State == stateFailed || app.State == stateSuspect || app.State == stateErrorAuth {
+	state := app.GetState()
+	if state == stateFailed || state == stateSuspect || state == stateErrorAuth {
 		return true
 	}
 	return false

--- a/cluster/app_set.go
+++ b/cluster/app_set.go
@@ -105,16 +105,20 @@ func (app *App) SetNoConfigFetchCookie() error {
 	return app.createCookie("cookie_noconfigfetch")
 }
 
+// SetPrevState is locked (app.Lock()) because it, like SetState, is read
+// cross-goroutine by GetAppAPIView() (cluster/app_get.go) while
+// maybeRefreshAppsAsync's worker concurrently calls it during Refresh().
 func (app *App) SetPrevState(state string) {
+	app.Lock()
+	defer app.Unlock()
 	app.PrevState = state
 }
 
 // SetRefreshInProgress marks whether this app's Refresh() is currently
-// running, under app.Lock() -- unlike State/PrevState (historically
-// unlocked, see the KNOWN ISSUE notes elsewhere in this package), this is
-// meant to be read from a different goroutine than the one that writes it
-// (any status/API reader vs. the maybeRefreshAppsAsync worker calling
-// Refresh()), so it needs to actually be safe to do so.
+// running, under app.Lock() -- meant to be read from a different goroutine
+// than the one that writes it (any status/API reader vs. the
+// maybeRefreshAppsAsync worker calling Refresh()), so it needs to actually
+// be safe to do so.
 func (app *App) SetRefreshInProgress(v bool) {
 	app.Lock()
 	defer app.Unlock()
@@ -143,7 +147,10 @@ func (app *App) SetSuspect() {
 	app.State = stateSuspect
 }
 
+// SetFailCount is locked (app.Lock()) -- see SetPrevState.
 func (app *App) SetFailCount(c int) {
+	app.Lock()
+	defer app.Unlock()
 	app.FailCount = c
 }
 
@@ -151,7 +158,10 @@ func (app *App) SetCredential(credential string) {
 	app.User, app.Pass = misc.SplitPair(credential)
 }
 
+// SetState is locked (app.Lock()) -- see SetPrevState.
 func (app *App) SetState(v string) {
+	app.Lock()
+	defer app.Unlock()
 	app.State = v
 }
 

--- a/cluster/app_set.go
+++ b/cluster/app_set.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/misc"
@@ -106,6 +107,36 @@ func (app *App) SetNoConfigFetchCookie() error {
 
 func (app *App) SetPrevState(state string) {
 	app.PrevState = state
+}
+
+// SetRefreshInProgress marks whether this app's Refresh() is currently
+// running, under app.Lock() -- unlike State/PrevState (historically
+// unlocked, see the KNOWN ISSUE notes elsewhere in this package), this is
+// meant to be read from a different goroutine than the one that writes it
+// (any status/API reader vs. the maybeRefreshAppsAsync worker calling
+// Refresh()), so it needs to actually be safe to do so.
+func (app *App) SetRefreshInProgress(v bool) {
+	app.Lock()
+	defer app.Unlock()
+	app.RefreshInProgress = v
+}
+
+// SetRefreshResult records one Refresh() call's timing/outcome under
+// app.Lock() -- see SetRefreshInProgress. err is whatever internal error
+// Refresh() captured along the way (currently just
+// GetAppsSubstitutionJSon's); Refresh() itself still always returns nil to
+// its caller, unchanged, so this is purely additive observability.
+func (app *App) SetRefreshResult(start, end time.Time, err error) {
+	app.Lock()
+	defer app.Unlock()
+	app.LastRefreshStart = start
+	app.LastRefreshEnd = end
+	app.LastRefreshDurationMs = end.Sub(start).Milliseconds()
+	if err != nil {
+		app.LastRefreshError = err.Error()
+	} else {
+		app.LastRefreshError = ""
+	}
 }
 
 func (app *App) SetSuspect() {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -394,9 +394,28 @@ type Cluster struct {
 	s3SyncApplyMu               sync.Mutex                 `json:"-"`
 	appListEpoch                uint64                     `json:"-"`
 	// appListRebuildMu serializes newAppList() (held internally, see app.go).
-	appListRebuildMu        sync.Mutex `json:"-"`
-	secretVersionStoreMu    sync.Mutex `json:"-"`
-	secretVersionStoreDirty bool       `json:"-"`
+	appListRebuildMu sync.Mutex `json:"-"`
+	// App refresh is decoupled from the tick's critical path (see
+	// maybeRefreshAppsAsync in cluster_app.go): appRefreshInProgress is a
+	// single-flight guard so a slow batch is never overlapped by the next
+	// tick's launch attempt, appRefreshEpoch mirrors appListEpoch as a
+	// monotonic counter bumped once per completed batch, and
+	// publishedAppErrStates is the whole-batch aggregate that
+	// EmitAppErrors() reads -- it is only ever replaced wholesale after a
+	// batch fully completes, so readers never observe a half-old/half-new
+	// mix of app error state.
+	appRefreshInProgress  atomic.Bool                            `json:"-"`
+	appRefreshEpoch       uint64                                 `json:"-"`
+	publishedAppErrStates atomic.Pointer[map[string]state.State] `json:"-"`
+
+	AppRefreshLastStart      time.Time  `json:"appRefreshLastStart" groups:"web"`
+	AppRefreshLastEnd        time.Time  `json:"appRefreshLastEnd" groups:"web"`
+	AppRefreshLastSuccess    bool       `json:"appRefreshLastSuccess" groups:"web"`
+	AppRefreshLastDurationMs int64      `json:"appRefreshLastDurationMs" groups:"web"`
+	AppRefreshLastError      string     `json:"appRefreshLastError" groups:"web"`
+	AppRefreshLastAppCount   int        `json:"appRefreshLastAppCount" groups:"web"`
+	secretVersionStoreMu     sync.Mutex `json:"-"`
+	secretVersionStoreDirty  bool       `json:"-"`
 	// reloadMu serializes Run()'s per-tick synchronous work (topology
 	// discovery, the wg-joined Phase 1/2/3 monitoring work) against
 	// ReloadConfig() rebuilding Conf/state machines/Servers out from under
@@ -1095,9 +1114,12 @@ func (cluster *Cluster) tickBody() {
 
 				// Phase 2: parallel reads of stable topology — Phase 3 depends on these
 				goRun(cluster.ArbitratorHandler)
-				wg.Add(2)
+				wg.Add(1)
 				go cluster.refreshProxies(wg)
-				go cluster.refreshApps(wg)
+				// App refresh is deliberately not part of this waited group: it
+				// must never stall topology discovery/failover detection behind
+				// slow or unresponsive app backends. See maybeRefreshAppsAsync.
+				cluster.trackTickGoroutine(cluster.maybeRefreshAppsAsync)
 				if heartbeats%10 == 0 {
 					goRun(cluster.MonitorTableSchemaDiff)
 				}
@@ -1176,6 +1198,22 @@ func (cluster *Cluster) tickBody() {
 				}
 				if !cluster.CanConnectVault {
 					cluster.SetState("ERR00089", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["ERR00089"], cluster.errorConnectVault), ErrFrom: "OPENSVC"})
+				}
+				// App refresh now runs off the tick's critical path (see
+				// maybeRefreshAppsAsync); warn only if it's genuinely stale or
+				// stuck, not merely because it's async. No warning before the
+				// first batch has ever run.
+				if len(cluster.Apps) > 0 {
+					cluster.Lock()
+					lastStart := cluster.AppRefreshLastStart
+					lastEnd := cluster.AppRefreshLastEnd
+					cluster.Unlock()
+					threshold := time.Duration(10*cluster.Conf.MonitoringTicker) * time.Second
+					inProgress := cluster.appRefreshInProgress.Load()
+					stale, stuck := appRefreshStaleness(inProgress, lastStart, lastEnd, time.Now(), threshold)
+					if stale || stuck {
+						cluster.SetState("APPERR007", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["APPERR007"], cluster.Name, threshold, lastEnd.Format(time.RFC3339)), ErrFrom: "APP"})
+					}
 				}
 			} else {
 				cluster.StateMachine.PreserveState("ERR00100")

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -408,14 +408,24 @@ type Cluster struct {
 	appRefreshEpoch       uint64                                 `json:"-"`
 	publishedAppErrStates atomic.Pointer[map[string]state.State] `json:"-"`
 
-	AppRefreshLastStart      time.Time  `json:"appRefreshLastStart" groups:"web"`
-	AppRefreshLastEnd        time.Time  `json:"appRefreshLastEnd" groups:"web"`
-	AppRefreshLastSuccess    bool       `json:"appRefreshLastSuccess" groups:"web"`
-	AppRefreshLastDurationMs int64      `json:"appRefreshLastDurationMs" groups:"web"`
-	AppRefreshLastError      string     `json:"appRefreshLastError" groups:"web"`
-	AppRefreshLastAppCount   int        `json:"appRefreshLastAppCount" groups:"web"`
-	secretVersionStoreMu     sync.Mutex `json:"-"`
-	secretVersionStoreDirty  bool       `json:"-"`
+	AppRefreshLastStart      time.Time `json:"appRefreshLastStart" groups:"web"`
+	AppRefreshLastEnd        time.Time `json:"appRefreshLastEnd" groups:"web"`
+	AppRefreshLastSuccess    bool      `json:"appRefreshLastSuccess" groups:"web"`
+	AppRefreshLastDurationMs int64     `json:"appRefreshLastDurationMs" groups:"web"`
+	AppRefreshLastError      string    `json:"appRefreshLastError" groups:"web"`
+	AppRefreshLastAppCount   int       `json:"appRefreshLastAppCount" groups:"web"`
+	// AppRefreshSkippedCount counts single-flight rejections (a previous
+	// batch still running when the tick tries to launch the next one)
+	// since the current/most recent batch started -- a rising count means
+	// the app fleet has outgrown current refresh capacity
+	// (AppRefreshConcurrency/Conf.Timeout), a visibility signal that's
+	// otherwise only a DBG log line. Reset to 0 when a new batch starts
+	// (not when one finishes -- see maybeRefreshAppsAsync for why), so it
+	// stays visible for inspection after a batch completes until the next
+	// one begins.
+	AppRefreshSkippedCount  int        `json:"appRefreshSkippedCount" groups:"web"`
+	secretVersionStoreMu    sync.Mutex `json:"-"`
+	secretVersionStoreDirty bool       `json:"-"`
 	// reloadMu serializes Run()'s per-tick synchronous work (topology
 	// discovery, the wg-joined Phase 1/2/3 monitoring work) against
 	// ReloadConfig() rebuilding Conf/state machines/Servers out from under
@@ -1202,13 +1212,20 @@ func (cluster *Cluster) tickBody() {
 				// App refresh now runs off the tick's critical path (see
 				// maybeRefreshAppsAsync); warn only if it's genuinely stale or
 				// stuck, not merely because it's async. No warning before the
-				// first batch has ever run.
-				if len(cluster.Apps) > 0 {
-					cluster.Lock()
-					lastStart := cluster.AppRefreshLastStart
-					lastEnd := cluster.AppRefreshLastEnd
-					cluster.Unlock()
-					threshold := time.Duration(10*cluster.Conf.MonitoringTicker) * time.Second
+				// first batch has ever run. appCount is read under the same
+				// lock as the freshness fields: cluster.Apps is reassigned
+				// wholesale under cluster.Lock() elsewhere (newAppList,
+				// cluster_del.go), so reading its length unlocked would race
+				// on the slice header itself, same as the bug already fixed
+				// in maybeRefreshAppsAsync's fan-out loop.
+				cluster.Lock()
+				appCount := len(cluster.Apps)
+				lastStart := cluster.AppRefreshLastStart
+				lastEnd := cluster.AppRefreshLastEnd
+				lastDurationMs := cluster.AppRefreshLastDurationMs
+				cluster.Unlock()
+				if appCount > 0 {
+					threshold := appRefreshStaleThreshold(cluster.Conf.MonitoringTicker, appCount, cluster.Conf.AppRefreshConcurrency, cluster.Conf.Timeout, lastDurationMs)
 					inProgress := cluster.appRefreshInProgress.Load()
 					stale, stuck := appRefreshStaleness(inProgress, lastStart, lastEnd, time.Now(), threshold)
 					if stale || stuck {

--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -11,11 +11,14 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/pelletier/go-toml"
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/share"
 	"github.com/signal18/replication-manager/utils/misc"
+	"github.com/signal18/replication-manager/utils/state"
 	"github.com/spf13/viper"
 )
 
@@ -1133,8 +1136,37 @@ func (cluster *Cluster) GetAppHATopology(appcnf *config.AppConfig) string {
 	return haTopology
 }
 
-func (cluster *Cluster) refreshApps(wg *sync.WaitGroup) {
-	defer wg.Done()
+// appRefreshStaleness reports whether the last completed app-refresh batch
+// is too old (stale) or the current batch has been running too long
+// (stuck), relative to threshold. Pure function, factored out of the tick
+// loop for direct unit testing.
+func appRefreshStaleness(inProgress bool, lastStart, lastEnd, now time.Time, threshold time.Duration) (stale, stuck bool) {
+	stale = !inProgress && !lastEnd.IsZero() && now.Sub(lastEnd) > threshold
+	stuck = inProgress && !lastStart.IsZero() && now.Sub(lastStart) > threshold
+	return stale, stuck
+}
+
+// maybeRefreshAppsAsync runs one app-refresh batch, unless a previous batch
+// is still in flight (single-flight, guarded by cluster.appRefreshInProgress).
+// It is launched via trackTickGoroutine as fire-and-forget background work,
+// deliberately kept off the tick's waited-on critical path: topology
+// discovery and failover detection must not stall behind slow or
+// unresponsive app backends. Per-app results are aggregated locally and
+// published to cluster.publishedAppErrStates in a single atomic Store once
+// the whole batch completes, so EmitAppErrors() never observes a
+// half-old/half-new mix of app error state.
+func (cluster *Cluster) maybeRefreshAppsAsync() {
+	if !cluster.appRefreshInProgress.CompareAndSwap(false, true) {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlDbg,
+			"Skipping app refresh: previous batch still in progress")
+		return
+	}
+	defer cluster.appRefreshInProgress.Store(false)
+
+	start := time.Now()
+	cluster.Lock()
+	cluster.AppRefreshLastStart = start
+	cluster.Unlock()
 
 	var workerWg sync.WaitGroup
 	appChan := make(chan *App)
@@ -1144,12 +1176,22 @@ func (cluster *Cluster) refreshApps(wg *sync.WaitGroup) {
 		workerCount = 1
 	}
 
+	var aggMu sync.Mutex
+	aggregated := make(map[string]state.State)
+
 	for range workerCount {
 		workerWg.Add(1)
 		go func() {
 			defer workerWg.Done()
 			for app := range appChan {
 				app.Refresh()
+				app.Lock()
+				for key, st := range app.ErrState {
+					aggMu.Lock()
+					aggregated[key] = st
+					aggMu.Unlock()
+				}
+				app.Unlock()
 			}
 		}()
 	}
@@ -1162,22 +1204,36 @@ func (cluster *Cluster) refreshApps(wg *sync.WaitGroup) {
 	close(appChan)
 
 	workerWg.Wait()
+
+	cluster.publishedAppErrStates.Store(&aggregated)
+	atomic.AddUint64(&cluster.appRefreshEpoch, 1)
+
+	cluster.Lock()
+	cluster.AppRefreshLastEnd = time.Now()
+	cluster.AppRefreshLastDurationMs = cluster.AppRefreshLastEnd.Sub(start).Milliseconds()
+	cluster.AppRefreshLastSuccess = true
+	cluster.AppRefreshLastError = ""
+	cluster.AppRefreshLastAppCount = len(cluster.Apps)
+	cluster.Unlock()
 }
 
+// EmitAppErrors feeds the cluster-wide state machine from the last
+// completed app-refresh batch (see maybeRefreshAppsAsync). It deliberately
+// does not read cluster.Apps live: since app refresh runs asynchronously
+// and can be mid-batch on any given tick, reading live per-app state here
+// would risk mixing already-refreshed apps with stale ones into a single
+// "cluster-wide" snapshot. Reading the published aggregate instead means
+// this always reflects one fully-coherent batch, old or new.
 func (cluster *Cluster) EmitAppErrors() {
-	for _, app := range cluster.Apps {
-		if app == nil {
-			continue
+	snap := cluster.publishedAppErrStates.Load()
+	if snap == nil {
+		return
+	}
+	for key, st := range *snap {
+		if st.ErrKey == "" {
+			st.ErrKey = key
 		}
-		app.Lock()
-		for key, st := range app.ErrState {
-			if st.ErrKey == "" {
-				st.ErrKey = key
-			}
-
-			cluster.SetState(key, st)
-		}
-		app.Unlock()
+		cluster.SetState(key, st)
 	}
 }
 

--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -1153,6 +1153,23 @@ func (cluster *Cluster) GetAppHATopology(appcnf *config.AppConfig) string {
 //     larger batch would false-positive as "stuck" before bound (2) has
 //     any data reflecting the new size. Bound (3) reacts immediately
 //     because it's computed from the current snapshot, not history.
+//
+// This is a deliberately coarse, heuristic pipeline-health signal, not a
+// per-app health check -- see App's own LastRefresh*/RefreshInProgress
+// fields (app.go, set via SetRefreshInProgress/SetRefreshResult) for which
+// specific app is slow. The x4 in bound (3) is a fixed safety margin, not a
+// measurement: a fleet with unusually route-heavy apps (e.g. most apps
+// having 5+ routes, each potentially doing a local+external check) can
+// still exceed it on the very first batch after a fleet/route-count jump,
+// producing one false "stuck"/"stale" warning. This is accepted as a known
+// limitation rather than chased further: it's warning noise, not a
+// functional failure (app monitoring itself is unaffected), and it
+// self-corrects on the very next completed batch once bound (2) reflects
+// the new reality. Closing it fully would require summing actual route
+// counts across the snapshot under each app's own lock before every
+// threshold check, adding real complexity for a one-cycle, self-healing
+// symptom -- not worth it without production evidence that the x4 margin
+// is actually being hit in practice.
 func appRefreshStaleThreshold(monitoringTicker int64, appCount, concurrency, timeoutSeconds int, lastDurationMs int64) time.Duration {
 	threshold := time.Duration(10*monitoringTicker) * time.Second
 

--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -1136,6 +1136,46 @@ func (cluster *Cluster) GetAppHATopology(appcnf *config.AppConfig) string {
 	return haTopology
 }
 
+// appRefreshStaleThreshold picks the staleness/stuck threshold for
+// APPERR007: the largest of three lower bounds.
+//
+//  1. A flat floor (10x the tick interval), covering the bootstrap case
+//     before any batch has ever completed.
+//  2. 4x the last observed batch duration -- adapts to a fleet that has
+//     been steady for a while, without needing to know its size,
+//     concurrency, or timeout directly.
+//  3. A theoretical bound derived from the *current* fleet size,
+//     ceil(appCount/concurrency) rounds x timeoutSeconds, x4 for headroom
+//     (apps commonly have more than one route, and each route check is
+//     bounded by timeoutSeconds, not the whole app). Bound (2) alone lags
+//     by one batch: if the fleet just grew (e.g. 1 app -> 11 apps), the
+//     last observed duration is still the old, small one, so the first
+//     larger batch would false-positive as "stuck" before bound (2) has
+//     any data reflecting the new size. Bound (3) reacts immediately
+//     because it's computed from the current snapshot, not history.
+func appRefreshStaleThreshold(monitoringTicker int64, appCount, concurrency, timeoutSeconds int, lastDurationMs int64) time.Duration {
+	threshold := time.Duration(10*monitoringTicker) * time.Second
+
+	if appCount > 0 && timeoutSeconds > 0 {
+		workers := concurrency
+		if workers <= 0 {
+			workers = 1
+		}
+		rounds := (appCount + workers - 1) / workers // ceil division
+		if fleetBound := time.Duration(4*rounds*timeoutSeconds) * time.Second; fleetBound > threshold {
+			threshold = fleetBound
+		}
+	}
+
+	if lastDurationMs > 0 {
+		if adaptive := time.Duration(4*lastDurationMs) * time.Millisecond; adaptive > threshold {
+			threshold = adaptive
+		}
+	}
+
+	return threshold
+}
+
 // appRefreshStaleness reports whether the last completed app-refresh batch
 // is too old (stale) or the current batch has been running too long
 // (stuck), relative to threshold. Pure function, factored out of the tick
@@ -1157,6 +1197,9 @@ func appRefreshStaleness(inProgress bool, lastStart, lastEnd, now time.Time, thr
 // half-old/half-new mix of app error state.
 func (cluster *Cluster) maybeRefreshAppsAsync() {
 	if !cluster.appRefreshInProgress.CompareAndSwap(false, true) {
+		cluster.Lock()
+		cluster.AppRefreshSkippedCount++
+		cluster.Unlock()
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModApp, config.LvlDbg,
 			"Skipping app refresh: previous batch still in progress")
 		return
@@ -1164,8 +1207,30 @@ func (cluster *Cluster) maybeRefreshAppsAsync() {
 	defer cluster.appRefreshInProgress.Store(false)
 
 	start := time.Now()
+
+	// Snapshot cluster.Apps under cluster.Lock(): it's reassigned wholesale
+	// under this lock elsewhere (newAppList, cluster_del.go), so iterating
+	// the live slice without it races on the slice header itself -- same
+	// class of bug already found and fixed in GetAppsSubstitutionJSon
+	// (cluster/app_get.go). appCount is taken from this same snapshot so
+	// AppRefreshLastAppCount reflects the batch actually processed, not a
+	// possibly-since-changed cluster.Apps read again after the fact.
+	//
+	// AppRefreshSkippedCount is reset here, at batch start, not at batch
+	// end: resetting at the end races against the deferred
+	// appRefreshInProgress.Store(false) above, which only runs after this
+	// whole function returns -- a tick landing in that gap would fail the
+	// CompareAndSwap and increment a counter that was just zeroed,
+	// appearing as stray leftover contention from a batch that actually
+	// just succeeded cleanly. Resetting at start has no such window: it
+	// happens strictly after this goroutine wins the CompareAndSwap above,
+	// so every rejection counted from here on is unambiguously "since this
+	// batch started."
 	cluster.Lock()
 	cluster.AppRefreshLastStart = start
+	cluster.AppRefreshSkippedCount = 0
+	apps := make([]*App, len(cluster.Apps))
+	copy(apps, cluster.Apps)
 	cluster.Unlock()
 
 	var workerWg sync.WaitGroup
@@ -1196,7 +1261,7 @@ func (cluster *Cluster) maybeRefreshAppsAsync() {
 		}()
 	}
 
-	for _, app := range cluster.Apps {
+	for _, app := range apps {
 		if app != nil {
 			appChan <- app
 		}
@@ -1213,7 +1278,7 @@ func (cluster *Cluster) maybeRefreshAppsAsync() {
 	cluster.AppRefreshLastDurationMs = cluster.AppRefreshLastEnd.Sub(start).Milliseconds()
 	cluster.AppRefreshLastSuccess = true
 	cluster.AppRefreshLastError = ""
-	cluster.AppRefreshLastAppCount = len(cluster.Apps)
+	cluster.AppRefreshLastAppCount = len(apps)
 	cluster.Unlock()
 }
 

--- a/cluster/cluster_app_refresh_test.go
+++ b/cluster/cluster_app_refresh_test.go
@@ -1,0 +1,346 @@
+package cluster
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/state"
+)
+
+// newAppRefreshTestApp builds an App wired to cluster, following the shape
+// of newMonitoringTestApp (app_error_test.go) but sharing the caller's
+// Cluster instance so cluster.Apps can hold several apps pointing back at
+// the same cluster -- the same shape production uses (needed to exercise
+// maybeRefreshAppsAsync's batch iteration and aggregation).
+func newAppRefreshTestApp(cluster *Cluster, name string, routes []config.Route) *App {
+	return &App{
+		Id:                   name,
+		Name:                 name,
+		Host:                 "127.0.0.1",
+		Mutex:                &sync.Mutex{},
+		ErrState:             make(map[string]state.State),
+		AppErrConsecutiveMap: make(map[string]int),
+		AppConfig: &config.AppConfig{
+			Deployment: &config.Deployment{Routes: routes},
+		},
+		ClusterGroup: cluster,
+	}
+}
+
+// blockingHTTPServer returns a test server whose handler signals on entered
+// (once per request) and then blocks until block is closed. Closing block
+// releases the current and all future requests (reads from a closed channel
+// never block), so a single close is enough to let a whole Refresh() call
+// (which may hit the handler more than once -- local then external check)
+// run to completion.
+func blockingHTTPServer(entered chan<- struct{}, block <-chan struct{}) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		entered <- struct{}{}
+		<-block
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+// httpRouteFor builds a route that makes both the local and external check
+// hit srv: Host+DestinationPort is what GetAppLocalHTTPStatus dials, CName
+// is what the external GetAppHTTPStatus call dials directly.
+func httpRouteFor(srv *httptest.Server) config.Route {
+	_, port, err := net.SplitHostPort(srv.Listener.Addr().String())
+	if err != nil {
+		panic(err)
+	}
+	return config.Route{Protocol: "http", CName: "127.0.0.1:" + port, DestinationPort: port, Primary: true}
+}
+
+func TestMaybeRefreshAppsAsync_SingleFlight(t *testing.T) {
+	entered := make(chan struct{}, 8)
+	block := make(chan struct{})
+	var hits int64
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		entered <- struct{}{}
+		<-block
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cluster := &Cluster{
+		Name: "single-flight",
+		Conf: &config.Config{Timeout: 5, AppRefreshConcurrency: 1},
+	}
+	app := newAppRefreshTestApp(cluster, "app1", []config.Route{httpRouteFor(srv)})
+	cluster.Apps = []*App{app}
+
+	done := make(chan struct{})
+	go func() {
+		cluster.maybeRefreshAppsAsync()
+		close(done)
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the batch to start checking the app")
+	}
+
+	// A second call while the first batch is still stuck mid-check must be a
+	// no-op: it should return immediately and must not touch the app itself
+	// (which would show up as extra hits on the blocked handler).
+	start := time.Now()
+	cluster.maybeRefreshAppsAsync()
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("expected an overlapping call to return immediately (single-flight guard), took %s", elapsed)
+	}
+	if got := atomic.LoadInt64(&hits); got != 1 {
+		t.Fatalf("expected exactly 1 check hit while the first batch is in flight, got %d", got)
+	}
+
+	close(block)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the batch to finish")
+	}
+
+	// One full Refresh() on one http route hits the handler twice: once for
+	// the local check, once for the external check.
+	if got := atomic.LoadInt64(&hits); got != 2 {
+		t.Fatalf("expected exactly 2 total check hits from a single batch, got %d", got)
+	}
+	if cluster.AppRefreshLastAppCount != 1 {
+		t.Fatalf("expected AppRefreshLastAppCount=1, got %d", cluster.AppRefreshLastAppCount)
+	}
+	if !cluster.AppRefreshLastSuccess {
+		t.Fatalf("expected AppRefreshLastSuccess=true")
+	}
+	if atomic.LoadUint64(&cluster.appRefreshEpoch) != 1 {
+		t.Fatalf("expected appRefreshEpoch=1 after one completed batch, got %d", cluster.appRefreshEpoch)
+	}
+}
+
+func TestMaybeRefreshAppsAsync_AtomicPublish(t *testing.T) {
+	entered := make(chan struct{}, 8)
+	block := make(chan struct{})
+	slowSrv := blockingHTTPServer(entered, block)
+	defer slowSrv.Close()
+
+	cluster := &Cluster{
+		Name: "atomic-publish",
+		Conf: &config.Config{Timeout: 5, AppRefreshConcurrency: 2, AppErrorDebounceThreshold: 1},
+	}
+	slowApp := newAppRefreshTestApp(cluster, "slow", []config.Route{httpRouteFor(slowSrv)})
+	failApp := newAppRefreshTestApp(cluster, "fail", []config.Route{
+		{Protocol: "tcp", CName: "127.0.0.1", Port: "1", DestinationPort: "1", Primary: true},
+	})
+	cluster.Apps = []*App{slowApp, failApp}
+
+	done := make(chan struct{})
+	go func() {
+		cluster.maybeRefreshAppsAsync()
+		close(done)
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the slow app's check to start")
+	}
+
+	// The fast-failing app should finish (and record its own live error)
+	// well before the slow app is unblocked.
+	deadline := time.Now().Add(2 * time.Second)
+	recorded := false
+	for time.Now().Before(deadline) {
+		failApp.Lock()
+		_, recorded = failApp.ErrState[ErrAppTCPConnectFailed]
+		failApp.Unlock()
+		if recorded {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !recorded {
+		t.Fatal("expected the fast-failing app to have already recorded its own error while the slow app is still blocked")
+	}
+
+	// Even though one app in the batch is fully done, the cluster-wide
+	// published snapshot must not reflect a partial batch.
+	if snap := cluster.publishedAppErrStates.Load(); snap != nil {
+		t.Fatalf("expected no published snapshot while the batch is still in flight, got %v", *snap)
+	}
+
+	close(block)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the batch to finish")
+	}
+
+	snap := cluster.publishedAppErrStates.Load()
+	if snap == nil {
+		t.Fatal("expected a published snapshot once the batch completes")
+	}
+	if _, ok := (*snap)[ErrAppTCPConnectFailed]; !ok {
+		t.Fatalf("expected the published snapshot to contain %s from the completed batch", ErrAppTCPConnectFailed)
+	}
+}
+
+func TestMaybeRefreshAppsAsync_FreshnessFields(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	cluster := &Cluster{
+		Name: "freshness",
+		Conf: &config.Config{Timeout: 5, AppRefreshConcurrency: 2},
+	}
+	app := newAppRefreshTestApp(cluster, "app1", []config.Route{
+		{Protocol: "tcp", CName: "127.0.0.1", Port: strconv.Itoa(port), DestinationPort: strconv.Itoa(port), Primary: true},
+	})
+	cluster.Apps = []*App{app}
+
+	before := time.Now()
+	cluster.maybeRefreshAppsAsync()
+	after := time.Now()
+
+	if cluster.AppRefreshLastStart.Before(before) || cluster.AppRefreshLastStart.After(after) {
+		t.Fatalf("AppRefreshLastStart %s not within [%s, %s]", cluster.AppRefreshLastStart, before, after)
+	}
+	if cluster.AppRefreshLastEnd.Before(cluster.AppRefreshLastStart) {
+		t.Fatalf("AppRefreshLastEnd %s before AppRefreshLastStart %s", cluster.AppRefreshLastEnd, cluster.AppRefreshLastStart)
+	}
+	if cluster.AppRefreshLastDurationMs < 0 {
+		t.Fatalf("expected non-negative AppRefreshLastDurationMs, got %d", cluster.AppRefreshLastDurationMs)
+	}
+	if !cluster.AppRefreshLastSuccess {
+		t.Fatalf("expected AppRefreshLastSuccess=true")
+	}
+	if cluster.AppRefreshLastAppCount != 1 {
+		t.Fatalf("expected AppRefreshLastAppCount=1, got %d", cluster.AppRefreshLastAppCount)
+	}
+	if cluster.appRefreshInProgress.Load() {
+		t.Fatalf("expected appRefreshInProgress=false after batch completion")
+	}
+}
+
+func TestEmitAppErrors_ReadsPublishedSnapshotNotLiveApps(t *testing.T) {
+	cluster := &Cluster{
+		Name:         "emit-errors",
+		Conf:         &config.Config{},
+		StateMachine: &state.StateMachine{},
+	}
+	cluster.StateMachine.Init()
+
+	// A live app with an error that has NOT been published yet -- e.g. a
+	// batch that's still in flight. EmitAppErrors must not see this.
+	liveOnlyApp := newAppRefreshTestApp(cluster, "live-only", nil)
+	liveOnlyApp.ErrState[ErrAppTCPConnectFailed] = state.State{ErrKey: ErrAppTCPConnectFailed, ErrDesc: "should not be emitted"}
+	cluster.Apps = []*App{liveOnlyApp}
+
+	published := map[string]state.State{
+		ErrAppConnectFailed: {ErrKey: ErrAppConnectFailed, ErrDesc: "published batch error"},
+	}
+	cluster.publishedAppErrStates.Store(&published)
+
+	cluster.EmitAppErrors()
+
+	if !cluster.StateMachine.IsInState(ErrAppConnectFailed) {
+		t.Fatalf("expected %s from the published snapshot to be emitted", ErrAppConnectFailed)
+	}
+	if cluster.StateMachine.IsInState(ErrAppTCPConnectFailed) {
+		t.Fatalf("expected %s (live-only, unpublished) to NOT be emitted", ErrAppTCPConnectFailed)
+	}
+}
+
+func TestEmitAppErrors_NoPublishedSnapshotYetIsNoop(t *testing.T) {
+	cluster := &Cluster{
+		Name:         "emit-errors-cold",
+		Conf:         &config.Config{},
+		StateMachine: &state.StateMachine{},
+	}
+	cluster.StateMachine.Init()
+
+	// Should not panic and should not emit anything before any batch has
+	// ever completed.
+	cluster.EmitAppErrors()
+
+	if cluster.StateMachine.IsInState(ErrAppConnectFailed) {
+		t.Fatalf("did not expect any state before the first published batch")
+	}
+}
+
+func TestAppRefreshStaleness(t *testing.T) {
+	now := time.Now()
+	threshold := 20 * time.Second
+
+	cases := []struct {
+		name       string
+		inProgress bool
+		lastStart  time.Time
+		lastEnd    time.Time
+		wantStale  bool
+		wantStuck  bool
+	}{
+		{
+			name:      "never run yet",
+			wantStale: false,
+			wantStuck: false,
+		},
+		{
+			name:      "recently completed, not stale",
+			lastEnd:   now.Add(-1 * time.Second),
+			wantStale: false,
+			wantStuck: false,
+		},
+		{
+			name:      "completed long ago, stale",
+			lastEnd:   now.Add(-1 * time.Hour),
+			wantStale: true,
+			wantStuck: false,
+		},
+		{
+			name:       "in progress, started recently, not stuck",
+			inProgress: true,
+			lastStart:  now.Add(-1 * time.Second),
+			wantStale:  false,
+			wantStuck:  false,
+		},
+		{
+			name:       "in progress, started long ago, stuck",
+			inProgress: true,
+			lastStart:  now.Add(-1 * time.Hour),
+			wantStale:  false,
+			wantStuck:  true,
+		},
+		{
+			name:       "in progress overrides a stale prior completion",
+			inProgress: true,
+			lastStart:  now.Add(-1 * time.Second),
+			lastEnd:    now.Add(-1 * time.Hour),
+			wantStale:  false,
+			wantStuck:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			stale, stuck := appRefreshStaleness(tc.inProgress, tc.lastStart, tc.lastEnd, now, threshold)
+			if stale != tc.wantStale || stuck != tc.wantStuck {
+				t.Fatalf("appRefreshStaleness() = (stale=%v, stuck=%v), want (stale=%v, stuck=%v)",
+					stale, stuck, tc.wantStale, tc.wantStuck)
+			}
+		})
+	}
+}

--- a/cluster/cluster_app_refresh_test.go
+++ b/cluster/cluster_app_refresh_test.go
@@ -126,6 +126,109 @@ func TestMaybeRefreshAppsAsync_SingleFlight(t *testing.T) {
 	}
 }
 
+// TestMaybeRefreshAppsAsync_ConcurrentAppListRebuildNoRace guards against
+// cluster.Apps being reassigned wholesale (as newAppList/cluster_del.go do,
+// under cluster.Lock()) while maybeRefreshAppsAsync is iterating it. Before
+// the fix, the fan-out loop read cluster.Apps directly with no lock -- the
+// same class of bug already found and fixed in GetAppsSubstitutionJSon
+// (cluster/app_get.go). Run with -race.
+func TestMaybeRefreshAppsAsync_ConcurrentAppListRebuildNoRace(t *testing.T) {
+	cluster := &Cluster{
+		Name: "list-rebuild",
+		Conf: &config.Config{Timeout: 5, AppRefreshConcurrency: 2},
+	}
+	app1 := newAppRefreshTestApp(cluster, "app1", nil)
+	app2 := newAppRefreshTestApp(cluster, "app2", nil)
+	cluster.Apps = []*App{app1, app2}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Mutator: repeatedly rebuilds cluster.Apps under cluster.Lock(),
+	// mirroring newAppList's atomic swap.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				cluster.Lock()
+				cluster.Apps = []*App{app1, app2}
+				cluster.Unlock()
+			}
+		}
+	}()
+
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		cluster.maybeRefreshAppsAsync()
+	}
+
+	close(stop)
+	wg.Wait()
+}
+
+// TestMaybeRefreshAppsAsync_SkippedCount asserts AppRefreshSkippedCount
+// increments once per rejected overlapping launch, stays visible after the
+// batch that saw the rejections finishes (not reset at completion -- that
+// would race against the deferred appRefreshInProgress clear, see
+// maybeRefreshAppsAsync), and resets to 0 only once the next batch starts.
+func TestMaybeRefreshAppsAsync_SkippedCount(t *testing.T) {
+	entered := make(chan struct{}, 8)
+	block := make(chan struct{})
+
+	srv := blockingHTTPServer(entered, block)
+	defer srv.Close()
+
+	cluster := &Cluster{
+		Name: "skipped-count",
+		Conf: &config.Config{Timeout: 5, AppRefreshConcurrency: 1},
+	}
+	app := newAppRefreshTestApp(cluster, "app1", []config.Route{httpRouteFor(srv)})
+	cluster.Apps = []*App{app}
+
+	done := make(chan struct{})
+	go func() {
+		cluster.maybeRefreshAppsAsync()
+		close(done)
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the batch to start checking the app")
+	}
+
+	const rejectedAttempts = 3
+	for i := 0; i < rejectedAttempts; i++ {
+		cluster.maybeRefreshAppsAsync()
+	}
+	if got := cluster.AppRefreshSkippedCount; got != rejectedAttempts {
+		t.Fatalf("expected AppRefreshSkippedCount=%d after %d overlapping calls, got %d", rejectedAttempts, rejectedAttempts, got)
+	}
+
+	close(block)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the batch to finish")
+	}
+
+	// Finishing the batch must NOT reset the count -- it stays visible for
+	// inspection until the next batch starts.
+	if got := cluster.AppRefreshSkippedCount; got != rejectedAttempts {
+		t.Fatalf("expected AppRefreshSkippedCount to remain %d after the batch finishes, got %d", rejectedAttempts, got)
+	}
+
+	// Starting the next batch resets it.
+	cluster.maybeRefreshAppsAsync()
+	if got := cluster.AppRefreshSkippedCount; got != 0 {
+		t.Fatalf("expected AppRefreshSkippedCount reset to 0 once the next batch starts, got %d", got)
+	}
+}
+
 func TestMaybeRefreshAppsAsync_AtomicPublish(t *testing.T) {
 	entered := make(chan struct{}, 8)
 	block := make(chan struct{})
@@ -340,6 +443,81 @@ func TestAppRefreshStaleness(t *testing.T) {
 			if stale != tc.wantStale || stuck != tc.wantStuck {
 				t.Fatalf("appRefreshStaleness() = (stale=%v, stuck=%v), want (stale=%v, stuck=%v)",
 					stale, stuck, tc.wantStale, tc.wantStuck)
+			}
+		})
+	}
+}
+
+// TestAppRefreshStaleThreshold guards two fixes for a flat threshold not
+// scaling with app count:
+//
+//  1. Worst-case batch duration is roughly
+//     ceil(apps/AppRefreshConcurrency) x routesPerApp x Conf.Timeout, which
+//     at even 5 apps and default settings can exceed a flat
+//     10xMonitoringTicker floor under a plausible worst case, producing
+//     false "stuck" warnings on a batch that's still working normally.
+//  2. Bound (1)'s fix -- scaling off the *last observed* batch duration --
+//     still lags by one batch when the fleet just grew (e.g. 1 app -> 11
+//     apps): the last duration reflects the old, small fleet, so the first
+//     larger batch would still false-positive before any history catches
+//     up. The current-fleet-size bound must react immediately, using the
+//     current snapshot's app count rather than history.
+func TestAppRefreshStaleThreshold(t *testing.T) {
+	cases := []struct {
+		name             string
+		monitoringTicker int64
+		appCount         int
+		concurrency      int
+		timeoutSeconds   int
+		lastDurationMs   int64
+		want             time.Duration
+	}{
+		{
+			name:             "no batch completed yet: flat floor",
+			monitoringTicker: 2,
+			appCount:         1,
+			concurrency:      2,
+			timeoutSeconds:   5,
+			lastDurationMs:   0,
+			want:             20 * time.Second,
+		},
+		{
+			name:             "fast batch, small fleet: flat floor still wins",
+			monitoringTicker: 2,
+			appCount:         1,
+			concurrency:      2,
+			timeoutSeconds:   5,
+			lastDurationMs:   1000, // 4x = 4s, less than the 20s floor
+			want:             20 * time.Second,
+		},
+		{
+			name:             "slow observed batch: adaptive-from-history wins",
+			monitoringTicker: 2,
+			appCount:         1,
+			concurrency:      2,
+			timeoutSeconds:   5,
+			lastDurationMs:   25000, // 4x = 100s, more than the 20s floor
+			want:             100 * time.Second,
+		},
+		{
+			name:             "fleet just grew, no history yet: current-size bound wins",
+			monitoringTicker: 2,
+			appCount:         11,
+			concurrency:      2,
+			timeoutSeconds:   5,
+			lastDurationMs:   200, // still reflects the old 1-app fleet
+			// ceil(11/2)=6 rounds x 5s x4 = 120s
+			want: 120 * time.Second,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := appRefreshStaleThreshold(tc.monitoringTicker, tc.appCount, tc.concurrency, tc.timeoutSeconds, tc.lastDurationMs)
+			if got != tc.want {
+				t.Fatalf("appRefreshStaleThreshold(%d, %d, %d, %d, %d) = %s, want %s",
+					tc.monitoringTicker, tc.appCount, tc.concurrency, tc.timeoutSeconds, tc.lastDurationMs, got, tc.want)
 			}
 		})
 	}

--- a/cluster/cluster_app_refresh_test.go
+++ b/cluster/cluster_app_refresh_test.go
@@ -522,3 +522,58 @@ func TestAppRefreshStaleThreshold(t *testing.T) {
 		})
 	}
 }
+
+// TestAppRefresh_TracksInProgressDuringSlowCheck guards the App-level
+// (not batch-level) RefreshInProgress/LastRefreshDurationMs fields:
+// RefreshInProgress must be observably true for the whole duration of a
+// slow Refresh() call, and LastRefreshDurationMs must reflect that it
+// actually blocked, not just that Refresh() was called.
+func TestAppRefresh_TracksInProgressDuringSlowCheck(t *testing.T) {
+	entered := make(chan struct{}, 4)
+	block := make(chan struct{})
+	srv := blockingHTTPServer(entered, block)
+	defer srv.Close()
+
+	cluster := &Cluster{
+		Name: "app-refresh-tracking",
+		Conf: &config.Config{Timeout: 5},
+	}
+	app := newAppRefreshTestApp(cluster, "app1", []config.Route{httpRouteFor(srv)})
+
+	done := make(chan struct{})
+	go func() {
+		app.Refresh()
+		close(done)
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the refresh to start checking the app")
+	}
+
+	app.Lock()
+	inProgress := app.RefreshInProgress
+	app.Unlock()
+	if !inProgress {
+		t.Fatalf("expected RefreshInProgress=true while Refresh() is still running")
+	}
+
+	close(block)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Refresh() to finish")
+	}
+
+	app.Lock()
+	inProgress = app.RefreshInProgress
+	lastDurationMs := app.LastRefreshDurationMs
+	app.Unlock()
+	if inProgress {
+		t.Fatalf("expected RefreshInProgress=false after Refresh() finishes")
+	}
+	if lastDurationMs <= 0 {
+		t.Fatalf("expected positive LastRefreshDurationMs for a check that blocked, got %d", lastDurationMs)
+	}
+}

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -506,6 +506,28 @@ func (cluster *Cluster) GetConf() *config.Config {
 	return cluster.Conf
 }
 
+// GetConfigSnapshotForWire returns an independent copy of cluster.Conf with
+// Apps cleared, safe to hand to a generic marshaler (e.g. encoding/json)
+// even while CheckPrimaryRoute or other app-refresh work concurrently
+// mutates AppConfig.Deployment for entries in the live Conf.Apps.
+// cluster.Conf.Apps[i] and the corresponding App's AppConfig are literally
+// the same *config.AppConfig pointer (see GetAppConfig), so any caller that
+// doesn't need the apps list -- e.g. an API response that strips
+// "config.apps" anyway -- should use this instead of reading cluster.Conf
+// directly. config.Config has no embedded lock, so the value copy itself is
+// safe; it's taken under cluster.Lock() because Conf.Apps is reassigned
+// wholesale under that same lock elsewhere (newAppList, cluster_del.go).
+func (cluster *Cluster) GetConfigSnapshotForWire() *config.Config {
+	cluster.Lock()
+	defer cluster.Unlock()
+	if cluster.Conf == nil {
+		return nil
+	}
+	confCopy := *cluster.Conf
+	confCopy.Apps = nil
+	return &confCopy
+}
+
 func (cluster *Cluster) GetWaitTrx() int64 {
 	return cluster.Conf.SwitchWaitTrx
 }

--- a/cluster/prx_external.go
+++ b/cluster/prx_external.go
@@ -72,7 +72,7 @@ func (proxy *ExternalProxy) Refresh() error {
 		//proxy.ClusterGroup.LogModulePrintf(cluster.Conf.Verbose,config.ConstLogModProxy,config.LvlErr, "Sharding proxy refresh error (%s)", err)
 		return err
 	}
-	proxy.Version = proxy.ShardProxy.Variables.Get("VERSION")
+	proxy.SetVersion(proxy.ShardProxy.Variables.Get("VERSION"))
 	proxyByteOut := proxy.ShardProxy.Status.Get("BYTES_SENT")
 	proxyByteIn := proxy.ShardProxy.Status.Get("BYTES_RECEIVED")
 	proxyCnx := proxy.ShardProxy.Status.Get("THREADS_CREATED")

--- a/cluster/prx_get.go
+++ b/cluster/prx_get.go
@@ -400,7 +400,10 @@ func (p *Proxy) GetType() string {
 	return p.Type
 }
 
+// GetVersion reads Version under p.Lock -- see SetVersion.
 func (p *Proxy) GetVersion() string {
+	p.Lock.Lock()
+	defer p.Lock.Unlock()
 	return p.Version
 }
 

--- a/cluster/prx_haproxy.go
+++ b/cluster/prx_haproxy.go
@@ -267,7 +267,7 @@ func (proxy *HaproxyProxy) Refresh() error {
 		vstring, err := haRuntime.GetVersion()
 		if err == nil {
 			if vstring != "" {
-				proxy.Version = vstring
+				proxy.SetVersion(vstring)
 			}
 		}
 	}

--- a/cluster/prx_janitor.go
+++ b/cluster/prx_janitor.go
@@ -196,7 +196,7 @@ func (proxy *ProxyJanitor) Refresh() error {
 		return err
 	}
 	defer psql.Connection.Close()
-	proxy.Version = psql.GetVersion()
+	proxy.SetVersion(psql.GetVersion())
 
 	var updated bool
 	proxy.BackendsWrite = nil

--- a/cluster/prx_mariadbshardproxy.go
+++ b/cluster/prx_mariadbshardproxy.go
@@ -224,7 +224,7 @@ func (proxy *MariadbShardProxy) Refresh() error {
 		//proxy.ClusterGroup.LogModulePrintf(cluster.Conf.Verbose,config.ConstLogModProxy,config.LvlErr, "Sharding proxy refresh error (%s)", err)
 		return err
 	}
-	proxy.Version = proxy.ShardProxy.Variables.Get("VERSION")
+	proxy.SetVersion(proxy.ShardProxy.Variables.Get("VERSION"))
 
 	proxy.BackendsWrite = nil
 	proxy.BackendsRead = nil
@@ -275,7 +275,7 @@ func (cluster *Cluster) refreshMdbsproxy(oldmaster *ServerMonitor, proxy *Mariad
 
 		return err
 	}
-	proxy.Version = proxy.ShardProxy.Variables.Get("VERSION")
+	proxy.SetVersion(proxy.ShardProxy.Variables.Get("VERSION"))
 
 	proxy.BackendsWrite = nil
 	proxy.BackendsRead = nil

--- a/cluster/prx_proxysql.go
+++ b/cluster/prx_proxysql.go
@@ -304,7 +304,7 @@ func (proxy *ProxySQLProxy) Refresh() error {
 		return err
 	}
 	defer psql.Connection.Close()
-	proxy.Version = psql.GetVersion()
+	proxy.SetVersion(psql.GetVersion())
 
 	var updated bool
 	bkWriters := make([]Backend, 0)

--- a/cluster/prx_set.go
+++ b/cluster/prx_set.go
@@ -31,6 +31,21 @@ func (p *Proxy) SetLock() {
 	p.Lock.Lock()
 }
 
+// SetVersion sets Version under p.Lock. Refresh() implementations on
+// several proxy types (ExternalProxy, MariadbShardProxy, ProxySQLProxy,
+// HaproxyProxy, ProxyJanitor, SphinxProxy) reassign Version every refresh
+// cycle; GetAppsSubstitutionJSon's buildProxySubstitutionView reads it
+// concurrently from a different goroutine (refreshProxies runs
+// independently of app-refresh workers). Locking inside the setter/getter
+// (see GetVersion) means callers never manually pair SetLock()/DelLock()
+// around this field -- a manual pairing left the lock permanently held if
+// anything between the calls ever panicked or returned early.
+func (p *Proxy) SetVersion(v string) {
+	p.Lock.Lock()
+	defer p.Lock.Unlock()
+	p.Version = v
+}
+
 // TODO: clarify where this is used, can maybe be replaced with a Getter
 func (proxy *Proxy) SetServiceName(namespace string) {
 	proxy.ServiceName = namespace + "/svc/" + proxy.Name

--- a/cluster/prx_sphinx.go
+++ b/cluster/prx_sphinx.go
@@ -108,7 +108,7 @@ func (proxy *SphinxProxy) Refresh() error {
 		return err
 	}
 	defer sphinx.Connection.Close()
-	proxy.Version = sphinx.GetVersion()
+	proxy.SetVersion(sphinx.GetVersion())
 
 	proxy.BackendsWrite = nil
 	proxy.BackendsRead = nil

--- a/config/error.go
+++ b/config/error.go
@@ -17,6 +17,7 @@ var ClusterError = map[string]string{
 	"APPERR004": "Unsupported protocol %s for application %s",
 	"APPERR005": "Gateway route conflict for application %s: %s — gateway routes blocked, fix route config to resolve",
 	"APPERR006": "Failed to create provision cookie for application %s: %s",
+	"APPERR007": "App refresh for cluster %s has not completed in over %s (last success: %s)",
 	"CREDIT01":  "Credit cap (%d) exceeded by planned allocation (%d). Over-subscription is allowed; cap auto-rebases to actual usage on successful provision.",
 	"CREDIT02":  "Application %s has negative planned credit (%d). Please check the configuration.",
 	"CREDIT03":  "Application %s has negative used credit (%d). Please check the configuration.",

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -6056,7 +6056,27 @@ func (repman *ReplicationManager) handlerMuxClusterWaitDatabases(w http.Response
 // with a safely-snapshotted copy (acquired under the grouped s3Providers state lock) so
 // concurrent CRUD mutations cannot produce a racy or inconsistent response.
 func buildClusterAPIPayload(mycluster *cluster.Cluster) ([]byte, error) {
-	cl, err := json.Marshal(mycluster)
+	// Apps must be excluded from the marshal walk entirely, not just from
+	// the output. encoding/json's embedded-field conflict resolution only
+	// promotes a shallower field over a deeper one when both compete for
+	// the same JSON name; a shallower field tagged json:"-" is dropped from
+	// that competition instead of winning it, so it does NOT suppress the
+	// embedded Cluster.Apps field (tag json:"apps") -- Apps would still be
+	// visited and marshaled live. Instead, the shadow field below is tagged
+	// json:"apps" (matching Cluster.Apps's tag) so it wins the conflict and
+	// the deep, live Apps field is never visited by json.Marshal at all;
+	// the harmless empty-struct placeholder it produces is deleted from the
+	// bytes afterward alongside servers/proxies. Conf is substituted with a
+	// locked snapshot that has its own Apps cleared for the same reason
+	// (cluster.Conf.Apps[i] and the corresponding App's AppConfig are the
+	// same pointer -- see GetAppConfig).
+	view := struct {
+		*cluster.Cluster
+		Apps struct{}       `json:"apps"`
+		Conf *config.Config `json:"config"`
+	}{Cluster: mycluster, Conf: mycluster.GetConfigSnapshotForWire()}
+
+	cl, err := json.Marshal(&view)
 	if err != nil {
 		return nil, fmt.Errorf("marshal cluster: %w", err)
 	}
@@ -6068,11 +6088,21 @@ func buildClusterAPIPayload(mycluster *cluster.Cluster) ([]byte, error) {
 		}
 	}
 
-	// Reduce the content of the cluster object
+	// Reduce the content of the cluster object. "apps" is the harmless
+	// placeholder from the shadow field above (never touched live Apps
+	// data). "config.apps" comes from GetConfigSnapshotForWire's cleared
+	// (nil) Apps slice, which config.Config's `json:"apps"` tag (no
+	// omitempty) would otherwise emit as "apps":null rather than omitting
+	// the key -- deleting it here is safe: unlike the old
+	// "marshal-live-then-delete" pattern this fix replaced, cl at this
+	// point was already produced from a race-free snapshot, so this delete
+	// only tidies already-inert bytes, it doesn't touch live memory.
+	// Servers/Proxies are intentionally left as live-marshaled-then-deleted,
+	// unchanged -- out of scope for this pass.
+	cl, _ = sjson.DeleteBytes(cl, "apps")
 	cl, _ = sjson.DeleteBytes(cl, "config.apps")
 	cl, _ = sjson.DeleteBytes(cl, "servers")
 	cl, _ = sjson.DeleteBytes(cl, "proxies")
-	cl, _ = sjson.DeleteBytes(cl, "apps")
 
 	// Overwrite clusterS3Providers with a safe snapshot acquired under the mutex
 	// to prevent races with concurrent CRUD mutations (AddS3Provider, etc.).
@@ -8907,21 +8937,29 @@ func (repman *ReplicationManager) handlerMuxClusterVariablesPreserve(w http.Resp
 
 func (repman *ReplicationManager) handlerMuxApps(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	//marshal unmarchal for ofuscation deep copy of struc
 	vars := mux.Vars(r)
 	mycluster := repman.getClusterByName(vars["clusterName"])
 	if mycluster != nil {
-		apps, err := json.MarshalIndent(mycluster.Apps, "", "\t")
+		// GetAppsCopy() snapshots the slice under cluster.Lock() (cluster.Apps
+		// is reassigned wholesale elsewhere under that same lock), and
+		// GetAppAPIView() snapshots each app under its own lock -- so this
+		// never hands encoding/json a live *App the way the previous
+		// json.MarshalIndent(mycluster.Apps, ...) did. Deployment/appDbPass
+		// redaction is baked into GetAppAPIView() itself now, so no sjson
+		// post-processing is needed here.
+		appsSnapshot := mycluster.GetAppsCopy()
+		views := make([]*cluster.AppAPIView, 0, len(appsSnapshot))
+		for _, a := range appsSnapshot {
+			if a != nil {
+				views = append(views, a.GetAppAPIView())
+			}
+		}
+
+		apps, err := json.MarshalIndent(views, "", "\t")
 		if err != nil {
 			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "API Error encoding JSON: ", err)
 			http.Error(w, "Encoding error", http.StatusInternalServerError)
 			return
-		}
-
-		for idx := range mycluster.Apps {
-			apps, _ = sjson.DeleteBytes(apps, fmt.Sprintf("%d.appClusterSubstitute", idx))
-			apps, _ = sjson.DeleteBytes(apps, fmt.Sprintf("%d.config.deployment", idx))
-			apps, _ = sjson.SetBytes(apps, fmt.Sprintf("%d.config.appDbPass", idx), "*****")
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/server/api_cluster_test.go
+++ b/server/api_cluster_test.go
@@ -460,6 +460,188 @@ func TestBuildClusterAPIPayload_ConcurrentMutationNoRace(t *testing.T) {
 	<-done
 }
 
+// TestBuildClusterAPIPayload_AppsAbsent verifies that "apps" is never present
+// at the top level or inside "config", now that buildClusterAPIPayload
+// suppresses Cluster.Apps and substitutes a Conf snapshot with Apps cleared,
+// instead of marshaling then sjson-deleting them.
+func TestBuildClusterAPIPayload_AppsAbsent(t *testing.T) {
+	cl := newTestClusterForAPI(t)
+	app := &cluster.App{
+		Id: "app1", Name: "app1", Mutex: &sync.Mutex{},
+		AppConfig: &config.AppConfig{Deployment: &config.Deployment{}},
+	}
+	cl.Apps = []*cluster.App{app}
+	cl.Conf.Apps = []*config.AppConfig{app.AppConfig}
+
+	payload, err := buildClusterAPIPayload(cl)
+	if err != nil {
+		t.Fatalf("buildClusterAPIPayload: %v", err)
+	}
+
+	var out map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &out); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if _, ok := out["apps"]; ok {
+		t.Errorf("expected top-level \"apps\" key to be absent")
+	}
+
+	var cfg map[string]json.RawMessage
+	if err := json.Unmarshal(out["config"], &cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	if _, ok := cfg["apps"]; ok {
+		t.Errorf("expected \"config.apps\" key to be absent")
+	}
+}
+
+// TestBuildClusterAPIPayload_AppConcurrentMutationNoRace verifies that
+// buildClusterAPIPayload no longer races against concurrent App state writes.
+// Run with `go test -race`: before this fix, buildClusterAPIPayload did
+// json.Marshal(mycluster) directly, reflecting over every live *App in
+// mycluster.Apps (and mycluster.Conf.Apps) while SetState/SetFailCount could
+// concurrently mutate them.
+func TestBuildClusterAPIPayload_AppConcurrentMutationNoRace(t *testing.T) {
+	cl := newTestClusterForAPI(t)
+	app := &cluster.App{
+		Id: "app1", Name: "app1", Mutex: &sync.Mutex{},
+		AppConfig: &config.AppConfig{Deployment: &config.Deployment{}},
+	}
+	cl.Apps = []*cluster.App{app}
+	cl.Conf.Apps = []*config.AppConfig{app.AppConfig}
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				app.SetState(fmt.Sprintf("state-%d", i))
+				app.SetFailCount(i)
+				i++
+			}
+		}
+	}()
+
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, err := buildClusterAPIPayload(cl); err != nil {
+			close(stop)
+			<-done
+			t.Fatalf("buildClusterAPIPayload: %v", err)
+		}
+	}
+
+	close(stop)
+	<-done
+}
+
+// TestHandlerMuxApps_AppConcurrentMutationNoRace verifies that handlerMuxApps
+// no longer races against concurrent App state writes. Run with `go test
+// -race`: before GetAppsCopy()/GetAppAPIView(), handlerMuxApps did
+// json.MarshalIndent(mycluster.Apps, ...) directly against the live slice.
+func TestHandlerMuxApps_AppConcurrentMutationNoRace(t *testing.T) {
+	cl := newTestClusterForAPI(t)
+	app := &cluster.App{
+		Id: "app1", Name: "app1", Mutex: &sync.Mutex{},
+		AppConfig: &config.AppConfig{
+			AppDbUser: "u", AppDbPass: "secret",
+			Deployment: &config.Deployment{},
+		},
+	}
+	cl.Apps = []*cluster.App{app}
+	repman := newTestRepmanWithCluster(t, cl.Name, cl)
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				app.SetState(fmt.Sprintf("state-%d", i))
+				app.SetFailCount(i)
+				i++
+			}
+		}
+	}()
+
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		req := httptest.NewRequest("GET", "/api/clusters/"+cl.Name+"/topology/apps", nil)
+		req = setMuxVars(req, map[string]string{"clusterName": cl.Name})
+		w := httptest.NewRecorder()
+		repman.handlerMuxApps(w, req)
+		if w.Code != http.StatusOK {
+			close(stop)
+			<-done
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	}
+
+	close(stop)
+	<-done
+}
+
+// TestHandlerMuxApps_ShapePreserved verifies that handlerMuxApps's output
+// still matches the shape the previous sjson-based post-processing produced:
+// no "appClusterSubstitute" key, no "config.deployment" key, and
+// "config.appDbPass" masked to "*****" -- now baked into GetAppAPIView()
+// instead of being stripped from the marshaled bytes afterward.
+func TestHandlerMuxApps_ShapePreserved(t *testing.T) {
+	cl := newTestClusterForAPI(t)
+	app := &cluster.App{
+		Id: "app1", Name: "app1", State: "Running", Mutex: &sync.Mutex{},
+		AppClusterSubstitute: "should-not-appear",
+		AppConfig: &config.AppConfig{
+			AppDbUser: "u", AppDbPass: "supersecret",
+			Deployment: &config.Deployment{Routes: config.Routes{{CName: "x"}}},
+		},
+	}
+	cl.Apps = []*cluster.App{app}
+	repman := newTestRepmanWithCluster(t, cl.Name, cl)
+
+	req := httptest.NewRequest("GET", "/api/clusters/"+cl.Name+"/topology/apps", nil)
+	req = setMuxVars(req, map[string]string{"clusterName": cl.Name})
+	w := httptest.NewRecorder()
+	repman.handlerMuxApps(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "supersecret") {
+		t.Fatalf("appDbPass leaked raw value in response body")
+	}
+
+	var parsed []map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &parsed); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(parsed) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(parsed))
+	}
+	if _, ok := parsed[0]["appClusterSubstitute"]; ok {
+		t.Errorf("expected \"appClusterSubstitute\" key to be absent")
+	}
+	cfg, ok := parsed[0]["config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected \"config\" object in response, got: %v", parsed[0]["config"])
+	}
+	if _, ok := cfg["deployment"]; ok {
+		t.Errorf("expected \"config.deployment\" key to be absent, got: %v", cfg["deployment"])
+	}
+	if cfg["appDbPass"] != "*****" {
+		t.Errorf("expected appDbPass masked to \"*****\", got %v", cfg["appDbPass"])
+	}
+}
+
 // truncate returns s truncated to max chars, for safe error display.
 func truncate(s string, max int) string {
 	if len(s) > max {


### PR DESCRIPTION
## Summary
- move app refresh off the cluster tick critical path with single-flight batch execution
- add cluster-level and per-app refresh observability, including stale/stuck detection
- snapshot app and cluster API payloads before marshaling to avoid races against live app/proxy/server state
- add regression tests covering async refresh behavior, payload shape preservation, and race-prone concurrent mutations

## Testing
- Not run (PR creation only)

## Notes
- Follow-up app refresh and API safety work after #1640