### PR TITLE
fix(cluster): ignore redundant active status changes

### DIFF
--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -1234,6 +1234,9 @@ func (cluster *Cluster) SetUnDiscovered() {
 }
 
 func (cluster *Cluster) SetActiveStatus(status string) {
+	if cluster.Status == status {
+		return
+	}
 	cluster.Status = status
 	if cluster.Conf.MonitorScheduler {
 		if cluster.Status == ConstMonitorActif {

--- a/cluster/cluster_set_test.go
+++ b/cluster/cluster_set_test.go
@@ -1,0 +1,132 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+
+package cluster
+
+import (
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"testing"
+	"time"
+
+	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/cron"
+)
+
+// goroutineSlack tolerates unrelated runtime/test goroutines appearing or
+// disappearing around the measurement (GC workers, timers, -race
+// bookkeeping). A real leak from N redundant SetActiveStatus calls grows the
+// count by N, which dwarfs this slack.
+const goroutineSlack = 3
+
+// newSchedulerTestCluster builds a minimal Cluster sufficient to exercise
+// SetActiveStatus's scheduler start/stop side effects, without the rest of
+// cluster init (no servers, no state machine).
+func newSchedulerTestCluster() *Cluster {
+	return &Cluster{
+		Name:      "cluster1",
+		Conf:      &config.Config{MonitorScheduler: true},
+		scheduler: cron.New(),
+		Status:    ConstMonitorStandby,
+	}
+}
+
+// waitForGoroutineAtLeast polls runtime.NumGoroutine() until it reaches at
+// least min or the timeout elapses, returning the last observed count.
+// cron.Cron.Start() spawns its run loop in a separate goroutine, so the
+// count only settles after that goroutine has actually been scheduled.
+func waitForGoroutineAtLeast(t *testing.T, min int, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	got := runtime.NumGoroutine()
+	for got < min && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+		got = runtime.NumGoroutine()
+	}
+	return got
+}
+
+// waitForGoroutineAtMost polls until runtime.NumGoroutine() settles at or
+// below max, or the timeout elapses, returning the last observed count.
+// Callers must assert on the returned value: a timeout without convergence
+// means teardown didn't happen, not that the assertion passed.
+func waitForGoroutineAtMost(t *testing.T, max int, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	got := runtime.NumGoroutine()
+	for got > max && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+		got = runtime.NumGoroutine()
+	}
+	return got
+}
+
+// TestSetActiveStatusRedundantCallsDoNotLeakGoroutines is the regression test
+// for GH-1674: repeated arbitration winner/loser ticks used to call
+// SetActiveStatus(sameStatus) every tick, and since cron.Cron.Start() always
+// does `go c.run()` regardless of whether it is already running, each
+// redundant call leaked another scheduler goroutine forever. SetActiveStatus
+// must now no-op when the status does not actually change.
+func TestSetActiveStatusRedundantCallsDoNotLeakGoroutines(t *testing.T) {
+	cluster := newSchedulerTestCluster()
+	// Safety net: Cron.Stop() is a no-op if never started or already stopped,
+	// so this fires harmlessly on the success path and only matters if a
+	// t.Fatalf below skips the explicit Stop() further down.
+	t.Cleanup(func() { cluster.scheduler.Stop() })
+
+	before := runtime.NumGoroutine()
+
+	cluster.SetActiveStatus(ConstMonitorActif)
+	afterFirst := waitForGoroutineAtLeast(t, before+1, time.Second)
+	if afterFirst < before+1 {
+		t.Fatalf("expected scheduler goroutine to start on activation: before=%d after=%d", before, afterFirst)
+	}
+
+	// Simulate repeated arbitration winner ticks re-affirming the same status.
+	for i := 0; i < 20; i++ {
+		cluster.SetActiveStatus(ConstMonitorActif)
+	}
+	// Give any (buggy) extra goroutines time to actually spawn before sampling.
+	time.Sleep(50 * time.Millisecond)
+
+	afterRedundant := runtime.NumGoroutine()
+	if delta := afterRedundant - afterFirst; delta > goroutineSlack {
+		pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+		t.Fatalf("redundant SetActiveStatus calls leaked goroutines: afterFirst=%d afterRedundant=%d (delta=%d exceeds slack=%d)",
+			afterFirst, afterRedundant, delta, goroutineSlack)
+	}
+
+	cluster.scheduler.Stop()
+	afterStop := waitForGoroutineAtMost(t, before+goroutineSlack, time.Second)
+	if delta := afterStop - before; delta > goroutineSlack {
+		t.Fatalf("teardown left scheduler goroutine(s) running: before=%d afterStop=%d (delta=%d exceeds slack=%d)",
+			before, afterStop, delta, goroutineSlack)
+	}
+}
+
+// TestSetActiveStatusRealTransitionStartsAndStopsScheduler ensures the
+// early-return guard only skips no-op transitions: an actual actif<->standby
+// flip must still start/stop the scheduler as before.
+func TestSetActiveStatusRealTransitionStartsAndStopsScheduler(t *testing.T) {
+	cluster := newSchedulerTestCluster()
+	// Safety net: if a t.Fatalf below fires after activation but before the
+	// standby transition stops the scheduler, this still tears it down.
+	t.Cleanup(func() { cluster.scheduler.Stop() })
+
+	before := runtime.NumGoroutine()
+
+	cluster.SetActiveStatus(ConstMonitorActif)
+	afterStart := waitForGoroutineAtLeast(t, before+1, time.Second)
+	if afterStart < before+1 {
+		t.Fatalf("expected scheduler goroutine to start: before=%d after=%d", before, afterStart)
+	}
+
+	cluster.SetActiveStatus(ConstMonitorStandby)
+	afterStop := waitForGoroutineAtMost(t, before+goroutineSlack, time.Second)
+	if delta := afterStop - before; delta > goroutineSlack {
+		t.Fatalf("expected scheduler goroutine to stop: before=%d afterStop=%d (delta=%d exceeds slack=%d)",
+			before, afterStop, delta, goroutineSlack)
+	}
+}

--- a/doc/implementation/cluster/HEARTBEAT_AND_ARBITRATION.md
+++ b/doc/implementation/cluster/HEARTBEAT_AND_ARBITRATION.md
@@ -179,6 +179,16 @@ Two writers to the same arbitrator row caused flapping: `WriteHeartbeat` (POST `
 
 Previously `ArbitratorElection()` only fired on the split-brain transition (`IsSplitBrainBck != IsSplitBrain`). After the first tick, `IsSplitBrainBck` was updated to match, so subsequent ticks skipped the election. This broke election transfer when one repman was stopped. Fixed: election now runs every tick during split-brain via `arbitratorElection()`.
 
+### ~~SetActiveStatus Goroutine Leak~~ (Fixed, GH-1674)
+
+Because election runs every tick during split-brain (see above), `arbitratorElection()` (`cluster/cluster_split.go`) calls `SetActiveStatus(ConstMonitorActif)` or `SetActiveStatus(ConstMonitorStandby)` on *every* tick the verdict holds, not only on the tick it actually changes — the surrounding code already logs the transition once, but the status write and its scheduler side effect were unconditional.
+
+`utils/cron.Cron.Start()` is not idempotent — it unconditionally does `go c.run()` on the same `*Cron` — so every redundant `SetActiveStatus(sameStatus)` call while a cluster stayed the winner (or loser) leaked another `run()` goroutine for the rest of the process. All leaked goroutines loop over the *same* shared `c.entries` slice (there is no per-goroutine copy), so each one independently fires `Job.Run()` for every entry whose schedule matches — a single scheduled tick gets executed once per leaked goroutine (duplicate backups, optimize/analyze runs, etc.). Since the election re-affirms the same verdict every tick, the leak scaled with the duration of the split brain, not with the number of real transitions — unbounded monitoring-loop growth (F2/F3/F4, T18).
+
+Fixed in `cluster/cluster_set.go`: `SetActiveStatus()` now returns early when the requested status equals `cluster.Status`, making it safe to call redundantly from any caller rather than pushing "only call on an actual transition" bookkeeping onto `arbitratorElection()`. `cron.Cron.Start`/`Stop` remain non-idempotent, and this fix only guards the `SetActiveStatus` path — `SetMonitoringScheduler`, `SwitchMonitoringScheduler`, and `initScheduler` still call `scheduler.Start()`/`Stop()` directly and would need their own guard if a caller ever re-invoked them redundantly.
+
+Regression coverage: `cluster/cluster_set_test.go` exercises a real `*cron.Cron` and asserts via `runtime.NumGoroutine()` diffs that (a) 20 redundant same-status calls after activation add no goroutines, and (b) a real actif↔standby flip still starts/stops the scheduler goroutine. Passes under `go test ./cluster/ -run TestSetActiveStatus -race -count=5`.
+
 ## Known Issues (Current)
 
 ### INSERT OR REPLACE Destroys Election Status
@@ -192,6 +202,10 @@ Both `ArbitratorHandler` (via `arbitratorElection()`, runs during split-brain) a
 ### Server-Level Status Not Derived from Quorum
 
 `repman.Status` is set to Standby at startup (when arbitration enabled) and is only changed by the manual toggle API. It does not reflect the actual quorum state. The GUI Navbar shows split brain state (`"In Majority"` / `"Split Brain"`) based on `repman.SplitBrain`, but this only checks peer reachability — not arbitrator reachability. A full lost-majority state (peer AND arbitrator unreachable) is not surfaced at the server level.
+
+### No Regtest for Repeated Arbitration Reinforcement (GH-1674 follow-up)
+
+The `SetActiveStatus` goroutine-leak fix above has unit coverage (`cluster/cluster_set_test.go`) but no Docker-backed `regtest/` scenario drives a real split-brain incident through many arbitration ticks end to end, per T13. GH-1674 also has no labels or milestone set yet (T11/T12).
 
 ### Split-Brain Badge Scope
 


### PR DESCRIPTION
## Summary
- return early from `SetActiveStatus()` when the requested status already matches the cluster status
- add regression coverage for repeated arbitration reinforcement so redundant status updates do not leak scheduler goroutines
- document the GH-1674 root cause, fix, and remaining regtest/process follow-ups

## Validation
- `go test ./cluster -run TestSetActiveStatus -race -count=5`