### PR TITLE
fix(jobs): converge stale DB log job state in API and SQL modes

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -822,6 +822,9 @@ func (cluster *Cluster) InitFromConf() {
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Could not set server list %s", err)
 	}
+	if !cluster.initiated {
+		cluster.ReconcileRestoredAPIJobs()
+	}
 	cluster.ClearOldCookies()
 
 	err = cluster.newProxyList()
@@ -2504,6 +2507,20 @@ func (cluster *Cluster) ClearOldCookies() {
 		s.DelWaitErrorlogCookie()
 		s.DelWaitSqlErrorlogCookie()
 		s.DelWaitSlowqueryCookie()
+	}
+}
+
+// ReconcileRestoredAPIJobs converts restored-but-unfinished API-mode jobs on
+// every server into a terminal error state. Must only be called on a genuine
+// process startup (see the cluster.initiated gate in InitFromConf) — calling
+// it on a cluster settings reload would wrongly interrupt a job that started
+// after the reload, not before a process restart.
+func (cluster *Cluster) ReconcileRestoredAPIJobs() {
+	for _, s := range cluster.Servers {
+		if s == nil {
+			continue
+		}
+		s.ReconcileRestoredAPIJobs()
 	}
 }
 func (cluster *Cluster) RotateLogs() {

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -595,6 +595,47 @@ func (server *ServerMonitor) setTaskCookie(task string) error {
 	}
 }
 
