### PR TITLE
fix(jobs): populate API and runtime-only job timestamps

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1350,7 +1350,9 @@ func (cluster *Cluster) StateProcessing() {
 				cluster.trackTickGoroutine(func() {
 					err := srvReseed.ProcessReseedLogical(reseedTask)
 					if err != nil {
-						srvReseed.JobsUpdateState(reseedTask, err.Error(), 5, 1)
+						// ProcessReseedLogical never calls JobInsertTask, so there is no
+						// DB row for this task regardless of scheduler state.
+						srvReseed.JobsUpdateStateRuntimeOnly(reseedTask, err.Error(), 5, 1)
 						if srvReseed.HasReseedingState(reseedTask) {
 							srvReseed.SetInReseedBackup("")
 						}

--- a/cluster/cluster_staging.go
+++ b/cluster/cluster_staging.go
@@ -434,8 +434,6 @@ func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster, target *ServerM
 		dest = "mysqldump.sql.gz"
 	case config.ConstBackupLogicalTypeMydumper:
 		dest = "mydumper"
-	case config.ConstBackupLogicalTypeDumpling:
-		dest = "dumpling"
 	}
 
 	// Can't handle script validation, unknown logic
@@ -456,6 +454,18 @@ func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster, target *ServerM
 			target.SetInReseedBackup("")
 		}
 	}()
+
+	// Stamp the real start time now, before the potentially slow work below
+	// (StopSlaveChannel, ChangeMaster) -- but only for a type the dispatch
+	// below actually executes. Stamping unconditionally here would risk
+	// leaving an unsupported type stuck at "processing" forever, since the
+	// dispatch below has no case for it; only stamp when we know a terminal
+	// call is guaranteed to follow, without changing what counts as a
+	// supported type. No JobInsertTask call anywhere in this function, so
+	// there is no DB row either way.
+	if backtype == config.ConstBackupLogicalTypeMysqldump || backtype == config.ConstBackupLogicalTypeMydumper {
+		target.JobsUpdateStateRuntimeOnly(task, "processing", 1, 0)
+	}
 
 	//Delete wait logical backup cookie
 	target.DelWaitLogicalBackupCookie()
@@ -481,13 +491,12 @@ func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster, target *ServerM
 		dbhelper.ChangeMaster(target.Conn, changeOpt, target.DBVersion) // Ignore error
 	}
 
-	target.JobsUpdateState(task, "processing", 1, 0)
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Receive reseed logical backup %s request for server: %s", backtype, target.URL)
 
 	if backtype == config.ConstBackupLogicalTypeMysqldump {
 		if pmaster.LastBackupMeta.Logical != nil && !pmaster.LastBackupMeta.Logical.SplitUser {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Reseed mysqldump with no split user is not supported")
-			target.JobsUpdateState(task, "Reseed mysqldump with no split user is not supported", 5, 1)
+			target.JobsUpdateStateRuntimeOnly(task, "Reseed mysqldump with no split user is not supported", 5, 1)
 			return "", fmt.Errorf("Reseed mysqldump with no split user is not supported")
 		}
 		err = target.JobReseedMysqldump(backupfile, false)
@@ -517,16 +526,12 @@ func (cluster *Cluster) ReseedFromParentCluster(parent *Cluster, target *ServerM
 
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error reseed %s on %s: %s", backtype, target.URL, err.Error())
-		if e2 := target.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-		}
+		target.JobsUpdateStateRuntimeOnly(task, err.Error(), 5, 1)
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Reseed logical backup %s from parent cluster failed on %s", backtype, target.URL)
 		return "", err
 	}
 
