### PR TITLE
feat(cloud18): offline license file for air-gapped/PCI subscription plan (#1715)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -964,6 +964,10 @@ type Config struct {
 	Cloud18OpenDbops                       bool                   `mapstructure:"cloud18-open-dbops"  toml:"cloud18-open-dbops" json:"cloud18OpenDbops"`
 	Cloud18SubscribedDbops                 bool                   `mapstructure:"cloud18-subscribed-dbops"  toml:"cloud18-subscribed-dbops" json:"cloud18SubscribedDbops"`
 	Cloud18SubscriptionPlan                string                 `scope:"server" mapstructure:"cloud18-subscription-plan" toml:"cloud18-subscription-plan" json:"cloud18SubscriptionPlan"`
+	// Cloud18LicenseFile, when set, is the single switch for offline-license mode:
+	// the instance sources its plan from this signed file instead of the CRM (for
+	// air-gapped/PCI instances). Empty = normal online CRM path.
+	Cloud18LicenseFile                     string                 `scope:"server" mapstructure:"cloud18-license-file" toml:"cloud18-license-file" json:"cloud18LicenseFile"`
 	Cloud18PeerHealthMode                  string                 `scope:"server" mapstructure:"cloud18-peer-health-mode" toml:"cloud18-peer-health-mode" json:"cloud18PeerHealthMode"`
 	Cloud18DisablePeers                    bool                   `scope:"server" mapstructure:"cloud18-disable-peers" toml:"cloud18-disable-peers" json:"cloud18DisablePeers"`
 	Cloud18DisableForSale                  bool                   `scope:"server" mapstructure:"cloud18-disable-for-sale" toml:"cloud18-disable-for-sale" json:"cloud18DisableForSale"`

--- a/config/error.go
+++ b/config/error.go
@@ -323,6 +323,7 @@ var GlobalError = map[string]string{
 	"GWARN012": "ReplicationManager cannot reach Meet support service: %s",
 	"GWARN013": "Periodic %s task still running from previous cycle — possible network hang",
 	"GWARN014": "Instance not registered on Cloud18 (%s) — some community features may be disabled",
+	"GWARN015": "Offline license invalid — plan falls back to free: %s",
 	// GINF: informational operating modes (state-as-tag), never counted as alerts
 	"GINF001": "ReplicationManager has %d cluster(s) in standby pulling config from active peer: %s",
 	"GINF002": "ReplicationManager has %d unprovisioned cluster(s): %s",

--- a/doc/implementation/cloud18/OFFLINE_LICENSE.md
+++ b/doc/implementation/cloud18/OFFLINE_LICENSE.md
@@ -1,0 +1,80 @@
+# Offline License — Cloud18 plan for air-gapped / PCI instances
+
+*repman-side (this public repo). The signing/generation pipeline is back-office
+and documented in the private BO repo — never here (T15).*
+
+## Problem
+Some instances (PCI, air-gapped) run with **no internet**, so they cannot reach
+the CRM to learn their Cloud18 **subscription plan**, and plan-gated features stay
+disabled. The online path is `server.syncSubscriptionPlanFromCRM()`.
+
+## Design
+A **signed offline license file** is the offline courier of the same plan the CRM
+would return. The client obtains a per-identity license artifact through their
+Signal18 GitLab account (from a machine that has internet) and drops it on the
+offline instance; repman verifies it **offline** and loads the plan into memory.
+
+### Trust
+- **Ed25519**, reusing the **existing plugin-signing keypair**. repman verifies
+  with the already-embedded public key (`plugin-signing-public-key` /
+  `Conf.PluginSigningPublicKey`) — the same key that verifies plugins. No new key
+  material in repman.
+- Only the **public key** is embedded in repman (the verifier). The `license.json`
+  and its detached `license.sig` are **delivered/downloaded**, never embedded —
+  they are per-client, generated after the binary is built, so they cannot be
+  baked in. (Contrast plugins, whose binary + `.sig` are static and ship embedded
+  together.)
+
+### Identity binding
+The signed payload carries `domain / sub-domain / sub-domain-zone`. repman accepts
+a license **only** if that identity matches this instance's own `cloud18-domain` /
+`cloud18-sub-domain` / `cloud18-sub-domain-zone`. A license copied to another
+instance is rejected.
+
+### No expiry — revocation = key rotation
+No expiry field: a license is valid as long as the embedded public key verifies it.
+To revoke/refresh, rotate the signing key — a new release embeds a new public key,
+invalidating every license signed with the old one. Nothing time-based to drift on
+an air-gapped box.
+
+### Soft enforcement
+Missing file / bad signature / identity mismatch / wrong (rotated) key ⇒ the plan
+falls back to its default (`free`), plan-gated features are unavailable, and a
+`GWARN015@license` WARN state is raised. **Monitoring is never blocked** — the plan
+is self-declared/soft; the license is a cryptographically-vouched courier, not a
+DRM lock.
+
+## Config (TOML)
+Single switch — no redundant boolean:
+- `cloud18-license-file` — path to `license.json`. **Empty (default) = normal
+  online CRM path.** When set, the instance sources its plan from this file and
+  does **not** call the CRM.
+- Verification key: reuses `plugin-signing-public-key`.
+
+## `license.json` shape
+```json
+{
+  "domain": "client",
+  "subDomain": "site",
+  "subDomainZone": "fr-1",
+  "plan": "partner",
+  "issuedAt": "2026-08-19T00:00:00Z",
+  "nonce": "<random>"
+}
+```
+`license.sig` = raw Ed25519 signature over the exact bytes of `license.json`,
+alongside it (also accepts `license.json.sig`).
+
+## Code
+- `server/license.go` — `OfflineLicense` + `loadOfflineLicensePlan()` (read →
+  verify Ed25519 → identity check → `persistInstanceSubscriptionPlan()`).
+- `server/server.go` — post-config-load: `cloud18-license-file` set ⇒
+  `loadOfflineLicensePlan()`, else `syncSubscriptionPlanFromCRM()`.
+- `config/error.go` — `GWARN015` license-invalid state template.
+
+## Follow-ups
+- GUI surface showing license status (loaded / valid / identity / plan) so an
+  operator can see why plan-gated features are (un)available (T6).
+- Continuous re-evaluation of the WARN state across ticks (stamped once at startup
+  load today).
+- **BO side (private repo):** generate + sign + publish the per-client license.

--- a/server/license.go
+++ b/server/license.go
@@ -1,0 +1,124 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+// See LICENSE in this directory for the integral text.
+
+package server
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/utils/state"
+)
+
+// OfflineLicense is the signed payload an air-gapped / PCI instance uses to obtain
+// its Cloud18 subscription plan without reaching the CRM. It is generated and
+// signed back-office side (per client, from their plan), the client downloads it
+// from their GitLab account and drops it on the instance. repman verifies it
+// OFFLINE against the embedded plugin-signing public key and only accepts a
+// license whose identity matches this instance's configured domain/sub-domain/zone.
+//
+// No expiry: validity is tied to the signing key — rotating the key invalidates
+// every license signed with the old one (revocation = key rotation). Only the
+// PUBLIC key is embedded in repman; the license + its .sig are delivered (they are
+// per-client, generated after the binary is built, so they cannot be embedded).
+type OfflineLicense struct {
+	Domain        string `json:"domain"`
+	SubDomain     string `json:"subDomain"`
+	SubDomainZone string `json:"subDomainZone"`
+	Plan          string `json:"plan"`
+	IssuedAt      string `json:"issuedAt"`
+	Nonce         string `json:"nonce"`
+}
+
+const licenseStateKey = "GWARN015@license"
+
+// loadOfflineLicensePlan sources the Cloud18 subscription plan from the signed
+// offline license (cloud18-license-file) instead of the CRM. It is the offline
+// courier of the plan that syncSubscriptionPlanFromCRM would fetch online, and is
+// used only when cloud18-license-file is set (air-gapped / PCI instances).
+//
+// Soft by design (never gates monitoring): any failure — missing file, bad
+// signature, identity mismatch, wrong/rotated key — leaves the plan at its
+// configured default (free) and raises a WARN state; it never blocks. The plan is
+// self-declared/soft, and the license is a cryptographically-vouched courier, not
+// a DRM lock.
+func (repman *ReplicationManager) loadOfflineLicensePlan() {
+	licPath := repman.Conf.Cloud18LicenseFile
+	uri := repman.registeredInstanceURI()
+
+	fail := func(format string, args ...interface{}) {
+		desc := fmt.Sprintf(format, args...)
+		repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"offline license: %s", desc)
+		repman.SetState(licenseStateKey, state.State{ErrType: "WARNING", ErrKey: "GWARN015",
+			ErrDesc: fmt.Sprintf(config.GlobalError["GWARN015"], desc), ErrFrom: "REPMAN"})
+	}
+
+	// Verify with the SAME embedded public key used for plugin signatures.
+	pubKeyPath := repman.Conf.PluginSigningPublicKey
+	pubBytes, err := os.ReadFile(pubKeyPath)
+	if err != nil {
+		fail("cannot read signing public key %s: %s", pubKeyPath, err)
+		return
+	}
+	if len(pubBytes) != ed25519.PublicKeySize {
+		fail("invalid public key length %d (expected %d)", len(pubBytes), ed25519.PublicKeySize)
+		return
+	}
+
+	data, err := os.ReadFile(licPath)
+	if err != nil {
+		fail("cannot read license file %s: %s", licPath, err)
+		return
+	}
+
+	// Detached signature: <name>.sig next to the license (license.json -> license.sig),
+	// also accepting the <name>.json.sig form.
+	sigPath := strings.TrimSuffix(licPath, filepath.Ext(licPath)) + ".sig"
+	sig, err := os.ReadFile(sigPath)
+	if err != nil {
+		if alt, altErr := os.ReadFile(licPath + ".sig"); altErr == nil {
+			sig = alt
+		} else {
+			fail("cannot read license signature %s: %s", sigPath, err)
+			return
+		}
+	}
+
+	if !ed25519.Verify(ed25519.PublicKey(pubBytes), data, sig) {
+		fail("signature mismatch — not signed by the current signing key (or tampered)")
+		return
+	}
+
+	var lic OfflineLicense
+	if err := json.Unmarshal(data, &lic); err != nil {
+		fail("cannot parse license JSON: %s", err)
+		return
+	}
+
+	// Identity binding: the license only applies to the instance it was issued for.
+	if lic.Domain != repman.Conf.Cloud18Domain ||
+		lic.SubDomain != repman.Conf.Cloud18SubDomain ||
+		lic.SubDomainZone != repman.Conf.Cloud18SubDomainZone {
+		fail("identity mismatch — license is for %s.%s.%s but this instance is %q",
+			lic.Domain, lic.SubDomain, lic.SubDomainZone, uri)
+		return
+	}
+
+	if lic.Plan == "" {
+		fail("license carries no plan")
+		return
+	}
+
+	// Success: apply the plan just like the CRM path.
+	repman.persistInstanceSubscriptionPlan(lic.Plan, uri)
+	repman.LogModulePrintf(repman.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+		"offline license: applied plan %q for %s (signed, identity-verified)", lic.Plan, uri)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1180,6 +1180,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.BoolVar(&conf.Cloud18DisableForSale, "cloud18-disable-for-sale", false, "Hide clusters for sale from marketplace (paid plans only)")
 	flags.StringVar(&conf.Cloud18GatewayDomainName, "cloud18-gateway-domain-name", "", "Cloud18 janitor gateway DNS ")
 	flags.StringVar(&conf.Cloud18SubscriptionPlan, "cloud18-subscription-plan", "free", "Cloud18 subscription plan code (validated by CRM)")
+	flags.StringVar(&conf.Cloud18LicenseFile, "cloud18-license-file", "", "Path to a signed offline license (license.json; detached signature license.sig alongside). When set, the instance sources its Cloud18 plan from this file instead of the CRM — for air-gapped/PCI instances. Verified with plugin-signing-public-key. Empty = normal online CRM path")
 	flags.StringVar(&conf.Cloud18CrmApiUrl, "cloud18-crm-api-url", "https://api.crm.ovh-fr-2.signal18.cloud18.io", "Cloud18 CRM API base URL used for cluster registration")
 	flags.IntVar(&conf.Cloud18ApplicationCredits, "cloud18-application-credits", 2, "Cloud18 application credits(1 core 4G Ram 8G Disk)")
 	flags.IntVar(&conf.Cloud18ApplicationCreditsPrice, "cloud18-application-credits-price", 20, "Cloud18 application credits price in Eur")
@@ -2016,13 +2017,21 @@ func (repman *ReplicationManager) InitConfig(conf config.Config, init_git bool) 
 	repman.PeerManager.SetInterval(repman.Conf.Cloud18HealthRefreshInterval)
 
 	if init_git {
-		// Sync the CRM's current plan for this URI so a node booting with cloud18
-		// already set (e.g. a copied config, or a second node registering against
-		// an already-subscribed URI) doesn't stay stuck on a stale local plan.
-		// Must run after *repman.Conf = conf above, since it persists directly onto
-		// repman.Conf — any earlier and this assignment would clobber it back to
-		// the stale pre-sync value. Best-effort: see syncSubscriptionPlanFromCRM.
-		repman.syncSubscriptionPlanFromCRM()
+		if repman.Conf.Cloud18LicenseFile != "" {
+			// Air-gapped / PCI: no internet to reach the CRM. Source the plan from
+			// the signed offline license instead (verified against the embedded
+			// plugin-signing public key, identity-bound to this instance). Soft:
+			// on any failure the plan stays at its default (free) with a WARN.
+			repman.loadOfflineLicensePlan()
+		} else {
+			// Sync the CRM's current plan for this URI so a node booting with cloud18
+			// already set (e.g. a copied config, or a second node registering against
+			// an already-subscribed URI) doesn't stay stuck on a stale local plan.
+			// Must run after *repman.Conf = conf above, since it persists directly onto
+			// repman.Conf — any earlier and this assignment would clobber it back to
+			// the stale pre-sync value. Best-effort: see syncSubscriptionPlanFromCRM.
+			repman.syncSubscriptionPlanFromCRM()
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #1715.

## Problem
Air-gapped / PCI instances have no internet to reach the CRM, so they never learn their Cloud18 subscription plan and plan-gated features stay disabled. **A client is currently blocked by this.**

## Design (agreed in #1715)
A signed offline license carries the plan the CRM would return. The client downloads a per-identity artifact from their GitLab account and drops it on the instance; repman verifies it **offline** and loads the plan.

- **Ed25519**, reusing the existing **plugin-signing keypair** — repman verifies with the already-embedded `plugin-signing-public-key`. No new key material. (Only the *public key* is embedded; the license + `.sig` are delivered — they're per-client, generated after the build.)
- **Identity-bound** to `domain/sub-domain/zone`; a license copied to another instance is rejected.
- **No expiry** — validity tied to the signing key (revocation = key rotation).
- **Soft**: missing/invalid/mismatch → plan falls back to `free` + `GWARN015` WARN state; monitoring never blocked (self-declared-plan philosophy).
- **Single switch**: `cloud18-license-file` set ⇒ offline mode (skip CRM); empty (default) ⇒ normal CRM path. No redundant boolean (dropped an earlier `cloud18-license-offline` flag on review).

## Scope
repman-side load/verify/apply only, reusing `persistInstanceSubscriptionPlan` (same as the CRM path). Wired at post-config-load in `server.go`.

- `server/license.go` — `OfflineLicense` + `loadOfflineLicensePlan()`
- `config/config.go` — `cloud18-license-file` (TOML)
- `config/error.go` — `GWARN015`
- `doc/implementation/cloud18/OFFLINE_LICENSE.md` (T8)

## Verified
- `go build ./config/... ./server/` passes.

## Out of scope (private BO repo, T15)
Generate + sign + publish the per-client license in `dbaas-portal` (private signing key, GitLab delivery).

## Follow-ups
- GUI license-status surface (T6).
- Continuous WARN re-eval across ticks (stamped once at startup today).
- Regtest (T13).