### PR TITLE
Fix DB log rotation cluster setting toggles

### DIFF
--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2957,6 +2957,15 @@ func (repman *ReplicationManager) switchClusterSettings(mycluster *cluster.Clust
 		mycluster.Conf.LogArbitration = !mycluster.Conf.LogArbitration
 	case "onpremise-ssh":
 		mycluster.Conf.OnPremiseSSH = !mycluster.Conf.OnPremiseSSH
+	case "db-log-rotate":
+		mycluster.Conf.DBLogRotate = !mycluster.Conf.DBLogRotate
+	case "db-log-on-backup-storage":
+		mycluster.Conf.DBLogOnBackupStorage = !mycluster.Conf.DBLogOnBackupStorage
+		// Already-running tailers keep following whatever path they were opened
+		// against; restart them so they pick up the new canonical location
+		// instead of silently going stale until a repman restart (mirrors the
+		// setClusterSetting case for this same setting).
+		mycluster.RestartDBLogTailers()
 	case "monitoring-binlog-events":
 		mycluster.SwitchMonitorBinlogEvents()
 	default:


### PR DESCRIPTION
## Summary
- handle `db-log-rotate` in the cluster settings toggle API
- handle `db-log-on-backup-storage` in the same toggle path
- restart DB log tailers immediately when the backup-storage log location is toggled so they follow the new canonical path

## Why
These DB log settings were missing from the cluster settings toggle API, so the frontend/API toggle path could not persist them consistently. The backup-storage toggle also changes the canonical fetched-log path, and without restarting the already-running tailers they keep following the old file path until Replication Manager restarts.

## Validation
- `go test ./server -run "^TestDoesNotExist$"`