-	if e2 := target.JobsUpdateState(task, "Reseed completed", 3, 1); e2 != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-	}
+	target.JobsUpdateStateRuntimeOnly(task, "Reseed completed", 3, 1)
 
 	if target.IsMaster() {
 		_, err2 := target.StartSlaveChannel(parent.Conf.MasterConn)

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -1233,7 +1233,40 @@ func (server *ServerMonitor) JobRunViaSSH() error {
 }
 
 // Job state always updated in replication-manager runtime.
+// JobsUpdateState updates a task's state for the normal case, where a real
+// jobs-table row may exist (it was created via JobInsertTask). Start/End are
+// only stamped here in API mode, where there is no jobs table at all;
+// otherwise the SQL UPDATE below (when the scheduler is active) is the
+// source of truth for those fields.
+//
+// Call sites that deliberately skip JobInsertTask — so there is no DB row for
+// this task run regardless of scheduler state — must use
+// JobsUpdateStateRuntimeOnly instead, not infer "no DB row" from
+// !MonitorScheduler: some callers (JobServerStop, JobServerRestart,
+// JobOptimize) call JobInsertTask unconditionally and do get a real row even
+// with the scheduler disabled.
 func (server *ServerMonitor) JobsUpdateState(task, result string, state, done int) error {
+	cluster := server.ClusterGroup
+	return server.jobsUpdateState(task, result, state, done, cluster.Conf.SchedulerJobsMode == "api")
+}
+
+// JobsUpdateStateRuntimeOnly behaves like JobsUpdateState but always stamps
+// Start/End from the in-memory cache, regardless of SchedulerJobsMode or
+// MonitorScheduler, and never touches the jobs table. Use it only from call
+// sites that never call JobInsertTask for this task, e.g. manual logical
+// backup/reseed flows (cluster/srv_job_backup.go) — JobsUpdateState alone
+// would leave Start/End blank forever there since there is no DB row to fall
+// back on, and running the SQL UPDATE against a task that was never inserted
+// would just be a wasted round trip against zero matching rows.
+//
+// No error return: jobsUpdateState's runtimeOnly path only ever touches the
+// in-memory cache and always returns nil, so a caller checking an error here
+// would be dead code that can never fire — do not add one back.
+func (server *ServerMonitor) JobsUpdateStateRuntimeOnly(task, result string, state, done int) {
+	server.jobsUpdateState(task, result, state, done, true)
+}
+
+func (server *ServerMonitor) jobsUpdateState(task, result string, state, done int, runtimeOnly bool) error {
 	var err error
 	cluster := server.ClusterGroup
 	now := time.Now().Unix()
@@ -1249,7 +1282,7 @@ func (server *ServerMonitor) JobsUpdateState(task, result string, state, done in
 		t.Done = done
 		t.Result = result
 
-		if cluster.Conf.SchedulerJobsMode == "api" {
+		if runtimeOnly {
 			if done == 1 {
 				if t.Start == 0 {
 					t.Start = now
@@ -1262,7 +1295,7 @@ func (server *ServerMonitor) JobsUpdateState(task, result string, state, done in
 				t.End = 0
 			}
 		}
-	} else if cluster.Conf.SchedulerJobsMode == "api" {
+	} else if runtimeOnly {
 		if done == 1 {
 			t.Start = now
 			t.End = now
@@ -1271,12 +1304,17 @@ func (server *ServerMonitor) JobsUpdateState(task, result string, state, done in
 			t.End = 0
 		}
 	}
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "Job state updated in runtime. Continue to update state in jobs table.")
 
-	// In API mode, state is tracked in memory only — no jobs table
-	if cluster.Conf.SchedulerJobsMode == "api" {
+	// runtimeOnly callers (JobsUpdateState in API mode, or JobsUpdateStateRuntimeOnly)
+	// never have a DB row for this task -- API mode has no jobs table at all, and
+	// JobsUpdateStateRuntimeOnly's callers deliberately never call JobInsertTask.
+	// Stop here, or this would fall through to the SQL section below and run a
+	// no-op UPDATE against a row that was never inserted.
+	if runtimeOnly {
 		return nil
 	}
+
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "Job state updated in runtime. Continue to update state in jobs table.")
 
 	if !cluster.Conf.MonitorScheduler {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Monitoring scheduler is inactive, task only updated in runtime")
@@ -1306,7 +1344,32 @@ func (server *ServerMonitor) JobsUpdateState(task, result string, state, done in
 	return err
 }
 
+// JobsUpdatePayload updates a task's payload for the normal case, where a
+// real jobs-table row may exist (it was created via JobInsertTask).
+//
+// Call sites that deliberately skip JobInsertTask — so there is no DB row for
+// this task run regardless of scheduler state — must use
+// JobsUpdatePayloadRuntimeOnly instead; see JobsUpdateState/
+// JobsUpdateStateRuntimeOnly for the same distinction and why it can't be
+// inferred from !MonitorScheduler alone.
 func (server *ServerMonitor) JobsUpdatePayload(task, payload string) error {
+	cluster := server.ClusterGroup
+	return server.jobsUpdatePayload(task, payload, cluster.Conf.SchedulerJobsMode == "api")
+}
+
+// JobsUpdatePayloadRuntimeOnly behaves like JobsUpdatePayload but never
+// touches the jobs table, regardless of SchedulerJobsMode or
+// MonitorScheduler. Use it only from call sites that never call
+// JobInsertTask for this task (e.g. JobReseedLogicalBackupPrepare).
+//
+// No error return: jobsUpdatePayload's runtimeOnly path only ever touches the
+// in-memory cache and always returns nil, so a caller checking an error here
+// would be dead code that can never fire — do not add one back.
+func (server *ServerMonitor) JobsUpdatePayloadRuntimeOnly(task, payload string) {
+	server.jobsUpdatePayload(task, payload, true)
+}
+
+func (server *ServerMonitor) jobsUpdatePayload(task, payload string, runtimeOnly bool) error {
 	cluster := server.ClusterGroup
 	if t, exists := server.JobResults.LoadOrStore(task, &config.Task{
 		Task: task,
@@ -1316,7 +1379,9 @@ func (server *ServerMonitor) JobsUpdatePayload(task, payload string) error {
 		t.Payload = payload
 	}
 
-	if cluster.Conf.SchedulerJobsMode == "api" {
+	// See jobsUpdateState's identical early return for why this must not fall
+	// through to the SQL section: there is no DB row for a runtimeOnly task.
+	if runtimeOnly {
 		return nil
 	}
 

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -441,26 +441,44 @@ func (server *ServerMonitor) jobInsertTask(task string, port string, repmanhost 
 	// Remote tasks: set a cookie so the dbjobs script discovers them via the needs API.
 	// Local tasks (mysqldump, mydumper): only track state in memory — repman runs them directly.
 	if cluster.Conf.SchedulerJobsMode == "api" {
-		if server.IsInTask(task) {
-			return 0, fmt.Errorf("task %s is already in progress", task)
+		newTask := &config.Task{Task: task, Start: time.Now().Unix(), State: JobStateAvailable}
+		if payload != nil {
+			newTask.Payload = *payload
 		}
 
-		// Attempt dispatch (cookie write for remote tasks) before storing the fresh
-		// snapshot: IsInTask treats any stored Done=0 entry as in-progress, so
-		// storing first and only then attempting the cookie would leave a stale
-		// entry that blocks every retry forever if the cookie write fails.
+		// Atomically claim the task slot with LoadOrStore instead of a separate
+		// IsInTask check followed by a later Store: two concurrent callers can
+		// both pass a plain check before either stores, dispatching the task
+		// twice. LoadOrStore performs the check-and-set as one operation, so at
+		// most one caller ever claims a given task.
+		for {
+			existing, loaded := server.JobResults.LoadOrStore(task, newTask)
+			if !loaded {
+				break // we claimed the slot
+			}
+			if existing.Done == 0 {
+				return 0, fmt.Errorf("task %s is already in progress", task)
+			}
+			// Previous run finished; try to replace it with our claim. If another
+			// caller wins this race, existing has since changed and we loop to
+			// re-evaluate it rather than clobber their claim.
+			if server.JobResults.CompareAndSwap(task, existing, newTask) {
+				break
+			}
+		}
+
+		// Attempt dispatch (cookie write for remote tasks) after claiming the
+		// slot above, since the claim is what makes the check-and-set atomic.
+		// On failure, release the claim so a stale Done=0 entry doesn't block
+		// every retry forever.
 		if config.IsRemoteTask(config.TaskName(task), cluster.Conf.SchedulerJobsExecOverrides) {
 			if err := server.setTaskCookie(task); err != nil {
+				server.JobResults.CompareAndDelete(task, newTask)
 				return 0, fmt.Errorf("Failed to set cookie for remote task %s: %v", task, err)
 			}
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "API mode: set cookie for task %s on %s", task, server.URL)
 		}
 
-		newTask := &config.Task{Task: task, Start: time.Now().Unix(), State: JobStateAvailable}
-		if payload != nil {
-			newTask.Payload = *payload
-		}
-		server.JobResults.Store(task, newTask)
 		return 0, nil
 	}
 

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -441,15 +441,26 @@ func (server *ServerMonitor) jobInsertTask(task string, port string, repmanhost 
 	// Remote tasks: set a cookie so the dbjobs script discovers them via the needs API.
 	// Local tasks (mysqldump, mydumper): only track state in memory — repman runs them directly.
 	if cluster.Conf.SchedulerJobsMode == "api" {
+		if server.IsInTask(task) {
+			return 0, fmt.Errorf("task %s is already in progress", task)
+		}
+
+		// Attempt dispatch (cookie write for remote tasks) before storing the fresh
+		// snapshot: IsInTask treats any stored Done=0 entry as in-progress, so
+		// storing first and only then attempting the cookie would leave a stale
+		// entry that blocks every retry forever if the cookie write fails.
 		if config.IsRemoteTask(config.TaskName(task), cluster.Conf.SchedulerJobsExecOverrides) {
 			if err := server.setTaskCookie(task); err != nil {
 				return 0, fmt.Errorf("Failed to set cookie for remote task %s: %v", task, err)
 			}
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "API mode: set cookie for task %s on %s", task, server.URL)
-		} else {
-			// Local task — track in memory only, no cookie, no dbjobs dispatch
-			server.JobsUpdateState(task, "", 0, 0)
 		}
+
+		newTask := &config.Task{Task: task, Start: time.Now().Unix(), State: JobStateAvailable}
+		if payload != nil {
+			newTask.Payload = *payload
+		}
+		server.JobResults.Store(task, newTask)
 		return 0, nil
 	}
 
@@ -861,7 +872,11 @@ func (server *ServerMonitor) JobsCheckErrors(Conn *sqlx.Conn) error {
 	}
 
 	if ct > 0 {
-		query := "UPDATE replication_manager_schema.jobs SET done=1 WHERE done=0 AND state=5 and task in (%s)"
+		// end=NOW() here (not at the original failure site) because this is where
+		// these rows are actually settled: WaitAndSendSST/WaitAndSendSSTStream
+		// deliberately leave reseed/flashback SST failures at done=0 so this scan
+		// can find them and run the cleanup above before marking them done.
+		query := "UPDATE replication_manager_schema.jobs SET done=1, end=NOW() WHERE done=0 AND state=5 and task in (%s)"
 		server.ExecQueryNoBinLog(fmt.Sprintf(query, strings.Join(p, ",")), JobTimeout)
 		server.SetNeedRefreshJobs(true)
 	}
@@ -1221,6 +1236,7 @@ func (server *ServerMonitor) JobRunViaSSH() error {
 func (server *ServerMonitor) JobsUpdateState(task, result string, state, done int) error {
 	var err error
 	cluster := server.ClusterGroup
+	now := time.Now().Unix()
 
 	if t, exists := server.JobResults.LoadOrStore(task, &config.Task{
 		Task:   task,
@@ -1228,9 +1244,32 @@ func (server *ServerMonitor) JobsUpdateState(task, result string, state, done in
 		Result: result,
 		Done:   done,
 	}); exists {
+		wasDone := t.Done
 		t.State = state
 		t.Done = done
 		t.Result = result
+
+		if cluster.Conf.SchedulerJobsMode == "api" {
+			if done == 1 {
+				if t.Start == 0 {
+					t.Start = now
+				}
+				t.End = now
+			} else {
+				if t.Start == 0 || wasDone == 1 {
+					t.Start = now
+				}
+				t.End = 0
+			}
+		}
+	} else if cluster.Conf.SchedulerJobsMode == "api" {
+		if done == 1 {
+			t.Start = now
+			t.End = now
+		} else {
+			t.Start = now
+			t.End = 0
+		}
 	}
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg, "Job state updated in runtime. Continue to update state in jobs table.")
 

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -3948,6 +3948,10 @@ func (server *ServerMonitor) WaitAndSendSST(task string, filename string, uncomp
 				elapsed := time.Since(sendStart).Round(time.Second)
 				if err != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModSST, config.LvlErr, "SST send for %s failed after %s: %s", task, elapsed, err.Error())
+					// done=0: JobsCheckErrors (srv_job.go) owns settling this row —
+					// it finds done=0/state=5 rows, runs restic-cookie/mount cleanup
+					// for reseed/flashback task names, then marks done=1 with End set.
+					// Marking done=1 here would hide the row from that cleanup.
 					server.JobsUpdateState(task, err.Error(), 5, 0)
 					return
 				}
@@ -3962,6 +3966,7 @@ func (server *ServerMonitor) WaitAndSendSST(task string, filename string, uncomp
 		}
 	}
 
+	// done=0: see JobsCheckErrors ownership note above.
 	server.JobsUpdateState(task, "Waiting more than max loop", 5, 0)
 	server.SetNeedRefreshJobs(true)
 	return errors.New("Error: waiting for " + task + " more than max loop.")
@@ -4016,6 +4021,7 @@ func (server *ServerMonitor) WaitAndSendSSTStream(ctx context.Context, task stri
 				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModSST, config.LvlInfo, "SST stream send for %s started at %s (source: %s)", task, sendStart.Format(time.RFC3339), sourceName)
 				if err := ctx.Err(); err != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModSST, config.LvlErr, "SST stream for %s canceled before start: %s", task, err)
+					// done=0: see JobsCheckErrors ownership note in WaitAndSendSST.
 					server.JobsUpdateState(task, err.Error(), 5, 0)
 					return
 				}

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -656,6 +656,11 @@ func (server *ServerMonitor) JobReseedLogicalBackupPrepare(ctx context.Context, 
 		return nil, err
 	}
 
+	// Stamp the real start time now, before the potentially slow work below
+	// (StopSlave/ResetSlave for PITR). No JobInsertTask call anywhere in this
+	// function, so there is no DB row.
+	server.JobsUpdateStateRuntimeOnly(task, "", 1, 0)
+
 	resetReseed := func() {
 		if server.HasReseedingState(task) {
 			server.SetInReseedBackup("")
@@ -672,6 +677,7 @@ func (server *ServerMonitor) JobReseedLogicalBackupPrepare(ctx context.Context, 
 		if err != nil {
 			if mysqlErr, ok := err.(*mysql.MySQLError); ok && mysqlErr.Number != 1617 {
 				resetReseed()
+				server.JobsUpdateStateRuntimeOnly(task, err.Error(), 5, 1)
 				return nil, err
 			}
 		}
@@ -684,11 +690,11 @@ func (server *ServerMonitor) JobReseedLogicalBackupPrepare(ctx context.Context, 
 	payload, err := buildLogicalReseedPayload(backtype, backupfile, splitUser, false, false, isPITR, server.URL)
 	if err != nil {
 		resetReseed()
+		server.JobsUpdateStateRuntimeOnly(task, err.Error(), 5, 1)
 		return nil, err
 	}
 
-	server.JobsUpdateState(task, "", 1, 0)
-	server.JobsUpdatePayload(task, payload)
+	server.JobsUpdatePayloadRuntimeOnly(task, payload)
 	cluster.SetState("WARN0075", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(cluster.GetErrorList()["WARN0075"], backtype, server.URL), ErrFrom: "JOB", ServerUrl: server.URL})
 
 	plan := &logicalReseedPlan{
@@ -1749,6 +1755,17 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 		return err
 	}
 
+	// Stamp the real start time now, before the potentially slow work below
+	// (backup file resolution, StopAllSlaves, pointSlaveToMaster, the restore
+	// itself) -- but only for a type the dispatch below actually executes.
+	// Stamping unconditionally here would risk leaving an unsupported type
+	// stuck at "processing" forever, since the dispatch below has no case for
+	// it; only stamp when we know a terminal call is guaranteed to follow,
+	// without changing what counts as a supported type.
+	if cluster.Conf.BackupLoadScript != "" || backtype == config.ConstBackupLogicalTypeMysqldump || backtype == config.ConstBackupLogicalTypeMydumper {
+		server.JobsUpdateStateRuntimeOnly(task, "processing", JobStateRunning, 0)
+	}
+
 	// Decide on backup filename depending on the backup type
 	useMaster := true
 	source := master
@@ -1759,8 +1776,6 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 		destCandidates = []string{"mysqldump.sql.gz", "splitdump"}
 	case config.ConstBackupLogicalTypeMydumper:
 		dest = "mydumper"
-	case config.ConstBackupLogicalTypeDumpling:
-		dest = "dumpling"
 	}
 	if len(destCandidates) == 0 {
 		destCandidates = []string{dest}
@@ -1805,7 +1820,9 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 			if useMaster {
 				if _, err := os.Stat(backupfile); err != nil {
 					master.DelBackupTypeCookie(cluster.Conf.BackupPhysicalType)
-					return fmt.Errorf("Cancelling reseed. No logical %s backup found on any node", backtype)
+					noBackupErr := fmt.Errorf("Cancelling reseed. No logical %s backup found on any node", backtype)
+					server.JobsUpdateStateRuntimeOnly(task, noBackupErr.Error(), 5, 1)
+					return noBackupErr
 				}
 			}
 		}
@@ -1842,6 +1859,7 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 	}
 	if err != nil {
 		cluster.LogSQL(logs, err, server.URL, "Rejoin", config.LvlErr, "flashback can't changing master for logical backup %s request for server: %s %s", cluster.Conf.BackupLogicalType, server.URL, err)
+		server.JobsUpdateStateRuntimeOnly(task, err.Error(), 5, 1)
 		return err
 	}
 
@@ -1852,14 +1870,10 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Using script from backup-load-script on %s", server.URL)
 		if err := server.JobReseedBackupScript(); err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error flashback %s on %s: %s", backtype, server.URL, err.Error())
-			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-			}
+			server.JobsUpdateStateRuntimeOnly(task, err.Error(), 5, 1)
 			return err
 		}
-		if e2 := server.JobsUpdateState(task, "Flashback completed", 3, 1); e2 != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-		}
+		server.JobsUpdateStateRuntimeOnly(task, "Flashback completed", 3, 1)
 		return nil
 
 		// Handle mysqldump-based reseed
@@ -1867,9 +1881,7 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 		err := server.reseedMysqldumpWithMetadata(context.Background(), backupfile, cluster.Conf.BackupRestoreMysqlUser && source.LastBackupMeta.Logical != nil && source.LastBackupMeta.Logical.SplitUser, source.LastBackupMeta.Logical)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error flashback %s on %s: %s", backtype, server.URL, err.Error())
-			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-			}
+			server.JobsUpdateStateRuntimeOnly(task, err.Error(), 5, 1)
 		} else {
 			// Restart slave if needed. Symmetric with StopAllSlaves above: restart
 			// every connection by its real ConnectionName so a multi-source server
@@ -1883,9 +1895,7 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 				}
 			}
 
-			if e2 := server.JobsUpdateState(task, "Flashback completed", 3, 1); e2 != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-			}
+			server.JobsUpdateStateRuntimeOnly(task, "Flashback completed", 3, 1)
 		}
 
 		// Handle mydumper-based reseed
@@ -1893,9 +1903,7 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 		err := server.JobReseedMyLoader(backupfile, cluster.Conf.BackupRestoreMysqlUser)
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error flashback %s on %s: %s", backtype, server.URL, err.Error())
-			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-			}
+			server.JobsUpdateStateRuntimeOnly(task, err.Error(), 5, 1)
 		} else {
 			// Parse metadata from mydumper
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Parsing mydumper metadata ")
@@ -1921,9 +1929,7 @@ func (server *ServerMonitor) JobFlashbackLogicalBackup() error {
 				}
 			}
 
