### PR TITLE
feat(global): add global jobs dashboard

### DIFF
--- a/cluster/cluster_acl.go
+++ b/cluster/cluster_acl.go
@@ -108,6 +108,7 @@ func (u *APIUser) Granted(grant string) error {
 //   - no password        => SSO identity. Authenticated by OIDC only; local
 //     password auth is refused — an empty stored or submitted password must
 //     never authenticate, closing the blank-password bypass.
+//
 // IsLocalOnlyAccount reports whether strUser is a local (password-protected)
 // account that must authenticate by password only — SSO must never bind or
 // authenticate it, or a same-named GitLab identity would ride its ACL. The
@@ -124,6 +125,19 @@ func (cluster *Cluster) IsLocalOnlyAccount(strUser string) bool {
 }
 
 func (cluster *Cluster) IsValidACL(strUser string, strPassword string, URL string, AuthMethod string) bool {
+	return cluster.isValidACL(strUser, strPassword, URL, AuthMethod, true)
+}
+
+// IsValidACLQuiet behaves exactly like IsValidACL (same password re-verification,
+// same grant check) but does not log denied checks. Intended for aggregate/probing
+// callers, e.g. the global jobs dashboard, that deliberately test many clusters per
+// request and would otherwise flood cluster logs with expected denials for clusters
+// the caller can't see.
+func (cluster *Cluster) IsValidACLQuiet(strUser string, strPassword string, URL string, AuthMethod string) bool {
+	return cluster.isValidACL(strUser, strPassword, URL, AuthMethod, false)
+}
+
+func (cluster *Cluster) isValidACL(strUser string, strPassword string, URL string, AuthMethod string, errorPrint bool) bool {
 	user, ok := cluster.APIUsers[strUser]
 	if !ok {
 		return false
@@ -135,7 +149,7 @@ func (cluster *Cluster) IsValidACL(strUser string, strPassword string, URL strin
 		if cluster.IsLocalOnlyAccount(strUser) {
 			return false
 		}
-		return cluster.IsURLPassACL(strUser, URL, true)
+		return cluster.IsURLPassACL(strUser, URL, errorPrint)
 	}
 
 	// Local password auth: passwordless accounts are SSO-only, and a blank
@@ -144,7 +158,7 @@ func (cluster *Cluster) IsValidACL(strUser string, strPassword string, URL strin
 		return false
 	}
 	if subtle.ConstantTimeCompare([]byte(user.Password), []byte(cluster.Conf.GetDecryptedPassword("api-credentials", strPassword))) == 1 {
-		return cluster.IsURLPassACL(strUser, URL, true)
+		return cluster.IsURLPassACL(strUser, URL, errorPrint)
 	}
 	return false
 }

--- a/doc/global_jobs_dashboard.md
+++ b/doc/global_jobs_dashboard.md
@@ -1,0 +1,69 @@
+# Global Jobs Dashboard
+
+## What it solves
+When you manage multiple clusters, checking job activity cluster by cluster is slow. The Global Jobs dashboard gives you one place to see:
+- what is active right now,
+- what just completed,
+- whether any cluster has a current restic task.
+
+## Where to find it
+Open the web dashboard and go to:
+- **Dashboard** (global view)
+- **Global Jobs** accordion
+
+## What you will see
+
+### Active Jobs
+Shows DB jobs that are still active or waiting for completion.
+
+Columns:
+- Cluster
+- Server
+- Task
+- State
+- Description
+- Start
+- End
+
+Active jobs include these states:
+- **Init**
+- **Running**
+- **Halted**
+
+### Recently Done
+Shows the most recent completed DB jobs across clusters.
+
+Behavior:
+- keeps a small recent history per cluster,
+- then sorts the combined results so the newest completions appear first.
+
+This helps you quickly answer questions like:
+- what just finished?
+- what just failed?
+
+### Current Restic Tasks
+Shows the current active restic task, when one exists.
+
+Columns include:
+- Cluster
+- Task Type
+- Status
+- Phase
+- Progress
+- Started
+- Error
+
+## Access control
+You only see data for clusters and sections your account is already allowed to access.
+
+That means:
+- if you cannot access a cluster's jobs, they do not appear here,
+- if you cannot access a cluster's restic task state, it is omitted here as well.
+
+## Limits and behavior
+- The dashboard uses one aggregate request instead of polling each cluster separately from the browser.
+- Restic history here is **current-task only**. This view is not a durable history of past restic work.
+- The dashboard is read-only in this first version.
+
+## Why this matters
+This view reduces click-through, improves fleet-wide visibility, and helps operators see active and recently completed work quickly during normal operations and incident response.

--- a/doc/implementation/README.md
+++ b/doc/implementation/README.md
@@ -47,6 +47,11 @@ Frontend UI component documentation.
 - **ServerMenu.REVIEW.md** - ServerMenu component review notes
 - **ServerMenu.SUMMARY.md** - ServerMenu component summary
 
+### `/server/`
+Server API and cross-cluster aggregation documentation.
+
+- **GLOBAL_JOBS_DASHBOARD.md** - Global jobs aggregate endpoint, ACL behavior, and dashboard wiring
+
 ### `/utils/dbhelper/`
 Database helper utilities documentation.
 

--- a/doc/implementation/server/GLOBAL_JOBS_DASHBOARD.md
+++ b/doc/implementation/server/GLOBAL_JOBS_DASHBOARD.md
@@ -1,0 +1,93 @@
+# Server: Global Jobs Dashboard
+
+## Scope
+This document covers the read-only global jobs aggregate added for the dashboard. It exposes one server endpoint and one GUI section that let an operator see cross-cluster job activity without opening every cluster's Maintenance page.
+
+## Why this exists
+- Operators needed a fleet-wide view of what is active now and what just finished.
+- The per-cluster Maintenance page already had the data, but only one cluster at a time.
+- Frontend fan-out to every cluster would create many HTTP requests every refresh and scale poorly as cluster count grows.
+
+## Backend API
+- New endpoint: `GET /api/global/jobs`
+- File: `server/api_global.go`
+- Route registration: `server/http.go`
+
+The response contains three arrays:
+- `runningJobs`
+- `recentCompletedJobs`
+- `resticCurrentTasks`
+
+## Aggregation model
+The endpoint snapshots `repman.Clusters` under the repman lock, then iterates the snapshot. This avoids races with dynamic cluster add/remove while the global dashboard polls.
+
+For each cluster, the handler:
+1. resolves the caller identity from the JWT once,
+2. checks whether the caller could already access the equivalent per-cluster endpoint,
+3. includes only the sections the caller is allowed to see,
+4. reuses existing cluster data paths rather than introducing new job/restic execution logic.
+
+## ACL behavior
+Global visibility is gated by `global-admin-show`, but that grant alone does **not** authorize every cluster's job data.
+
+Per cluster, the aggregate probes the same access the caller would need for:
+- `/api/clusters/{cluster}/jobs`
+- `/api/clusters/{cluster}/restic/task-current`
+
+Expected denials are checked with `IsValidACLQuiet`, which preserves the normal ACL decision but suppresses log noise during regular dashboard polling.
+
+## Job semantics
+### Active jobs
+The dashboard intentionally treats these DB job states as active:
+- `0` = Init
+- `1` = Running
+- `2` = Halted
+
+This matches the operational goal: show work that is still in flight or needs attention, not only tasks already executing.
+
+### Recently done jobs
+The dashboard treats these states as completed history:
+- `3` = Done
+- `4` = Success
+- `5` = Error
+- `6` = PTError
+
+Rules:
+- keep the last `5` completed DB jobs per cluster,
+- then sort the combined cross-cluster list by `end DESC`,
+- so the final view is globally newest-first.
+
+### Stable row order
+`entries.Servers` is a map, so active-job iteration order is not stable by default. The aggregate sorts `runningJobs` by:
+1. `clusterName`
+2. `serverUrl`
+3. `task`
+
+This avoids distracting row shuffling on each poll.
+
+## Restic semantics
+The dashboard exposes only the **current** restic task per cluster.
+
+It does **not** claim durable recent restic history. The backend only retains a completed/failed current task briefly before clearing it, so a stable "recently done restic tasks" history would require separate persistence and was intentionally left out of this feature.
+
+## Frontend wiring
+- Service: `share/dashboard_react/src/services/globalClustersService.js`
+- Redux state/thunk: `share/dashboard_react/src/redux/globalClustersSlice.js`
+- Poll trigger: `share/dashboard_react/src/Pages/Home/index.jsx`
+- GUI component: `share/dashboard_react/src/Pages/GlobalItems/GlobalJobs.jsx`
+
+The global dashboard now fetches one aggregate payload instead of issuing one jobs request and one restic request per cluster from the browser.
+
+## GUI sections
+The dashboard renders three sections:
+- **Active Jobs**
+- **Recently Done**
+- **Current Restic Tasks**
+
+## Validation expectations
+At minimum, validate:
+- only authorized clusters appear,
+- Active Jobs shows states `0/1/2`,
+- Recently Done is globally newest-first,
+- Current Restic Tasks matches the per-cluster Maintenance view,
+- the endpoint remains one request per global dashboard refresh.

--- a/server/api_global.go
+++ b/server/api_global.go
@@ -13,13 +13,19 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"sort"
+	"strings"
 	"time"
 
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/golang-jwt/jwt/v5/request"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/disk"
 	"github.com/shirou/gopsutil/mem"
 	"github.com/shirou/gopsutil/process"
+	"github.com/signal18/replication-manager/cluster"
 	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/backupmgr"
 	"github.com/signal18/replication-manager/utils/s18log"
 	"github.com/signal18/replication-manager/utils/state"
 )
@@ -315,4 +321,234 @@ func (repman *ReplicationManager) handlerMuxForgetArbitration(w http.ResponseWri
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(resp.StatusCode)
 	w.Write(body)
+}
+
+// globalJobsRecentLimit caps how many recently completed DB jobs are kept per cluster.
+const globalJobsRecentLimit = 5
+
+// globalRequestIdentity is the JWT-derived caller identity used to evaluate
+// per-cluster ACL for /api/global/jobs sections.
+type globalRequestIdentity struct {
+	Username   string
+	Password   string
+	AuthMethod string
+}
+
+// resolveGlobalRequestIdentity parses the request JWT once so the same
+// (username, password, authMethod) can be checked against multiple clusters'
+// cluster.IsValidACL with synthetic per-section URLs. It mirrors the claims
+// handling in IsValidClusterACL, kept local here rather than factored into that
+// shared, widely-used function to avoid touching behavior other endpoints rely on.
+func (repman *ReplicationManager) resolveGlobalRequestIdentity(r *http.Request) (globalRequestIdentity, bool) {
+	token, err := request.ParseFromRequest(r, request.AuthorizationHeaderExtractor, func(token *jwt.Token) (interface{}, error) {
+		vk, _ := jwt.ParseRSAPublicKeyFromPEM(verificationKey)
+		return vk, nil
+	})
+	if err != nil {
+		return globalRequestIdentity{}, false
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return globalRequestIdentity{}, false
+	}
+	mycutinfo, ok := claims["CustomUserInfo"].(map[string]interface{})
+	if !ok {
+		return globalRequestIdentity{}, false
+	}
+	username, _ := mycutinfo["Name"].(string)
+	password, _ := mycutinfo["Password"].(string)
+
+	if profile, ok := mycutinfo["profile"].(string); ok {
+		if strings.Contains(profile, repman.Conf.OAuthProvider) {
+			email, _ := mycutinfo["email"].(string)
+			return globalRequestIdentity{Username: email, Password: password, AuthMethod: "oidc"}, true
+		}
+	}
+	return globalRequestIdentity{Username: username, Password: password, AuthMethod: "password"}, true
+}
+
+// globalJobEntry is a single DB job entry surfaced in the global jobs aggregate,
+// annotated with the cluster and server it belongs to.
+type globalJobEntry struct {
+	ClusterName string `json:"clusterName"`
+	ServerId    string `json:"serverId"`
+	ServerUrl   string `json:"serverUrl"`
+	Task        string `json:"task"`
+	State       int    `json:"state"`
+	StateLabel  string `json:"stateLabel"`
+	Result      string `json:"result,omitempty"`
+	Start       int64  `json:"start"`
+	End         int64  `json:"end,omitempty"`
+}
+
+// globalClusterResticTask is the current restic task for one cluster in the global jobs aggregate.
+type globalClusterResticTask struct {
+	ClusterName string                     `json:"clusterName"`
+	CurrentTask *backupmgr.ResticTaskState `json:"currentTask"`
+}
+
+// globalJobsResponse is the JSON payload for GET /api/global/jobs.
+type globalJobsResponse struct {
+	RunningJobs         []globalJobEntry          `json:"runningJobs"`
+	RecentCompletedJobs []globalJobEntry          `json:"recentCompletedJobs"`
+	ResticCurrentTasks  []globalClusterResticTask `json:"resticCurrentTasks"`
+}
+
+// jobStateLabel mirrors the state labels used by the per-cluster jobs UI
+// (share/dashboard_react/src/Pages/Maintenance/DatabaseJobs).
+func jobStateLabel(jobState int) string {
+	switch jobState {
+	case cluster.JobStateAvailable:
+		return "Init"
+	case cluster.JobStateRunning:
+		return "Running"
+	case cluster.JobStateHalted:
+		return "Halted"
+	case cluster.JobStateFinished:
+		return "Done"
+	case cluster.JobStateSuccess:
+		return "Success"
+	case cluster.JobStateErrorExec:
+		return "Error"
+	case cluster.JobStateErrorAfter:
+		return "PTError"
+	default:
+		return "Unknown"
+	}
+}
+
+// handlerMuxGlobalJobs returns a cross-cluster aggregate of running DB jobs, the
+// last few completed DB jobs per cluster, and the current Restic task per cluster.
+//
+// @Summary Get global jobs
+// @Description Returns running and recently completed DB jobs, and current Restic tasks, across all clusters.
+// @Tags Global
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Success 200 {object} globalJobsResponse
+// @Failure 401 {string} string "Unauthorized"
+// @Router /api/global/jobs [get]
+func (repman *ReplicationManager) handlerMuxGlobalJobs(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	if !repman.UserHasGlobalGrant(r, config.GrantGlobalAdminShow) {
+		http.Error(w, "Forbidden: requires "+config.GrantGlobalAdminShow+" grant", http.StatusForbidden)
+		return
+	}
+
+	resp := globalJobsResponse{
+		RunningJobs:         []globalJobEntry{},
+		RecentCompletedJobs: []globalJobEntry{},
+		ResticCurrentTasks:  []globalClusterResticTask{},
+	}
+
+	identity, ok := repman.resolveGlobalRequestIdentity(r)
+	if !ok {
+		http.Error(w, "Forbidden: unable to resolve caller identity", http.StatusForbidden)
+		return
+	}
+
+	// Snapshot the Clusters map under the repman lock to avoid racing with
+	// StartCluster / cluster removal, which mutate the map under that same lock.
+	// This endpoint is polled continuously, so an unsynchronized range here would
+	// eventually overlap a dynamic add/remove and panic (concurrent map read/write).
+	repman.Lock()
+	clusterSnapshot := make(map[string]*cluster.Cluster, len(repman.Clusters))
+	for k, v := range repman.Clusters {
+		clusterSnapshot[k] = v
+	}
+	repman.Unlock()
+
+	clusterNames := make([]string, 0, len(clusterSnapshot))
+	for name := range clusterSnapshot {
+		clusterNames = append(clusterNames, name)
+	}
+	sort.Strings(clusterNames)
+
+	for _, name := range clusterNames {
+		cl := clusterSnapshot[name]
+		if cl == nil {
+			continue
+		}
+
+		// Per-cluster ACL: only include a section if this caller would already be
+		// allowed to reach the equivalent per-cluster endpoint. global-admin-show
+		// grants visibility into the aggregate, not into every cluster's data.
+		// Quiet variant: this endpoint is polled and probes every cluster, so a
+		// caller without access to cluster X would otherwise log a denial on X
+		// every refresh even though the denial here is expected, not an incident.
+		canViewJobs := cl.IsValidACLQuiet(identity.Username, identity.Password, "/api/clusters/"+name+"/jobs", identity.AuthMethod)
+		canViewRestic := cl.IsValidACLQuiet(identity.Username, identity.Password, "/api/clusters/"+name+"/restic/task-current", identity.AuthMethod)
+
+		if canViewJobs {
+			if entries, err := cl.JobsGetEntries(); err == nil {
+				var completed []globalJobEntry
+				for serverId, list := range entries.Servers {
+					for _, t := range list.Tasks {
+						entry := globalJobEntry{
+							ClusterName: name,
+							ServerId:    serverId,
+							ServerUrl:   list.ServerURL,
+							Task:        t.Task,
+							State:       t.State,
+							StateLabel:  jobStateLabel(t.State),
+							Result:      t.Result,
+							Start:       t.Start,
+							End:         t.End,
+						}
+						switch t.State {
+						case cluster.JobStateAvailable, cluster.JobStateRunning, cluster.JobStateHalted:
+							resp.RunningJobs = append(resp.RunningJobs, entry)
+						case cluster.JobStateFinished, cluster.JobStateSuccess, cluster.JobStateErrorExec, cluster.JobStateErrorAfter:
+							completed = append(completed, entry)
+						}
+					}
+				}
+				sort.Slice(completed, func(i, j int) bool { return completed[i].End > completed[j].End })
+				if len(completed) > globalJobsRecentLimit {
+					completed = completed[:globalJobsRecentLimit]
+				}
+				resp.RecentCompletedJobs = append(resp.RecentCompletedJobs, completed...)
+			}
+		}
+
+		if canViewRestic && cl.ResticManager != nil {
+			if task := cl.ResticManager.GetCurrentTaskState(); task != nil {
+				resp.ResticCurrentTasks = append(resp.ResticCurrentTasks, globalClusterResticTask{
+					ClusterName: name,
+					CurrentTask: task,
+				})
+			}
+		}
+	}
+
+	// Per-cluster capping above keeps any one cluster from crowding out the rest;
+	// this final sort makes the combined list globally newest-first.
+	sort.Slice(resp.RecentCompletedJobs, func(i, j int) bool {
+		return resp.RecentCompletedJobs[i].End > resp.RecentCompletedJobs[j].End
+	})
+
+	// entries.Servers (cluster/cluster_job.go) is a map, so the per-server
+	// iteration order that built RunningJobs is randomized per request; sort it
+	// for a stable row order across polls even when nothing has changed.
+	sort.Slice(resp.RunningJobs, func(i, j int) bool {
+		a, b := resp.RunningJobs[i], resp.RunningJobs[j]
+		if a.ClusterName != b.ClusterName {
+			return a.ClusterName < b.ClusterName
+		}
+		if a.ServerUrl != b.ServerUrl {
+			return a.ServerUrl < b.ServerUrl
+		}
+		return a.Task < b.Task
+	})
+
+	out, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(w, "Error encoding response", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(out)
 }

--- a/server/http.go
+++ b/server/http.go
@@ -366,6 +366,10 @@ func (repman *ReplicationManager) httpserver() {
 			negroni.HandlerFunc(repman.validateTokenMiddleware),
 			negroni.Wrap(http.HandlerFunc(repman.handlerMuxGlobalLogs)),
 		))
+		router.Handle("/api/global/jobs", negroni.New(
+			negroni.HandlerFunc(repman.validateTokenMiddleware),
+			negroni.Wrap(http.HandlerFunc(repman.handlerMuxGlobalJobs)),
+		))
 		repman.apiMeetProtectedHandler(router)
 		repman.apiClusterProtectedHandler(router)
 		repman.apiDatabaseProtectedHandler(router)

--- a/share/dashboard_react/src/Pages/GlobalItems/GlobalJobs.jsx
+++ b/share/dashboard_react/src/Pages/GlobalItems/GlobalJobs.jsx
@@ -1,0 +1,158 @@
+import { useMemo } from 'react'
+import { useSelector } from 'react-redux'
+import { Flex, Text } from '@chakra-ui/react'
+import { createColumnHelper } from '@tanstack/react-table'
+import { DataTable } from '../../components/DataTable'
+import TagPill from '../../components/TagPill'
+import AccordionComponent from '../../components/AccordionComponent'
+import { formatDate } from '../../utility/common'
+
+const jobStateColor = {
+  0: 'gray',
+  1: 'blue',
+  2: 'orange',
+  3: 'blue',
+  4: 'green',
+  5: 'red',
+  6: 'red'
+}
+
+function JobStateTag({ state, stateLabel }) {
+  return <TagPill colorScheme={jobStateColor[state] ?? 'gray'} text={stateLabel ?? 'Unknown'} />
+}
+
+const resticTaskType = (rtt) => {
+  switch (rtt) {
+    case 0:
+      return 'init'
+    case 1:
+      return 'fetch'
+    case 2:
+      return 'backup'
+    case 3:
+      return 'purge'
+    case 4:
+      return 'unlock'
+    case 5:
+      return 'changepass'
+    case 6:
+      return 'restore'
+    case 7:
+      return 'check'
+    case 8:
+      return 'copy'
+    default:
+      return 'Unknown'
+  }
+}
+
+function EmptyState({ text }) {
+  return (
+    <Text fontSize='sm' opacity={0.7} p='8px'>
+      {text}
+    </Text>
+  )
+}
+
+function JobsTable({ jobs, emptyText }) {
+  const columnHelper = createColumnHelper()
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor('clusterName', { header: 'Cluster' }),
+      columnHelper.accessor('serverUrl', { header: 'Server' }),
+      columnHelper.accessor('task', { header: 'Task' }),
+      columnHelper.accessor('state', {
+        header: 'State',
+        cell: (info) => <JobStateTag state={info.getValue()} stateLabel={info.row.original.stateLabel} />
+      }),
+      columnHelper.accessor('result', { header: 'Desc' }),
+      columnHelper.accessor((row) => (row.start ? formatDate(new Date(row.start * 1000)) : ''), {
+        id: 'start',
+        header: 'Start'
+      }),
+      columnHelper.accessor((row) => (row.end ? formatDate(new Date(row.end * 1000)) : ''), {
+        id: 'end',
+        header: 'End'
+      })
+    ],
+    []
+  )
+
+  if (!jobs || jobs.length === 0) {
+    return <EmptyState text={emptyText} />
+  }
+
+  return <DataTable data={jobs} columns={columns} />
+}
+
+function ResticTasksTable({ tasks }) {
+  const columnHelper = createColumnHelper()
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor('clusterName', { header: 'Cluster' }),
+      columnHelper.accessor((row) => resticTaskType(row.currentTask?.task_type), {
+        id: 'taskType',
+        header: 'Task Type'
+      }),
+      columnHelper.accessor((row) => row.currentTask?.status, { id: 'status', header: 'Status' }),
+      columnHelper.accessor((row) => row.currentTask?.phase || '-', { id: 'phase', header: 'Phase' }),
+      columnHelper.accessor(
+        (row) => (typeof row.currentTask?.percent_done === 'number' ? `${(row.currentTask.percent_done * 100).toFixed(1)}%` : '-'),
+        { id: 'percentDone', header: 'Progress' }
+      ),
+      columnHelper.accessor((row) => (row.currentTask?.started_at ? formatDate(new Date(row.currentTask.started_at)) : ''), {
+        id: 'startedAt',
+        header: 'Started'
+      }),
+      columnHelper.accessor((row) => row.currentTask?.error || '', { id: 'error', header: 'Error' })
+    ],
+    []
+  )
+
+  if (!tasks || tasks.length === 0) {
+    return <EmptyState text='No active Restic tasks.' />
+  }
+
+  return <DataTable data={tasks} columns={columns} />
+}
+
+function GlobalJobsBody() {
+  const globalJobs = useSelector((state) => state.globalClusters.globalJobs)
+  const runningJobs = globalJobs?.runningJobs ?? []
+  const recentCompletedJobs = globalJobs?.recentCompletedJobs ?? []
+  const resticCurrentTasks = globalJobs?.resticCurrentTasks ?? []
+
+  return (
+    <Flex direction='column' gap='12px' p='12px'>
+      <AccordionComponent
+        heading={
+          <Flex align='center' gap='8px'>
+            <Text>Active Jobs</Text>
+            <TagPill colorScheme='blue' text={`${runningJobs.length}`} />
+          </Flex>
+        }
+        body={<JobsTable jobs={runningJobs} emptyText='No active jobs.' />}
+      />
+      <AccordionComponent
+        heading={
+          <Flex align='center' gap='8px'>
+            <Text>Recently Done</Text>
+            <TagPill colorScheme='gray' text={`${recentCompletedJobs.length}`} />
+          </Flex>
+        }
+        body={<JobsTable jobs={recentCompletedJobs} emptyText='No recently completed jobs.' />}
+      />
+      <AccordionComponent
+        heading={
+          <Flex align='center' gap='8px'>
+            <Text>Current Restic Tasks</Text>
+            <TagPill colorScheme='purple' text={`${resticCurrentTasks.length}`} />
+          </Flex>
+        }
+        body={<ResticTasksTable tasks={resticCurrentTasks} />}
+      />
+    </Flex>
+  )
+}
+
+export default GlobalJobsBody

