### PR TITLE
fix(dblogs): reuse rotating writers for fetched logs

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -460,6 +460,18 @@ type Cluster struct {
 	pluginRejections    map[string]string `json:"-"`
 	pluginPubKeyMissing string            `json:"-"`
 	pluginStateLock     sync.Mutex        `json:"-"`
+	// dbLogWriterMutex protects dbLogWriters, this cluster's cache of
+	// long-lived rotating writers for fetched DB log files. Cluster-scoped
+	// (not per-ServerMonitor) and keyed by canonical absolute path (see
+	// getDBLogRotatingWriter in srv_job_logs.go): a reload replaces every
+	// *ServerMonitor with a fresh instance even when the underlying host is
+	// unchanged, so a per-instance cache would otherwise let an old
+	// ServerMonitor's in-flight writer and a new ServerMonitor's freshly
+	// acquired writer both exist for the same physical file at once.
+	// Cluster-scoping and path-keying means the same cache entry is found
+	// and reused across that handoff instead.
+	dbLogWriterMutex sync.Mutex                   `json:"-"`
+	dbLogWriters     map[string]*dbLogWriterEntry `json:"-"`
 	// variableDiffSignature is the identity of the last logged variable diff
 	// set so MonitorVariablesDiff only logs/persists on real changes.
 	variableDiffSignature string `json:"-"`
@@ -2420,6 +2432,7 @@ func (cluster *Cluster) Close() {
 	for _, server := range cluster.Servers {
 		defer server.Conn.Close()
 	}
+	cluster.CloseAllDBLogWriters()
 }
 
 func (cluster *Cluster) ResetFailoverCtr() {

--- a/cluster/cluster_del.go
+++ b/cluster/cluster_del.go
@@ -20,6 +20,11 @@ func (cluster *Cluster) RemoveServerFromIndex(index int) {
 	newServers = append(newServers, cluster.Servers[:index]...)
 	newServers = append(newServers, cluster.Servers[index+1:]...)
 	cluster.Servers = newServers
+
+	// The removed server's canonical DB log paths no longer belong to any
+	// current server; close any writers cached for them (see
+	// pruneStaleDBLogWriters -- other still-valid entries are left alone).
+	cluster.pruneStaleDBLogWriters()
 }
 
 func (cluster *Cluster) RemoveServerMonitor(host string, port string) error {
@@ -46,6 +51,10 @@ func (cluster *Cluster) RemoveServerMonitor(host string, port string) error {
 		cluster.Servers = newServers
 		cluster.Unlock()
 		cluster.StateMachine.RemoveFailoverState()
+		// Same as RemoveServerFromIndex: the removed server's canonical DB
+		// log paths no longer belong to any current server, so close any
+		// writers cached for them.
+		cluster.pruneStaleDBLogWriters()
 	} else {
 		return fmt.Errorf("Host with address %s:%s not found in cluster", host, port)
 	}

--- a/cluster/cluster_sst.go
+++ b/cluster/cluster_sst.go
@@ -20,20 +20,33 @@ import (
 
 	gzip "github.com/klauspost/pgzip"
 	"github.com/signal18/replication-manager/config"
-	"github.com/signal18/replication-manager/utils/s18log"
 )
 
+// sstStreamIdleTimeout bounds how long stream_copy_to_file will wait for the
+// next byte before giving up on a stalled/hung sender. A var, not a const,
+// so tests can shrink it.
+//
+// Matches the existing 1-hour accept-deadline convention already used by
+// both SSTRunReceiverToFile and SSTRunReceiverToDBLogFile: listener
+// SetDeadline only bounds Accept() (see net.TCPListener.SetDeadline), not
+// the connection it returns, so without a deadline of its own here a stuck
+// sender blocks stream_copy_to_file's Read loop -- and anything holding the
+// SST receiver's DB log writer borrow open (see getDBLogRotatingWriter,
+// srv_job_logs.go) -- forever.
+var sstStreamIdleTimeout = time.Hour
+
 type SST struct {
-	in                io.Reader
-	file              *os.File
-	rotateWriter      io.WriteCloser
-	listener          net.Listener
-	tcplistener       *net.TCPListener
-	outfilewriter     io.Writer
-	outresticreader   io.WriteCloser
-	outfilegzipwriter *gzip.Writer
-	cluster           *Cluster
-	Filename          string // destination path, if this receiver writes to a file; used to detect an in-flight receiver for a given path (see IsFileOpenForSSTReceive)
+	in                 io.Reader
+	file               *os.File
+	rotateWriter       io.WriteCloser
+	listener           net.Listener
+	tcplistener        *net.TCPListener
+	outfilewriter      io.Writer
+	outresticreader    io.WriteCloser
+	outfilegzipwriter  *gzip.Writer
+	cluster            *Cluster
+	Filename           string // destination path, if this receiver writes to a file; used to detect an in-flight receiver for a given path (see IsFileOpenForSSTReceive)
+	dbLogWriterRelease func() // set when outfilewriter is a shared ServerMonitor.getDBLogRotatingWriter borrow; must be called exactly once when this receiver is done writing (see tcp_con_handle_to_file), so a concurrent cache eviction doesn't close the writer out from under this still-streaming receiver
 }
 
 // IsFileOpenForSSTReceive reports whether filename currently has an active
@@ -172,17 +185,24 @@ func (cluster *Cluster) SSTRunReceiverToFile(server *ServerMonitor, filename str
 	return strconv.Itoa(destinationPort), nil
 }
 
-// SSTRunReceiverToDBLogFile opens a receiver for fetched DB working-dir logs
-// (log_error.log, log_slow_query.log, log_sql_error.log, log_audit.log).
+// SSTRunReceiverToDBLogFile opens a receiver for one fetched DB working-dir
+// log (log_error.log, log_slow_query.log, log_sql_error.log, log_audit.log),
+// identified by kind.
 //
 // When cluster.Conf.DBLogRotate is disabled (compatibility-first default),
 // it behaves exactly like SSTRunReceiverToFile in append mode: repman does
 // not rotate or prune the file, leaving retention to external logrotate.
 //
-// When enabled, writes go through the shared s18log rotating writer using
-// DB-log-specific thresholds, independent of the generic log-rotate-* repman
-// settings.
-func (cluster *Cluster) SSTRunReceiverToDBLogFile(server *ServerMonitor, filename string, task string) (string, error) {
+// When enabled, writes go through this server's shared, long-lived rotating
+// writer for kind (see ServerMonitor.getDBLogRotatingWriter) using DB-log-
+// specific thresholds, independent of the generic log-rotate-* repman
+// settings. That writer is server-owned and outlives this receiver, so it is
+// intentionally not assigned to sst.rotateWriter -- only sst.outfilewriter --
+// and the borrow is released (not closed) via sst.dbLogWriterRelease once the
+// receiver's stream ends, in tcp_con_handle_to_file's cleanup.
+func (cluster *Cluster) SSTRunReceiverToDBLogFile(server *ServerMonitor, kind DBLogKind, task string) (string, error) {
+	filename := server.DBLogFilePath(kind)
+
 	if !cluster.Conf.DBLogRotate {
 		return cluster.SSTRunReceiverToFile(server, filename, ConstJobAppendFile, task)
 	}
@@ -191,21 +211,17 @@ func (cluster *Cluster) SSTRunReceiverToDBLogFile(server *ServerMonitor, filenam
 	sst.cluster = cluster
 	sst.Filename = filename
 
-	rw, err := s18log.NewRotateWriter(s18log.RotateFileConfig{
-		Filename:   filename,
-		MaxSize:    cluster.Conf.DBLogRotateMaxSize,
-		MaxBackups: cluster.Conf.DBLogRotateMaxBackup,
-		MaxAge:     cluster.Conf.DBLogRotateMaxAge,
-	})
+	rw, release, err := server.getDBLogRotatingWriter(kind)
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModSST, config.LvlErr, "Open rotating writer failed for job %s %s", filename, err)
 		return "", err
 	}
-	sst.rotateWriter = rw
 	sst.outfilewriter = rw
+	sst.dbLogWriterRelease = release
 
 	sst.listener, err = net.Listen("tcp", cluster.Conf.BindAddr+":"+cluster.SSTGetSenderPort())
 	if err != nil {
+		release()
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModSST, config.LvlErr, "Exiting SST on socket listen %s", err)
 		return "", err
 	}
@@ -320,6 +336,9 @@ func (sst *SST) tcp_con_handle_to_file(server *ServerMonitor, task string) {
 		if sst.rotateWriter != nil {
 			sst.rotateWriter.Close()
 		}
+		if sst.dbLogWriterRelease != nil {
+			sst.dbLogWriterRelease()
+		}
 		sst.listener.Close()
 		SSTs.Lock()
 		delete(SSTs.SSTconnections, port)
@@ -399,6 +418,9 @@ func (sst *SST) stream_copy_to_file() <-chan int {
 			var nBytes int
 			var err error
 
+			if con, ok := sst.in.(net.Conn); ok {
+				con.SetReadDeadline(time.Now().Add(sstStreamIdleTimeout))
+			}
 			nBytes, err = sst.in.Read(buf)
 
 			if err != nil {

--- a/cluster/cluster_sst_test.go
+++ b/cluster/cluster_sst_test.go
@@ -1,0 +1,88 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// Authors: Guillaume Lefranc <guillaume@signal18.io>
+//          Stephane Varoqui  <svaroqui@gmail.com>
+// This source code is licensed under the GNU General Public License, version 3.
+
+package cluster
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/signal18/replication-manager/config"
+)
+
+// TestStreamCopyToFile_IdleReadTimeoutEndsStalledReceiver guards against a
+// stalled/hung SST sender blocking stream_copy_to_file's Read loop forever.
+// The listener's own SetDeadline (SSTRunReceiverToFile,
+// SSTRunReceiverToDBLogFile) only bounds Accept(), not the connection it
+// returns -- sstStreamIdleTimeout is what actually bounds this loop, which
+// in turn is what lets closeDBLogWriterEntryWhenIdle's wg.Wait() resolve
+// instead of leaking a waiter goroutine forever.
+func TestStreamCopyToFile_IdleReadTimeoutEndsStalledReceiver(t *testing.T) {
+	prevTimeout := sstStreamIdleTimeout
+	sstStreamIdleTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { sstStreamIdleTimeout = prevTimeout })
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() { clientConn.Close() })
+
+	var out bytes.Buffer
+	sst := &SST{
+		in:            serverConn,
+		outfilewriter: &out,
+		cluster: &Cluster{
+			Conf: &config.Config{},
+			Name: "testcluster",
+		},
+	}
+
+	done := sst.stream_copy_to_file()
+
+	select {
+	case <-done:
+		// Expected: the idle read deadline fired, ending the loop.
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream_copy_to_file did not exit after the idle read deadline elapsed -- a stalled sender would leak this goroutine forever")
+	}
+}
+
+// TestStreamCopyToFile_CopiesDataBeforeEOF confirms the idle-deadline change
+// doesn't disturb normal operation: data written by the sender before it
+// closes the connection still reaches outfilewriter.
+func TestStreamCopyToFile_CopiesDataBeforeEOF(t *testing.T) {
+	prevTimeout := sstStreamIdleTimeout
+	t.Cleanup(func() { sstStreamIdleTimeout = prevTimeout })
+
+	clientConn, serverConn := net.Pipe()
+
+	var out bytes.Buffer
+	sst := &SST{
+		in:            serverConn,
+		outfilewriter: &out,
+		cluster: &Cluster{
+			Conf: &config.Config{},
+			Name: "testcluster",
+		},
+	}
+
+	done := sst.stream_copy_to_file()
+
+	go func() {
+		clientConn.Write([]byte("hello from sender\n"))
+		clientConn.Close()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream_copy_to_file did not exit after the sender closed the connection")
+	}
+
+	if got := out.String(); got != "hello from sender\n" {
+		t.Fatalf("expected data written before EOF to reach outfilewriter, got %q", got)
+	}
+}

--- a/cluster/cluster_sst_test.go
+++ b/cluster/cluster_sst_test.go
@@ -19,9 +19,10 @@ import (
 // stalled/hung SST sender blocking stream_copy_to_file's Read loop forever.
 // The listener's own SetDeadline (SSTRunReceiverToFile,
 // SSTRunReceiverToDBLogFile) only bounds Accept(), not the connection it
-// returns -- sstStreamIdleTimeout is what actually bounds this loop, which
-// in turn is what lets closeDBLogWriterEntryWhenIdle's wg.Wait() resolve
-// instead of leaking a waiter goroutine forever.
+// returns -- sstStreamIdleTimeout is what actually bounds this loop, which in
+// turn is what lets a stalled receiver's DB log writer borrow (see
+// getDBLogRotatingWriter, srv_job_logs.go) actually get released instead of
+// leaving a stale, still-borrowed cache entry parked forever.
 func TestStreamCopyToFile_IdleReadTimeoutEndsStalledReceiver(t *testing.T) {
 	prevTimeout := sstStreamIdleTimeout
 	sstStreamIdleTimeout = 50 * time.Millisecond

--- a/cluster/cluster_topo.go
+++ b/cluster/cluster_topo.go
@@ -48,6 +48,14 @@ func (cluster *Cluster) newServerList() error {
 
 	cluster.RefreshDatabaseConfigs()
 	cluster.Unlock()
+
+	// The DB log writer cache is Cluster-scoped and keyed by canonical path
+	// (see getDBLogRotatingWriter), not by *ServerMonitor identity, so an
+	// ordinary reload -- new *ServerMonitor objects for the same, still
+	// monitored hosts -- leaves every still-valid entry alone to be reused.
+	// This only closes entries for hosts that actually dropped out of the
+	// topology.
+	cluster.pruneStaleDBLogWriters()
 	return nil
 }
 

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -244,14 +244,14 @@ type ServerMonitor struct {
 	LastBackupMeta              ServerBackupMeta        `json:"lastBackupMeta"`
 	IsNeedPathCheck             bool
 	HasConfigPathChanged        bool
-	HasConfigDiff               bool       `json:"hasConfigDiff"` // Indicates if there are differences between deployed and generated config
-	RestartNode                 string     // RestartNode stores node parameter for restart container cookie (owned by cookie mechanism, single writer assumption)
-	RestartRid                  string     // RestartRid stores rid parameter for restart container cookie (owned by cookie mechanism, single writer assumption)
-	jobMutex                    sync.Mutex // protects IsRunningJobs flag
-	configGenMutex              sync.Mutex // protects config generation operations
-	dbLogMigrateMutex           sync.Mutex // serializes concurrent attempts at the lazy legacy->backup-backed fetched DB log migration
-	dbLogMigrated               atomic.Bool // set once a migration pass completes with no errors; left false to allow retry after a transient failure
-	backupMetaMutex             sync.Mutex  // protects LastBackupMeta from concurrent Restic callback updates
+	HasConfigDiff               bool         `json:"hasConfigDiff"` // Indicates if there are differences between deployed and generated config
+	RestartNode                 string       // RestartNode stores node parameter for restart container cookie (owned by cookie mechanism, single writer assumption)
+	RestartRid                  string       // RestartRid stores rid parameter for restart container cookie (owned by cookie mechanism, single writer assumption)
+	jobMutex                    sync.Mutex   // protects IsRunningJobs flag
+	configGenMutex              sync.Mutex   // protects config generation operations
+	dbLogMigrateMutex           sync.Mutex   // serializes concurrent attempts at the lazy legacy->backup-backed fetched DB log migration
+	dbLogMigrated               atomic.Bool  // set once a migration pass completes with no errors; left false to allow retry after a transient failure
+	backupMetaMutex             sync.Mutex   // protects LastBackupMeta from concurrent Restic callback updates
 	rejoinInProgress            atomic.Bool  // guards RejoinMaster re-entrancy so it runs async (a reseed can take hours/days; it must never block the monitor loop)
 	reseedFromRejoin            atomic.Bool  // set when a rejoin armed an ASYNC reseed; reconcileDeferredRejoinReseeds records finishRejoin from observed health once the reseed completes (IsReseeding clears), and RejoinMaster holds the one-shot while it is set
 	rejoinReseedStart           atomic.Int64 // unix-nanos when the rejoin armed its reseed; drives the generic "rejoin reseed in progress, started T" state (WARN0189) for methods without byte instrumentation

--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -1301,24 +1301,34 @@ func (server *ServerMonitor) GetSlowLogTable(wg *sync.WaitGroup) error {
 		return fmt.Errorf("Error truncate slow logs buffer table on %s. Err : %v", server.URL, err)
 	}
 
-	logfile := server.DBLogFilePath(DBLogSlowQuery)
-	var f io.WriteCloser
+	var f io.Writer
+	releaseWriter := func() {} // no-op unless the DBLogRotate branch below sets it
 	if cluster.Conf.DBLogRotate {
-		f, err = s18log.NewRotateWriter(s18log.RotateFileConfig{
-			Filename:   logfile,
-			MaxSize:    cluster.Conf.DBLogRotateMaxSize,
-			MaxBackups: cluster.Conf.DBLogRotateMaxBackup,
-			MaxAge:     cluster.Conf.DBLogRotateMaxAge,
-		})
+		// Shared, server-owned rotating writer: reused across calls instead
+		// of opening a fresh lumberjack.Logger every time, so callers must
+		// NOT close it -- release it instead (see getDBLogRotatingWriter).
+		var rawRelease func()
+		f, rawRelease, err = server.getDBLogRotatingWriter(DBLogSlowQuery)
+		if err != nil {
+			return fmt.Errorf("Error writing slow queries logs on %s. Err : %v", server.URL, err)
+		}
+		// sync.Once so releaseWriter can be called explicitly right after the
+		// last write below *and* safely again via defer (covering any error
+		// return in between) without double-Done()-ing the entry's WaitGroup.
+		var once sync.Once
+		releaseWriter = func() { once.Do(rawRelease) }
+		defer releaseWriter()
 	} else {
 		// db-log-rotate disabled: append only, no rotation/pruning, leave
 		// retention to external logrotate/custom tooling.
-		f, err = os.OpenFile(logfile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+		logfile := server.DBLogFilePath(DBLogSlowQuery)
+		file, ferr := os.OpenFile(logfile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+		if ferr != nil {
+			return fmt.Errorf("Error writing slow queries logs on %s. Err : %v", server.URL, ferr)
+		}
+		defer file.Close()
+		f = file
 	}
-	if err != nil {
-		return fmt.Errorf("Error writing slow queries logs on %s. Err : %v", server.URL, err)
-	}
-	defer f.Close()
 
 	// Stream rows one at a time instead of loading the whole buffer table
 	// into memory: this query has no LIMIT, and a large backlog (first run
@@ -1354,6 +1364,12 @@ func (server *ServerMonitor) GetSlowLogTable(wg *sync.WaitGroup) error {
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("Error iterating slow queries logs in buffer table on %s: %v", server.URL, err)
 	}
+
+	// Done writing through f: release now instead of waiting for this call's
+	// ~60s tail (RotateSystemLogs + Sleep below), so a reload racing with
+	// that tail can't leave this borrow open for tens of seconds after the
+	// last actual write (see getDBLogRotatingWriter).
+	releaseWriter()
 
 	if err := dbhelper.MoveLogsToDailyTable(Conn, server.DBVersion, "slow_log", timeStampString, timeout); err != nil {
 		return fmt.Errorf("Error moving logs from buffer to daily table on %s: %v", server.URL, err)

--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -1304,7 +1304,7 @@ func (server *ServerMonitor) GetSlowLogTable(wg *sync.WaitGroup) error {
 	var f io.Writer
 	releaseWriter := func() {} // no-op unless the DBLogRotate branch below sets it
 	if cluster.Conf.DBLogRotate {
-		// Shared, server-owned rotating writer: reused across calls instead
+		// Shared, cluster-owned rotating writer: reused across calls instead
 		// of opening a fresh lumberjack.Logger every time, so callers must
 		// NOT close it -- release it instead (see getDBLogRotatingWriter).
 		var rawRelease func()
@@ -1314,7 +1314,9 @@ func (server *ServerMonitor) GetSlowLogTable(wg *sync.WaitGroup) error {
 		}
 		// sync.Once so releaseWriter can be called explicitly right after the
 		// last write below *and* safely again via defer (covering any error
-		// return in between) without double-Done()-ing the entry's WaitGroup.
+		// return in between) without double-releasing -- rawRelease is
+		// already idempotent on its own (see releaseDBLogWriterFunc), so this
+		// is defense in depth, not strictly required.
 		var once sync.Once
 		releaseWriter = func() { once.Do(rawRelease) }
 		defer releaseWriter()

--- a/cluster/srv_job_logs.go
+++ b/cluster/srv_job_logs.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -103,6 +104,84 @@ func (cluster *Cluster) RestartDBLogTailers() {
 		srv.dbLogMigrated.Store(false)
 		srv.RestartLogTailers()
 	}
+	// Every server's DBLogFilePath just moved (legacy <-> backup-backed), so
+	// every currently-cached writer is now keyed by a stale path; nothing
+	// will ever look it up again under that old key.
+	cluster.pruneStaleDBLogWriters()
+}
+
+// CloseAllDBLogWriters closes every cached DB log rotating writer for this
+// cluster that is not currently borrowed, and marks every borrowed one stale
+// so its last release (see getDBLogRotatingWriter) closes it instead. Call
+// whenever every cached path can become stale or unreachable at once and
+// nothing else would notice:
+//   - db-log-rotate disabled at runtime (server/api_cluster.go) -- unlike a
+//     path/threshold change, nothing re-acquires (and so nothing lazily
+//     replaces) a cached writer once DBLogRotate goes false, since both call
+//     sites (GetSlowLogTable, SSTRunReceiverToDBLogFile) gate on the flag
+//     before ever calling getDBLogRotatingWriter.
+//   - cluster teardown (Cluster.Close).
+//
+// For a reload or single-server removal, where most cached paths are still
+// valid and should be left alone/reused, use pruneStaleDBLogWriters instead.
+func (cluster *Cluster) CloseAllDBLogWriters() {
+	cluster.dbLogWriterMutex.Lock()
+	defer cluster.dbLogWriterMutex.Unlock()
+
+	for path, entry := range cluster.dbLogWriters {
+		if entry.borrowers > 0 {
+			entry.stale = true
+			continue
+		}
+		delete(cluster.dbLogWriters, path)
+		entry.writer.Close()
+	}
+}
+
+// pruneStaleDBLogWriters closes every cached DB log writer whose canonical
+// path no longer corresponds to any current server's DBLogFilePath (marking
+// a still-borrowed one stale instead, same as CloseAllDBLogWriters -- see
+// getDBLogRotatingWriter). Call after cluster.Servers changes (reload's
+// newServerList, server removal) or after any single server's canonical DB
+// log path changes (a db-log-on-backup-storage flip, via
+// RestartDBLogTailers).
+//
+// This is deliberately NOT "close everything and let callers recreate":
+// an ordinary reload gives every still-monitored host a brand new
+// *ServerMonitor object (see newServerMonitor), even though its
+// DBLogFilePath is unchanged. Evicting on every reload would let an old
+// ServerMonitor's in-flight GetSlowLogTable/SST borrow and a new
+// ServerMonitor's freshly acquired writer both exist for the same physical
+// path at once -- two independent *lumberjack.Logger instances with
+// independent size/rotation bookkeeping, which can lose data into a backup
+// file if either one rotates. Diffing by path and only closing entries with
+// no current owner avoids that: still-valid entries are left cached and
+// reused across the handoff.
+func (cluster *Cluster) pruneStaleDBLogWriters() {
+	valid := make(map[string]bool)
+	for _, srv := range cluster.Servers {
+		if srv == nil {
+			continue
+		}
+		for _, kind := range []DBLogKind{DBLogError, DBLogSlowQuery, DBLogAudit, DBLogSqlError} {
+			valid[srv.DBLogFilePath(kind)] = true
+		}
+	}
+
+	cluster.dbLogWriterMutex.Lock()
+	defer cluster.dbLogWriterMutex.Unlock()
+
+	for path, entry := range cluster.dbLogWriters {
+		if valid[path] {
+			continue
+		}
+		if entry.borrowers > 0 {
+			entry.stale = true
+			continue
+		}
+		delete(cluster.dbLogWriters, path)
+		entry.writer.Close()
+	}
 }
 
 // maybeRetryDBLogMigration re-attempts the legacy->backup-backed DB log
@@ -155,6 +234,154 @@ func (server *ServerMonitor) DBLogDir() string {
 // DBLogFilePath returns the canonical path for one fetched DB log file.
 func (server *ServerMonitor) DBLogFilePath(kind DBLogKind) string {
 	return filepath.Join(server.DBLogDir(), kind.filename())
+}
+
+// dbLogWriterEntry is one cached, long-lived rotating writer for a fetched DB
+// log file, keyed by its canonical absolute path in Cluster.dbLogWriters
+// (see getDBLogRotatingWriter), along with the rotation thresholds it was
+// opened against.
+//
+// borrowers and stale (both protected by Cluster.dbLogWriterMutex, like the
+// map itself) track in-flight borrows and defer closing a writer that no
+// longer matches -- a threshold change, a path becoming unreachable
+// (pruneStaleDBLogWriters), CloseAllDBLogWriters, or cluster teardown --
+// until the last borrower releases it, instead of replacing it immediately.
+// Replacing immediately would let a still-in-flight borrower (the SST
+// receiver path, SSTRunReceiverToDBLogFile, can hold one open for as long as
+// sstStreamIdleTimeout allows via an async goroutine, stream_copy_to_file,
+// that keeps writing after the acquire call returns) keep using the old
+// writer while a fresh acquire gets a second, independent *lumberjack.Logger
+// for the very same path -- two independent size/rotation bookkeepers that
+// can lose data into a backup file if either one rotates. Marking stale and
+// deferring the swap keeps at most one live writer per path at all times, at
+// the cost of a threshold/path change not taking effect until whoever is
+// currently borrowing the old writer finishes.
+type dbLogWriterEntry struct {
+	writer     io.WriteCloser
+	maxSize    int
+	maxBackups int
+	maxAge     int
+	borrowers  int
+	stale      bool
+}
+
+// getDBLogRotatingWriter acquires this cluster's long-lived rotating writer
+// for server/kind, creating it -- or replacing it, once no borrower is left
+// using it, if the db-log-rotate-max-* thresholds changed at runtime
+// (server/api_cluster.go) -- as needed. Only call when
+// cluster.Conf.DBLogRotate is true.
+//
+// The cache is Cluster-scoped and keyed by server.DBLogFilePath(kind), not
+// per-ServerMonitor: a reload replaces every *ServerMonitor with a fresh
+// instance even for an unchanged host (see newServerMonitor), so keying by
+// ServerMonitor identity would make an ordinary reload evict and recreate a
+// writer whose underlying file hasn't gone anywhere, opening a window where
+// an old ServerMonitor's still-in-flight borrow and a new ServerMonitor's
+// fresh writer both exist for the same physical path at once. Keying by path
+// instead means both old and new ServerMonitor objects for the same host
+// resolve to the very same cache entry.
+//
+// lumberjack.Logger.MaxSize/MaxBackups/MaxAge are plain fields copied in at
+// construction, not re-read from cluster.Conf on every write, so a runtime
+// threshold change would otherwise never reach an already-cached writer.
+// Comparing them here on every acquire keeps that setting live the same way
+// it was before caching was introduced -- modulo the deferral described on
+// dbLogWriterEntry: a threshold change while the current writer is still
+// borrowed keeps serving that writer (now marked stale) to every acquirer
+// until the last one releases it, rather than risk a second live writer for
+// the same path.
+//
+// The returned writer is cluster-owned: callers write to it but must NOT
+// close it. Instead, the caller MUST call the returned release func exactly
+// once when it is done writing through it -- when GetSlowLogTable's export
+// finishes, or when an SST receiver's stream ends.
+//
+// A fresh lumberjack.Logger leaks a goroutine on every Close (mill() starts
+// millRun on first Write, and Close never stops it), so creating one per call
+// -- as this used to do -- accumulates one leaked goroutine per call. Caching
+// it here means the leak happens at most once per path/threshold-set instead
+// of once per call.
+func (server *ServerMonitor) getDBLogRotatingWriter(kind DBLogKind) (io.Writer, func(), error) {
+	cluster := server.ClusterGroup
+	logfile := server.DBLogFilePath(kind)
+	maxSize := cluster.Conf.DBLogRotateMaxSize
+	maxBackups := cluster.Conf.DBLogRotateMaxBackup
+	maxAge := cluster.Conf.DBLogRotateMaxAge
+
+	cluster.dbLogWriterMutex.Lock()
+	defer cluster.dbLogWriterMutex.Unlock()
+
+	if entry := cluster.dbLogWriters[logfile]; entry != nil {
+		matches := entry.maxSize == maxSize && entry.maxBackups == maxBackups && entry.maxAge == maxAge
+		if !entry.stale && matches {
+			entry.borrowers++
+			return entry.writer, cluster.releaseDBLogWriterFunc(logfile, entry), nil
+		}
+		if entry.borrowers > 0 {
+			// Still borrowed: keep serving this writer (now stale) rather
+			// than start a second live *lumberjack.Logger for this path. The
+			// last release below swaps it out.
+			entry.stale = true
+			entry.borrowers++
+			return entry.writer, cluster.releaseDBLogWriterFunc(logfile, entry), nil
+		}
+		// Nobody borrowing it: safe to replace right now.
+		delete(cluster.dbLogWriters, logfile)
+		entry.writer.Close()
+	}
+
+	rw, err := s18log.NewRotateWriter(s18log.RotateFileConfig{
+		Filename:   logfile,
+		MaxSize:    maxSize,
+		MaxBackups: maxBackups,
+		MaxAge:     maxAge,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	entry := &dbLogWriterEntry{writer: rw, maxSize: maxSize, maxBackups: maxBackups, maxAge: maxAge, borrowers: 1}
+
+	if cluster.dbLogWriters == nil {
+		cluster.dbLogWriters = make(map[string]*dbLogWriterEntry)
+	}
+	cluster.dbLogWriters[logfile] = entry
+	return rw, cluster.releaseDBLogWriterFunc(logfile, entry), nil
+}
+
+// releaseDBLogWriterFunc returns the release func getDBLogRotatingWriter
+// hands back to a caller: decrements entry's borrower count, and if that was
+// the last borrower of a stale entry, removes it from the cache and closes
+// its writer. A non-stale entry's release is just accounting -- it stays
+// cached for reuse.
+//
+// Wrapped in a sync.Once so the func is safe to call more than once: callers
+// are documented to call it exactly once, but a defensive Once here means a
+// caller mistake (e.g. an extra defer alongside an explicit call on an early
+// return path) can't double-decrement borrowers -- which would otherwise
+// desync the count from actual outstanding borrows and risk closing a writer
+// a still-active, unrelated borrower is using.
+func (cluster *Cluster) releaseDBLogWriterFunc(logfile string, entry *dbLogWriterEntry) func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			cluster.dbLogWriterMutex.Lock()
+			defer cluster.dbLogWriterMutex.Unlock()
+
+			entry.borrowers--
+			if entry.borrowers > 0 || !entry.stale {
+				return
+			}
+			// Only remove it if it's still the cached entry for this path --
+			// always true in practice, since a stale entry is never replaced
+			// in the map until it drains (see getDBLogRotatingWriter), but
+			// cheap to guard rather than assume.
+			if cluster.dbLogWriters[logfile] == entry {
+				delete(cluster.dbLogWriters, logfile)
+			}
+			entry.writer.Close()
+		})
+	}
 }
 
 // ensureDBLogsMigrated runs the legacy->backup-backed DB log migration at
@@ -310,9 +537,7 @@ func (server *ServerMonitor) JobBackupErrorLog() (int64, error) {
 	}
 	server.SetWaitErrorlogCookie()
 
-	filename := server.DBLogFilePath(DBLogError)
-
-	port, err := cluster.SSTRunReceiverToDBLogFile(server, filename, task)
+	port, err := cluster.SSTRunReceiverToDBLogFile(server, DBLogError, task)
 	if err != nil {
 		return 0, nil
 	}
@@ -335,9 +560,7 @@ func (server *ServerMonitor) JobBackupAuditLog() (int64, error) {
 	}
 	server.SetWaitAuditlogCookie()
 
-	filename := server.DBLogFilePath(DBLogAudit)
-
-	port, err := cluster.SSTRunReceiverToDBLogFile(server, filename, task)
+	port, err := cluster.SSTRunReceiverToDBLogFile(server, DBLogAudit, task)
 	if err != nil {
 		return 0, nil
 	}
@@ -360,9 +583,7 @@ func (server *ServerMonitor) JobBackupSqlErrorLog() (int64, error) {
 	}
 	server.SetWaitSqlErrorlogCookie()
 
-	filename := server.DBLogFilePath(DBLogSqlError)
-
-	port, err := cluster.SSTRunReceiverToDBLogFile(server, filename, task)
+	port, err := cluster.SSTRunReceiverToDBLogFile(server, DBLogSqlError, task)
 	if err != nil {
 		return 0, nil
 	}
@@ -388,9 +609,7 @@ func (server *ServerMonitor) JobBackupSlowQueryLog() (int64, error) {
 		return 0, nil
 	}
 
-	filename := server.DBLogFilePath(DBLogSlowQuery)
-
-	port, err := cluster.SSTRunReceiverToDBLogFile(server, filename, task)
+	port, err := cluster.SSTRunReceiverToDBLogFile(server, DBLogSlowQuery, task)
 	if err != nil {
 		return 0, nil
 	}

--- a/cluster/srv_job_logs_test.go
+++ b/cluster/srv_job_logs_test.go
@@ -9,10 +9,24 @@ import (
 	"time"
 
 	"github.com/hpcloud/tail"
+	"github.com/jmoiron/sqlx"
 	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/state"
 )
 
 func newTestServerForDBLogs(t *testing.T, workingDir string) *ServerMonitor {
+	t.Helper()
+	return newTestServerForDBLogsWithHost(t, workingDir, "node1", "3306")
+}
+
+// newTestServerForDBLogsWithHost is newTestServerForDBLogs for tests that
+// need multiple distinct servers -- Datadir (and so every DBLogFilePath) is
+// derived from host/port, so distinct hosts get genuinely distinct canonical
+// DB log paths. Needed because the DB log writer cache is now keyed by
+// absolute path (see getDBLogRotatingWriter), so two ServerMonitor fixtures
+// that happened to share a Datadir would collide in the cache regardless of
+// their Host field.
+func newTestServerForDBLogsWithHost(t *testing.T, workingDir string, host string, port string) *ServerMonitor {
 	t.Helper()
 	cluster := &Cluster{
 		Conf: &config.Config{
@@ -22,9 +36,9 @@ func newTestServerForDBLogs(t *testing.T, workingDir string) *ServerMonitor {
 	}
 	server := &ServerMonitor{
 		ClusterGroup: cluster,
-		Datadir:      filepath.Join(workingDir, "cluster-dir", "node1_3306"),
-		Host:         "node1",
-		Port:         "3306",
+		Datadir:      filepath.Join(workingDir, "cluster-dir", host+"_"+port),
+		Host:         host,
+		Port:         port,
 	}
 	return server
 }
@@ -671,6 +685,639 @@ func TestNewLogTailer_PrunesOldStyleRotatedFilesWhenRotateEnabled(t *testing.T) 
 	}
 }
 
+// TestGetDBLogRotatingWriter_ReusesSameWriterAcrossCalls guards against the
+// original bug: NewRotateWriter used to be called fresh on every fetch/job,
+// and each fresh *lumberjack.Logger leaks a millRun goroutine on Close (mill()
+// starts it on first Write; Close never stops it). Repeated calls for the
+// same server/kind must now return the exact same writer instance instead of
+// allocating a new one.
+func TestGetDBLogRotatingWriter_ReusesSameWriterAcrossCalls(t *testing.T) {
+	tmp := t.TempDir()
+	server := newTestServerForDBLogs(t, tmp)
+	server.ClusterGroup.Conf.DBLogRotate = true
+
+	w1, release1, err := server.getDBLogRotatingWriter(DBLogSlowQuery)
+	if err != nil {
+		t.Fatalf("first getDBLogRotatingWriter call returned error: %v", err)
+	}
+	defer release1()
+	w2, release2, err := server.getDBLogRotatingWriter(DBLogSlowQuery)
+	if err != nil {
+		t.Fatalf("second getDBLogRotatingWriter call returned error: %v", err)
+	}
+	defer release2()
+	if w1 != w2 {
+		t.Fatal("expected repeated calls for the same kind to return the same cached writer instance")
+	}
+
+	if len(server.ClusterGroup.dbLogWriters) != 1 {
+		t.Fatalf("expected exactly one cached writer entry, got %d", len(server.ClusterGroup.dbLogWriters))
+	}
+}
+
+// TestGetDBLogRotatingWriter_DistinctKindsGetDistinctWriters confirms the
+// cache is keyed per canonical path, not shared across all four fetched log
+// files for one server.
+func TestGetDBLogRotatingWriter_DistinctKindsGetDistinctWriters(t *testing.T) {
+	tmp := t.TempDir()
+	server := newTestServerForDBLogs(t, tmp)
+	server.ClusterGroup.Conf.DBLogRotate = true
+
+	errW, releaseErr, err := server.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter(DBLogError) returned error: %v", err)
+	}
+	defer releaseErr()
+	slowW, releaseSlow, err := server.getDBLogRotatingWriter(DBLogSlowQuery)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter(DBLogSlowQuery) returned error: %v", err)
+	}
+	defer releaseSlow()
+	if errW == slowW {
+		t.Fatal("expected distinct DBLogKinds to get distinct writers")
+	}
+	if len(server.ClusterGroup.dbLogWriters) != 2 {
+		t.Fatalf("expected two cached writer entries, got %d", len(server.ClusterGroup.dbLogWriters))
+	}
+}
+
+// TestGetDBLogRotatingWriter_DistinctServersGetDistinctWriters confirms the
+// cluster-scoped cache does not accidentally collapse two different
+// servers' entries for the same DBLogKind onto one writer.
+func TestGetDBLogRotatingWriter_DistinctServersGetDistinctWriters(t *testing.T) {
+	tmp := t.TempDir()
+	node1 := newTestServerForDBLogsWithHost(t, tmp, "node1", "3306")
+	node2 := newTestServerForDBLogsWithHost(t, tmp, "node2", "3306")
+	node2.ClusterGroup = node1.ClusterGroup
+	node1.ClusterGroup.Conf.DBLogRotate = true
+
+	w1, release1, err := node1.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter for node1 returned error: %v", err)
+	}
+	defer release1()
+	w2, release2, err := node2.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter for node2 returned error: %v", err)
+	}
+	defer release2()
+
+	if w1 == w2 {
+		t.Fatal("expected distinct servers to get distinct writers even for the same DBLogKind")
+	}
+	if len(node1.ClusterGroup.dbLogWriters) != 2 {
+		t.Fatalf("expected two cached writer entries (one per server), got %d", len(node1.ClusterGroup.dbLogWriters))
+	}
+}
+
+// TestGetDBLogRotatingWriter_OrdinaryReloadReusesSameWriter is the core
+// regression test for the cluster-scoped, path-keyed redesign: an ordinary
+// reload (same host, brand new *ServerMonitor object -- see
+// newServerMonitor, which never reuses an existing instance) must resolve to
+// the SAME cached writer as the old ServerMonitor, not a second independent
+// one. Two independent *lumberjack.Logger instances for the same path have
+// independent size/rotation bookkeeping and can lose data into a backup file
+// if either one rotates -- which is exactly what a per-ServerMonitor cache
+// allowed across a reload racing a long-running GetSlowLogTable export.
+func TestGetDBLogRotatingWriter_OrdinaryReloadReusesSameWriter(t *testing.T) {
+	tmp := t.TempDir()
+	oldServer := newTestServerForDBLogs(t, tmp)
+	oldServer.ClusterGroup.Conf.DBLogRotate = true
+
+	oldWriter, oldRelease, err := oldServer.getDBLogRotatingWriter(DBLogSlowQuery)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter on old server returned error: %v", err)
+	}
+	defer oldRelease()
+
+	// Simulate a reload: a brand new *ServerMonitor for the identical host
+	// (same Datadir/Host/Port -- same ClusterGroup), exactly as
+	// newServerMonitor produces on every reload regardless of whether the
+	// host actually changed.
+	newServer := newTestServerForDBLogs(t, tmp)
+	newServer.ClusterGroup = oldServer.ClusterGroup
+
+	newWriter, newRelease, err := newServer.getDBLogRotatingWriter(DBLogSlowQuery)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter on new server returned error: %v", err)
+	}
+	defer newRelease()
+
+	if oldWriter != newWriter {
+		t.Fatal("expected the new ServerMonitor to resolve to the same cached writer as the old one for an unchanged path")
+	}
+	if len(oldServer.ClusterGroup.dbLogWriters) != 1 {
+		t.Fatalf("expected exactly one cache entry shared across both ServerMonitor instances, got %d", len(oldServer.ClusterGroup.dbLogWriters))
+	}
+}
+
+// TestGetDBLogRotatingWriter_ReplacesWriterWhenMaxSettingsChange guards
+// against a regression where db-log-rotate-max-size/backup/age (mutable at
+// runtime via the cluster settings API, server/api_cluster.go) would get
+// baked into a cached writer at creation and then silently stop applying
+// after that, since lumberjack.Logger's MaxSize/MaxBackups/MaxAge are plain
+// fields copied in once, not re-read from cluster.Conf on every write.
+func TestGetDBLogRotatingWriter_ReplacesWriterWhenMaxSettingsChange(t *testing.T) {
+	tmp := t.TempDir()
+	server := newTestServerForDBLogs(t, tmp)
+	server.ClusterGroup.Conf.DBLogRotate = true
+	server.ClusterGroup.Conf.DBLogRotateMaxSize = 100
+	server.ClusterGroup.Conf.DBLogRotateMaxBackup = 10
+	server.ClusterGroup.Conf.DBLogRotateMaxAge = 7
+
+	w1, release1, err := server.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("first getDBLogRotatingWriter call returned error: %v", err)
+	}
+	release1()
+
+	// Simulate a runtime "db-log-rotate-max-size" API call.
+	server.ClusterGroup.Conf.DBLogRotateMaxSize = 250
+
+	w2, release2, err := server.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter after threshold change returned error: %v", err)
+	}
+	defer release2()
+	if w1 == w2 {
+		t.Fatal("expected a new writer instance once db-log-rotate-max-size changed at runtime")
+	}
+	logfile := server.DBLogFilePath(DBLogError)
+	if server.ClusterGroup.dbLogWriters[logfile].maxSize != 250 {
+		t.Fatalf("expected cached entry to record the new maxSize, got %d", server.ClusterGroup.dbLogWriters[logfile].maxSize)
+	}
+
+	// A repeated call with unchanged settings must go back to reusing the
+	// writer, not keep recreating it forever.
+	w3, release3, err := server.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter returned error: %v", err)
+	}
+	defer release3()
+	if w2 != w3 {
+		t.Fatal("expected the writer to be reused once settings stop changing")
+	}
+}
+
+// TestGetDBLogRotatingWriter_EvictionDoesNotCloseWriterWhileBorrowed guards
+// against the core risk this refcounting exists to prevent: an eviction
+// (threshold change, CloseAllDBLogWriters, pruneStaleDBLogWriters) racing
+// with a long-lived borrower -- an SST receiver's async stream_copy_to_file
+// goroutine can hold a writer open for as long as sstStreamIdleTimeout
+// allows -- must not actually Close the underlying writer until that
+// borrower releases it, since lumberjack silently reopens a closed writer on
+// next Write rather than erroring, which would otherwise leave two
+// independent *lumberjack.Logger instances (with independent size/rotation
+// bookkeeping) writing the same path concurrently.
+func TestGetDBLogRotatingWriter_EvictionDoesNotCloseWriterWhileBorrowed(t *testing.T) {
+	tmp := t.TempDir()
+	server := newTestServerForDBLogs(t, tmp)
+	server.ClusterGroup.Conf.DBLogRotate = true
+
+	if err := os.MkdirAll(server.legacyDBLogDir(), 0755); err != nil {
+		t.Fatalf("failed to create legacy dir: %v", err)
+	}
+
+	// Simulate a long-lived borrower (an in-flight SST receiver) that has
+	// acquired the writer but not released it yet.
+	w, release, err := server.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter returned error: %v", err)
+	}
+	if _, err := w.Write([]byte("in-flight receiver data\n")); err != nil {
+		t.Fatalf("write through the borrowed writer failed: %v", err)
+	}
+
+	// Evict it (mirrors CloseAllDBLogWriters/pruneStaleDBLogWriters).
+	server.ClusterGroup.CloseAllDBLogWriters()
+
+	// It must still be cached (marked stale, not removed): the borrower
+	// isn't done with it yet.
+	logfile := server.DBLogFilePath(DBLogError)
+	if len(server.ClusterGroup.dbLogWriters) != 1 {
+		t.Fatalf("expected the borrowed entry to remain cached (stale) after eviction, got %d entries", len(server.ClusterGroup.dbLogWriters))
+	}
+
+	// The borrower must still be able to write successfully after eviction:
+	// the real Close is deferred until it releases.
+	if _, err := w.Write([]byte("more data while still borrowed\n")); err != nil {
+		t.Fatalf("write through the evicted-but-still-borrowed writer failed: %v", err)
+	}
+
+	got, err := os.ReadFile(logfile)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+	if !strings.Contains(string(got), "in-flight receiver data") || !strings.Contains(string(got), "more data while still borrowed") {
+		t.Fatalf("expected both writes to land in the log file, got %q", got)
+	}
+
+	// Release: this is the last (only) borrower, so the deferred close/removal
+	// happens synchronously inside release().
+	release()
+
+	if len(server.ClusterGroup.dbLogWriters) != 0 {
+		t.Fatalf("expected release() to close and remove the stale entry once the last borrower is done, got %d entries", len(server.ClusterGroup.dbLogWriters))
+	}
+}
+
+// TestCloseAllDBLogWriters_MarksBorrowedWriterStaleInsteadOfClosing is the
+// CloseAllDBLogWriters-specific companion to
+// TestGetDBLogRotatingWriter_EvictionDoesNotCloseWriterWhileBorrowed: with
+// two borrowers on the same entry, it must take both releases -- not just
+// one -- before the entry is actually closed and removed.
+func TestCloseAllDBLogWriters_MarksBorrowedWriterStaleInsteadOfClosing(t *testing.T) {
+	tmp := t.TempDir()
+	server := newTestServerForDBLogs(t, tmp)
+	server.ClusterGroup.Conf.DBLogRotate = true
+	server.ClusterGroup.Servers = serverList{server}
+
+	_, release1, err := server.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("first getDBLogRotatingWriter call returned error: %v", err)
+	}
+	_, release2, err := server.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("second getDBLogRotatingWriter call returned error: %v", err)
+	}
+
+	server.ClusterGroup.CloseAllDBLogWriters()
+
+	if len(server.ClusterGroup.dbLogWriters) != 1 {
+		t.Fatalf("expected the twice-borrowed entry to remain cached (stale), got %d entries", len(server.ClusterGroup.dbLogWriters))
+	}
+
+	release1()
+	if len(server.ClusterGroup.dbLogWriters) != 1 {
+		t.Fatal("expected the entry to remain cached after only one of two borrowers released")
+	}
+
+	release2()
+	if len(server.ClusterGroup.dbLogWriters) != 0 {
+		t.Fatalf("expected the last release to close and remove the entry, got %d entries", len(server.ClusterGroup.dbLogWriters))
+	}
+}
+
+// TestPruneStaleDBLogWriters_MarksBorrowedWriterStaleInsteadOfClosing is the
+// pruneStaleDBLogWriters-specific companion to
+// TestCloseAllDBLogWriters_MarksBorrowedWriterStaleInsteadOfClosing: a
+// server dropping out of the topology (host removal, reload) while its
+// writer is still borrowed must not have that writer closed out from under
+// the borrower -- it should be marked stale and only actually closed once
+// the last borrower releases it.
+func TestPruneStaleDBLogWriters_MarksBorrowedWriterStaleInsteadOfClosing(t *testing.T) {
+	tmp := t.TempDir()
+	server := newTestServerForDBLogs(t, tmp)
+	server.ClusterGroup.Conf.DBLogRotate = true
+	cluster := server.ClusterGroup
+	cluster.Servers = serverList{server}
+
+	_, release, err := server.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter returned error: %v", err)
+	}
+
+	// The server drops out of the topology entirely (e.g. host removed from
+	// config on reload) while its writer is still borrowed.
+	cluster.Servers = serverList{}
+	cluster.pruneStaleDBLogWriters()
+
+	if len(cluster.dbLogWriters) != 1 {
+		t.Fatalf("expected the borrowed entry to remain cached (stale) after pruning, got %d entries", len(cluster.dbLogWriters))
+	}
+
+	release()
+
+	if len(cluster.dbLogWriters) != 0 {
+		t.Fatalf("expected release() to close and remove the pruned-but-borrowed entry once drained, got %d entries", len(cluster.dbLogWriters))
+	}
+}
+
+// TestGetDBLogRotatingWriter_ReleaseIsSafeToCallMoreThanOnce guards against a
+// caller mistake (e.g. both an explicit release call and an unconditional
+// deferred one) desyncing the borrower count from actual outstanding
+// borrows, which could cause a still-in-use writer to be closed out from
+// under an unrelated, later borrower. The release func returned by
+// getDBLogRotatingWriter must be idempotent.
+func TestGetDBLogRotatingWriter_ReleaseIsSafeToCallMoreThanOnce(t *testing.T) {
+	tmp := t.TempDir()
+	server := newTestServerForDBLogs(t, tmp)
+	server.ClusterGroup.Conf.DBLogRotate = true
+
+	_, release, err := server.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter returned error: %v", err)
+	}
+
+	// Force the entry stale so a release can actually trigger a close --
+	// otherwise a non-stale entry's release is pure accounting and a repeat
+	// call wouldn't reveal anything (the bug only bites once stale=true).
+	server.ClusterGroup.Conf.DBLogRotateMaxSize++
+	_, release2, err := server.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("second getDBLogRotatingWriter call returned error: %v", err)
+	}
+	defer release2()
+
+	// First (legitimate) release: one borrower left (release2's), entry
+	// stays cached.
+	release()
+	if len(server.ClusterGroup.dbLogWriters) != 1 {
+		t.Fatal("expected the stale entry to remain cached while release2's borrow is still outstanding")
+	}
+
+	// Calling release again must be a no-op. Without the sync.Once guard,
+	// this would decrement borrowers a second time (to -1, since release2's
+	// borrow is the only real one left) and, because the entry is stale,
+	// incorrectly close and remove it out from under release2's still-active
+	// borrow.
+	release()
+
+	if len(server.ClusterGroup.dbLogWriters) != 1 {
+		t.Fatal("expected a repeated release call to be a no-op and not close the entry out from under a later, unrelated borrower")
+	}
+}
+
+// TestGetDBLogRotatingWriter_ThresholdChangeWhileBorrowedDefersReplacement is
+// the regression test for the gap CloseAllDBLogWriters/
+// pruneStaleDBLogWriters already handled but getDBLogRotatingWriter's own
+// threshold-mismatch path did not: on a db-log-rotate-max-* change
+// (server/api_cluster.go) while the current writer is still borrowed, a
+// naive "evict now, create the replacement now" would spin up a second live
+// *lumberjack.Logger for the same path immediately -- not just delay closing
+// the old one -- which is exactly the dual-writer hazard this cache exists
+// to prevent. The fix keeps serving the same (now stale) writer to every
+// acquirer until the last borrower releases it, and only then creates the
+// replacement.
+func TestGetDBLogRotatingWriter_ThresholdChangeWhileBorrowedDefersReplacement(t *testing.T) {
+	tmp := t.TempDir()
+	server := newTestServerForDBLogs(t, tmp)
+	server.ClusterGroup.Conf.DBLogRotate = true
+	server.ClusterGroup.Conf.DBLogRotateMaxSize = 100
+
+	// Acquire A and do not release it -- simulates an in-flight SST receiver
+	// or GetSlowLogTable export still writing through it.
+	writerA, releaseA, err := server.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("first getDBLogRotatingWriter call returned error: %v", err)
+	}
+
+	// Simulate a runtime "db-log-rotate-max-size" API call while A is still
+	// borrowed.
+	server.ClusterGroup.Conf.DBLogRotateMaxSize = 250
+
+	// A second acquire for the same path, while A is still outstanding, must
+	// get A back -- NOT a second, independent writer -- even though the
+	// thresholds no longer match what A was created with.
+	writerAAgain, releaseAAgain, err := server.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("second getDBLogRotatingWriter call returned error: %v", err)
+	}
+	if writerAAgain != writerA {
+		t.Fatal("expected a threshold change to keep serving the still-borrowed writer instead of creating a second one for the same path")
+	}
+	if len(server.ClusterGroup.dbLogWriters) != 1 {
+		t.Fatalf("expected exactly one cache entry while A is still borrowed, got %d", len(server.ClusterGroup.dbLogWriters))
+	}
+
+	// Release one of the two borrows: still not the last one, so no
+	// replacement yet.
+	releaseA()
+	if len(server.ClusterGroup.dbLogWriters) != 1 {
+		t.Fatal("expected the entry to remain cached after only one of two borrowers released")
+	}
+
+	// Release the last borrow: NOW the stale entry is closed and removed.
+	releaseAAgain()
+	if len(server.ClusterGroup.dbLogWriters) != 0 {
+		t.Fatalf("expected the last release to close and remove the stale entry, got %d entries", len(server.ClusterGroup.dbLogWriters))
+	}
+
+	// A fresh acquire now gets a genuinely new writer, with the current
+	// (changed) threshold.
+	writerB, releaseB, err := server.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter after drain returned error: %v", err)
+	}
+	defer releaseB()
+	if writerB == writerA {
+		t.Fatal("expected a genuinely new writer instance once the stale one fully drained")
+	}
+	logfile := server.DBLogFilePath(DBLogError)
+	if server.ClusterGroup.dbLogWriters[logfile].maxSize != 250 {
+		t.Fatalf("expected the new writer to be created with the current maxSize, got %d", server.ClusterGroup.dbLogWriters[logfile].maxSize)
+	}
+}
+
+// TestClusterClose_ClosesAllDBLogWriters guards against the reload/teardown
+// paths bypassing DB log writer cleanup: Cluster.Close used to close each
+// server's Conn directly without ever touching the cached rotating writers,
+// leaking their millRun goroutines on every cluster shutdown.
+func TestClusterClose_ClosesAllDBLogWriters(t *testing.T) {
+	tmp := t.TempDir()
+	server := newTestServerForDBLogs(t, tmp)
+	server.ClusterGroup.Conf.DBLogRotate = true
+	server.ClusterGroup.Servers = serverList{server}
+	// A real but unconnected *sqlx.DB: Cluster.Close unconditionally calls
+	// Conn.Close(), which panics on a nil *sqlx.DB, so the test needs a live
+	// (if never-dialed) handle rather than leaving Conn nil.
+	conn, err := sqlx.Open("mysql", "user:pass@tcp(127.0.0.1:3306)/db")
+	if err != nil {
+		t.Fatalf("failed to open test DB handle: %v", err)
+	}
+	server.Conn = conn
+
+	_, release, err := server.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter returned error: %v", err)
+	}
+	if len(server.ClusterGroup.dbLogWriters) != 1 {
+		t.Fatalf("expected one cached writer entry before Close, got %d", len(server.ClusterGroup.dbLogWriters))
+	}
+	// Release before Close: this test is about Close reaching an unborrowed
+	// writer, not about the stale/borrow deferral (see
+	// TestGetDBLogRotatingWriter_EvictionDoesNotCloseWriterWhileBorrowed for
+	// that).
+	release()
+
+	server.ClusterGroup.Close()
+
+	if len(server.ClusterGroup.dbLogWriters) != 0 {
+		t.Fatalf("expected Cluster.Close to clear the cluster's DB log writer cache, got %d entries", len(server.ClusterGroup.dbLogWriters))
+	}
+}
+
+// TestNewServerList_PrunesWritersForHostsDroppedFromTopology guards against
+// a reload (ReloadConfig -> InitFromConf -> newServerList) silently
+// abandoning cached writers for hosts that actually left the topology, with
+// no cleanup call at all.
+func TestNewServerList_PrunesWritersForHostsDroppedFromTopology(t *testing.T) {
+	tmp := t.TempDir()
+	oldServer := newTestServerForDBLogs(t, tmp)
+	oldServer.ClusterGroup.Conf.DBLogRotate = true
+
+	_, release, err := oldServer.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter returned error: %v", err)
+	}
+	if len(oldServer.ClusterGroup.dbLogWriters) != 1 {
+		t.Fatalf("expected one cached writer entry before reload, got %d", len(oldServer.ClusterGroup.dbLogWriters))
+	}
+	// Release before the reload: this test is about pruning reaching an
+	// unborrowed writer, not about the stale/borrow deferral.
+	release()
+
+	cluster := oldServer.ClusterGroup
+	cluster.Servers = serverList{oldServer}
+	// No hosts configured: newServerList will rebuild Servers into an empty
+	// slice, i.e. this host actually left the topology, which is what should
+	// make its cached writer stale.
+	cluster.Conf.Hosts = ""
+
+	if err := cluster.newServerList(); err != nil {
+		t.Fatalf("newServerList returned error: %v", err)
+	}
+
+	if len(cluster.dbLogWriters) != 0 {
+		t.Fatalf("expected newServerList to prune the dropped host's DB log writers, got %d entries", len(cluster.dbLogWriters))
+	}
+}
+
+// TestPruneStaleDBLogWriters_OrdinaryReloadLeavesStillValidWriterAlone is the
+// complement of the drop test above: when a host's canonical DB log path is
+// still produced by some current server (the common reload case -- see
+// newServerMonitor, srv.go:421, which deterministically derives Datadir from
+// WorkingDir/cluster name/host/port, so an unchanged host always recomputes
+// the same path regardless of which *ServerMonitor generation asks), pruning
+// must NOT close its cached writer just because the specific *ServerMonitor
+// instance that created it is no longer the one in cluster.Servers.
+//
+// This is the core regression test for the cluster-scoped, path-keyed
+// redesign: it is what makes an ordinary reload -- which always replaces
+// every *ServerMonitor object, even for unchanged hosts -- safe to run
+// concurrently with a long-running GetSlowLogTable export instead of
+// spawning a second independent *lumberjack.Logger for the same path.
+func TestPruneStaleDBLogWriters_OrdinaryReloadLeavesStillValidWriterAlone(t *testing.T) {
+	tmp := t.TempDir()
+	oldServer := newTestServerForDBLogs(t, tmp)
+	oldServer.ClusterGroup.Conf.DBLogRotate = true
+	cluster := oldServer.ClusterGroup
+	cluster.Servers = serverList{oldServer}
+
+	writer, release, err := oldServer.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter returned error: %v", err)
+	}
+	defer release()
+
+	// Simulate a reload: a brand new *ServerMonitor for the identical host
+	// (same Datadir/Host/Port), exactly as newServerMonitor produces on every
+	// reload regardless of whether the host actually changed, replaces the
+	// old one in cluster.Servers.
+	newServer := newTestServerForDBLogs(t, tmp)
+	newServer.ClusterGroup = cluster
+	cluster.Servers = serverList{newServer}
+
+	cluster.pruneStaleDBLogWriters()
+
+	if len(cluster.dbLogWriters) != 1 {
+		t.Fatalf("expected the still-valid writer to remain cached across an ordinary reload, got %d entries", len(cluster.dbLogWriters))
+	}
+
+	// The new ServerMonitor for the same host must resolve to the exact same
+	// writer instance -- not a second one -- for this to be a real fix.
+	newWriter, newRelease, err := newServer.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter on the post-reload server returned error: %v", err)
+	}
+	defer newRelease()
+	if newWriter != writer {
+		t.Fatal("expected the post-reload ServerMonitor to reuse the pre-reload cached writer for the same path")
+	}
+}
+
+// TestRemoveServerFromIndex_PrunesRemovedServersDBLogWriters guards against
+// dynamic server removal (e.g. topology churn dropping an unlinked
+// child-cluster server, cluster_topo.go) silently abandoning cached writers
+// for the removed server's paths, with no cleanup call.
+func TestRemoveServerFromIndex_PrunesRemovedServersDBLogWriters(t *testing.T) {
+	tmp := t.TempDir()
+	removed := newTestServerForDBLogsWithHost(t, tmp, "node1", "3306")
+	removed.ClusterGroup.Conf.DBLogRotate = true
+
+	kept := newTestServerForDBLogsWithHost(t, tmp, "node2", "3306")
+	kept.ClusterGroup = removed.ClusterGroup
+
+	cluster := removed.ClusterGroup
+	cluster.Servers = serverList{removed, kept}
+
+	_, removedRelease, err := removed.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter returned error: %v", err)
+	}
+	// Release before removal: this test is about pruning reaching an
+	// unborrowed writer, not about the stale/borrow deferral.
+	removedRelease()
+	_, keptRelease, err := kept.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter returned error: %v", err)
+	}
+	defer keptRelease()
+
+	cluster.RemoveServerFromIndex(0)
+
+	if len(cluster.Servers) != 1 || cluster.Servers[0] != kept {
+		t.Fatalf("expected only the kept server to remain, got %v", cluster.Servers)
+	}
+	if len(cluster.dbLogWriters) != 1 {
+		t.Fatalf("expected only the kept server's writer to remain cached, got %d entries", len(cluster.dbLogWriters))
+	}
+}
+
+// TestRemoveServerMonitor_PrunesRemovedServersDBLogWriters is the
+// RemoveServerMonitor (host/port-based removal, used by the server-removal
+// API) counterpart of TestRemoveServerFromIndex_PrunesRemovedServersDBLogWriters.
+func TestRemoveServerMonitor_PrunesRemovedServersDBLogWriters(t *testing.T) {
+	tmp := t.TempDir()
+	removed := newTestServerForDBLogsWithHost(t, tmp, "node1", "3306")
+	removed.ClusterGroup.Conf.DBLogRotate = true
+
+	kept := newTestServerForDBLogsWithHost(t, tmp, "node2", "3306")
+	kept.ClusterGroup = removed.ClusterGroup
+
+	cluster := removed.ClusterGroup
+	cluster.Servers = serverList{removed, kept}
+	// RemoveServerMonitor drives the cluster's failover state machine; the
+	// bare test fixture doesn't set one up, unlike a real cluster (see
+	// InitFromConf).
+	cluster.StateMachine = new(state.StateMachine)
+	cluster.StateMachine.Init()
+
+	_, removedRelease, err := removed.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter returned error: %v", err)
+	}
+	// Release before removal: this test is about pruning reaching an
+	// unborrowed writer, not about the stale/borrow deferral.
+	removedRelease()
+	_, keptRelease, err := kept.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter returned error: %v", err)
+	}
+	defer keptRelease()
+
+	if err := cluster.RemoveServerMonitor("node1", "3306"); err != nil {
+		t.Fatalf("RemoveServerMonitor returned error: %v", err)
+	}
+
+	if len(cluster.Servers) != 1 || cluster.Servers[0] != kept {
+		t.Fatalf("expected only the kept server to remain, got %v", cluster.Servers)
+	}
+	if len(cluster.dbLogWriters) != 1 {
+		t.Fatalf("expected only the kept server's writer to remain cached, got %d entries", len(cluster.dbLogWriters))
+	}
+}
+
 func TestNewLogTailer_DoesNotPruneWhenRotateDisabled(t *testing.T) {
 	tmp := t.TempDir()
 	server := newTestServerForDBLogs(t, tmp)
@@ -694,5 +1341,50 @@ func TestNewLogTailer_DoesNotPruneWhenRotateDisabled(t *testing.T) {
 
 	if _, err := os.Stat(oldStyle); err != nil {
 		t.Fatalf("expected old-style rotated file to remain untouched when db-log-rotate is disabled: %v", err)
+	}
+}
+
+// TestCloseAllDBLogWriters_ClosesEveryCachedWriter guards against runtime
+// db-log-rotate=false leaving cached writers behind: once the flag is off,
+// neither GetSlowLogTable nor SSTRunReceiverToDBLogFile ever calls
+// getDBLogRotatingWriter again for that cluster, so nothing else would ever
+// evict/close writers created while it was on. CloseAllDBLogWriters (called
+// from server/api_cluster.go's db-log-rotate handlers on an actual flip) is
+// the only thing that does.
+func TestCloseAllDBLogWriters_ClosesEveryCachedWriter(t *testing.T) {
+	tmp := t.TempDir()
+	first := newTestServerForDBLogsWithHost(t, tmp, "node1", "3306")
+	first.ClusterGroup.Conf.DBLogRotate = true
+
+	second := newTestServerForDBLogsWithHost(t, tmp, "node2", "3306")
+	second.ClusterGroup = first.ClusterGroup
+
+	cluster := first.ClusterGroup
+	cluster.Servers = serverList{first, second}
+
+	_, releaseFirst, err := first.getDBLogRotatingWriter(DBLogError)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter returned error: %v", err)
+	}
+	_, releaseSecond, err := second.getDBLogRotatingWriter(DBLogSlowQuery)
+	if err != nil {
+		t.Fatalf("getDBLogRotatingWriter returned error: %v", err)
+	}
+	if len(cluster.dbLogWriters) != 2 {
+		t.Fatalf("expected two cached writer entries before disabling, got %d", len(cluster.dbLogWriters))
+	}
+	// Release before disabling: this test is about CloseAllDBLogWriters
+	// reaching unborrowed writers, not about the stale/borrow deferral (see
+	// TestCloseAllDBLogWriters_MarksBorrowedWriterStaleInsteadOfClosing).
+	releaseFirst()
+	releaseSecond()
+
+	// Simulate the runtime "db-log-rotate" toggle/set-value handlers in
+	// server/api_cluster.go flipping the flag off and calling this.
+	cluster.Conf.DBLogRotate = false
+	cluster.CloseAllDBLogWriters()
+
+	if len(cluster.dbLogWriters) != 0 {
+		t.Fatalf("expected CloseAllDBLogWriters to close every cached writer, got %d entries", len(cluster.dbLogWriters))
 	}
 }

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2961,6 +2961,10 @@ func (repman *ReplicationManager) switchClusterSettings(mycluster *cluster.Clust
 		mycluster.Conf.OnPremiseSSH = !mycluster.Conf.OnPremiseSSH
 	case "db-log-rotate":
 		mycluster.Conf.DBLogRotate = !mycluster.Conf.DBLogRotate
+		// Nothing else notices this flag turning off -- close any writers
+		// cached while it was on instead of leaving them open indefinitely
+		// (mirrors the db-log-on-backup-storage case below).
+		mycluster.CloseAllDBLogWriters()
 	case "db-log-on-backup-storage":
 		mycluster.Conf.DBLogOnBackupStorage = !mycluster.Conf.DBLogOnBackupStorage
 		// Already-running tailers keep following whatever path they were opened
@@ -3442,7 +3446,15 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		}
 		mycluster.Conf.CompressBackupsCompressionLevel = val
 	case "db-log-rotate":
