### PR TITLE
fix(cluster): protect staging standalone recovery from read-only (#1716) — forward-port of #1711 to develop

### DIFF
--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -680,6 +680,22 @@ func gzipFileAndRemove(src, dst string) error {
 	return os.Remove(src)
 }
 
+// IsActiveStagingServer reports whether server is the currently configured staging
+// standalone for this cluster. cluster.Conf.StagingServerHost is the single source of
+// truth for which server that is: SetStagingServer() is the only place that assigns
+// cluster.StagingServer, and it always keeps StagingServerHost in sync with it. The live
+// pointer itself is only populated once topology discovery has run (cluster_topo.go), so
+// it can be nil right after a restart or briefly stale after staging-server-host changes
+// via a live config reload - going straight to config avoids depending on it here.
+func (cluster *Cluster) IsActiveStagingServer(server *ServerMonitor) bool {
+	if !cluster.Conf.TopologyStaging {
+		return false
+	}
+
+	stagingSrv := cluster.GetStagingServerFromConfig()
+	return stagingSrv != nil && stagingSrv.Id == server.Id
+}
+
 func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 	cluster := server.ClusterGroup
 	defer wg.Done()
@@ -868,10 +884,7 @@ func (server *ServerMonitor) Ping(wg *sync.WaitGroup) {
 	if errss == sql.ErrNoRows || noChannel {
 		// If we have no replication channel found
 		// This is either a master or a standalone server
-		isStagingServer := false
-		if cluster.Conf.TopologyStaging && cluster.StagingServer != nil && cluster.StagingServer.Id == server.Id {
-			isStagingServer = true
-		}
+		isStagingServer := cluster.IsActiveStagingServer(server)
 
 		// stateSuspect intentionally excluded — enabling it would cause false standalone
 		// detection during network glitches (ab0e92ba0, Aug 2021). 2-node clusters

--- a/cluster/srv_staging_test.go
+++ b/cluster/srv_staging_test.go
@@ -1,0 +1,134 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// Authors: Guillaume Lefranc <guillaume@signal18.io>
+//          Stephane Varoqui  <svaroqui@gmail.com>
+// This source code is licensed under the GNU General Public License, version 3.
+// Redistribution/Reuse of this code is permitted under the GNU v3 license, as
+// an additional term, ALL code must carry the original Author(s) credit in comment form.
+// See LICENSE in this directory for the integral text.
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+)
+
+// TestIsActiveStagingServer_TopologyStagingDisabled ensures that when
+// topology-staging is off, no server is ever treated as staging, regardless
+// of any other state - i.e. no behavior change outside staging topology.
+func TestIsActiveStagingServer_TopologyStagingDisabled(t *testing.T) {
+	staging := &ServerMonitor{Id: "db1", HostCnf: "staging-host"}
+	cluster := &Cluster{
+		Conf: &config.Config{
+			TopologyStaging:   false,
+			StagingServerHost: "staging-host",
+		},
+		StagingServer: staging,
+		Servers:       serverList{staging},
+	}
+
+	if cluster.IsActiveStagingServer(staging) {
+		t.Fatal("expected IsActiveStagingServer to be false when topology-staging is disabled")
+	}
+}
+
+// TestIsActiveStagingServer_RecognizesConfiguredStagingServer covers the
+// common, steady-state case: StagingServerHost (kept in sync with the live
+// StagingServer pointer by SetStagingServer()) names the staging server.
+func TestIsActiveStagingServer_RecognizesConfiguredStagingServer(t *testing.T) {
+	staging := &ServerMonitor{Id: "db1", HostCnf: "staging-host"}
+	other := &ServerMonitor{Id: "db2", HostCnf: "other-host"}
+	cluster := &Cluster{
+		Conf: &config.Config{
+			TopologyStaging:   true,
+			StagingServerHost: "staging-host",
+		},
+		StagingServer: staging,
+		Servers:       serverList{staging, other},
+	}
+
+	if !cluster.IsActiveStagingServer(staging) {
+		t.Fatal("expected the staging server to be recognized as the staging server")
+	}
+	if cluster.IsActiveStagingServer(other) {
+		t.Fatal("expected a non-staging server not to be recognized as the staging server")
+	}
+}
+
+// TestIsActiveStagingServer_WorksBeforeLivePointerIsSet reproduces the
+// reported bug: right after a staging standalone recovers, Ping() runs
+// before cluster_topo.go's TopologyDiscover has had a chance to populate
+// cluster.StagingServer (see cluster_topo.go, "Set staging server from
+// config if not yet set"). Since the check goes straight to
+// Conf.StagingServerHost, it doesn't depend on that pointer at all - before
+// this fix, isStagingServer stayed false in that window and the recovering
+// staging standalone was forced read-only.
+func TestIsActiveStagingServer_WorksBeforeLivePointerIsSet(t *testing.T) {
+	staging := &ServerMonitor{Id: "db1", HostCnf: "staging-host"}
+	other := &ServerMonitor{Id: "db2", HostCnf: "other-host"}
+	cluster := &Cluster{
+		Conf: &config.Config{
+			TopologyStaging:   true,
+			StagingServerHost: "staging-host",
+		},
+		StagingServer: nil, // not yet assigned by topology discovery
+		Servers:       serverList{staging, other},
+	}
+
+	if !cluster.IsActiveStagingServer(staging) {
+		t.Fatal("expected config-based lookup to recognize the staging server before cluster.StagingServer is set")
+	}
+	if cluster.IsActiveStagingServer(other) {
+		t.Fatal("expected a non-staging server not to be recognized as the staging server via config fallback")
+	}
+}
+
+// TestIsActiveStagingServer_NoStagingConfigured ensures that when
+// topology-staging is enabled but no server matches the config, nothing is
+// treated as staging.
+func TestIsActiveStagingServer_NoStagingConfigured(t *testing.T) {
+	srv := &ServerMonitor{Id: "db1", HostCnf: "some-host"}
+	cluster := &Cluster{
+		Conf: &config.Config{
+			TopologyStaging:   true,
+			StagingServerHost: "",
+		},
+		StagingServer: nil,
+		Servers:       serverList{srv},
+	}
+
+	if cluster.IsActiveStagingServer(srv) {
+		t.Fatal("expected IsActiveStagingServer to be false when no staging server is configured")
+	}
+}
+
+// TestIsActiveStagingServer_FollowsConfigOverStalePointer covers a live
+// config reload of staging-server-host: StagingServerHost is not
+// scope:"server", so it can change without a repman restart, and
+// cluster.StagingServer only gets reassigned once topology discovery runs
+// (cluster_topo.go), which can lag behind. IsActiveStagingServer must follow
+// Conf.StagingServerHost - the single source of truth SetStagingServer()
+// always keeps in sync - rather than trusting a stale pointer: the newly
+// configured server must be protected immediately, and the old one must
+// immediately stop being treated as staging once config has moved on.
+func TestIsActiveStagingServer_FollowsConfigOverStalePointer(t *testing.T) {
+	oldStaging := &ServerMonitor{Id: "db1", HostCnf: "old-staging-host"}
+	newStaging := &ServerMonitor{Id: "db2", HostCnf: "new-staging-host"}
+	cluster := &Cluster{
+		Conf: &config.Config{
+			TopologyStaging:   true,
+			StagingServerHost: "new-staging-host", // reassigned by a live config reload
+		},
+		StagingServer: oldStaging, // cluster_topo.go has not caught up yet
+		Servers:       serverList{oldStaging, newStaging},
+	}
+
+	if !cluster.IsActiveStagingServer(newStaging) {
+		t.Fatal("expected the newly configured staging server to be recognized immediately, even before the live pointer catches up")
+	}
+	if cluster.IsActiveStagingServer(oldStaging) {
+		t.Fatal("expected the old staging server to stop being recognized once config points elsewhere, regardless of the stale live pointer")
+	}
+}

--- a/regtest/regtest.go
+++ b/regtest/regtest.go
@@ -62,6 +62,12 @@ var tests = []string{
 	"testSetDualActive",
 	"testSplitBrainNoWinner",
 	"testMasterNil",
+	// testStagingRecoverNoReadOnly is intentionally not in this list: it
+	// requires topology-staging=true and a resolvable staging-server-host,
+	// which most clusters don't have. Including it here would make it run
+	// (and hard-FAIL, since this framework has no "skip" result) as part of
+	// "ALL" on every non-staging cluster. Run it explicitly by name instead:
+	// --test=testStagingRecoverNoReadOnly
 	"testRunSysbenchTPCPerMinuteIncreaseThreads",
 	"testConfigPersistBackupOption",
 	"testConfigCookiePushBasic",

--- a/regtest/test_staging_recover_noreadonly.go
+++ b/regtest/test_staging_recover_noreadonly.go
@@ -1,0 +1,149 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// Authors: Guillaume Lefranc <guillaume@signal18.io>
+//          Stephane Varoqui  <svaroqui@gmail.com>
+// This source code is licensed under the GNU General Public License, version 3.
+
+package regtest
+
+import (
+	"time"
+
+	"github.com/signal18/replication-manager/cluster"
+	"github.com/signal18/replication-manager/config"
+)
+
+// TestStagingRecoverNoReadOnly reproduces the preprod incident reported on
+// mzsc-de-prex-ang (2026-08-18): the topology-staging standalone flapped
+// Suspect -> Failed -> StandAlone and got forced read-only on recovery, even
+// though topology-staging is meant to exempt it. Requires the target cluster
+// to already be configured with topology-staging=true and a valid
+// staging-server-host pointing at a live standalone node.
+//
+// Not registered in the tests list regtest.go's "ALL" mode draws from, since
+// most clusters don't have topology-staging configured and this framework
+// has no "skip" result (see regtest.go). "SUITE" mode never drew from that
+// list anyway - it discovers scenarios from .todo files under share/tests/,
+// so it was never a factor here. Run this one explicitly by name instead:
+// --test=testStagingRecoverNoReadOnly
+func (regtest *RegTest) TestStagingRecoverNoReadOnly(cluster *cluster.Cluster, conf string, test *cluster.Test) bool {
+
+	// Applicability checks only below this line - no mutation of the live
+	// cluster object yet, so an explicit run against a non-staging or
+	// not-yet-applicable cluster leaves it exactly as found.
+	if !cluster.Conf.TopologyStaging {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "topology-staging is not enabled on this cluster, skipping")
+		return false
+	}
+
+	staging := cluster.GetStagingServerFromConfig()
+	if staging == nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "no staging server resolved from staging-server-host, skipping")
+		return false
+	}
+
+	master := cluster.GetMaster()
+	if master == nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "no master discovered, cannot exercise the recovery read-only path")
+		return false
+	}
+	if master.Id == staging.Id {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "staging server %s is currently classified as master, cannot exercise this test", staging.URL)
+		return false
+	}
+
+	if cluster.IsInFailover() {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "cluster is in failover, cannot run this test right now")
+		return false
+	}
+
+	if !cluster.IsDiscovered() {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "cluster topology is not discovered yet, cannot exercise the recovery read-only path")
+		return false
+	}
+
+	// SetReadOnly() only fires as an active monitor, or as a standby monitor
+	// under arbitration (cluster/srv.go:615-619) - "A"/"S" match
+	// config.ConstMonitorActif/ConstMonitorStandby, which can't be referenced
+	// by name here since this function's own receiver-style parameter is
+	// also named cluster, shadowing the cluster package.
+	if cluster.Status != "A" && !(cluster.Status == "S" && cluster.Conf.Arbitration) {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "cluster monitor status %s satisfies neither the active-monitor nor standby+arbitration branch, cannot exercise this test", cluster.Status)
+		return false
+	}
+
+	if staging.HaveWsrep {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "staging server %s is a wsrep node, the read-only recovery path under test does not apply to it", staging.URL)
+		return false
+	}
+
+	if staging.IsIgnoredReadonly() {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "staging server %s is in the ignore-readonly list, cannot exercise this test", staging.URL)
+		return false
+	}
+
+	if staging.IsReadOnly() {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "staging server %s already read-only before test start", staging.URL)
+		return false
+	}
+
+	// All preconditions hold - now, and only now, mutate the cluster object.
+	// Restore what we touch via defer so a caller chaining multiple explicit
+	// scenarios in one invocation (server/regtest.go's loop) doesn't observe
+	// leftover state.
+	origReadOnly := cluster.Conf.ReadOnly
+	defer func() {
+		cluster.Conf.ReadOnly = origReadOnly
+
+		// Deliberately not restoring a frozen pre-test snapshot of
+		// StagingServer here: unlike ReadOnly, it's a field the background
+		// monitoring loop actively recomputes every tick (cluster_topo.go),
+		// and it may have legitimately repopulated it with a fresh, correct
+		// value while this test was sleeping below. Reverting to whatever it
+		// was before the test started would stomp that newer value with a
+		// stale (possibly nil) one. Recompute the same way the system itself
+		// does instead, so this is correct regardless of what the
+		// background loop did or didn't get to during the test.
+		cluster.StagingServer = cluster.GetStagingServerFromConfig()
+	}()
+
+	cluster.SetFailSync(false)
+	cluster.SetInteractive(true)
+	cluster.SetRplChecks(true)
+	// Force the gate SetReadOnly() itself requires, so this test can't pass
+	// for the unrelated reason that the target cluster's own config has
+	// read-only disabled.
+	cluster.SetReadOnly(true)
+
+	// Clear the live pointer so IsActiveStagingServer() (cluster/srv.go) is
+	// forced through the config-based fallback exactly like it is right
+	// after a repman restart - that's the actual bug window. If left as-is,
+	// cluster.StagingServer would almost certainly already be populated by
+	// the ambient monitoring loop by the time this test runs, in which case
+	// the test would pass against the pre-fix code too and prove nothing.
+	cluster.StagingServer = nil
+
+	// Reproduce the recovery path in cluster/srv.go Ping(): a server whose
+	// PrevState is Failed transitions back to StandAlone on the next
+	// successful connect, which is exactly the branch that used to call
+	// SetReadOnly() on the staging node. Fake the Suspect -> Failed
+	// transition here instead of killing the real node, mirroring
+	// TestMasterSuspect / TestMasterNil.
+	staging.FailCount = 1
+	staging.SetState("Suspect")
+	staging.PrevState = "Failed"
+
+	time.Sleep(10 * time.Second)
+
+	if staging.State != "StandAlone" {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "staging server %s did not recover to StandAlone, state is %s", staging.URL, staging.State)
+		return false
+	}
+
+	if staging.IsReadOnly() {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, "TEST", "staging server %s was forced read-only after recovering from a failed state", staging.URL)
+		return false
+	}
+
+	return true
+}