+// delTaskCookie removes the wait cookie for a remote task, mirroring
+// setTaskCookie's mapping in reverse. Used by ReconcileRestoredAPIJobs for
+// best-effort cleanup: without it, a task already reconciled to a terminal
+// state would still get dispatched to dbjobs off a stale cookie the next
+// time it polls CheckTaskNeeded (server/api_database.go), contradicting the
+// terminal state we just recorded.
+func (server *ServerMonitor) delTaskCookie(task string) error {
+	switch config.TaskName(task) {
+	case config.ConstTaskXB, config.ConstTaskMB:
+		return server.DelWaitPhysicalBackupCookie()
+	case config.ConstTaskOptimize:
+		return server.DelWaitOptimizeCookie()
+	case config.ConstTaskRestart:
+		return server.DelWaitRestartCookie()
+	case config.ConstTaskStop:
+		return server.DelWaitStopCookie()
+	case config.ConstTaskStart:
+		return server.DelWaitStartCookie()
+	case config.ConstTaskReseedXB:
+		return server.DelWaitReseedXtrabackupCookie()
+	case config.ConstTaskReseedMB:
+		return server.DelWaitReseedMariabackupCookie()
+	case config.ConstTaskFlashXB:
+		return server.DelWaitFlashbackXtrabackupCookie()
+	case config.ConstTaskFlashMB:
+		return server.DelWaitFlashbackMariabackupCookie()
+	case config.ConstTaskError:
+		return server.DelWaitErrorlogCookie()
+	case config.ConstTaskSlowQuery:
+		return server.DelWaitSlowqueryCookie()
+	case config.ConstTaskAuditLog:
+		return server.DelWaitAuditlogCookie()
+	case config.ConstTaskSqlError:
+		return server.DelWaitSqlErrorlogCookie()
+	case config.ConstTaskZFS:
+		return server.delCookie("cookie_waitzfssnapback")
+	default:
+		return nil
+	}
+}
+
 func (server *ServerMonitor) HasRunningDBJobs() (bool, error) {
 	if server.ClusterGroup.Conf.SchedulerJobsMode == "api" {
 		return false, nil
@@ -809,6 +850,48 @@ func (server *ServerMonitor) jobsCheckRunningFromMemory() error {
 	})
 
 	return nil
+}
+
+// ReconcileRestoredAPIJobs converts any restored-but-unfinished API-mode job
+// (Done == 0) into a terminal error state, and best-effort clears any wait
+// cookie for a reconciled remote task so it cannot still be dispatched to
+// dbjobs off stale disk state after we've already recorded it as failed.
+// Call once per server, only on a genuine process startup (never on a
+// cluster settings reload) — see cluster.go's InitFromConf/cluster.initiated
+// gating.
+func (server *ServerMonitor) ReconcileRestoredAPIJobs() {
+	cluster := server.ClusterGroup
+	if cluster.Conf.SchedulerJobsMode != "api" || server.JobResults == nil {
+		return
+	}
+	now := time.Now().Unix()
+	server.JobResults.Callback(func(task string, t *config.Task) bool {
+		if t.Done != 0 {
+			return true
+		}
+		t.Done = 1
+		t.State = JobStateErrorExec
+		t.Result = "replication-manager restarted before this job finished"
+		if t.Start == 0 {
+			t.Start = now
+		}
+		t.End = now
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlWarn,
+			"Reconciled stale API job %s on %s to error state: job was still unfinished when repman restarted", task, server.URL)
+
+		// Not gated on IsRemoteTask(...): that reflects the *current*
+		// SchedulerJobsExecOverrides, which can differ from what was in
+		// effect when the cookie was originally set (it's parsed fresh from
+		// config on every load, not fixed for the process lifetime). Whether
+		// a cookie exists is what actually drives dispatch in
+		// CheckTaskNeeded(), so always attempt cleanup — delTaskCookie is
+		// already a no-op for tasks that never had one.
+		if err := server.delTaskCookie(task); err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlDbg,
+				"Cookie cleanup for reconciled task %s on %s: %v", task, server.URL, err)
+		}
+		return true
+	})
 }
 
 func (server *ServerMonitor) JobsCheckPending(Conn *sqlx.Conn) error {

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -906,6 +906,24 @@ func (server *ServerMonitor) JobsCheckPending(Conn *sqlx.Conn) error {
 	// Set timeout for old task
 	server.ConnExecQueryWithTimeout(Conn, JobTimeout, "UPDATE replication_manager_schema.jobs SET state=5, result='Timeout waiting for job to start', done=1, end=now() where state=0 and start <= DATE_SUB(NOW(), interval 1 hour)")
 
+	// Stale-running cleanup, scoped to short-lived DB log jobs only: if one
+	// of these is still state=1/done=0 after an hour, its completion write
+	// (doneJob's backgrounded final UPDATE, or the dbjobs process itself)
+	// was lost, not that it's still legitimately running. Backup/reseed/
+	// flashback jobs are deliberately excluded — they can legitimately run
+	// far longer than an hour, so timing them out generically would risk
+	// cancelling real in-progress work.
+	logTasks := fmt.Sprintf("'%s','%s','%s','%s'", config.ConstTaskError, config.ConstTaskSlowQuery, config.ConstTaskAuditLog, config.ConstTaskSqlError)
+	if res, err := server.ConnExecQueryWithTimeout(Conn, JobTimeout, fmt.Sprintf(
+		"UPDATE replication_manager_schema.jobs SET state=5, done=1, end=now(), result='Timeout waiting for job to finish' where state=1 and done=0 and task in (%s) and start <= DATE_SUB(NOW(), interval 1 hour)", logTasks)); err == nil {
+		if n, _ := res.RowsAffected(); n > 0 {
+			server.SetNeedRefreshJobs(true)
+		}
+	} else {
+		server.ClusterGroup.LogModulePrintf(server.ClusterGroup.Conf.Verbose, config.ConstLogModTask, config.LvlWarn,
+			"Stale-running log job cleanup failed on %s: %v", server.URL, err)
+	}
+
 	tasks, err := server.GetTasksByState(Conn, JobStateHalted)
 	if err != nil {
 		return fmt.Errorf("Error retrieving pending tasks on %s: %s", server.URL, err)

--- a/cluster/srv_job_test.go
+++ b/cluster/srv_job_test.go
@@ -188,6 +188,153 @@ func TestJobInsertTask_APIMode_RemoteTask_CookieFailureDoesNotBlockRetry(t *test
 	}
 }
 
+// TestReconcileRestoredAPIJobs_UnfinishedBecomesTerminal simulates a restart
+// mid-job: a restored JobResults entry with Done=0 (as ReloadSaveInfosVariables
+// would leave it) must be converted to a terminal error state so the UI stops
+// showing it as Running forever.
+func TestReconcileRestoredAPIJobs_UnfinishedBecomesTerminal(t *testing.T) {
+	server := newTestServerForAPIJobs(t)
+	task := string(config.ConstTaskOptimize)
+	server.JobResults.Set(task, &config.Task{Task: task, State: JobStateAvailable, Done: 0, Start: 100})
+
+	server.ReconcileRestoredAPIJobs()
+
+	got := server.JobResults.Get(task)
+	if got == nil {
+		t.Fatal("expected job entry to still exist")
+	}
+	if got.Done != 1 {
+		t.Fatalf("expected Done=1, got %d", got.Done)
+	}
+	if got.State != JobStateErrorExec {
+		t.Fatalf("expected State=JobStateErrorExec, got %d", got.State)
+	}
+	if got.End == 0 {
+		t.Fatal("expected End to be stamped")
+	}
+	if got.Result == "" {
+		t.Fatal("expected a Result message explaining the restart")
+	}
+}
+
+// TestReconcileRestoredAPIJobs_CompletedUnchanged ensures reconciliation never
+// touches a job that already finished before the restart.
+func TestReconcileRestoredAPIJobs_CompletedUnchanged(t *testing.T) {
+	server := newTestServerForAPIJobs(t)
+	task := string(config.ConstTaskOptimize)
+	want := &config.Task{Task: task, State: JobStateSuccess, Done: 1, Start: 100, End: 200, Result: "completed"}
+	server.JobResults.Set(task, want)
+
+	server.ReconcileRestoredAPIJobs()
+
+	got := server.JobResults.Get(task)
+	if got.State != JobStateSuccess || got.Done != 1 || got.End != 200 || got.Result != "completed" {
+		t.Fatalf("expected completed job to remain unchanged, got %+v", got)
+	}
+}
+
+// TestReconcileRestoredAPIJobs_SQLModeNoop ensures this API-mode-only
+// reconciliation never mutates jobs when the scheduler runs in SQL mode,
+// which already has its own stale-job timeout in JobsCheckPending.
+func TestReconcileRestoredAPIJobs_SQLModeNoop(t *testing.T) {
+	server := newTestServerForAPIJobs(t)
+	server.ClusterGroup.Conf.SchedulerJobsMode = "sql"
+	task := string(config.ConstTaskOptimize)
+	server.JobResults.Set(task, &config.Task{Task: task, State: JobStateAvailable, Done: 0, Start: 100})
+
+	server.ReconcileRestoredAPIJobs()
+
+	got := server.JobResults.Get(task)
+	if got.Done != 0 || got.State != JobStateAvailable {
+		t.Fatalf("expected SQL mode job to remain unchanged, got %+v", got)
+	}
+}
+
+// TestReconcileRestoredAPIJobs_MultipleUnfinished checks every restored
+// Done=0 task is reconciled, not just the first one encountered.
+func TestReconcileRestoredAPIJobs_MultipleUnfinished(t *testing.T) {
+	server := newTestServerForAPIJobs(t)
+	tasks := []string{string(config.ConstTaskOptimize), string(config.ConstTaskRestart), string(config.ConstTaskDump)}
+	for _, task := range tasks {
+		server.JobResults.Set(task, &config.Task{Task: task, State: JobStateAvailable, Done: 0, Start: 100})
+	}
+
+	server.ReconcileRestoredAPIJobs()
+
+	for _, task := range tasks {
+		got := server.JobResults.Get(task)
+		if got.Done != 1 || got.State != JobStateErrorExec {
+			t.Fatalf("expected task %s to be reconciled, got %+v", task, got)
+		}
+	}
+}
+
+// TestReconcileRestoredAPIJobs_ClearsRemoteTaskCookie guards against a stale
+// wait cookie surviving reconciliation: if left in place, dbjobs would still
+// consume it via CheckTaskNeeded on its next poll and dispatch a task we
+// just recorded as failed, contradicting the reconciled state.
+func TestReconcileRestoredAPIJobs_ClearsRemoteTaskCookie(t *testing.T) {
+	server := newTestServerForAPIJobs(t)
+	task := string(config.ConstTaskOptimize)
+	if err := server.SetWaitOptimizeCookie(); err != nil {
+		t.Fatalf("failed to seed optimize cookie: %v", err)
+	}
+	server.JobResults.Set(task, &config.Task{Task: task, State: JobStateAvailable, Done: 0, Start: 100})
+
+	server.ReconcileRestoredAPIJobs()
+
+	if server.HasWaitOptimizeCookie() {
+		t.Fatal("expected reconciled remote task's wait cookie to be removed")
+	}
+}
+
+// TestReconcileRestoredAPIJobs_ClearsCookieDespiteCurrentOverride guards
+// against gating cleanup on IsRemoteTask(): SchedulerJobsExecOverrides is
+// re-parsed from config on every load and can differ from what was in effect
+// when the cookie was originally set (e.g. an admin edited
+// scheduler-jobs-exec-remote while repman was down). Whether the cookie
+// exists is what actually drives dbjobs dispatch via CheckTaskNeeded(), so
+// cleanup must not depend on the current override value.
+func TestReconcileRestoredAPIJobs_ClearsCookieDespiteCurrentOverride(t *testing.T) {
+	server := newTestServerForAPIJobs(t)
+	task := string(config.ConstTaskOptimize)
+	if err := server.SetWaitOptimizeCookie(); err != nil {
+		t.Fatalf("failed to seed optimize cookie: %v", err)
+	}
+	server.JobResults.Set(task, &config.Task{Task: task, State: JobStateAvailable, Done: 0, Start: 100})
+
+	// Force IsRemoteTask(optimize, ...) to false under the *current* config,
+	// simulating an override change made while repman was restarting.
+	server.ClusterGroup.Conf.SchedulerJobsExecOverrides = map[config.TaskName]bool{
+		config.ConstTaskOptimize: false,
+	}
+
+	server.ReconcileRestoredAPIJobs()
+
+	got := server.JobResults.Get(task)
+	if got.Done != 1 || got.State != JobStateErrorExec {
+		t.Fatalf("expected job to be reconciled, got %+v", got)
+	}
+	if server.HasWaitOptimizeCookie() {
+		t.Fatal("expected stale cookie to be removed even though current override reports the task as local")
+	}
+}
+
+// TestReconcileRestoredAPIJobs_LocalTaskCookieUntouched ensures reconciliation
+// does not try to manage cookies for local-only tasks, which never have one.
+func TestReconcileRestoredAPIJobs_LocalTaskCookieUntouched(t *testing.T) {
+	server := newTestServerForAPIJobs(t)
+	task := string(config.ConstTaskDump)
+	server.JobResults.Set(task, &config.Task{Task: task, State: JobStateAvailable, Done: 0, Start: 100})
+
+	server.ReconcileRestoredAPIJobs()
+
+	got := server.JobResults.Get(task)
+	if got.Done != 1 || got.State != JobStateErrorExec {
+		t.Fatalf("expected local task to still be reconciled, got %+v", got)
+	}
+}
+
 // newTestServerForRuntimeOnlyJobs builds a fixture for the non-API,
 // scheduler-disabled case: SQL-identity mode, but MonitorScheduler=false, so
 // JobsUpdateState is the only thing ever touching this task (JobInsertTask's

--- a/doc/implementation/cluster/API_JOB_STARTUP_RECONCILIATION.md
+++ b/doc/implementation/cluster/API_JOB_STARTUP_RECONCILIATION.md
@@ -57,14 +57,35 @@ actually drives dispatch is whether the cookie file exists
 attempts `delTaskCookie`, which is already a safe no-op for task names that
 never had a cookie.
 
+## Related fix: the HTTP 404 on terminal callback (dbjobs_new.sh)
+
+The HTTP 404 mentioned in #1690 turned out to have its own root cause,
+separate from the Go-side reconciliation above, fixed in the same pass in
+`share/scripts/dbjobs_new.sh`. `report_job_state()`'s caller built its result
+in `local api_job_result="done"`, but that line runs in the top-level `JOBS`
+loop, not inside a function — `local` outside a function prints `local: can
+only be used in a function` and does not assign. The script has no `set -e`,
+so execution continues with the variable left unset for any job that doesn't
+hit the mariabackup/xtrabackup/reseed/flashback case branches (e.g.
+`auditlog`, `sqlerrorlog`). `report_job_state` was then called with an empty
+state, producing a URL with an empty `{jobstate}` path segment that gorilla
+mux never matches — hence 404, not the handler's 400 for a
+recognized-but-invalid state.
+
+Fixed by dropping `local`. `report_job_state()` also now fails fast (no
+network call) on an empty state so this bug class can't silently 404 again,
+and retries via the existing `send_to_api_with_retry` helper for genuine
+transient failures during restart timing — the scenario #1690 actually
+describes. Only the terminal `done`/`error` report gets the larger budget (5
+attempts vs. the 3 used for log lines): a dropped terminal report is what
+leaves a job stuck with no resolution, whereas a dropped `processing` or
+`waiting` report (`pauseJob`, before job execution) doesn't strand the job —
+the later terminal report or startup reconciliation still resolves it.
+
 ## Explicitly out of scope
 
 - SQL-mode jobs: unaffected. `JobsCheckPending` already has its own SQL-side
   timeout for stale `state=0` rows.
-- The HTTP 404 mentioned in #1690 when a late dbjobs callback reports a
-  result: the issue itself calls this a secondary symptom, not the primary
-  gap. The route exists in code; a late callback simply overwrites the
-  reconciled entry with the real outcome, which is expected and fine.
 - `zfssnapback`'s dispatch: found during review that `CheckTaskNeeded`
   (`cluster/srv_chk.go`) unconditionally returns `false` for
   `ConstTaskZFS`, so its cookie (created by `setTaskCookie`, now also

--- a/doc/implementation/cluster/API_JOB_STARTUP_RECONCILIATION.md
+++ b/doc/implementation/cluster/API_JOB_STARTUP_RECONCILIATION.md
@@ -82,10 +82,45 @@ leaves a job stuck with no resolution, whereas a dropped `processing` or
 `waiting` report (`pauseJob`, before job execution) doesn't strand the job —
 the later terminal report or startup reconciliation still resolves it.
 
+## SQL-mode stale-running jobs (default `scheduler-jobs-mode = "sql"`)
+
+`scheduler-jobs-mode` defaults to `"sql"`, so the API-mode fixes above don't
+cover the common case. `JobsCheckPending` (`cluster/srv_job.go`) already
+timed out `state=0` (not-yet-started) rows past an hour, but had no
+equivalent for `state=1` (processing) — a SQL-mode DB log job
+(`errorlog`/`slowquery`/`auditlog`/`sqlerrorlog`) that reached `processing`
+but never wrote its completion row stayed visibly `Running` forever, same
+symptom as the API-mode case.
+
+Two contributing causes, both in `share/scripts/dbjobs_new.sh`:
+- `doneJob()`'s final completion `UPDATE` was backgrounded (`&`), with
+  nothing after it — `remove_run_lockdir`, the next loop iteration, or script
+  exit — waiting for it to land. If the process group got reaped at that
+  point (cron/systemd/container exit), the write was lost and the row stayed
+  at `state=1`/`done=0` indefinitely. Fixed by dropping the `&`; nothing
+  after this call does other useful concurrent work, so there's no cost to
+  making it synchronous.
+- No cleanup existed for the resulting stale rows. Added a second UPDATE in
+  `JobsCheckPending`, right after the existing `state=0` timeout, scoped to
+  `state=1 and done=0 and task in ('errorlog','slowquery','auditlog',
+  'sqlerrorlog')` past the same one-hour threshold, converting to terminal
+  error and calling `SetNeedRefreshJobs(true)` so the UI cache converges.
+
+Deliberately **not** extended to backup/reseed/flashback tasks: those can
+legitimately run for hours, so a generic `state=1` timeout across all task
+types would risk cancelling real in-progress work. `pauseJob()`'s SQL-mode
+`state=2` ("waiting") write is also left backgrounded — it's not a terminal
+write, so losing it doesn't strand the job the way losing `doneJob`'s write
+does.
+
+No Go unit test was added for the new query: `JobsCheckPending` (including
+its existing, unmodified `state=0` sibling) has no unit test today — this
+class of SQL-executing function is validated by the regtest/Docker suite
+(T13), not Go unit tests, and this change doesn't alter that. Not run here —
+needs either a live SQL-mode cluster or the regtest suite.
+
 ## Explicitly out of scope
 
-- SQL-mode jobs: unaffected. `JobsCheckPending` already has its own SQL-side
-  timeout for stale `state=0` rows.
 - `zfssnapback`'s dispatch: found during review that `CheckTaskNeeded`
   (`cluster/srv_chk.go`) unconditionally returns `false` for
   `ConstTaskZFS`, so its cookie (created by `setTaskCookie`, now also

--- a/doc/implementation/cluster/API_JOB_STARTUP_RECONCILIATION.md
+++ b/doc/implementation/cluster/API_JOB_STARTUP_RECONCILIATION.md
@@ -1,0 +1,93 @@
+# API-mode job startup reconciliation
+
+Fixes [#1690](https://github.com/signal18/replication-manager/issues/1690):
+interrupted API-mode jobs (`scheduler-jobs-mode = "api"`) could remain shown as
+`Running` indefinitely after a restart that happened mid-job.
+
+## Root cause
+
+API-mode job state lives only in memory (`server.JobResults`, a
+`*config.TasksMap`), persisted to `serverstate.json` and restored via
+`ReloadSaveInfosVariables()`. If repman stops while a task is still `Done ==
+0`, that entry is saved and restored exactly as-is — nothing ever reconciled
+it, so the UI and `jobsCheckRunningFromMemory()` kept trusting a `Running`
+entry whose owning process no longer existed.
+
+## Fix
+
+`ServerMonitor.ReconcileRestoredAPIJobs()` (`cluster/srv_job.go`) walks
+`JobResults` and converts any `Done == 0` entry to a terminal error state
+(`Done=1`, `State=JobStateErrorExec`, a restart-explaining `Result`, `End`
+stamped). It also calls `delTaskCookie()` — the reverse of the existing
+`setTaskCookie()` mapping — so a reconciled task's wait cookie can't still
+cause `dbjobs` to dispatch it later via `CheckTaskNeeded()`
+(`cluster/srv_chk.go`), which would contradict the terminal state just
+recorded.
+
+`Cluster.ReconcileRestoredAPIJobs()` fans this out over `cluster.Servers`, and
+is called from `InitFromConf()` in `cluster/cluster.go`, right after
+`newServerList()` (which is what restores `JobResults` in the first place, via
+`newServerMonitor` → `ReloadSaveInfosVariables()`).
+
+## The startup-vs-reload gate
+
+`InitFromConf()` runs on **every** cluster settings reload, not just process
+start — it already branches its own log message on `cluster.initiated` for
+exactly that reason. Naively reconciling here unconditionally would wrongly
+mark a job that started *after* a config reload (not before a process
+restart) as interrupted. The call is gated on `!cluster.initiated`, which is
+`false` only through the very first `Init()` for this process and `true` on
+every subsequent reload — the existing flag that already distinguishes the
+two cases.
+
+`ReloadSaveInfosVariables()` itself was deliberately *not* used as the hook
+point: it's also called lazily from `GetDatabaseDatadir` /
+`GetBinaryLogName` / `GetBinaryLogDir` whenever `SensitiveVariables == nil`,
+so it can re-fire well after startup.
+
+## Cookie cleanup is unconditional, not gated on `IsRemoteTask`
+
+An earlier version gated the `delTaskCookie()` call on
+`config.IsRemoteTask(task, cluster.Conf.SchedulerJobsExecOverrides)`. That's
+wrong: `SchedulerJobsExecOverrides` is re-parsed from config on every load, so
+it can differ from what was in effect when the cookie was originally written
+(e.g. an admin edits `scheduler-jobs-exec-remote` while repman is down). What
+actually drives dispatch is whether the cookie file exists
+(`CheckTaskNeeded`), not the current override value — so cleanup always
+attempts `delTaskCookie`, which is already a safe no-op for task names that
+never had a cookie.
+
+## Explicitly out of scope
+
+- SQL-mode jobs: unaffected. `JobsCheckPending` already has its own SQL-side
+  timeout for stale `state=0` rows.
+- The HTTP 404 mentioned in #1690 when a late dbjobs callback reports a
+  result: the issue itself calls this a secondary symptom, not the primary
+  gap. The route exists in code; a late callback simply overwrites the
+  reconciled entry with the real outcome, which is expected and fine.
+- `zfssnapback`'s dispatch: found during review that `CheckTaskNeeded`
+  (`cluster/srv_chk.go`) unconditionally returns `false` for
+  `ConstTaskZFS`, so its cookie (created by `setTaskCookie`, now also
+  cleared by `delTaskCookie`) was already never consulted by the dbjobs poll
+  loop in API mode — a separate, pre-existing bug, unrelated to this fix.
+
+## Tests
+
+`cluster/srv_job_test.go`, all exercising `ReconcileRestoredAPIJobs()`
+directly against `JobResults`/cookie fixtures:
+- unfinished job → terminal state
+- completed job → unchanged
+- SQL mode → no-op
+- multiple unfinished jobs → all reconciled
+- remote task's wait cookie is cleared
+- cookie is cleared even when the *current* `SchedulerJobsExecOverrides`
+  would say the task is local
+- local-only task → reconciled without touching cookies
+
+## Manual validation (not yet run — see PR)
+
+1. Start an API-mode job, kill repman before it finishes, restart, confirm it
+   shows a terminal error state instead of `Running`, then re-trigger it.
+2. Trigger a **cluster settings reload** (not a process restart) while a job
+   is genuinely running, and confirm it is left untouched — this is what the
+   `!cluster.initiated` gate protects against.

--- a/share/scripts/dbjobs_new.sh
+++ b/share/scripts/dbjobs_new.sh
@@ -86,6 +86,7 @@ readonly LOCK_DIR="${TMP_DIR}/locks"
 # Constants
 readonly BATCH_SIZE=5
 readonly MAX_RETRIES=3
+readonly JOB_STATE_MAX_RETRIES=5
 readonly API_LOG_FILE="${LOG_DIR}/api_calls.log"
 readonly LOG_MAX_SIZE=1048576  # 1MB
 
@@ -508,18 +509,40 @@ get_task_receiver() {
 report_job_state() {
     local taskname="$1"
     local jobstate="$2"
-    local api_host="$REPLICATION_MANAGER_HOST"
-    local api_port="$REPLICATION_MANAGER_PORT"
 
-    local endpoint="/api/clusters/${CLUSTER_NAME}/servers/${MYSQL_SERVER}/${MYSQL_PORT}/actions/job-state/${taskname}/${jobstate}"
-    local response=$(send_encrypted_api_request "$api_host" "$api_port" "$endpoint" "{\"server\":\"$MYSQL_SERVER:$MYSQL_PORT\",\"secret\":\"$MYSQL_ROOT_PASSWORD\"}")
-
-    local http_code=$(extract_http_code "$response")
-    if [[ "$http_code" != "200" ]]; then
-        send_lines_to_api "Failed to report job state $jobstate for $taskname (HTTP $http_code)" "$taskname" "$LVL_ERROR"
+    # An empty state means the caller has a bug (e.g. an unset result
+    # variable) — the route requires a non-empty {jobstate} path segment, so
+    # sending this would just 404 against a URL like .../job-state/task/.
+    # Fail fast locally instead of spending retries on a request that can
+    # never succeed.
+    if [[ -z "$jobstate" ]]; then
+        send_lines_to_api "report_job_state called with empty state for $taskname" "$taskname" "$LVL_ERROR"
         return 1
     fi
-    return 0
+
+    local api_host="$REPLICATION_MANAGER_HOST"
+    local api_port="$REPLICATION_MANAGER_PORT"
+    local endpoint="/api/clusters/${CLUSTER_NAME}/servers/${MYSQL_SERVER}/${MYSQL_PORT}/actions/job-state/${taskname}/${jobstate}"
+    local data="{\"server\":\"$MYSQL_SERVER:$MYSQL_PORT\",\"secret\":\"$MYSQL_ROOT_PASSWORD\"}"
+
+    # Retry like send_lines_to_api already does via send_to_api_with_retry.
+    # done/error are terminal — a dropped report there is what leaves a job
+    # stuck with no resolution (the #1690 symptom) — so they get a larger
+    # budget to ride out restart/startup timing. processing/waiting use the
+    # same budget as log lines; losing one of those doesn't strand the job,
+    # since the terminal report (or startup reconciliation) still resolves
+    # it later.
+    local retries="$MAX_RETRIES"
+    case "$jobstate" in
+        done|error) retries="$JOB_STATE_MAX_RETRIES" ;;
+    esac
+
+    if send_to_api_with_retry "$api_host" "$api_port" "$endpoint" "$data" "$retries"; then
+        return 0
+    fi
+
+    send_lines_to_api "Failed to report job state $jobstate for $taskname after $retries attempts" "$taskname" "$LVL_ERROR"
+    return 1
 }
 
 ##################################
@@ -1863,8 +1886,16 @@ for job in "${JOBS[@]}"; do
 
         # Report job completion
         if [[ "$JOBS_MODE" == "api" ]]; then
-            # Check backup success the same way doneJob does
-            local api_job_result="done"
+            # Check backup success the same way doneJob does.
+            # Not `local`: this code runs in the top-level JOBS loop, not
+            # inside a function — `local` here prints "local: can only be
+            # used in a function" and does not assign. The script has no
+            # set -e, so execution continues with api_job_result left
+            # unset/stale for any job that doesn't hit the case branches
+            # below (e.g. auditlog, sqlerrorlog), which then calls
+            # report_job_state with an empty state and 404s on the route's
+            # non-empty {jobstate} segment.
+            api_job_result="done"
             case "$job" in
             mariabackup|xtrabackup)
                 if ! grep -q '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\} [0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\} completed OK!' "$LOG_DIR/backup.out" 2>/dev/null; then

--- a/share/scripts/dbjobs_new.sh
+++ b/share/scripts/dbjobs_new.sh
@@ -1380,7 +1380,14 @@ doneJob() {
     else
         send_lines_to_api "Job $job ended with state: Error" "$job" "$LVL_ERROR"
     fi
-    $BINARY_CLIENT -e "set sql_log_bin=0;UPDATE replication_manager_schema.jobs set end=NOW(), state=$jobstate, result=LOAD_FILE('$LOG_DIR/$job.out'), done=$done  WHERE id='$ID';" &
+    # Not backgrounded (no trailing &): this is the final completion write
+    # for the job row. Backgrounding it let the script move on to the next
+    # loop iteration (or exit) before the write landed — if the process
+    # group got reaped at that point (cron/systemd/container exit), the row
+    # was left at state=1/done=0 forever, indistinguishable from a job still
+    # actually running. Nothing after this call does other useful work
+    # concurrently, so there's no benefit to backgrounding it.
+    $BINARY_CLIENT -e "set sql_log_bin=0;UPDATE replication_manager_schema.jobs set end=NOW(), state=$jobstate, result=LOAD_FILE('$LOG_DIR/$job.out'), done=$done  WHERE id='$ID';"
 }
 
 pauseJob() {


### PR DESCRIPTION
## Contributor Agreement

By submitting this pull request, I agree to the terms outlined in the [Contributor Agreement](CONTRIBUTING.md).

## Summary

This branch fixes the two stale DB job-state variants we investigated on the jobs dashboard:

1. **API mode**: unfinished jobs could survive a repman restart and remain visible as `Running` because restored in-memory job state was never reconciled.
2. **SQL mode**: short-lived DB log jobs could reach `processing` / `Running` in `replication_manager_schema.jobs` and never converge to a terminal state if their completion write was missed.
3. **API terminal callback reliability**: the dbjobs script could call `report_job_state` with an empty final state for non-backup jobs, producing a `404` on `/actions/job-state/{task}/{jobstate}` and leaving the job unresolved.

## Why this branch fixes the reported issues

### API-mode stale running after restart
- Adds startup-only reconciliation for restored API-mode jobs with `Done == 0`
- Converts them to a terminal error state instead of restoring them as still active
- Best-effort clears any stale wait cookie so the DB host cannot redispatch a task that repman has already marked as interrupted

This addresses the stale API-mode `Running` symptom tracked in issue #1690.

### API callback 404 during final state reporting
- Fixes `dbjobs_new.sh` so `api_job_result` is assigned correctly in the top-level `JOBS` loop
- Rejects empty `jobstate` values before sending the callback
- Retries terminal `done` / `error` callbacks with a larger retry budget to ride out restart/startup timing

This addresses the empty-`jobstate` / `HTTP 404` callback symptom tracked in issue #1691.

### SQL-mode stale running / processing log jobs
- Makes the final SQL completion write in `doneJob()` synchronous instead of backgrounding it
- Adds stale-running cleanup for SQL-mode DB log jobs only (`errorlog`, `slowquery`, `auditlog`, `sqlerrorlog`) when they remain `state=1` / `done=0` past one hour
- Leaves long-running backup/reseed/flashback jobs untouched to avoid timing out legitimate work

This extends the stale-jobs fix path for the SQL-mode variant now documented in issue #1690.

## Files changed
- `cluster/cluster.go`
- `cluster/srv_job.go`
- `cluster/srv_job_test.go`
- `share/scripts/dbjobs_new.sh`
- `doc/implementation/cluster/API_JOB_STARTUP_RECONCILIATION.md`

## Validation

Ran locally:
- `bash -n share/scripts/dbjobs_new.sh`
- `go test ./cluster -run TestReconcileRestoredAPIJobs_SQLModeNoop -count=1`

Additional notes:
- The new SQL cleanup in `JobsCheckPending()` follows the existing SQL timeout style in that function and is intended for validation in a live SQL-mode cluster or regtest/docker environment.

## Related issues
- Related to #1690
- Related to #1691

(Linked intentionally without auto-closing so the issues can be verified in deployment first.)
