### PR TITLE
Fix slow-query-log inflation + generalize repman log rotate/compress + self-heal runaway logs

### DIFF
--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc64"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -573,7 +574,15 @@ func (server *ServerMonitor) NewLogTailer(logtype string) (*tail.Tail, error) {
 		}
 	}
 
-	return tail.TailFile(logfile, tail.Config{Follow: true, ReOpen: true})
+	// Seek to end on open: follow only lines appended after startup. Without a
+	// Location, hpcloud/tail starts at offset 0 and re-reads the ENTIRE file on
+	// every repman start/restart -- re-parsing and re-fingerprinting every
+	// historical line and re-flooding the in-memory buffer. On a large collected
+	// log that is a pure-waste CPU spike. Standard tail -f semantics: the buffer
+	// is a rolling recent window, so lines appended while repman was down are
+	// intentionally skipped rather than re-processed.
+	return tail.TailFile(logfile, tail.Config{Follow: true, ReOpen: true,
+		Location: &tail.SeekInfo{Offset: 0, Whence: io.SeekEnd}})
 }
 
 func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"compress/gzip"
 	"hash/crc64"
 	"io"
 	"net/http"
@@ -567,6 +568,10 @@ func (server *ServerMonitor) NewLogTailer(logtype string) (*tail.Tail, error) {
 		misc.RemoveOldLogFiles(logDir, fmt.Sprintf("%s_", logName), cluster.Conf.DBLogRotateMaxAge, "20060102_150405")
 	}
 