--- a/share/dashboard_react/src/Pages/GlobalItems/index.jsx
+++ b/share/dashboard_react/src/Pages/GlobalItems/index.jsx
@@ -9,6 +9,7 @@ import styles from './styles.module.scss'
 import Logs from '../Dashboard/components/Logs'
 import AccordionComponent from '../../components/AccordionComponent'
 import AlertModal from '../../components/Modals/AlertModal'
+import GlobalJobsBody from './GlobalJobs'
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -343,6 +344,7 @@ function GlobalItems() {
         body={<GlobalAlertsBody globalAlerts={globalAlerts} onOpenModal={setGlobalAlertModalType} />}
       />
       <AccordionComponent heading='Global Logs' body={<GlobalLogs />} />
+      <AccordionComponent heading='Global Jobs' body={<GlobalJobsBody />} />
       <AlertModal
         type={globalAlertModalType}
         isOpen={globalAlertModalType.length !== 0}

--- a/share/dashboard_react/src/Pages/Home/index.jsx
+++ b/share/dashboard_react/src/Pages/Home/index.jsx
@@ -29,7 +29,7 @@ import {
   getBackups,
   getResticCurrentTask
 } from '../../redux/clusterSlice'
-import { getClusters, getMonitoredData, getClusterPeers, getClusterForSale, getGlobalAlerts, getGlobalMetrics, getGlobalLogs } from '../../redux/globalClustersSlice'
+import { getClusters, getMonitoredData, getClusterPeers, getClusterForSale, getGlobalAlerts, getGlobalMetrics, getGlobalLogs, getGlobalJobs } from '../../redux/globalClustersSlice'
 import { AppSettings } from '../../AppSettings'
 import { isAutoReloadPaused } from '../../utility/autoReloadPause'
 import styles from './styles.module.scss'
@@ -251,6 +251,7 @@ function Home() {
           dispatch(getGlobalAlerts({}))
           dispatch(getGlobalMetrics({}))
           dispatch(getGlobalLogs({}))
+          dispatch(getGlobalJobs({}))
         }
       }
     } else if (selectedClusterNameRef.current) {

--- a/share/dashboard_react/src/redux/globalClustersSlice.js
+++ b/share/dashboard_react/src/redux/globalClustersSlice.js
@@ -428,6 +428,18 @@ export const getGlobalAlerts = createGuardedAsyncThunk('globalClusters/getGlobal
   }
 })
 
