### PR TITLE
fix(server): refresh server-level ServiceRepos from BO-pushed repos.json (#1702)

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2655,10 +2655,10 @@ func (repman *ReplicationManager) Run() error {
 	repman.ReloadTerms()
 	repman.InitSharedAppTemplates()
 	repman.MonitorType = config.GetMonitorType()
-	repman.ServiceRepos, err = repman.Conf.GetDockerRepos(repman.Conf.ShareDir+"/repo/repos.json", repman.Conf.Test)
-	if err != nil {
-		repman.Logrus.WithError(err).Errorf("Initialization docker repo failed: %s %s", repman.Conf.ShareDir+"/repo/repos.json", err)
-	}
+	// ServiceRepos (the docker image tag list the GUI reads via json:"serviceRepos")
+	// is loaded through ReloadServiceRepos so the exact same path is reused when the
+	// back office pushes a fresh plugins/data/repos.json after startup (issue #1702).
+	repman.ReloadServiceRepos()
 	repman.ServiceTarballs, err = repman.Conf.GetTarballs(repman.Conf.Test)
 	if err != nil {
 		repman.Logrus.WithError(err).Errorf("Initialization tarballs repo failed: %s %s", repman.Conf.ShareDir+"/repo/tarballs.json", err)
@@ -3124,6 +3124,29 @@ func (repman *ReplicationManager) Run() error {
 	os.Exit(0)
 	return nil
 
+}
+
+// ReloadServiceRepos reloads the server-level ServiceRepos -- the docker image
+// tag list the GUI reads via json:"serviceRepos" (monitor.serviceRepos). It is
+// sourced from GetDockerRepos, which prefers the back-office-pushed
+// plugins/data/repos.json over the embedded fallback. It MUST be called whenever
+// the -pull repo delivers a fresh repos.json; otherwise the GUI keeps showing the
+// tag list captured at startup, while newer tags only land in the per-cluster
+// DockerRepos (which is json:"-" and never serialized to the GUI). See issue #1702.
+func (repman *ReplicationManager) ReloadServiceRepos() {
+	repos, err := repman.Conf.GetDockerRepos(repman.Conf.ShareDir+"/repo/repos.json", repman.Conf.Test)
+	if err != nil {
+		repman.Logrus.WithError(err).Errorf("Reload docker repos failed: %s %s", repman.Conf.ShareDir+"/repo/repos.json", err)
+		return
+	}
+	if len(repos) == 0 {
+		return
+	}
+	if len(repos) != len(repman.ServiceRepos) {
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+			"Service docker image repos updated: %d repos loaded from back office plugins/data/repos.json", len(repos))
+	}
+	repman.ServiceRepos = repos
 }
 
 // loadMainConfigInto reads the server's main config.toml into v, using the

--- a/server/server_git.go
+++ b/server/server_git.go
@@ -1019,9 +1019,14 @@ func (repman *ReplicationManager) syncPluginDataFromPull(pullDir string) {
 			}
 			// Reload db_distributions.json (safe to auto-refresh)
 			cluster.Configurator.ReloadDBDistributions()
-			// Reload repos.json (docker image tags)
+			// Reload repos.json (docker image tags) into the per-cluster list.
 			cluster.ReloadDockerRepos()
 		}
+		// Also refresh the server-level ServiceRepos -- what the GUI reads -- from the
+		// same BO-pushed repos.json. ReloadDockerRepos only updates the per-cluster
+		// DockerRepos (json:"-", not serialized), so without this the GUI version
+		// dropdown stays frozen on the tag list captured at startup (issue #1702).
+		repman.ReloadServiceRepos()
 
 		// Compliance modules are NOT auto-reloaded — the enterprise-compliance
 		// plugin detects the change and raises a state; the user must explicitly


### PR DESCRIPTION
Fixes #1702.

## Problem
The GUI DB-version dropdown (Configs → Orchestrator images) reads `repman.ServiceRepos` (`json:"serviceRepos"`). That field is loaded **once at startup** and never refreshed, so when the back office pushes a fresh `plugins/data/repos.json`, the new image tags (e.g. `mariadb:11.4.12`) land only in the per-cluster `DockerRepos` (`json:"-"`, not serialized) — the GUI keeps showing the startup list. A restart doesn't help (it reloads the same startup source).

Root cause: the BO-push feature `fc57e7a8c` wired `cluster.ReloadDockerRepos()` (per-cluster) but not the server-level `ServiceRepos`, leaving the comment *"the server-level ServiceRepos is updated by the caller if needed"* with no caller.

## Fix
- Add `ReplicationManager.ReloadServiceRepos()` — reloads `ServiceRepos` via `GetDockerRepos(...)` (which already prefers the BO `plugins/data/repos.json`). Startup now uses it too (DRY).
- Call it from the `-pull` git-pull hook (`server_git.go`) alongside `cluster.ReloadDockerRepos()`, so the GUI list refreshes as soon as the BO delivers a new `repos.json` — no restart/rebuild.

## Verified
- Live evidence: on a running instance the delivered `…/plugins/data/repos.json` contained `11.4.12` while `/api/monitor`'s `serviceRepos` was still capped at `11.4.7` — exactly the split this closes.
- `go build -tags server ./server/ ./cluster/` passes.
- Manual check after deploy: on the next `-pull` sync that changes global plugin data, `/api/monitor` `serviceRepos` should reflect the delivered tag list.

## Follow-up (not in this PR)
The checked-in embedded fallback `share/repo/repos.json` is itself stale (tops at 11.4.7, plus a few malformed tags). Worth regenerating so the baked-in default is sane when no BO push exists.
