### PR TITLE
fix(graphite): passive monitor emits metrics only when carbon is embedded (#1680)

### DIFF
--- a/cluster/cluster_has.go
+++ b/cluster/cluster_has.go
@@ -503,6 +503,21 @@ func (cluster *Cluster) IsActive() bool {
 	}
 }
 
+// CanSendGraphiteMetrics reports whether this monitor should collect and emit
+// graphite metrics this tick. The active monitor always does. A passive/standby
+// monitor does so only when carbon is embedded: it then records its OWN
+// observation of the cluster into its OWN local carbon — each monitor keeps its
+// independent view of the world (comparing the active vs passive perspective is
+// diagnostic, e.g. split-brain). This way a standby never duplicates the active
+// monitor's series on a shared carbon, and never doubles the metric query load
+// on the monitored DB for nothing. See issue #1680.
+func (cluster *Cluster) CanSendGraphiteMetrics() bool {
+	if !cluster.Conf.GraphiteMetrics {
+		return false
+	}
+	return cluster.IsActive() || cluster.Conf.GraphiteEmbedded
+}
+
 func (cluster *Cluster) IsVerbose() bool {
 	if cluster.Conf.Verbose {
 		return true

--- a/cluster/cluster_has_test.go
+++ b/cluster/cluster_has_test.go
@@ -1,0 +1,34 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+)
+
+func TestCanSendGraphiteMetrics(t *testing.T) {
+	cases := []struct {
+		name     string
+		metrics  bool
+		status   string
+		embedded bool
+		want     bool
+	}{
+		{"active sends", true, ConstMonitorActif, false, true},
+		{"active sends (embedded too)", true, ConstMonitorActif, true, true},
+		{"standby embedded records own view", true, ConstMonitorStandby, true, true},
+		{"standby non-embedded stays silent", true, ConstMonitorStandby, false, false},
+		{"metrics disabled: never", false, ConstMonitorActif, true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cl := &Cluster{
+				Status: c.status,
+				Conf:   &config.Config{GraphiteMetrics: c.metrics, GraphiteEmbedded: c.embedded},
+			}
+			if got := cl.CanSendGraphiteMetrics(); got != c.want {
+				t.Fatalf("CanSendGraphiteMetrics() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/cluster/prx.go
+++ b/cluster/prx.go
@@ -490,7 +490,7 @@ func (cluster *Cluster) refreshProxies(wcg *sync.WaitGroup) {
 				cluster.BashScriptPrxServersChangeState(pr, pr.GetState(), pr.GetPrevState())
 				pr.SetPrevState(pr.GetState())
 			}
-			if cluster.Conf.GraphiteMetrics {
+			if cluster.CanSendGraphiteMetrics() {
 				pr.FetchStats()
 			}
 			//	pr.DelLock()

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -10,12 +10,12 @@
 package cluster
 
 import (
+	"compress/gzip"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"compress/gzip"
 	"hash/crc64"
 	"io"
 	"net/http"
@@ -1465,7 +1465,7 @@ func (server *ServerMonitor) Refresh() error {
 	server.CheckMaxConnections()
 
 	// Initialize graphite monitoring
-	if cluster.Conf.GraphiteMetrics {
+	if cluster.CanSendGraphiteMetrics() {
 		go server.FetchDatabaseStats()
 	}
 	return nil

--- a/cluster/srv_log_plugins.go
+++ b/cluster/srv_log_plugins.go
@@ -209,7 +209,7 @@ func (server *ServerMonitor) RunLogPlugins(spikeCache map[string]*logplugin.Spik
 
 		// Send synthetic graphite metric if the plugin produced one.
 		// This ensures history accumulates even before any spike is detected.
-		if result.MetricName != "" && cluster.Conf.GraphiteMetrics && cluster.ClusterGraphite != nil {
+		if result.MetricName != "" && cluster.CanSendGraphiteMetrics() && cluster.ClusterGraphite != nil {
 			m := graphite.NewMetric(
 				result.MetricName,
 				fmt.Sprintf("%d", result.CurrentCount),
@@ -785,11 +785,11 @@ func (cluster *Cluster) GetLogPluginStates(serverURL string) []state.State {
 	SM := cluster.GetStateMachine()
 	opened := SM.GetLastOpenedStates()
 	keys := map[string]bool{
-		logplugin.ErrKeyDBError24h:          true,
-		logplugin.ErrKeySQLError24h:         true,
-		logplugin.ErrKeySlowLog24h:          true,
-		logplugin.ErrKeyAuditDrift:          true,
-		"WARN0205":                           true,
+		logplugin.ErrKeyDBError24h:            true,
+		logplugin.ErrKeySQLError24h:           true,
+		logplugin.ErrKeySlowLog24h:            true,
+		logplugin.ErrKeyAuditDrift:            true,
+		"WARN0205":                            true,
 		logplugin.ErrKeyMissingMonitoringFeed: true,
 	}
 	var out []state.State


### PR DESCRIPTION
Closes #1680.

### Problem
A standby/passive monitor (`Status != ConstMonitorActif`) still collected and sent graphite metrics. The feed was gated only on `graphite-metrics`, not on active — unlike `SendAlert`, which returns early on standby. Result: **duplicate series** on a shared carbon, and **doubled metric query load** on the monitored DB.

### Fix
Gate the feed on a new predicate:
```go
func (cluster *Cluster) CanSendGraphiteMetrics() bool {
    return cluster.Conf.GraphiteMetrics && (cluster.IsActive() || cluster.Conf.GraphiteEmbedded)
}
```
Applied to all three producers: `srv.go` (`FetchDatabaseStats`), `prx.go` (proxy `FetchStats`), `srv_log_plugins.go` (synthetic metric).

- **Active** always emits (to wherever carbon points).
- **Passive + embedded** emits only to its **own local carbon** — each monitor records its **own observation of the cluster** (comparing the active vs passive view is diagnostic, e.g. split-brain). No collision, since embedded carbons are per-instance.
- **Passive + shared carbon** stays silent → no duplicate series, no doubled DB query load.

Only the **feed** is gated; the flush and the repman disk-usage check are untouched (the flush is a harmless no-op on an empty queue). Unit test covers the predicate matrix.

### Scope
Independent of #1675 / PR #1679 (the queue cap). Different files, no conflict. Both are needed: the cap bounds the queue; this stops a standby from feeding it in the first place.