-			if e2 := server.JobsUpdateState(task, "Flashback completed", 3, 1); e2 != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-			}
+			server.JobsUpdateStateRuntimeOnly(task, "Flashback completed", 3, 1)
 		}
 	}
 
@@ -3123,26 +3129,39 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(ctx context.Context, op
 		server.LastBackupMeta.Logical.BackupTool = task
 		server.LastBackupMeta.Logical.Dest = filename
 
-		// Record task for metadata check
-		server.JobsUpdateState(task, "", 1, 0)
+		// Record task for metadata check. No JobInsertTask call for this task,
+		// so there is no DB row regardless of scheduler state.
+		server.JobsUpdateStateRuntimeOnly(task, "", 1, 0)
 
 		err = server.JobBackupScript(filename)
 		if err == nil {
-			server.JobsUpdateState(task, "Backup completed", 3, 1)
+			server.JobsUpdateStateRuntimeOnly(task, "Backup completed", 3, 1)
 			server.LastBackupMeta.Logical.Completed = true
 			if !isAdhoc {
 				server.SetBackupLogicalCookie(task)
 			}
 		} else {
-			server.JobsUpdateState(task, err.Error(), 5, 1)
+			server.JobsUpdateStateRuntimeOnly(task, err.Error(), 5, 1)
 		}
 	} else {
 		task := cluster.Conf.BackupLogicalType
 
+		// JobInsertTask creates a DB row only when the scheduler is active; when
+		// it's off every JobsUpdateState call below for this task run must go
+		// through JobsUpdateStateRuntimeOnly instead, or Start/End are never
+		// stamped anywhere (there is no DB row and no SQL UPDATE will run).
+		// JobsUpdateStateRuntimeOnly never returns an error (it only touches
+		// the in-memory cache), so it's wrapped here to match JobsUpdateState's
+		// signature and let every call site below share one variable.
+		updateJobState := server.JobsUpdateState
 		if cluster.Conf.MonitorScheduler {
 			server.JobInsertTask(task, "0", cluster.Conf.MonitorAddress)
 		} else {
-			server.JobsUpdateState(task, "", 0, 0)
+			updateJobState = func(task, result string, state, done int) error {
+				server.JobsUpdateStateRuntimeOnly(task, result, state, done)
+				return nil
+			}
+			updateJobState(task, "", 0, 0)
 		}
 
 		//Change to switch since we only allow one type of backup (for now)
@@ -3176,11 +3195,11 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(ctx context.Context, op
 				if errors.Is(err, errJobCanceledByUser) {
 					result = "cancelled by user"
 				}
-				if e2 := server.JobsUpdateState(task, result, 5, 1); e2 != nil {
+				if e2 := updateJobState(task, result, 5, 1); e2 != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
 				}
 			} else {
-				if e2 := server.JobsUpdateState(task, "Backup completed", 3, 1); e2 != nil {
+				if e2 := updateJobState(task, "Backup completed", 3, 1); e2 != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
 				}
 				checkPath := filename
@@ -3214,11 +3233,11 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(ctx context.Context, op
 
 			err = server.JobBackupDumpling(outputdir + "/")
 			if err != nil {
-				if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
+				if e2 := updateJobState(task, err.Error(), 5, 1); e2 != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
 				}
 			} else {
-				if e2 := server.JobsUpdateState(task, "Backup completed", 3, 1); e2 != nil {
+				if e2 := updateJobState(task, "Backup completed", 3, 1); e2 != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
 				}
 				_, e3 := os.Stat(outputdir)
@@ -3248,11 +3267,11 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(ctx context.Context, op
 			}
 			err = server.JobBackupMyDumper(outputdir + "/")
 			if err != nil {
-				if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
+				if e2 := updateJobState(task, err.Error(), 5, 1); e2 != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
 				}
 			} else {
-				if e2 := server.JobsUpdateState(task, "Backup completed", 3, 1); e2 != nil {
+				if e2 := updateJobState(task, "Backup completed", 3, 1); e2 != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
 				}
 
@@ -3270,11 +3289,11 @@ func (server *ServerMonitor) JobBackupLogicalWithOptions(ctx context.Context, op
 			//No change on river
 			err = server.JobBackupRiver()
 			if err != nil {
-				if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
+				if e2 := updateJobState(task, err.Error(), 5, 1); e2 != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
 				}
 			} else {
-				if e2 := server.JobsUpdateState(task, "Backup completed", 3, 1); e2 != nil {
+				if e2 := updateJobState(task, "Backup completed", 3, 1); e2 != nil {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
 				}
 			}
@@ -4069,6 +4088,12 @@ func (server *ServerMonitor) ProcessReseedLogical(task string) error {
 		return errors.New("Slave is in super read-only")
 	}
 
+	// Stamp the real start time now, before the potentially slow work below
+	// (StopSlave, pointSlaveToMaster, the restore itself). No JobInsertTask
+	// call anywhere in this function, in any scheduler state, so there is
+	// never a DB row for a logical reseed task run.
+	server.JobsUpdateStateRuntimeOnly(task, "processing", 1, 0)
+
 	backupType := cluster.Conf.BackupLogicalType
 	payloadBackupPath := ""
 	splitUser := false
@@ -4140,19 +4165,14 @@ func (server *ServerMonitor) ProcessReseedLogical(task string) error {
 			}
 		}
 
-		server.JobsUpdateState(task, "processing", 1, 0)
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Receive reseed logical backup %s request for server: %s", backupType, server.URL)
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Using script from backup-load-script on %s", server.URL)
 		if err := server.JobReseedBackupScript(); err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error reseed %s on %s: %s", backupType, server.URL, err.Error())
-			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-			}
+			server.JobsUpdateStateRuntimeOnly(task, err.Error(), 5, 1)
 			return err
 		}
-		if e2 := server.JobsUpdateState(task, "Reseed completed", 3, 1); e2 != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-		}
+		server.JobsUpdateStateRuntimeOnly(task, "Reseed completed", 3, 1)
 		return nil
 	}
 
