### PR TITLE
nightly plugins: one latest set per wire, not per commit (fix WARN0206 on nightly)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,17 +146,18 @@ PLUGIN_SIGNER_CLONE := $(PLUGIN_KEY_DIR)/signer-repo
 # ---- Publishing channel -----------------------------------------------------
 # release (default): binaries → plugins/<platform>/wire-v<N>/, version symlink
 #                    keyed by the base tag (VERSION). Cut on tagged release builds.
-# nightly          : binaries → plugins/<platform>/nightly/<full-version>/, version
-#                    symlink keyed by the FULL git-describe (FULLVERSION). The back
-#                    office resolves replication-manager-<repmgr_version> exactly
-#                    (repmgr_version == FullVersion), so a nightly gets its OWN build's
-#                    plugins — matching the .sig baked in the same image — and never
-#                    clobbers the release wire-v<N>/ set. See NIGHTLY_PLUGIN_DELIVERY.
+# nightly          : binaries → plugins/<platform>/nightly/wire-v<N>/, OVERWRITTEN
+#                    every develop build — one "latest" set per wire version. No
+#                    per-commit dirs and no version symlink. The back office delivers
+#                    a nightly image exactly like a release, but instead of resolving
+#                    the exact version it picks the nightly set (the newest
+#                    nightly/wire-v<N>/). The :nightly image is a moving tag, so a
+#                    nightly container is expected to run the latest image; its
+#                    embedded .sig matches this latest set. Never clobbers release wire-v<N>/.
 PLUGIN_CHANNEL       ?= release
-PLUGIN_NIGHTLY_KEEP  ?= 10
 ifeq ($(PLUGIN_CHANNEL),nightly)
-  PLUGIN_PUBLISH_SUBDIR  := nightly/$(FULLVERSION)
-  PLUGIN_SYMLINK_VERSION := $(FULLVERSION)
+  PLUGIN_PUBLISH_SUBDIR  := nightly/wire-v$(WIRE_VERSION)
+  PLUGIN_SYMLINK_VERSION :=
 else
   PLUGIN_PUBLISH_SUBDIR  := wire-v$(WIRE_VERSION)
   PLUGIN_SYMLINK_VERSION := $(VERSION)
@@ -281,8 +282,8 @@ plugin-sigs: plugin-keys
 	@echo "Public key → $(PLUGIN_SIG_DIR)/plugin-signing.pub"
 
 # Push built plugins back to the signer repo under (channel-dependent):
-#   release: plugins/$(PLUGIN_PLATFORM)/wire-v$(WIRE_VERSION)/   + symlink replication-manager-$(VERSION)
-#   nightly: plugins/$(PLUGIN_PLATFORM)/nightly/$(FULLVERSION)/  + symlink replication-manager-$(FULLVERSION)
+#   release: plugins/$(PLUGIN_PLATFORM)/wire-v$(WIRE_VERSION)/          + symlink replication-manager-$(VERSION)
+#   nightly: plugins/$(PLUGIN_PLATFORM)/nightly/wire-v$(WIRE_VERSION)/  (overwritten, no symlink — one latest set per wire)
 # The .sig are NOT pushed here — they ship with the package/image (ShareDir); the BO
 # delivers binaries only and the instance verifies against the package .sig. Binary and
 # .sig come from this same build, so they match.
@@ -291,9 +292,9 @@ plugin-sigs: plugin-keys
 # Skipped silently for dev/source builds.
 plugin-push:
 	@if [ -n "$(PLUGIN_SIGNER_USER)" ] && [ -n "$(PLUGIN_SIGNER_TOKEN)" ] && [ -d "$(PLUGIN_SIGNER_CLONE)/.git" ]; then \
-		echo "Publishing plugins to signer repo [$(PLUGIN_CHANNEL): $(PLUGIN_SYMLINK_VERSION) → $(PLUGIN_PLATFORM)/$(PLUGIN_PUBLISH_SUBDIR)]"; \
+		echo "Publishing plugins to signer repo [$(PLUGIN_CHANNEL) → $(PLUGIN_PLATFORM)/$(PLUGIN_PUBLISH_SUBDIR)]"; \
 		WIREDIR="$(PLUGIN_SIGNER_CLONE)/plugins/$(PLUGIN_PLATFORM)/$(PLUGIN_PUBLISH_SUBDIR)"; \
-		mkdir -p "$$WIREDIR"; \
+		rm -rf "$$WIREDIR"; mkdir -p "$$WIREDIR"; \
 		for name in $(PLUGIN_NAMES); do \
 			bin=$(PLUGIN_BINDIR)/$$name; \
 			if [ -f $$bin ]; then \
@@ -301,31 +302,21 @@ plugin-push:
 				echo "  published $$name → plugins/$(PLUGIN_PLATFORM)/$(PLUGIN_PUBLISH_SUBDIR)/"; \
 			fi; \
 		done; \
-		SYMLINK_DIR="$(PLUGIN_SIGNER_CLONE)/$(PLUGIN_PLATFORM)"; \
-		mkdir -p "$$SYMLINK_DIR"; \
 		cd "$(PLUGIN_SIGNER_CLONE)" && \
