### PR TITLE
fix(arbitrator): fail over backend DB connections

### DIFF
--- a/arbitrator/arbitrator.go
+++ b/arbitrator/arbitrator.go
@@ -201,6 +201,26 @@ var (
 	reconnectCooldown    = 2 * time.Second
 )
 
+// defaultArbitratorConnectTimeoutSeconds is both the flag default and the
+// fallback used whenever arbitrator-connect-timeout is non-positive.
+const defaultArbitratorConnectTimeoutSeconds = 3
+
+// arbitratorConnectTimeoutSeconds returns the configured connect/ping
+// timeout, clamping non-positive values to the default. Passing 0 through
+// unclamped would flip this flag's two use sites to opposite failure modes:
+// context.WithTimeout(ctx, 0) expires immediately (every liveness ping on an
+// otherwise-healthy connection would fail, forcing a reconnect on every
+// request), while the MySQL DSN's "timeout=0s" means unbounded on the dial
+// side — exactly backwards from what a operator typing 0 for "no timeout"
+// would expect from either.
+func arbitratorConnectTimeoutSeconds() int {
+	t := RepMan.Confs["arbitrator"].ArbitratorConnectTimeout
+	if t <= 0 {
+		return defaultArbitratorConnectTimeoutSeconds
+	}
+	return t
+}
+
 func init() {
 	cobra.OnInitialize()
 	rootCmd.AddCommand(arbitratorCmd)
@@ -208,7 +228,7 @@ func init() {
 	arbitratorCmd.Flags().StringVar(&conf.ArbitratorDriver, "arbitrator-driver", "sqlite", "sqlite|mysql, use a local sqllite or use a mysql backend")
 	arbitratorCmd.Flags().BoolVar(&conf.ArbitratorURICheck, "arbitrator-uri-check", false, "When true, validate client URI against CRM before accepting requests")
 	arbitratorCmd.Flags().StringVar(&conf.ArbitratorURICheckURL, "arbitrator-uri-check-url", "", "CRM health endpoint URL for URI validation (e.g. https://crm.cloud18.io/api/health)")
-	arbitratorCmd.Flags().IntVar(&conf.ArbitratorConnectTimeout, "arbitrator-connect-timeout", 3, "MySQL connect timeout in seconds per backend host when the arbitrator connects or reconnects, and the bound on liveness-checking an existing connection, kept short so a down host doesn't stall the whole arbitrator")
+	arbitratorCmd.Flags().IntVar(&conf.ArbitratorConnectTimeout, "arbitrator-connect-timeout", defaultArbitratorConnectTimeoutSeconds, "MySQL connect timeout in seconds per backend host when the arbitrator connects or reconnects, and the bound on liveness-checking an existing connection, kept short so a down host doesn't stall the whole arbitrator. Non-positive values fall back to the default rather than meaning \"no timeout\"")
 
 }
 
@@ -308,7 +328,7 @@ func connectArbitratorMySQL() (*sqlx.DB, error) {
 		host, port := misc.SplitHostPort(h)
 		// dbhelper.MySQLConnect uses sqlx.Connect, which already opens and
 		// pings the connection, so err == nil here implies a verified connection.
-		db, err := dbhelper.MySQLConnect(user, pass, dbhelper.GetAddress(host, port, ""), fmt.Sprintf("timeout=%ds", arbConf.ArbitratorConnectTimeout))
+		db, err := dbhelper.MySQLConnect(user, pass, dbhelper.GetAddress(host, port, ""), fmt.Sprintf("timeout=%ds", arbitratorConnectTimeoutSeconds()))
 		if err != nil {
 			lastErr = err
 			log.Warnf("Arbitrator failed to connect to MySQL backend %s: %s", h, err)
@@ -356,7 +376,7 @@ func getArbitratorDB() (*sqlx.DB, error) {
 		// would stall the whole arbitrator for every cluster, not just the one
 		// hitting the dead connection — exactly the failure mode this reconnect
 		// path exists to avoid.
-		pingTimeout := time.Duration(RepMan.Confs["arbitrator"].ArbitratorConnectTimeout) * time.Second
+		pingTimeout := time.Duration(arbitratorConnectTimeoutSeconds()) * time.Second
 		ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
 		err := arbitratorDB.PingContext(ctx)
 		cancel()
@@ -396,14 +416,12 @@ func handlerVersion(w http.ResponseWriter, r *http.Request) {
 func handlerHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 
-	db, err := getArbitratorDB()
-	if err != nil {
-		w.WriteHeader(http.StatusServiceUnavailable)
-		_ = json.NewEncoder(w).Encode(map[string]string{"status": "failed"})
-		return
-	}
-
-	if err := db.Ping(); err != nil {
+	// getArbitratorDB already validates the handle with a bounded PingContext
+	// before returning it — a second, unbounded db.Ping() here would be both
+	// redundant on the healthy path and, in the narrow window where the
+	// connection dies between the two calls, exactly the unbounded-block
+	// hazard the bounded ping was added to eliminate.
+	if _, err := getArbitratorDB(); err != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_ = json.NewEncoder(w).Encode(map[string]string{"status": "failed"})
 		return

--- a/arbitrator/arbitrator.go
+++ b/arbitrator/arbitrator.go
@@ -73,10 +73,10 @@ func newRouter() *mux.Router {
 }
 
 var (
-	uriCacheMu sync.RWMutex
-	uriCache   = make(map[string]time.Time)
+	uriCacheMu  sync.RWMutex
+	uriCache    = make(map[string]time.Time)
 	uriCacheTTL = 5 * time.Minute
-	crmClient  = &http.Client{Timeout: 5 * time.Second}
+	crmClient   = &http.Client{Timeout: 5 * time.Second}
 )
 
 func uriCheckMiddleware(next http.HandlerFunc) http.HandlerFunc {
@@ -190,7 +190,14 @@ type response struct {
 }
 
 var (
-	arbitratorDB *sqlx.DB
+	arbitratorDB   *sqlx.DB
+	arbitratorDBMu sync.Mutex
+
+	lastGoodHostMu sync.Mutex
+	lastGoodHost   string
+
+	lastReconnectAttempt time.Time
+	reconnectCooldown    = 2 * time.Second
 )
 
 func init() {
@@ -200,6 +207,7 @@ func init() {
 	arbitratorCmd.Flags().StringVar(&conf.ArbitratorDriver, "arbitrator-driver", "sqlite", "sqlite|mysql, use a local sqllite or use a mysql backend")
 	arbitratorCmd.Flags().BoolVar(&conf.ArbitratorURICheck, "arbitrator-uri-check", false, "When true, validate client URI against CRM before accepting requests")
 	arbitratorCmd.Flags().StringVar(&conf.ArbitratorURICheckURL, "arbitrator-uri-check-url", "", "CRM health endpoint URL for URI validation (e.g. https://crm.cloud18.io/api/health)")
+	arbitratorCmd.Flags().IntVar(&conf.ArbitratorConnectTimeout, "arbitrator-connect-timeout", 3, "MySQL connect timeout in seconds per backend host when the arbitrator connects or reconnects, kept short so a down host doesn't stall failover to the next one")
 
 }
 
@@ -215,26 +223,10 @@ var arbitratorCmd = &cobra.Command{
 			log.Fatal("Could not find [arbitrator] configuration section. Provide a config file with an [arbitrator] section or use the Docker env-backed entrypoint configuration.")
 		}
 
-		var err error
-		arbitratorDB, err = getArbitratorBackendStorageConnection()
-		if err != nil {
-			log.Fatal("Error opening arbitrator database: ", err)
+		if _, err := getArbitratorDB(); err != nil {
+			log.WithError(err).Error("Arbitrator database unavailable at startup, will keep retrying on incoming requests")
 		}
 
-		if RepMan.Confs["arbitrator"].ArbitratorDriver == "sqlite" {
-			arbitratorDB.SetMaxOpenConns(1)
-			arbitratorDB.SetMaxIdleConns(1)
-		}
-
-		err = arbitratorDB.Ping()
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		err = dbhelper.SetHeartbeatTable(arbitratorDB)
-		if err != nil {
-			log.WithError(err).Error("Error creating tables")
-		}
 		router := newRouter()
 		log.Infof("Arbitrator listening on %s", RepMan.Confs["arbitrator"].ArbitratorAddress)
 		log.Fatal(http.ListenAndServe(RepMan.Confs["arbitrator"].ArbitratorAddress, router))
@@ -242,48 +234,142 @@ var arbitratorCmd = &cobra.Command{
 }
 
 func getArbitratorBackendStorageConnection() (*sqlx.DB, error) {
-
-	var err error
-	var db *sqlx.DB
-	if RepMan.Confs["arbitrator"].ArbitratorDriver == "sqlite" {
-		db, err = dbhelper.SQLiteConnect(conf.WorkingDir)
+	switch RepMan.Confs["arbitrator"].ArbitratorDriver {
+	case "sqlite":
+		return dbhelper.SQLiteConnect(conf.WorkingDir)
+	case "mysql":
+		return connectArbitratorMySQL()
+	default:
+		return nil, fmt.Errorf("unsupported arbitrator-driver %q", RepMan.Confs["arbitrator"].ArbitratorDriver)
 	}
-	if RepMan.Confs["arbitrator"].ArbitratorDriver == "mysql" {
-		hosts := strings.Split(RepMan.Confs["arbitrator"].Hosts, ",")
-		if len(hosts) == 0 || hosts[0] == "" {
-			return nil, fmt.Errorf("arbitrator mysql backend requires [arbitrator].db-servers-hosts (example: \"127.0.0.1:3306\")")
-		}
-		arbConf := RepMan.Confs["arbitrator"]
-		credential := arbConf.DecryptSecretValue("db-servers-credential", arbConf.User)
-		if !strings.Contains(credential, ":") {
-			return nil, fmt.Errorf("arbitrator mysql backend requires [arbitrator].db-servers-credential in \"user:password\" format")
-		}
-		user, pass := misc.SplitPair(credential)
-		for _, h := range hosts {
-			h = strings.TrimSpace(h)
-			if h == "" {
-				continue
-			}
-			host, port := misc.SplitHostPort(h)
-			db, err = dbhelper.MySQLConnect(user, pass, dbhelper.GetAddress(host, port, ""), fmt.Sprintf("timeout=%ds", RepMan.Confs["arbitrator"].Timeout))
-			if err == nil {
-				if pingErr := db.Ping(); pingErr == nil {
-					log.Infof("Arbitrator connected to MySQL backend %s", h)
-					return db, nil
-				}
-				db.Close()
-			}
-			log.Warnf("Arbitrator failed to connect to MySQL backend %s: %s", h, err)
-		}
-		return nil, fmt.Errorf("arbitrator could not connect to any MySQL backend from: %s", RepMan.Confs["arbitrator"].Hosts)
-	}
-	return db, err
 }
 
-func getArbitratorDB() (*sqlx.DB, error) {
-	if arbitratorDB == nil {
-		return nil, fmt.Errorf("arbitrator database is not initialized")
+// arbitratorMySQLHosts returns the configured MySQL backend hosts in
+// configured order.
+func arbitratorMySQLHosts() ([]string, error) {
+	var hosts []string
+	for _, h := range strings.Split(RepMan.Confs["arbitrator"].Hosts, ",") {
+		h = strings.TrimSpace(h)
+		if h != "" {
+			hosts = append(hosts, h)
+		}
 	}
+	if len(hosts) == 0 {
+		return nil, fmt.Errorf("arbitrator mysql backend requires [arbitrator].db-servers-hosts (example: \"127.0.0.1:3306\")")
+	}
+	return hosts, nil
+}
+
+// arbitratorHostTrialOrder puts the last-known-good host first (if any),
+// followed by the remaining configured hosts in their configured order, so
+// reconnects prefer the backend that was last reachable.
+func arbitratorHostTrialOrder(hosts []string) []string {
+	lastGoodHostMu.Lock()
+	good := lastGoodHost
+	lastGoodHostMu.Unlock()
+
+	if good == "" {
+		return hosts
+	}
+	ordered := make([]string, 0, len(hosts))
+	ordered = append(ordered, good)
+	for _, h := range hosts {
+		if h != good {
+			ordered = append(ordered, h)
+		}
+	}
+	return ordered
+}
+
+func setLastGoodHost(h string) {
+	lastGoodHostMu.Lock()
+	lastGoodHost = h
+	lastGoodHostMu.Unlock()
+}
+
+// connectArbitratorMySQL tries the configured MySQL backend hosts, last-known-
+// good host first, and returns the first one that accepts a connection.
+func connectArbitratorMySQL() (*sqlx.DB, error) {
+	hosts, err := arbitratorMySQLHosts()
+	if err != nil {
+		return nil, err
+	}
+
+	arbConf := RepMan.Confs["arbitrator"]
+	credential := arbConf.DecryptSecretValue("db-servers-credential", arbConf.User)
+	if !strings.Contains(credential, ":") {
+		return nil, fmt.Errorf("arbitrator mysql backend requires [arbitrator].db-servers-credential in \"user:password\" format")
+	}
+	user, pass := misc.SplitPair(credential)
+
+	var lastErr error
+	for _, h := range arbitratorHostTrialOrder(hosts) {
+		host, port := misc.SplitHostPort(h)
+		// dbhelper.MySQLConnect uses sqlx.Connect, which already opens and
+		// pings the connection, so err == nil here implies a verified connection.
+		db, err := dbhelper.MySQLConnect(user, pass, dbhelper.GetAddress(host, port, ""), fmt.Sprintf("timeout=%ds", arbConf.ArbitratorConnectTimeout))
+		if err != nil {
+			lastErr = err
+			log.Warnf("Arbitrator failed to connect to MySQL backend %s: %s", h, err)
+			continue
+		}
+		log.Infof("Arbitrator connected to MySQL backend %s", h)
+		setLastGoodHost(h)
+		return db, nil
+	}
+	return nil, fmt.Errorf("arbitrator could not connect to any MySQL backend from: %s (last error: %v)", RepMan.Confs["arbitrator"].Hosts, lastErr)
+}
+
+// prepareNewArbitratorConnection finishes setting up a connection freshly
+// opened by getArbitratorBackendStorageConnection (pool limits, schema)
+// before it is published as the active handle. The caller only publishes the
+// connection if this succeeds. db is already a verified connection: both
+// SQLiteConnect and MySQLConnect go through sqlx.Connect, which pings before
+// returning, so no extra Ping() is needed here.
+// Schema creation is best-effort: a least-privilege MySQL account (DML-only
+// against a pre-provisioned schema) lacks CREATE and would otherwise never
+// be allowed to reconnect even though the existing table works fine.
+func prepareNewArbitratorConnection(db *sqlx.DB) {
+	if RepMan.Confs["arbitrator"].ArbitratorDriver == "sqlite" {
+		db.SetMaxOpenConns(1)
+		db.SetMaxIdleConns(1)
+	}
+	if err := dbhelper.SetHeartbeatTable(db); err != nil {
+		log.WithError(err).Warn("Error creating arbitrator heartbeat table, continuing with existing schema")
+	}
+}
+
+// getArbitratorDB is the single recovery path for the arbitrator's database
+// handle: it returns the existing connection if healthy, or transparently
+// reconnects (last-known-good host first for MySQL) if not. A short cooldown
+// avoids hammering an unreachable backend on every request.
+func getArbitratorDB() (*sqlx.DB, error) {
+	arbitratorDBMu.Lock()
+	defer arbitratorDBMu.Unlock()
+
+	if arbitratorDB != nil {
+		if err := arbitratorDB.Ping(); err == nil {
+			return arbitratorDB, nil
+		}
+		log.Warn("Arbitrator database connection lost, attempting to reconnect")
+		arbitratorDB.Close()
+		arbitratorDB = nil
+	}
+
+	if !lastReconnectAttempt.IsZero() && time.Since(lastReconnectAttempt) < reconnectCooldown {
+		return nil, fmt.Errorf("arbitrator database is unavailable, retrying shortly")
+	}
+	lastReconnectAttempt = time.Now()
+
+	newDB, err := getArbitratorBackendStorageConnection()
+	if err != nil {
+		return nil, fmt.Errorf("arbitrator database is unavailable: %w", err)
+	}
+
+	prepareNewArbitratorConnection(newDB)
+
+	arbitratorDB = newDB
+	lastReconnectAttempt = time.Time{}
 	return arbitratorDB, nil
 }
 
@@ -596,8 +682,8 @@ func handlerForget(w http.ResponseWriter, r *http.Request) {
 }
 
 type clusterStats struct {
-	Cluster   string           `json:"cluster"`
-	Instances []instanceStats  `json:"instances"`
+	Cluster   string          `json:"cluster"`
+	Instances []instanceStats `json:"instances"`
 }
 
 type instanceStats struct {

--- a/arbitrator/arbitrator.go
+++ b/arbitrator/arbitrator.go
@@ -10,6 +10,7 @@
 package arbitrator
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -207,7 +208,7 @@ func init() {
 	arbitratorCmd.Flags().StringVar(&conf.ArbitratorDriver, "arbitrator-driver", "sqlite", "sqlite|mysql, use a local sqllite or use a mysql backend")
 	arbitratorCmd.Flags().BoolVar(&conf.ArbitratorURICheck, "arbitrator-uri-check", false, "When true, validate client URI against CRM before accepting requests")
 	arbitratorCmd.Flags().StringVar(&conf.ArbitratorURICheckURL, "arbitrator-uri-check-url", "", "CRM health endpoint URL for URI validation (e.g. https://crm.cloud18.io/api/health)")
-	arbitratorCmd.Flags().IntVar(&conf.ArbitratorConnectTimeout, "arbitrator-connect-timeout", 3, "MySQL connect timeout in seconds per backend host when the arbitrator connects or reconnects, kept short so a down host doesn't stall failover to the next one")
+	arbitratorCmd.Flags().IntVar(&conf.ArbitratorConnectTimeout, "arbitrator-connect-timeout", 3, "MySQL connect timeout in seconds per backend host when the arbitrator connects or reconnects, and the bound on liveness-checking an existing connection, kept short so a down host doesn't stall the whole arbitrator")
 
 }
 
@@ -348,10 +349,21 @@ func getArbitratorDB() (*sqlx.DB, error) {
 	defer arbitratorDBMu.Unlock()
 
 	if arbitratorDB != nil {
-		if err := arbitratorDB.Ping(); err == nil {
+		// Bounded: a plain Ping() has no deadline and can block on the OS-level
+		// TCP timeout (minutes) against a backend that silently drops packets
+		// (network partition) instead of refusing the connection. Since this
+		// runs under arbitratorDBMu on every request, an unbounded ping here
+		// would stall the whole arbitrator for every cluster, not just the one
+		// hitting the dead connection — exactly the failure mode this reconnect
+		// path exists to avoid.
+		pingTimeout := time.Duration(RepMan.Confs["arbitrator"].ArbitratorConnectTimeout) * time.Second
+		ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
+		err := arbitratorDB.PingContext(ctx)
+		cancel()
+		if err == nil {
 			return arbitratorDB, nil
 		}
-		log.Warn("Arbitrator database connection lost, attempting to reconnect")
+		log.WithError(err).Warn("Arbitrator database connection lost, attempting to reconnect")
 		arbitratorDB.Close()
 		arbitratorDB = nil
 	}

--- a/arbitrator/arbitrator_test.go
+++ b/arbitrator/arbitrator_test.go
@@ -4,6 +4,8 @@
 package arbitrator
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -174,6 +176,73 @@ func TestGetArbitratorDB_SQLiteReconnectAndCooldown(t *testing.T) {
 		}
 		if !lastReconnectAttempt.IsZero() {
 			t.Error("expected lastReconnectAttempt to be reset to zero after a successful reconnect")
+		}
+	})
+}
+
+func TestArbitratorConnectTimeoutSeconds(t *testing.T) {
+	cases := []struct {
+		name       string
+		configured int
+		want       int
+	}{
+		{"positive value passes through", 5, 5},
+		{"zero clamps to default", 0, defaultArbitratorConnectTimeoutSeconds},
+		{"negative clamps to default", -1, defaultArbitratorConnectTimeoutSeconds},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			RepMan = &server.ReplicationManager{Confs: map[string]config.Config{
+				"arbitrator": {ArbitratorConnectTimeout: tc.configured},
+			}}
+			if got := arbitratorConnectTimeoutSeconds(); got != tc.want {
+				t.Errorf("arbitratorConnectTimeoutSeconds() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHandlerHealth(t *testing.T) {
+	t.Run("healthy sqlite backend returns 200", func(t *testing.T) {
+		resetArbitratorTestState(t)
+		conf.WorkingDir = t.TempDir()
+		RepMan = &server.ReplicationManager{Confs: map[string]config.Config{
+			"arbitrator": {ArbitratorDriver: "sqlite", ArbitratorConnectTimeout: 3},
+		}}
+
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		rr := httptest.NewRecorder()
+		handlerHealth(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("status = %d, want %d, body=%s", rr.Code, http.StatusOK, rr.Body.String())
+		}
+	})
+
+	t.Run("unreachable backend returns 503, not a hang", func(t *testing.T) {
+		resetArbitratorTestState(t)
+		// A directory sqlite cannot open a database file in, so every
+		// connect attempt fails and getArbitratorDB returns an error.
+		conf.WorkingDir = t.TempDir() + "/does-not-exist"
+		RepMan = &server.ReplicationManager{Confs: map[string]config.Config{
+			"arbitrator": {ArbitratorDriver: "sqlite", ArbitratorConnectTimeout: 3},
+		}}
+
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		rr := httptest.NewRecorder()
+		done := make(chan struct{})
+		go func() {
+			handlerHealth(rr, req)
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("handlerHealth did not return within 5s")
+		}
+
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Errorf("status = %d, want %d, body=%s", rr.Code, http.StatusServiceUnavailable, rr.Body.String())
 		}
 	})
 }

--- a/arbitrator/arbitrator_test.go
+++ b/arbitrator/arbitrator_test.go
@@ -1,0 +1,179 @@
+//go:build arbitrator
+// +build arbitrator
+
+package arbitrator
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/server"
+)
+
+// resetArbitratorTestState clears the package-level connection state shared
+// by getArbitratorDB and friends so tests don't leak state into each other.
+func resetArbitratorTestState(t *testing.T) {
+	t.Helper()
+	arbitratorDBMu.Lock()
+	if arbitratorDB != nil {
+		arbitratorDB.Close()
+		arbitratorDB = nil
+	}
+	lastReconnectAttempt = time.Time{}
+	arbitratorDBMu.Unlock()
+
+	lastGoodHostMu.Lock()
+	lastGoodHost = ""
+	lastGoodHostMu.Unlock()
+}
+
+func TestArbitratorHostTrialOrder(t *testing.T) {
+	hosts := []string{"h1:3306", "h2:3306", "h3:3306"}
+
+	t.Run("no last-good host keeps configured order", func(t *testing.T) {
+		resetArbitratorTestState(t)
+		got := arbitratorHostTrialOrder(hosts)
+		want := []string{"h1:3306", "h2:3306", "h3:3306"}
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("last-good host moves to front", func(t *testing.T) {
+		resetArbitratorTestState(t)
+		setLastGoodHost("h2:3306")
+		got := arbitratorHostTrialOrder(hosts)
+		want := []string{"h2:3306", "h1:3306", "h3:3306"}
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("last-good host not in current list is prepended, list unchanged otherwise", func(t *testing.T) {
+		resetArbitratorTestState(t)
+		setLastGoodHost("stale:3306")
+		got := arbitratorHostTrialOrder(hosts)
+		want := []string{"stale:3306", "h1:3306", "h2:3306", "h3:3306"}
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+}
+
+func TestArbitratorMySQLHosts(t *testing.T) {
+	t.Run("parses, trims, and drops empty entries", func(t *testing.T) {
+		RepMan = &server.ReplicationManager{Confs: map[string]config.Config{
+			"arbitrator": {Hosts: " h1:3306 ,h2:3306,,h3:3306 "},
+		}}
+		got, err := arbitratorMySQLHosts()
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		want := []string{"h1:3306", "h2:3306", "h3:3306"}
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("empty hosts config errors", func(t *testing.T) {
+		RepMan = &server.ReplicationManager{Confs: map[string]config.Config{
+			"arbitrator": {Hosts: ""},
+		}}
+		if _, err := arbitratorMySQLHosts(); err == nil {
+			t.Fatal("expected error for empty hosts, got nil")
+		}
+	})
+}
+
+func TestGetArbitratorDB_SQLiteReconnectAndCooldown(t *testing.T) {
+	resetArbitratorTestState(t)
+	defer resetArbitratorTestState(t)
+
+	tmpDir := t.TempDir()
+	conf.WorkingDir = tmpDir
+	RepMan = &server.ReplicationManager{Confs: map[string]config.Config{
+		"arbitrator": {
+			ArbitratorDriver:         "sqlite",
+			ArbitratorConnectTimeout: 3,
+		},
+	}}
+
+	db, err := getArbitratorDB()
+	if err != nil {
+		t.Fatalf("initial connect failed: %s", err)
+	}
+	if db == nil {
+		t.Fatal("expected non-nil db")
+	}
+
+	t.Run("healthy handle is reused without reconnecting", func(t *testing.T) {
+		again, err := getArbitratorDB()
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if again != db {
+			t.Error("expected the same *sqlx.DB handle to be returned when healthy")
+		}
+	})
+
+	t.Run("dead handle triggers a transparent reconnect", func(t *testing.T) {
+		arbitratorDBMu.Lock()
+		arbitratorDB.Close() // simulate the connection going bad
+		arbitratorDBMu.Unlock()
+
+		reconnected, err := getArbitratorDB()
+		if err != nil {
+			t.Fatalf("expected reconnect to succeed against the same sqlite file, got: %s", err)
+		}
+		if reconnected == db {
+			t.Error("expected a new *sqlx.DB handle after reconnect")
+		}
+	})
+
+	t.Run("cooldown short-circuits repeated attempts after a failure", func(t *testing.T) {
+		resetArbitratorTestState(t)
+		// Point at a working directory sqlite cannot open a database file in,
+		// so every connect attempt fails.
+		conf.WorkingDir = t.TempDir() + "/does-not-exist"
+
+		if _, err := getArbitratorDB(); err == nil {
+			t.Fatal("expected first attempt to fail")
+		}
+		firstAttempt := lastReconnectAttempt
+
+		start := time.Now()
+		if _, err := getArbitratorDB(); err == nil {
+			t.Fatal("expected cooldown-gated attempt to fail")
+		}
+		elapsed := time.Since(start)
+
+		if lastReconnectAttempt != firstAttempt {
+			t.Error("expected lastReconnectAttempt to be unchanged during cooldown (no real retry attempted)")
+		}
+		if elapsed >= reconnectCooldown {
+			t.Errorf("expected cooldown-gated call to return quickly, took %s", elapsed)
+		}
+
+		time.Sleep(reconnectCooldown)
+		if _, err := getArbitratorDB(); err == nil {
+			t.Fatal("expected retry after cooldown to still fail (bad path)")
+		}
+		if !lastReconnectAttempt.After(firstAttempt) {
+			t.Error("expected a fresh retry attempt after the cooldown window elapsed")
+		}
+	})
+
+	t.Run("lastReconnectAttempt resets to zero after a successful reconnect", func(t *testing.T) {
+		resetArbitratorTestState(t)
+		conf.WorkingDir = tmpDir
+
+		if _, err := getArbitratorDB(); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if !lastReconnectAttempt.IsZero() {
+			t.Error("expected lastReconnectAttempt to be reset to zero after a successful reconnect")
+		}
+	})
+}

--- a/config/config.go
+++ b/config/config.go
@@ -539,6 +539,7 @@ type Config struct {
 	ArbitratorDriver                          string                       `mapstructure:"arbitrator-driver" toml:"arbitrator-driver" json:"arbitratorDriver"`
 	ArbitratorURICheck                        bool                         `mapstructure:"arbitrator-uri-check" toml:"arbitrator-uri-check" json:"arbitratorUriCheck"`
 	ArbitratorURICheckURL                     string                       `mapstructure:"arbitrator-uri-check-url" toml:"arbitrator-uri-check-url" json:"arbitratorUriCheckUrl"`
+	ArbitratorConnectTimeout                  int                          `mapstructure:"arbitrator-connect-timeout" toml:"arbitrator-connect-timeout" json:"arbitratorConnectTimeout"`
 	ArbitrationReadTimout                     int                          `scope:"server" mapstructure:"arbitration-read-timeout" toml:"arbitration-read-timeout" json:"arbitrationReadTimout"`
 	SwitchoverCopyOldLeaderGtid               bool                         `toml:"-" json:"-"` //suspicious code
 	Test                                      bool                         `mapstructure:"test" toml:"test" json:"test"`


### PR DESCRIPTION
## Why
When the arbitrator database backend goes down, the arbitrator should not go down with it. In deployments with multiple backend database hosts, we need the arbitrator to keep serving and fail over to a secondary backend if the current or primary host is unavailable.

## What changed
- stop treating arbitrator DB connection loss as a fatal startup condition
- add reconnect logic for the arbitrator DB handle
- try configured MySQL backend hosts in order, preferring the last known good host first
- add a short per-host connect timeout so a dead primary does not stall failover
- keep heartbeat table creation best-effort so least-privilege accounts can still reconnect

## Validation
- go test -tags arbitrator ./arbitrator ./config