### PR TITLE
docs/config: scrub client PII + client hostname from public repo (T15)

### DIFF
--- a/doc/implementation/config/CONFIG_EVENT_LOG.md
+++ b/doc/implementation/config/CONFIG_EVENT_LOG.md
@@ -22,7 +22,7 @@ side is authoritative, standby peers pull and apply `<cluster>.toml` from the
 shared config git repo (isolated `.config/` clone). Mutations born on a peer
 that is *standby* for that cluster are stranded:
 
-- A marketplace visitor signup (`r1mfd@powerscrews.com` on belair) was
+- A marketplace visitor signup (`visitor@example.com` on belair) was
   accepted by the main instance while belair was standby there. The user was
   saved into main's local `belair.toml`, but the active peer (DR) never pulls,
   so the user never reaches it — and the next active-side push will make the

--- a/etc/local/kafka/config.toml
+++ b/etc/local/kafka/config.toml
@@ -18,7 +18,7 @@ haproxy-read-port = 3302
 [[MasterSlaveHaproxy.cdc]]
 # cloud_store address
 type = "kafka"
-hosts = "mixr-fr-2.signal18.io:9092"
+hosts = "kafka-1.example.net:9092"
 name = "kafkareplication"
 replication-server-id = 10001
 


### PR DESCRIPTION
Removes two pieces of non-generic data from the **public** repo:
1. `doc/implementation/config/CONFIG_EVENT_LOG.md` — a real marketplace-visitor **email** replaced with `visitor@example.com` (personal data must not be public).
2. `etc/local/kafka/config.toml` — a real **client hostname** replaced with a generic example host.

Both are illustrative-only; behavior is unchanged. This is the urgent-two scrub from an infra-leak audit of the public repo.

**Follow-up (separate, not in this PR):** a broader sweep of internal infra hostnames (`s18-fr-*`, `dbaas-fr-*`) and real cluster names in several implementation docs + code comments. Flagged for a dedicated pass.