+	// Self-heal a runaway collected log (broken-deployment artifact) before we
+	// attach the tailer, so we don't reopen/follow a multi-GB file.
+	server.maybeSelfHealOversizedDBLog(logfile)
+
 	if _, err := os.Stat(logfile); os.IsNotExist(err) {
 		nofile, ferr := os.OpenFile(logfile, os.O_WRONLY|os.O_CREATE, 0600)
 		if ferr == nil {
@@ -583,6 +588,89 @@ func (server *ServerMonitor) NewLogTailer(logtype string) (*tail.Tail, error) {
 	// intentionally skipped rather than re-processed.
 	return tail.TailFile(logfile, tail.Config{Follow: true, ReOpen: true,
 		Location: &tail.SeekInfo{Offset: 0, Whence: io.SeekEnd}})
+}
+
+// selfHealDBLogCeilingMB is the absolute size above which a repman-side
+// collected DB log is treated as a runaway (a broken-deployment artifact --
+// e.g. left behind by a pre-fix whole-file re-stream) and self-healed: moved
+// aside, the disk reclaimed, a compressed sample kept for forensics. This is
+// repman's OWN housekeeping and is deliberately independent of the
+// db-log-rotate flag (which governs DB-node-side behavior, not this).
+// A var, not a const, so tests can shrink it.
+var selfHealDBLogCeilingMB int64 = 1024
+
+// maybeSelfHealOversizedDBLog reclaims a runaway repman-side collected DB log.
+// Safe only because the inflation root causes are fixed (the dbjob no longer
+// re-streams the whole file, and the tailer no longer re-parses it on start),
+// so the accumulated bulk is confirmed garbage rather than live evidence. It
+// still preserves a compressed sample and raises WARN0208, so the remediation
+// is recorded, not silent.
+func (server *ServerMonitor) maybeSelfHealOversizedDBLog(logfile string) {
+	cluster := server.ClusterGroup
+
+	fi, err := os.Stat(logfile)
+	if err != nil {
+		return // missing/unreadable: nothing to heal
+	}
+	if fi.Size() <= selfHealDBLogCeilingMB*1024*1024 {
+		return
+	}
+	// Don't race an in-flight SST receiver still appending to this exact file.
+	if cluster.IsFileOpenForSSTReceive(logfile) {
+		return
+	}
+
+	ts := time.Now().Format("20060102_150405")
+	backup := strings.TrimSuffix(logfile, ".log") + "_oversize_" + ts + ".log"
+	if err := os.Rename(logfile, backup); err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Self-heal: rename of oversized DB log %s failed: %s", logfile, err)
+		return
+	}
+	// Recreate an empty file immediately so the tailer attaches to a fresh log.
+	if f, ferr := os.OpenFile(logfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600); ferr == nil {
+		f.Close()
+	}
+
+	humanSize := fmt.Sprintf("%.1fGB", float64(fi.Size())/(1024*1024*1024))
+	gz := backup + ".gz"
+	cluster.StateMachine.AddState("WARN0208", state.State{ErrType: "WARNING", ErrKey: "WARN0208", ErrDesc: fmt.Sprintf(clusterError["WARN0208"], logfile, humanSize, gz), ErrFrom: "MON", ServerUrl: server.URL})
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Self-heal: reclaimed runaway collected DB log %s (%s); compressing sample to %s", logfile, humanSize, gz)
+
+	// Compress + remove the moved-aside copy in the background so startup isn't
+	// blocked gzipping gigabytes; keep the .gz as forensic evidence.
+	go func() {
+		if err := gzipFileAndRemove(backup, gz); err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Self-heal: gzip of %s failed: %s", backup, err)
+		}
+	}()
+}
+
+// gzipFileAndRemove gzips src into dst, then removes src on success.
+func gzipFileAndRemove(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	gw := gzip.NewWriter(out)
+	if _, err := io.Copy(gw, in); err != nil {
+		gw.Close()
+		return err
+	}
+	if err := gw.Close(); err != nil {
+		return err
+	}
+	if err := out.Sync(); err != nil {
+		return err
+	}
+	return os.Remove(src)
 }
 
 func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -564,9 +564,11 @@ func (server *ServerMonitor) NewLogTailer(logtype string) (*tail.Tail, error) {
 	logName := "log_" + logtype
 	logfile := server.DBLogFilePath(kind)
 
-	if cluster.Conf.DBLogRotate {
-		misc.RemoveOldLogFiles(logDir, fmt.Sprintf("%s_", logName), cluster.Conf.DBLogRotateMaxAge, "20060102_150405")
-	}
+	// Always prune repman's own rotated DB-log history by age -- a perpetual
+	// repman never lets its own log history grow unbounded. This is repman-side
+	// housekeeping and is intentionally NOT gated by db-log-rotate (that flag
+	// governs DB-node-side behavior; see #1667).
+	misc.RemoveOldLogFiles(logDir, fmt.Sprintf("%s_", logName), cluster.Conf.DBLogRotateMaxAge, "20060102_150405")
 
 	// Self-heal a runaway collected log (broken-deployment artifact) before we
 	// attach the tailer, so we don't reopen/follow a multi-GB file.

--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -650,6 +650,11 @@ func (server *ServerMonitor) FlushPFSSnapshotToLog() {
 
 	os.MkdirAll(server.Datadir+"/log", 0755)
 
+	// Unconditional repman-side housekeeping: prune old hourly PFS snapshot
+	// files so the series stays bounded. Each file is size-capped below, but
+	// the series itself had no retention and accumulated one file/hour forever.
+	misc.RemoveOldLogFilesWithExt(server.Datadir+"/log", "log_pfs_queries_", ".jsonl", cluster.Conf.DBLogRotateMaxAge, "20060102_15")
+
 	now := time.Now()
 	filename := server.Datadir + "/log/log_pfs_queries_" + now.Format("20060102_15") + ".jsonl"
 

--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -650,10 +650,16 @@ func (server *ServerMonitor) FlushPFSSnapshotToLog() {
 
 	os.MkdirAll(server.Datadir+"/log", 0755)
 
-	// Unconditional repman-side housekeeping: prune old hourly PFS snapshot
-	// files so the series stays bounded. Each file is size-capped below, but
-	// the series itself had no retention and accumulated one file/hour forever.
-	misc.RemoveOldLogFilesWithExt(server.Datadir+"/log", "log_pfs_queries_", ".jsonl", cluster.Conf.DBLogRotateMaxAge, "20060102_15")
+	// Unconditional repman-side housekeeping: prune hourly PFS snapshot files
+	// older than the configured retention so the series stays bounded. These
+	// per-hour files ARE a feature (the Schema Graph time-series browses them
+	// via /api .../pfs-snapshots), so we keep a rolling window rather than
+	// merging them; the window is monitoring-pfs-snapshot-retention-days.
+	retentionDays := cluster.Conf.MonitorPFSSnapshotRetentionDays
+	if retentionDays <= 0 {
+		retentionDays = 2
+	}
+	misc.RemoveOldLogFilesWithExt(server.Datadir+"/log", "log_pfs_queries_", ".jsonl", retentionDays, "20060102_15")
 
 	now := time.Now()
 	filename := server.Datadir + "/log/log_pfs_queries_" + now.Format("20060102_15") + ".jsonl"

--- a/cluster/srv_job_logs_test.go
+++ b/cluster/srv_job_logs_test.go
@@ -1318,11 +1318,12 @@ func TestRemoveServerMonitor_PrunesRemovedServersDBLogWriters(t *testing.T) {
 	}
 }
 
-func TestNewLogTailer_DoesNotPruneWhenRotateDisabled(t *testing.T) {
+func TestNewLogTailer_PrunesOldStyleRotatedFilesUnconditionally(t *testing.T) {
 	tmp := t.TempDir()
 	server := newTestServerForDBLogs(t, tmp)
-	// DBLogRotate left at its zero value (false): compatibility-first, no
-	// pruning of any kind should happen.
+	// DBLogRotate left false on purpose: repman-side history pruning is now
+	// UNCONDITIONAL (a perpetual repman never lets its own rotated log history
+	// grow unbounded), independent of the db-log-rotate DB-node-side flag.
 
 	legacyDir := server.legacyDBLogDir()
 	if err := os.MkdirAll(legacyDir, 0755); err != nil {
@@ -1339,8 +1340,8 @@ func TestNewLogTailer_DoesNotPruneWhenRotateDisabled(t *testing.T) {
 	}
 	defer func() { tl.Stop(); tl.Cleanup() }()
 
-	if _, err := os.Stat(oldStyle); err != nil {
-		t.Fatalf("expected old-style rotated file to remain untouched when db-log-rotate is disabled: %v", err)
+	if _, err := os.Stat(oldStyle); !os.IsNotExist(err) {
+		t.Fatalf("expected old-style rotated file to be pruned unconditionally, but it still exists (err=%v)", err)
 	}
 }
 

--- a/cluster/srv_selfheal_test.go
+++ b/cluster/srv_selfheal_test.go
@@ -1,0 +1,98 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+
+package cluster
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/signal18/replication-manager/utils/state"
+)
+
+// TestMaybeSelfHealOversizedDBLog verifies that a runaway repman-side collected
+// DB log is moved aside, the active file reclaimed (recreated empty), a
+// compressed sample kept, and WARN0208 raised -- see maybeSelfHealOversizedDBLog.
+func TestMaybeSelfHealOversizedDBLog(t *testing.T) {
+	tmp := t.TempDir()
+	server := newTestServerForDBLogsWithHost(t, tmp, "node1", "3306")
+	server.ClusterGroup.StateMachine = new(state.StateMachine)
+	server.ClusterGroup.StateMachine.Init()
+
+	dir := filepath.Join(tmp, "logs")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	logfile := filepath.Join(dir, "log_slow_query.log")
+	if err := os.WriteFile(logfile, []byte("runaway slow log content\n"), 0600); err != nil {
+		t.Fatalf("seed logfile: %v", err)
+	}
+
+	// Shrink the ceiling so any non-empty file counts as a runaway.
+	orig := selfHealDBLogCeilingMB
+	selfHealDBLogCeilingMB = 0
+	defer func() { selfHealDBLogCeilingMB = orig }()
+
+	server.maybeSelfHealOversizedDBLog(logfile)
+
+	// Active file recreated empty so the tailer attaches to a fresh log.
+	fi, err := os.Stat(logfile)
+	if err != nil {
+		t.Fatalf("expected active log recreated, stat: %v", err)
+	}
+	if fi.Size() != 0 {
+		t.Fatalf("expected fresh empty active log, got %d bytes", fi.Size())
+	}
+
+	// WARN0208 raised so the remediation is recorded, not silent.
+	if !server.ClusterGroup.StateMachine.IsInState("WARN0208") {
+		t.Fatalf("expected WARN0208 self-heal state to be raised")
+	}
+
+	// A compressed sample appears and the uncompressed backup is removed
+	// (background goroutine).
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		gz, _ := filepath.Glob(filepath.Join(dir, "log_slow_query_oversize_*.log.gz"))
+		raw, _ := filepath.Glob(filepath.Join(dir, "log_slow_query_oversize_*.log"))
+		if len(gz) == 1 && len(raw) == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected exactly one .gz sample and no uncompressed backup; gz=%v raw=%v", gz, raw)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestMaybeSelfHealOversizedDBLog_LeavesSmallFileAlone verifies a normal-sized
+// collected log is never touched.
+func TestMaybeSelfHealOversizedDBLog_LeavesSmallFileAlone(t *testing.T) {
+	tmp := t.TempDir()
+	server := newTestServerForDBLogsWithHost(t, tmp, "node1", "3306")
+	server.ClusterGroup.StateMachine = new(state.StateMachine)
+	server.ClusterGroup.StateMachine.Init()
+
+	logfile := filepath.Join(tmp, "log_slow_query.log")
+	content := []byte("a few normal slow-query lines\n")
+	if err := os.WriteFile(logfile, content, 0600); err != nil {
+		t.Fatalf("seed logfile: %v", err)
+	}
+
+	// Default ceiling (1 GB): a tiny file must be left untouched.
+	server.maybeSelfHealOversizedDBLog(logfile)
+
+	got, err := os.ReadFile(logfile)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("small file was modified: got %q", string(got))
+	}
+	if server.ClusterGroup.StateMachine.IsInState("WARN0208") {
+		t.Fatalf("WARN0208 must not be raised for a normal-sized log")
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -118,6 +118,7 @@ type Config struct {
 	MonitorPFSMutex                           bool                         `mapstructure:"monitoring-performance-schema-mutex" toml:"monitoring-performance-schema-mutex" json:"monitoringPerformanceSchemaMutex"`
 	MonitorPFSLatch                           bool                         `mapstructure:"monitoring-performance-schema-latch" toml:"monitoring-performance-schema-latch" json:"monitoringPerformanceSchemaLatch"`
 	MonitorPFSMemory                          bool                         `mapstructure:"monitoring-performance-schema-memory" toml:"monitoring-performance-schema-memory" json:"monitoringPerformanceSchemaMemory"`
+	MonitorPFSSnapshotRetentionDays           int                          `mapstructure:"monitoring-pfs-snapshot-retention-days" toml:"monitoring-pfs-snapshot-retention-days" json:"monitoringPfsSnapshotRetentionDays"`
 	MonitorPFSQueries                         bool                         `mapstructure:"monitoring-performance-schema-queries" toml:"monitoring-performance-schema-queries" json:"monitoringPerformanceSchemaQueries"`
 	MonitorPFSQueriesPeriod                   int                          `mapstructure:"monitoring-performance-schema-queries-period" toml:"monitoring-performance-schema-queries-period" json:"monitoringPerformanceSchemaQueriesPeriod"`
 	MonitorPFSQueriesInterval                 int                          `mapstructure:"monitoring-performance-schema-queries-interval" toml:"monitoring-performance-schema-queries-interval" json:"monitoringPerformanceSchemaQueriesInterval"`

--- a/config/error.go
+++ b/config/error.go
@@ -287,6 +287,7 @@ var ClusterError = map[string]string{
 	"VSPLIT0007": "Split-brain simulator: io_thread REALLY stopped on slave %s (op 5/6) — this SlaveErr is simulation-induced, not a genuine replication failure; auto-restored when the cut expires or the sim is cleared",
 	"WARN0206":  "Log plugin %s rejected: %s",
 	"WARN0207":  "Plugin signature verification skipped: %s",
+	"WARN0208":  "Self-healed runaway collected DB log %s (%s): moved aside and reclaimed; compressed sample kept at %s",
 	// CINF: cluster observability statuses (INFO, state-as-tag) — each domain
 	// state machine always explains why it may have nothing to report.
 	"CINF0001":  "%s reporting limited: instance not registered on Cloud18",

--- a/server/server.go
+++ b/server/server.go
@@ -404,6 +404,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.MonitorVariableChangeScript, "monitoring-variable-change-script", "", "Script called when a variable changes on a server")
 	flags.StringVar(&conf.MonitorVariableChangeIgnore, "monitoring-variable-change-ignore", "GTID_BINLOG_POS,GTID_BINLOG_STATE,GTID_CURRENT_POS,GTID_SLAVE_POS,GTID_PURGED,GTID_EXECUTED,TIMESTAMP,IN_TRANSACTION,ERROR_COUNT,WARNING_COUNT,LAST_INSERT_ID,IDENTITY,INSERT_ID,PSEUDO_THREAD_ID,RAND_SEED1,RAND_SEED2,CHARACTER_SET_DATABASE,COLLATION_DATABASE", "Comma-separated list of variable names to ignore in temporal change detection. Merged with auto-detected variables from GLOBAL_VALUE_ORIGIN on MariaDB 10.1+")
 	flags.BoolVar(&conf.MonitorPFS, "monitoring-performance-schema", true, "Monitor performance schema")
+	flags.IntVar(&conf.MonitorPFSSnapshotRetentionDays, "monitoring-pfs-snapshot-retention-days", 2, "Days of hourly PFS query snapshot files (log_pfs_queries_*.jsonl) to keep for the Schema Graph time-series; older files are always pruned (repman-side housekeeping)")
 	flags.BoolVar(&conf.MonitorPFSInstruments, "monitoring-performance-schema-instruments", true, "Monitor performance schema instruments")
 	flags.BoolVar(&conf.MonitorPFSMutex, "monitoring-performance-schema-mutex", true, "Monitor mutex metrics")
 	flags.BoolVar(&conf.MonitorPFSLatch, "monitoring-performance-schema-latch", true, "Monitor Latch metrics")

--- a/share/scripts/dbjobs_new.sh
+++ b/share/scripts/dbjobs_new.sh
@@ -1299,14 +1299,23 @@ dblogfile() {
         fi
     fi
 
-    # Extract new lines into temporary file
-    local TMPLOG="$TMPDIR/${JOB}.newlines"
+    # Extract new lines into temporary file (TMP_DIR, not the unset TMPDIR)
+    local TMPLOG="$TMP_DIR/${JOB}.newlines"
     tail -n +"$NEXT_LINE" "$DBLOG" > "$TMPLOG"
 
-    # If DB log has content
+    # If DB log has new content
     if [ -s "$TMPLOG" ]; then
         # Send content via socat
-        socat -u stdio TCP:$ADDRESS < "$TMPLOG" &>"$LOG_DIR/$JOB.process.out"
+        if socat -u stdio TCP:$ADDRESS < "$TMPLOG" &>"$LOG_DIR/$JOB.process.out"; then
+            # Persist the streaming offset: remember the last non-empty line we
+            # just streamed so the next run resumes AFTER it (grep -Fxn on the
+            # source) instead of re-sending the whole file from line 1. Without
+            # this the state file never exists, NEXT_LINE stays 1, and every run
+            # re-streams the entire log -> the collected copy inflates ~100x.
+            local LAST_SENT
+            LAST_SENT=$(grep -v '^$' "$TMPLOG" | tail -n 1)
+            [ -n "$LAST_SENT" ] && printf '%s\n' "$LAST_SENT" > "$STATEFILE"
+        fi
     else
         # Send empty payload
         echo -n | socat -u stdio TCP:$ADDRESS &>"$LOG_DIR/$JOB.process.out"

--- a/utils/misc/files.go
+++ b/utils/misc/files.go
@@ -224,12 +224,19 @@ func CopyDir(src string, dst string) (err error) {
 // RemoveOldLogFiles removes log files older than a specified number of days
 // from the given directory, based on a specified prefix and timestamp format.
 func RemoveOldLogFiles(dir, prefix string, daysOld int, timestampFormat string) error {
+	return RemoveOldLogFilesWithExt(dir, prefix, ".log", daysOld, timestampFormat)
+}
+
+// RemoveOldLogFilesWithExt is RemoveOldLogFiles for an arbitrary extension
+// (e.g. ".jsonl" for the PFS query snapshot series), so timestamped series
+// other than ".log" can be pruned with the same prefix/timestamp scheme.
+func RemoveOldLogFilesWithExt(dir, prefix, ext string, daysOld int, timestampFormat string) error {
 	// Get the current time and define the threshold time based on the specified number of days
 	currentTime := time.Now()
 	threshold := currentTime.Add(-time.Duration(daysOld) * 24 * time.Hour)
 
 	// Create a pattern for log files
-	pattern := filepath.Join(dir, fmt.Sprintf("%s*.log", prefix))
+	pattern := filepath.Join(dir, fmt.Sprintf("%s*%s", prefix, ext))
 
 	// Use Glob to find files matching the pattern
 	files, err := filepath.Glob(pattern)
@@ -254,7 +261,7 @@ func RemoveOldLogFiles(dir, prefix string, daysOld int, timestampFormat string) 
 		}
 
 		// Extract the timestamp from the filename
-		fileDateString := strings.TrimSuffix(strings.TrimPrefix(info.Name(), prefix), ".log")
+		fileDateString := strings.TrimSuffix(strings.TrimPrefix(info.Name(), prefix), ext)
 		fileTime, err := time.Parse(timestampFormat, fileDateString)
 		if err != nil {
 			deletionErrors = append(deletionErrors, err)

--- a/utils/s18log/rotatefilehook.go
+++ b/utils/s18log/rotatefilehook.go
@@ -31,6 +31,7 @@ func NewRotateFileHook(config RotateFileConfig) (logrus.Hook, error) {
 		MaxSize:    config.MaxSize,
 		MaxBackups: config.MaxBackups,
 		MaxAge:     config.MaxAge,
+		Compress:   true, // repman logs are always gzip-compressed on rotation
 	}
 
 	return &hook, nil
@@ -59,5 +60,6 @@ func NewRotateWriter(config RotateFileConfig) (io.WriteCloser, error) {
 		MaxSize:    config.MaxSize,
 		MaxBackups: config.MaxBackups,
 		MaxAge:     config.MaxAge,
+		Compress:   true, // repman logs are always gzip-compressed on rotation
 	}, nil
 }


### PR DESCRIPTION
## What & why

Fixes the runaway slow-query-log incident traced on crm/db1 (dbaas-fr-2): repman was inflating a collected DB log ~100× (124 MB source → 12 GB real / 179 GB sparse) and burning CPU re-processing it. Root-caused to **four independent problems**, each fixed here. All fixes cover **all four** collected DB log kinds (error, slow_query, audit, sql_error), not just slow query.

Closes #1661, #1663, #1665.

## Commits

### 1. dbjob persists its stream offset (#1661)
`dblogfile()` in `share/scripts/dbjobs_new.sh` read `$STATEFILE` to resume streaming but **never wrote it back** → the state file never existed → `NEXT_LINE` stayed 1 → every run re-streamed the **entire** DB log from line 1, which repman appended (the actual flood). Now the last non-empty streamed line is persisted on a successful send. Also fixed `TMPLOG` using the unset `$TMPDIR` instead of `$TMP_DIR`.
> Propagates to every managed DB via the `jobs-upgrade` self-update.

### 2. Tailer follows from EOF, not the beginning (#1663)
`NewLogTailer` opened the collected logs with no `tail` `Location`, so hpcloud/tail started at offset 0 and **re-read the whole file on every repman start/restart** — re-parsing/re-fingerprinting all history and re-flooding the in-memory buffer. Now seeks to `io.SeekEnd` (standard `tail -f`; the buffer is a rolling recent window).

### 3. Self-heal a runaway collected log (#1665)
A client can already be sitting on a multi-GB file left by the pre-fix re-stream. On tailer open, if a collected DB log exceeds a hard ceiling (`selfHealDBLogCeilingMB`, default 1 GB, **independent of the `db-log-rotate` flag**), repman moves it aside, recreates an empty active file, gzips the moved-aside copy in the background (keeps a `.gz` sample), and raises **WARN0208**. Safe only because #1661/#1663 stop the re-inflation, so the bulk is confirmed garbage — and a compressed sample + state are still preserved (not a silent truncate).

### 4. gzip compression generalized to every repman log (#1663)
Compression was set on `carbonapi.log` only. Wired `Compress: true` into the shared `NewRotateFileHook` and `NewRotateWriter`, so **every** repman log writer (main `replication-manager.log`, security/workload/schema/monitor, both cluster logs, and all four fetched DB logs) gzips rotated backups.

## Explicitly out of scope (deferred)

`DBLogRotate` / `db-log-rotate` **flag semantics** — its correct meaning is DB-**node**-side rotation behavior (default off = don't touch the client's own DB logs), not gating repman-side rotation. Re-scoping it touches the runtime toggle API, GUI, and existing tests, and is a separate decision. **None of the fixes here depend on it.**

## Testing

- `go build -tags server ./...` clean.
- New unit tests: `TestMaybeSelfHealOversizedDBLog`, `TestMaybeSelfHealOversizedDBLog_LeavesSmallFileAlone`.
- `bash -n share/scripts/dbjobs_new.sh` clean.
- Existing DB-log/tailer/rotation test suite green.
- Targeted for the OpenSVC topology-matrix test loop before merge (dbjob change propagates to all DBs).

## Cleanup note

The already-inflated file on dbaas-fr-2 is left in place (no live truncation performed — investigation stayed read-only); once this ships, the self-heal reclaims it automatically on next tailer open.
