### PR TITLE
Fix WARN0190/WARN0191 alert flap (rejoin-catalog states missing from pstates30)

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -926,6 +926,7 @@ var pstates30 = []string{
 	"WARN0141", "WARN0142", "WARN0143", "WARN0150", "WARN0151", // Tresholds
 	"WARN0153", // Job related
 	"WARN0158", // Job secrets mismatch
+	"WARN0190", "WARN0191", // Rejoin catalog (HasCatalogBackupForRejoin runs %30)
 	"CREDIT01", // Credit related
 }
 

--- a/cluster/cluster_bck_test.go
+++ b/cluster/cluster_bck_test.go
@@ -2381,3 +2381,68 @@ func TestResticInitRepoWithOptions_ProceedsWhenBucketPreCheckFails(t *testing.T)
 		t.Fatal("expected init to still attempt and fail (no real restic binary here), not return nil early")
 	}
 }
+
+// TestPstates30_IncludesRejoinCatalogStates guards the contract documented in
+// doc/monitoring.md: a state whose check runs only every N ticks MUST be listed
+// in pstatesN, or it flaps open/resolve on every intermediate tick and storms
+// alerting. HasCatalogBackupForRejoin runs at heartbeats%30==0 and asserts
+// WARN0190/WARN0191, so both must be preserved by pstates30.
+func TestPstates30_IncludesRejoinCatalogStates(t *testing.T) {
+	for _, want := range []string{"WARN0190", "WARN0191"} {
+		found := false
+		for _, k := range pstates30 {
+			if k == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("pstates30 must include %s (HasCatalogBackupForRejoin runs every 30 ticks; "+
+				"without preservation the state flaps open/resolve every intermediate tick)", want)
+		}
+	}
+}
+
+// TestRejoinCatalog_WARN0191_PreservedAcrossIntermediateTicks reproduces the
+// alert-storm flap and proves pstates30 preservation fixes it. The check that
+// raises WARN0191 only runs on %30 ticks; on the 29 intermediate ticks the loop
+// calls PreserveState(pstates30...). A control state absent from pstates30 keeps
+// the test honest by verifying it really does resolve when not preserved.
+func TestRejoinCatalog_WARN0191_PreservedAcrossIntermediateTicks(t *testing.T) {
+	sm := new(state.StateMachine)
+	sm.Init()
+
+	// Tick %30==0: HasCatalogBackupForRejoin raises WARN0191 (no physical backup for rejoin).
+	sm.AddState("WARN0191", state.State{ErrType: "WARNING", ErrDesc: "no physical backup", ErrFrom: "JOIN"})
+	// Control: not in pstates30, so it must resolve on the intermediate tick.
+	sm.AddState("WARN9999", state.State{ErrType: "WARNING", ErrDesc: "control unpreserved", ErrFrom: "TEST"})
+	sm.ClearState() // end of tick 30: OldState = {WARN0191, WARN9999}, CurState = {}
+
+	if !sm.IsInState("WARN0191") {
+		t.Fatal("setup: WARN0191 should be open after the %30 tick that raised it")
+	}
+
+	// Intermediate tick (%30 != 0): the check does NOT run, so nothing re-raises the
+	// states. The monitor loop calls PreserveState(pstates30...) (cluster.go:1196).
+	sm.PreserveState(pstates30...)
+
+	resolvedHas := func(key string) bool {
+		for _, s := range sm.GetLastResolvedStates() {
+			if s.ErrKey == key {
+				return true
+			}
+		}
+		return false
+	}
+	if resolvedHas("WARN0191") {
+		t.Fatal("WARN0191 flapped to RESOLVED on an intermediate tick: it must be in pstates30")
+	}
+	if !resolvedHas("WARN9999") {
+		t.Fatal("control WARN9999 should resolve when not preserved; test is not sensitive to the flap")
+	}
+
+	sm.ClearState()
+	if !sm.IsInState("WARN0191") {
+		t.Fatal("WARN0191 dropped after an intermediate tick despite pstates30 preservation")
+	}
+}

--- a/doc/implementation/cluster/MONITOR_LOOP_FLOW.md
+++ b/doc/implementation/cluster/MONITOR_LOOP_FLOW.md
@@ -74,6 +74,7 @@ Cluster Monitor Loop (every tick, per cluster)
     │   ├── PrintDelayStat()                                               │
     │   ├── CheckJobsVersion()               (every 10)                   │
     │   ├── HasValidBackup()                 (every 30)                    │
+    │   ├── HasCatalogBackupForRejoin()      (every 30) WARN0190/WARN0191   │
     │   ├── CheckCanSaveDynamicConfig()      (every 30)                    │
     │   ├── CheckIsOverwrite()               (every 30)                    │
     │   ├── CheckAllBackupEstimatedSize()    (every 30)                    │


### PR DESCRIPTION
## Problem

`HasCatalogBackupForRejoin()` runs only every 30 ticks (`heartbeats%30==0`) and asserts **WARN0190/WARN0191**, but neither was listed in `pstates30`.

On the 29 intermediate ticks between checks, the state machine sees these states in `OldState` but not `CurState` and **resolves** them — then tick 30 re-raises them. The result is a continuous open→resolve→open **flap** that:

- spams the monitoring log (one line per transition), and
- fires **~10K Mattermost alerts/day/cluster** (every transition is an alert), making real alerts un-surveillable.

This is precisely the contract documented in `doc/monitoring.md`:

> For checks that run periodically (every N ticks), `PreserveState()` keeps their alerts visible on intermediate ticks.

A state raised by a `%N`-cadence check **must** be in `pstatesN`, or it flaps. WARN0190/WARN0191 were simply never registered.

## Fix

- **`cluster/cluster.go`** — add `WARN0190`/`WARN0191` to `pstates30` (with a comment tying them to the `%30` check).
- **`doc/implementation/cluster/MONITOR_LOOP_FLOW.md`** — the `%30` enumeration was also stale; added `HasValidBackup()` and `HasCatalogBackupForRejoin()` so the documented list matches the loop.
- **`cluster/cluster_bck_test.go`** — two regression guards:
  - `TestPstates30_IncludesRejoinCatalogStates` — membership guard.
  - `TestRejoinCatalog_WARN0191_PreservedAcrossIntermediateTicks` — reproduces the flap and proves `pstates30` preservation fixes it, with a control state (`WARN9999`, absent from `pstates30`) that must resolve — keeping the test sensitive so it fails if WARN0191 is ever removed.

## Scope / safety

Alerting/state-preservation only. No change to rejoin, failover, or any orchestration behavior — the underlying `HasCatalogBackupForRejoin()` logic is untouched; this only stops its state from self-resolving between checks.

## Test

```
go build ./cluster/            # OK
go test ./cluster/ -run 'TestPstates30_IncludesRejoinCatalogStates|TestRejoinCatalog_WARN0191_PreservedAcrossIntermediateTicks'   # PASS
```