-		ln -sfn "../plugins/$(PLUGIN_PLATFORM)/$(PLUGIN_PUBLISH_SUBDIR)" \
-		        "$(PLUGIN_PLATFORM)/replication-manager-$(PLUGIN_SYMLINK_VERSION)" && \
-		if [ "$(PLUGIN_CHANNEL)" = "nightly" ]; then \
-			NDIR="plugins/$(PLUGIN_PLATFORM)/nightly"; \
-			ls -1d "$$NDIR"/*/ 2>/dev/null | while read d; do \
-				ct=$$(git log -1 --format=%ct -- "$$d" 2>/dev/null); \
-				[ "$$d" = "$$NDIR/$(FULLVERSION)/" ] && ct=9999999999; \
-				printf '%s %s\n' "$${ct:-0}" "$$d"; \
-			done | sort -rn | awk 'NR>$(PLUGIN_NIGHTLY_KEEP){print $$2}' | while read old; do \
-				echo "  pruning old nightly set $$old"; rm -rf "$$old"; \
-			done; \
-			find "$(PLUGIN_PLATFORM)" -maxdepth 1 -xtype l -delete 2>/dev/null || true; \
+		if [ -n "$(PLUGIN_SYMLINK_VERSION)" ]; then \
+			mkdir -p "$(PLUGIN_PLATFORM)"; \
+			ln -sfn "../plugins/$(PLUGIN_PLATFORM)/$(PLUGIN_PUBLISH_SUBDIR)" \
+			        "$(PLUGIN_PLATFORM)/replication-manager-$(PLUGIN_SYMLINK_VERSION)"; \
 		fi; \
 		git config user.email "ci@signal18.io" && \
 		git config user.name  "replication-manager CI" && \
 		git add -A && \
 		git diff --cached --quiet || \
-		  git commit -m "plugins($(PLUGIN_CHANNEL)): $(PLUGIN_SYMLINK_VERSION) [$(PLUGIN_PLATFORM)] → $(PLUGIN_PUBLISH_SUBDIR) [$(FULLVERSION)]" && \
+		  git commit -m "plugins($(PLUGIN_CHANNEL)) [$(PLUGIN_PLATFORM)] → $(PLUGIN_PUBLISH_SUBDIR) [$(FULLVERSION)]" && \
 		AUTH_URL=$$(echo "$(PLUGIN_SIGNER_REPO)" | sed "s|https://|https://$(PLUGIN_SIGNER_USER):$(PLUGIN_SIGNER_TOKEN)@|"); \
 		git fetch --quiet "$$AUTH_URL" main && git rebase FETCH_HEAD --quiet 2>/dev/null || true; \
 		git -c http.postBuffer=104857600 push "$$AUTH_URL" HEAD:main && \
-		echo "Pushed $(PLUGIN_SYMLINK_VERSION) → $(PLUGIN_PLATFORM)/$(PLUGIN_PUBLISH_SUBDIR) to signer repo"; \
+		echo "Pushed $(PLUGIN_CHANNEL) → $(PLUGIN_PLATFORM)/$(PLUGIN_PUBLISH_SUBDIR) to signer repo"; \
 	else \
 		echo "Skipping plugin-push (no credentials or dev build)"; \
 	fi

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -295,6 +295,8 @@ type Cluster struct {
 	runUUID                             string                      `json:"-"`
 	cfgGroupDisplay                     string                      `json:"-"`
 	RepMgrVersion                       string                      `json:"-"`
+	RepMgrFullVersion                   string                      `json:"-"`
+	RepMgrRestartTime                   int64                       `json:"-"`
 	RepMgrHostname                      string                      `json:"-"`
 	exitMsg                             string                      `json:"-"`
 	exit                                atomic.Bool                 `json:"-"`
@@ -936,8 +938,8 @@ var pstates30 = []string{
 	"WARN0093", "WARN0134", "WARN0145", // Restic related
 	"WARN0101", "WARN0111", "WARN0112", // Backup related
 	"WARN0141", "WARN0142", "WARN0143", "WARN0150", "WARN0151", // Tresholds
-	"WARN0153", // Job related
-	"WARN0158", // Job secrets mismatch
+	"WARN0153",             // Job related
+	"WARN0158",             // Job secrets mismatch
 	"WARN0190", "WARN0191", // Rejoin catalog (HasCatalogBackupForRejoin runs %30)
 	"CREDIT01", // Credit related
 }
@@ -1715,8 +1717,15 @@ type ClusterState struct {
 	Crashes       crashList `json:"crashes"`
 	IsAllDbUp     bool      `json:"provisioned"`
 	RepmgrVersion string    `json:"repmgrVersion"`
-	RepmgrArch    string    `json:"repmgrArch"`
-	RepmgrOS      string    `json:"repmgrOS"`
+	// RepmgrFullVersion is the full git-describe version (e.g. v3.1.38-40-gbfd7fb334).
+	// RepmgrVersion above stays the base tag for backward compat; the BO reads this
+	// to distinguish a nightly (has a -N-g<hash> suffix) from a release.
+	RepmgrFullVersion string `json:"repmgrFullVersion"`
+	// RepmgrRestartTime is when THIS repman process started (Unix seconds) — repman's
+	// own restart time, distinct from the database-side SLA/uptime.
+	RepmgrRestartTime int64  `json:"repmgrRestartTime"`
+	RepmgrArch        string `json:"repmgrArch"`
+	RepmgrOS          string `json:"repmgrOS"`
 	// Peer health fields — consumed by the BO to build peer.json with health data,
 	// removing the need for direct peer-to-peer HTTP polling.
 	IsDown        bool `json:"isDown"`
@@ -1818,6 +1827,8 @@ func (cluster *Cluster) SaveCallBack() error {
 	clsave.Servers = cluster.Conf.Hosts
 	clsave.IsAllDbUp = cluster.IsAllDbUp
 	clsave.RepmgrVersion = cluster.RepMgrVersion
+	clsave.RepmgrFullVersion = cluster.RepMgrFullVersion
+	clsave.RepmgrRestartTime = cluster.RepMgrRestartTime
 	clsave.RepmgrArch = cluster.Conf.GoArch
 	clsave.RepmgrOS = cluster.Conf.GoOS
 	clsave.IsDown = cluster.IsDown

--- a/server/server.go
+++ b/server/server.go
@@ -3374,6 +3374,10 @@ func (repman *ReplicationManager) initCluster(clusterName string) (*cluster.Clus
 	repman.currentCluster.DiskStatManager = repman.DiskStatManager
 	repman.currentCluster.Mailer = repman.Mailer
 	repman.currentCluster.Init(repman.VersionConfs[clusterName], clusterName, &repman.tlog, &repman.Logs, repman.termlength, repman.UUID, repman.Version, repman.Hostname)
+	// Report the full git-describe version (nightly detection) and repman's own
+	// process start time to the BO via clusterstate.json — RepMgrVersion stays the base tag.
+	repman.currentCluster.RepMgrFullVersion = repman.Fullversion
+	repman.currentCluster.RepMgrRestartTime = repman.StartTime.Unix()
 	repman.Lock()
 	repman.Clusters[clusterName] = repman.currentCluster
 	repman.Unlock()


### PR DESCRIPTION
## Problem

WARN0206 *"signature mismatch for plugin plugin-security-hardening — binary may have been tampered with"* on `:nightly` instances.

The nightly channel published a **distinct plugin set per git-describe FULLVERSION** (`plugins/<platform>/nightly/<full-version>/`) with a per-commit version symlink, and BO resolved a nightly image to the **newest** such set. So a `:nightly` container running a slightly older image received binaries from a **newer** build than the one whose `.sig` is embedded in its image → signature mismatch.

Keying a plugin set to every commit is the wrong model for nightly. Nightly is a single moving thing.

## Fix

Nightly now behaves like release delivery — BO fetches binaries, the `.sig` + public key stay **embedded in the image** (via `plugin-sigs` → `share/plugins/`, unchanged and common to both channels). The only difference: nightly resolves to the **nightly set** rather than an exact version.

- `Makefile`: nightly publishes to `plugins/<platform>/nightly/wire-v<N>/`, **overwritten every build** — one latest set per wire version. No per-commit dirs, no version symlink, no pruning logic.
- `plugin-sigs` (sig + pubkey embedding) is **untouched**: `PLUGIN_SIG_DIR = share/plugins` is fixed and channel-independent.

## Paired change (separate repo)

`dbaas-portal/scripts/inject_plugins.sh`: a nightly image (base tag with no release symlink) resolves to the newest `plugins/<platform>/nightly/wire-v<N>` instead of the per-commit `replication-manager-<base>-<N>-g<hash>` symlink.

## Operational note

Because the nightly set moves, a `:nightly` container running a **stale** image (not re-pulled) can still mismatch the newer set. This model assumes nightly containers are kept on the latest image — which is the intended behavior for a moving tag.

## Test

- `make -pn PLUGIN_CHANNEL=nightly` → `PLUGIN_PUBLISH_SUBDIR = nightly/wire-v3`, `PLUGIN_SYMLINK_VERSION` empty
- `make -pn PLUGIN_CHANNEL=release` → `wire-v3` + `replication-manager-v3.1.38` (unchanged)
- `make plugin-push` (no creds) → clean skip; recipe parses

---

### Added: what repman pushes so the BO can tell nightly from release
Second commit adds `repmgrFullVersion` (full git-describe) + `repmgrRestartTime` to `ClusterState`/`clusterstate.json`. This is the missing prerequisite: repman currently reports only the **base tag** (`repmgrVersion` = `v3.1.38`), so the BO can't distinguish a nightly from a release and serves nightlies the release plugin set → WARN0206. Verified against the live BO: every `repmgrVersion` is a base tag, and the full version is committed nowhere. `repmgrVersion` stays the base tag for compat.

**BO side (paired, dbaas-portal):** generated column `repmgr_full_version` + `inject_plugins.sh` derives nightly from the `-N-g<hash>` suffix to route nightly vs release.