### PR TITLE
Fix #1666 code-review findings: self-heal data-loss race + PFS prune skipped on idle servers

### DIFF
--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -621,6 +621,18 @@ func (server *ServerMonitor) maybeSelfHealOversizedDBLog(logfile string) {
 	if cluster.IsFileOpenForSSTReceive(logfile) {
 		return
 	}
+	// Don't race a long-lived cached rotating writer either. GetSlowLogTable and
+	// the SST rotate path borrow a shared *lumberjack.Logger for this exact path
+	// (getDBLogRotatingWriter) that holds the file open by fd. If we renamed the
+	// file out from under it, its subsequent writes would go to the renamed inode
+	// -- which gzipFileAndRemove then compresses and deletes -- silently losing
+	// data. A cached writer also already bounds the file, so defer to it.
+	cluster.dbLogWriterMutex.Lock()
+	_, hasCachedWriter := cluster.dbLogWriters[logfile]
+	cluster.dbLogWriterMutex.Unlock()
+	if hasCachedWriter {
+		return
+	}
 
 	ts := time.Now().Format("20060102_150405")
 	backup := strings.TrimSuffix(logfile, ".log") + "_oversize_" + ts + ".log"

--- a/cluster/srv_get.go
+++ b/cluster/srv_get.go
@@ -640,14 +640,6 @@ type PFSSnapshotEntry struct {
 func (server *ServerMonitor) FlushPFSSnapshotToLog() {
 	cluster := server.ClusterGroup
 
-	// We need an up-to-date fetch to get sample queries before the TRUNCATE.
-	pfsq, _, err := dbhelper.GetQueries(server.Conn, server.DBVersion)
-	if err != nil || len(pfsq) == 0 {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg,
-			"PFS snapshot: nothing to flush on %s", server.URL)
-		return
-	}
-
 	os.MkdirAll(server.Datadir+"/log", 0755)
 
 	// Unconditional repman-side housekeeping: prune hourly PFS snapshot files
@@ -655,11 +647,24 @@ func (server *ServerMonitor) FlushPFSSnapshotToLog() {
 	// per-hour files ARE a feature (the Schema Graph time-series browses them
 	// via /api .../pfs-snapshots), so we keep a rolling window rather than
 	// merging them; the window is monitoring-pfs-snapshot-retention-days.
+	//
+	// This runs BEFORE the "nothing to flush" early-return below so it fires on
+	// EVERY cycle -- an idle server, or one whose PFS fetch is temporarily
+	// disabled/erroring, must still have its old snapshots pruned, otherwise the
+	// series grows unbounded exactly like the bug this PR was written to fix.
 	retentionDays := cluster.Conf.MonitorPFSSnapshotRetentionDays
 	if retentionDays <= 0 {
 		retentionDays = 2
 	}
 	misc.RemoveOldLogFilesWithExt(server.Datadir+"/log", "log_pfs_queries_", ".jsonl", retentionDays, "20060102_15")
+
+	// We need an up-to-date fetch to get sample queries before the TRUNCATE.
+	pfsq, _, err := dbhelper.GetQueries(server.Conn, server.DBVersion)
+	if err != nil || len(pfsq) == 0 {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg,
+			"PFS snapshot: nothing to flush on %s", server.URL)
+		return
+	}
 
 	now := time.Now()
 	filename := server.Datadir + "/log/log_pfs_queries_" + now.Format("20060102_15") + ".jsonl"

--- a/cluster/srv_selfheal_test.go
+++ b/cluster/srv_selfheal_test.go
@@ -68,6 +68,47 @@ func TestMaybeSelfHealOversizedDBLog(t *testing.T) {
 	}
 }
 
+// TestMaybeSelfHealOversizedDBLog_SkipsWhenCachedWriterHoldsFile verifies the
+// fix for the review finding: self-heal must NOT rename/reclaim a file that a
+// long-lived cached rotating writer (getDBLogRotatingWriter) holds open, or the
+// writer's later writes go to the renamed inode and get gzip+deleted -> silent
+// data loss.
+func TestMaybeSelfHealOversizedDBLog_SkipsWhenCachedWriterHoldsFile(t *testing.T) {
+	tmp := t.TempDir()
+	server := newTestServerForDBLogsWithHost(t, tmp, "node1", "3306")
+	server.ClusterGroup.StateMachine = new(state.StateMachine)
+	server.ClusterGroup.StateMachine.Init()
+
+	dir := filepath.Join(tmp, "logs")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	logfile := filepath.Join(dir, "log_slow_query.log")
+	if err := os.WriteFile(logfile, []byte("runaway content that a writer still owns\n"), 0600); err != nil {
+		t.Fatalf("seed logfile: %v", err)
+	}
+
+	orig := selfHealDBLogCeilingMB
+	selfHealDBLogCeilingMB = 0 // any non-empty file is "oversized"
+	defer func() { selfHealDBLogCeilingMB = orig }()
+
+	// A cached rotating writer holds this exact path open.
+	server.ClusterGroup.dbLogWriters = map[string]*dbLogWriterEntry{logfile: {}}
+
+	server.maybeSelfHealOversizedDBLog(logfile)
+
+	// The file must be untouched (not renamed), no backup created, no WARN0208.
+	if _, err := os.Stat(logfile); err != nil {
+		t.Fatalf("expected file untouched while a cached writer holds it, but it was moved: %v", err)
+	}
+	if moved, _ := filepath.Glob(filepath.Join(dir, "log_slow_query_oversize_*")); len(moved) != 0 {
+		t.Fatalf("expected NO backup when self-heal is skipped, got %v", moved)
+	}
+	if server.ClusterGroup.StateMachine.IsInState("WARN0208") {
+		t.Fatalf("WARN0208 must not be raised when self-heal is skipped")
+	}
+}
+
 // TestMaybeSelfHealOversizedDBLog_LeavesSmallFileAlone verifies a normal-sized
 // collected log is never touched.
 func TestMaybeSelfHealOversizedDBLog_LeavesSmallFileAlone(t *testing.T) {


### PR DESCRIPTION
Follow-up to #1666, addressing the code-review findings on that PR.

## Fixes

**Finding 1 (HIGH — silent data loss)** — `maybeSelfHealOversizedDBLog` guarded only on `IsFileOpenForSSTReceive`, missing the long-lived cached lumberjack writer that `GetSlowLogTable` / the SST rotate path hold open via `getDBLogRotatingWriter`. Renaming the file out from under that writer sent its later writes to the renamed inode, which `gzipFileAndRemove` then compressed + deleted → lost slow-query data. Now self-heal also **skips when a cached writer holds the path** (that writer already bounds the file). New regression test `TestMaybeSelfHealOversizedDBLog_SkipsWhenCachedWriterHoldsFile`.

**Finding 2 (HIGH — unbounded growth)** — the PFS snapshot retention prune sat *after* the "nothing to flush" early-return, so idle/erroring servers never reached it and `log_pfs_queries_*.jsonl` grew unbounded — the exact bug class #1666 was written to fix. Moved the prune **ahead of the early-return** so it runs every cycle.

## Deliberately deferred (tracked separately)

**Finding 3 (Low/Med — duplicate gzip)** — `gzipFileAndRemove` reinvents what the rotating writer already does. The correct fix is to make the repman-side collected-log writer **always** go through the rotating writer (lumberjack), so a runaway file is rotated+gzipped+pruned by the one mechanism — which would delete `maybeSelfHealOversizedDBLog` + `gzipFileAndRemove` entirely and also remove the Finding-1 race by construction. That's a larger refactor with a test cascade, intentionally **not** rushed right before an official release. Tracking issue to follow.

## Testing
- `go build -tags server ./...` clean.
- `go test ./cluster -run 'SelfHeal|PFS|Flush|Prune|Tailer'` green, incl. the new guard test.