+export const getGlobalJobs = createGuardedAsyncThunk('globalClusters/getGlobalJobs', async ({ baseURL = '' } = {}, thunkAPI) => {
+  try {
+    const { data, status } = await globalClustersService.getGlobalJobs(baseURL)
+    if (status !== 200) {
+      throw new Error(data)
+    }
+    return { data, status }
+  } catch (error) {
+    return handleError(error, thunkAPI)
+  }
+})
+
 export const refreshAppTemplateRepo = createGuardedAsyncThunk(
   'globalClusters/refreshAppTemplateRepo',
   async ({ clusterName, silent = false, forceRefresh = false }, thunkAPI) => {
@@ -494,7 +506,8 @@ const initialState = {
   terms: ``,
   globalAlerts: { errors: [], warnings: [], infos: [] },
   globalMetrics: null,
-  globalLogs: { general: { buffer: [], len: 0, line: 0 } }
+  globalLogs: { general: { buffer: [], len: 0, line: 0 } },
+  globalJobs: { runningJobs: [], recentCompletedJobs: [], resticCurrentTasks: [] }
 }
 
 export const globalClustersSlice = createSlice({
@@ -623,6 +636,16 @@ export const globalClustersSlice = createSlice({
         state.globalLogs = action.payload.data ?? { general: { buffer: [], len: 0, line: 0 } }
       })
       .addCase(getGlobalLogs.rejected, (state, action) => {
+        state.error = action.error
+      })
+      .addCase(getGlobalJobs.fulfilled, (state, action) => {
+        state.globalJobs = {
+          runningJobs: action.payload.data?.runningJobs ?? [],
+          recentCompletedJobs: action.payload.data?.recentCompletedJobs ?? [],
+          resticCurrentTasks: action.payload.data?.resticCurrentTasks ?? []
+        }
+      })
+      .addCase(getGlobalJobs.rejected, (state, action) => {
         state.error = action.error
       })
 

--- a/share/dashboard_react/src/services/globalClustersService.js
+++ b/share/dashboard_react/src/services/globalClustersService.js
@@ -9,6 +9,7 @@ export const globalClustersService = {
   getGlobalAlerts,
   getGlobalMetrics,
   getGlobalLogs,
+  getGlobalJobs,
   switchGlobalSetting,
   setGlobalSetting,
   clearGlobalSetting,
@@ -48,6 +49,10 @@ function getGlobalMetrics(baseURL) {
 
 function getGlobalLogs(baseURL) {
   return getApi(baseURL).get('global/http-logs')
+}
+
+function getGlobalJobs(baseURL) {
+  return getApi(baseURL).get('global/jobs')
 }
 
 function getTermsData(baseURL) {


### PR DESCRIPTION
## Summary
- add a global `/api/global/jobs` aggregate endpoint for active jobs, recent completed jobs, and current restic tasks
- add the Global Jobs dashboard accordion and redux/service wiring
- document the user-facing behavior and technical implementation

## Why
Closes #1683

This gives operators one place to see what is active right now and what just finished across accessible clusters, without clicking through every cluster Maintenance page.

## Validation
- go test ./server/...
- manual review of ACL behavior, active/recent ordering, and global dashboard wiring
