### PR TITLE
fix(docker): pin dev tools for Go 1.25 compat

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -11,8 +11,8 @@ RUN /usr/local/go/bin/go install -v github.com/cweill/gotests/gotests@v1.6.0
 RUN /usr/local/go/bin/go install -v github.com/fatih/gomodifytags@v1.16.0
 RUN /usr/local/go/bin/go install -v github.com/josharian/impl@v1.1.0
 RUN /usr/local/go/bin/go install -v github.com/haya14busa/goplay/cmd/goplay@v1.0.0
-RUN /usr/local/go/bin/go install -v github.com/go-delve/delve/cmd/dlv@latest
-RUN /usr/local/go/bin/go install -v honnef.co/go/tools/cmd/staticcheck@latest
+RUN /usr/local/go/bin/go install -v github.com/go-delve/delve/cmd/dlv@v1.27.1
+RUN /usr/local/go/bin/go install -v honnef.co/go/tools/cmd/staticcheck@v0.7.0
 RUN /usr/local/go/bin/go install -v github.com/moul/gotty-client/cmd/gotty-client@v1.10.0
 
 # Install Node.js 22 from NodeSource

--- a/docker/Dockerfile.dev_rootless
+++ b/docker/Dockerfile.dev_rootless
@@ -11,8 +11,8 @@ RUN /usr/local/go/bin/go install -v github.com/cweill/gotests/gotests@v1.6.0
 RUN /usr/local/go/bin/go install -v github.com/fatih/gomodifytags@v1.16.0
 RUN /usr/local/go/bin/go install -v github.com/josharian/impl@v1.1.0
 RUN /usr/local/go/bin/go install -v github.com/haya14busa/goplay/cmd/goplay@v1.0.0
-RUN /usr/local/go/bin/go install -v github.com/go-delve/delve/cmd/dlv@latest
-RUN /usr/local/go/bin/go install -v honnef.co/go/tools/cmd/staticcheck@latest
+RUN /usr/local/go/bin/go install -v github.com/go-delve/delve/cmd/dlv@v1.27.1
+RUN /usr/local/go/bin/go install -v honnef.co/go/tools/cmd/staticcheck@v0.7.0
 RUN /usr/local/go/bin/go install -v github.com/moul/gotty-client/cmd/gotty-client@v1.10.0
 
 # Install Node.js 22 from NodeSource


### PR DESCRIPTION
## Summary
- pin `dlv` in dev Docker images to `v1.27.1`
- pin `staticcheck` in dev Docker images to `v0.7.0`
- stop `@latest` drift from breaking Go 1.25-based dev image builds

## Why
The dev Dockerfiles build with Go 1.25, but `@latest` tool installs are unbounded. `staticcheck@latest` has already moved to a Go 1.26-only release, and `dlv@latest` is the same kind of drift risk.

Fixes #1733

## Validation
- `docker run --rm golang:1.25-bookworm /bin/sh -c '/usr/local/go/bin/go install github.com/go-delve/delve/cmd/dlv@v1.27.1 && /usr/local/go/bin/go install honnef.co/go/tools/cmd/staticcheck@v0.7.0 && /go/bin/dlv version && /go/bin/staticcheck -version'`
