### PR TITLE
monitor: run log-plugin subprocesses off the tick (cached eval) — fix loop stall

### DIFF
--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -227,6 +227,8 @@ type ServerMonitor struct {
 	PFSLastExplainPurge         time.Time                   // timestamp of last explain cache purge run
 	PFSExplainCache             map[string]PFSExplainRecord // digest → cached explain plan, keyed by digest hash
 	PFSExplainCacheMu           sync.Mutex                  // protects PFSExplainCache against goroutine/monitor-loop races
+	pluginEval                  map[string]*pluginEvalEntry // per-plugin cached Evaluate() result; refreshed OFF the tick so a slow plugin subprocess can't freeze the monitor loop
+	pluginEvalMu                sync.Mutex                  // protects pluginEval
 	pfsExplainCancel            context.CancelFunc          // cancels any in-flight RunPFSExplainCapture goroutine
 	InPurgingBinaryLog          bool
 	IsBackingUpBinaryLog        bool

--- a/cluster/srv_log_plugins.go
+++ b/cluster/srv_log_plugins.go
@@ -55,6 +55,64 @@ func spikeCacheKey(serverURL, pluginName string) string {
 	return serverURL + ":" + pluginName
 }
 
+// pluginEvalIntervalTicks is how many monitor ticks a cached plugin Evaluate()
+// result is reused before an off-tick refresh is triggered.
+const pluginEvalIntervalTicks = 15
+
+type pluginEvalEntry struct {
+	result   logplugin.EvaluateResult
+	have     bool
+	inFlight bool
+	lastTick int64
+}
+
+// cachedPluginEval returns the last cached result of p.Evaluate(src) for this
+// server, refreshing it in a BACKGROUND goroutine when stale or absent.
+// p.Evaluate shells out to the plugin binary (os/exec) whose run time can spike
+// on a slow/unresponsive server; running it here OFF the monitor tick is what
+// keeps a slow plugin from freezing the loop (it used to run inline in tickBody).
+// RunLogPlugins applies the returned result to the state machines EVERY tick, so
+// findings stay asserted between refreshes and never flap open/resolve — the
+// whole reason this is a cached read and not a fire-and-forget of the apply.
+func (server *ServerMonitor) cachedPluginEval(p logplugin.LogPlugin, src logplugin.LogSource) logplugin.EvaluateResult {
+	cluster := server.ClusterGroup
+	name := p.Name()
+
+	server.pluginEvalMu.Lock()
+	if server.pluginEval == nil {
+		server.pluginEval = make(map[string]*pluginEvalEntry)
+	}
+	e := server.pluginEval[name]
+	if e == nil {
+		e = &pluginEvalEntry{}
+		server.pluginEval[name] = e
+	}
+	hb := cluster.StateMachine.GetHeartbeats()
+	if !e.inFlight && (!e.have || hb-e.lastTick >= pluginEvalIntervalTicks) {
+		e.inFlight = true
+		e.lastTick = hb
+		// src is a snapshot (copies), safe to read from the goroutine.
+		go func() {
+			defer cluster.LogPanicToFile("cluster")
+			res := p.Evaluate(src) // slow subprocess — OFF the monitor tick
+			server.pluginEvalMu.Lock()
+			e.result = res
+			e.have = true
+			e.inFlight = false
+			server.pluginEvalMu.Unlock()
+		}()
+	}
+	res, have := e.result, e.have
+	server.pluginEvalMu.Unlock()
+
+	if !have {
+		// No cached result yet (first eval still running): apply nothing this tick.
+		// Findings appear the tick after the first background Evaluate completes.
+		return logplugin.EvaluateResult{}
+	}
+	return res
+}
+
 // RunLogPlugins evaluates every enabled plugin, injects Findings into the
 // state machine, and queues synthetic graphite metrics for plugins that lack
 // a native MySQL status metric for their dimension.
@@ -158,7 +216,10 @@ func (server *ServerMonitor) RunLogPlugins(spikeCache map[string]*logplugin.Spik
 			}
 		}
 
-		result := p.Evaluate(src)
+		// Cached read: p.Evaluate() (the plugin subprocess) runs OFF the tick and
+		// is refreshed in the background. The apply below runs every tick from the
+		// cached result, so findings stay asserted and never flap.
+		result := server.cachedPluginEval(p, src)
 
 		// Determine result type for log routing.
 		// isSecurityPlugin covers score plugins AND pure-security plugins
