### PR TITLE
fix(app): preserve per-app async refresh errors

### DIFF
--- a/cluster/cluster_app.go
+++ b/cluster/cluster_app.go
@@ -1258,6 +1258,10 @@ func (cluster *Cluster) maybeRefreshAppsAsync() {
 		workerCount = 1
 	}
 
+	// Keyed by state.BuildStateKey(errKey, ServerUrl), not the bare error
+	// key: multiple apps can raise the same error code (e.g. APPERR002), and
+	// a bare key would let one app's entry overwrite another's here before
+	// the batch is ever published.
 	var aggMu sync.Mutex
 	aggregated := make(map[string]state.State)
 
@@ -1269,8 +1273,11 @@ func (cluster *Cluster) maybeRefreshAppsAsync() {
 				app.Refresh()
 				app.Lock()
 				for key, st := range app.ErrState {
+					if st.ErrKey == "" {
+						st.ErrKey = key
+					}
 					aggMu.Lock()
-					aggregated[key] = st
+					aggregated[state.BuildStateKey(key, st.ServerUrl)] = st
 					aggMu.Unlock()
 				}
 				app.Unlock()
@@ -1306,16 +1313,21 @@ func (cluster *Cluster) maybeRefreshAppsAsync() {
 // would risk mixing already-refreshed apps with stale ones into a single
 // "cluster-wide" snapshot. Reading the published aggregate instead means
 // this always reflects one fully-coherent batch, old or new.
+//
+// SetState is called with st.ErrKey (the bare error code), not the map key:
+// the map key is a composite (state.BuildStateKey) used only to keep
+// different apps' same-error-code entries from colliding in the published
+// snapshot. AddState independently re-derives the correct per-app storage
+// key from st.ServerUrl, so passing the bare key here keeps ErrKey on the
+// stored state as the plain error code, matching what callers (UI, alerts,
+// config.ClusterError lookups) expect.
 func (cluster *Cluster) EmitAppErrors() {
 	snap := cluster.publishedAppErrStates.Load()
 	if snap == nil {
 		return
 	}
-	for key, st := range *snap {
-		if st.ErrKey == "" {
-			st.ErrKey = key
-		}
-		cluster.SetState(key, st)
+	for _, st := range *snap {
+		cluster.SetState(st.ErrKey, st)
 	}
 }
 

--- a/cluster/cluster_app_refresh_test.go
+++ b/cluster/cluster_app_refresh_test.go
@@ -291,8 +291,51 @@ func TestMaybeRefreshAppsAsync_AtomicPublish(t *testing.T) {
 	if snap == nil {
 		t.Fatal("expected a published snapshot once the batch completes")
 	}
-	if _, ok := (*snap)[ErrAppTCPConnectFailed]; !ok {
-		t.Fatalf("expected the published snapshot to contain %s from the completed batch", ErrAppTCPConnectFailed)
+	wantKey := state.BuildStateKey(ErrAppTCPConnectFailed, failApp.Host)
+	if _, ok := (*snap)[wantKey]; !ok {
+		t.Fatalf("expected the published snapshot to contain %s from the completed batch", wantKey)
+	}
+}
+
+// TestMaybeRefreshAppsAsync_PreservesPerAppErrorsWithSameCode is a
+// regression test for the async-refresh aggregation collapsing per-app
+// state: two different apps raising the exact same error code must both
+// survive into the published snapshot, keyed by app (ServerUrl), not
+// overwrite each other under the bare error code.
+func TestMaybeRefreshAppsAsync_PreservesPerAppErrorsWithSameCode(t *testing.T) {
+	cluster := &Cluster{
+		Name: "same-code-per-app",
+		Conf: &config.Config{Timeout: 5, AppRefreshConcurrency: 2, AppErrorDebounceThreshold: 1},
+	}
+	failAppA := newAppRefreshTestApp(cluster, "fail-a", []config.Route{
+		{Protocol: "tcp", CName: "127.0.0.1", Port: "1", DestinationPort: "1", Primary: true},
+	})
+	failAppA.Host = "app-a.example.com"
+	failAppB := newAppRefreshTestApp(cluster, "fail-b", []config.Route{
+		{Protocol: "tcp", CName: "127.0.0.1", Port: "1", DestinationPort: "1", Primary: true},
+	})
+	failAppB.Host = "app-b.example.com"
+	cluster.Apps = []*App{failAppA, failAppB}
+
+	cluster.maybeRefreshAppsAsync()
+
+	snap := cluster.publishedAppErrStates.Load()
+	if snap == nil {
+		t.Fatal("expected a published snapshot")
+	}
+
+	keyA := state.BuildStateKey(ErrAppTCPConnectFailed, failAppA.Host)
+	keyB := state.BuildStateKey(ErrAppTCPConnectFailed, failAppB.Host)
+	if keyA == keyB {
+		t.Fatalf("test setup error: expected distinct keys, got %q for both apps", keyA)
+	}
+	stA, okA := (*snap)[keyA]
+	stB, okB := (*snap)[keyB]
+	if !okA || !okB {
+		t.Fatalf("expected both apps' %s errors to survive aggregation, got snapshot %v", ErrAppTCPConnectFailed, *snap)
+	}
+	if stA.ServerUrl != failAppA.Host || stB.ServerUrl != failAppB.Host {
+		t.Fatalf("expected each entry to retain its own app's ServerUrl, got %q and %q", stA.ServerUrl, stB.ServerUrl)
 	}
 }
 
@@ -380,6 +423,39 @@ func TestEmitAppErrors_NoPublishedSnapshotYetIsNoop(t *testing.T) {
 
 	if cluster.StateMachine.IsInState(ErrAppConnectFailed) {
 		t.Fatalf("did not expect any state before the first published batch")
+	}
+}
+
+// TestEmitAppErrors_EmitsPerAppStateForSameErrorCode is a regression test
+// covering the full publish -> emit path: a published snapshot holding the
+// same error code for two different apps (composite-keyed, as
+// maybeRefreshAppsAsync now produces) must result in both apps' states
+// landing in the cluster-wide state machine, not just one.
+func TestEmitAppErrors_EmitsPerAppStateForSameErrorCode(t *testing.T) {
+	cluster := &Cluster{
+		Name:         "emit-errors-per-app",
+		Conf:         &config.Config{},
+		StateMachine: &state.StateMachine{},
+	}
+	cluster.StateMachine.Init()
+
+	hostA := "app-a.example.com"
+	hostB := "app-b.example.com"
+	published := map[string]state.State{
+		state.BuildStateKey(ErrAppUnexpectedStatus, hostA): {ErrKey: ErrAppUnexpectedStatus, ServerUrl: hostA, ErrDesc: "app A unexpected status"},
+		state.BuildStateKey(ErrAppUnexpectedStatus, hostB): {ErrKey: ErrAppUnexpectedStatus, ServerUrl: hostB, ErrDesc: "app B unexpected status"},
+	}
+	cluster.publishedAppErrStates.Store(&published)
+
+	cluster.EmitAppErrors()
+
+	keyA := state.BuildStateKey(ErrAppUnexpectedStatus, hostA)
+	keyB := state.BuildStateKey(ErrAppUnexpectedStatus, hostB)
+	if !cluster.StateMachine.IsInState(keyA) {
+		t.Fatalf("expected app A's %s to be emitted under %s", ErrAppUnexpectedStatus, keyA)
+	}
+	if !cluster.StateMachine.IsInState(keyB) {
+		t.Fatalf("expected app B's %s to be emitted under %s", ErrAppUnexpectedStatus, keyB)
 	}
 }
 

--- a/utils/state/state.go
+++ b/utils/state/state.go
@@ -185,17 +185,27 @@ func (SM *StateMachine) IsInSchemaMonitor() bool {
 	return SM.InSchemaMonitor
 }
 
+// BuildStateKey returns the storage key for a state entry: the bare key, or
+// "key@serverUrl" when the state is scoped to a specific server/app instance
+// and the key isn't already scoped. Shared between AddState and any code that
+// needs to pre-scope keys before they reach AddState (e.g. batching per-app
+// errors from multiple apps into one map without collisions).
+func BuildStateKey(key string, serverUrl string) string {
+	if serverUrl != "" && !strings.Contains(key, "@") {
+		return key + "@" + serverUrl
+	}
+	return key
+}
+
 // if state is cluster based the key is the error if state is server based then we concat server URL
 func (SM *StateMachine) AddState(key string, s State) {
 	//Retain the state
 	s.ErrKey = key
-	if s.ServerUrl != "" && !strings.Contains(key, "@") {
-		key = key + "@" + s.ServerUrl
-	}
+	storageKey := BuildStateKey(key, s.ServerUrl)
 	SM.Lock()
-	SM.CurState.Add(key, s)
+	SM.CurState.Add(storageKey, s)
 	if SM.heartbeats == 0 {
-		SM.OldState.Add(key, s)
+		SM.OldState.Add(storageKey, s)
 	}
 	SM.Unlock()
 }

--- a/utils/state/state_test.go
+++ b/utils/state/state_test.go
@@ -1,0 +1,39 @@
+package state
+
+import "testing"
+
+func TestBuildStateKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		serverUrl string
+		want      string
+	}{
+		{"no server url returns bare key", "APPERR002", "", "APPERR002"},
+		{"server url appends scoped suffix", "APPERR002", "app.example.com", "APPERR002@app.example.com"},
+		{"already-scoped key is left unchanged", "APPERR002@app.example.com", "app.example.com", "APPERR002@app.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BuildStateKey(tt.key, tt.serverUrl); got != tt.want {
+				t.Fatalf("BuildStateKey(%q, %q) = %q, want %q", tt.key, tt.serverUrl, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddState_ScopesKeyByServerUrl(t *testing.T) {
+	sm := &StateMachine{}
+	sm.Init()
+
+	sm.AddState("APPERR002", State{ErrType: "WARN", ServerUrl: "app-a.example.com", ErrDesc: "a"})
+	sm.AddState("APPERR002", State{ErrType: "WARN", ServerUrl: "app-b.example.com", ErrDesc: "b"})
+
+	if !sm.IsInState("APPERR002@app-a.example.com") {
+		t.Fatal("expected app A's scoped state to be present")
+	}
+	if !sm.IsInState("APPERR002@app-b.example.com") {
+		t.Fatal("expected app B's scoped state to be present")
+	}
+}


### PR DESCRIPTION
## Summary
- preserve per-app app-refresh errors in the async published snapshot
- stop same-code app errors like `APPERR002` from overwriting each other before emission
- add regression tests for publish and emit behavior with multiple apps sharing the same error code

## Why
The async app refresh path introduced in `c279e8a4b` aggregates app errors into a single `map[string]state.State` keyed only by the bare error code. When two different apps raise the same code (for example `APPERR002` for unexpected HTTP status), the later app overwrites the earlier one in the batch snapshot.

That removed effective per-app state for shared app error codes:
- detection still happened in each app
- but publication collapsed multiple apps into one cluster state entry

This change restores per-app preservation by keying the published snapshot with `state.BuildStateKey(errKey, ServerUrl)`, while still emitting the plain `ErrKey` back through `SetState()` so the stored error metadata, UI lookups, and alerts keep the expected error code.

## Validation
- `go test ./cluster -run 'TestMaybeRefreshAppsAsync_|TestEmitAppErrors_'`