-		mycluster.Conf.DBLogRotate = applyIsActive(mycluster.Conf.DBLogRotate, isactive)
+		oldVal := mycluster.Conf.DBLogRotate
+		newVal := applyIsActive(mycluster.Conf.DBLogRotate, isactive)
+		mycluster.Conf.DBLogRotate = newVal
+		if newVal != oldVal {
+			// Nothing else notices this flag turning off -- close any writers
+			// cached while it was on instead of leaving them open
+			// indefinitely (mirrors the db-log-on-backup-storage case below).
+			mycluster.CloseAllDBLogWriters()
+		}
 	case "db-log-on-backup-storage":
 		oldVal := mycluster.Conf.DBLogOnBackupStorage
 		newVal := applyIsActive(mycluster.Conf.DBLogOnBackupStorage, isactive)

--- a/server/api_database.go
+++ b/server/api_database.go
@@ -5175,8 +5175,7 @@ func (repman *ReplicationManager) handlerMuxServerReceiveTask(w http.ResponseWri
 			http.Error(w, "Unknown DB log task: "+taskname, 500)
 			return
 		}
-		dest = node.DBLogFilePath(kind)
-		rcvPort, err = mycluster.SSTRunReceiverToDBLogFile(node, dest, taskname)
+		rcvPort, err = mycluster.SSTRunReceiverToDBLogFile(node, kind, taskname)
 	case config.ConstTaskReseedXB, config.ConstTaskReseedMB, config.ConstTaskFlashXB, config.ConstTaskFlashMB:
 		dest = node.GetMyBackupDirectory() + taskname
 		rcvPort, err = mycluster.SSTRunReceiverToFile(node, dest, cluster.ConstJobCreateFile, taskname)