--- a/server/regtest.go
+++ b/server/regtest.go
@@ -224,6 +224,9 @@ func (repman *ReplicationManager) RunAllTests(cl *cluster.Cluster, testExp strin
 		if test.Name == "testMasterNil" {
 			res = regtest.TestMasterNil(cl, test.ConfigFile, &test)
 		}
+		if test.Name == "testStagingRecoverNoReadOnly" {
+			res = regtest.TestStagingRecoverNoReadOnly(cl, test.ConfigFile, &test)
+		}
 		if test.Name == "testRunSysbenchTPCPerMinuteIncreaseThreads" {
 			res = regtest.TestRunSysbenchTPCPerMinuteIncreaseThreads(cl, test.ConfigFile, &test)
 		}


### PR DESCRIPTION
Fixes #1716. Forward-port of #1711 (merged to the `3.0` branch) to `develop`.

## Context
`topology-staging=true`: the staging standalone was wrongly set read-only and auto-rejoined (reseed → disk+network IO storm) when it went through `Failed → StandAlone`, because the exemption used the transient `cluster.StagingServer` pointer, which topology discovery only re-resolves a tick **after** the read-only/auto-rejoin decision runs on the `Failed→up` edge.

3.0 was already fixed by @caffeinated92 in #1711; **develop still had the buggy inline check** — this closes that gap.

## Change
Uses `cluster.Conf.StagingServerHost` as the single source of truth via `Cluster.IsActiveStagingServer()`, **identical to the 3.0 implementation** (same method name, same behavior — so the branches stay consistent). Includes the unit test (`cluster/srv_staging_test.go`) and the targeted regtest (`regtest/test_staging_recover_noreadonly.go`, run by name `--test=testStagingRecoverNoReadOnly`; kept out of the ALL list since it needs a staging topology).

## Verified
- `go build ./cluster/ ./regtest/ ./server/` passes.
- Diff is byte-for-byte equivalent to #1711 (21/134/6/149/3).

## Client note (3.0.32-1)
Already fixed on the `3.0` branch via #1711 — needs the next 3.0 build; no new code for them.