@@ -4254,7 +4274,6 @@ func (server *ServerMonitor) ProcessReseedLogical(task string) error {
 	}
 
 	ctx := context.Background()
-	server.JobsUpdateState(task, "processing", 1, 0)
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Receive reseed logical backup %s request for server: %s", backupType, server.URL)
 	if splitUserOverride {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo,
@@ -4270,9 +4289,7 @@ func (server *ServerMonitor) ProcessReseedLogical(task string) error {
 		}
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error reseed %s on %s: %s", backupType, server.URL, err.Error())
-			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-			}
+			server.JobsUpdateStateRuntimeOnly(task, err.Error(), 5, 1)
 			return err
 		}
 
@@ -4281,9 +4298,7 @@ func (server *ServerMonitor) ProcessReseedLogical(task string) error {
 			server.StartSlave()
 		}
 
-		if e2 := server.JobsUpdateState(task, "Reseed completed", 3, 1); e2 != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-		}
+		server.JobsUpdateStateRuntimeOnly(task, "Reseed completed", 3, 1)
 		return nil
 	}
 
@@ -4310,15 +4325,11 @@ func (server *ServerMonitor) ProcessReseedLogical(task string) error {
 
 		if err != nil {
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr, "Error reseed %s on %s: %s", backupType, server.URL, err.Error())
-			if e2 := server.JobsUpdateState(task, err.Error(), 5, 1); e2 != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-			}
+			server.JobsUpdateStateRuntimeOnly(task, err.Error(), 5, 1)
 			return err
 		}
 