### PR DESCRIPTION
## Summary
- reuse fetched DB log rotating writers instead of creating a fresh lumberjack logger per operation
- make writer lifecycle cluster-scoped and path-keyed so reloads, removals, and runtime setting changes do not create duplicate writers for the same file
- add cleanup and stale-writer handling for path changes, runtime `db-log-rotate` changes, teardown, and server removal
- add focused tests for writer reuse, threshold changes while borrowed, stale pruning, idempotent release, and SST receiver idle timeout behavior

## Why
The last commit was created to stop fetched DB log operations from repeatedly creating new rotating loggers whose background goroutines could accumulate over time. This change keeps one live rotating writer per canonical log path, defers replacement safely while a writer is still borrowed, and closes stale writers at the right lifecycle boundaries.

## Validation
- `go test ./cluster -run 'Test(GetDBLogRotatingWriter|CloseAllDBLogWriters|PruneStaleDBLogWriters|StreamCopyToFile)'`
- `go test ./cluster/...`
- `go test ./server/...`
- `go test ./utils/s18log/...`
- `go test -race ./cluster -run 'Test(GetDBLogRotatingWriter|CloseAllDBLogWriters|PruneStaleDBLogWriters|StreamCopyToFile)'`

## Notes
- `cluster/logplugin` still has the pre-existing unrelated audit-drift test failures seen outside this change set.