### PR TITLE
configurator: floor every allocated engine buffer at 128M (fix innodb_buffer_pool_size=0M)

### DIFF
--- a/cluster/configurator/configurator_get.go
+++ b/cluster/configurator/configurator_get.go
@@ -96,67 +96,88 @@ func (configurator *Configurator) getUsableMemoryMB() (int64, error) {
 	return usable, nil
 }
 
+// minEngineMemMB is the floor for any allocated storage-engine buffer, in MB.
+// Below this an engine can drop under its own startup minimum — e.g. InnoDB with
+// a 16K page size refuses to start with innodb_buffer_pool_size under 6 MiB — which
+// is exactly how a small/misresolved prov-db-memory produced innodb_buffer_pool_size=0M
+// and stopped the DB from booting. Every engine that is allocated memory gets at least this.
+const minEngineMemMB int64 = 128
+
+// engineMemMB returns an engine buffer size in MB from the usable memory and the
+// engine's shared-memory percentage. An enabled engine (pct > 0) never gets less
+// than minEngineMemMB; a disabled engine (pct <= 0) stays at 0 (so we never silently
+// turn on an engine, e.g. the query cache, that is meant to be off).
+func engineMemMB(usableMB, pct int64) int64 {
+	if pct <= 0 {
+		return 0
+	}
+	if v := usableMB * pct / 100; v > minEngineMemMB {
+		return v
+	}
+	return minEngineMemMB
+}
+
 func (configurator *Configurator) GetConfigInnoDBBPSize() string {
 	usable, err := configurator.getUsableMemoryMB()
 	if err != nil {
-		return "128"
+		return strconv.FormatInt(minEngineMemMB, 10)
 	}
 	sharedmempcts, _ := configurator.ClusterConfig.GetMemoryPctShared()
-	return strconv.FormatInt(usable*int64(sharedmempcts["innodb"])/100, 10)
+	return strconv.FormatInt(engineMemMB(usable, int64(sharedmempcts["innodb"])), 10)
 }
 
 func (configurator *Configurator) GetConfigMyISAMKeyBufferSize() string {
 	usable, err := configurator.getUsableMemoryMB()
 	if err != nil {
-		return "128"
+		return strconv.FormatInt(minEngineMemMB, 10)
 	}
 	sharedmempcts, _ := configurator.ClusterConfig.GetMemoryPctShared()
-	return strconv.FormatInt(usable*int64(sharedmempcts["myisam"])/100, 10)
+	return strconv.FormatInt(engineMemMB(usable, int64(sharedmempcts["myisam"])), 10)
 }
 
 func (configurator *Configurator) GetConfigTokuDBBufferSize() string {
 	usable, err := configurator.getUsableMemoryMB()
 	if err != nil {
-		return "128"
+		return strconv.FormatInt(minEngineMemMB, 10)
 	}
 	sharedmempcts, _ := configurator.ClusterConfig.GetMemoryPctShared()
-	return strconv.FormatInt(usable*int64(sharedmempcts["tokudb"])/100, 10)
+	return strconv.FormatInt(engineMemMB(usable, int64(sharedmempcts["tokudb"])), 10)
 }
 
 func (configurator *Configurator) GetConfigQueryCacheSize() string {
 	usable, err := configurator.getUsableMemoryMB()
 	if err != nil {
-		return "128"
+		return strconv.FormatInt(minEngineMemMB, 10)
 	}
 	sharedmempcts, _ := configurator.ClusterConfig.GetMemoryPctShared()
-	return strconv.FormatInt(usable*int64(sharedmempcts["querycache"])/100, 10)
+	return strconv.FormatInt(engineMemMB(usable, int64(sharedmempcts["querycache"])), 10)
 }
 
 func (configurator *Configurator) GetConfigAriaCacheSize() string {
 	usable, err := configurator.getUsableMemoryMB()
 	if err != nil {
-		return "128"
+		return strconv.FormatInt(minEngineMemMB, 10)
 	}
 	sharedmempcts, _ := configurator.ClusterConfig.GetMemoryPctShared()
-	return strconv.FormatInt(usable*int64(sharedmempcts["aria"])/100, 10)
+	return strconv.FormatInt(engineMemMB(usable, int64(sharedmempcts["aria"])), 10)
 }
 
 func (configurator *Configurator) GetConfigS3CacheSize() string {
 	usable, err := configurator.getUsableMemoryMB()
 	if err != nil {
-		return "128"
+		return strconv.FormatInt(minEngineMemMB, 10)
 	}
 	sharedmempcts, _ := configurator.ClusterConfig.GetMemoryPctShared()
-	return strconv.FormatInt(usable*int64(sharedmempcts["s3"])/100, 10)
+	return strconv.FormatInt(engineMemMB(usable, int64(sharedmempcts["s3"])), 10)
 }
 
 func (configurator *Configurator) GetConfigRocksDBCacheSize() string {
 	usable, err := configurator.getUsableMemoryMB()
 	if err != nil {
-		return "128"
+		return strconv.FormatInt(minEngineMemMB, 10)
 	}
 	sharedmempcts, _ := configurator.ClusterConfig.GetMemoryPctShared()
-	return strconv.FormatInt(usable*int64(sharedmempcts["rocksdb"])/100, 10)
+	return strconv.FormatInt(engineMemMB(usable, int64(sharedmempcts["rocksdb"])), 10)
 }
 
 func (configurator *Configurator) GetConfigMyISAMKeyBufferSegements() string {

--- a/cluster/configurator/configurator_mem_test.go
+++ b/cluster/configurator/configurator_mem_test.go
@@ -51,13 +51,13 @@ func TestGetConfigInnoDBBPSize(t *testing.T) {
 		mem  string
 		want string
 	}{
-		{"4G default", "4G", "1126"},       // (4096-2048)*55/100 = 1126
+		{"4G default", "4G", "1126"}, // (4096-2048)*55/100 = 1126
 		{"4g lowercase", "4g", "1126"},
 		{"4096M", "4096M", "1126"},
 		{"4096m lowercase", "4096m", "1126"},
 		{"4096 bare", "4096", "1126"},
-		{"8G", "8G", "3379"},               // (8192-2048)*55/100 = 3379
-		{"256M below reserve", "256M", "0"}, // usable=0, 0*55/100=0
+		{"8G", "8G", "3379"},                          // (8192-2048)*55/100 = 3379
+		{"256M below reserve floored", "256M", "128"}, // usable=0 → 0*55/100=0, floored to minEngineMemMB
 	}
 
 	for _, tt := range tests {
@@ -71,6 +71,16 @@ func TestGetConfigInnoDBBPSize(t *testing.T) {
 	}
 }
 
+// TestGetConfigQueryCacheSizeDisabled guards the deliberate exception: an engine
+// with a 0% share (query cache is off by default) must stay 0 and NOT be floored
+// to 128M — flooring it would silently enable a feature that is meant to be off.
+func TestGetConfigQueryCacheSizeDisabled(t *testing.T) {
+	c := newConfiguratorWithMem("8G") // plenty of usable memory
+	if got := c.GetConfigQueryCacheSize(); got != "0" {
+		t.Errorf("GetConfigQueryCacheSize(disabled 0%%) = %q, want %q", got, "0")
+	}
+}
+
 func TestGetConfigMyISAMKeyBufferSize(t *testing.T) {
 	// myisam share is 10% of usable memory
 	tests := []struct {
@@ -78,9 +88,9 @@ func TestGetConfigMyISAMKeyBufferSize(t *testing.T) {
 		mem  string
 		want string
 	}{
-		{"4G", "4G", "204"},       // (4096-2048)*10/100 = 204
+		{"4G", "4G", "204"}, // (4096-2048)*10/100 = 204
 		{"4096m", "4096m", "204"},
-		{"8G", "8G", "614"},       // (8192-2048)*10/100 = 614
+		{"8G", "8G", "614"}, // (8192-2048)*10/100 = 614
 	}
 
 	for _, tt := range tests {
@@ -102,7 +112,7 @@ func TestGetConfigAriaCacheSize(t *testing.T) {
 		want string
 	}{
 		{"4G", "4G", "204"},
-		{"1G below reserve", "1G", "0"},
+		{"1G below reserve floored", "1G", "128"}, // usable=0 → floored to minEngineMemMB
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

`GetConfigInnoDBBPSize()` — and its `myisam`/`aria`/`tokudb`/`querycache`/`s3`/`rocksdb` siblings — sized each buffer as:

```
usable = prov-db-memory - memReserveMB(2048)   // clamped to 0
buffer = usable * share% / 100
```

For any `prov-db-memory <= 2 GB`, `usable` clamps to **0**, so the buffer emits **`0M`**. InnoDB with a 16K page size refuses to start below **6 MiB**, so a small/misresolved `prov-db-memory` produces `innodb_buffer_pool_size = 0M` and **the DB will not boot** (`InnoDB: … requires innodb_buffer_pool_size >= 6 MiB, current 2 MiB` → `Plugin 'InnoDB' registration … failed`).

This was hit in the field: a DB whose `prov-db-memory` had become `256` (via `ConfigDiscovery()` back-deriving it from the live buffers) → `usable = 256-2048 → 0` → `0M` → dead instance. A unit test even asserted the broken value (`256M → 0`).

## Fix

A shared floor, applied to every engine getter:

```go
func engineMemMB(usableMB, pct int64) int64 {
    if pct <= 0 { return 0 }                 // disabled engine stays off
    if v := usableMB * pct / 100; v > minEngineMemMB { return v }
    return minEngineMemMB                     // 128M
}
```

- **Enabled** engine (share `pct > 0`) never gets less than **128M** → InnoDB always clears its start minimum.
- **Disabled** engine (`pct <= 0`, e.g. query cache at `0%`) stays **0** — we do not silently enable a feature meant to be off.

## Tests

- `256M → 128`, `1G → 128` (were `0`).
- New `TestGetConfigQueryCacheSizeDisabled`: a 0%-share engine stays `0` even at 8G.
- Large-memory expectations unchanged (`4G → 1126`, `8G → 3379`).

## Follow-up (not in this PR)

`ConfigDiscovery()` reverse-derives `prov-db-memory` by summing the *live* buffer variables, which can shrink it across restarts — that feedback loop is why `prov-db-memory` became `256` in the first place, and still needs a separate guard.