### PR TITLE
git: self-heal legacy .pull/<cluster>/plugins dir before cloud18 pull

### DIFF
--- a/server/server_git.go
+++ b/server/server_git.go
@@ -660,9 +660,14 @@ func (repman *ReplicationManager) PullCloud18Configs() {
 	filePath := pullDir + "/cloud18.toml"
 
 	if repman.Conf.GitUrlPull != "" {
+		// Self-heal a pre-symlink upgrade: a legacy real .pull/<cluster>/plugins
+		// directory blocks the checkout of the ../plugins symlink the -pull repo now
+		// ships, which aborts the whole pull. Normalize it up front.
+		repman.normalizePullPluginSymlinks(pullDir)
 		err := repman.Conf.CloneConfigFromGit(repman.Conf.GitUrlPull, repman.Conf.GitUsername, repman.Conf.Secrets["git-acces-token"].Value, pullDir)
 		if err != nil {
 			os.RemoveAll(pullDir + "/.git")
+			repman.normalizePullPluginSymlinks(pullDir) // clear any remaining conflict before the retry
 			err = repman.Conf.CloneConfigFromGit(repman.Conf.GitUrlPull, repman.Conf.GitUsername, repman.Conf.Secrets["git-acces-token"].Value, pullDir)
 			if err != nil {
 				pullErr = err
@@ -894,6 +899,45 @@ func (repman *ReplicationManager) ensurePluginSymlink(clusterPluginDir, sharedDi
 		return false
 	}
 	return true
+}
+
+// normalizePullPluginSymlinks converts any legacy real .pull/<cluster>/plugins
+// directory into the ../plugins symlink the -pull repo ships, BEFORE the git
+// checkout runs. go-git cannot lay a tracked symlink over a real directory
+// ("symlink ../plugins ...: file exists"), which aborts the whole cloud18 pull and
+// never recovers (the retry only wipes .git, not the working tree). Instances
+// upgraded from the pre-symlink layout still carry those real dirs, so this lets
+// them self-heal on the next pull. .pull is fully git-authoritative, so removing a
+// stale dir loses nothing — the shared plugins/ and the symlink are restored by the
+// pull. No-op when .pull is absent (first clone) or the entry is already a symlink.
+func (repman *ReplicationManager) normalizePullPluginSymlinks(pullDir string) {
+	entries, err := os.ReadDir(pullDir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() || e.Name() == ".git" || e.Name() == logplugin.PluginDirName {
+			continue
+		}
+		clusterPluginDir := filepath.Join(pullDir, e.Name(), logplugin.PluginDirName)
+		fi, lerr := os.Lstat(clusterPluginDir)
+		if lerr != nil || fi.Mode()&os.ModeSymlink != 0 {
+			continue // absent, or already the symlink we want — leave it
+		}
+		if rerr := os.RemoveAll(clusterPluginDir); rerr != nil {
+			repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlWarn,
+				"[git] cannot normalize legacy plugin dir %s: %v", clusterPluginDir, rerr)
+			continue
+		}
+		rel, rerr := filepath.Rel(filepath.Dir(clusterPluginDir), filepath.Join(pullDir, logplugin.PluginDirName))
+		if rerr != nil {
+			rel = filepath.Join("..", logplugin.PluginDirName)
+		}
+		// Best-effort: the checkout will also (re)create it from the repo.
+		os.Symlink(rel, clusterPluginDir)
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGit, config.LvlInfo,
+			"[git] normalized legacy real plugin dir %s -> %s (pre-symlink upgrade self-heal)", clusterPluginDir, rel)
+	}
 }
 
 // ensurePluginSymlinksAtStartup creates the shared plugin dir and migrates
@@ -1680,4 +1724,3 @@ func (repman *ReplicationManager) ShallowClone() error {
 
 	return err
 }
-

--- a/server/server_git_plugin_symlink_test.go
+++ b/server/server_git_plugin_symlink_test.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+)
+
+// TestNormalizePullPluginSymlinks verifies the pre-symlink-upgrade self-heal:
+// a legacy real .pull/<cluster>/plugins directory (which blocks go-git from
+// checking out the ../plugins symlink the -pull repo ships) is converted to the
+// symlink, while an already-correct symlink and .git are left untouched.
+func TestNormalizePullPluginSymlinks(t *testing.T) {
+	tmp := t.TempDir()
+	pullDir := filepath.Join(tmp, ".pull")
+
+	// shared, git-authoritative plugins dir
+	if err := os.MkdirAll(filepath.Join(pullDir, "plugins"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// legacy real per-cluster plugins dir (the conflict) with a stale binary
+	benchPlugins := filepath.Join(pullDir, "bench", "plugins")
+	if err := os.MkdirAll(benchPlugins, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(benchPlugins, "plugin-stale"), []byte("x"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// a cluster already correct (symlink) — must be left untouched
+	if err := os.MkdirAll(filepath.Join(pullDir, "evaluo"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("..", "plugins"), filepath.Join(pullDir, "evaluo", "plugins")); err != nil {
+		t.Fatal(err)
+	}
+	// .git must be skipped
+	if err := os.MkdirAll(filepath.Join(pullDir, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	repman := &ReplicationManager{Conf: &config.Config{}}
+	repman.normalizePullPluginSymlinks(pullDir)
+
+	// bench/plugins is now a symlink to ../plugins
+	fi, err := os.Lstat(benchPlugins)
+	if err != nil {
+		t.Fatalf("bench/plugins missing after normalize: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("bench/plugins should be a symlink, got mode %v", fi.Mode())
+	}
+	if tgt, _ := os.Readlink(benchPlugins); tgt != filepath.Join("..", "plugins") {
+		t.Errorf("bench/plugins -> %q, want %q", tgt, filepath.Join("..", "plugins"))
+	}
+
+	// evaluo/plugins remains the symlink (unchanged)
+	if fi2, err := os.Lstat(filepath.Join(pullDir, "evaluo", "plugins")); err != nil || fi2.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("evaluo/plugins should remain a symlink (err=%v)", err)
+	}
+
+	// .git untouched (still a real dir)
+	if fi3, err := os.Lstat(filepath.Join(pullDir, ".git")); err != nil || !fi3.IsDir() {
+		t.Errorf(".git should be untouched")
+	}
+}
+
+// TestNormalizePullPluginSymlinks_NoPullDir ensures a missing .pull (first clone)
+// is a safe no-op and does not panic.
+func TestNormalizePullPluginSymlinks_NoPullDir(t *testing.T) {
+	repman := &ReplicationManager{Conf: &config.Config{}}
+	repman.normalizePullPluginSymlinks(filepath.Join(t.TempDir(), "does-not-exist"))
+}


### PR DESCRIPTION
## Problem

An instance upgraded from the **pre-symlink** plugin layout still carries a real `.pull/<cluster>/plugins` **directory**. The `-pull` repo now tracks that path as a `../plugins` **symlink**, and go-git cannot lay a symlink over an existing real directory — so the **entire** cloud18 pull aborts:

```
[git] Error pulling cloud18 git config: symlink ../plugins
      /var/lib/replication-manager/.pull/bench/plugins: file exists
```

And it never recovers: the retry at `server_git.go` only wipes `.git`, not the working tree, so the conflicting directory survives and the retry fails too. The instance is stuck — no config/peer/plugin updates until someone `rm`s the directory by hand.

Confirmed on a live box: `.pull/bench/plugins` was a real directory full of stale plugin binaries, not the symlink the repo ships.

## Fix

`normalizePullPluginSymlinks(pullDir)` runs **before** the checkout in the cloud18 pull flow (and again in the retry path as a conflict-scoped fallback). It walks `.pull/<cluster>/plugins` and, for any that is a **real directory** (legacy), removes it and lays down the `../plugins` symlink the repo ships. It skips `.git`, the shared `plugins/`, and already-correct symlinks. `.pull` is fully git-authoritative, so nothing of value is lost — the shared `plugins/` and the symlink are restored by the pull.

Result: an upgraded instance **self-heals on the next pull**, no manual intervention.

Deliberately **not** changing the retry to `RemoveAll(pullDir)` — that would nuke and re-download the whole cache on *any* failure (including a transient network blip). Pre-normalizing fixes the actual dir→symlink conflict at its source and leaves the cache intact on unrelated errors.

## Tests

`server/server_git_plugin_symlink_test.go`:
- legacy real dir → converted to `../plugins` symlink
- an already-correct symlink is left untouched
- `.git` is left untouched
- missing `.pull` (first clone) is a safe no-op

Build + tests green.