@@ -785,11 +846,11 @@ func (cluster *Cluster) GetLogPluginStates(serverURL string) []state.State {
 	SM := cluster.GetStateMachine()
 	opened := SM.GetLastOpenedStates()
 	keys := map[string]bool{
-		logplugin.ErrKeyDBError24h:          true,
-		logplugin.ErrKeySQLError24h:         true,
-		logplugin.ErrKeySlowLog24h:          true,
-		logplugin.ErrKeyAuditDrift:          true,
-		"WARN0205":                           true,
+		logplugin.ErrKeyDBError24h:            true,
+		logplugin.ErrKeySQLError24h:           true,
+		logplugin.ErrKeySlowLog24h:            true,
+		logplugin.ErrKeyAuditDrift:            true,
+		"WARN0205":                            true,
 		logplugin.ErrKeyMissingMonitoringFeed: true,
 	}
 	var out []state.State

--- a/cluster/srv_log_plugins_eval_cache_test.go
+++ b/cluster/srv_log_plugins_eval_cache_test.go
@@ -1,0 +1,73 @@
+package cluster
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/signal18/replication-manager/cluster/logplugin"
+	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/state"
+)
+
+type fakeEvalPlugin struct {
+	name  string
+	calls int32
+	res   logplugin.EvaluateResult
+}
+
+func (f *fakeEvalPlugin) Name() string { return f.name }
+func (f *fakeEvalPlugin) Evaluate(src logplugin.LogSource) logplugin.EvaluateResult {
+	atomic.AddInt32(&f.calls, 1)
+	return f.res
+}
+
+// TestCachedPluginEval_OffTickAndNoFlap verifies the two guarantees of the
+// off-tick plugin evaluation:
+//  1. Evaluate() (the subprocess) runs in a background goroutine, not inline —
+//     the first call returns an empty result and triggers an async refresh.
+//  2. Once cached, repeated calls within the refresh interval return the SAME
+//     cached result WITHOUT re-running Evaluate — so the per-tick apply keeps
+//     asserting the findings and they never flap.
+func TestCachedPluginEval_OffTickAndNoFlap(t *testing.T) {
+	sm := new(state.StateMachine)
+	sm.Init()
+	cluster := &Cluster{Conf: &config.Config{}, StateMachine: sm}
+	server := &ServerMonitor{ClusterGroup: cluster, URL: "db1:3306"}
+
+	p := &fakeEvalPlugin{name: "test", res: logplugin.EvaluateResult{MetricName: "x", CurrentCount: 7}}
+	src := logplugin.LogSource{ServerURL: "db1:3306"}
+
+	// (1) First call: nothing cached yet → empty result, and it must NOT have run
+	// Evaluate inline (it's dispatched to a goroutine).
+	if got := server.cachedPluginEval(p, src); got.MetricName != "" || got.CurrentCount != 0 {
+		t.Fatalf("first call must return empty result (eval is async), got %+v", got)
+	}
+
+	// Wait for the background Evaluate to populate the cache.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		server.pluginEvalMu.Lock()
+		e := server.pluginEval["test"]
+		have := e != nil && e.have
+		server.pluginEvalMu.Unlock()
+		if have || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if c := atomic.LoadInt32(&p.calls); c != 1 {
+		t.Fatalf("expected exactly 1 background Evaluate, got %d", c)
+	}
+
+	// (2) Repeated calls within the interval: cached result, no new Evaluate.
+	for i := 0; i < 8; i++ {
+		got := server.cachedPluginEval(p, src)
+		if got.MetricName != "x" || got.CurrentCount != 7 {
+			t.Fatalf("expected cached result {x,7}, got %+v", got)
+		}
+	}
+	if c := atomic.LoadInt32(&p.calls); c != 1 {
+		t.Fatalf("cached reads must not re-run Evaluate within the interval; Evaluate calls=%d (want 1)", c)
+	}
+}


### PR DESCRIPTION
## Problem (proven from a live goroutine dump on dbaas-fr-2)

`tickBody → CheckLogPlugins → RunLogPlugins → ExternalLogPlugin.Evaluate` shells out to the plugin **binary** (`os/exec`) **inline in the monitor tick**. The dump showed `tickBody` parked in `os.Process.Wait` inside `cmd.Output()`. With N plugins × M servers run **serially** in the tick, a slow/unresponsive server makes the tick's cadence collapse to minutes → heartbeat stalls → `GWARN001` (the HB supervision correctly reports it). This is the violation of "the monitor loop must never block on anything."

## Fix

Move **only** the `Evaluate()` subprocess off the tick: `cachedPluginEval()` caches the result per (server, plugin) and refreshes it in a **background goroutine**. The plugin binaries, wire protocol, and `Evaluate` itself are **untouched**.

The **entire apply half is unchanged** and still runs **every tick** from the cached result — findings → `SecurityStateMachine`/`WorkloadStateMachine`/`SchemaStateMachine`/`StateMachine`, score, WTAG, graphite.

## Why it's flap-safe

Those plugin state machines are `ClearState`'d **every tick** (cluster.go:1470-1472). Because the apply still runs every tick (from cache), every finding is **re-asserted every tick** and never resolves-and-reopens. A naive fire-and-forget of the whole `CheckLogPlugins` would have flapped all findings (dynamic per-server composite keys, not listable in `pstatesN`) — this cached-read design avoids that.

## Notes
- Cold start: a plugin's findings appear one tick after its first background eval completes.
- Refresh cadence: `pluginEvalIntervalTicks = 15` (const; can become a flag).
- `inFlight` guard prevents duplicate concurrent evals; goroutines are bounded by the plugin's own 5s+WaitDelay.

## Tests
- New `TestCachedPluginEval_OffTickAndNoFlap`: eval runs async (first call empty), then cached, and is **not** re-run within the interval.
- Full Plugin/Security/Workload/Schema suite passes; no existing test relied on inline evaluation.

Delicate state code — should be validated on the OpenSVC topology matrix before it ships.