### PR TITLE
fix(dashboard): correct proxy start route

### DIFF
--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -624,8 +624,8 @@ function unprovisionProxy(clusterName, proxyId, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/proxies/${proxyId}/actions/unprovision`)
 }
 
-function startProxy(clusterName, proxyId, cfgAction, baseURL) {
-  return getApi(baseURL).get(`clusters/${clusterName}/proxies/${proxyId}/actions/start/${cfgAction}`)
+function startProxy(clusterName, proxyId, baseURL) {
+  return getApi(baseURL).get(`clusters/${clusterName}/proxies/${proxyId}/actions/start`)
 }
 
 function stopProxy(clusterName, proxyId, baseURL) {


### PR DESCRIPTION
## Summary
- fix the React dashboard proxy start endpoint to use the backend route that actually exists
- remove the unused cfgAction parameter from the proxy start service helper
- preserve existing proxy stop behavior

## Validation
- npm run build

## Notes
- npm run lint still reports many pre-existing frontend lint issues unrelated to this change