### PR TITLE
fix(cluster): surface direct reseed progress and recent rate

### DIFF
--- a/cluster/restore_progress.go
+++ b/cluster/restore_progress.go
@@ -26,6 +26,7 @@ func (cluster *Cluster) assertReseedProgressStates() {
 		if info == nil {
 			continue
 		}
+		sv.sampleReseedRate()
 		cluster.SetState("WARN0189", state.State{
 			ErrType:   "WARNING",
 			ErrKey:    "WARN0189",
@@ -68,11 +69,13 @@ func (server *ServerMonitor) startReseedProgress(info *ReseedProgress, r io.Read
 	server.reseedTotal.Store(total)
 	server.reseedStart.Store(time.Now().UnixNano())
 	server.reseedInfo.Store(info)
+	server.reseedRateWindow.Store([]reseedRateSample(nil))
 	return &countingReader{r: r, n: &server.reseedBytes}
 }
 
 func (server *ServerMonitor) stopReseedProgress() {
 	server.reseedInfo.Store((*ReseedProgress)(nil))
+	server.reseedRateWindow.Store([]reseedRateSample(nil))
 }
 
 // beginReseedProgress stamps an in-flight restore whose streamed bytes accumulate
@@ -85,6 +88,7 @@ func (server *ServerMonitor) beginReseedProgress(info *ReseedProgress, total int
 	server.reseedTotal.Store(total)
 	server.reseedStart.Store(time.Now().UnixNano())
 	server.reseedInfo.Store(info)
+	server.reseedRateWindow.Store([]reseedRateSample(nil))
 }
 
 // countReseedReader wraps r so bytes read accumulate into the current reseed's
@@ -116,6 +120,59 @@ func sumSplitdumpBytes(dir string) int64 {
 		}
 	}
 	return total
+}
+
+// reseedRateWindowSize is how many per-tick samples sampleReseedRate keeps. A single
+// tick's delta is too noisy to show (e.g. the direct-reseed pump copies in ~32KB
+// io.Copy chunks, so one tick can land on "nothing copied this instant" right next to
+// a burst); averaging over a handful of ticks smooths that out while still being far
+// more responsive than the lifetime average (reseedBytes/reseedStart), which barely
+// moves once a restore has been running for a while.
+const reseedRateWindowSize = 3
+
+// reseedRateSample is one (bytes, sampled-at) point used to compute a windowed
+// "recent" rate, distinct from the RateBytesSec lifetime average.
+type reseedRateSample struct {
+	bytes int64
+	at    time.Time
+}
+
+// sampleReseedRate appends the current byte count to the rolling sample window, called
+// once per monitoring tick (assertReseedProgressStates) for every server with an
+// active byte-instrumented reseed. Single-writer (the tick goroutine runs serially per
+// cluster) -- reseedRateWindow is an atomic.Value so concurrent readers (GetReseedProgress,
+// called from HTTP handlers) never see a partially-built slice.
+func (server *ServerMonitor) sampleReseedRate() {
+	prev, _ := server.reseedRateWindow.Load().([]reseedRateSample)
+	window := append(append([]reseedRateSample{}, prev...), reseedRateSample{
+		bytes: server.reseedBytes.Load(),
+		at:    time.Now(),
+	})
+	if len(window) > reseedRateWindowSize {
+		window = window[len(window)-reseedRateWindowSize:]
+	}
+	server.reseedRateWindow.Store(window)
+}
+
+// recentReseedRate returns the average bytes/sec over the sample window (0 until at
+// least two ticks have been sampled) -- a noisier but far more current-throughput
+// signal than the lifetime average, e.g. it will trend toward 0 while a reseed is
+// stalled well before the stall watchdog's timeout fires and aborts it.
+func (server *ServerMonitor) recentReseedRate() (rate int64, ready bool) {
+	window, _ := server.reseedRateWindow.Load().([]reseedRateSample)
+	if len(window) < 2 {
+		return 0, false
+	}
+	first, last := window[0], window[len(window)-1]
+	elapsed := last.at.Sub(first.at)
+	if elapsed <= 0 {
+		return 0, false
+	}
+	delta := last.bytes - first.bytes
+	if delta < 0 {
+		delta = 0
+	}
+	return int64(float64(delta) / elapsed.Seconds()), true
 }
 
 // reseedProgressLine returns a human progress line + the backup being restored,
@@ -151,18 +208,20 @@ func (server *ServerMonitor) reseedProgressLine() (string, *ReseedProgress) {
 // dashboard: enough to render a progress bar (bytes/total/percent) or a generic
 // "started T (elapsed)" timer when the method has no byte instrumentation.
 type ReseedProgressView struct {
-	InProgress   bool   `json:"inProgress"`
-	FromRejoin   bool   `json:"fromRejoin"`   // armed by a rejoin (reseedFromRejoin)
-	Task         string `json:"task"`         // reseed task: "reseedmysqldump", "reseedmariabackup", "direct", …
-	Backup       string `json:"backup"`       // backup file/dir being restored ("" if generic)
-	Tool         string `json:"tool"`         // restore tool
-	Bytes        int64  `json:"bytes"`        // streamed (compressed) so far
-	Total        int64  `json:"total"`        // total compressed size (0 = unknown)
-	Percent      int    `json:"percent"`      // 0..100, or -1 when total is unknown
-	StartedUnix  int64  `json:"startedUnix"`  // restore start (byte path) or rejoin-arm time (generic)
-	ElapsedSecs  int64  `json:"elapsedSecs"`
-	RateBytesSec int64  `json:"rateBytesSec"` // average over elapsed (0 when no bytes)
-	Line         string `json:"line"`         // the human progress line
+	InProgress         bool   `json:"inProgress"`
+	FromRejoin         bool   `json:"fromRejoin"`  // armed by a rejoin (reseedFromRejoin)
+	Task               string `json:"task"`        // reseed task: "reseedmysqldump", "reseedmariabackup", "direct", …
+	Backup             string `json:"backup"`      // backup file/dir being restored ("" if generic)
+	Tool               string `json:"tool"`        // restore tool
+	Bytes              int64  `json:"bytes"`       // streamed (compressed) so far
+	Total              int64  `json:"total"`       // total compressed size (0 = unknown)
+	Percent            int    `json:"percent"`     // 0..100, or -1 when total is unknown
+	StartedUnix        int64  `json:"startedUnix"` // restore start (byte path) or rejoin-arm time (generic)
+	ElapsedSecs        int64  `json:"elapsedSecs"`
+	RateBytesSec       int64  `json:"rateBytesSec"`       // lifetime average over elapsed (0 when no bytes) — stable, but lags a real slowdown/speedup
+	RecentRateBytesSec int64  `json:"recentRateBytesSec"` // windowed rate over the last few ticks (~reseedRateWindowSize * monitoring-ticker) — noisier, reflects current throughput
+	RecentRateReady    bool   `json:"recentRateReady"`    // true once enough ticks have been sampled for RecentRateBytesSec to be meaningful
+	Line               string `json:"line"`               // the human progress line
 }
 
 // GetReseedProgress returns a snapshot of the server's in-flight restore, or nil
@@ -186,6 +245,7 @@ func (server *ServerMonitor) GetReseedProgress() *ReseedProgressView {
 		if v.Total > 0 {
 			v.Percent = int(v.Bytes * 100 / v.Total)
 		}
+		v.RecentRateBytesSec, v.RecentRateReady = server.recentReseedRate()
 	} else if startNanos == 0 {
 		startNanos = server.rejoinReseedStart.Load() // generic rejoin timer, no byte instrumentation
 	}

--- a/cluster/restore_progress.go
+++ b/cluster/restore_progress.go
@@ -26,6 +26,14 @@ func (cluster *Cluster) assertReseedProgressStates() {
 		if info == nil {
 			continue
 		}
+		// Benign race: info was non-nil above, but the job goroutine can concurrently
+		// call stopReseedProgress (this reseed finishing) or begin*ReseedProgress (a
+		// new one starting) between that check and this call, since neither is under a
+		// shared lock with the tick goroutine here. Worst case sampleReseedRate appends
+		// one stray/near-zero sample against a window that just got reset (or is about
+		// to be) -- it self-heals within a tick or two once the window fills with real
+		// samples again, and never blocks or panics, so it doesn't touch monitor-loop
+		// liveness (F2-F4). Not worth a lock for a display-only, self-correcting value.
 		sv.sampleReseedRate()
 		cluster.SetState("WARN0189", state.State{
 			ErrType:   "WARNING",
@@ -219,7 +227,7 @@ type ReseedProgressView struct {
 	StartedUnix        int64  `json:"startedUnix"` // restore start (byte path) or rejoin-arm time (generic)
 	ElapsedSecs        int64  `json:"elapsedSecs"`
 	RateBytesSec       int64  `json:"rateBytesSec"`       // lifetime average over elapsed (0 when no bytes) — stable, but lags a real slowdown/speedup
-	RecentRateBytesSec int64  `json:"recentRateBytesSec"` // windowed rate over the last few ticks (~reseedRateWindowSize * monitoring-ticker) — noisier, reflects current throughput
+	RecentRateBytesSec int64  `json:"recentRateBytesSec"` // windowed rate spanning the oldest-to-newest sample currently held (~(reseedRateWindowSize-1) * monitoring-ticker) — noisier, reflects current throughput
 	RecentRateReady    bool   `json:"recentRateReady"`    // true once enough ticks have been sampled for RecentRateBytesSec to be meaningful
 	Line               string `json:"line"`               // the human progress line
 }

--- a/cluster/restore_progress_test.go
+++ b/cluster/restore_progress_test.go
@@ -98,6 +98,7 @@ func TestSampleReseedRate_ClearedByLifecycle(t *testing.T) {
 	server := &ServerMonitor{}
 	server.reseedBytes.Store(500)
 	server.sampleReseedRate()
+	time.Sleep(5 * time.Millisecond) // guarantee a positive delta, see TestRecentReseedRate_NotReadyUntilTwoSamples
 	server.reseedBytes.Store(1000)
 	server.sampleReseedRate()
 	if _, ready := server.recentReseedRate(); !ready {
@@ -111,6 +112,7 @@ func TestSampleReseedRate_ClearedByLifecycle(t *testing.T) {
 
 	server.reseedBytes.Store(10)
 	server.sampleReseedRate()
+	time.Sleep(5 * time.Millisecond)
 	server.reseedBytes.Store(20)
 	server.sampleReseedRate()
 	if _, ready := server.recentReseedRate(); !ready {

--- a/cluster/restore_progress_test.go
+++ b/cluster/restore_progress_test.go
@@ -1,0 +1,124 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// This source code is licensed under the GNU General Public License, version 3.
+
+package cluster
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRecentReseedRate_NotReadyUntilTwoSamples verifies the windowed "recent" rate
+// stays unready (0, false) until at least two ticks have been sampled -- a single
+// sample has no time delta to compute a rate from.
+func TestRecentReseedRate_NotReadyUntilTwoSamples(t *testing.T) {
+	server := &ServerMonitor{}
+
+	if rate, ready := server.recentReseedRate(); ready || rate != 0 {
+		t.Fatalf("expected (0, false) with no samples, got (%d, %v)", rate, ready)
+	}
+
+	server.reseedBytes.Store(1000)
+	server.sampleReseedRate()
+	if rate, ready := server.recentReseedRate(); ready || rate != 0 {
+		t.Fatalf("expected (0, false) after a single sample, got (%d, %v)", rate, ready)
+	}
+
+	server.reseedBytes.Store(2000)
+	time.Sleep(5 * time.Millisecond)
+	server.sampleReseedRate()
+	rate, ready := server.recentReseedRate()
+	if !ready {
+		t.Fatal("expected ready after two samples")
+	}
+	if rate <= 0 {
+		t.Fatalf("expected a positive rate once bytes advanced between two samples, got %d", rate)
+	}
+}
+
+// TestSampleReseedRate_WindowCapEvictsOldSamples verifies sampleReseedRate caps the
+// window at reseedRateWindowSize, evicting the oldest sample once it's full -- the
+// windowed rate must reflect CURRENT throughput, not grow unbounded.
+func TestSampleReseedRate_WindowCapEvictsOldSamples(t *testing.T) {
+	server := &ServerMonitor{}
+
+	for i, bytes := range []int64{0, 100, 200, 300, 400} {
+		server.reseedBytes.Store(bytes)
+		server.sampleReseedRate()
+		window, _ := server.reseedRateWindow.Load().([]reseedRateSample)
+		if want := min(i+1, reseedRateWindowSize); len(window) != want {
+			t.Fatalf("after %d sample(s): expected window length %d, got %d", i+1, want, len(window))
+		}
+	}
+
+	// 5 samples taken (bytes 0,100,200,300,400), window capped at reseedRateWindowSize
+	// (3) -- only the 3 most recent (200,300,400) should remain.
+	window, _ := server.reseedRateWindow.Load().([]reseedRateSample)
+	if window[0].bytes != 200 {
+		t.Fatalf("expected the two oldest samples (bytes 0,100) evicted, oldest remaining has bytes=%d", window[0].bytes)
+	}
+}
+
+// TestRecentReseedRate_ReflectsWindowNotWholeHistory verifies the rate math only looks
+// at whatever is currently in the window -- i.e. once an early burst has been evicted
+// (simulated here directly, deterministically, rather than via real elapsed time),
+// recentReseedRate must reflect the recent stall, not the burst that's no longer in
+// the window. This is the property that makes it useful where RateBytesSec (the
+// lifetime average) is known to lag: a stalled reseed's average stays inflated for a
+// long time after real throughput has collapsed, but the windowed rate catches up
+// within a few ticks.
+func TestRecentReseedRate_ReflectsWindowNotWholeHistory(t *testing.T) {
+	server := &ServerMonitor{}
+	base := time.Now()
+
+	// Window as it would look right after the burst sample (bytes:0) has already been
+	// evicted: 1MB arrived in the first second, then it crawls at ~1 byte/sec.
+	server.reseedRateWindow.Store([]reseedRateSample{
+		{bytes: 1_000_000, at: base},
+		{bytes: 1_000_001, at: base.Add(1 * time.Second)},
+		{bytes: 1_000_002, at: base.Add(2 * time.Second)},
+	})
+
+	rate, ready := server.recentReseedRate()
+	if !ready {
+		t.Fatal("expected ready with a full window")
+	}
+	// ~1 byte/sec over the window, nowhere near the ~1MB/sec the burst would suggest
+	// if the window still held it.
+	if rate > 100 {
+		t.Fatalf("expected the windowed rate to reflect the recent stall (~1B/s), not the early burst, got %d B/s", rate)
+	}
+}
+
+// TestSampleReseedRate_ClearedByLifecycle verifies begin/start/stopReseedProgress all
+// reset the sample window, so a new reseed doesn't inherit stale samples from a
+// previous one on the same server (which would produce a bogus recent rate for a few
+// ticks -- e.g. a huge negative-clamped-to-zero delta against ancient bytes).
+func TestSampleReseedRate_ClearedByLifecycle(t *testing.T) {
+	server := &ServerMonitor{}
+	server.reseedBytes.Store(500)
+	server.sampleReseedRate()
+	server.reseedBytes.Store(1000)
+	server.sampleReseedRate()
+	if _, ready := server.recentReseedRate(); !ready {
+		t.Fatal("expected ready before starting a new reseed (test setup sanity check)")
+	}
+
+	server.beginReseedProgress(&ReseedProgress{Backup: "next-reseed"}, 0)
+	if rate, ready := server.recentReseedRate(); ready || rate != 0 {
+		t.Fatalf("expected beginReseedProgress to clear the sample window, got (%d, %v)", rate, ready)
+	}
+
+	server.reseedBytes.Store(10)
+	server.sampleReseedRate()
+	server.reseedBytes.Store(20)
+	server.sampleReseedRate()
+	if _, ready := server.recentReseedRate(); !ready {
+		t.Fatal("expected ready again after sampling the new reseed (test setup sanity check)")
+	}
+
+	server.stopReseedProgress()
+	if rate, ready := server.recentReseedRate(); ready || rate != 0 {
+		t.Fatalf("expected stopReseedProgress to clear the sample window, got (%d, %v)", rate, ready)
+	}
+}

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -10,12 +10,12 @@
 package cluster
 
 import (
-	"compress/gzip"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"compress/gzip"
 	"hash/crc64"
 	"io"
 	"net/http"

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -10,12 +10,12 @@
 package cluster
 
 import (
+	"compress/gzip"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"compress/gzip"
 	"hash/crc64"
 	"io"
 	"net/http"
@@ -261,6 +261,7 @@ type ServerMonitor struct {
 	reseedBytes                 atomic.Int64 // raw bytes streamed so far (compressed input; no decompression accounting yet)
 	reseedTotal                 atomic.Int64 // total compressed backup file size (0 = unknown)
 	reseedStart                 atomic.Int64 // unix-nanos the current restore started (for MB/s)
+	reseedRateWindow            atomic.Value // []reseedRateSample: last few per-tick (bytes,time) samples, for a windowed "recent" rate distinct from the lifetime average (reseedBytes/reseedStart) — see restore_progress.go
 	// Lock ordering (to prevent deadlocks):
 	// 1. Cluster.stateMutex (highest)
 	// 2. ServerMonitor.stateMutex

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -3967,6 +3967,19 @@ func (cluster *Cluster) JobRejoinMysqldumpFromSource(source *ServerMonitor, dest
 	dest.JobsUpdateStateRuntimeOnly(task, "processing", 1, 0)
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Rejoining from direct mysqldump from %s", source.URL)
 
+	// Reseed progress (WARN0189): stamp the in-flight restore so the per-tick
+	// state and the dashboard reseed modal show streamed bytes/avg speed
+	// instead of a generic "in progress" timer, and so the backup/tool text
+	// distinguishes this direct stream from a file-based mysqldump restore.
+	// Total is unknown for a live stream (0 -- GetReseedProgress renders
+	// Percent=-1 for that case, same as other unknown-total restores).
+	dest.beginReseedProgress(&ReseedProgress{
+		Backup: "direct stream from " + source.URL,
+		Source: source.URL,
+		Tool:   "mysqldump",
+	}, 0)
+	defer dest.stopReseedProgress()
+
 	// Stop ALL replication connections before the RESET MASTER below. StopSlave()
 	// only stops cluster.Conf.MasterConn (empty by default → the unnamed default
 	// connection), so a dest replicating on a NAMED connection (e.g. 'curepipe')
@@ -4157,7 +4170,9 @@ func (cluster *Cluster) JobRejoinMysqldumpFromSource(source *ServerMonitor, dest
 	// way an explicit failure would. Reuses the existing backup-write-stall-
 	// timeout config rather than adding a second stall knob -- same signal
 	// ("is data still flowing"), same semantics (0 disables, <0 warns+disables).
-	var pumpProgress atomic.Int64
+	// Uses dest.reseedBytes (the same counter beginReseedProgress above stamped
+	// for the dashboard/WARN0189) rather than a local counter, so the stall
+	// watchdog and the displayed progress can never diverge.
 	var stalled atomic.Bool
 	stallDone := make(chan struct{})
 	stallFired := make(chan struct{})
@@ -4170,7 +4185,7 @@ func (cluster *Cluster) JobRejoinMysqldumpFromSource(source *ServerMonitor, dest
 	if checkInterval < time.Second {
 		checkInterval = time.Second
 	}
-	go backupStallWatchdog(stallDone, cancel, &pumpProgress, stallTimeout, checkInterval, func() {
+	go backupStallWatchdog(stallDone, cancel, &dest.reseedBytes, stallTimeout, checkInterval, func() {
 		stalled.Store(true)
 		close(stallFired)
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlErr,
@@ -4195,7 +4210,7 @@ func (cluster *Cluster) JobRejoinMysqldumpFromSource(source *ServerMonitor, dest
 			pumpErrCh <- fmt.Errorf("writing restore preamble to mysql client stdin: %w", err)
 			return
 		}
-		counted := &progressCountingWriter{w: clientStdin, progress: &pumpProgress}
+		counted := &progressCountingWriter{w: clientStdin, progress: &dest.reseedBytes}
 		if _, err := io.Copy(counted, dumpStdoutR); err != nil {
 			cancel()
 			pumpErrCh <- fmt.Errorf("streaming mysqldump output to mysql client stdin: %w", err)

--- a/cluster/srv_job_test.go
+++ b/cluster/srv_job_test.go
@@ -882,6 +882,79 @@ exec cat >/dev/null
 	}
 }
 
+// TestJobRejoinMysqldumpFromSource_ReportsProgress verifies that the bytes
+// already forwarded by the pump (progressCountingWriter -> dest.reseedBytes)
+// surface through the shared reseed-progress framework (beginReseedProgress /
+// GetReseedProgress), and that the progress is cleared once the function
+// returns. The fake dump writes one line then stalls forever, exactly like
+// TestJobRejoinMysqldumpFromSource_StallClearsReseed, giving a deterministic
+// window in which bytes have been forwarded but the function hasn't returned
+// yet -- and a short stall timeout so the function still returns quickly.
+func TestJobRejoinMysqldumpFromSource_ReportsProgress(t *testing.T) {
+	cluster, source := newTestRuntimeOnlyClusterServer(t, "direct-reseed-progress-test", "source", "3306")
+	dest := newTestRuntimeOnlyServer(t, cluster, "dest", "3307")
+	cluster.Servers = append(cluster.Servers, dest)
+	binDir := t.TempDir()
+
+	fakeDump := writeFakeExecutable(t, binDir, "fakeprogressdump.sh", `#!/bin/sh
+echo "-- fake dump header" >&2
+echo "INSERT INTO t VALUES (1, 'some-known-payload-bytes');"
+exec sleep 300
+`)
+
+	fakeClient := writeFakeExecutable(t, binDir, "fakeprogressclient.sh", `#!/bin/sh
+exec cat >/dev/null
+`)
+
+	cluster.Conf.BackupMysqldumpPath = fakeDump
+	cluster.Conf.BackupMysqlclientPath = fakeClient
+	cluster.Conf.BackupWriteStallTimeout = 1 // seconds; small so the test stays fast
+
+	dest.SetInReseedBackup("direct")
+
+	resultCh := make(chan error, 1)
+	go func() {
+		resultCh <- cluster.JobRejoinMysqldumpFromSource(source, dest)
+	}()
+
+	// Poll for mid-flight progress rather than a fixed sleep: the pump forwards
+	// the fake dump's line asynchronously.
+	const pollTimeout = 5 * time.Second
+	deadline := time.Now().Add(pollTimeout)
+	var rp *ReseedProgressView
+	for time.Now().Before(deadline) {
+		if v := dest.GetReseedProgress(); v != nil && v.Bytes > 0 {
+			rp = v
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if rp == nil {
+		t.Fatalf("expected GetReseedProgress() to report streamed bytes within %s", pollTimeout)
+	}
+	if rp.Task != "direct" {
+		t.Fatalf("expected Task %q, got %q", "direct", rp.Task)
+	}
+	if rp.Tool != "mysqldump" {
+		t.Fatalf("expected Tool %q, got %q", "mysqldump", rp.Tool)
+	}
+	if !strings.HasPrefix(rp.Backup, "direct stream from ") {
+		t.Fatalf("expected Backup to start with %q, got %q", "direct stream from ", rp.Backup)
+	}
+
+	const timeout = 10 * time.Second
+	select {
+	case <-resultCh:
+		// good -- returned within the timeout (stall watchdog fired)
+	case <-time.After(timeout):
+		t.Fatalf("JobRejoinMysqldumpFromSource did not return within %s", timeout)
+	}
+
+	if v := dest.GetReseedProgress(); v != nil {
+		t.Fatalf("expected reseed progress to clear after return, got %+v", v)
+	}
+}
+
 // mustSignalExitError runs a throwaway subprocess that kills itself with sig
 // and returns the resulting *exec.ExitError. This gives reseedFailureMessage
 // tests a real, signal-terminated os.ProcessState to inspect -- the same

--- a/share/dashboard_react/src/components/Modals/ReseedProgressModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/ReseedProgressModal/index.jsx
@@ -7,7 +7,7 @@ import {
   reseedHasBytes,
   formatBytes,
   formatElapsed,
-  formatRate,
+  formatRateLine,
 } from '../../../utility/reseedProgress'
 
 // ReseedProgressModal shows every server currently being reseeded/rejoined with a
@@ -45,7 +45,7 @@ function ReseedProgressModal({ isOpen, closeModal, servers }) {
                 />
                 <Text fontSize='sm' mt={1}>
                   {formatBytes(rp.bytes)} / {formatBytes(rp.total)} ({rp.percent}%)
-                  {` · ${formatRate(rp.rateBytesSec, rp.elapsedSecs)}`}
+                  {` · ${formatRateLine(rp)}`}
                   {` · ${formatElapsed(rp.elapsedSecs)}`}
                 </Text>
               </>
@@ -56,7 +56,7 @@ function ReseedProgressModal({ isOpen, closeModal, servers }) {
                   {hasBytes ? (
                     <>
                       {formatBytes(rp.bytes)} streamed
-                      {` · ${formatRate(rp.rateBytesSec, rp.elapsedSecs)}`}
+                      {` · ${formatRateLine(rp)}`}
                       {` · ${formatElapsed(rp.elapsedSecs)}`}
                     </>
                   ) : (

--- a/share/dashboard_react/src/components/Modals/ReseedProgressModal/index.jsx
+++ b/share/dashboard_react/src/components/Modals/ReseedProgressModal/index.jsx
@@ -4,8 +4,10 @@ import CommonModal from '../CommonModal'
 import {
   getActiveReseeds,
   reseedHasBar,
+  reseedHasBytes,
   formatBytes,
   formatElapsed,
+  formatRate,
 } from '../../../utility/reseedProgress'
 
 // ReseedProgressModal shows every server currently being reseeded/rejoined with a
@@ -20,6 +22,7 @@ function ReseedProgressModal({ isOpen, closeModal, servers }) {
       {active.length === 0 && <Text>No reseed in progress.</Text>}
       {active.map((rp) => {
         const hasBar = reseedHasBar(rp)
+        const hasBytes = reseedHasBytes(rp)
         return (
           <Box key={rp.url} borderWidth='1px' borderRadius='md' p={3}>
             <Flex justify='space-between' align='center' mb={2}>
@@ -42,7 +45,7 @@ function ReseedProgressModal({ isOpen, closeModal, servers }) {
                 />
                 <Text fontSize='sm' mt={1}>
                   {formatBytes(rp.bytes)} / {formatBytes(rp.total)} ({rp.percent}%)
-                  {rp.rateBytesSec > 0 ? ` · ${formatBytes(rp.rateBytesSec)}/s` : ''}
+                  {` · ${formatRate(rp.rateBytesSec, rp.elapsedSecs)}`}
                   {` · ${formatElapsed(rp.elapsedSecs)}`}
                 </Text>
               </>
@@ -50,7 +53,15 @@ function ReseedProgressModal({ isOpen, closeModal, servers }) {
               <>
                 <Progress size='sm' colorScheme='blue' isIndeterminate borderRadius='md' />
                 <Text fontSize='sm' mt={1}>
-                  {rp.line || `in progress · ${formatElapsed(rp.elapsedSecs)}`}
+                  {hasBytes ? (
+                    <>
+                      {formatBytes(rp.bytes)} streamed
+                      {` · ${formatRate(rp.rateBytesSec, rp.elapsedSecs)}`}
+                      {` · ${formatElapsed(rp.elapsedSecs)}`}
+                    </>
+                  ) : (
+                    rp.line || `in progress · ${formatElapsed(rp.elapsedSecs)}`
+                  )}
                 </Text>
               </>
             )}

--- a/share/dashboard_react/src/utility/__tests__/reseedProgress.test.js
+++ b/share/dashboard_react/src/utility/__tests__/reseedProgress.test.js
@@ -9,8 +9,10 @@ import {
   getActiveReseeds,
   hasActiveReseed,
   reseedHasBar,
+  reseedHasBytes,
   formatBytes,
   formatElapsed,
+  formatRate,
 } from '../reseedProgress.js'
 
 let passed = 0
@@ -51,12 +53,45 @@ function assert(condition, description) {
   assert(reseedHasBar(null) === false, 'null → no bar')
 }
 
+// ─── reseedHasBytes (byte counts shown even with unknown total, e.g. direct reseed) ─
+{
+  assert(
+    reseedHasBytes({ percent: -1, total: 0, bytes: 12345 }) === true,
+    'unknown total but bytes streamed (direct reseed) → hasBytes'
+  )
+  assert(
+    reseedHasBytes({ percent: -1, total: 0, bytes: 0 }) === false,
+    'no bytes streamed yet → no hasBytes'
+  )
+  assert(
+    reseedHasBytes({ percent: -1, fromRejoin: true }) === false,
+    'generic rejoin timer with no byte instrumentation → no hasBytes'
+  )
+  assert(reseedHasBytes(null) === false, 'null → no hasBytes')
+}
+
 // ─── formatBytes (mirrors backend humanBytes) ────────────────────────────────
 {
   assert(formatBytes(0) === '0B', '0 → 0B')
   assert(formatBytes(512) === '512B', '512 → 512B')
   assert(formatBytes(1024) === '1K', '1024 → 1K')
   assert(formatBytes(100 * 1024 * 1024 * 1024) === '100G', '100 GiB → 100G')
+}
+
+// ─── formatRate ("measuring…" for the sub-1s window, real rate/0B/s after) ────
+{
+  assert(
+    formatRate(0, 0) === 'measuring…',
+    'elapsedSecs 0 (just started) → measuring placeholder, even though rate is also 0'
+  )
+  assert(
+    formatRate(3 * 1024 * 1024, 10) === '3M/s',
+    'elapsed + nonzero rate → formatted rate'
+  )
+  assert(
+    formatRate(0, 5) === '0B/s',
+    'elapsed has passed but rate is genuinely 0 → real 0B/s shown, not hidden'
+  )
 }
 
 // ─── formatElapsed ───────────────────────────────────────────────────────────

--- a/share/dashboard_react/src/utility/__tests__/reseedProgress.test.js
+++ b/share/dashboard_react/src/utility/__tests__/reseedProgress.test.js
@@ -13,6 +13,7 @@ import {
   formatBytes,
   formatElapsed,
   formatRate,
+  formatRateLine,
 } from '../reseedProgress.js'
 
 let passed = 0
@@ -92,6 +93,37 @@ function assert(condition, description) {
     formatRate(0, 5) === '0B/s',
     'elapsed has passed but rate is genuinely 0 → real 0B/s shown, not hidden'
   )
+}
+
+// ─── formatRateLine (recent "now" rate + lifetime "avg" rate combined) ────────
+{
+  assert(
+    formatRateLine({ rateBytesSec: 0, elapsedSecs: 0, recentRateReady: false }) === 'measuring…',
+    'not enough ticks for recent, and avg not ready either → measuring placeholder'
+  )
+  assert(
+    formatRateLine({ rateBytesSec: 5 * 1024 * 1024, elapsedSecs: 20, recentRateReady: false }) === '5M/s',
+    'recent not ready yet → falls back to plain avg (same as formatRate alone)'
+  )
+  assert(
+    formatRateLine({
+      rateBytesSec: 18 * 1024 * 1024,
+      elapsedSecs: 20,
+      recentRateBytesSec: 3 * 1024 * 1024,
+      recentRateReady: true,
+    }) === '3M/s now · 18M/s avg',
+    'both ready → "recent now · avg avg"'
+  )
+  assert(
+    formatRateLine({
+      rateBytesSec: 0,
+      elapsedSecs: 0,
+      recentRateBytesSec: 2 * 1024 * 1024,
+      recentRateReady: true,
+    }) === '2M/s now · measuring…',
+    'recent ready before avg is (edge case) → "recent now · measuring…", no "avg" suffix on a placeholder'
+  )
+  assert(formatRateLine(null) === 'measuring…', 'null row → measuring placeholder, no throw')
 }
 
 // ─── formatElapsed ───────────────────────────────────────────────────────────

--- a/share/dashboard_react/src/utility/reseedProgress.js
+++ b/share/dashboard_react/src/utility/reseedProgress.js
@@ -29,6 +29,13 @@ export const hasActiveReseed = (clusterServers) => getActiveReseeds(clusterServe
 export const reseedHasBar = (rp) =>
   !!rp && typeof rp.percent === 'number' && rp.percent >= 0 && rp.total > 0
 
+// reseedHasBytes reports whether a row has streamed-bytes/rate to show even though
+// the total is unknown (percent -1) — e.g. a direct-stream reseed, which counts real
+// bytes forwarded but has no fixed size to divide by. Distinct from reseedHasBar: a
+// row can have bytes without a bar (unknown total) or a bar without bytes (n/a here,
+// reseedHasBar already implies total>0 which implies byte instrumentation).
+export const reseedHasBytes = (rp) => !!rp && typeof rp.bytes === 'number' && rp.bytes > 0
+
 // formatBytes → "223M" / "100G" (mirror of the backend humanBytes).
 export const formatBytes = (b) => {
   if (!b || b < 1024) return `${b || 0}B`
@@ -41,6 +48,17 @@ export const formatBytes = (b) => {
   }
   return `${Math.round(n)}${units[i]}`
 }
+
+// formatRate → "<rate>/s", or a "measuring…" placeholder for the sub-1s window right
+// after a reseed starts (backend elapsedSecs is truncated to whole seconds, so
+// rateBytesSec reads 0 for that window regardless of how fast bytes are actually
+// flowing). Once elapsedSecs > 0 this shows the real average rate as-is, including a
+// genuine 0B/s if the reseed truly is that slow -- this is NOT a staleness detector
+// (rateBytesSec is a cumulative average, so it decays slowly rather than snapping to 0
+// on a stall; real staleness is caught server-side by the reseed stall watchdog, which
+// aborts the task instead of leaving a misleading rate on screen).
+export const formatRate = (rateBytesSec, elapsedSecs) =>
+  elapsedSecs > 0 ? `${formatBytes(rateBytesSec)}/s` : 'measuring…'
 
 // formatElapsed(seconds) → "1h23m" / "3m12s" / "45s".
 export const formatElapsed = (secs) => {

--- a/share/dashboard_react/src/utility/reseedProgress.js
+++ b/share/dashboard_react/src/utility/reseedProgress.js
@@ -4,7 +4,10 @@
 // structured progress the backend attaches to /api/clusters/{name}/topology/servers
 // as `server.reseedProgress` (absent when idle). Shape:
 //   { inProgress, fromRejoin, task, backup, tool, bytes, total, percent,
-//     startedUnix, elapsedSecs, rateBytesSec, line }
+//     startedUnix, elapsedSecs, rateBytesSec, recentRateBytesSec, recentRateReady, line }
+// rateBytesSec is a lifetime average (stable, but lags a real slowdown/speedup);
+// recentRateBytesSec is a windowed rate over the last few ticks (noisier, reflects
+// current throughput), valid only once recentRateReady is true (enough ticks sampled).
 // `percent` is -1 when the reseed method has no byte instrumentation — those show a
 // generic "rejoin reseed in progress, started T" timer instead of a filled bar.
 //
@@ -59,6 +62,20 @@ export const formatBytes = (b) => {
 // aborts the task instead of leaving a misleading rate on screen).
 export const formatRate = (rateBytesSec, elapsedSecs) =>
   elapsedSecs > 0 ? `${formatBytes(rateBytesSec)}/s` : 'measuring…'
+
+// formatRateLine combines the windowed "recent" rate (current throughput) with the
+// lifetime "average" rate into one display string, e.g. "3M/s now · 18M/s avg". The
+// average alone is known to lag a real slowdown/speedup (it barely moves once a
+// restore has been running a while), so once the backend has sampled enough ticks to
+// report a recent rate (rp.recentRateReady), lead with that. Before then -- the first
+// few ticks of a fresh reseed -- there's nothing windowed to show yet, so this falls
+// back to exactly what formatRate alone would show (including "measuring…").
+export const formatRateLine = (rp) => {
+  const avg = formatRate(rp && rp.rateBytesSec, rp && rp.elapsedSecs)
+  if (!rp || !rp.recentRateReady) return avg
+  const recent = `${formatBytes(rp.recentRateBytesSec)}/s now`
+  return avg === 'measuring…' ? `${recent} · ${avg}` : `${recent} · ${avg} avg`
+}
 
 // formatElapsed(seconds) → "1h23m" / "3m12s" / "45s".
 export const formatElapsed = (secs) => {


### PR DESCRIPTION
## Why this PR exists

Direct reseed from master (`RejoinDirectDump` / `JobRejoinMysqldumpFromSource`) already had byte accounting internally for its stall watchdog, but it did not surface that progress to the shared reseed progress model or the dashboard. Operators could see a reseed was in flight, but not how much data had been streamed or what speed it was moving at.

The existing reseed progress UI also only worked well for file-based restores with a known total size. Direct stream reseeds have real byte progress but no fixed total, and the prior UI could only fall back to a generic in-progress timer.

## What this PR brings

### Backend
- surfaces direct reseed progress through the shared reseed progress framework
- distinguishes direct reseed from backup-based mysqldump restore in the structured progress payload
- reuses the same byte counter for both the stall watchdog and displayed progress, so they cannot diverge
- adds a sampled recent/windowed reseed rate alongside the existing lifetime average rate
- resets recent-rate sampling cleanly across reseed lifecycle boundaries

### Frontend
- improves the reseed progress modal for unknown-total byte-stream reseeds
- shows streamed bytes, elapsed time, and rate for direct reseed instead of only a generic timer
- shows both current-ish (`now`) and lifetime average (`avg`) rate when recent-rate samples are ready

### Tests
- adds direct reseed progress coverage in Go tests
- adds backend reseed recent-rate sampling tests
- adds React utility tests for byte-instrumented unknown-total reseeds and combined recent/average rate formatting

## Validation
- `go test ./cluster -run 'TestRecentReseedRate|TestSampleReseedRate'`
- `node "share/dashboard_react/src/utility/__tests__/reseedProgress.test.js"`
- earlier direct reseed changes were also validated with targeted cluster tests before commit

## Notes
- this PR contains only the branch commits on top of `develop`