-		if e2 := server.JobsUpdateState(task, "Reseed completed", 3, 1); e2 != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn, "Task only updated in runtime. Error while writing to jobs table: %s", e2.Error())
-		}
+		server.JobsUpdateStateRuntimeOnly(task, "Reseed completed", 3, 1)
 		return nil
 	}
 

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -4088,12 +4088,6 @@ func (server *ServerMonitor) ProcessReseedLogical(task string) error {
 		return errors.New("Slave is in super read-only")
 	}
 
-	// Stamp the real start time now, before the potentially slow work below
-	// (StopSlave, pointSlaveToMaster, the restore itself). No JobInsertTask
-	// call anywhere in this function, in any scheduler state, so there is
-	// never a DB row for a logical reseed task run.
-	server.JobsUpdateStateRuntimeOnly(task, "processing", 1, 0)
-
 	backupType := cluster.Conf.BackupLogicalType
 	payloadBackupPath := ""
 	splitUser := false
@@ -4148,6 +4142,12 @@ func (server *ServerMonitor) ProcessReseedLogical(task string) error {
 	}()
 
 	if cluster.Conf.BackupLoadScript != "" {
+		// Stamp the real start time now, before the potentially slow work below
+		// (StopSlave, pointSlaveToMaster, the restore itself). No JobInsertTask
+		// call anywhere in this function, in any scheduler state, so there is
+		// never a DB row for a logical reseed task run.
+		server.JobsUpdateStateRuntimeOnly(task, "processing", 1, 0)
+
 		if !isPITR {
 			logs, err := server.StopSlave()
 			if err != nil {
@@ -4185,6 +4185,12 @@ func (server *ServerMonitor) ProcessReseedLogical(task string) error {
 	if backupType != config.ConstBackupLogicalTypeMysqldump && backupType != config.ConstBackupLogicalTypeMydumper {
 		return fmt.Errorf("Logical reseed backup type %s is not supported", backupType)
 	}
+
+	// Stamp the real start time now, before the potentially slow work below
+	// (StopSlave, pointSlaveToMaster, the restore itself). No JobInsertTask
+	// call anywhere in this function, in any scheduler state, so there is
+	// never a DB row for a logical reseed task run.
+	server.JobsUpdateStateRuntimeOnly(task, "processing", 1, 0)
 
 	useMaster := true
 	source := master

--- a/cluster/srv_job_test.go
+++ b/cluster/srv_job_test.go
@@ -1,11 +1,14 @@
 package cluster
 
 import (
+	"os"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/signal18/replication-manager/config"
 	"github.com/signal18/replication-manager/utils/backupmgr"
+	"github.com/signal18/replication-manager/utils/state"
 )
 
 func TestDumpStreamParserExtractsBinlogAndGTID(t *testing.T) {
@@ -122,5 +125,196 @@ func TestShouldParseDumpBinlogGTIDRespectsExistingMetadata(t *testing.T) {
 	}
 	if parseGTID {
 		t.Fatalf("expected parseGTID to be false when GTID already set")
+	}
+}
+
+func newTestServerForAPIJobs(t *testing.T) *ServerMonitor {
+	t.Helper()
+	tmp := t.TempDir()
+	cluster := &Cluster{
+		Conf: &config.Config{
+			WorkingDir:        tmp,
+			SchedulerJobsMode: "api",
+		},
+		Name:         "testcluster",
+		StateMachine: &state.StateMachine{},
+	}
+	server := &ServerMonitor{
+		ClusterGroup: cluster,
+		Datadir:      tmp + "/node1_3306",
+		Host:         "node1",
+		Port:         "3306",
+	}
+	server.JobResults = config.NewTasksMap()
+	if err := os.MkdirAll(server.Datadir, 0755); err != nil {
+		t.Fatalf("failed to create server datadir: %v", err)
+	}
+	return server
+}
+
+// TestJobInsertTask_APIMode_RemoteTask_CookieFailureDoesNotBlockRetry guards
+// against a stale in-progress entry: if the cookie write fails, jobInsertTask
+// must not have stored a Done=0 snapshot, or IsInTask would block every retry
+// forever since nothing (no dbjobs dispatch happened) would ever move it out
+// of Done=0.
+func TestJobInsertTask_APIMode_RemoteTask_CookieFailureDoesNotBlockRetry(t *testing.T) {
+	server := newTestServerForAPIJobs(t)
+	task := string(config.ConstTaskError)
+
+	// Force the cookie write to fail deterministically: os.Create does not
+	// create parent directories, so pointing Datadir at a path whose parent
+	// doesn't exist makes createCookie fail with ENOENT every time.
+	server.Datadir = server.Datadir + "/missing/nested"
+
+	if _, err := server.JobInsertTask(task, "0", "monitor-host"); err == nil {
+		t.Fatal("expected JobInsertTask to fail when the cookie write fails")
+	}
+
+	if server.IsInTask(task) {
+		t.Fatal("expected no stale in-progress entry after a failed cookie write")
+	}
+	if got := server.JobResults.Get(task); got != nil {
+		t.Fatalf("expected no JobResults entry after a failed cookie write, got %+v", got)
+	}
+}
+
+func assertFreshAPITask(t *testing.T, task *config.Task, previousStart int64) {
+	t.Helper()
+	if task == nil {
+		t.Fatal("expected task entry")
+	}
+	if task.Start <= previousStart {
+		t.Fatalf("expected refreshed Start > %d, got %d", previousStart, task.Start)
+	}
+	if task.End != 0 {
+		t.Fatalf("expected End to be cleared, got %d", task.End)
+	}
+	if task.Done != 0 {
+		t.Fatalf("expected Done=0, got %d", task.Done)
+	}
+	if task.State != JobStateAvailable {
+		t.Fatalf("expected State=JobStateAvailable, got %d", task.State)
+	}
+}
+
+func TestJobInsertTask_APIMode_RemoteTask_ResetsTimestamps(t *testing.T) {
+	server := newTestServerForAPIJobs(t)
+	task := string(config.ConstTaskError)
+	server.JobResults.Store(task, &config.Task{Task: task, Start: 100, End: 200, Done: 1, State: JobStateSuccess, Result: "old", Payload: "old payload"})
+
+	if _, err := server.JobInsertTaskWithPayload(task, "0", "monitor-host", "new payload"); err != nil {
+		t.Fatalf("JobInsertTaskWithPayload returned unexpected error: %v", err)
+	}
+
+	got := server.JobResults.Get(task)
+	assertFreshAPITask(t, got, 100)
+	if got.Payload != "new payload" {
+		t.Fatalf("expected Payload=new payload, got %q", got.Payload)
+	}
+}
+
+func TestJobInsertTask_APIMode_LocalTask_ResetsTimestamps(t *testing.T) {
+	server := newTestServerForAPIJobs(t)
+	task := string(config.ConstTaskDump)
+	server.JobResults.Store(task, &config.Task{Task: task, Start: 100, End: 200, Done: 1, State: JobStateSuccess, Result: "old"})
+
+	if _, err := server.JobInsertTask(task, "0", "monitor-host"); err != nil {
+		t.Fatalf("JobInsertTask returned unexpected error: %v", err)
+	}
+
+	got := server.JobResults.Get(task)
+	assertFreshAPITask(t, got, 100)
+	if got.Payload != "" {
+		t.Fatalf("expected Payload to be cleared, got %q", got.Payload)
+	}
+}
+
+func TestJobsUpdateState_APIMode_RunningPreservesRunStartAndClearsEnd(t *testing.T) {
+	server := newTestServerForAPIJobs(t)
+	task := "errorlog"
+
+	if err := server.JobsUpdateState(task, "processing", JobStateRunning, 0); err != nil {
+		t.Fatalf("JobsUpdateState returned unexpected error: %v", err)
+	}
+	first := server.JobResults.Get(task)
+	if first == nil || first.Start == 0 {
+		t.Fatal("expected Start to be set on first processing update")
+	}
+	firstStart := first.Start
+
+	if err := server.JobsUpdateState(task, "processing", JobStateRunning, 0); err != nil {
+		t.Fatalf("JobsUpdateState returned unexpected error: %v", err)
+	}
+	second := server.JobResults.Get(task)
+	if second.Start != firstStart {
+		t.Fatalf("expected repeated processing update to preserve Start=%d, got %d", firstStart, second.Start)
+	}
+	if second.End != 0 {
+		t.Fatalf("expected End=0 while running, got %d", second.End)
+	}
+
+	if err := server.JobsUpdateState(task, "completed", JobStateSuccess, 1); err != nil {
+		t.Fatalf("JobsUpdateState returned unexpected error: %v", err)
+	}
+	finished := server.JobResults.Get(task)
+	if finished.End == 0 {
+		t.Fatal("expected End to be set on terminal update")
+	}
+
+	time.Sleep(1100 * time.Millisecond)
+	if err := server.JobsUpdateState(task, "processing", JobStateRunning, 0); err != nil {
+		t.Fatalf("JobsUpdateState returned unexpected error: %v", err)
+	}
+	rerun := server.JobResults.Get(task)
+	if rerun.Start <= finished.End {
+		t.Fatalf("expected rerun Start (%d) to be refreshed after previous End (%d)", rerun.Start, finished.End)
+	}
+	if rerun.End != 0 {
+		t.Fatalf("expected rerun End to be cleared, got %d", rerun.End)
+	}
+}
+
+func TestJobsUpdateState_APIMode_TerminalStatesSetEnd(t *testing.T) {
+	server := newTestServerForAPIJobs(t)
+
+	if err := server.JobsUpdateState("optimize", "completed", JobStateSuccess, 1); err != nil {
+		t.Fatalf("JobsUpdateState returned unexpected error: %v", err)
+	}
+	if got := server.JobResults.Get("optimize"); got.End == 0 || got.State != JobStateSuccess || got.Done != 1 {
+		t.Fatalf("expected success end timestamp, got %+v", got)
+	}
+
+	if err := server.JobsUpdateState("restart", "boom", JobStateErrorExec, 1); err != nil {
+		t.Fatalf("JobsUpdateState returned unexpected error: %v", err)
+	}
+	if got := server.JobResults.Get("restart"); got.End == 0 || got.State != JobStateErrorExec || got.Done != 1 || got.Result != "boom" {
+		t.Fatalf("expected error end timestamp, got %+v", got)
+	}
+}
+
+func TestJobInsertTask_APIMode_RejectsRescheduleWhileInProgress(t *testing.T) {
+	server := newTestServerForAPIJobs(t)
+	for _, task := range []string{string(config.ConstTaskOptimize), string(config.ConstTaskDump)} {
+		if _, err := server.JobInsertTask(task, "0", "monitor-host"); err != nil {
+			t.Fatalf("first JobInsertTask(%s) returned unexpected error: %v", task, err)
+		}
+		first := server.JobResults.Get(task)
+		if first == nil || first.Done != 0 {
+			t.Fatalf("expected task %s to be in progress after first schedule, got %+v", task, first)
+		}
+		firstStart := first.Start
+
+		if _, err := server.JobInsertTask(task, "0", "monitor-host"); err == nil {
+			t.Fatalf("expected second JobInsertTask(%s) while in progress to return an error", task)
+		}
+
+		second := server.JobResults.Get(task)
+		if second.Start != firstStart || second.Done != 0 {
+			t.Fatalf("expected task %s to remain unchanged in progress, got %+v", task, second)
+		}
+
+		if err := server.JobsUpdateState(task, "completed", JobStateSuccess, 1); err != nil {
+			t.Fatalf("JobsUpdateState(%s) returned unexpected error: %v", task, err)
+		}
 	}
 }

--- a/cluster/srv_job_test.go
+++ b/cluster/srv_job_test.go
@@ -178,6 +178,140 @@ func TestJobInsertTask_APIMode_RemoteTask_CookieFailureDoesNotBlockRetry(t *test
 	}
 }
 
+// newTestServerForRuntimeOnlyJobs builds a fixture for the non-API,
+// scheduler-disabled case: SQL-identity mode, but MonitorScheduler=false, so
+// JobsUpdateState is the only thing ever touching this task (JobInsertTask's
+// SQL INSERT is skipped by the caller, e.g. cluster/srv_job_backup.go).
+func newTestServerForRuntimeOnlyJobs(t *testing.T) *ServerMonitor {
+	t.Helper()
+	tmp := t.TempDir()
+	cluster := &Cluster{
+		Conf: &config.Config{
+			WorkingDir:        tmp,
+			SchedulerJobsMode: "sql",
+			MonitorScheduler:  false,
+		},
+		Name:         "testcluster",
+		StateMachine: &state.StateMachine{},
+	}
+	server := &ServerMonitor{
+		ClusterGroup: cluster,
+		Datadir:      tmp + "/node1_3306",
+		Host:         "node1",
+		Port:         "3306",
+	}
+	server.JobResults = config.NewTasksMap()
+	if err := os.MkdirAll(server.Datadir, 0755); err != nil {
+		t.Fatalf("failed to create server datadir: %v", err)
+	}
+	return server
+}
+
+// TestJobsUpdatePayloadRuntimeOnly_SchedulerEnabled_NeverTouchesSQL mirrors
+// TestJobsUpdateStateRuntimeOnly_SchedulerEnabled_NeverTouchesSQL for the
+// payload helper: JobReseedLogicalBackupPrepare calls this right after
+// JobsUpdateStateRuntimeOnly, for the same task that never gets a DB row via
+// JobInsertTask, so it must never fall through to the SQL UPDATE either.
+func TestJobsUpdatePayloadRuntimeOnly_SchedulerEnabled_NeverTouchesSQL(t *testing.T) {
+	server := newTestServerForRuntimeOnlyJobs(t)
+	server.ClusterGroup.Conf.MonitorScheduler = true
+	task := "reseedmysqldump"
+
+	// No connection pool is configured; if this ever fell through to the SQL
+	// section it would hit a nil server.Conn there. It doesn't panic or hang,
+	// which is the observable proof it stayed fully in-memory.
+	server.JobsUpdatePayloadRuntimeOnly(task, "some-payload")
+	got := server.JobResults.Get(task)
+	if got == nil || got.Payload != "some-payload" {
+		t.Fatalf("expected payload to be set in the cache, got %+v", got)
+	}
+}
+
+// TestJobsUpdateStateRuntimeOnly_SchedulerEnabled_NeverTouchesSQL guards
+// against JobsUpdateStateRuntimeOnly falling through to the SQL UPDATE
+// section when the scheduler happens to be enabled: its callers (e.g.
+// ProcessReseedLogical) never call JobInsertTask, so there is no DB row
+// regardless of MonitorScheduler, and reaching the SQL section would either
+// run a no-op UPDATE against zero matching rows or, as here with no
+// connection pool configured, return "No connection pool" -- a scheduler-only
+// error a purely in-memory call must never surface.
+func TestJobsUpdateStateRuntimeOnly_SchedulerEnabled_NeverTouchesSQL(t *testing.T) {
+	server := newTestServerForRuntimeOnlyJobs(t)
+	server.ClusterGroup.Conf.MonitorScheduler = true
+	task := "reseedmysqldump"
+
+	// No connection pool is configured; if this ever fell through to the SQL
+	// section it would hit a nil server.Conn there. It doesn't panic or hang,
+	// which is the observable proof it stayed fully in-memory.
+	server.JobsUpdateStateRuntimeOnly(task, "processing", JobStateRunning, 0)
+	running := server.JobResults.Get(task)
+	if running == nil || running.Start == 0 {
+		t.Fatal("expected Start to be stamped")
+	}
+
+	server.JobsUpdateStateRuntimeOnly(task, "Reseed completed", JobStateFinished, 1)
+	finished := server.JobResults.Get(task)
+	if finished.End == 0 {
+		t.Fatal("expected End to be stamped on terminal update")
+	}
+}
+
+// TestJobsUpdateStateRuntimeOnly_SchedulerDisabled_StampsTimestamps guards
+// manual backup/reseed working outside the scheduler: cluster/srv_job_backup.go
+// call sites that never call JobInsertTask (e.g. ProcessReseedLogical) use
+// JobsUpdateStateRuntimeOnly, which must stamp Start/End itself since there is
+// no DB row and, outside API mode, the SQL UPDATE never runs while
+// MonitorScheduler is false.
+func TestJobsUpdateStateRuntimeOnly_SchedulerDisabled_StampsTimestamps(t *testing.T) {
+	server := newTestServerForRuntimeOnlyJobs(t)
+	task := "mysqldump"
+
+	server.JobsUpdateStateRuntimeOnly(task, "", JobStateRunning, 0)
+	running := server.JobResults.Get(task)
+	if running == nil || running.Start == 0 {
+		t.Fatal("expected Start to be stamped when scheduler is disabled")
+	}
+	if running.End != 0 {
+		t.Fatalf("expected End=0 while running, got %d", running.End)
+	}
+
+	server.JobsUpdateStateRuntimeOnly(task, "Backup completed", JobStateFinished, 1)
+	finished := server.JobResults.Get(task)
+	if finished.End == 0 {
+		t.Fatal("expected End to be stamped on terminal update when scheduler is disabled")
+	}
+}
+
+// TestJobsUpdateState_SchedulerDisabled_DoesNotStampTimestamps locks in the
+// narrowed condition: plain JobsUpdateState must NOT infer "no DB row" from
+// !MonitorScheduler alone, since some callers (JobServerStop, JobServerRestart,
+// JobOptimize) call JobInsertTask unconditionally and do get a real row even
+// with the scheduler disabled. Only JobsUpdateStateRuntimeOnly (used by call
+// sites that skip JobInsertTask) should stamp in that case.
+func TestJobsUpdateState_SchedulerDisabled_DoesNotStampTimestamps(t *testing.T) {
+	server := newTestServerForRuntimeOnlyJobs(t)
+	task := "restart"
+
+	if err := server.JobsUpdateState(task, "", JobStateRunning, 0); err != nil {
+		t.Fatalf("JobsUpdateState returned unexpected error: %v", err)
+	}
+	running := server.JobResults.Get(task)
+	if running == nil {
+		t.Fatal("expected a JobResults entry")
+	}
+	if running.Start != 0 {
+		t.Fatalf("expected Start to stay 0 (no DB row to fall back on here), got %d", running.Start)
+	}
+
+	if err := server.JobsUpdateState(task, "done", JobStateSuccess, 1); err != nil {
+		t.Fatalf("JobsUpdateState returned unexpected error: %v", err)
+	}
+	finished := server.JobResults.Get(task)
+	if finished.End != 0 {
+		t.Fatalf("expected End to stay 0, got %d", finished.End)
+	}
+}
+
 func assertFreshAPITask(t *testing.T, task *config.Task, previousStart int64) {
 	t.Helper()
 	if task == nil {

--- a/cluster/srv_job_test.go
+++ b/cluster/srv_job_test.go
@@ -139,11 +139,14 @@ func newTestServerForAPIJobs(t *testing.T) *ServerMonitor {
 		Name:         "testcluster",
 		StateMachine: &state.StateMachine{},
 	}
+	cluster.StateMachine.Init()
 	server := &ServerMonitor{
+		Id:           "node1",
 		ClusterGroup: cluster,
 		Datadir:      tmp + "/node1_3306",
 		Host:         "node1",
 		Port:         "3306",
+		URL:          "node1:3306",
 	}
 	server.JobResults = config.NewTasksMap()
 	if err := os.MkdirAll(server.Datadir, 0755); err != nil {
@@ -183,6 +186,11 @@ func TestJobInsertTask_APIMode_RemoteTask_CookieFailureDoesNotBlockRetry(t *test
 // JobsUpdateState is the only thing ever touching this task (JobInsertTask's
 // SQL INSERT is skipped by the caller, e.g. cluster/srv_job_backup.go).
 func newTestServerForRuntimeOnlyJobs(t *testing.T) *ServerMonitor {
+	_, server := newTestRuntimeOnlyClusterServer(t, "testcluster", "node1", "3306")
+	return server
+}
+
+func newTestRuntimeOnlyClusterServer(t *testing.T, clusterName, host, port string) (*Cluster, *ServerMonitor) {
 	t.Helper()
 	tmp := t.TempDir()
 	cluster := &Cluster{
@@ -191,20 +199,25 @@ func newTestServerForRuntimeOnlyJobs(t *testing.T) *ServerMonitor {
 			SchedulerJobsMode: "sql",
 			MonitorScheduler:  false,
 		},
-		Name:         "testcluster",
+		Name:         clusterName,
 		StateMachine: &state.StateMachine{},
 	}
+	cluster.StateMachine.Init()
+	cluster.StateMachine.Discovered = true
 	server := &ServerMonitor{
+		Id:           host,
 		ClusterGroup: cluster,
-		Datadir:      tmp + "/node1_3306",
-		Host:         "node1",
-		Port:         "3306",
+		Datadir:      tmp + "/" + host + "_" + port,
+		Host:         host,
+		Port:         port,
+		URL:          host + ":" + port,
 	}
 	server.JobResults = config.NewTasksMap()
 	if err := os.MkdirAll(server.Datadir, 0755); err != nil {
 		t.Fatalf("failed to create server datadir: %v", err)
 	}
-	return server
+	cluster.Servers = serverList{server}
+	return cluster, server
 }
 
 // TestJobsUpdatePayloadRuntimeOnly_SchedulerEnabled_NeverTouchesSQL mirrors
@@ -309,6 +322,69 @@ func TestJobsUpdateState_SchedulerDisabled_DoesNotStampTimestamps(t *testing.T) 
 	finished := server.JobResults.Get(task)
 	if finished.End != 0 {
 		t.Fatalf("expected End to stay 0, got %d", finished.End)
+	}
+}
+
+// TestProcessReseedLogical_UnsupportedType_DoesNotCreateRunningTask guards the
+// srv_job_backup.go call site where the regression lived: unsupported logical
+// restore types must fail before the function stamps an in-memory runtime-only
+// task as running, or the jobs view gets stuck at processing forever.
+func TestProcessReseedLogical_UnsupportedType_DoesNotCreateRunningTask(t *testing.T) {
+	cluster, server := newTestRuntimeOnlyClusterServer(t, "reseed-cluster", "target", "3307")
+	cluster.Conf.BackupLogicalType = "unsupported"
+	cluster.master = &ServerMonitor{
+		Id:           "master",
+		Host:         "master",
+		Port:         "3306",
+		URL:          "master:3306",
+		ClusterGroup: cluster,
+	}
+
+	task := "reseedunsupported"
+	server.SetInReseedBackup(task)
+
+	err := server.ProcessReseedLogical(task)
+	if err == nil {
+		t.Fatal("expected ProcessReseedLogical to reject unsupported logical reseed type")
+	}
+	if err.Error() != "Logical reseed backup type unsupported is not supported" {
+		t.Fatalf("unexpected ProcessReseedLogical error: %v", err)
+	}
+	if got := server.JobResults.Get(task); got != nil {
+		t.Fatalf("expected no runtime task entry for unsupported logical reseed type, got %+v", got)
+	}
+	if server.HasAnyReseedingState() {
+		t.Fatalf("expected reseeding state to be cleared after failure, got %q", server.IsReseeding)
+	}
+}
+
+// TestReseedFromParentCluster_UnsupportedType_DoesNotCreateRunningTask guards
+// the cluster_staging.go call site where the regression lived: an unsupported
+// parent logical backup type must not stamp a runtime-only task as processing
+// before the dispatch switch rejects it.
+func TestReseedFromParentCluster_UnsupportedType_DoesNotCreateRunningTask(t *testing.T) {
+	parentCluster, parentServer := newTestRuntimeOnlyClusterServer(t, "parent", "parent-master", "3306")
+	parentCluster.Conf.BackupLogicalType = "unsupported"
+	parentCluster.master = parentServer
+	if err := parentServer.SetBackupLogicalCookie(config.ConstBackupLogicalTypeMysqldump); err != nil {
+		t.Fatalf("failed to set parent logical backup cookie: %v", err)
+	}
+
+	targetCluster, target := newTestRuntimeOnlyClusterServer(t, "child", "child-slave", "3307")
+	targetCluster.master = nil // keep IsMaster() false so the unsupported-type path stays DB-free in this regression test
+
+	_, err := targetCluster.ReseedFromParentCluster(parentCluster, target, "")
+	if err == nil {
+		t.Fatal("expected ReseedFromParentCluster to reject unsupported parent logical backup type")
+	}
+	if err.Error() != "Unknown backup type unsupported" {
+		t.Fatalf("unexpected ReseedFromParentCluster error: %v", err)
+	}
+	if got := target.JobResults.Get("reseedunsupported"); got != nil {
+		t.Fatalf("expected no runtime task entry for unsupported parent reseed type, got %+v", got)
+	}
+	if target.HasAnyReseedingState() {
+		t.Fatalf("expected reseeding state to be cleared after failure, got %q", target.IsReseeding)
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR fixes missing job `start` and `end` timestamps in API-mode and runtime-only job flows.

## What this achieves
- stamps `start` when API-mode and runtime-only jobs actually begin
- stamps `end` when those jobs reach terminal success or failure
- keeps jobs-table-backed behavior unchanged
- keeps backup and restore behavior unchanged while improving job visibility

## Scope
The change is limited to job state tracking for flows that do not rely on a jobs-table row, including manual and scheduler-disabled logical backup, logical reseed, and flashback paths.

## Validation
- `go test ./cluster -run 'TestJobsUpdate(PayloadRuntimeOnly_SchedulerEnabled_NeverTouchesSQL|StateRuntimeOnly_SchedulerEnabled_NeverTouchesSQL|StateRuntimeOnly_SchedulerDisabled_StampsTimestamps|State_SchedulerDisabled_DoesNotStampTimestamps)$'`
- `go test ./cluster`

Closes #1685
