### PR TITLE
fix(k8s): harden native provisioning correctness/lifecycle bugs

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -388,6 +388,11 @@ type Cluster struct {
 	opensvcPoolInfoCache   []opensvc.PoolInfo `json:"-"`
 	opensvcPoolInfoCacheAt time.Time          `json:"-"`
 	opensvcPoolInfoCacheMu sync.RWMutex       `json:"-"`
+	// k8sNodeHostnameLabels caches node.Name -> the node's "kubernetes.io/hostname"
+	// label value, captured during K8SGetNodes' nodes/list so Kubernetes
+	// Deployment NodeSelector placement doesn't need a per-node nodes/get call.
+	k8sNodeHostnameLabels   map[string]string `json:"-"`
+	k8sNodeHostnameLabelsMu sync.RWMutex      `json:"-"`
 	// Per-cluster preserved variables (replaces ProvDBConfigPreserveVars mechanism)
 	preservedVars               map[string]string          `json:"-"`
 	preservedVarsExcludeServers map[string]map[string]bool `json:"-"` // varName -> {serverID -> true}

--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -26,7 +26,7 @@ var databaseACLRules = []ACLRule{
 	{"/actions/run-jobs", nil, []string{config.GrantClusterProcess}},
 	{"/actions/provision", nil, []string{config.GrantProvDBProvision}},
 	{"/actions/update-opensvc-template", nil, []string{config.GrantProvDBProvision}},
-	{"/service-opensvc", nil, []string{config.GrantProvDBProvision}},
+	{"/service/", nil, []string{config.GrantProvDBProvision}},
 	{"/actions/unprovision", nil, []string{config.GrantProvDBUnprovision}},
 	{"/actions/start", nil, []string{config.GrantDBStart}},
 	{"/actions/stop", nil, []string{config.GrantDBStop}},

--- a/cluster/cluster_acl_test.go
+++ b/cluster/cluster_acl_test.go
@@ -1245,3 +1245,42 @@ func TestIsURLPassACLOpenSVCPools(t *testing.T) {
 		})
 	}
 }
+
+// The database service/manifest route was generalized from a literal
+// "/service-opensvc" path to a dynamic "/service/{orchestrator}" one
+// (server/api_database.go, #1497 gap 6) -- the databaseACLRules pattern for
+// it (cluster_acl_rules.go) uses strings.Contains, so it had to move from
+// the old literal segment to the "/service/" prefix or every orchestrator
+// would 403 through IsValidClusterACL even with the right grant. Found via
+// live testing against a real JWT-authenticated request, not caught by
+// buildDatabaseServiceConfigResponse's own tests (server/api_database_test.go),
+// since those deliberately bypass this ACL layer.
+func TestIsURLPassACLDatabaseServiceRoute(t *testing.T) {
+	cluster := setupACLTestCluster()
+	cluster.Name = "test"
+
+	cluster.APIUsers["provision_user"] = APIUser{
+		User:   "provision_user",
+		Grants: map[string]bool{config.GrantProvDBProvision: true},
+	}
+
+	tests := []struct {
+		name     string
+		user     string
+		url      string
+		expected bool
+	}{
+		{"opensvc manifest route allowed with provision grant", "provision_user", "/api/clusters/test/servers/db1/service/opensvc", true},
+		{"kubernetes manifest route allowed with provision grant", "provision_user", "/api/clusters/test/servers/db1/service/kube", true},
+		{"denied without provision grant", "user_no_grants", "/api/clusters/test/servers/db1/service/kube", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := cluster.IsURLPassACL(tt.user, tt.url, false)
+			if result != tt.expected {
+				t.Errorf("User %s on URL %s: Expected %v, got %v", tt.user, tt.url, tt.expected, result)
+			}
+		})
+	}
+}

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -319,8 +319,24 @@ func (cluster *Cluster) GetMysqlServerBinaryPath() string {
 	return fmt.Sprintf("%sd", cluster.Conf.BackupMysqlclientPath) // Add d to the end of the path (mysql to mysqld, mariadb to mariadbd)
 }
 
+// GetDomain returns the DNS suffix appended to a server's short s.Name to
+// build its connectable address (server.Domain / server.Host), gated on
+// prov-net-cni for both orchestrators. OpenSVC's CNI-published
+// ".<namespace>.svc.<domain>" resolves to a real, routable address;
+// Kubernetes' equivalent bare Service name resolves to a virtual,
+// in-cluster-only ClusterIP, so Kubernetes instead routes through a headless
+// Service (k8sHeadlessServiceName) for a real per-pod address. Each branch
+// checks its own orchestrator explicitly so the flag can never leak a
+// domain for a cluster using the other orchestrator (or a third one
+// inheriting the flag from [DEFAULT]).
 func (cluster *Cluster) GetDomain() string {
-	if cluster.Conf.ProvNetCNI {
+	if cluster.GetOrchestrator() == config.ConstOrchestratorKubernetes {
+		if cluster.Conf.ProvNetCNI {
+			return "." + k8sHeadlessServiceName + "." + cluster.Name + ".svc." + k8sClusterDomain(cluster)
+		}
+		return ""
+	}
+	if cluster.Conf.ProvNetCNI && cluster.GetOrchestrator() == config.ConstOrchestratorOpenSVC {
 		return "." + cluster.Name + ".svc." + cluster.Conf.ProvOrchestratorCluster
 	}
 	return ""
@@ -330,8 +346,16 @@ func (cluster *Cluster) GetOrchestrator() string {
 	return cluster.Conf.ProvOrchestrator
 }
 
+// GetDomainHeadCluster is GetDomain for a child cluster resolving its
+// parent (cluster.Conf.ClusterHead).
 func (cluster *Cluster) GetDomainHeadCluster() string {
-	if cluster.Conf.ProvNetCNI {
+	if cluster.GetOrchestrator() == config.ConstOrchestratorKubernetes {
+		if cluster.Conf.ProvNetCNI {
+			return "." + k8sHeadlessServiceName + "." + cluster.Conf.ClusterHead + ".svc." + k8sClusterDomain(cluster)
+		}
+		return ""
+	}
+	if cluster.Conf.ProvNetCNI && cluster.GetOrchestrator() == config.ConstOrchestratorOpenSVC {
 		return "." + cluster.Conf.ClusterHead + ".svc." + cluster.Conf.ProvOrchestratorCluster
 	}
 	return ""

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -1577,6 +1577,15 @@ func (cluster *Cluster) SetProvOrchestratorCluster(value string) error {
 	return nil
 }
 
+// SetProvKubeStorageClass only affects the PVC built for a server's *next*
+// (re)provision (k8sDatabasePVC, prov_k8s_db.go), same as SetDBDiskSize --
+// so it needs the DB reprov cookie, not the proxy one.
+func (cluster *Cluster) SetProvKubeStorageClass(value string) error {
+	cluster.Conf.ProvKubeStorageClass = value
+	cluster.SetDBReprovCookie()
+	return nil
+}
+
 func (cluster *Cluster) SetProvDbAgents(value string) error {
 	cluster.Conf.ProvAgents = value
 	return nil

--- a/cluster/prov.go
+++ b/cluster/prov.go
@@ -588,6 +588,21 @@ func (cluster *Cluster) RestartDatabaseService(server *ServerMonitor, node strin
 		return err
 	}
 
+	// Kubernetes has no scale-to-zero/drain semantic (K8SStopDatabaseService
+	// always errors), so the generic stop→wait→start dance below can never
+	// work for it -- a rolling pod replacement (the same mechanism that
+	// makes prov-kube-image-force-pull's ImagePullPolicy: Always actually
+	// take effect on demand) is the equivalent operation instead.
+	if cluster.GetOrchestrator() == config.ConstOrchestratorKubernetes {
+		err = cluster.K8SForceRepullDatabaseService(server)
+		if err == nil {
+			server.DelRestartContainerCookie()
+			server.RestartNode = ""
+			server.RestartRid = ""
+		}
+		return err
+	}
+
 	// Generic restart: stop → wait failed → start
 	// This allows pre-stop hooks (e.g. innodb_fast_shutdown=0 before upgrade)
 	// and post-stop hooks (e.g. redo log relocation) between the two phases.

--- a/cluster/prov_k8s.go
+++ b/cluster/prov_k8s.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/signal18/replication-manager/config"
+	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/client-go/kubernetes"
@@ -29,31 +30,71 @@ func (cluster *Cluster) K8SConnectAPI() (*kubernetes.Clientset, error) {
 	return clientset, err
 }
 
-func (cluster *Cluster) K8SGetNodes() ([]Agent, error) {
+// Agent.HostName must stay the Kubernetes node name: GetAgentInOrchetrator
+// matches operator-supplied prov-db-agents entries against it. hostnameLabel
+// is the node's "kubernetes.io/hostname" label value, which is not guaranteed
+// to equal n.Name and is what NodeSelector-based placement actually needs.
+func k8sAgentFromNode(n apiv1.Node) (agent Agent, address string, hostnameLabel string) {
+	if len(n.Status.Addresses) > 0 {
+		address = n.Status.Addresses[0].Address
+	}
+	agent.Id = n.Status.NodeInfo.MachineID
+	agent.OsName = n.Status.NodeInfo.OperatingSystem
+	agent.OsKernel = n.Status.NodeInfo.KernelVersion
+	agent.CpuCores = n.Status.Capacity.Cpu().MilliValue() / 1000
+	agent.MemBytes = n.Status.Capacity.Memory().Value()
+	agent.MemFreeBytes = n.Status.Allocatable.Memory().Value()
+	agent.HostName = n.Name
+	return agent, address, n.Labels["kubernetes.io/hostname"]
+}
 
+func (cluster *Cluster) k8sNodesFromClient(client kubernetes.Interface) ([]Agent, error) {
+	nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot list Kubernetes nodes %s ", err)
+		return nil, err
+	}
+	agents := []Agent{}
+	hostnameLabels := make(map[string]string, len(nodes.Items))
+	for _, n := range nodes.Items {
+		data, _ := json.Marshal(n)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "%s\n", data)
+		agent, address, hostnameLabel := k8sAgentFromNode(n)
+		if address != "" {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "IP %s ", address)
+		} else {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn, "Kubernetes node %s reports no addresses", n.Name)
+		}
+		agents = append(agents, agent)
+		hostnameLabels[n.Name] = hostnameLabel
+	}
+	cluster.k8sNodeHostnameLabelsMu.Lock()
+	cluster.k8sNodeHostnameLabels = hostnameLabels
+	cluster.k8sNodeHostnameLabelsMu.Unlock()
+	return agents, nil
+}
+
+func (cluster *Cluster) K8SGetNodes() ([]Agent, error) {
 	client, err := cluster.K8SConnectAPI()
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot init Kubernetes client API %s ", err)
 		return nil, err
 	}
-	nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
-	agents := []Agent{}
-	for _, n := range nodes.Items {
-		var agent Agent
-		data, _ := json.Marshal(n)
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "%s\n", data)
-		nodeip := n.Status.Addresses
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "IP %s ", nodeip[0].Address)
-		agent.Id = n.Status.NodeInfo.MachineID
-		agent.OsName = n.Status.NodeInfo.OperatingSystem
-		agent.OsKernel = n.Status.NodeInfo.KernelVersion
-		//	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator,LvlInfo, "nodes %s ", n)
-		agent.CpuCores = (n.Status.Capacity.Cpu().MilliValue() / 1000)
-		agent.MemBytes = n.Status.Capacity.Memory().Value()
-		agent.MemFreeBytes = n.Status.Allocatable.Memory().Value()
+	return cluster.k8sNodesFromClient(client)
+}
 
-		agent.HostName = n.Name
-		agents = append(agents, agent)
+// k8sHostnameLabel returns the cached "kubernetes.io/hostname" label value for
+// a node (populated by the last K8SGetNodes/nodes-list call), falling back to
+// nodeName if it was never captured (e.g. no nodes/list has run yet) or the
+// node reported no such label. This avoids a per-node nodes/get call — a
+// least-privilege RBAC setup that grants nodes/list but not nodes/get still
+// gets correct NodeSelector placement.
+func (cluster *Cluster) k8sHostnameLabel(nodeName string) string {
+	cluster.k8sNodeHostnameLabelsMu.RLock()
+	label, ok := cluster.k8sNodeHostnameLabels[nodeName]
+	cluster.k8sNodeHostnameLabelsMu.RUnlock()
+	if ok && label != "" {
+		return label
 	}
-	return agents, err
+	return nodeName
 }

--- a/cluster/prov_k8s_db.go
+++ b/cluster/prov_k8s_db.go
@@ -240,7 +240,38 @@ func (cluster *Cluster) k8sDatabaseDeployment(s *ServerMonitor, port int, nodeHo
 	// reconfigured. Only sent when actually required: embedding a real
 	// credential in every Deployment spec regardless of whether the
 	// endpoint enforces auth would be needless exposure.
-	authority := cluster.Conf.MonitorAddress + ":" + cluster.Conf.HttpPort
+	//
+	// HTTPS on api-port (10005) when the API server is actually running:
+	// api.go's apiserver() registers the exact same unprotected routes
+	// (config, static binary) as http.go's httpserver(), and always
+	// terminates TLS -- a generated self-signed cert when
+	// monitoring-ssl-cert isn't set, same as every other orchestrator's
+	// bootstrap fetch already does (REPLICATION_MANAGER_URL in
+	// prov_opensvc.go, prov_onpremise_db.go, cluster_get.go all use
+	// "https://"+MonitorAddress+":"+APIPort). --no-check-certificate matches
+	// those callers' wget invocations for the same reason: the cert is
+	// self-signed, so there's no CA for the init container to validate
+	// against, and pinning/distributing that generated cert is out of scope
+	// here (#1497).
+	//
+	// api-server is a real, independently-togglable flag (api-server,
+	// default true) -- a deployment with api-server=false and
+	// http-server=true has nothing listening on api-port at all, which
+	// would previously have worked fine over plain HTTP on http-port
+	// (httpserver() registers the identical routes). Falling back to that
+	// combination when the API server is disabled preserves that config
+	// instead of silently breaking it: the init container's wget would
+	// otherwise hang on an unanswered connection with no error to surface
+	// (confirmed live in the same failure shape when a Service didn't route
+	// to the right port at all).
+	scheme := "https"
+	noCheckCert := " --no-check-certificate"
+	authority := cluster.Conf.MonitorAddress + ":" + cluster.Conf.APIPort
+	if !cluster.Conf.ApiServ {
+		scheme = "http"
+		noCheckCert = ""
+		authority = cluster.Conf.MonitorAddress + ":" + cluster.Conf.HttpPort
+	}
 	authHeader := ""
 	if cluster.Conf.APISecureConfig {
 		adminPass := "repman"
@@ -290,10 +321,10 @@ func (cluster *Cluster) k8sDatabaseDeployment(s *ServerMonitor, port int, nodeHo
 	cmd := []string{
 		"sh", "-c",
 		"mkdir -p /tmp/cfg /docker-entrypoint-initdb.d " + systemDirs +
-			" && wget -qO-" + authHeader + " http://" + authority + "/api/clusters/" + cluster.Name + "/servers/" + serverPath + "/" + s.Port + "/config | tar xzf - -C /tmp/cfg" +
+			" && wget" + noCheckCert + " -qO-" + authHeader + " " + scheme + "://" + authority + "/api/clusters/" + cluster.Name + "/servers/" + serverPath + "/" + s.Port + "/config | tar xzf - -C /tmp/cfg" +
 			" && cp /tmp/cfg/etc/mysql/conf.d/*.cnf /etc/mysql/conf.d/ 2>/dev/null" +
 			" && cp -r /tmp/cfg/init/. /docker-entrypoint-initdb.d/ 2>/dev/null" +
-			" && wget -qO /docker-entrypoint-initdb.d/replication-manager-cli http://" + authority + "/static/configurator/bin/replication-manager-cli" +
+			" && wget" + noCheckCert + " -qO /docker-entrypoint-initdb.d/replication-manager-cli " + scheme + "://" + authority + "/static/configurator/bin/replication-manager-cli" +
 			" && chmod +x /docker-entrypoint-initdb.d/replication-manager-cli /docker-entrypoint-initdb.d/dbjobs_new /docker-entrypoint-initdb.d/dbjobs_launcher_with_sigterm 2>/dev/null",
 	}
 	// Subdomain/role label are gated on prov-net-cni so a cluster that

--- a/cluster/prov_k8s_db.go
+++ b/cluster/prov_k8s_db.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"os"
 	"strconv"
@@ -28,6 +29,64 @@ func (cluster *Cluster) k8sEnsureNamespace(client kubernetes.Interface, name str
 	}
 }
 
+// k8sHeadlessServiceName is the shared headless Service every DB pod is a
+// member of, for per-pod DNS (see Subdomain in k8sDatabaseDeployment). Not
+// cluster.Name-prefixed: Service names only need to be unique per namespace,
+// and every cluster already gets its own namespace.
+const k8sHeadlessServiceName = "db"
+
+// k8sRoleLabel distinguishes DB pods from proxy pods (prov_k8s_prx.go),
+// which share the "app" label but not this one -- needed so the headless
+// Service's selector doesn't also match proxies.
+const k8sRoleLabel = "role"
+const k8sRoleDB = "db"
+
+// k8sClusterDomain is the Kubernetes cluster's DNS domain (kubelet
+// --cluster-domain), read from prov-orchestrator-cluster and falling back to
+// the Kubernetes default "cluster.local" when unset. "local" (the flag's own
+// CLI default, server/server.go) is treated the same as unset -- it's an
+// OpenSVC-oriented default (their own env-naming convention), never a real
+// Kubernetes --cluster-domain, so any cluster that doesn't explicitly
+// override this shared flag would otherwise silently build ".svc.local", not
+// resolvable by CoreDNS (confirmed live: clusterin got Failed on every
+// server until this fallback existed).
+func k8sClusterDomain(cluster *Cluster) string {
+	if cluster.Conf.ProvOrchestratorCluster != "" && cluster.Conf.ProvOrchestratorCluster != "local" {
+		return cluster.Conf.ProvOrchestratorCluster
+	}
+	return "cluster.local"
+}
+
+// k8sEnsureHeadlessService creates the shared headless Service if it doesn't
+// already exist, selecting every DB pod (app+role, not the per-server "tag")
+// so each one's Hostname+Subdomain DNS record gets published.
+func (cluster *Cluster) k8sEnsureHeadlessService(client kubernetes.Interface, port int) {
+	svc := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: k8sHeadlessServiceName,
+		},
+		Spec: apiv1.ServiceSpec{
+			ClusterIP: apiv1.ClusterIPNone,
+			Ports: []apiv1.ServicePort{
+				{
+					Name:     "mysql",
+					Protocol: apiv1.ProtocolTCP,
+					Port:     int32(port),
+				},
+			},
+			Selector: map[string]string{
+				"app":        "repication-manager",
+				k8sRoleLabel: k8sRoleDB,
+			},
+		},
+	}
+	_, err := client.CoreV1().Services(cluster.Name).Create(context.TODO(), svc, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot create Kubernetes headless service %s ", err)
+	}
+}
+
+
 // k8sDatabaseDeployment is a pure builder — no API calls, no ServerMonitor
 // methods invoked — so the Deployment's placement/selector/env can be
 // asserted directly in tests. In particular NodeSelector, not
@@ -37,10 +96,56 @@ func (cluster *Cluster) k8sEnsureNamespace(client kubernetes.Interface, name str
 // scheduling. NodeSelector pins the pod to the same node while still going
 // through the scheduler.
 func (cluster *Cluster) k8sDatabaseDeployment(s *ServerMonitor, port int, nodeHostnameLabel string) *appsv1.Deployment {
-	// No auth header: 403s if api-credentials-secure-config is enabled.
+	// api-credentials-secure-config requires a Bearer JWT or HTTP Basic Auth;
+	// sent as a base64 wget --header rather than raw user:pass@host userinfo,
+	// since the whole cmd runs through the init container's shell and
+	// base64's alphabet can't contain shell metacharacters. Uses "admin",
+	// same convention as every other bootstrap credential injection in this
+	// codebase (GetExecEnv, OpenSVC's secrets injection, onpremise env
+	// exports) -- not "whichever api-credentials entry is configured
+	// first", which may lack the grant /config actually requires. Falls
+	// back to the default password "repman" if admin hasn't been
+	// reconfigured. Only sent when actually required: embedding a real
+	// credential in every Deployment spec regardless of whether the
+	// endpoint enforces auth would be needless exposure.
+	authority := cluster.Conf.MonitorAddress + ":" + cluster.Conf.HttpPort
+	authHeader := ""
+	if cluster.Conf.APISecureConfig {
+		adminPass := "repman"
+		if u, ok := cluster.APIUsers["admin"]; ok {
+			adminPass = u.Password
+		}
+		authHeader = " --header=\"Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte("admin:"+adminPass)) + "\""
+	}
+	// MariaDB's !includedir is non-recursive, so only the generated
+	// etc/mysql/conf.d/*.cnf fragments are copied in -- those point
+	// log/binlog/tmp/innodb/aria paths at ./.system/... under the datadir,
+	// which mariadbd needs pre-created (OpenSVC's moduleset does this as
+	// explicit directory resources; nothing analogous exists for K8s).
+	systemDirs := "/var/lib/mysql/.system/tmp /var/lib/mysql/.system/logs " +
+		"/var/lib/mysql/.system/repl /var/lib/mysql/.system/innodb/undo " +
+		"/var/lib/mysql/.system/innodb/redo /var/lib/mysql/.system/aria"
+	// GetServerFromURL (cluster_get.go), which handlerMuxServersPortConfig
+	// uses to resolve the {serverName} path segment, matches only
+	// server.Host -- the domain-qualified name when prov-net-cni is on, not
+	// the bare s.Name. Using s.Name here alone would 500 ("No server") on
+	// every fetch once the flag is enabled, since it would never match.
+	serverPath := s.Name + cluster.GetDomain()
 	cmd := []string{
 		"sh", "-c",
-		"wget -qO- http://" + cluster.Conf.MonitorAddress + ":" + cluster.Conf.HttpPort + "/api/clusters/" + cluster.Name + "/servers/" + s.Name + "/" + s.Port + "/config|tar xzvf - -C /data",
+		"mkdir -p /tmp/cfg " + systemDirs + " && wget -qO-" + authHeader + " http://" + authority + "/api/clusters/" + cluster.Name + "/servers/" + serverPath + "/" + s.Port + "/config | tar xzf - -C /tmp/cfg && cp /tmp/cfg/etc/mysql/conf.d/*.cnf /etc/mysql/conf.d/ 2>/dev/null",
+	}
+	// Subdomain/role label are gated on prov-net-cni so a cluster that
+	// hasn't opted in gets byte-identical Deployments to before; the role
+	// label must match k8sEnsureHeadlessService's selector.
+	var subdomain string
+	podLabels := map[string]string{
+		"app": "repication-manager",
+		"tag": s.Name,
+	}
+	if cluster.Conf.ProvNetCNI {
+		subdomain = k8sHeadlessServiceName
+		podLabels[k8sRoleLabel] = k8sRoleDB
 	}
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -56,13 +161,13 @@ func (cluster *Cluster) k8sDatabaseDeployment(s *ServerMonitor, port int, nodeHo
 			},
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"app": "repication-manager",
-						"tag": s.Name,
-					},
+					Labels: podLabels,
 				},
 				Spec: apiv1.PodSpec{
 					Hostname: s.Name,
+					// Hostname+Subdomain, paired with the headless Service, is
+					// what makes CoreDNS publish this pod's current real IP.
+					Subdomain: subdomain,
 					NodeSelector: map[string]string{
 						"kubernetes.io/hostname": nodeHostnameLabel,
 					},
@@ -73,8 +178,12 @@ func (cluster *Cluster) k8sDatabaseDeployment(s *ServerMonitor, port int, nodeHo
 							Command: cmd,
 							VolumeMounts: []apiv1.VolumeMount{
 								{
+									Name:      s.Name + "-conf",
+									MountPath: "/etc/mysql/conf.d",
+								},
+								{
 									Name:      s.Name + "-persistent-storage",
-									MountPath: "/data",
+									MountPath: "/var/lib/mysql",
 								},
 							},
 						},
@@ -101,6 +210,10 @@ func (cluster *Cluster) k8sDatabaseDeployment(s *ServerMonitor, port int, nodeHo
 									Name:      s.Name + "-persistent-storage",
 									MountPath: "/var/lib/mysql",
 								},
+								{
+									Name:      s.Name + "-conf",
+									MountPath: "/etc/mysql/conf.d",
+								},
 							},
 						},
 					},
@@ -111,6 +224,16 @@ func (cluster *Cluster) k8sDatabaseDeployment(s *ServerMonitor, port int, nodeHo
 								PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{
 									ClaimName: cluster.Name + "-" + s.Name + "-claim",
 								},
+							},
+						},
+						{
+							// Not the data PVC: config is regenerated by the init
+							// container on every pod start, so it doesn't need to
+							// survive a restart -- an emptyDir keeps it off the
+							// persistent volume entirely.
+							Name: s.Name + "-conf",
+							VolumeSource: apiv1.VolumeSource{
+								EmptyDir: &apiv1.EmptyDirVolumeSource{},
 							},
 						},
 					},
@@ -129,8 +252,10 @@ func (cluster *Cluster) K8SProvisionDatabaseService(s *ServerMonitor) {
 		return
 	}
 	if cluster.Conf.APISecureConfig {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn,
-			"api-credentials-secure-config is enabled: the Kubernetes DB init-container config fetch sends no credentials and will get HTTP 403, so %s will not bootstrap", s.Name)
+		if u, ok := cluster.APIUsers["admin"]; !ok || u.Grants == nil || !u.Grants[config.GrantDBConfigFlag] {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn,
+				"api-credentials-secure-config is enabled but the admin user lacks the db-config-flag grant: the Kubernetes DB init-container config fetch will get HTTP 403, so %s will not bootstrap", s.Name)
+		}
 	}
 	cluster.k8sEnsureNamespace(client, cluster.Name)
 
@@ -244,6 +369,9 @@ func (cluster *Cluster) K8SProvisionDatabaseService(s *ServerMonitor) {
 		cluster.errorChan <- err
 		return
 	}
+	if cluster.Conf.ProvNetCNI {
+		cluster.k8sEnsureHeadlessService(client, port)
+	}
 	agent, err := cluster.GetDatabaseAgent(s)
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not provision database  %s ", err)
@@ -278,7 +406,6 @@ func (cluster *Cluster) K8SProvisionDatabaseService(s *ServerMonitor) {
 					Port:     int32(port),
 				},
 			},
-			//			ClusterIP: "",
 			Selector: map[string]string{
 				"app": "repication-manager",
 				"tag": s.Name,
@@ -294,6 +421,10 @@ func (cluster *Cluster) K8SProvisionDatabaseService(s *ServerMonitor) {
 	}
 	if err2 == nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Created Kubernetes service %s.\n", result2.GetObjectMeta().GetName())
+	}
+	if cluster.Conf.ProvNetCNI {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo,
+			"Server %s reachable via CoreDNS at %s (in-cluster clients, or an external repman with its resolver pointed at CoreDNS)", s.Name, s.Name+cluster.GetDomain())
 	}
 	cluster.errorChan <- nil
 }

--- a/cluster/prov_k8s_db.go
+++ b/cluster/prov_k8s_db.go
@@ -28,6 +28,98 @@ func (cluster *Cluster) k8sEnsureNamespace(client kubernetes.Interface, name str
 	}
 }
 
+// k8sDatabaseDeployment is a pure builder — no API calls, no ServerMonitor
+// methods invoked — so the Deployment's placement/selector/env can be
+// asserted directly in tests. In particular NodeSelector, not
+// Spec.NodeName: NodeName bypasses the scheduler entirely, which means a
+// WaitForFirstConsumer StorageClass (the default for most dynamic
+// provisioners) never binds the PVC, since that only happens during
+// scheduling. NodeSelector pins the pod to the same node while still going
+// through the scheduler.
+func (cluster *Cluster) k8sDatabaseDeployment(s *ServerMonitor, port int, nodeHostnameLabel string) *appsv1.Deployment {
+	// No auth header: 403s if api-credentials-secure-config is enabled.
+	cmd := []string{
+		"sh", "-c",
+		"wget -qO- http://" + cluster.Conf.MonitorAddress + ":" + cluster.Conf.HttpPort + "/api/clusters/" + cluster.Name + "/servers/" + s.Name + "/" + s.Port + "/config|tar xzvf - -C /data",
+	}
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: s.Name,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "repication-manager",
+					"tag": s.Name,
+				},
+			},
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "repication-manager",
+						"tag": s.Name,
+					},
+				},
+				Spec: apiv1.PodSpec{
+					Hostname: s.Name,
+					NodeSelector: map[string]string{
+						"kubernetes.io/hostname": nodeHostnameLabel,
+					},
+					InitContainers: []apiv1.Container{
+						{
+							Name:    s.Name + "-init",
+							Image:   "alpine",
+							Command: cmd,
+							VolumeMounts: []apiv1.VolumeMount{
+								{
+									Name:      s.Name + "-persistent-storage",
+									MountPath: "/data",
+								},
+							},
+						},
+					},
+					Containers: []apiv1.Container{
+						{
+							Name:  s.Name,
+							Image: cluster.Conf.ProvDbImg,
+							Ports: []apiv1.ContainerPort{
+								{
+									Name:          "mysql",
+									Protocol:      apiv1.ProtocolTCP,
+									ContainerPort: int32(port),
+								},
+							},
+							Env: []apiv1.EnvVar{
+								{
+									Name:  "MYSQL_ROOT_PASSWORD",
+									Value: s.Pass,
+								},
+							},
+							VolumeMounts: []apiv1.VolumeMount{
+								{
+									Name:      s.Name + "-persistent-storage",
+									MountPath: "/var/lib/mysql",
+								},
+							},
+						},
+					},
+					Volumes: []apiv1.Volume{
+						{
+							Name: s.Name + "-persistent-storage",
+							VolumeSource: apiv1.VolumeSource{
+								PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{
+									ClaimName: cluster.Name + "-" + s.Name + "-claim",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func (cluster *Cluster) K8SProvisionDatabaseService(s *ServerMonitor) {
 
 	client, err := cluster.K8SConnectAPI()
@@ -159,93 +251,7 @@ func (cluster *Cluster) K8SProvisionDatabaseService(s *ServerMonitor) {
 		return
 	}
 	nodeHostnameLabel := cluster.k8sHostnameLabel(agent.HostName)
-	// No auth header: 403s if api-credentials-secure-config is enabled.
-	cmd := []string{
-		"sh", "-c",
-		"wget -qO- http://" + cluster.Conf.MonitorAddress + ":" + cluster.Conf.HttpPort + "/api/clusters/" + cluster.Name + "/servers/" + s.Name + "/" + s.Port + "/config|tar xzvf - -C /data",
-	}
-	deployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: s.Name,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: int32Ptr(1),
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"app": "repication-manager",
-					"tag": s.Name,
-				},
-			},
-			Template: apiv1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"app": "repication-manager",
-						"tag": s.Name,
-					},
-				},
-				Spec: apiv1.PodSpec{
-					Hostname: s.Name,
-					// NodeSelector, not NodeName: NodeName bypasses the scheduler
-					// entirely, which means a WaitForFirstConsumer StorageClass
-					// (the default for most dynamic provisioners) never binds the
-					// PVC, since that only happens during scheduling. NodeSelector
-					// pins the pod to the same node while still going through the
-					// scheduler.
-					NodeSelector: map[string]string{
-						"kubernetes.io/hostname": nodeHostnameLabel,
-					},
-					InitContainers: []apiv1.Container{
-						{
-							Name:    s.Name + "-init",
-							Image:   "alpine",
-							Command: cmd,
-							VolumeMounts: []apiv1.VolumeMount{
-								{
-									Name:      s.Name + "-persistent-storage",
-									MountPath: "/data",
-								},
-							},
-						},
-					},
-					Containers: []apiv1.Container{
-						{
-							Name:  s.Name,
-							Image: cluster.Conf.ProvDbImg,
-							Ports: []apiv1.ContainerPort{
-								{
-									Name:          "mysql",
-									Protocol:      apiv1.ProtocolTCP,
-									ContainerPort: int32(port),
-								},
-							},
-							Env: []apiv1.EnvVar{
-								{
-									Name:  "MYSQL_ROOT_PASSWORD",
-									Value: s.Pass,
-								},
-							},
-							VolumeMounts: []apiv1.VolumeMount{
-								{
-									Name:      s.Name + "-persistent-storage",
-									MountPath: "/var/lib/mysql",
-								},
-							},
-						},
-					},
-					Volumes: []apiv1.Volume{
-						{
-							Name: s.Name + "-persistent-storage",
-							VolumeSource: apiv1.VolumeSource{
-								PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{
-									ClaimName: cluster.Name + "-" + s.Name + "-claim",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	deployment := cluster.k8sDatabaseDeployment(s, port, nodeHostnameLabel)
 
 	// Create Deployment
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Creating Kubernetes deployment...")

--- a/cluster/prov_k8s_db.go
+++ b/cluster/prov_k8s_db.go
@@ -3,9 +3,11 @@ package cluster
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/signal18/replication-manager/config"
 	appsv1 "k8s.io/api/apps/v1"
@@ -13,6 +15,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -55,6 +58,135 @@ func k8sClusterDomain(cluster *Cluster) string {
 		return cluster.Conf.ProvOrchestratorCluster
 	}
 	return "cluster.local"
+}
+
+// k8sImagePullPolicy mirrors opensvc-image-force-pull's exact semantic
+// (prov_opensvc_db.go) for Kubernetes: PullAlways when the flag is set,
+// otherwise an explicit PullIfNotPresent rather than leaving the field
+// unset -- the K8s implicit default already differs by tag (Always for
+// ":latest", IfNotPresent otherwise), which is surprising/undocumented
+// behavior; being explicit here means redeploying with the same non-latest
+// tag never silently skips a genuinely updated image without this flag.
+func k8sImagePullPolicy(cluster *Cluster) apiv1.PullPolicy {
+	if cluster.Conf.ProvKubeImageForcePull {
+		return apiv1.PullAlways
+	}
+	return apiv1.PullIfNotPresent
+}
+
+// k8sSecretKeyRootPassword is the key MYSQL_ROOT_PASSWORD is stored under in
+// each server's own Secret (k8sSecretName) -- one Secret per server, not
+// shared, since each server can have its own password.
+const k8sSecretKeyRootPassword = "MYSQL_ROOT_PASSWORD"
+
+func k8sSecretName(s *ServerMonitor) string {
+	return s.Name + "-secret"
+}
+
+// k8sEnsureDatabaseSecret creates or updates the Secret holding
+// MYSQL_ROOT_PASSWORD, referenced by the container via SecretKeyRef rather
+// than a raw Env value -- a raw value would put the password in cleartext
+// in the Deployment spec (kubectl get deploy -o yaml, RBAC permitting), the
+// same class of exposure the config-bootstrap Basic Auth header was fixed
+// to avoid. Update (not just create-if-missing): password rotation must
+// take effect on the next pod restart, not silently keep the old one -- a
+// merge Patch, not Update with a freshly-constructed object: Update()
+// requires the current resourceVersion for optimistic concurrency, which a
+// fresh object never has, so it would be rejected by a real API server
+// (the fake clientset used in tests doesn't enforce this, so that gap
+// wasn't test-visible). A merge patch needs no resourceVersion at all.
+func (cluster *Cluster) k8sEnsureDatabaseSecret(client kubernetes.Interface, s *ServerMonitor) error {
+	secretsClient := client.CoreV1().Secrets(cluster.Name)
+	secret := &apiv1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: k8sSecretName(s),
+		},
+		Type: apiv1.SecretTypeOpaque,
+		StringData: map[string]string{
+			k8sSecretKeyRootPassword: s.Pass,
+		},
+	}
+	_, err := secretsClient.Create(context.TODO(), secret, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		// json.Marshal, not manual string concatenation: a password can
+		// contain arbitrary characters, and Go's own quoting syntax
+		// (strconv.Quote) isn't guaranteed identical to JSON's.
+		patch, marshalErr := json.Marshal(struct {
+			StringData map[string]string `json:"stringData"`
+		}{StringData: map[string]string{k8sSecretKeyRootPassword: s.Pass}})
+		if marshalErr != nil {
+			return marshalErr
+		}
+		_, err = secretsClient.Patch(context.TODO(), k8sSecretName(s), ktypes.MergePatchType, patch, metav1.PatchOptions{})
+	}
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot provision Kubernetes secret %s ", err)
+	}
+	return err
+}
+
+// k8sDatabasePVC is a pure builder for the database PVC, following
+// k8sDatabaseDeployment's own "no API calls" convention so it can be
+// asserted directly in tests. StorageClassName is a *string in the K8s API
+// specifically to distinguish "use the cluster's default StorageClass" (nil)
+// from "use no StorageClass, static pre-bound PV matching only" (a pointer
+// to ""), so prov-kube-storage-class empty must stay nil, not "". Size comes
+// from prov-db-disk-size (e.g. "20G"), already used by every other
+// orchestrator for the same purpose, not the 1Gi that was hardcoded here
+// before -- a size that never matched what the operator actually asked for.
+func (cluster *Cluster) k8sDatabasePVC(s *ServerMonitor) *apiv1.PersistentVolumeClaim {
+	size, err := resource.ParseQuantity(cluster.Conf.ProvDisk)
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn,
+			"Cannot parse prov-db-disk-size %q, falling back to the default 20G: %s ", cluster.Conf.ProvDisk, err)
+		size = resource.MustParse("20G")
+	}
+	pvc := &apiv1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cluster.Name + "-" + s.Name + "-claim",
+		},
+		Spec: apiv1.PersistentVolumeClaimSpec{
+			AccessModes: []apiv1.PersistentVolumeAccessMode{
+				apiv1.ReadWriteOnce,
+			},
+			Resources: apiv1.VolumeResourceRequirements{
+				Requests: apiv1.ResourceList{
+					apiv1.ResourceName(apiv1.ResourceStorage): size,
+				},
+			},
+		},
+	}
+	if cluster.Conf.ProvKubeStorageClass != "" {
+		storageClass := cluster.Conf.ProvKubeStorageClass
+		pvc.Spec.StorageClassName = &storageClass
+	}
+	return pvc
+}
+
+// k8sStorageClassesFromClient lists the cluster's available StorageClass
+// names, for the provisioning GUI's dropdown (see prov-kube-storage-class) --
+// same "*FromClient testable + public live-connecting wrapper" split as
+// k8sNodesFromClient/K8SGetNodes (prov_k8s.go).
+func (cluster *Cluster) k8sStorageClassesFromClient(client kubernetes.Interface) ([]string, error) {
+	scs, err := client.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot list Kubernetes storage classes %s ", err)
+		return nil, err
+	}
+	names := make([]string, 0, len(scs.Items))
+	for _, sc := range scs.Items {
+		names = append(names, sc.Name)
+	}
+	return names, nil
+}
+
+func (cluster *Cluster) K8SGetStorageClasses() ([]string, error) {
+	client, err := cluster.K8SConnectAPI()
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot init Kubernetes client API %s ", err)
+		return nil, err
+	}
+	return cluster.k8sStorageClassesFromClient(client)
 }
 
 // k8sEnsureHeadlessService creates the shared headless Service if it doesn't
@@ -122,18 +254,47 @@ func (cluster *Cluster) k8sDatabaseDeployment(s *ServerMonitor, port int, nodeHo
 	// log/binlog/tmp/innodb/aria paths at ./.system/... under the datadir,
 	// which mariadbd needs pre-created (OpenSVC's moduleset does this as
 	// explicit directory resources; nothing analogous exists for K8s).
+	// .system/jobs (JOBS_DATADIR) is where the dbjobs sidecar's launcher
+	// script (dbjobs_launcher_with_sigterm) cleans up stale *.run
+	// directories on every cycle -- confirmed live: missing this one made
+	// cleanup_run_dirs fail immediately on startup. Hardcoded, matching the
+	// other paths here, rather than calling s.GetJobDatadir(): that method
+	// dereferences s.ClusterGroup.Configurator with no nil check, which
+	// would violate this function's own "pure builder, no ServerMonitor
+	// methods" contract and panic on a bare *ServerMonitor (confirmed via a
+	// test). Matches GetJobDatadir()'s own Kubernetes-path result unless
+	// the "nosplitpath" db-tag is set, which would use
+	// /var/lib/replication-manager-jobs instead -- not handled here.
 	systemDirs := "/var/lib/mysql/.system/tmp /var/lib/mysql/.system/logs " +
 		"/var/lib/mysql/.system/repl /var/lib/mysql/.system/innodb/undo " +
-		"/var/lib/mysql/.system/innodb/redo /var/lib/mysql/.system/aria"
+		"/var/lib/mysql/.system/innodb/redo /var/lib/mysql/.system/aria " +
+		"/var/lib/mysql/.system/jobs"
 	// GetServerFromURL (cluster_get.go), which handlerMuxServersPortConfig
 	// uses to resolve the {serverName} path segment, matches only
 	// server.Host -- the domain-qualified name when prov-net-cni is on, not
 	// the bare s.Name. Using s.Name here alone would 500 ("No server") on
 	// every fetch once the flag is enabled, since it would never match.
 	serverPath := s.Name + cluster.GetDomain()
+	// The fetched archive's root is repman's own Datadir/init (confirmed via
+	// configurator.TarGz's caller, configurator.go) -- so its "init/" entry
+	// (dbjobs_new, dbjobs_launcher_with_sigterm, already fully resolved
+	// server-side: GenerateDatabaseConfig substitutes every %%ENV:...%%
+	// placeholder, including JOBS_DATADIR, before the archive is built, so
+	// nothing needs to be templated again here) is copied into a shared
+	// volume the dbjobs sidecar mounts at /docker-entrypoint-initdb.d,
+	// matching OpenSVC's own mount path for the same purpose
+	// (OpenSVCGetJobsContainerSection, prov_opensvc_db.go). No auth on the
+	// replication-manager-cli fetch: /static/ is a plain, unauthenticated
+	// file server (server/http.go), the same as OpenSVC's own bootstrap
+	// script fetching it.
 	cmd := []string{
 		"sh", "-c",
-		"mkdir -p /tmp/cfg " + systemDirs + " && wget -qO-" + authHeader + " http://" + authority + "/api/clusters/" + cluster.Name + "/servers/" + serverPath + "/" + s.Port + "/config | tar xzf - -C /tmp/cfg && cp /tmp/cfg/etc/mysql/conf.d/*.cnf /etc/mysql/conf.d/ 2>/dev/null",
+		"mkdir -p /tmp/cfg /docker-entrypoint-initdb.d " + systemDirs +
+			" && wget -qO-" + authHeader + " http://" + authority + "/api/clusters/" + cluster.Name + "/servers/" + serverPath + "/" + s.Port + "/config | tar xzf - -C /tmp/cfg" +
+			" && cp /tmp/cfg/etc/mysql/conf.d/*.cnf /etc/mysql/conf.d/ 2>/dev/null" +
+			" && cp -r /tmp/cfg/init/. /docker-entrypoint-initdb.d/ 2>/dev/null" +
+			" && wget -qO /docker-entrypoint-initdb.d/replication-manager-cli http://" + authority + "/static/configurator/bin/replication-manager-cli" +
+			" && chmod +x /docker-entrypoint-initdb.d/replication-manager-cli /docker-entrypoint-initdb.d/dbjobs_new /docker-entrypoint-initdb.d/dbjobs_launcher_with_sigterm 2>/dev/null",
 	}
 	// Subdomain/role label are gated on prov-net-cni so a cluster that
 	// hasn't opted in gets byte-identical Deployments to before; the role
@@ -185,13 +346,18 @@ func (cluster *Cluster) k8sDatabaseDeployment(s *ServerMonitor, port int, nodeHo
 									Name:      s.Name + "-persistent-storage",
 									MountPath: "/var/lib/mysql",
 								},
+								{
+									Name:      s.Name + "-init",
+									MountPath: "/docker-entrypoint-initdb.d",
+								},
 							},
 						},
 					},
 					Containers: []apiv1.Container{
 						{
-							Name:  s.Name,
-							Image: cluster.Conf.ProvDbImg,
+							Name:            s.Name,
+							Image:           cluster.Conf.ProvDbImg,
+							ImagePullPolicy: k8sImagePullPolicy(cluster),
 							Ports: []apiv1.ContainerPort{
 								{
 									Name:          "mysql",
@@ -201,8 +367,13 @@ func (cluster *Cluster) k8sDatabaseDeployment(s *ServerMonitor, port int, nodeHo
 							},
 							Env: []apiv1.EnvVar{
 								{
-									Name:  "MYSQL_ROOT_PASSWORD",
-									Value: s.Pass,
+									Name: "MYSQL_ROOT_PASSWORD",
+									ValueFrom: &apiv1.EnvVarSource{
+										SecretKeyRef: &apiv1.SecretKeySelector{
+											LocalObjectReference: apiv1.LocalObjectReference{Name: k8sSecretName(s)},
+											Key:                  k8sSecretKeyRootPassword,
+										},
+									},
 								},
 							},
 							VolumeMounts: []apiv1.VolumeMount{
@@ -216,6 +387,44 @@ func (cluster *Cluster) k8sDatabaseDeployment(s *ServerMonitor, port int, nodeHo
 								},
 							},
 						},
+						// dbjobs sidecar: runs backups/optimize/config-refresh via
+						// share/scripts/dbjobs_new.sh, fetched pre-resolved (every
+						// %%ENV:...%% placeholder, including JOBS_DATADIR, already
+						// substituted server-side by GenerateDatabaseConfig) as part
+						// of the same config archive the init container already
+						// fetches -- see the init container's Command above.
+						// Same pod as the DB container, so no netns/socket sharing
+						// is needed the way OpenSVC's own jobs container
+						// (OpenSVCGetJobsContainerSection, prov_opensvc_db.go) needs:
+						// Kubernetes pods share network by default, and the script
+						// connects over TCP (DB_CONN_PARAMETERS uses -h$MYSQL_SERVER,
+						// server.Host), not a local socket.
+						{
+							Name:    s.Name + "-dbjobs",
+							Image:   cluster.Conf.ProvDbImg,
+							Command: []string{"/bin/bash", "/docker-entrypoint-initdb.d/dbjobs_launcher_with_sigterm"},
+							Env: []apiv1.EnvVar{
+								{
+									Name: "MYSQL_ROOT_PASSWORD",
+									ValueFrom: &apiv1.EnvVarSource{
+										SecretKeyRef: &apiv1.SecretKeySelector{
+											LocalObjectReference: apiv1.LocalObjectReference{Name: k8sSecretName(s)},
+											Key:                  k8sSecretKeyRootPassword,
+										},
+									},
+								},
+							},
+							VolumeMounts: []apiv1.VolumeMount{
+								{
+									Name:      s.Name + "-persistent-storage",
+									MountPath: "/var/lib/mysql",
+								},
+								{
+									Name:      s.Name + "-init",
+									MountPath: "/docker-entrypoint-initdb.d",
+								},
+							},
+						},
 					},
 					Volumes: []apiv1.Volume{
 						{
@@ -224,6 +433,16 @@ func (cluster *Cluster) k8sDatabaseDeployment(s *ServerMonitor, port int, nodeHo
 								PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{
 									ClaimName: cluster.Name + "-" + s.Name + "-claim",
 								},
+							},
+						},
+						{
+							// dbjobs_new/dbjobs_launcher_with_sigterm/replication-manager-cli,
+							// populated by the init container, consumed by the dbjobs
+							// sidecar -- not the data PVC, since like -conf it's
+							// regenerated by the init container on every pod start.
+							Name: s.Name + "-init",
+							VolumeSource: apiv1.VolumeSource{
+								EmptyDir: &apiv1.EmptyDirVolumeSource{},
 							},
 						},
 						{
@@ -258,6 +477,10 @@ func (cluster *Cluster) K8SProvisionDatabaseService(s *ServerMonitor) {
 		}
 	}
 	cluster.k8sEnsureNamespace(client, cluster.Name)
+	if err := cluster.k8sEnsureDatabaseSecret(client, s); err != nil {
+		cluster.errorChan <- err
+		return
+	}
 
 	/*
 			apiVersion: v1
@@ -309,21 +532,7 @@ func (cluster *Cluster) K8SProvisionDatabaseService(s *ServerMonitor) {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator,LvlInfo, "Created Kubernetes physical volume %q.\n", pvresult.GetObjectMeta().GetName())
 	*/
 	persistentVolumeClaims := client.CoreV1().PersistentVolumeClaims(cluster.Name)
-	pvc := &apiv1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: cluster.Name + "-" + s.Name + "-claim",
-		},
-		Spec: apiv1.PersistentVolumeClaimSpec{
-			AccessModes: []apiv1.PersistentVolumeAccessMode{
-				apiv1.ReadWriteOnce,
-			},
-			Resources: apiv1.VolumeResourceRequirements{
-				Requests: apiv1.ResourceList{
-					apiv1.ResourceName(apiv1.ResourceStorage): resource.MustParse("1Gi"),
-				},
-			},
-		},
-	}
+	pvc := cluster.k8sDatabasePVC(s)
 	pvcresult, pvcerr := persistentVolumeClaims.Create(context.TODO(), pvc, metav1.CreateOptions{})
 	if pvcerr != nil && !apierrors.IsAlreadyExists(pvcerr) {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot deploy Kubernetes pvc %s ", pvcerr)
@@ -463,6 +672,44 @@ func (cluster *Cluster) K8SStartDatabaseService(s *ServerMonitor) error {
 		return err
 	}
 	return cluster.k8sStartDatabaseServiceWithClient(client, s.Name)
+}
+
+// k8sForceRepullDatabaseServiceWithClient triggers a rolling pod
+// replacement the same way `kubectl rollout restart` does -- patching the
+// pod template's own restartedAt annotation, which the Deployment
+// controller treats as a spec change and rolls out even though nothing
+// else differs. The container's ImagePullPolicy is patched in the same
+// call, to the *current* prov-kube-image-force-pull value: the Deployment
+// object itself only ever gets ImagePullPolicy at creation time
+// (k8sDatabaseDeployment), so toggling the setting later would otherwise
+// have no effect on an already-provisioned server -- IfNotPresent, in
+// particular, would then keep skipping the re-pull this action exists to
+// force. name (both the Deployment and its DB container's name, s.Name) is
+// a Kubernetes object name -- restricted to [a-z0-9-], so, like the pull
+// policy (one of two fixed constants), it can't contain characters that
+// need JSON escaping, unlike the password in k8sEnsureDatabaseSecret.
+// StrategicMergePatchType's containers[].name merge key targets that one
+// container without needing its other fields. Not Update(): same
+// resourceVersion problem as k8sEnsureDatabaseSecret had.
+func (cluster *Cluster) k8sForceRepullDatabaseServiceWithClient(client kubernetes.Interface, name string) error {
+	patch := []byte(`{"spec":{"template":{` +
+		`"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"` + time.Now().Format(time.RFC3339) + `"}},` +
+		`"spec":{"containers":[{"name":"` + name + `","imagePullPolicy":"` + string(k8sImagePullPolicy(cluster)) + `"}]}` +
+		`}}}`)
+	_, err := client.AppsV1().Deployments(cluster.Name).Patch(context.TODO(), name, ktypes.StrategicMergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot force image re-pull for %s: %s ", name, err)
+	}
+	return err
+}
+
+func (cluster *Cluster) K8SForceRepullDatabaseService(s *ServerMonitor) error {
+	client, err := cluster.K8SConnectAPI()
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot init Kubernetes client API %s ", err)
+		return err
+	}
+	return cluster.k8sForceRepullDatabaseServiceWithClient(client, s.Name)
 }
 
 // ConfigMap, PVC and Namespace are intentionally retained — PVC deletion is

--- a/cluster/prov_k8s_db.go
+++ b/cluster/prov_k8s_db.go
@@ -2,15 +2,31 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strconv"
 
 	"github.com/signal18/replication-manager/config"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
+
+// Never fatal: a least-privilege RBAC setup may grant no verb at all on the
+// cluster-scoped "namespaces" resource, so Create() can be Forbidden even when
+// the namespace already exists and provisioning would otherwise succeed. A
+// genuinely missing namespace still surfaces below, at the PVC/Deployment/
+// Service creates that actually need it.
+func (cluster *Cluster) k8sEnsureNamespace(client kubernetes.Interface, name string) {
+	namespace := &apiv1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	_, err := client.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn, "Cannot create namespace %s ", err)
+	}
+}
 
 func (cluster *Cluster) K8SProvisionDatabaseService(s *ServerMonitor) {
 
@@ -20,11 +36,11 @@ func (cluster *Cluster) K8SProvisionDatabaseService(s *ServerMonitor) {
 		cluster.errorChan <- err
 		return
 	}
-	namespace := &apiv1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.Name}}
-	_, err = client.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot create namespace %s ", err)
+	if cluster.Conf.APISecureConfig {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn,
+			"api-credentials-secure-config is enabled: the Kubernetes DB init-container config fetch sends no credentials and will get HTTP 403, so %s will not bootstrap", s.Name)
 	}
+	cluster.k8sEnsureNamespace(client, cluster.Name)
 
 	/*
 			apiVersion: v1
@@ -92,48 +108,62 @@ func (cluster *Cluster) K8SProvisionDatabaseService(s *ServerMonitor) {
 		},
 	}
 	pvcresult, pvcerr := persistentVolumeClaims.Create(context.TODO(), pvc, metav1.CreateOptions{})
-	if pvcerr != nil {
+	if pvcerr != nil && !apierrors.IsAlreadyExists(pvcerr) {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot deploy Kubernetes pvc %s ", pvcerr)
+		cluster.errorChan <- pvcerr
+		return
 	}
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Created Kubernetes physical volume claim %q.\n", pvcresult.GetObjectMeta().GetName())
+	if pvcerr == nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Created Kubernetes physical volume claim %q.\n", pvcresult.GetObjectMeta().GetName())
+	}
 
+	// Not mounted or consumed by the Deployment below (bootstrap is the HTTP
+	// init-container fetch further down) — best-effort only.
 	s.GetDatabaseConfig()
 	data, err := os.ReadFile(s.Datadir + "/config.tar.gz")
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Provision can not found file %s ", s.Datadir+"/config.tar.gz")
-	}
+	} else {
+		configMapName := s.Name + "-config-map"
+		configMap := apiv1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: cluster.Name,
+			},
+			BinaryData: map[string][]byte{
+				"config.tar.gz": data,
+			},
+		}
 
-	configMapName := s.Name + "-config-map"
-	configMap := apiv1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ConfigMap",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      configMapName,
-			Namespace: cluster.Name,
-		},
-		BinaryData: map[string][]byte{
-			"config.tar.gz": data,
-		},
-	}
-
-	//var cm *apiv1.ConfigMap
-	_, err = client.CoreV1().ConfigMaps(cluster.Name).Create(context.TODO(), &configMap, metav1.CreateOptions{})
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not provision config map  %s ", err)
+		_, cmerr := client.CoreV1().ConfigMaps(cluster.Name).Create(context.TODO(), &configMap, metav1.CreateOptions{})
+		if cmerr != nil && !apierrors.IsAlreadyExists(cmerr) {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not provision config map  %s ", cmerr)
+		}
 	}
 	deploymentsClient := client.AppsV1().Deployments(cluster.Name)
 
-	port, _ := strconv.Atoi(s.Port)
+	port, err := strconv.Atoi(s.Port)
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Invalid database port %s: %s ", s.Port, err)
+		cluster.errorChan <- err
+		return
+	}
 	agent, err := cluster.GetDatabaseAgent(s)
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not provision database  %s ", err)
 		cluster.errorChan <- err
 		return
 	}
-	var cmd []string
-	cmd = append(cmd, "sh -c 'wget -qO- http://"+cluster.Conf.MonitorAddress+":"+cluster.Conf.HttpPort+"/api/clusters/"+cluster.Name+"/servers/"+s.Name+"/"+s.Port+"/config|tar xzvf - -C /data'")
+	nodeHostnameLabel := cluster.k8sHostnameLabel(agent.HostName)
+	// No auth header: 403s if api-credentials-secure-config is enabled.
+	cmd := []string{
+		"sh", "-c",
+		"wget -qO- http://" + cluster.Conf.MonitorAddress + ":" + cluster.Conf.HttpPort + "/api/clusters/" + cluster.Name + "/servers/" + s.Name + "/" + s.Port + "/config|tar xzvf - -C /data",
+	}
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: s.Name,
@@ -155,7 +185,15 @@ func (cluster *Cluster) K8SProvisionDatabaseService(s *ServerMonitor) {
 				},
 				Spec: apiv1.PodSpec{
 					Hostname: s.Name,
-					NodeName: agent.HostName,
+					// NodeSelector, not NodeName: NodeName bypasses the scheduler
+					// entirely, which means a WaitForFirstConsumer StorageClass
+					// (the default for most dynamic provisioners) never binds the
+					// PVC, since that only happens during scheduling. NodeSelector
+					// pins the pod to the same node while still going through the
+					// scheduler.
+					NodeSelector: map[string]string{
+						"kubernetes.io/hostname": nodeHostnameLabel,
+					},
 					InitContainers: []apiv1.Container{
 						{
 							Name:    s.Name + "-init",
@@ -212,10 +250,14 @@ func (cluster *Cluster) K8SProvisionDatabaseService(s *ServerMonitor) {
 	// Create Deployment
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Creating Kubernetes deployment...")
 	result, err := deploymentsClient.Create(context.TODO(), deployment, metav1.CreateOptions{})
-	if err != nil {
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot deploy Kubernetes deployment %s ", err)
+		cluster.errorChan <- err
+		return
 	}
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Created Kubernetes deployment %q.\n", result.GetObjectMeta().GetName())
+	if err == nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Created Kubernetes deployment %q.\n", result.GetObjectMeta().GetName())
+	}
 	servicesClient := client.CoreV1().Services(cluster.Name)
 
 	service := &apiv1.Service{
@@ -239,50 +281,91 @@ func (cluster *Cluster) K8SProvisionDatabaseService(s *ServerMonitor) {
 	}
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Creating service...")
 	result2, err2 := servicesClient.Create(context.TODO(), service, metav1.CreateOptions{})
-	if err2 != nil {
+	if err2 != nil && !apierrors.IsAlreadyExists(err2) {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot deploy Kubernetes service %s ", err2)
 		cluster.errorChan <- err2
 		return
 	}
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Created Kubernetes service %s.\n", result2.GetObjectMeta().GetName())
+	if err2 == nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Created Kubernetes service %s.\n", result2.GetObjectMeta().GetName())
+	}
 	cluster.errorChan <- nil
 }
 
+// No scale-to-zero/drain semantic exists for the Deployment; an explicit
+// error here (not silent nil) makes RestartDatabaseService fail fast instead
+// of timing out in WaitDatabaseFailed for a stop that never happened.
 func (cluster *Cluster) K8SStopDatabaseService(s *ServerMonitor) error {
+	return errors.New("stop is not supported for the kubernetes orchestrator")
+}
+
+// No real start/scale-up exists either; this only confirms the Deployment is
+// present with a non-zero desired replica count before reporting success.
+func (cluster *Cluster) k8sStartDatabaseServiceWithClient(client kubernetes.Interface, name string) error {
+	dep, err := client.AppsV1().Deployments(cluster.Name).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot start database %s: deployment not found: %s ", name, err)
+		return err
+	}
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot start database %s: %s ", name, err)
+		return err
+	}
+	if dep.Spec.Replicas == nil || *dep.Spec.Replicas == 0 {
+		err := errors.New("database deployment " + name + " is scaled to zero and kubernetes start does not scale it back up")
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot start database %s: %s ", name, err)
+		return err
+	}
 	return nil
 }
 
 func (cluster *Cluster) K8SStartDatabaseService(s *ServerMonitor) error {
-	return nil
+	client, err := cluster.K8SConnectAPI()
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot init Kubernetes client API %s ", err)
+		return err
+	}
+	return cluster.k8sStartDatabaseServiceWithClient(client, s.Name)
 }
 
+// ConfigMap, PVC and Namespace are intentionally retained — PVC deletion is
+// destructive and retention semantics are an open question.
+func (cluster *Cluster) k8sUnprovisionDatabaseServiceWithClient(client kubernetes.Interface, name string) error {
+	deletePolicy := metav1.DeletePropagationForeground
+	var firstErr error
+
+	deploymentsClient := client.AppsV1().Deployments(cluster.Name)
+	if err := deploymentsClient.Delete(context.TODO(), name, metav1.DeleteOptions{
+		PropagationPolicy: &deletePolicy,
+	}); err != nil && !apierrors.IsNotFound(err) {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot delete Kubernetes deployment %s %s ", name, err)
+		firstErr = err
+	} else {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Deleted Kubernetes deployment %s.", name)
+	}
+
+	servicesClient := client.CoreV1().Services(cluster.Name)
+	if err := servicesClient.Delete(context.TODO(), name, metav1.DeleteOptions{
+		PropagationPolicy: &deletePolicy,
+	}); err != nil && !apierrors.IsNotFound(err) {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot delete Kubernetes service %s %s ", name, err)
+		if firstErr == nil {
+			firstErr = err
+		}
+	} else {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Deleted Kubernetes service %s.", name)
+	}
+
+	return firstErr
+}
+
+// Exactly one value is ever sent on cluster.errorChan.
 func (cluster *Cluster) K8SUnprovisionDatabaseService(s *ServerMonitor) {
 	client, err := cluster.K8SConnectAPI()
-	deploymentsClient := client.AppsV1().Deployments(cluster.Name)
-
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot init Kubernetes client API %s ", err)
 		cluster.errorChan <- err
 		return
 	}
-
-	deletePolicy := metav1.DeletePropagationForeground
-	if err := deploymentsClient.Delete(context.TODO(), s.Name, metav1.DeleteOptions{
-		PropagationPolicy: &deletePolicy,
-	}); err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot delete Kubernetes deployment %s %s ", s.Name, err)
-		cluster.errorChan <- err
-	}
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Deleted Kubernetes deployment %s.", s.Name)
-	servicesClient := client.CoreV1().Services(cluster.Name)
-	if err := servicesClient.Delete(context.TODO(), s.Name, metav1.DeleteOptions{
-		PropagationPolicy: &deletePolicy,
-	}); err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot delete Kubernetes service %s %s ", s.Name, err)
-		cluster.errorChan <- err
-	}
-
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Deleted Kubernetes service %s.", s.Name)
-	cluster.errorChan <- nil
-
+	cluster.errorChan <- cluster.k8sUnprovisionDatabaseServiceWithClient(client, s.Name)
 }

--- a/cluster/prov_k8s_manifest.go
+++ b/cluster/prov_k8s_manifest.go
@@ -1,0 +1,102 @@
+package cluster
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
+)
+
+// K8SDatabaseManifests is the read-only, live-fetched counterpart to
+// GetDatabaseServiceConfig (OpenSVC): OpenSVC's viewer shows the template
+// repman would push, but Kubernetes has no equivalent single "service
+// config" -- what's actually useful is what's actually running, so every
+// field here is fetched live from the API server, not re-rendered from
+// k8sDatabaseDeployment/k8sDatabasePVC (#1497 gap 6).
+type K8SDatabaseManifests struct {
+	Deployment string `json:"deployment"`
+	Service    string `json:"service"`
+	PVC        string `json:"pvc"`
+	Pods       string `json:"pods"`
+}
+
+// yamlOrError marshals a live-fetched object to YAML for display, or
+// renders the fetch error as a YAML comment -- NotFound is expected and
+// common (e.g. no PVC yet on a server that failed provisioning before that
+// step), so the GUI shows why a section is empty instead of a raw 500.
+func k8sManifestYAMLOrError(obj interface{}, err error) string {
+	if err != nil {
+		return "# " + err.Error() + "\n"
+	}
+	b, merr := yaml.Marshal(obj)
+	if merr != nil {
+		return "# error rendering manifest: " + merr.Error() + "\n"
+	}
+	return string(b)
+}
+
+// k8sDatabaseManifestsFromClient is the *FromClient testable half (same
+// split as k8sStorageClassesFromClient/K8SGetStorageClasses) -- resource
+// names/namespace/selector here must match what k8sDatabaseDeployment
+// (Deployment/Service name == s.Name), k8sDatabasePVC (claim name), and the
+// pod labels it sets actually create, or every section 404s against a
+// genuinely-provisioned server.
+func (cluster *Cluster) k8sDatabaseManifestsFromClient(client kubernetes.Interface, s *ServerMonitor) K8SDatabaseManifests {
+	ns := cluster.Name
+
+	dep, err := client.AppsV1().Deployments(ns).Get(context.TODO(), s.Name, metav1.GetOptions{})
+	if err == nil {
+		dep.ManagedFields = nil
+		dep.TypeMeta = metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}
+	}
+	deployment := k8sManifestYAMLOrError(dep, err)
+
+	svc, err := client.CoreV1().Services(ns).Get(context.TODO(), s.Name, metav1.GetOptions{})
+	if err == nil {
+		svc.ManagedFields = nil
+		svc.TypeMeta = metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}
+	}
+	service := k8sManifestYAMLOrError(svc, err)
+
+	pvcName := cluster.Name + "-" + s.Name + "-claim"
+	pvc, err := client.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), pvcName, metav1.GetOptions{})
+	if err == nil {
+		pvc.ManagedFields = nil
+		pvc.TypeMeta = metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"}
+	}
+	pvcYAML := k8sManifestYAMLOrError(pvc, err)
+
+	pods, err := client.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "app=repication-manager,tag=" + s.Name,
+	})
+	if err == nil {
+		for i := range pods.Items {
+			pods.Items[i].ManagedFields = nil
+			pods.Items[i].TypeMeta = metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}
+		}
+		pods.TypeMeta = metav1.TypeMeta{Kind: "PodList", APIVersion: "v1"}
+	}
+	podsYAML := k8sManifestYAMLOrError(pods, err)
+
+	return K8SDatabaseManifests{
+		Deployment: deployment,
+		Service:    service,
+		PVC:        pvcYAML,
+		Pods:       podsYAML,
+	}
+}
+
+// K8SGetDatabaseManifests is the live-connecting wrapper (see
+// K8SGetStorageClasses for the same pattern) -- a connection failure
+// (kubeconfig unreachable, etc.) surfaces as an error comment in every
+// section rather than an empty response, since the caller (the API
+// handler) always returns 200 with this struct regardless.
+func (cluster *Cluster) K8SGetDatabaseManifests(s *ServerMonitor) K8SDatabaseManifests {
+	client, err := cluster.K8SConnectAPI()
+	if err != nil {
+		errText := "# " + err.Error() + "\n"
+		return K8SDatabaseManifests{Deployment: errText, Service: errText, PVC: errText, Pods: errText}
+	}
+	return cluster.k8sDatabaseManifestsFromClient(client, s)
+}

--- a/cluster/prov_k8s_manifest_test.go
+++ b/cluster/prov_k8s_manifest_test.go
@@ -1,0 +1,128 @@
+package cluster
+
+import (
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestK8SDatabaseManifests_FetchesLiveDeploymentServicePVCPods(t *testing.T) {
+	cluster := newTestCluster("clustera")
+	s := &ServerMonitor{Name: "clustera-0", Port: "3306"}
+
+	client := fake.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "clustera-0", Namespace: "clustera"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: int32Ptr(1),
+			},
+		},
+		&apiv1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "clustera-0", Namespace: "clustera"},
+		},
+		&apiv1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "clustera-clustera-0-claim", Namespace: "clustera"},
+		},
+		&apiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "clustera-0-abc123",
+				Namespace: "clustera",
+				Labels:    map[string]string{"app": "repication-manager", "tag": "clustera-0"},
+			},
+			Status: apiv1.PodStatus{Phase: apiv1.PodRunning},
+		},
+	)
+
+	m := cluster.k8sDatabaseManifestsFromClient(client, s)
+
+	if !strings.Contains(m.Deployment, "kind: Deployment") {
+		t.Fatalf("expected Deployment YAML with kind set, got: %s", m.Deployment)
+	}
+	if !strings.Contains(m.Service, "kind: Service") {
+		t.Fatalf("expected Service YAML with kind set, got: %s", m.Service)
+	}
+	if !strings.Contains(m.PVC, "kind: PersistentVolumeClaim") {
+		t.Fatalf("expected PVC YAML with kind set, got: %s", m.PVC)
+	}
+	if !strings.Contains(m.Pods, "clustera-0-abc123") || !strings.Contains(m.Pods, "Running") {
+		t.Fatalf("expected Pods YAML to include the live pod's name and phase, got: %s", m.Pods)
+	}
+}
+
+// A server with no Deployment yet (e.g. provisioning failed before that
+// step, or it was never provisioned) must surface *why* each section is
+// empty, not silently omit it or 500 the whole response -- the GUI always
+// gets a 200 with this struct (see K8SGetDatabaseManifests).
+func TestK8SDatabaseManifests_MissingResourcesReportNotFoundNotPanic(t *testing.T) {
+	cluster := newTestCluster("clustera")
+	s := &ServerMonitor{Name: "clustera-9", Port: "3306"}
+	client := fake.NewSimpleClientset()
+
+	m := cluster.k8sDatabaseManifestsFromClient(client, s)
+
+	for name, got := range map[string]string{"Deployment": m.Deployment, "Service": m.Service, "PVC": m.PVC} {
+		if !strings.Contains(got, "not found") {
+			t.Fatalf("expected %s section to report a not-found error, got: %s", name, got)
+		}
+	}
+	// An empty pod list is not an error -- List() succeeds with zero items.
+	if strings.Contains(m.Pods, "not found") {
+		t.Fatalf("expected an empty pod list, not a not-found error, got: %s", m.Pods)
+	}
+}
+
+// The pod selector must match exactly what k8sDatabaseDeployment actually
+// labels pods with (app=repication-manager, tag=<server name>) -- a pod
+// belonging to a different server in the same namespace must never leak
+// into this server's manifest view.
+func TestK8SDatabaseManifests_PodSelectorScopedToServer(t *testing.T) {
+	cluster := newTestCluster("clustera")
+	s := &ServerMonitor{Name: "clustera-0", Port: "3306"}
+	client := fake.NewSimpleClientset(
+		&apiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "clustera-0-pod",
+				Namespace: "clustera",
+				Labels:    map[string]string{"app": "repication-manager", "tag": "clustera-0"},
+			},
+		},
+		&apiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "clustera-1-pod",
+				Namespace: "clustera",
+				Labels:    map[string]string{"app": "repication-manager", "tag": "clustera-1"},
+			},
+		},
+	)
+
+	m := cluster.k8sDatabaseManifestsFromClient(client, s)
+
+	if !strings.Contains(m.Pods, "clustera-0-pod") {
+		t.Fatalf("expected clustera-0's own pod in the result, got: %s", m.Pods)
+	}
+	if strings.Contains(m.Pods, "clustera-1-pod") {
+		t.Fatalf("expected clustera-1's pod to be excluded, got: %s", m.Pods)
+	}
+}
+
+// K8SConnectAPI failure (unreachable kubeconfig, etc.) must still return a
+// 200-shaped struct with the error visible in every section, matching what
+// the API handler always does -- not a nil struct or a panic.
+func TestK8SGetDatabaseManifests_ConnectFailureReportsErrorInEverySection(t *testing.T) {
+	cluster := newTestCluster("clustera")
+	cluster.Conf.KubeConfig = "/nonexistent/kubeconfig-path-for-test"
+	s := &ServerMonitor{Name: "clustera-0", Port: "3306"}
+
+	m := cluster.K8SGetDatabaseManifests(s)
+
+	for name, got := range map[string]string{"Deployment": m.Deployment, "Service": m.Service, "PVC": m.PVC, "Pods": m.Pods} {
+		if !strings.HasPrefix(got, "# ") {
+			t.Fatalf("expected %s section to render the connect error as a YAML comment, got: %s", name, got)
+		}
+	}
+}

--- a/cluster/prov_k8s_prx.go
+++ b/cluster/prov_k8s_prx.go
@@ -8,34 +8,66 @@ import (
 	"github.com/signal18/replication-manager/config"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
-func (cluster *Cluster) K8SProvisionProxyService(prx DatabaseProxy) {
-	clientset, err := cluster.K8SConnectAPI()
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot init Kubernetes client API %s ", err)
-		cluster.errorChan <- err
-		return
-	}
+// Unique per proxy instance: a shared name/selector would collide across
+// proxies in the same cluster.
+func k8sProxyDeploymentName(clusterName, proxyName string) string {
+	return clusterName + "-" + proxyName + "-deployment"
+}
 
-	deploymentsClient := clientset.AppsV1().Deployments(cluster.Name)
-	port, _ := strconv.Atoi(prx.GetPort())
+// Shared cluster-wide across every proxy — never auto-deleted, since no
+// single-proxy-scoped operation can prove it belongs to that proxy rather
+// than a different, not-yet-migrated one in the same cluster.
+func k8sLegacyProxyDeploymentName(clusterName string) string {
+	return clusterName + "-deployment"
+}
+
+// Read-only: never deletes, only warns. Its selector ("app: repication-manager"
+// only) label-matches new per-proxy Deployments' pods too, and a proxy that
+// never migrated off it would otherwise look successfully unprovisioned while
+// still running. See doc/implementation/cluster/KUBERNETES_PROVISIONING.md.
+func (cluster *Cluster) k8sWarnIfLegacyProxyDeploymentExists(client kubernetes.Interface) {
+	name := k8sLegacyProxyDeploymentName(cluster.Name)
+	if _, err := client.AppsV1().Deployments(cluster.Name).Get(context.TODO(), name, metav1.GetOptions{}); err == nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn,
+			"Legacy Kubernetes proxy deployment %s still exists alongside per-proxy deployments — see doc/implementation/cluster/KUBERNETES_PROVISIONING.md for manual migration steps", name)
+	}
+}
+
+// Only creates a Deployment: no Namespace ensure, no Service, no config
+// bootstrap/ConfigMap, and ProvProxProxysqlImg is used regardless of proxy
+// type. See doc/implementation/cluster/KUBERNETES_PROVISIONING.md.
+func (cluster *Cluster) k8sProvisionProxyServiceWithClient(client kubernetes.Interface, prx DatabaseProxy) error {
+	cluster.k8sWarnIfLegacyProxyDeploymentExists(client)
+
+	deploymentsClient := client.AppsV1().Deployments(cluster.Name)
+	port, err := strconv.Atoi(prx.GetPort())
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Invalid proxy port %s: %s ", prx.GetPort(), err)
+		return err
+	}
+	deploymentName := k8sProxyDeploymentName(cluster.Name, prx.GetName())
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: cluster.Name + "-deployment",
+			Name: deploymentName,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: int32Ptr(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": "repication-manager",
+					"tag": prx.GetName(),
 				},
 			},
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"app": "repication-manager",
+						"tag": prx.GetName(),
 					},
 				},
 				Spec: apiv1.PodSpec{
@@ -60,17 +92,49 @@ func (cluster *Cluster) K8SProvisionProxyService(prx DatabaseProxy) {
 	// Create Deployment
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Creating deployment...")
 	result, err := deploymentsClient.Create(context.TODO(), deployment, metav1.CreateOptions{})
-
-	if err != nil {
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot deploy Kubernetes service %s ", err)
-		cluster.errorChan <- err
+		return err
 	}
-	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Created deployment %q.\n", result.GetObjectMeta().GetName())
-	cluster.errorChan <- nil
+	if err == nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Created deployment %q.\n", result.GetObjectMeta().GetName())
+	}
+	return nil
+}
+
+func (cluster *Cluster) K8SProvisionProxyService(prx DatabaseProxy) {
+	clientset, err := cluster.K8SConnectAPI()
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot init Kubernetes client API %s ", err)
+		cluster.errorChan <- err
+		return
+	}
+	cluster.errorChan <- cluster.k8sProvisionProxyServiceWithClient(clientset, prx)
+}
+
+func (cluster *Cluster) k8sUnprovisionProxyServiceWithClient(client kubernetes.Interface, prx DatabaseProxy) error {
+	deletePolicy := metav1.DeletePropagationForeground
+	deploymentName := k8sProxyDeploymentName(cluster.Name, prx.GetName())
+	if err := client.AppsV1().Deployments(cluster.Name).Delete(context.TODO(), deploymentName, metav1.DeleteOptions{
+		PropagationPolicy: &deletePolicy,
+	}); err != nil && !apierrors.IsNotFound(err) {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot delete Kubernetes deployment %s %s ", deploymentName, err)
+		return err
+	}
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "Deleted Kubernetes deployment %s.", deploymentName)
+
+	cluster.k8sWarnIfLegacyProxyDeploymentExists(client)
+	return nil
 }
 
 func (cluster *Cluster) K8SUnprovisionProxyService(prx DatabaseProxy) {
-	cluster.errorChan <- nil
+	clientset, err := cluster.K8SConnectAPI()
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot init Kubernetes client API %s ", err)
+		cluster.errorChan <- err
+		return
+	}
+	cluster.errorChan <- cluster.k8sUnprovisionProxyServiceWithClient(clientset, prx)
 }
 
 func (cluster *Cluster) K8SStartProxyService(server DatabaseProxy) error {

--- a/cluster/prov_k8s_test.go
+++ b/cluster/prov_k8s_test.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"context"
+	"encoding/base64"
+	"strings"
 	"testing"
 
 	"github.com/signal18/replication-manager/config"
@@ -416,5 +418,377 @@ func TestK8SUnprovisionDatabase_GenuineDeleteFailurePropagates(t *testing.T) {
 	err := cluster.k8sUnprovisionDatabaseServiceWithClient(client, "db1")
 	if err == nil {
 		t.Fatal("expected the genuine deployment-delete failure to be reported, not swallowed")
+	}
+}
+
+// --- Container port ---
+//
+// No HostPort: reachability comes from the headless-service DNS record.
+
+func TestK8SDatabaseDeployment_NoHostPortBinding(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+
+	ports := dep.Spec.Template.Spec.Containers[0].Ports
+	if len(ports) != 1 {
+		t.Fatalf("expected exactly one container port, got %d", len(ports))
+	}
+	if ports[0].HostPort != 0 {
+		t.Fatalf("expected no HostPort binding (DNS is the only reachability path now), got %d", ports[0].HostPort)
+	}
+	if ports[0].ContainerPort != 3306 {
+		t.Fatalf("expected ContainerPort to track the port argument, got %d", ports[0].ContainerPort)
+	}
+}
+
+// --- Config-bootstrap Basic Auth (init container) ---
+//
+// Credentials are sent as a base64 Authorization header for the "admin"
+// user -- the same fixed-account convention every other bootstrap
+// credential injection in this codebase uses (GetExecEnv, OpenSVC's
+// secrets injection, onpremise env exports), not "whichever api-credentials
+// entry is configured first" (which may lack the grant /config requires).
+// Only sent when api-credentials-secure-config actually requires it.
+
+func TestK8SDatabaseDeployment_ConfigFetchUsesBasicAuthHeader(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.APISecureConfig = true
+	cluster.APIUsers = map[string]APIUser{"admin": {User: "admin", Password: "s3cr3t"}}
+	cluster.Conf.MonitorAddress = "127.0.0.1"
+	cluster.Conf.HttpPort = "10005"
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+	cmd := strings.Join(dep.Spec.Template.Spec.InitContainers[0].Command, " ")
+
+	if strings.Contains(cmd, "admin:s3cr3t") || strings.Contains(cmd, "admin:s3cr3t@") {
+		t.Fatalf("expected credentials to never appear in cleartext in the init container command, got: %s", cmd)
+	}
+	wantHeader := "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte("admin:s3cr3t"))
+	if !strings.Contains(cmd, wantHeader) {
+		t.Fatalf("expected the base64-encoded Basic Auth header %q in the init container command, got: %s", wantHeader, cmd)
+	}
+}
+
+// A credential with shell metacharacters must not change what the shell
+// actually executes.
+func TestK8SDatabaseDeployment_ConfigFetchAuthSafeWithShellMetacharacters(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.APISecureConfig = true
+	cluster.APIUsers = map[string]APIUser{"admin": {User: "admin", Password: `p"$(rm -rf /)"\`}}
+	cluster.Conf.MonitorAddress = "127.0.0.1"
+	cluster.Conf.HttpPort = "10005"
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+	cmd := strings.Join(dep.Spec.Template.Spec.InitContainers[0].Command, " ")
+
+	for _, meta := range []string{"$(", "`", "\"$", ";rm"} {
+		if strings.Contains(cmd, meta) {
+			t.Fatalf("expected no raw shell metacharacter sequence %q from the credential to reach the command, got: %s", meta, cmd)
+		}
+	}
+}
+
+// No admin user configured falls back to the documented default password
+// "repman" -- matching api-credentials' own CLI default ("admin:repman"),
+// never silently skipping auth when secure-config requires it.
+func TestK8SDatabaseDeployment_ConfigFetchFallsBackToDefaultAdminPassword(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.APISecureConfig = true
+	cluster.Conf.MonitorAddress = "127.0.0.1"
+	cluster.Conf.HttpPort = "10005"
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+	cmd := strings.Join(dep.Spec.Template.Spec.InitContainers[0].Command, " ")
+
+	wantHeader := "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte("admin:repman"))
+	if !strings.Contains(cmd, wantHeader) {
+		t.Fatalf("expected the default admin:repman header %q, got: %s", wantHeader, cmd)
+	}
+}
+
+// A non-admin api-credentials entry, even a differently-privileged one
+// configured alongside admin, must never end up in the bootstrap header --
+// only the admin user's own password is ever used.
+func TestK8SDatabaseDeployment_ConfigFetchIgnoresNonAdminUsers(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.APISecureConfig = true
+	cluster.APIUsers = map[string]APIUser{
+		"admin": {User: "admin", Password: "admin-pass"},
+		"dba":   {User: "dba", Password: "dba-pass"},
+	}
+	cluster.Conf.MonitorAddress = "127.0.0.1"
+	cluster.Conf.HttpPort = "10005"
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+	cmd := strings.Join(dep.Spec.Template.Spec.InitContainers[0].Command, " ")
+
+	wantHeader := "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte("admin:admin-pass"))
+	if !strings.Contains(cmd, wantHeader) {
+		t.Fatalf("expected the admin user's own header %q, got: %s", wantHeader, cmd)
+	}
+	if strings.Contains(cmd, "dba-pass") {
+		t.Fatalf("expected the dba user's credential to never be used, got: %s", cmd)
+	}
+}
+
+// api-credentials-secure-config off means the endpoint doesn't enforce auth
+// at all -- embedding a real admin credential in every Deployment spec
+// regardless would be needless exposure, so no header should be sent.
+func TestK8SDatabaseDeployment_ConfigFetchNoAuthHeaderWhenSecureConfigOff(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.APISecureConfig = false
+	cluster.APIUsers = map[string]APIUser{"admin": {User: "admin", Password: "s3cr3t"}}
+	cluster.Conf.MonitorAddress = "127.0.0.1"
+	cluster.Conf.HttpPort = "10005"
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+	cmd := strings.Join(dep.Spec.Template.Spec.InitContainers[0].Command, " ")
+
+	if strings.Contains(cmd, "Authorization") || strings.Contains(cmd, "s3cr3t") {
+		t.Fatalf("expected no Authorization header when api-credentials-secure-config is off, got: %s", cmd)
+	}
+}
+
+// GetServerFromURL (cluster_get.go), which handlerMuxServersPortConfig uses
+// to resolve the init container's request, matches only server.Host -- the
+// domain-qualified name when prov-net-cni is on -- never the bare s.Name.
+// The request path must match what GetServerFromURL actually looks for, or
+// every config fetch 500s ("No server") on a freshly (re)provisioned pod
+// (confirmed live: this exact mismatch broke clusterin's bootstrap).
+func TestK8SDatabaseDeployment_ConfigFetchURLMatchesServerHost(t *testing.T) {
+	cluster := newTestCluster("clustera")
+	cluster.Conf.ProvNetCNI = true
+	cluster.Conf.ProvOrchestrator = config.ConstOrchestratorKubernetes
+	cluster.Conf.ProvOrchestratorCluster = "cluster.local"
+	cluster.Conf.MonitorAddress = "127.0.0.1"
+	cluster.Conf.HttpPort = "10005"
+	s := &ServerMonitor{Name: "clustera-0", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+	cmd := strings.Join(dep.Spec.Template.Spec.InitContainers[0].Command, " ")
+
+	wantPath := "/servers/clustera-0.db.clustera.svc.cluster.local/3306/config"
+	if !strings.Contains(cmd, wantPath) {
+		t.Fatalf("expected the request path to use the domain-qualified name %q (matching server.Host), got: %s", wantPath, cmd)
+	}
+}
+
+func TestK8SDatabaseDeployment_ConfigFetchURLStaysBareWhenProvNetCNIDisabled(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvNetCNI = false
+	cluster.Conf.MonitorAddress = "127.0.0.1"
+	cluster.Conf.HttpPort = "10005"
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+	cmd := strings.Join(dep.Spec.Template.Spec.InitContainers[0].Command, " ")
+
+	wantPath := "/servers/db1/3306/config"
+	if !strings.Contains(cmd, wantPath) {
+		t.Fatalf("expected the bare short name in the request path when prov-net-cni is off, got: %s", cmd)
+	}
+}
+
+// --- Headless Service DNS (per-pod names that follow pod recreation) ---
+
+func TestK8SDatabaseDeployment_SubdomainMatchesHeadlessServiceName(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvNetCNI = true
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+
+	got := dep.Spec.Template.Spec.Subdomain
+	want := k8sHeadlessServiceName
+	if got != want {
+		t.Fatalf("expected Pod Subdomain to match the headless service name %q, got %q", want, got)
+	}
+}
+
+// prov-net-cni gates the whole mechanism; disabled must stay byte-identical
+// to before.
+func TestK8SDatabaseDeployment_NoSubdomainWhenProvNetCNIDisabled(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvNetCNI = false
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+
+	if got := dep.Spec.Template.Spec.Subdomain; got != "" {
+		t.Fatalf("expected no Subdomain when prov-net-cni is disabled, got %q", got)
+	}
+}
+
+// The Service selector and pod labels are defined in two places -- assert
+// they agree, or the Service silently gets zero endpoints.
+func TestK8SDatabaseDeployment_PodLabelsSatisfyHeadlessServiceSelector(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvNetCNI = true
+	cluster.k8sEnsureHeadlessService(client, 3306)
+	svc, err := client.CoreV1().Services("k8stest").Get(context.TODO(), k8sHeadlessServiceName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+	podLabels := dep.Spec.Template.ObjectMeta.Labels
+
+	for k, want := range svc.Spec.Selector {
+		if got := podLabels[k]; got != want {
+			t.Fatalf("headless Service selects %s=%q, but DB pod is labeled %s=%q -- Service would get zero endpoints", k, want, k, got)
+		}
+	}
+}
+
+func TestK8SEnsureHeadlessService_CreatesClusterIPNone(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	cluster := newTestCluster("k8stest")
+
+	cluster.k8sEnsureHeadlessService(client, 3306)
+
+	svc, err := client.CoreV1().Services("k8stest").Get(context.TODO(), k8sHeadlessServiceName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected the headless service to have been created, got error: %s", err)
+	}
+	if svc.Spec.ClusterIP != apiv1.ClusterIPNone {
+		t.Fatalf("expected ClusterIP %q (headless), got %q", apiv1.ClusterIPNone, svc.Spec.ClusterIP)
+	}
+}
+
+func TestK8SEnsureHeadlessService_AlreadyExistsDoesNotPanic(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	client := fake.NewSimpleClientset(&apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: k8sHeadlessServiceName, Namespace: "k8stest"},
+	})
+
+	cluster.k8sEnsureHeadlessService(client, 3306)
+}
+
+func TestK8SEnsureHeadlessService_SelectsEveryDBPodNotJustOneServer(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	cluster := newTestCluster("k8stest")
+
+	cluster.k8sEnsureHeadlessService(client, 3306)
+
+	svc, err := client.CoreV1().Services("k8stest").Get(context.TODO(), k8sHeadlessServiceName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if _, ok := svc.Spec.Selector["tag"]; ok {
+		t.Fatal("expected the headless service to select on \"app\" alone, not a per-server \"tag\" -- a per-server tag would mean only one server's pod ever gets a published DNS record")
+	}
+	if svc.Spec.Selector["app"] != "repication-manager" {
+		t.Fatalf("expected selector app=repication-manager, got %q", svc.Spec.Selector["app"])
+	}
+}
+
+// --- Cluster DNS domain (prov-orchestrator-cluster) ---
+
+func TestK8SClusterDomain_UsesConfiguredValue(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvOrchestratorCluster = "k8s.internal"
+
+	if got := k8sClusterDomain(cluster); got != "k8s.internal" {
+		t.Fatalf("expected the configured prov-orchestrator-cluster value, got %q", got)
+	}
+}
+
+func TestK8SClusterDomain_FallsBackWhenUnset(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvOrchestratorCluster = ""
+
+	if got := k8sClusterDomain(cluster); got != "cluster.local" {
+		t.Fatalf("expected the Kubernetes default cluster.local when unset, got %q", got)
+	}
+}
+
+// "local" is prov-orchestrator-cluster's own CLI default (server/server.go)
+// -- an OpenSVC-oriented value, never a real Kubernetes --cluster-domain --
+// so a cluster that never touched this flag must still get "cluster.local",
+// not a malformed ".svc.local" CoreDNS can't resolve.
+func TestK8SClusterDomain_FallsBackWhenLiteralCLIDefault(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvOrchestratorCluster = "local"
+
+	if got := k8sClusterDomain(cluster); got != "cluster.local" {
+		t.Fatalf("expected the CLI default \"local\" to fall back to cluster.local, got %q", got)
+	}
+}
+
+// --- GetDomain (cluster_get.go): Kubernetes routes through the headless
+// Service, OpenSVC keeps its original plain-namespace shape ---
+
+func TestGetDomain_KubernetesRoutesThroughHeadlessService(t *testing.T) {
+	cluster := newTestCluster("clustera")
+	cluster.Conf.ProvNetCNI = true
+	cluster.Conf.ProvOrchestrator = config.ConstOrchestratorKubernetes
+	cluster.Conf.ProvOrchestratorCluster = "cluster.local"
+
+	got := cluster.GetDomain()
+	want := ".db.clustera.svc.cluster.local"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestGetDomain_KubernetesTracksNonDefaultClusterDomain(t *testing.T) {
+	cluster := newTestCluster("clustera")
+	cluster.Conf.ProvNetCNI = true
+	cluster.Conf.ProvOrchestrator = config.ConstOrchestratorKubernetes
+	cluster.Conf.ProvOrchestratorCluster = "k8s.internal"
+
+	got := cluster.GetDomain()
+	want := ".db.clustera.svc.k8s.internal"
+	if got != want {
+		t.Fatalf("expected the domain to track the configured cluster domain, got %q (want %q)", got, want)
+	}
+}
+
+func TestGetDomain_OpenSVCUnaffectedByKubernetesChange(t *testing.T) {
+	cluster := newTestCluster("clustera")
+	cluster.Conf.ProvNetCNI = true
+	cluster.Conf.ProvOrchestrator = config.ConstOrchestratorOpenSVC
+	cluster.Conf.ProvOrchestratorCluster = "signal18.id"
+
+	got := cluster.GetDomain()
+	want := ".clustera.svc.signal18.id"
+	if got != want {
+		t.Fatalf("expected OpenSVC's plain-namespace shape to be untouched, got %q (want %q)", got, want)
+	}
+}
+
+// prov-net-cni set in [DEFAULT] must not leak a domain for a cluster whose
+// orchestrator isn't OpenSVC.
+func TestGetDomain_OnPremiseIgnoresProvNetCNI(t *testing.T) {
+	cluster := newTestCluster("clustera")
+	cluster.Conf.ProvNetCNI = true
+	cluster.Conf.ProvOrchestrator = config.ConstOrchestratorOnPremise
+	cluster.Conf.ProvOrchestratorCluster = "signal18.id"
+
+	if got := cluster.GetDomain(); got != "" {
+		t.Fatalf("expected prov-net-cni to have no effect on a non-OpenSVC orchestrator, got %q", got)
+	}
+}
+
+func TestGetDomainHeadCluster_KubernetesRoutesThroughParentsHeadlessService(t *testing.T) {
+	cluster := newTestCluster("clustera-child")
+	cluster.Conf.ProvNetCNI = true
+	cluster.Conf.ProvOrchestrator = config.ConstOrchestratorKubernetes
+	cluster.Conf.ProvOrchestratorCluster = "cluster.local"
+	cluster.Conf.ClusterHead = "clustera"
+
+	got := cluster.GetDomainHeadCluster()
+	want := ".db.clustera.svc.cluster.local"
+	if got != want {
+		t.Fatalf("expected the parent's own headless service name, got %q (want %q)", got, want)
 	}
 }

--- a/cluster/prov_k8s_test.go
+++ b/cluster/prov_k8s_test.go
@@ -1,0 +1,385 @@
+package cluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func newTestCluster(name string) *Cluster {
+	return &Cluster{Name: name, Conf: &config.Config{}}
+}
+
+// Embeds a nil DatabaseProxy so only GetName/GetPort need overriding.
+type fakeProxy struct {
+	DatabaseProxy
+	name string
+	port string
+}
+
+func (f *fakeProxy) GetName() string { return f.name }
+func (f *fakeProxy) GetPort() string { return f.port }
+
+// --- K8SGetNodes / node discovery safety ---
+
+func TestK8SAgentFromNode_NoAddresses(t *testing.T) {
+	n := apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+		Status: apiv1.NodeStatus{
+			Addresses: nil, // node reporting no addresses must not panic
+			Capacity: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("2"),
+				apiv1.ResourceMemory: resource.MustParse("4Gi"),
+			},
+			Allocatable: apiv1.ResourceList{
+				apiv1.ResourceMemory: resource.MustParse("3Gi"),
+			},
+		},
+	}
+
+	agent, address, hostnameLabel := k8sAgentFromNode(n)
+	if address != "" {
+		t.Fatalf("expected empty address for node with no reported addresses, got %q", address)
+	}
+	if agent.HostName != "node-1" {
+		t.Fatalf("expected HostName to be preserved as the Kubernetes node name, got %q", agent.HostName)
+	}
+	if agent.CpuCores != 2 {
+		t.Fatalf("expected 2 CPU cores, got %d", agent.CpuCores)
+	}
+	if hostnameLabel != "" {
+		t.Fatalf("expected empty hostname label when the node has no labels, got %q", hostnameLabel)
+	}
+}
+
+func TestK8SAgentFromNode_WithAddress(t *testing.T) {
+	n := apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-2",
+			Labels: map[string]string{"kubernetes.io/hostname": "node-2-label"},
+		},
+		Status: apiv1.NodeStatus{
+			Addresses: []apiv1.NodeAddress{{Type: apiv1.NodeInternalIP, Address: "10.0.0.5"}},
+		},
+	}
+	_, address, hostnameLabel := k8sAgentFromNode(n)
+	if address != "10.0.0.5" {
+		t.Fatalf("expected address 10.0.0.5, got %q", address)
+	}
+	if hostnameLabel != "node-2-label" {
+		t.Fatalf("expected hostname label node-2-label, got %q", hostnameLabel)
+	}
+}
+
+func TestK8SNodesFromClient_ListError(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, context.DeadlineExceeded
+	})
+
+	cluster := newTestCluster("k8stest")
+	agents, err := cluster.k8sNodesFromClient(client)
+	if err == nil {
+		t.Fatal("expected error to propagate from a failed node List(), got nil")
+	}
+	if agents != nil {
+		t.Fatalf("expected nil agents on list error, got %v", agents)
+	}
+}
+
+func TestK8SNodesFromClient_Success(t *testing.T) {
+	client := fake.NewSimpleClientset(&apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-a"},
+	})
+	cluster := newTestCluster("k8stest")
+	agents, err := cluster.k8sNodesFromClient(client)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(agents) != 1 || agents[0].HostName != "node-a" {
+		t.Fatalf("expected one agent named node-a, got %v", agents)
+	}
+}
+
+// --- Node hostname-label resolution for NodeSelector ---
+//
+// k8sHostnameLabel reads a cache populated by k8sNodesFromClient's nodes/list
+// call, not a per-node nodes/get — a least-privilege RBAC setup that grants
+// nodes/list but not nodes/get still resolves the label correctly.
+
+func TestK8SHostnameLabel_LabelDiffersFromNodeName(t *testing.T) {
+	client := fake.NewSimpleClientset(&apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a.internal",
+			Labels: map[string]string{"kubernetes.io/hostname": "node-a"},
+		},
+	})
+	cluster := newTestCluster("k8stest")
+	if _, err := cluster.k8sNodesFromClient(client); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	got := cluster.k8sHostnameLabel("node-a.internal")
+	if got != "node-a" {
+		t.Fatalf("expected the actual hostname label value %q, got %q", "node-a", got)
+	}
+}
+
+func TestK8SHostnameLabel_MissingLabelFallsBackToNodeName(t *testing.T) {
+	client := fake.NewSimpleClientset(&apiv1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-a"},
+	})
+	cluster := newTestCluster("k8stest")
+	if _, err := cluster.k8sNodesFromClient(client); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	got := cluster.k8sHostnameLabel("node-a")
+	if got != "node-a" {
+		t.Fatalf("expected fallback to node name %q, got %q", "node-a", got)
+	}
+}
+
+func TestK8SHostnameLabel_UncachedNodeFallsBackToNodeName(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	got := cluster.k8sHostnameLabel("node-a")
+	if got != "node-a" {
+		t.Fatalf("expected fallback to node name %q when nothing has been cached, got %q", "node-a", got)
+	}
+}
+
+// --- Proxy naming uniqueness ---
+
+func TestK8SProxyDeploymentName_UniquePerProxy(t *testing.T) {
+	n1 := k8sProxyDeploymentName("mycluster", "proxysql1")
+	n2 := k8sProxyDeploymentName("mycluster", "proxysql2")
+	if n1 == n2 {
+		t.Fatalf("expected distinct deployment names for distinct proxies, got %q for both", n1)
+	}
+}
+
+// --- Proxy provisioning ---
+
+func TestK8SProvisionProxy_InvalidPort(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	cluster := newTestCluster("k8stest")
+	prx := &fakeProxy{name: "proxysql1", port: "not-a-port"}
+
+	err := cluster.k8sProvisionProxyServiceWithClient(client, prx)
+	if err == nil {
+		t.Fatal("expected an explicit error for an invalid proxy port, not a silent port-0 deployment")
+	}
+}
+
+func TestK8SProvisionProxy_AlreadyExistsIsIdempotent(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	cluster := newTestCluster("k8stest")
+	prx := &fakeProxy{name: "proxysql1", port: "6033"}
+
+	if err := cluster.k8sProvisionProxyServiceWithClient(client, prx); err != nil {
+		t.Fatalf("first provision: unexpected error: %s", err)
+	}
+	if err := cluster.k8sProvisionProxyServiceWithClient(client, prx); err != nil {
+		t.Fatalf("second provision (AlreadyExists) should be idempotent, got error: %s", err)
+	}
+}
+
+func TestK8SProvisionProxy_TwoProxiesDoNotCollide(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	cluster := newTestCluster("k8stest")
+	prxA := &fakeProxy{name: "proxysql1", port: "6033"}
+	prxB := &fakeProxy{name: "proxysql2", port: "6034"}
+
+	if err := cluster.k8sProvisionProxyServiceWithClient(client, prxA); err != nil {
+		t.Fatalf("provision proxysql1: unexpected error: %s", err)
+	}
+	if err := cluster.k8sProvisionProxyServiceWithClient(client, prxB); err != nil {
+		t.Fatalf("provision proxysql2: unexpected error (name/selector collision?): %s", err)
+	}
+
+	list, err := client.AppsV1().Deployments("k8stest").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error listing deployments: %s", err)
+	}
+	if len(list.Items) != 2 {
+		t.Fatalf("expected 2 distinct proxy deployments, got %d", len(list.Items))
+	}
+}
+
+func TestK8SUnprovisionProxy_DeletesDeployment(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	prx := &fakeProxy{name: "proxysql1", port: "6033"}
+	client := fake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: k8sProxyDeploymentName("k8stest", "proxysql1"), Namespace: "k8stest"},
+	})
+
+	if err := cluster.k8sUnprovisionProxyServiceWithClient(client, prx); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	_, err := client.AppsV1().Deployments("k8stest").Get(context.TODO(), k8sProxyDeploymentName("k8stest", "proxysql1"), metav1.GetOptions{})
+	if err == nil {
+		t.Fatal("expected deployment to be deleted")
+	}
+}
+
+func TestK8SUnprovisionProxy_NotFoundIsIdempotent(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	prx := &fakeProxy{name: "does-not-exist", port: "6033"}
+	client := fake.NewSimpleClientset()
+
+	if err := cluster.k8sUnprovisionProxyServiceWithClient(client, prx); err != nil {
+		t.Fatalf("expected repeated/already-gone unprovision to succeed idempotently, got error: %s", err)
+	}
+}
+
+// --- Namespace ensure ---
+
+func TestK8SEnsureNamespace_AlreadyExistsDoesNotPanic(t *testing.T) {
+	client := fake.NewSimpleClientset(&apiv1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "k8stest"},
+	})
+	cluster := newTestCluster("k8stest")
+	cluster.k8sEnsureNamespace(client, "k8stest")
+}
+
+func TestK8SEnsureNamespace_ForbiddenDoesNotBlockProvisioning(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("create", "namespaces", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(apiv1.Resource("namespaces"), "k8stest", context.DeadlineExceeded)
+	})
+
+	cluster := newTestCluster("k8stest")
+	cluster.k8sEnsureNamespace(client, "k8stest")
+}
+
+// --- Legacy proxy deployment: left alone, only warned about ---
+
+func TestK8SProvisionProxy_DoesNotTouchLegacyDeployment(t *testing.T) {
+	legacyName := k8sLegacyProxyDeploymentName("k8stest")
+	client := fake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: legacyName, Namespace: "k8stest"},
+	})
+	cluster := newTestCluster("k8stest")
+	prx := &fakeProxy{name: "proxysql1", port: "6033"}
+
+	if err := cluster.k8sProvisionProxyServiceWithClient(client, prx); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if _, err := client.AppsV1().Deployments("k8stest").Get(context.TODO(), legacyName, metav1.GetOptions{}); err != nil {
+		t.Fatalf("expected the legacy deployment to be left alone by provisioning a different, unrelated proxy: %s", err)
+	}
+}
+
+func TestK8SUnprovisionProxy_DoesNotTouchLegacyDeployment(t *testing.T) {
+	legacyName := k8sLegacyProxyDeploymentName("k8stest")
+	client := fake.NewSimpleClientset(
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: k8sProxyDeploymentName("k8stest", "proxysql1"), Namespace: "k8stest"}},
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: legacyName, Namespace: "k8stest"}},
+	)
+	cluster := newTestCluster("k8stest")
+	prx := &fakeProxy{name: "proxysql1", port: "6033"}
+
+	if err := cluster.k8sUnprovisionProxyServiceWithClient(client, prx); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if _, err := client.AppsV1().Deployments("k8stest").Get(context.TODO(), legacyName, metav1.GetOptions{}); err != nil {
+		t.Fatalf("expected unprovisioning proxysql1 to leave a cluster-wide legacy deployment alone (it may belong to a different, not-yet-migrated proxy): %s", err)
+	}
+}
+
+func TestK8SWarnIfLegacyProxyDeployment_AbsentIsSilentNoOp(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	cluster := newTestCluster("k8stest")
+	cluster.k8sWarnIfLegacyProxyDeploymentExists(client)
+}
+
+// --- Database start: verify state instead of blindly reporting success ---
+
+func TestK8SStartDatabase_MissingDeploymentIsError(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	cluster := newTestCluster("k8stest")
+	if err := cluster.k8sStartDatabaseServiceWithClient(client, "db1"); err == nil {
+		t.Fatal("expected an error when the deployment to start does not exist, not a silent success")
+	}
+}
+
+func TestK8SStartDatabase_ScaledToZeroIsError(t *testing.T) {
+	zero := int32(0)
+	client := fake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "db1", Namespace: "k8stest"},
+		Spec:       appsv1.DeploymentSpec{Replicas: &zero},
+	})
+	cluster := newTestCluster("k8stest")
+	if err := cluster.k8sStartDatabaseServiceWithClient(client, "db1"); err == nil {
+		t.Fatal("expected an error when the deployment is scaled to zero, not a silent success")
+	}
+}
+
+func TestK8SStartDatabase_GenuineGetErrorPropagates(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("get", "deployments", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(appsv1.Resource("deployments"), "db1", context.DeadlineExceeded)
+	})
+	cluster := newTestCluster("k8stest")
+	if err := cluster.k8sStartDatabaseServiceWithClient(client, "db1"); err == nil {
+		t.Fatal("expected a genuine (non-NotFound) Get error to propagate")
+	}
+}
+
+func TestK8SStartDatabase_RunningDeploymentSucceeds(t *testing.T) {
+	one := int32(1)
+	client := fake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "db1", Namespace: "k8stest"},
+		Spec:       appsv1.DeploymentSpec{Replicas: &one},
+	})
+	cluster := newTestCluster("k8stest")
+	if err := cluster.k8sStartDatabaseServiceWithClient(client, "db1"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// --- Database unprovisioning ---
+
+func TestK8SUnprovisionDatabase_DeletesDeploymentAndService(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	client := fake.NewSimpleClientset(
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "db1", Namespace: "k8stest"}},
+		&apiv1.Service{ObjectMeta: metav1.ObjectMeta{Name: "db1", Namespace: "k8stest"}},
+	)
+
+	if err := cluster.k8sUnprovisionDatabaseServiceWithClient(client, "db1"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func TestK8SUnprovisionDatabase_NotFoundIsIdempotent(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	client := fake.NewSimpleClientset()
+
+	if err := cluster.k8sUnprovisionDatabaseServiceWithClient(client, "does-not-exist"); err != nil {
+		t.Fatalf("expected repeated/already-gone unprovision to succeed idempotently, got error: %s", err)
+	}
+}
+
+func TestK8SUnprovisionDatabase_GenuineDeleteFailurePropagates(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	client := fake.NewSimpleClientset(
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "db1", Namespace: "k8stest"}},
+	)
+	client.PrependReactor("delete", "deployments", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, context.DeadlineExceeded
+	})
+
+	err := cluster.k8sUnprovisionDatabaseServiceWithClient(client, "db1")
+	if err == nil {
+		t.Fatal("expected the genuine deployment-delete failure to be reported, not swallowed")
+	}
+}

--- a/cluster/prov_k8s_test.go
+++ b/cluster/prov_k8s_test.go
@@ -719,7 +719,7 @@ func TestK8SDatabaseDeployment_ConfigFetchUsesBasicAuthHeader(t *testing.T) {
 	cluster.Conf.APISecureConfig = true
 	cluster.APIUsers = map[string]APIUser{"admin": {User: "admin", Password: "s3cr3t"}}
 	cluster.Conf.MonitorAddress = "127.0.0.1"
-	cluster.Conf.HttpPort = "10005"
+	cluster.Conf.APIPort = "10005"
 	s := &ServerMonitor{Name: "db1", Port: "3306"}
 
 	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
@@ -741,7 +741,7 @@ func TestK8SDatabaseDeployment_ConfigFetchAuthSafeWithShellMetacharacters(t *tes
 	cluster.Conf.APISecureConfig = true
 	cluster.APIUsers = map[string]APIUser{"admin": {User: "admin", Password: `p"$(rm -rf /)"\`}}
 	cluster.Conf.MonitorAddress = "127.0.0.1"
-	cluster.Conf.HttpPort = "10005"
+	cluster.Conf.APIPort = "10005"
 	s := &ServerMonitor{Name: "db1", Port: "3306"}
 
 	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
@@ -761,7 +761,7 @@ func TestK8SDatabaseDeployment_ConfigFetchFallsBackToDefaultAdminPassword(t *tes
 	cluster := newTestCluster("k8stest")
 	cluster.Conf.APISecureConfig = true
 	cluster.Conf.MonitorAddress = "127.0.0.1"
-	cluster.Conf.HttpPort = "10005"
+	cluster.Conf.APIPort = "10005"
 	s := &ServerMonitor{Name: "db1", Port: "3306"}
 
 	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
@@ -784,7 +784,7 @@ func TestK8SDatabaseDeployment_ConfigFetchIgnoresNonAdminUsers(t *testing.T) {
 		"dba":   {User: "dba", Password: "dba-pass"},
 	}
 	cluster.Conf.MonitorAddress = "127.0.0.1"
-	cluster.Conf.HttpPort = "10005"
+	cluster.Conf.APIPort = "10005"
 	s := &ServerMonitor{Name: "db1", Port: "3306"}
 
 	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
@@ -807,7 +807,7 @@ func TestK8SDatabaseDeployment_ConfigFetchNoAuthHeaderWhenSecureConfigOff(t *tes
 	cluster.Conf.APISecureConfig = false
 	cluster.APIUsers = map[string]APIUser{"admin": {User: "admin", Password: "s3cr3t"}}
 	cluster.Conf.MonitorAddress = "127.0.0.1"
-	cluster.Conf.HttpPort = "10005"
+	cluster.Conf.APIPort = "10005"
 	s := &ServerMonitor{Name: "db1", Port: "3306"}
 
 	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
@@ -830,7 +830,7 @@ func TestK8SDatabaseDeployment_ConfigFetchURLMatchesServerHost(t *testing.T) {
 	cluster.Conf.ProvOrchestrator = config.ConstOrchestratorKubernetes
 	cluster.Conf.ProvOrchestratorCluster = "cluster.local"
 	cluster.Conf.MonitorAddress = "127.0.0.1"
-	cluster.Conf.HttpPort = "10005"
+	cluster.Conf.APIPort = "10005"
 	s := &ServerMonitor{Name: "clustera-0", Port: "3306"}
 
 	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
@@ -846,7 +846,7 @@ func TestK8SDatabaseDeployment_ConfigFetchURLStaysBareWhenProvNetCNIDisabled(t *
 	cluster := newTestCluster("k8stest")
 	cluster.Conf.ProvNetCNI = false
 	cluster.Conf.MonitorAddress = "127.0.0.1"
-	cluster.Conf.HttpPort = "10005"
+	cluster.Conf.APIPort = "10005"
 	s := &ServerMonitor{Name: "db1", Port: "3306"}
 
 	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
@@ -855,6 +855,72 @@ func TestK8SDatabaseDeployment_ConfigFetchURLStaysBareWhenProvNetCNIDisabled(t *
 	wantPath := "/servers/db1/3306/config"
 	if !strings.Contains(cmd, wantPath) {
 		t.Fatalf("expected the bare short name in the request path when prov-net-cni is off, got: %s", cmd)
+	}
+}
+// The config-bootstrap and replication-manager-cli fetches must use HTTPS
+// on api-port (10005, api.go's apiserver()), not HTTP on http-port (10001,
+// http.go's httpserver()) -- both routers register the same unprotected
+// routes, but only api.go always terminates TLS. --no-check-certificate is
+// required alongside it: the cert is self-signed (a generated temp cert
+// when monitoring-ssl-cert isn't set), matching every other orchestrator's
+// bootstrap fetch in this codebase (prov_opensvc.go, prov_onpremise_db.go).
+// This is conditional on api-server actually being enabled -- see
+// TestK8SDatabaseDeployment_ConfigFetchFallsBackToHTTPWhenAPIServerDisabled.
+func TestK8SDatabaseDeployment_ConfigFetchUsesHTTPSOnAPIPort(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.MonitorAddress = "127.0.0.1"
+	cluster.Conf.APIPort = "10005"
+	cluster.Conf.HttpPort = "10001"
+	cluster.Conf.ApiServ = true
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+	cmd := strings.Join(dep.Spec.Template.Spec.InitContainers[0].Command, " ")
+
+	if !strings.Contains(cmd, "https://127.0.0.1:10005/api/clusters/") {
+		t.Fatalf("expected the config fetch to use https:// on api-port 10005, got: %s", cmd)
+	}
+	if !strings.Contains(cmd, "https://127.0.0.1:10005/static/configurator/bin/replication-manager-cli") {
+		t.Fatalf("expected the replication-manager-cli fetch to use https:// on api-port 10005, got: %s", cmd)
+	}
+	if strings.Contains(cmd, ":10001") {
+		t.Fatalf("expected http-port (10001) to never appear in the init container command, got: %s", cmd)
+	}
+	if strings.Count(cmd, "--no-check-certificate") != 2 {
+		t.Fatalf("expected both wget calls to pass --no-check-certificate for the self-signed cert, got: %s", cmd)
+	}
+}
+
+// api-server (default true) is independently togglable from http-server --
+// a deployment with api-server=false has nothing listening on api-port at
+// all, which used to work fine over plain HTTP on http-port before the
+// HTTPS switch (httpserver() registers the identical routes). Falling back
+// to that combination preserves it instead of silently hanging the init
+// container on an unanswered connection with no error surfaced (found via
+// code review, not yet hit live -- this session's live clusters always run
+// with the api-server default of true).
+func TestK8SDatabaseDeployment_ConfigFetchFallsBackToHTTPWhenAPIServerDisabled(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.MonitorAddress = "127.0.0.1"
+	cluster.Conf.APIPort = "10005"
+	cluster.Conf.HttpPort = "10001"
+	cluster.Conf.ApiServ = false
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+	cmd := strings.Join(dep.Spec.Template.Spec.InitContainers[0].Command, " ")
+
+	if !strings.Contains(cmd, "http://127.0.0.1:10001/api/clusters/") {
+		t.Fatalf("expected the config fetch to fall back to http:// on http-port 10001, got: %s", cmd)
+	}
+	if !strings.Contains(cmd, "http://127.0.0.1:10001/static/configurator/bin/replication-manager-cli") {
+		t.Fatalf("expected the replication-manager-cli fetch to fall back to http:// on http-port 10001, got: %s", cmd)
+	}
+	if strings.Contains(cmd, ":10005") {
+		t.Fatalf("expected api-port (10005) to never appear in the init container command when api-server is disabled, got: %s", cmd)
+	}
+	if strings.Contains(cmd, "--no-check-certificate") {
+		t.Fatalf("expected no --no-check-certificate flag for the plain-HTTP fallback, got: %s", cmd)
 	}
 }
 
@@ -894,7 +960,7 @@ func TestK8SDatabaseDeployment_InitContainerCreatesJobsDatadir(t *testing.T) {
 func TestK8SDatabaseDeployment_InitContainerPopulatesDbjobsVolume(t *testing.T) {
 	cluster := newTestCluster("k8stest")
 	cluster.Conf.MonitorAddress = "127.0.0.1"
-	cluster.Conf.HttpPort = "10005"
+	cluster.Conf.APIPort = "10005"
 	s := &ServerMonitor{Name: "db1", Port: "3306"}
 
 	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")

--- a/cluster/prov_k8s_test.go
+++ b/cluster/prov_k8s_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/signal18/replication-manager/config"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -297,6 +298,171 @@ func TestK8SEnsureNamespace_ForbiddenDoesNotBlockProvisioning(t *testing.T) {
 	cluster.k8sEnsureNamespace(client, "k8stest")
 }
 
+// --- Database Secret (MYSQL_ROOT_PASSWORD, not a raw Env value) ---
+
+func TestK8SEnsureDatabaseSecret_CreatesSecretWithPassword(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	cluster := newTestCluster("k8stest")
+	s := &ServerMonitor{Name: "db1", Pass: "s3cr3t"}
+
+	if err := cluster.k8sEnsureDatabaseSecret(client, s); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	secret, err := client.CoreV1().Secrets("k8stest").Get(context.TODO(), k8sSecretName(s), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected the secret to have been created, got error: %s", err)
+	}
+	if secret.StringData[k8sSecretKeyRootPassword] != "s3cr3t" {
+		t.Fatalf("expected MYSQL_ROOT_PASSWORD %q, got %q", "s3cr3t", secret.StringData[k8sSecretKeyRootPassword])
+	}
+}
+
+// Password rotation must take effect on the next pod restart, not silently
+// keep whatever was there before.
+func TestK8SEnsureDatabaseSecret_UpdatesExistingSecret(t *testing.T) {
+	s := &ServerMonitor{Name: "db1", Pass: "new-pass"}
+	client := fake.NewSimpleClientset(&apiv1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: k8sSecretName(s), Namespace: "k8stest"},
+		StringData: map[string]string{k8sSecretKeyRootPassword: "old-pass"},
+	})
+	cluster := newTestCluster("k8stest")
+
+	if err := cluster.k8sEnsureDatabaseSecret(client, s); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	secret, err := client.CoreV1().Secrets("k8stest").Get(context.TODO(), k8sSecretName(s), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if secret.StringData[k8sSecretKeyRootPassword] != "new-pass" {
+		t.Fatalf("expected the rotated password %q, got %q", "new-pass", secret.StringData[k8sSecretKeyRootPassword])
+	}
+}
+
+// The Deployment must reference the Secret via SecretKeyRef, never embed
+// the password as a raw Env value -- that would put it in cleartext in the
+// Deployment spec (kubectl get deploy -o yaml, RBAC permitting).
+func TestK8SDatabaseDeployment_RootPasswordUsesSecretKeyRefNotRawValue(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	s := &ServerMonitor{Name: "db1", Port: "3306", Pass: "s3cr3t"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+	env := dep.Spec.Template.Spec.Containers[0].Env
+
+	var found *apiv1.EnvVar
+	for i := range env {
+		if env[i].Name == "MYSQL_ROOT_PASSWORD" {
+			found = &env[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("expected a MYSQL_ROOT_PASSWORD env var")
+	}
+	if found.Value != "" {
+		t.Fatalf("expected no raw Value (password must come from the Secret), got %q", found.Value)
+	}
+	if found.ValueFrom == nil || found.ValueFrom.SecretKeyRef == nil {
+		t.Fatal("expected MYSQL_ROOT_PASSWORD to be sourced from a SecretKeyRef")
+	}
+	if found.ValueFrom.SecretKeyRef.Name != k8sSecretName(s) {
+		t.Fatalf("expected SecretKeyRef to name %q, got %q", k8sSecretName(s), found.ValueFrom.SecretKeyRef.Name)
+	}
+	if found.ValueFrom.SecretKeyRef.Key != k8sSecretKeyRootPassword {
+		t.Fatalf("expected SecretKeyRef key %q, got %q", k8sSecretKeyRootPassword, found.ValueFrom.SecretKeyRef.Key)
+	}
+}
+
+// --- Database PVC (size, StorageClass) ---
+
+func TestK8SDatabasePVC_UsesProvDiskSize(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvDisk = "20G"
+	s := &ServerMonitor{Name: "db1"}
+
+	pvc := cluster.k8sDatabasePVC(s)
+
+	got := pvc.Spec.Resources.Requests[apiv1.ResourceStorage]
+	want := resource.MustParse("20G")
+	if got.Cmp(want) != 0 {
+		t.Fatalf("expected storage request %s, got %s", want.String(), got.String())
+	}
+}
+
+func TestK8SDatabasePVC_FallsBackToDefaultSizeWhenUnparseable(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvDisk = "not-a-size"
+	s := &ServerMonitor{Name: "db1"}
+
+	pvc := cluster.k8sDatabasePVC(s)
+
+	got := pvc.Spec.Resources.Requests[apiv1.ResourceStorage]
+	want := resource.MustParse("20G")
+	if got.Cmp(want) != 0 {
+		t.Fatalf("expected the fallback to match prov-db-disk-size's own default (20G), got %s", got.String())
+	}
+}
+
+// StorageClassName is a *string in the K8s API specifically to distinguish
+// "use the cluster's default StorageClass" (nil) from "use no StorageClass"
+// (a pointer to "") -- prov-kube-storage-class unset must stay nil, not a
+// pointer to an empty string, or PVC binding would behave differently than
+// leaving the field alone.
+func TestK8SDatabasePVC_NoStorageClassNameWhenUnset(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	s := &ServerMonitor{Name: "db1"}
+
+	pvc := cluster.k8sDatabasePVC(s)
+
+	if pvc.Spec.StorageClassName != nil {
+		t.Fatalf("expected a nil StorageClassName (use cluster default), got %q", *pvc.Spec.StorageClassName)
+	}
+}
+
+func TestK8SDatabasePVC_UsesConfiguredStorageClass(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvKubeStorageClass = "fast-ssd"
+	s := &ServerMonitor{Name: "db1"}
+
+	pvc := cluster.k8sDatabasePVC(s)
+
+	if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName != "fast-ssd" {
+		t.Fatalf("expected StorageClassName \"fast-ssd\", got %v", pvc.Spec.StorageClassName)
+	}
+}
+
+// --- StorageClass listing (provisioning GUI dropdown) ---
+
+func TestK8SStorageClassesFromClient_ListsNames(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "standard"}},
+		&storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "fast-ssd"}},
+	)
+	cluster := newTestCluster("k8stest")
+
+	names, err := cluster.k8sStorageClassesFromClient(client)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(names) != 2 {
+		t.Fatalf("expected 2 storage classes, got %d: %v", len(names), names)
+	}
+}
+
+func TestK8SStorageClassesFromClient_EmptyClusterReturnsEmptyNotNilError(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	cluster := newTestCluster("k8stest")
+
+	names, err := cluster.k8sStorageClassesFromClient(client)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(names) != 0 {
+		t.Fatalf("expected no storage classes, got %v", names)
+	}
+}
+
 // --- Legacy proxy deployment: left alone, only warned about ---
 
 func TestK8SProvisionProxy_DoesNotTouchLegacyDeployment(t *testing.T) {
@@ -380,6 +546,102 @@ func TestK8SStartDatabase_RunningDeploymentSucceeds(t *testing.T) {
 	cluster := newTestCluster("k8stest")
 	if err := cluster.k8sStartDatabaseServiceWithClient(client, "db1"); err != nil {
 		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// --- Image pull policy (prov-kube-image-force-pull) ---
+
+func TestK8SImagePullPolicy_AlwaysWhenForcePullSet(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvKubeImageForcePull = true
+
+	if got := k8sImagePullPolicy(cluster); got != apiv1.PullAlways {
+		t.Fatalf("expected PullAlways, got %q", got)
+	}
+}
+
+func TestK8SImagePullPolicy_ExplicitIfNotPresentByDefault(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvKubeImageForcePull = false
+
+	if got := k8sImagePullPolicy(cluster); got != apiv1.PullIfNotPresent {
+		t.Fatalf("expected an explicit PullIfNotPresent, got %q", got)
+	}
+}
+
+func TestK8SDatabaseDeployment_ContainerUsesConfiguredPullPolicy(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvKubeImageForcePull = true
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+
+	if got := dep.Spec.Template.Spec.Containers[0].ImagePullPolicy; got != apiv1.PullAlways {
+		t.Fatalf("expected the database container to use PullAlways, got %q", got)
+	}
+}
+
+// --- Force image re-pull action (rolling restart via annotation patch) ---
+
+func TestK8SForceRepullDatabaseService_PatchesRestartedAtAnnotation(t *testing.T) {
+	client := fake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "db1", Namespace: "k8stest"},
+	})
+	cluster := newTestCluster("k8stest")
+
+	if err := cluster.k8sForceRepullDatabaseServiceWithClient(client, "db1"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	dep, err := client.AppsV1().Deployments("k8stest").Get(context.TODO(), "db1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if _, ok := dep.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"]; !ok {
+		t.Fatal("expected the pod template to be annotated with kubectl.kubernetes.io/restartedAt")
+	}
+}
+
+// The Deployment object only ever gets ImagePullPolicy at creation time
+// (k8sDatabaseDeployment) -- toggling prov-kube-image-force-pull afterward
+// must still reach an already-provisioned server's Deployment through this
+// action, or the setting would silently do nothing until a full
+// reprovision.
+func TestK8SForceRepullDatabaseService_PatchesImagePullPolicyToCurrentSetting(t *testing.T) {
+	client := fake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "db1", Namespace: "k8stest"},
+		Spec: appsv1.DeploymentSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "db1", ImagePullPolicy: apiv1.PullIfNotPresent},
+					},
+				},
+			},
+		},
+	})
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvKubeImageForcePull = true
+
+	if err := cluster.k8sForceRepullDatabaseServiceWithClient(client, "db1"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	dep, err := client.AppsV1().Deployments("k8stest").Get(context.TODO(), "db1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if got := dep.Spec.Template.Spec.Containers[0].ImagePullPolicy; got != apiv1.PullAlways {
+		t.Fatalf("expected ImagePullPolicy to be patched to PullAlways, got %q", got)
+	}
+}
+
+func TestK8SForceRepullDatabaseService_MissingDeploymentIsError(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	cluster := newTestCluster("k8stest")
+
+	if err := cluster.k8sForceRepullDatabaseServiceWithClient(client, "db1"); err == nil {
+		t.Fatal("expected an error when the deployment doesn't exist, got nil")
 	}
 }
 
@@ -593,6 +855,153 @@ func TestK8SDatabaseDeployment_ConfigFetchURLStaysBareWhenProvNetCNIDisabled(t *
 	wantPath := "/servers/db1/3306/config"
 	if !strings.Contains(cmd, wantPath) {
 		t.Fatalf("expected the bare short name in the request path when prov-net-cni is off, got: %s", cmd)
+	}
+}
+
+// --- dbjobs sidecar (backups/optimize/config-refresh) ---
+
+// The init container's fetched archive root is repman's own Datadir/init
+// (configurator.TarGz's caller, cluster/configurator/configurator.go), so
+// its "init/" entry -- dbjobs_new, dbjobs_launcher_with_sigterm, already
+// fully resolved server-side, no runtime templating needed -- must be
+// copied into the shared volume the sidecar reads from, and
+// replication-manager-cli fetched separately (it isn't part of the config
+// archive, same as OpenSVC's own bootstrap script fetches it separately).
+// k8sDatabaseDeployment must stay callable with a bare *ServerMonitor (no
+// ClusterGroup) -- its own doc comment promises "no ServerMonitor methods
+// invoked" specifically so it stays testable this way. Confirmed live: an
+// earlier version called s.GetJobDatadir(), which dereferences
+// s.ClusterGroup.Configurator with no nil check, and panicked here.
+func TestK8SDatabaseDeployment_PureBuilderDoesNotPanicOnBareServerMonitor(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	_ = cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+}
+
+func TestK8SDatabaseDeployment_InitContainerCreatesJobsDatadir(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+	cmd := strings.Join(dep.Spec.Template.Spec.InitContainers[0].Command, " ")
+
+	if !strings.Contains(cmd, "/var/lib/mysql/.system/jobs") {
+		t.Fatalf("expected the init container to pre-create .system/jobs (JOBS_DATADIR), got: %s", cmd)
+	}
+}
+
+func TestK8SDatabaseDeployment_InitContainerPopulatesDbjobsVolume(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.MonitorAddress = "127.0.0.1"
+	cluster.Conf.HttpPort = "10005"
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+	cmd := strings.Join(dep.Spec.Template.Spec.InitContainers[0].Command, " ")
+
+	for _, want := range []string{
+		"cp -r /tmp/cfg/init/. /docker-entrypoint-initdb.d/",
+		"/static/configurator/bin/replication-manager-cli",
+		"chmod +x /docker-entrypoint-initdb.d/replication-manager-cli",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Fatalf("expected the init container command to contain %q, got: %s", want, cmd)
+		}
+	}
+}
+
+func TestK8SDatabaseDeployment_InitContainerMountsDbjobsVolume(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+
+	found := false
+	for _, vm := range dep.Spec.Template.Spec.InitContainers[0].VolumeMounts {
+		if vm.Name == "db1-init" && vm.MountPath == "/docker-entrypoint-initdb.d" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected the init container to mount db1-init at /docker-entrypoint-initdb.d")
+	}
+}
+
+func TestK8SDatabaseDeployment_DbjobsSidecarPresent(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvDbImg = "mariadb:10.11"
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+
+	containers := dep.Spec.Template.Spec.Containers
+	if len(containers) != 2 {
+		t.Fatalf("expected the DB container plus one dbjobs sidecar, got %d containers", len(containers))
+	}
+	sidecar := containers[1]
+	if sidecar.Name != "db1-dbjobs" {
+		t.Fatalf("expected the sidecar name %q, got %q", "db1-dbjobs", sidecar.Name)
+	}
+	if sidecar.Image != "mariadb:10.11" {
+		t.Fatalf("expected the sidecar to share the DB image %q, got %q", "mariadb:10.11", sidecar.Image)
+	}
+	wantCmd := []string{"/bin/bash", "/docker-entrypoint-initdb.d/dbjobs_launcher_with_sigterm"}
+	if len(sidecar.Command) != len(wantCmd) || sidecar.Command[0] != wantCmd[0] || sidecar.Command[1] != wantCmd[1] {
+		t.Fatalf("expected command %v, got %v", wantCmd, sidecar.Command)
+	}
+}
+
+// dbjobs_new.sh reads $MYSQL_ROOT_PASSWORD (a real runtime env var, not a
+// %%ENV:...%% template placeholder) -- must come from the same Secret as
+// the DB container, never a raw Value.
+func TestK8SDatabaseDeployment_DbjobsSidecarUsesSecretForRootPassword(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	s := &ServerMonitor{Name: "db1", Port: "3306", Pass: "s3cr3t"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+	sidecar := dep.Spec.Template.Spec.Containers[1]
+
+	var found *apiv1.EnvVar
+	for i := range sidecar.Env {
+		if sidecar.Env[i].Name == "MYSQL_ROOT_PASSWORD" {
+			found = &sidecar.Env[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("expected a MYSQL_ROOT_PASSWORD env var on the dbjobs sidecar")
+	}
+	if found.Value != "" {
+		t.Fatalf("expected no raw Value, got %q", found.Value)
+	}
+	if found.ValueFrom == nil || found.ValueFrom.SecretKeyRef == nil || found.ValueFrom.SecretKeyRef.Name != k8sSecretName(s) {
+		t.Fatal("expected MYSQL_ROOT_PASSWORD sourced from the same per-server Secret as the DB container")
+	}
+}
+
+// dbjobs_new.sh does raw filesystem operations directly against $DATADIR
+// (e.g. moving restored .ibd files into place), so the sidecar needs the
+// same persistent-storage volume the DB container writes to -- ReadWriteOnce
+// restricts a PVC to one node, not one container, and every container here
+// is in the same pod (so the same node) by construction.
+func TestK8SDatabaseDeployment_DbjobsSidecarMountsDataAndInitVolumes(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+	sidecar := dep.Spec.Template.Spec.Containers[1]
+
+	wantMounts := map[string]string{
+		"db1-persistent-storage": "/var/lib/mysql",
+		"db1-init":               "/docker-entrypoint-initdb.d",
+	}
+	if len(sidecar.VolumeMounts) != len(wantMounts) {
+		t.Fatalf("expected %d volume mounts, got %d: %v", len(wantMounts), len(sidecar.VolumeMounts), sidecar.VolumeMounts)
+	}
+	for _, vm := range sidecar.VolumeMounts {
+		if wantMounts[vm.Name] != vm.MountPath {
+			t.Fatalf("unexpected mount %s at %s", vm.Name, vm.MountPath)
+		}
 	}
 }
 

--- a/cluster/prov_k8s_test.go
+++ b/cluster/prov_k8s_test.go
@@ -240,6 +240,41 @@ func TestK8SUnprovisionProxy_NotFoundIsIdempotent(t *testing.T) {
 	}
 }
 
+// --- Database Deployment builder ---
+//
+// k8sDatabaseDeployment is a pure builder (no API calls, no ServerMonitor
+// methods invoked), so the placement fix — NodeSelector, not NodeName,
+// which is what actually made WaitForFirstConsumer PVC binding work — can
+// be asserted directly without a fake clientset or a live cluster.
+
+func TestK8SDatabaseDeployment_UsesNodeSelectorNotNodeName(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvDbImg = "mariadb:10.11"
+	s := &ServerMonitor{Name: "db1", Port: "3306", Pass: "secret"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
+
+	if dep.Spec.Template.Spec.NodeName != "" {
+		t.Fatalf("expected NodeName to be unset (placement must go through NodeSelector, not NodeName, or WaitForFirstConsumer PVC binding breaks again), got %q", dep.Spec.Template.Spec.NodeName)
+	}
+	got := dep.Spec.Template.Spec.NodeSelector["kubernetes.io/hostname"]
+	if got != "node-a" {
+		t.Fatalf("expected NodeSelector kubernetes.io/hostname=node-a, got %q", got)
+	}
+}
+
+func TestK8SDatabaseDeployment_NodeSelectorTracksHostnameLabelArgument(t *testing.T) {
+	cluster := newTestCluster("k8stest")
+	s := &ServerMonitor{Name: "db1", Port: "3306"}
+
+	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a-label")
+
+	got := dep.Spec.Template.Spec.NodeSelector["kubernetes.io/hostname"]
+	if got != "node-a-label" {
+		t.Fatalf("expected NodeSelector to use the passed-in hostname label, got %q", got)
+	}
+}
+
 // --- Namespace ensure ---
 
 func TestK8SEnsureNamespace_AlreadyExistsDoesNotPanic(t *testing.T) {

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -374,9 +374,13 @@ func (cluster *Cluster) newServerMonitor(url string, user string, pass string, c
 		server.SourceClusterName = cluster.Name
 	}
 
-	if cluster.Conf.ProvNetCNI && cluster.GetOrchestrator() == config.ConstOrchestratorOpenSVC {
-		// OpenSVC and Sharding proxy monitoring
-		url = server.Name + server.Domain + ":3306"
+	if server.Domain != "" {
+		// server.Domain comes from GetDomain()/GetDomainHeadCluster()
+		// (cluster_get.go), which already gates per orchestrator -- an empty
+		// Domain here means "don't qualify this name". server.Port, not a
+		// hardcoded "3306": a server can run on a non-default port, and it
+		// was already parsed from the original url two lines above.
+		url = server.Name + server.Domain + ":" + server.Port
 	}
 	var sid uint64
 	//will be overide in Refresh with show variables server_id, used for provisionning configurator for server_id

--- a/config/config.go
+++ b/config/config.go
@@ -683,6 +683,8 @@ type Config struct {
 	ProvSSLKeyUUID                            string                       `mapstructure:"prov-tls-server-key-uuid" toml:"-" json:"-"`
 	ProvNetCNI                                bool                         `mapstructure:"prov-net-cni" toml:"prov-net-cni" json:"provNetCni"`
 	ProvNetCNICluster                         string                       `mapstructure:"prov-net-cni-cluster" toml:"prov-net-cni-cluster" json:"provNetCniCluster"`
+	ProvKubeImageForcePull                    bool                         `mapstructure:"prov-kube-image-force-pull" toml:"prov-kube-image-force-pull" json:"provKubeImageForcePull"`
+	ProvKubeStorageClass                      string                       `mapstructure:"prov-kube-storage-class" toml:"prov-kube-storage-class" json:"provKubeStorageClass"`
 	ProvNetDockerRunArgs                      string                       `mapstructure:"prov-net-docker-run-args" toml:"prov-net-docker-run-args" json:"provNetDockerRunArgs"`
 	ProvDockerDaemonPrivate                   bool                         `mapstructure:"prov-docker-daemon-private" toml:"prov-docker-daemon-private" json:"provDockerDaemonPrivate"`
 	ProvServicePlan                           string                       `mapstructure:"prov-service-plan" toml:"prov-service-plan" json:"provServicePlan"`

--- a/doc/implementation/cluster/KUBERNETES_PROVISIONING.md
+++ b/doc/implementation/cluster/KUBERNETES_PROVISIONING.md
@@ -48,32 +48,85 @@ switch statements, not through the `DatabaseOrchetrator` interface in
 The init container fetches the DB config over HTTP:
 
 ```
-wget -qO- http://<monitoring-address>:<http-port>/api/clusters/<cluster>/servers/<server>/<port>/config | tar xzvf - -C /data
+wget -qO- --header="Authorization: Basic <base64(user:pass)>" http://<monitoring-address>:<http-port>/api/clusters/<cluster>/servers/<server>/<port>/config | tar xzf - -C /tmp/cfg
 ```
 
-handled by `handlerMuxServersPortConfig` (`server/api_database.go`). This is
-the only wired bootstrap mechanism; the ConfigMap above is not part of it.
+handled by `handlerMuxServersPortConfig` (`server/api_database.go`). Only
+`etc/mysql/conf.d/*.cnf` is copied in (MariaDB's `!includedir` is
+non-recursive); the init container also pre-creates
+`.system/{tmp,logs,repl,innodb/undo,innodb/redo,aria}` under the datadir,
+mirroring OpenSVC's moduleset directory resources.
 
-Limitations:
-
-- **No authentication.** If `api-credentials-secure-config=true`, the
-  endpoint requires a valid ACL/JWT via `IsValidClusterACL` and the init
-  container sends none, so it gets HTTP 403 and the DB never bootstraps.
-  `K8SProvisionDatabaseService()` logs a warning up front when this
-  combination is detected, since provisioning itself (Namespace/PVC/
-  Deployment/Service) still succeeds while the pod never bootstraps. Fixing
-  the incompatibility needs a credential injected into the pod (e.g. a
-  Kubernetes Secret plus an `Authorization` header) — tracked under #1497.
-- **HTTP, not HTTPS**, unlike the equivalent OpenSVC bootstrap path (also
-  tracked under #1497).
+- **Authentication**: only sent when `api-credentials-secure-config=true` —
+  the endpoint doesn't enforce auth otherwise, so embedding a real
+  credential in every Deployment spec regardless would be needless
+  exposure. When sent, it's a base64-encoded `Authorization: Basic` header
+  via `wget --header`, computed in Go — not interpolated as raw
+  `user:pass@host` userinfo into the `sh -c` string, since that would let
+  shell metacharacters in the password be interpreted by the init
+  container's shell. Uses the `admin` user specifically — the same
+  fixed-account convention every other bootstrap credential injection in
+  this codebase already uses (`GetExecEnv`, OpenSVC's secrets injection,
+  onpremise env exports), not "whichever `api-credentials` entry is
+  configured first," which may lack the `db-config-flag` grant `/config`
+  requires. Falls back to the documented default password `repman` if
+  `admin` hasn't been reconfigured — matches `api-credentials`' own CLI
+  default. `K8SProvisionDatabaseService()` logs a warning up front if
+  `api-credentials-secure-config=true` and `admin` lacks the grant.
+- **Residual risk**: base64 is encoding, not encryption — anyone able to
+  read the Deployment spec (`kubectl get deploy -o yaml`, RBAC permitting)
+  can recover the credential, and it still travels over plaintext HTTP.
+  Acceptable interim state; a real fix (Kubernetes `Secret` +
+  `secretKeyRef`, HTTPS) is tracked under #1497.
+- **HTTP, not HTTPS**, unlike OpenSVC's bootstrap path (tracked under #1497).
 
 ### Unprovisioning
 
 `K8SUnprovisionDatabaseService()` deletes the Deployment and Service, both
 idempotent via `apierrors.IsNotFound`. ConfigMap, PVC, and Namespace are
 retained — PVC deletion is destructive and Namespace/ConfigMap
-retention-vs-deletion semantics are an open question. Exactly one value is
-sent on `cluster.errorChan`.
+retention-vs-deletion semantics are an open question. The shared headless
+Service (below), if created, is not deleted by any single server's
+unprovision, since it's shared across every DB pod in the namespace. Exactly
+one value is sent on `cluster.errorChan`.
+
+### Per-pod DNS (`prov-net-cni`)
+
+The per-server `Service` (`ClusterIP`, named `s.Name`) that's always created
+resolves to a **virtual IP**, reachable only from inside the cluster —
+confirmed live: DNS resolved fine, but the MySQL connect failed (errno 115)
+from a replication-manager process running outside the cluster. Fine for a
+replication-manager Pod in the same namespace as the DB pods; not for one
+running externally.
+
+`prov-net-cni` — the same flag OpenSVC already uses for its own domain
+suffix — opts a Kubernetes cluster into a real, routable per-pod address
+instead. When on:
+
+- Every DB pod gets `role=db` added to its labels, and `Hostname`/`Subdomain: db`
+  on its Pod spec.
+- A shared headless `Service` (`ClusterIP: None`, name `db`) selects on
+  `app=repication-manager,role=db`.
+- That combination makes CoreDNS publish `<server>.db.<namespace>.svc.<cluster-domain>`
+  pointing at the pod's current real IP (live, not a snapshot).
+  `<cluster-domain>` is `prov-orchestrator-cluster`, falling back to
+  `cluster.local`.
+
+`cluster.GetDomain()`/`GetDomainHeadCluster()` (`cluster/cluster_get.go`)
+build this suffix and feed `server.Host`/`server.Domain` everywhere a server
+address is built (topology discovery, `AddChildServers`, proxies), not just
+at provision time. Each orchestrator branch checks its own type explicitly,
+so the shared flag can never leak a domain suffix meant for the other one
+(or a third orchestrator inheriting it from `[DEFAULT]`).
+
+With the flag off, Deployments/Services are byte-identical to before this
+mechanism existed. The Service selector and pod labels are defined in two
+places and must agree — `TestK8SDatabaseDeployment_PodLabelsSatisfyHeadlessServiceSelector`
+covers that.
+
+Proxy pods aren't part of this (no `role` label, so excluded from the `db`
+Service by construction) — they have no Service of any kind yet; a
+`role=proxy` follow-up is natural but not built (#1497).
 
 ## Proxy provisioning
 
@@ -252,7 +305,10 @@ Kubernetes-orchestrated scenarios.
   DBs or proxies.
 - No proxy Service exposure, and no Kubernetes proxy support beyond
   ProxySQL.
-- Config bootstrap is HTTP-only, unauthenticated.
+- Config bootstrap is HTTP, not HTTPS (Basic Auth-authenticated, see
+  "Bootstrap" above).
+- Per-pod DNS (`prov-net-cni`) covers DB pods only — no equivalent for
+  proxies yet (see "Per-pod DNS" above).
 - A `<cluster>-deployment` left over from before per-proxy Deployment
   naming requires manual operator cleanup (see "Legacy deployment name"
   above); repman only warns about it, since automatic cleanup can't prove

--- a/doc/implementation/cluster/KUBERNETES_PROVISIONING.md
+++ b/doc/implementation/cluster/KUBERNETES_PROVISIONING.md
@@ -1,12 +1,13 @@
 # Kubernetes native provisioning
 
-Covers `cluster/prov_k8s.go`, `cluster/prov_k8s_db.go`, `cluster/prov_k8s_prx.go`.
-Broader feature work tracked in issue #1497: HTTPS bootstrap, GUI manifest
-view, and proxy-type-aware image selection remain open. Secrets, image pull
-policy, StorageClass selection, and the dbjobs sidecar are implemented and
-verified live against both deployment models (see "Secrets, image pull
-policy, and storage class" and "dbjobs sidecar" below) — repman running
-outside the cluster (Model A) and repman running as an in-cluster Deployment
+Covers `cluster/prov_k8s.go`, `cluster/prov_k8s_db.go`, `cluster/prov_k8s_prx.go`,
+`cluster/prov_k8s_manifest.go`. Broader feature work tracked in issue #1497:
+proxy-type-aware image selection remains open. Secrets, image pull policy,
+StorageClass selection, the dbjobs sidecar, HTTPS config bootstrap, and a
+live manifest view are implemented and verified live against both deployment
+models (see "Secrets, image pull policy, and storage class", "dbjobs
+sidecar", "Bootstrap", and "Manifest view" below) — repman running outside
+the cluster (Model A) and repman running as an in-cluster Deployment
 (Model B), the latter requiring both an RBAC grant beyond what an
 earlier-written `ClusterRole` may have and, separately, `monitoring-address`
 set explicitly to a stable Service DNS name rather than left at its
@@ -52,11 +53,40 @@ switch statements, not through the `DatabaseOrchetrator` interface in
 
 ### Bootstrap
 
-The init container fetches the DB config over HTTP:
+The init container fetches the DB config over HTTPS, on `api-port` (10005,
+`api.go`'s `apiserver()`), not `http-port` (10001, `http.go`'s
+`httpserver()`) — both routers register the exact same unprotected routes
+(config fetch, static binary), but only `api.go` always terminates TLS. This
+matches every other orchestrator's own bootstrap fetch in this codebase
+(`REPLICATION_MANAGER_URL` in `prov_opensvc.go`, `prov_onpremise_db.go`,
+`cluster_get.go` all use `"https://"+MonitorAddress+":"+APIPort`); Kubernetes
+was the one outlier still on plain HTTP (#1497 gap 5, fixed):
 
 ```
-wget -qO- --header="Authorization: Basic <base64(user:pass)>" http://<monitoring-address>:<http-port>/api/clusters/<cluster>/servers/<server>/<port>/config | tar xzf - -C /tmp/cfg
+wget --no-check-certificate -qO- --header="Authorization: Basic <base64(user:pass)>" https://<monitoring-address>:<api-port>/api/clusters/<cluster>/servers/<server>/<port>/config | tar xzf - -C /tmp/cfg
 ```
+
+`--no-check-certificate` is required alongside the switch: the cert is
+self-signed (a generated temp cert when `monitoring-ssl-cert` isn't set), so
+there's no CA for the init container to validate against — same reasoning
+as `prov_opensvc.go`/`prov_onpremise_db.go`'s own `wget` calls, which have
+always used it for the same reason.
+
+**Falls back to plain HTTP on `http-port` when `api-server=false`**: `api-server`
+(default `true`) independently gates whether `apiserver()` — and therefore
+anything listening on `api-port` at all — starts (`server/server.go`). A
+deployment with `api-server=false` and `http-server=true` (both togglable
+independently; `httpserver()` registers the identical unprotected routes)
+would otherwise have nothing to connect to on `api-port`, silently breaking
+bootstrap that worked before this HTTPS switch — the `wget` would hang on
+an unanswered connection with no error surfaced. `k8sDatabaseDeployment`
+checks `cluster.Conf.ApiServ` and builds the command against
+`http://<monitoring-address>:<http-port>` with no `--no-check-certificate`
+in that case instead — tested in
+`TestK8SDatabaseDeployment_ConfigFetchFallsBackToHTTPWhenAPIServerDisabled`
+(`cluster/prov_k8s_test.go`), found via code review before it was hit live
+(every live cluster this feature was verified against runs with the
+`api-server` default of `true`).
 
 handled by `handlerMuxServersPortConfig` (`server/api_database.go`). Only
 `etc/mysql/conf.d/*.cnf` is copied in (MariaDB's `!includedir` is
@@ -82,10 +112,10 @@ mirroring OpenSVC's moduleset directory resources.
   `api-credentials-secure-config=true` and `admin` lacks the grant.
 - **Residual risk**: base64 is encoding, not encryption — anyone able to
   read the Deployment spec (`kubectl get deploy -o yaml`, RBAC permitting)
-  can recover the credential, and it still travels over plaintext HTTP.
-  Acceptable interim state; a real fix (Kubernetes `Secret` +
-  `secretKeyRef`, HTTPS) is tracked under #1497.
-- **HTTP, not HTTPS**, unlike OpenSVC's bootstrap path (tracked under #1497).
+  can recover the credential. It now travels over TLS (self-signed, so
+  passive network observation is defeated but active MITM isn't without
+  pinning the generated cert — out of scope here, same residual-risk
+  posture every other orchestrator's own bootstrap fetch already accepts).
 - **`<monitoring-address>` must be a stable address for in-cluster (Model B)
   deployments**: `monitoring-address` defaults to `localhost`, which triggers
   `resolveHostIp()` (`server/server.go`) to auto-detect and bake in repman's
@@ -105,6 +135,19 @@ mirroring OpenSVC's moduleset directory resources.
   left at the `localhost` default — the Service's ClusterIP is stable across
   pod reschedules even though the pod IP behind it isn't. No code change
   needed; this is purely a deployment-config requirement for Model B.
+- **The in-cluster Service must expose `api-port` (10005), not just
+  `http-port`**: since the HTTPS switch above, bootstrap always targets
+  `api-port` — a Model B Service manifest built before that switch (this
+  session's own example included) may only forward `http-port` (10001,
+  used for the pre-existing NodePort/dashboard access), leaving nothing
+  routing traffic to 10005 at all. Confirmed live: an otherwise-correct
+  bootstrap command (right DNS name, right port, `--no-check-certificate`)
+  hung indefinitely with no init container log output at all — not a
+  `wget` error, a plain unanswered TCP connection, since nothing was
+  listening on the Service side for that port. Fixed by adding a second
+  port to the Service (`kubectl patch svc repman-incluster --type=json
+  -p='[{"op":"add","path":"/spec/ports/-","value":{"name":"https","port":10005,"targetPort":10005,"protocol":"TCP"}}]'`);
+  any Model B deployment manifest must declare both ports going forward.
 
 ### Unprovisioning
 
@@ -295,6 +338,76 @@ functionality (DB connectivity, `.system/jobs` cleanup) is confirmed
 working regardless; this status-reporting channel (and, untested, the
 same mechanism backup streaming likely uses) is the open piece.
 
+### Manifest view
+
+#1497 gap 6: OpenSVC has `GetDatabaseServiceConfig` (above) to show what
+repman would push, but Kubernetes had no equivalent GUI visibility at all
+into the Deployment/PVC/Service/pod state actually running. Rather than add
+a second route, the existing single-server manifest/config view was
+generalized: `GET /api/clusters/{clusterName}/servers/{serverName}/service/{orchestrator}`
+(`handlerMuxGetDatabaseServiceConfig`, `server/api_database.go`) is now keyed
+by a dynamic `{orchestrator}` path segment instead of the literal
+`service-opensvc` it used to be — the same route serves both orchestrators'
+views rather than one route per orchestrator, since only one is ever
+relevant for a given cluster. The `{orchestrator}` segment must match the
+cluster's actually-configured orchestrator (`cluster.GetOrchestrator()`) —
+repman's own config is authoritative over what a caller requests, not the
+other way around; a mismatch is a 400. The branching itself is factored
+into `buildDatabaseServiceConfigResponse`, kept separate from the HTTP
+handler specifically so it's testable without a real JWT
+(`IsValidClusterACL` has no bypass) — `server/api_database_test.go`.
+
+`databaseACLRules` (`cluster/cluster_acl_rules.go`) gates this route by
+`strings.Contains` against a literal URL segment, independently of the
+handler's own logic — renaming the route from `/service-opensvc` to
+`/service/{orchestrator}` without updating that rule silently 403s every
+caller regardless of grants, since the ACL layer runs *before* the
+handler's own orchestrator switch and never reaches it. Found only via a
+live JWT-authenticated request (not by `buildDatabaseServiceConfigResponse`'s
+own tests, which deliberately bypass `IsValidClusterACL` to avoid needing a
+real JWT) — fixed by updating the rule to the `/service/` prefix, which
+matches every orchestrator's segment; regression-tested directly in
+`cluster/cluster_acl_test.go` (`TestIsURLPassACLDatabaseServiceRoute`).
+
+Unlike `GetDatabaseServiceConfig`'s locally-regenerated OpenSVC template,
+`K8SGetDatabaseManifests` (`cluster/prov_k8s_manifest.go`) fetches every
+section *live* from the Kubernetes API — Deployment, Service, PVC, and the
+server's pods (by the same `app=repication-manager,tag=<server>` label
+selector `k8sDatabaseDeployment` sets) — since PVC binding status and pod
+state only exist live; a static builder-function re-render (as OpenSVC's
+view effectively is) can't show either. Each object is marshaled to YAML
+(`sigs.k8s.io/yaml`, respecting the same JSON tags client-go itself uses)
+with `TypeMeta` filled in explicitly (`Get`/`List` through a typed client
+clears it) and `ManagedFields` stripped (noise, not useful to a human
+reader). A resource that doesn't exist yet (e.g. no PVC because
+provisioning failed before that step) renders as a `# <error>` YAML comment
+in its own section rather than failing the whole response — same
+"`*FromClient` testable + public live-connecting wrapper" split as
+`k8sStorageClassesFromClient`/`K8SGetStorageClasses`, tested against the
+fake clientset in `cluster/prov_k8s_manifest_test.go`.
+
+Model B's ClusterRole needs `get, list` on the core `pods` resource for the
+pod section — a rule set written before this feature existed won't have it.
+Confirmed live: without it, the pods section renders the exact Forbidden
+error as its YAML comment (the same "error surfaces per-section, not as a
+500" behavior covers this case too) rather than failing the whole response
+— visibly correct behavior even under a missing grant, but still worth
+granting for the feature to actually show pod state.
+
+Response shape differs by orchestrator and is Content-Type-discriminated:
+OpenSVC keeps returning raw text (unchanged); Kubernetes returns
+`{deployment, service, pvc, pods}` as `application/json`, each value being
+one YAML string. GUI-side, `ServiceOpenSvc` (component name predates this
+generalization, kept as-is —
+`share/dashboard_react/src/Pages/ClusterDB/components/ServiceOpenSvc`)
+renders the Kubernetes case as four labeled sections instead of one text
+blob, dispatching to `service/${orchestrator}` (the cluster's own
+`config.provOrchestrator`, never hardcoded) rather than the old literal
+`service-opensvc` service name. The "Service Config" tab (renamed from
+"Service OpenSVC") is only shown when the cluster's orchestrator actually
+has a view to offer (`opensvc` or `kube`) — every other orchestrator gets
+an empty body from this route, so showing the tab would be dead UX.
+
 ## Proxy provisioning
 
 `K8SProvisionProxyService()` creates only a Deployment — no Namespace ensure
@@ -472,8 +585,6 @@ Kubernetes-orchestrated scenarios.
   DBs or proxies.
 - No proxy Service exposure, and no Kubernetes proxy support beyond
   ProxySQL.
-- Config bootstrap is HTTP, not HTTPS (Basic Auth-authenticated, see
-  "Bootstrap" above).
 - Per-pod DNS (`prov-net-cni`) covers DB pods only — no equivalent for
   proxies yet (see "Per-pod DNS" above).
 - A `<cluster>-deployment` left over from before per-proxy Deployment

--- a/doc/implementation/cluster/KUBERNETES_PROVISIONING.md
+++ b/doc/implementation/cluster/KUBERNETES_PROVISIONING.md
@@ -1,9 +1,16 @@
 # Kubernetes native provisioning
 
 Covers `cluster/prov_k8s.go`, `cluster/prov_k8s_db.go`, `cluster/prov_k8s_prx.go`.
-Broader feature work (dbjobs sidecar, StorageClass selection, Secrets, HTTPS
-bootstrap, GUI manifest view, proxy-type-aware image selection) is tracked in
-issue #1497.
+Broader feature work tracked in issue #1497: HTTPS bootstrap, GUI manifest
+view, and proxy-type-aware image selection remain open. Secrets, image pull
+policy, StorageClass selection, and the dbjobs sidecar are implemented and
+verified live against both deployment models (see "Secrets, image pull
+policy, and storage class" and "dbjobs sidecar" below) — repman running
+outside the cluster (Model A) and repman running as an in-cluster Deployment
+(Model B), the latter requiring both an RBAC grant beyond what an
+earlier-written `ClusterRole` may have and, separately, `monitoring-address`
+set explicitly to a stable Service DNS name rather than left at its
+pod-IP-autodetecting default (see "Bootstrap" below).
 
 ## Dispatch
 
@@ -79,6 +86,25 @@ mirroring OpenSVC's moduleset directory resources.
   Acceptable interim state; a real fix (Kubernetes `Secret` +
   `secretKeyRef`, HTTPS) is tracked under #1497.
 - **HTTP, not HTTPS**, unlike OpenSVC's bootstrap path (tracked under #1497).
+- **`<monitoring-address>` must be a stable address for in-cluster (Model B)
+  deployments**: `monitoring-address` defaults to `localhost`, which triggers
+  `resolveHostIp()` (`server/server.go`) to auto-detect and bake in repman's
+  *own current pod IP* at process startup. That's fine for repman running
+  outside Kubernetes (Model A), but for repman running as an in-cluster
+  Deployment, the pod IP is not stable — any reschedule of repman's own pod
+  (rollout, eviction, node drain, crash) changes it, silently breaking the
+  bootstrap `wget` for every *already-provisioned* DB Deployment (their init
+  container command has the old IP baked in verbatim; only Deployments built
+  *after* the change get the new one). Confirmed live: after redeploying
+  `repman-incluster`'s binary via a pod delete/recreate, an existing DB's
+  restart action still succeeded (image-pull-policy/`restartedAt` patch), but
+  the new pod's init container failed with `wget: can't connect to remote
+  host (<old pod IP>): Host is unreachable`. Fix: set `monitoring-address`
+  explicitly in the in-cluster deployment's config to repman's own Service
+  DNS name (e.g. `repman-incluster.repman-system.svc.cluster.local`), not
+  left at the `localhost` default — the Service's ClusterIP is stable across
+  pod reschedules even though the pod IP behind it isn't. No code change
+  needed; this is purely a deployment-config requirement for Model B.
 
 ### Unprovisioning
 
@@ -127,6 +153,147 @@ covers that.
 Proxy pods aren't part of this (no `role` label, so excluded from the `db`
 Service by construction) — they have no Service of any kind yet; a
 `role=proxy` follow-up is natural but not built (#1497).
+
+### Secrets, image pull policy, and storage class
+
+`MYSQL_ROOT_PASSWORD` is not embedded as a raw `Env` value: `K8SProvisionDatabaseService()`
+creates (or updates, on password rotation) a `Secret` named `<server>-secret`
+holding it, and the container references it via `SecretKeyRef`
+(`k8sEnsureDatabaseSecret`, `k8sSecretName`, `prov_k8s_db.go`) — the same
+"don't put the credential in cleartext in an object anyone with `kubectl get
+-o yaml` and RBAC read access can see" reasoning as the config-bootstrap
+Basic Auth header. The update path is a merge `Patch`, not `Update()` with a
+freshly-constructed object: `Update()` requires the current
+`resourceVersion` for optimistic concurrency, which a fresh object never
+has, so it would be rejected by a real API server (a gap the fake clientset
+used in tests doesn't enforce, so it wasn't test-visible) — confirmed live
+against the `kind` cluster: a merge patch changing the value bumps
+`resourceVersion` correctly with no `resourceVersion` supplied in the
+request. Like the ConfigMap/PVC, the Secret is retained on unprovision, not
+deleted.
+
+`prov-kube-image-force-pull` (bool, off by default) sets the database
+container's `ImagePullPolicy` — `Always` when on, an explicit
+`IfNotPresent` when off (`k8sImagePullPolicy`). Explicit rather than left
+unset: Kubernetes' own implicit default already varies by tag (`Always` for
+`:latest`, `IfNotPresent` otherwise), which is surprising behavior to rely
+on implicitly.
+
+`k8sDatabaseDeployment` only sets `ImagePullPolicy` at creation time, so
+toggling this setting has no effect on an already-provisioned server on its
+own — `K8SForceRepullDatabaseService` (`k8sForceRepullDatabaseServiceWithClient`)
+patches both the pod template's `restartedAt` annotation (a
+`kubectl rollout restart`-style trigger) *and* the container's
+`ImagePullPolicy`, to the current config value, in the same call, so an
+existing Deployment actually picks up a changed setting. `RestartDatabaseService`
+(`cluster/prov.go`, API `/actions/restart`) routes to it for Kubernetes
+instead of the generic `Stop → WaitDatabaseFailed → Start`, which always
+failed for Kubernetes (`K8SStopDatabaseService` has no scale-to-zero/drain
+semantic).
+
+The API handler for that route (`handlerMuxServerRestart`,
+`server/api_database.go`) originally hardcoded `orchestrator == "opensvc"`
+and rejected everything else with 501 — meaning the Kubernetes branch above,
+despite existing and being unit-tested, was never actually reachable
+through the API: the handler never let a Kubernetes server's restart cookie
+get set, so `CheckRestartContainerCookies` (`cluster_chk.go`, the
+monitoring-loop consumer that calls `RestartDatabaseService`) never had
+anything to process. Found only by testing the real HTTP path end-to-end,
+not by unit tests or by testing the Go dispatch logic in isolation — fixed
+by extracting the check into `restartSupportedForOrchestrator()` and adding
+Kubernetes to it. Confirmed live: `/actions/restart` now returns "Restart
+queued successfully" for a Kubernetes server, and the resulting Deployment
+shows both the patched `ImagePullPolicy` and the new `restartedAt`
+annotation. Confirmed live on both deployment models — Model A (repman outside
+the cluster) and Model B (repman itself running as an in-cluster Deployment,
+`repman-incluster`). Model B additionally needs its ServiceAccount's
+`ClusterRole` to actually grant the verbs this phase of work added calls
+for: `patch` on `apps/deployments` (for the restart/repull path above) and
+`get, list, create, patch` on the core `secrets` resource (for
+`k8sEnsureDatabaseSecret`'s create-then-patch-on-rotate pattern) — an
+RBAC rule set written before these existed won't have them. Confirmed live:
+before granting `patch` on `deployments`, `/actions/restart` against a
+Kubernetes server returned a queued-success response but then failed
+server-side with `deployments.apps "<server>" is forbidden: ... cannot patch
+resource "deployments"`, invisible to the API caller (the async cookie
+mechanism only logs the failure, `CheckRestartContainerCookies` in
+`cluster_chk.go`) — visible only by checking `repman-incluster`'s own pod
+logs.
+
+The PVC (`k8sDatabasePVC`) uses `prov-db-disk-size` (already used by every
+other orchestrator for the same purpose — previously hardcoded to `1Gi`
+here, ignoring whatever the operator actually configured) and an optional
+`prov-kube-storage-class`, left unset (`nil`, not a pointer to `""`) to use
+the cluster's default StorageClass when not configured — the K8s API
+distinguishes those two states. `K8SGetStorageClasses()` lists the
+cluster's available StorageClasses for the provisioning GUI's dropdown
+(`/api/clusters/{clusterName}/kube-storage-classes`, mirroring
+`opensvc-pools`' existing disk-pool-list pattern).
+
+### dbjobs sidecar
+
+A second container, `<server>-dbjobs`, runs `share/scripts/dbjobs_new.sh`
+(backups, optimize, config refresh, log collection) — the same image as the
+DB container (`cluster.Conf.ProvDbImg`, matching OpenSVC's own jobs
+container), invoked as `/bin/bash /docker-entrypoint-initdb.d/dbjobs_launcher_with_sigterm`.
+
+The script arrives pre-resolved: the init container's fetched config
+archive's root is repman's own `Datadir/init` (confirmed via
+`configurator.TarGz`'s caller, `cluster/configurator/configurator.go`), and
+every `%%ENV:...%%` placeholder in it — including `JOBS_DATADIR`
+(`GetJobDatadir()`) — is already substituted server-side by
+`GenerateDatabaseConfig` before the archive is built, so nothing needs
+runtime templating. The init container now additionally copies that
+`init/` entry into a new shared `emptyDir` (`<server>-init`, mounted at
+`/docker-entrypoint-initdb.d` in both the init container and the sidecar)
+and separately fetches `replication-manager-cli` from
+`/static/configurator/bin/replication-manager-cli` (a plain,
+unauthenticated static file server — not part of the config archive, same
+as how OpenSVC's own bootstrap script fetches it).
+
+The sidecar mounts the same persistent-storage PVC as the DB container
+(`/var/lib/mysql`) alongside `-init`: `dbjobs_new.sh` does raw filesystem
+operations directly against `$DATADIR` (e.g. moving restored `.ibd` files
+into place during a physical-restore job), so it needs to see the exact
+data directory the DB container writes to. `ReadWriteOnce` restricts a PVC
+to one *node*, not one container — every container here is in the same
+pod, so the same node, by construction. `MYSQL_ROOT_PASSWORD` comes from
+the same per-server `Secret` as the DB container (the script reads it as a
+real runtime `$MYSQL_ROOT_PASSWORD`, not a `%%ENV:...%%` placeholder). No
+new gating flag: OpenSVC creates its own jobs container unconditionally
+(`OpenSVCGetJobsContainerSection`, `prov_opensvc_db.go`), so this matches
+that for parity.
+
+`.system/jobs` (`JOBS_DATADIR`) is pre-created by the init container
+alongside the other `.system/*` paths — confirmed live: without it,
+`cleanup_run_dirs` (the launcher's first action every cycle) fails
+immediately. It's a hardcoded literal here, not a call to
+`s.GetJobDatadir()`: that method dereferences
+`s.ClusterGroup.Configurator` with no nil check, which would violate
+`k8sDatabaseDeployment`'s own "pure builder, no ServerMonitor methods"
+contract and panic on a bare `*ServerMonitor` (confirmed via a test) — it
+matches `GetJobDatadir()`'s own Kubernetes-path result unless the
+`nosplitpath` db-tag is set, which isn't handled here.
+
+**Verified live**: the sidecar starts, the fetched script is correctly
+resolved (real host/port/user baked in, matching what the DB container
+actually is), it connects to the database successfully and repeats on its
+~60s schedule, and `.system/jobs` cleanup runs without error.
+
+**Known limitation, not yet resolved**: `dbjobs_new.sh` streams routine
+status/log lines back to repman over a `socat`-based channel
+(`send_lines_to_api`) on every cycle, using a receiver address/port
+repman allocates dynamically per call. Live testing (Model A: repman
+outside the cluster) got "connection refused" on that specific
+port — the packet reaches repman's host fine (the same address the
+config-bootstrap fetch already uses successfully), but nothing was
+listening on the dynamically-allocated port at that moment. This is
+pre-existing `dbjobs_new.sh`/repman receiver-port allocation machinery,
+not something this session's changes touch, and needs deeper
+investigation into that allocation path — not yet done. Core job
+functionality (DB connectivity, `.system/jobs` cleanup) is confirmed
+working regardless; this status-reporting channel (and, untested, the
+same mechanism backup streaming likely uses) is the open piece.
 
 ## Proxy provisioning
 
@@ -216,12 +383,7 @@ that list will leave the pod `Pending`.
 
 `K8SStopDatabaseService()` returns an explicit
 `"stop is not supported for the kubernetes orchestrator"` error; there is no
-scale-to-zero/drain semantic for the Deployment. This matters because
-`cluster/prov.go`'s `RestartDatabaseService` calls
-`Stop → WaitDatabaseFailed → Start` generically for every orchestrator,
-including Kubernetes: an explicit error here makes a Kubernetes restart fail
-fast instead of waiting out a `WaitDatabaseFailed` timeout for a stop that
-never happens.
+scale-to-zero/drain semantic for the Deployment.
 
 `K8SStartDatabaseService()` has no real start/scale-up either, but it does
 `Get()` the Deployment and returns an explicit error if it is missing or has
@@ -229,13 +391,18 @@ a desired replica count of zero — it only reports success if the Deployment
 exists with a non-zero desired replica count. This is a state check, not a
 health check, and never scales anything up.
 
-**Consequence:** `RestartDatabaseService`, `StopDatabaseServiceClean`,
-`RollingRestart`, `RollingUpgrade`, the scheduler rolling-restart path, and
-the security-fix rolling-restart path all fail fast with an explicit error
-for Kubernetes-orchestrated databases rather than completing. A real
-scale-based start/stop pair is deferred — tracked under #1497 alongside the
-dbjobs sidecar work, since a scale-to-zero pause would need to coordinate
-with a real lifecycle sidecar.
+`RestartDatabaseService` (`cluster/prov.go`) has a Kubernetes-specific
+branch that no longer routes through `Stop → WaitDatabaseFailed → Start` at
+all — it calls `K8SForceRepullDatabaseService` directly (see "Secrets,
+image pull policy, and storage class" above), a rolling pod replacement via
+annotation patch, which works with the Deployment model instead of fighting
+it. `StopDatabaseServiceClean`, `RollingUpgrade`, the scheduler
+rolling-restart path, and the security-fix rolling-restart path still
+dispatch through the generic stop lifecycle with no orchestrator-aware
+gating, so they still fail fast with an explicit error for Kubernetes —
+only the specific `RestartDatabaseService` path was fixed here. A real
+scale-based start/stop pair, and extending the rolling-replacement approach
+to those other paths, remains deferred under #1497.
 
 ## Idempotency and error propagation
 
@@ -328,13 +495,17 @@ Kubernetes-orchestrated scenarios.
   orchestrator, not Kubernetes-specific, and predates this change — not
   fixed here, since it would mean changing the generic `prov.go` contract
   and multiple API handlers shared by all orchestrators.
-- Rolling restart/upgrade (API `handlerMuxRollingAction`, the scheduler, and
-  the dashboard) dispatch with no orchestrator-aware gating, so they remain
-  triggerable for Kubernetes clusters even though they hit the unsupported
-  Kubernetes stop lifecycle (`RollingUpgrade` via `StopDatabaseServiceClean`,
-  `RestartDatabaseService` via a generic `Stop → WaitDatabaseFailed → Start`)
-  — same pre-existing, cross-orchestrator gap, not fixed here. `RollingReprov`
-  is different: it unprovisions and reprovisions each server rather than
-  stopping/starting it, so it does not hit the unsupported stop path.
+- `RestartDatabaseService` (API `/actions/restart`) now has a Kubernetes
+  branch that triggers a rolling pod replacement (the same mechanism
+  `prov-kube-image-force-pull` relies on) instead of the generic
+  `Stop → WaitDatabaseFailed → Start`, which always failed for Kubernetes
+  (`K8SStopDatabaseService` has no scale-to-zero/drain semantic and
+  unconditionally errors). `RollingUpgrade` (`handlerMuxRollingAction`, the
+  scheduler, the dashboard) still dispatches with no orchestrator-aware
+  gating and still hits that same unsupported stop lifecycle via
+  `StopDatabaseServiceClean` — same pre-existing, cross-orchestrator gap,
+  not fixed here. `RollingReprov` is different: it unprovisions and
+  reprovisions each server rather than stopping/starting it, so it never
+  hit the unsupported stop path in the first place.
 
 All of the above require a design decision and are tracked under issue #1497.

--- a/doc/implementation/cluster/KUBERNETES_PROVISIONING.md
+++ b/doc/implementation/cluster/KUBERNETES_PROVISIONING.md
@@ -1,0 +1,284 @@
+# Kubernetes native provisioning
+
+Covers `cluster/prov_k8s.go`, `cluster/prov_k8s_db.go`, `cluster/prov_k8s_prx.go`.
+Broader feature work (dbjobs sidecar, StorageClass selection, Secrets, HTTPS
+bootstrap, GUI manifest view, proxy-type-aware image selection) is tracked in
+issue #1497.
+
+## Dispatch
+
+Orchestrator selection is `cluster.GetOrchestrator()` → `cluster.Conf.ProvOrchestrator`.
+Dispatch to the `K8S*` functions happens in `cluster/prov.go`'s per-operation
+switch statements, not through the `DatabaseOrchetrator` interface in
+`cluster/orchestrator.go` (that interface is not used for the Kubernetes path).
+
+## Database provisioning
+
+`K8SProvisionDatabaseService()`:
+
+1. Connect to the API (`K8SConnectAPI()`).
+2. Best-effort ensure Namespace `cluster.Name`. A `Create()` failure other
+   than `AlreadyExists` is logged but never fatal on its own — some clusters
+   pre-create the namespace and grant repman only namespaced-resource
+   permissions, not `namespaces/create` or `namespaces/get`, so `Create()`
+   can legitimately return `Forbidden` even when the namespace already
+   exists. A namespace that genuinely doesn't exist surfaces as a real error
+   at the next step instead.
+3. Create PVC `<cluster>-<server>-claim`, 1Gi, `ReadWriteOnce`, no
+   StorageClass. `AlreadyExists` is idempotent; any other error is fatal.
+4. Generate DB config (`s.GetDatabaseConfig()`) and read
+   `<server-datadir>/config.tar.gz`.
+5. Best-effort create a ConfigMap `<server>-config-map` containing that
+   archive. It is not mounted or otherwise consumed by the Deployment created
+   in step 7 — its fate (mount it for real bootstrap, or remove it) is an
+   open question, so it is never treated as required for provisioning to
+   succeed.
+6. Resolve the Kubernetes node via `cluster.GetDatabaseAgent(s)`. Failure is
+   fatal.
+7. Create the Deployment (1 replica, pinned to that node via a
+   `NodeSelector` on `kubernetes.io/hostname`, an `alpine` init container,
+   the main DB container, PVC-backed volume). `AlreadyExists` is idempotent;
+   any other error is fatal and skips the
+   Service step.
+8. Create the Service (ClusterIP, same port). `AlreadyExists` is idempotent.
+9. Exactly one value is sent on `cluster.errorChan`.
+
+### Bootstrap
+
+The init container fetches the DB config over HTTP:
+
+```
+wget -qO- http://<monitoring-address>:<http-port>/api/clusters/<cluster>/servers/<server>/<port>/config | tar xzvf - -C /data
+```
+
+handled by `handlerMuxServersPortConfig` (`server/api_database.go`). This is
+the only wired bootstrap mechanism; the ConfigMap above is not part of it.
+
+Limitations:
+
+- **No authentication.** If `api-credentials-secure-config=true`, the
+  endpoint requires a valid ACL/JWT via `IsValidClusterACL` and the init
+  container sends none, so it gets HTTP 403 and the DB never bootstraps.
+  `K8SProvisionDatabaseService()` logs a warning up front when this
+  combination is detected, since provisioning itself (Namespace/PVC/
+  Deployment/Service) still succeeds while the pod never bootstraps. Fixing
+  the incompatibility needs a credential injected into the pod (e.g. a
+  Kubernetes Secret plus an `Authorization` header) — tracked under #1497.
+- **HTTP, not HTTPS**, unlike the equivalent OpenSVC bootstrap path (also
+  tracked under #1497).
+
+### Unprovisioning
+
+`K8SUnprovisionDatabaseService()` deletes the Deployment and Service, both
+idempotent via `apierrors.IsNotFound`. ConfigMap, PVC, and Namespace are
+retained — PVC deletion is destructive and Namespace/ConfigMap
+retention-vs-deletion semantics are an open question. Exactly one value is
+sent on `cluster.errorChan`.
+
+## Proxy provisioning
+
+`K8SProvisionProxyService()` creates only a Deployment — no Namespace ensure
+(it relies on one already existing from DB provisioning in the same
+cluster), no Service, no config bootstrap, no ConfigMap. It unconditionally
+uses `cluster.Conf.ProvProxProxysqlImg` regardless of the proxy's actual
+type, so Kubernetes proxy provisioning today only really supports ProxySQL.
+
+The Deployment name and selector are unique per proxy
+(`<cluster>-<proxy-name>-deployment`, label `tag: <proxy-name>`), so multiple
+proxies in the same cluster don't collide.
+
+`K8SUnprovisionProxyService()` deletes that Deployment, idempotent via
+`apierrors.IsNotFound`.
+
+### Legacy deployment name
+
+Clusters provisioned before per-proxy naming existed have a single
+`<cluster>-deployment` shared across every proxy, with selector
+`app: repication-manager` only (no `tag`). That selector label-matches new
+per-proxy Deployments' pods too (Kubernetes selector matching only requires
+the specified labels to be present; extra labels don't exclude a match), so
+a lingering legacy Deployment is not fully inert alongside new ones.
+
+It is not automatically deleted: a single proxy's provision or unprovision
+call has no way to prove the legacy Deployment belongs to that proxy rather
+than a different, not-yet-migrated one in the same cluster. Deleting it from
+a single-proxy-scoped operation could take down an unrelated proxy still
+running under the old scheme.
+
+Both `K8SProvisionProxyService()` and `K8SUnprovisionProxyService()` call
+`k8sWarnIfLegacyProxyDeploymentExists()` — a read-only `Get()` check that
+logs a warning if the legacy Deployment is still present, so its existence
+is visible rather than silent. Once every proxy in a cluster has been
+reprovisioned under the new per-proxy name, an operator should manually
+delete the leftover Deployment if
+`kubectl get deployment <cluster>-deployment -n <cluster>` still shows one.
+
+### Start/stop
+
+`K8SStartProxyService`/`K8SStopProxyService` return explicit "not supported"
+errors; no lifecycle is implemented.
+
+## Node discovery
+
+`K8SGetNodes()` propagates a `List()` failure and does not index
+`Status.Addresses[0]` unguarded — a node with no reported addresses no
+longer panics the caller. `Agent.HostName` is the node's API object name
+(`node.Name`), used to match operator-supplied `prov-db-agents` entries via
+`GetAgentInOrchetrator` — that must stay `node.Name`, since that's what an
+operator reads from `kubectl get nodes` and writes into config.
+
+Node pinning uses a `NodeSelector` on `kubernetes.io/hostname`, not
+`Spec.NodeName`. `NodeName` bypasses the scheduler entirely, and
+`WaitForFirstConsumer` volume binding — the default mode for most dynamic
+provisioners, including `kind`'s local-path-provisioner and typical cloud
+CSI drivers — only runs during scheduling. Verified against a live 3-node
+`kind` cluster: with `NodeName`, the PVC stayed `Pending` indefinitely (no
+`Scheduled` event ever appeared) and the pod never left `Init:0/1`; with
+`NodeSelector`, the pod went through `default-scheduler` normally, the PVC
+bound immediately, and the pod reached `Running`.
+
+`node.Name` is not guaranteed to equal the node's `kubernetes.io/hostname`
+label value (they usually match, but nothing enforces it — a node can be
+relabeled, or registered with a `--hostname-override` that diverges from its
+metadata name). `k8sNodesFromClient()` captures each node's
+`kubernetes.io/hostname` label value during the same `nodes/list` call
+`K8SGetNodes` already needs, caching it by `node.Name` on the `Cluster`
+(`k8sNodeHostnameLabels`, guarded by `k8sNodeHostnameLabelsMu`).
+`k8sHostnameLabel()` reads that cache when building the Deployment's
+`NodeSelector`, falling back to `node.Name` if the label was empty or the
+node was never seen. This resolves the mismatch case without any per-node
+`nodes/get` call — a least-privilege RBAC setup that grants only
+`nodes/list` still gets correct placement.
+
+Because pinning now goes through the scheduler instead of bypassing it, the
+target node must actually be schedulable under normal scheduler predicates:
+taints without a matching toleration, or any other predicate that would
+reject the pod, now block provisioning where a raw `NodeName` assignment
+previously would not have. No tolerations are added — the assumption is that
+nodes listed in `prov-db-agents` are meant to run database pods and are
+schedulable in the ordinary sense; a tainted or otherwise cordoned node in
+that list will leave the pod `Pending`.
+
+## Database start/stop lifecycle
+
+`K8SStopDatabaseService()` returns an explicit
+`"stop is not supported for the kubernetes orchestrator"` error; there is no
+scale-to-zero/drain semantic for the Deployment. This matters because
+`cluster/prov.go`'s `RestartDatabaseService` calls
+`Stop → WaitDatabaseFailed → Start` generically for every orchestrator,
+including Kubernetes: an explicit error here makes a Kubernetes restart fail
+fast instead of waiting out a `WaitDatabaseFailed` timeout for a stop that
+never happens.
+
+`K8SStartDatabaseService()` has no real start/scale-up either, but it does
+`Get()` the Deployment and returns an explicit error if it is missing or has
+a desired replica count of zero — it only reports success if the Deployment
+exists with a non-zero desired replica count. This is a state check, not a
+health check, and never scales anything up.
+
+**Consequence:** `RestartDatabaseService`, `StopDatabaseServiceClean`,
+`RollingRestart`, `RollingUpgrade`, the scheduler rolling-restart path, and
+the security-fix rolling-restart path all fail fast with an explicit error
+for Kubernetes-orchestrated databases rather than completing. A real
+scale-based start/stop pair is deferred — tracked under #1497 alongside the
+dbjobs sidecar work, since a scale-to-zero pause would need to coordinate
+with a real lifecycle sidecar.
+
+## Idempotency and error propagation
+
+Namespace/PVC/ConfigMap/Deployment/Service create paths distinguish
+`apierrors.IsAlreadyExists` from genuine failures via typed classification,
+not string matching. For PVC, ConfigMap (best-effort either way),
+Deployment, and Service, a genuine failure stops the provisioning flow and
+reports the error. Namespace is the one exception (see above) and stays
+best-effort/non-fatal, since a `Create()` failure there can't reliably be
+classified from this code alone. All delete paths use
+`apierrors.IsNotFound` the same way. Every `K8S*ProvisionService`/
+`K8S*UnprovisionService` function sends exactly one value on
+`cluster.errorChan`.
+
+Port parsing (`strconv.Atoi` on both the database port and the proxy port)
+returns an explicit error and aborts instead of silently defaulting to
+port `0`.
+
+**`AlreadyExists` means create-only idempotent, not reconciled to the
+current desired spec.** Treating it as success never diffs or patches the
+existing object — it only avoids a spurious failure on a second provision.
+An existing Deployment/Service/PVC with an outdated spec (e.g. from an older
+repman version) is not corrected by reprovisioning; `Create()` returns
+`AlreadyExists`, that is treated as success, and the stale object is left
+as-is. Spec reconciliation (diff + `Update()`/`Patch()`) is not implemented.
+The interim remediation for a stale object is manual: delete it and let the
+next provision recreate it correctly.
+
+## Testing
+
+Focused unit tests in `cluster/prov_k8s_test.go`, using
+`k8s.io/client-go/kubernetes/fake`, cover: node-address safety, node-list
+error propagation, proxy naming uniqueness and non-collision between two
+proxies, invalid-port rejection, `AlreadyExists`/`NotFound` idempotency on
+provisioning and unprovisioning, namespace-ensure never blocking on a
+`Create()` failure, the legacy proxy Deployment being left untouched by both
+provision and unprovision, `K8SStartDatabaseService`'s state check, and
+`k8sHostnameLabel()`'s cached label-vs-node-name resolution (matching label,
+missing label, uncached node).
+
+The provisioning/unprovisioning logic is split into
+`kubernetes.Interface`-parameterized helpers (e.g.
+`k8sProvisionProxyServiceWithClient`, `k8sUnprovisionDatabaseServiceWithClient`,
+`k8sNodesFromClient`) so a fake clientset can exercise them; the public
+`K8S*` methods are thin live-connection wrappers. `K8SConnectAPI()`'s
+concrete `*kubernetes.Clientset` return type and kubeconfig source are
+unchanged.
+
+Manually verified against a live 3-node `kind` cluster: DB provision (Namespace/
+PVC/Deployment/Service creation, node scheduling, PVC binding, config
+bootstrap via the init container, MariaDB startup), stop (explicit error,
+pod left untouched), start (state check passes against the running
+Deployment), and unprovision (Deployment/Service deleted, PVC/ConfigMap
+retained) all behaved as documented above.
+
+No Kubernetes-capable regtest/CI harness exists in this repository, so this
+verification is not repeatable/automated — it does not substitute for real
+CI integration coverage. Closing that gap requires provisioning a
+kind/minikube-style cluster in CI and extending `regtest/` with
+Kubernetes-orchestrated scenarios.
+
+## Known limitations
+
+- ConfigMap fate (mount it for real bootstrap, or remove it) is undecided.
+- PVC and Namespace deletion semantics on unprovision are undecided.
+- No real start/stop lifecycle (e.g. Deployment scale 0/1) for Kubernetes
+  DBs or proxies.
+- No proxy Service exposure, and no Kubernetes proxy support beyond
+  ProxySQL.
+- Config bootstrap is HTTP-only, unauthenticated.
+- A `<cluster>-deployment` left over from before per-proxy Deployment
+  naming requires manual operator cleanup (see "Legacy deployment name"
+  above); repman only warns about it, since automatic cleanup can't prove
+  ownership from a single-proxy-scoped operation.
+- `AlreadyExists` does not reconcile an existing object's spec (see
+  "Idempotency and error propagation" above).
+- Kubernetes provisioning code compiles regardless of `WithOpenSVC`, but
+  `--kube-config` and the `kube` orchestrator default are only
+  registered/exposed when `WithOpenSVC=="ON"` — `kube-config` remains
+  settable via TOML/env in any build regardless.
+- `K8SStopDatabaseService`/`K8SStartDatabaseService` returning a real error
+  (instead of always `nil`) does not by itself surface that error to
+  callers: `cluster/prov.go`'s `StopDatabaseService`/`StartDatabaseService`
+  run `StopDatabaseScript`/`StartDatabaseScript` unconditionally regardless
+  of the orchestrator result, and `server/api_database.go`'s stop/start
+  handlers discard the returned error entirely. This is the same for every
+  orchestrator, not Kubernetes-specific, and predates this change — not
+  fixed here, since it would mean changing the generic `prov.go` contract
+  and multiple API handlers shared by all orchestrators.
+- Rolling restart/upgrade (API `handlerMuxRollingAction`, the scheduler, and
+  the dashboard) dispatch with no orchestrator-aware gating, so they remain
+  triggerable for Kubernetes clusters even though they hit the unsupported
+  Kubernetes stop lifecycle (`RollingUpgrade` via `StopDatabaseServiceClean`,
+  `RestartDatabaseService` via a generic `Stop → WaitDatabaseFailed → Start`)
+  — same pre-existing, cross-orchestrator gap, not fixed here. `RollingReprov`
+  is different: it unprovisions and reprovisions each server rather than
+  stopping/starting it, so it does not hit the unsupported stop path.
+
+All of the above require a design decision and are tracked under issue #1497.

--- a/go.mod
+++ b/go.mod
@@ -112,6 +112,7 @@ require (
 	k8s.io/apimachinery v0.31.3
 	k8s.io/client-go v0.31.3
 	modernc.org/sqlite v1.46.1
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -309,7 +310,6 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -294,6 +294,7 @@ require (
 	golang.org/x/tools v0.47.0 // indirect
 	google.golang.org/genproto v0.0.0-20230530153820-e85fd2cbaebc // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1344,6 +1344,8 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/evanphx/json-patch.v4 v4.12.0 h1:n6jtcsulIzXPJaxegRbvFNNrZDjbij7ny3gmSPG+6V4=
+gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=

--- a/regtest/regtest.go
+++ b/regtest/regtest.go
@@ -92,6 +92,7 @@ var tests = []string{
 	"testResticReseedXtrabackup",
 	"testResticReseedMariabackup",
 	"testOpenSVCUpgradeWarnRecovery",
+	"testK8SProvisionSchedulerVolumeBinding",
 	"testSchemaPlugin",
 	"testGraphiteMetricsQueueBound",
 	"testDirectReseedSystemAllEmptyDestination",

--- a/regtest/test_k8s_provision_scheduler_volume_binding.go
+++ b/regtest/test_k8s_provision_scheduler_volume_binding.go
@@ -1,0 +1,131 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// Authors: Guillaume Lefranc <guillaume@signal18.io>
+//          Stephane Varoqui  <stephane@signal18.io>
+// This source code is licensed under the GNU General Public License, version 3.
+
+package regtest
+
+import (
+	"context"
+	"time"
+
+	"github.com/signal18/replication-manager/cluster"
+	"github.com/signal18/replication-manager/config"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestK8SProvisionSchedulerVolumeBinding reprovisions a Kubernetes-orchestrated
+// slave and verifies its PVC actually binds and its pod actually reaches
+// Running, rather than just checking that the Create() calls succeeded.
+//
+// This regresses a real bug found via live-cluster testing (not caught by the
+// fake-client unit tests in cluster/prov_k8s_test.go, since the fake API
+// server doesn't simulate the scheduler or the volume-binding controller):
+// pinning the Deployment's pod via Spec.NodeName bypasses the scheduler
+// entirely, so a WaitForFirstConsumer StorageClass (the default for most
+// dynamic provisioners, including kind's local-path-provisioner and typical
+// cloud CSI drivers) never binds the PVC, since that only happens during
+// scheduling — the pod hangs in Init forever. See
+// doc/implementation/cluster/KUBERNETES_PROVISIONING.md ("Node discovery").
+//
+// This test requires:
+//   - Kubernetes orchestrator (prov-orchestrator = kube)
+//   - At least one slave
+//   - A real Kubernetes API connection (cl.K8SConnectAPI()) — this cannot run
+//     against a fake/mocked cluster, only a real one (kind, minikube, or a
+//     real cluster), which is exactly the T13 gap this test is meant to close
+//     once a Kubernetes-capable CI harness exists.
+func (regtest *RegTest) TestK8SProvisionSchedulerVolumeBinding(cl *cluster.Cluster, conf string, test *cluster.Test) bool {
+	if cl.GetOrchestrator() != config.ConstOrchestratorKubernetes {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST", "Skipping: requires Kubernetes orchestrator")
+		return true
+	}
+
+	// Prefer a slave, to avoid disrupting a live master — but the
+	// scheduling/PVC-binding behavior under test is per-server and doesn't
+	// depend on replication role, so fall back to any server if no
+	// replication topology has been established yet (e.g. SQL connectivity
+	// to the pod isn't reachable from wherever repman itself is running,
+	// which is a deployment-topology concern orthogonal to what this test
+	// checks).
+	var slave *cluster.ServerMonitor
+	if slaves := cl.GetSlaves(); len(slaves) > 0 {
+		slave = slaves[0]
+	} else if servers := cl.GetServers(); len(servers) > 0 {
+		slave = servers[0]
+	} else {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST", "Skipping: no servers available")
+		return true
+	}
+	cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST",
+		"Testing Kubernetes scheduler/PVC-binding provisioning for %s", slave.URL)
+
+	client, err := cl.K8SConnectAPI()
+	if err != nil {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST",
+			"FAIL: cannot connect to Kubernetes API: %s", err)
+		return false
+	}
+
+	// Reprovision from scratch so this exercises the exact scheduling path a
+	// real provision goes through, not whatever state the slave was already
+	// left in (e.g. already Running from initial cluster bootstrap, in which
+	// case the scheduling/PVC-binding step being tested wouldn't happen at all).
+	if err := cl.UnprovisionDatabaseService(slave); err != nil {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST",
+			"Unprovision before reprovision reported: %s (continuing)", err)
+	}
+	time.Sleep(5 * time.Second)
+
+	if err := cl.InitDatabaseService(slave); err != nil {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST",
+			"FAIL: provisioning failed: %s", err)
+		return false
+	}
+
+	pvcName := cl.Name + "-" + slave.Name + "-claim"
+	pvcBound := false
+	for deadline := time.Now().Add(90 * time.Second); time.Now().Before(deadline); {
+		pvc, getErr := client.CoreV1().PersistentVolumeClaims(cl.Name).Get(context.TODO(), pvcName, metav1.GetOptions{})
+		if getErr == nil && pvc.Status.Phase == apiv1.ClaimBound {
+			pvcBound = true
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if !pvcBound {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST",
+			"FAIL: PVC %s did not bind within 90s — this is the WaitForFirstConsumer/scheduler-bypass regression", pvcName)
+		return false
+	}
+
+	podRunning := false
+	for deadline := time.Now().Add(120 * time.Second); time.Now().Before(deadline); {
+		pods, listErr := client.CoreV1().Pods(cl.Name).List(context.TODO(), metav1.ListOptions{
+			LabelSelector: "tag=" + slave.Name,
+		})
+		if listErr == nil {
+			for _, p := range pods.Items {
+				if p.Status.Phase == apiv1.PodRunning {
+					podRunning = true
+					break
+				}
+			}
+		}
+		if podRunning {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if !podRunning {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST",
+			"FAIL: pod for %s did not reach Running within 120s", slave.Name)
+		return false
+	}
+
+	cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, "TEST",
+		"PASS: %s provisioned, PVC bound, pod Running", slave.Name)
+	return true
+}

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -102,6 +102,11 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterOpenSVCPoolList)),
 	))
 
+	router.Handle("/api/clusters/{clusterName}/kube-storage-classes", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterKubeStorageClassList)),
+	))
+
 	//PROTECTED ENDPOINTS FOR CLUSTERS ACTIONS
 	router.Handle("/api/clusters/{clusterName}/settings", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
@@ -2749,6 +2754,8 @@ func (repman *ReplicationManager) switchClusterSettings(mycluster *cluster.Clust
 		mycluster.SwitchTestMode()
 	case "prov-net-cni":
 		mycluster.SwitchProvNetCNI()
+	case "prov-kube-image-force-pull":
+		mycluster.Conf.ProvKubeImageForcePull = !mycluster.Conf.ProvKubeImageForcePull
 	case "prov-db-config":
 		mycluster.Conf.ProvDBConfig = !mycluster.Conf.ProvDBConfig
 	case "prov-db-config-preserve":
@@ -3650,6 +3657,8 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		mycluster.SetProvNetCniCluster(value)
 	case "prov-orchestrator-cluster":
 		mycluster.SetProvOrchestratorCluster(value)
+	case "prov-kube-storage-class":
+		mycluster.SetProvKubeStorageClass(value)
 	case "prov-db-disk-size":
 		mycluster.SetDBDiskSize(value)
 	case "prov-db-cpu-cores":
@@ -4440,6 +4449,8 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		mycluster.Conf.Test = applyIsActive(mycluster.Conf.Test, isactive)
 	case "prov-net-cni":
 		mycluster.Conf.ProvNetCNI = applyIsActive(mycluster.Conf.ProvNetCNI, isactive)
+	case "prov-kube-image-force-pull":
+		mycluster.Conf.ProvKubeImageForcePull = applyIsActive(mycluster.Conf.ProvKubeImageForcePull, isactive)
 	case "prov-db-config":
 		mycluster.Conf.ProvDBConfig = applyIsActive(mycluster.Conf.ProvDBConfig, isactive)
 	case "prov-db-config-preserve":
@@ -9320,6 +9331,50 @@ func (repman *ReplicationManager) handlerMuxClusterOpenSVCPoolList(w http.Respon
 				continue
 			}
 			options = append(options, PoolOption{Value: pool.Name, Name: pool.Name, Shared: pool.Shared})
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(options); err != nil {
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "API Error writing response: %s", err)
+		}
+	} else {
+		http.Error(w, "No cluster", http.StatusInternalServerError)
+		return
+	}
+}
+
+// handlerMuxClusterKubeStorageClassList lists the Kubernetes cluster's
+// available StorageClasses, for the provisioning GUI's storage-class
+// dropdown (prov-kube-storage-class) -- Kubernetes' equivalent of
+// handlerMuxClusterOpenSVCPoolList's disk-pool list.
+// @Summary List available Kubernetes StorageClasses
+// @Description Lists the Kubernetes cluster's available StorageClasses.
+// @Tags Database
+// @Param clusterName path string true "Cluster Name"
+// @Success 200 {array} PoolOption "Kubernetes StorageClass list fetched"
+// @Failure 403 {string} string "No valid ACL"
+// @Failure 500 {string} string "No cluster" or "Error getting Kubernetes storage class list"
+// @Router /api/clusters/{clusterName}/kube-storage-classes [get]
+func (repman *ReplicationManager) handlerMuxClusterKubeStorageClassList(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster != nil {
+		if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+			http.Error(w, "No valid ACL", http.StatusForbidden)
+			return
+		}
+
+		names, err := mycluster.K8SGetStorageClasses()
+		if err != nil {
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Error getting Kubernetes storage class list: %s", err)
+			http.Error(w, "Error getting Kubernetes storage class list: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		options := make([]PoolOption, 0, len(names))
+		for _, name := range names {
+			options = append(options, PoolOption{Value: name, Name: name})
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/server/api_cluster_test.go
+++ b/server/api_cluster_test.go
@@ -247,6 +247,73 @@ func TestSwitchClusterSetting_HaproxyAPIBootstrapServers(t *testing.T) {
 	}
 }
 
+// Confirms prov-kube-image-force-pull actually reaches setClusterSetting's
+// switch (GUI dispatches switchSetting for it, OrchestratorDbVM.jsx) --
+// wiring a GUI control without a matching case here means the toggle
+// renders but silently never persists.
+func TestSwitchClusterSetting_ProvKubeImageForcePull(t *testing.T) {
+	cl := newTestClusterForAPI(t)
+	cl.Conf.Secrets = make(map[string]config.Secret)
+	cl.ConfigManager = newConfigManagerForTest()
+	repman := newTestRepmanWithCluster(t, cl.Name, cl)
+
+	cl.Conf.ProvKubeImageForcePull = false
+
+	if err := repman.switchClusterSettings(cl, "prov-kube-image-force-pull"); err != nil {
+		t.Fatalf("switchClusterSettings(prov-kube-image-force-pull): unexpected error: %v", err)
+	}
+	if !cl.Conf.ProvKubeImageForcePull {
+		t.Fatalf("expected ProvKubeImageForcePull=true after first switch, got false")
+	}
+
+	if err := repman.switchClusterSettings(cl, "prov-kube-image-force-pull"); err != nil {
+		t.Fatalf("switchClusterSettings(prov-kube-image-force-pull) second call: unexpected error: %v", err)
+	}
+	if cl.Conf.ProvKubeImageForcePull {
+		t.Fatalf("expected ProvKubeImageForcePull=false after second switch, got true")
+	}
+}
+
+func TestSetClusterSetting_ProvKubeImageForcePull(t *testing.T) {
+	cl := newTestClusterForAPI(t)
+	cl.Conf.Secrets = make(map[string]config.Secret)
+	cl.ConfigManager = newConfigManagerForTest()
+	repman := newTestRepmanWithCluster(t, cl.Name, cl)
+
+	cl.Conf.ProvKubeImageForcePull = false
+
+	if err := repman.setClusterSetting(cl, "prov-kube-image-force-pull", "on"); err != nil {
+		t.Fatalf(`setClusterSetting(prov-kube-image-force-pull, "on"): unexpected error: %v`, err)
+	}
+	if !cl.Conf.ProvKubeImageForcePull {
+		t.Fatalf("expected ProvKubeImageForcePull=true after explicit \"on\", got false")
+	}
+
+	if err := repman.setClusterSetting(cl, "prov-kube-image-force-pull", "off"); err != nil {
+		t.Fatalf(`setClusterSetting(prov-kube-image-force-pull, "off"): unexpected error: %v`, err)
+	}
+	if cl.Conf.ProvKubeImageForcePull {
+		t.Fatalf("expected ProvKubeImageForcePull=false after explicit \"off\", got true")
+	}
+}
+
+// Confirms prov-kube-storage-class (GUI dispatches setSetting for it,
+// OrchestratorDbVM.jsx) actually reaches SetProvKubeStorageClass through
+// setClusterSetting's switch.
+func TestSetClusterSetting_ProvKubeStorageClass(t *testing.T) {
+	cl := newTestClusterForAPI(t)
+	cl.Conf.Secrets = make(map[string]config.Secret)
+	cl.ConfigManager = newConfigManagerForTest()
+	repman := newTestRepmanWithCluster(t, cl.Name, cl)
+
+	if err := repman.setClusterSetting(cl, "prov-kube-storage-class", "fast-ssd"); err != nil {
+		t.Fatalf(`setClusterSetting(prov-kube-storage-class, "fast-ssd"): unexpected error: %v`, err)
+	}
+	if cl.Conf.ProvKubeStorageClass != "fast-ssd" {
+		t.Fatalf("expected ProvKubeStorageClass %q, got %q", "fast-ssd", cl.Conf.ProvKubeStorageClass)
+	}
+}
+
 func TestSetClusterSetting_HaproxyAPIBootstrapServers(t *testing.T) {
 	cl := newTestClusterForAPI(t)
 	cl.Conf.Secrets = make(map[string]config.Secret)

--- a/server/api_database.go
+++ b/server/api_database.go
@@ -265,7 +265,7 @@ func (repman *ReplicationManager) apiDatabaseProtectedHandler(router *mux.Router
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxServerMasterStatus)),
 	))
-	router.Handle("/api/clusters/{clusterName}/servers/{serverName}/service-opensvc", negroni.New(
+	router.Handle("/api/clusters/{clusterName}/servers/{serverName}/service/{orchestrator}", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxGetDatabaseServiceConfig)),
 	))
@@ -4578,44 +4578,80 @@ func (repman *ReplicationManager) handlerMuxSetInnoDBMonitor(w http.ResponseWrit
 	}
 }
 
-// handlerMuxGetDatabaseServiceConfig handles the HTTP request to get the database service configuration of a specific server within a cluster.
-// @Summary Get database service configuration of a server
-// @Description Retrieves the database service configuration of a specified server within a cluster.
+// handlerMuxGetDatabaseServiceConfig handles the HTTP request to get the
+// database service/manifest view of a specific server within a cluster --
+// one route shared by every orchestrator that has such a view, keyed by a
+// {orchestrator} path segment rather than one hardcoded route name per
+// orchestrator (the route used to be literally "service-opensvc", which
+// would have been misleading to also serve Kubernetes content under).
+// OpenSVC returns the raw service config text it would push
+// (GetDatabaseServiceConfig, prov_opensvc_db.go); Kubernetes has no
+// equivalent single "service config" object, so it returns the live
+// Deployment/Service/PVC/Pod manifests as JSON instead
+// (K8SGetDatabaseManifests, #1497 gap 6) -- Content-Type is set
+// accordingly so the caller can tell which shape it got. The path segment
+// must match the cluster's actual configured orchestrator (repman's own
+// config is always authoritative over what a caller requests) -- a
+// mismatch is a 400, not a silent fall-through to whichever branch the
+// caller asked for.
+// @Summary Get database service/manifest view of a server
+// @Description Retrieves the database service configuration or live manifests of a specified server within a cluster: raw OpenSVC service config text, or live Kubernetes manifests as JSON.
 // @Tags Database
 // @Produce json
 // @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
 // @Param clusterName path string true "Cluster Name"
 // @Param serverName path string true "Server Name"
+// @Param orchestrator path string true "Orchestrator (must match the cluster's configured orchestrator)"
 // @Success 200 {string} string "Database service configuration retrieved successfully"
+// @Failure 400 {string} string "Orchestrator does not match cluster configuration"
 // @Failure 403 {string} string "No valid ACL"
 // @Failure 500 {string} string "Cluster Not Found" or "Server Not Found"
-// @Router /api/clusters/{clusterName}/servers/{serverName}/service-opensvc [get]
+// @Router /api/clusters/{clusterName}/servers/{serverName}/service/{orchestrator} [get]
 func (repman *ReplicationManager) handlerMuxGetDatabaseServiceConfig(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	vars := mux.Vars(r)
 	mycluster := repman.getClusterByName(vars["clusterName"])
-	if mycluster != nil {
-		if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
-			http.Error(w, "No valid ACL", http.StatusForbidden)
-			return
-		}
-
-		if mycluster.Conf.ProvOrchestrator != "opensvc" {
-			w.Write([]byte(""))
-			return
-		}
-
-		node := mycluster.GetServerFromName(vars["serverName"])
-		if node != nil {
-			res := mycluster.GetDatabaseServiceConfig(node)
-			w.Write(res)
-		} else {
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("503 -Not a Valid Server!"))
-		}
-	} else {
+	if mycluster == nil {
 		http.Error(w, "No cluster", 500)
 		return
+	}
+	if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+		http.Error(w, "No valid ACL", http.StatusForbidden)
+		return
+	}
+	status, contentType, body := buildDatabaseServiceConfigResponse(mycluster, vars["serverName"], vars["orchestrator"])
+	if contentType != "" {
+		w.Header().Set("Content-Type", contentType)
+	}
+	w.WriteHeader(status)
+	w.Write(body)
+}
+
+// buildDatabaseServiceConfigResponse is handlerMuxGetDatabaseServiceConfig's
+// orchestrator switch, factored out so it's directly testable without a
+// real JWT (IsValidClusterACL requires one, with no bypass -- matching
+// buildS3ProviderReferencesResponse's "business logic separate from the
+// ACL-gated handler" pattern, api_cluster.go).
+func buildDatabaseServiceConfigResponse(mycluster *cluster.Cluster, serverName, orchestrator string) (status int, contentType string, body []byte) {
+	if orchestrator != mycluster.GetOrchestrator() {
+		return http.StatusBadRequest, "", []byte("Orchestrator does not match cluster configuration")
+	}
+	switch mycluster.GetOrchestrator() {
+	case config.ConstOrchestratorKubernetes:
+		node := mycluster.GetServerFromName(serverName)
+		if node == nil {
+			return http.StatusInternalServerError, "", []byte("503 -Not a Valid Server!")
+		}
+		b, _ := json.Marshal(mycluster.K8SGetDatabaseManifests(node))
+		return http.StatusOK, "application/json", b
+	case config.ConstOrchestratorOpenSVC:
+		node := mycluster.GetServerFromName(serverName)
+		if node == nil {
+			return http.StatusInternalServerError, "", []byte("503 -Not a Valid Server!")
+		}
+		return http.StatusOK, "", mycluster.GetDatabaseServiceConfig(node)
+	default:
+		return http.StatusOK, "", []byte("")
 	}
 }
 

--- a/server/api_database.go
+++ b/server/api_database.go
@@ -3501,7 +3501,16 @@ func (repman *ReplicationManager) handlerMuxServersPortConfig(w http.ResponseWri
 	mycluster := repman.getClusterByName(vars["clusterName"])
 	if mycluster != nil {
 		if mycluster.Conf.APISecureConfig {
-			if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+			valid, _ := repman.IsValidClusterACL(r, mycluster)
+			if !valid {
+				// Orchestrator-driven bootstrap (e.g. the K8s init-container
+				// wget in cluster/prov_k8s_db.go) has no JWT to send, only
+				// the HTTP Basic Auth it sends as an Authorization header.
+				if u, p, ok := r.BasicAuth(); ok {
+					valid = mycluster.IsValidACL(u, p, r.URL.Path, "password")
+				}
+			}
+			if !valid {
 				http.Error(w, "No valid ACL", http.StatusForbidden)
 				return
 			}

--- a/server/api_database.go
+++ b/server/api_database.go
@@ -2485,6 +2485,10 @@ func (repman *ReplicationManager) handlerMuxServerStart(w http.ResponseWriter, r
 // @Failure 404 {string} string "Cluster Not Found or Server Not Found"
 // @Failure 501 {string} string "Orchestrator not supported"
 // @Router /api/clusters/{clusterName}/servers/{serverName}/actions/restart [post]
+func restartSupportedForOrchestrator(orchestrator string) bool {
+	return orchestrator == config.ConstOrchestratorOpenSVC || orchestrator == config.ConstOrchestratorKubernetes
+}
+
 func (repman *ReplicationManager) handlerMuxServerRestart(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Content-Type", "application/json")
@@ -2502,9 +2506,17 @@ func (repman *ReplicationManager) handlerMuxServerRestart(w http.ResponseWriter,
 		return
 	}
 
-	if mycluster.GetOrchestrator() != "opensvc" {
+	// CheckRestartContainerCookies (cluster_chk.go), the monitoring-loop
+	// consumer of the cookie this handler sets below, already dispatches
+	// generically through RestartDatabaseService (cluster/prov.go) with no
+	// orchestrator gate of its own -- RestartDatabaseService has had a
+	// Kubernetes branch since #1497's image-pull-policy work, but this
+	// handler blocking Kubernetes here meant the cookie never got set, so
+	// that branch was never actually reachable through the API (confirmed
+	// live: a genuine gap, not by design).
+	if !restartSupportedForOrchestrator(mycluster.GetOrchestrator()) {
 		w.WriteHeader(http.StatusNotImplemented)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Restart is only supported for OpenSVC orchestrator"})
+		json.NewEncoder(w).Encode(map[string]string{"error": "Restart is only supported for OpenSVC and Kubernetes orchestrators"})
 		return
 	}
 

--- a/server/api_database_test.go
+++ b/server/api_database_test.go
@@ -83,6 +83,30 @@ func TestHandlerMuxServersPortConfig_NoAuthAtAllFailsACL(t *testing.T) {
 	}
 }
 
+// handlerMuxServerRestart gated Kubernetes out entirely (hardcoded to
+// OpenSVC only), even though RestartDatabaseService (cluster/prov.go) has
+// had a working Kubernetes branch since #1497's image-pull-policy work --
+// confirmed live: that branch was never actually reachable through the API
+// because this gate blocked the handler from ever setting the restart
+// cookie CheckRestartContainerCookies (cluster_chk.go) consumes.
+func TestRestartSupportedForOrchestrator(t *testing.T) {
+	tests := []struct {
+		orchestrator string
+		want         bool
+	}{
+		{config.ConstOrchestratorOpenSVC, true},
+		{config.ConstOrchestratorKubernetes, true},
+		{config.ConstOrchestratorOnPremise, false},
+		{config.ConstOrchestratorLocalhost, false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := restartSupportedForOrchestrator(tt.orchestrator); got != tt.want {
+			t.Errorf("restartSupportedForOrchestrator(%q) = %v, want %v", tt.orchestrator, got, tt.want)
+		}
+	}
+}
+
 // api-credentials-secure-config off bypasses the ACL gate entirely,
 // regardless of any credential -- matches the K8s init-container's own
 // behavior of sending no Authorization header at all in that case

--- a/server/api_database_test.go
+++ b/server/api_database_test.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/signal18/replication-manager/cluster"
+	"github.com/signal18/replication-manager/config"
+)
+
+// handlerMuxServersPortConfig's ACL gate: a Bearer JWT is checked first
+// (IsValidClusterACL), and HTTP Basic Auth is the fallback for callers with
+// no JWT to send -- the Kubernetes init-container config-bootstrap wget
+// being the motivating case (cluster/prov_k8s_db.go). These tests exercise
+// that fallback directly, without a real ServerMonitor: with no matching
+// server/proxy registered, a request that clears the ACL gate falls through
+// to "No server" (500), while one that doesn't gets "No valid ACL" (403) --
+// a cheap way to distinguish "auth succeeded" from "auth failed" without
+// wiring up real config generation.
+
+func newTestClusterWithAdminUser(t *testing.T, password string) *cluster.Cluster {
+	t.Helper()
+	cl := newTestClusterForAPI(t)
+	cl.Conf.APISecureConfig = true
+	cl.APIUsers = map[string]cluster.APIUser{
+		"admin": {
+			User:     "admin",
+			Password: password,
+			Grants:   map[string]bool{config.GrantDBConfigFlag: true},
+		},
+	}
+	return cl
+}
+
+func TestHandlerMuxServersPortConfig_ValidBasicAuthPassesACL(t *testing.T) {
+	cl := newTestClusterWithAdminUser(t, "s3cr3t")
+	repman := newTestRepmanWithCluster(t, cl.Name, cl)
+
+	req := httptest.NewRequest("GET", "/api/clusters/"+cl.Name+"/servers/db1/3306/config", nil)
+	req = setMuxVars(req, map[string]string{"clusterName": cl.Name, "serverName": "db1", "serverPort": "3306"})
+	req.SetBasicAuth("admin", "s3cr3t")
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxServersPortConfig(w, req)
+
+	if w.Code == http.StatusForbidden {
+		t.Fatalf("expected valid Basic Auth to pass the ACL gate, got 403: %s", w.Body.String())
+	}
+	if w.Code != http.StatusInternalServerError || w.Body.String() != "No server\n" {
+		t.Fatalf("expected to reach the no-matching-server branch (500 \"No server\"), got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlerMuxServersPortConfig_InvalidBasicAuthFailsACL(t *testing.T) {
+	cl := newTestClusterWithAdminUser(t, "s3cr3t")
+	repman := newTestRepmanWithCluster(t, cl.Name, cl)
+
+	req := httptest.NewRequest("GET", "/api/clusters/"+cl.Name+"/servers/db1/3306/config", nil)
+	req = setMuxVars(req, map[string]string{"clusterName": cl.Name, "serverName": "db1", "serverPort": "3306"})
+	req.SetBasicAuth("admin", "wrong-password")
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxServersPortConfig(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected invalid Basic Auth to be rejected with 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlerMuxServersPortConfig_NoAuthAtAllFailsACL(t *testing.T) {
+	cl := newTestClusterWithAdminUser(t, "s3cr3t")
+	repman := newTestRepmanWithCluster(t, cl.Name, cl)
+
+	req := httptest.NewRequest("GET", "/api/clusters/"+cl.Name+"/servers/db1/3306/config", nil)
+	req = setMuxVars(req, map[string]string{"clusterName": cl.Name, "serverName": "db1", "serverPort": "3306"})
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxServersPortConfig(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected no JWT and no Basic Auth to be rejected with 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// api-credentials-secure-config off bypasses the ACL gate entirely,
+// regardless of any credential -- matches the K8s init-container's own
+// behavior of sending no Authorization header at all in that case
+// (cluster/prov_k8s_db.go).
+func TestHandlerMuxServersPortConfig_SecureConfigOffSkipsACL(t *testing.T) {
+	cl := newTestClusterForAPI(t)
+	cl.Conf.APISecureConfig = false
+	repman := newTestRepmanWithCluster(t, cl.Name, cl)
+
+	req := httptest.NewRequest("GET", "/api/clusters/"+cl.Name+"/servers/db1/3306/config", nil)
+	req = setMuxVars(req, map[string]string{"clusterName": cl.Name, "serverName": "db1", "serverPort": "3306"})
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxServersPortConfig(w, req)
+
+	if w.Code == http.StatusForbidden {
+		t.Fatalf("expected api-credentials-secure-config=false to skip the ACL gate entirely, got 403: %s", w.Body.String())
+	}
+}

--- a/server/api_database_test.go
+++ b/server/api_database_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -104,6 +105,115 @@ func TestRestartSupportedForOrchestrator(t *testing.T) {
 		if got := restartSupportedForOrchestrator(tt.orchestrator); got != tt.want {
 			t.Errorf("restartSupportedForOrchestrator(%q) = %v, want %v", tt.orchestrator, got, tt.want)
 		}
+	}
+}
+
+// handlerMuxGetDatabaseServiceConfig is one route shared by every
+// orchestrator with a manifest/config concept to show (#1497 gap 6), keyed
+// by a dynamic {orchestrator} path segment rather than a hardcoded route
+// name per orchestrator (it used to be literally "service-opensvc", which
+// would have been misleading to also serve Kubernetes content under):
+// OpenSVC gets its existing raw service-config text unchanged; Kubernetes
+// gets the live Deployment/Service/PVC/Pod manifests as JSON instead, since
+// it has no equivalent single "service config" object; every other
+// orchestrator keeps the route's pre-existing empty-body behavior. The
+// path segment must match the cluster's actually configured orchestrator
+// -- repman's own config is authoritative, never the caller's say-so.
+// These exercise the handler's branching (cluster lookup, ACL, orchestrator
+// match, server lookup) without a live Kubernetes API server;
+// K8SGetDatabaseManifests's own live-fetch behavior is covered directly in
+// cluster/prov_k8s_manifest_test.go.
+
+func TestHandlerMuxGetDatabaseServiceConfig_NoClusterIs500(t *testing.T) {
+	repman := newTestRepmanWithCluster(t, "unused", newTestClusterForAPI(t))
+
+	req := httptest.NewRequest("GET", "/api/clusters/does-not-exist/servers/db1/service/opensvc", nil)
+	req = setMuxVars(req, map[string]string{"clusterName": "does-not-exist", "serverName": "db1", "orchestrator": "opensvc"})
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxGetDatabaseServiceConfig(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for an unknown cluster, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// buildDatabaseServiceConfigResponse is the ACL-free business logic behind
+// handlerMuxGetDatabaseServiceConfig, called directly here so these don't
+// need a real JWT (IsValidClusterACL has no bypass) -- matching
+// buildS3ProviderReferencesResponse's pattern (api_cluster_test.go).
+
+func TestBuildDatabaseServiceConfigResponse_OrchestratorMismatchIs400(t *testing.T) {
+	cl := newTestClusterForAPI(t)
+	cl.Conf.ProvOrchestrator = config.ConstOrchestratorOpenSVC
+
+	status, _, _ := buildDatabaseServiceConfigResponse(cl, "db1", config.ConstOrchestratorKubernetes)
+
+	if status != http.StatusBadRequest {
+		t.Fatalf("expected 400 when the requested orchestrator doesn't match the cluster's configured one, got %d", status)
+	}
+}
+
+func TestBuildDatabaseServiceConfigResponse_UnhandledOrchestratorReturnsEmptyBody(t *testing.T) {
+	cl := newTestClusterForAPI(t)
+
+	status, contentType, body := buildDatabaseServiceConfigResponse(cl, "db1", "")
+
+	if status != http.StatusOK || contentType != "" || string(body) != "" {
+		t.Fatalf("expected 200 with an empty body for an orchestrator with no manifest view, got %d %q %q", status, contentType, body)
+	}
+}
+
+func TestBuildDatabaseServiceConfigResponse_KubernetesReturnsJSONManifests(t *testing.T) {
+	cl := newTestClusterForAPI(t)
+	cl.Conf.ProvOrchestrator = config.ConstOrchestratorKubernetes
+	cl.Conf.KubeConfig = "/nonexistent/kubeconfig-path-for-test"
+	cl.Servers = []*cluster.ServerMonitor{{Id: "db1", Name: "db1"}}
+
+	status, contentType, body := buildDatabaseServiceConfigResponse(cl, "db1", config.ConstOrchestratorKubernetes)
+
+	if status != http.StatusOK {
+		t.Fatalf("expected 200 for a Kubernetes cluster, got %d: %s", status, body)
+	}
+	if contentType != "application/json" {
+		t.Fatalf("expected application/json Content-Type for the Kubernetes response, got %q", contentType)
+	}
+	var m cluster.K8SDatabaseManifests
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("expected a valid K8SDatabaseManifests JSON body: %v (body: %s)", err, body)
+	}
+	// K8SConnectAPI fails against the bogus kubeconfig above, so every
+	// section should carry that error rather than being silently empty --
+	// confirms this actually reached K8SGetDatabaseManifests.
+	if m.Deployment == "" {
+		t.Fatalf("expected a non-empty Deployment section (even if it's an error), got: %+v", m)
+	}
+}
+
+func TestBuildDatabaseServiceConfigResponse_KubernetesServerNotFoundIs500(t *testing.T) {
+	cl := newTestClusterForAPI(t)
+	cl.Conf.ProvOrchestrator = config.ConstOrchestratorKubernetes
+
+	status, _, _ := buildDatabaseServiceConfigResponse(cl, "does-not-exist", config.ConstOrchestratorKubernetes)
+
+	if status != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for an unknown server, got %d", status)
+	}
+}
+
+func TestHandlerMuxGetDatabaseServiceConfig_NoValidACLFailsWithForbidden(t *testing.T) {
+	cl := newTestClusterWithAdminUser(t, "s3cr3t")
+	cl.Conf.ProvOrchestrator = config.ConstOrchestratorKubernetes
+	repman := newTestRepmanWithCluster(t, cl.Name, cl)
+
+	req := httptest.NewRequest("GET", "/api/clusters/"+cl.Name+"/servers/db1/service/kube", nil)
+	req = setMuxVars(req, map[string]string{"clusterName": cl.Name, "serverName": "db1", "orchestrator": config.ConstOrchestratorKubernetes})
+	w := httptest.NewRecorder()
+
+	repman.handlerMuxGetDatabaseServiceConfig(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 with no credentials against a secured cluster, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/server/regtest.go
+++ b/server/regtest.go
@@ -257,6 +257,9 @@ func (repman *ReplicationManager) RunAllTests(cl *cluster.Cluster, testExp strin
 		if test.Name == "testOpenSVCUpgradeWarnRecovery" {
 			res = regtest.TestOpenSVCUpgradeWarnRecovery(cl, test.ConfigFile, &test)
 		}
+		if test.Name == "testK8SProvisionSchedulerVolumeBinding" {
+			res = regtest.TestK8SProvisionSchedulerVolumeBinding(cl, test.ConfigFile, &test)
+		}
 		if test.Name == "testSchemaPlugin" {
 			res = regtest.TestSchemaPlugin(cl, test.ConfigFile, &test)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -1264,6 +1264,8 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 		flags.StringVar(&conf.ProvSSLKey, "prov-tls-server-key", "", "server TLS key")
 		flags.BoolVar(&conf.ProvNetCNI, "prov-net-cni", false, "Networking use CNI")
 		flags.StringVar(&conf.ProvNetCNICluster, "prov-net-cni-cluster", "default", "Name of of the OpenSVC network")
+		flags.BoolVar(&conf.ProvKubeImageForcePull, "prov-kube-image-force-pull", false, "Kubernetes only: force ImagePullPolicy=Always on the database container instead of the default IfNotPresent")
+		flags.StringVar(&conf.ProvKubeStorageClass, "prov-kube-storage-class", "", "Kubernetes only: StorageClass for the database PVC (empty uses the cluster's default StorageClass)")
 		flags.StringVar(&conf.ProvNetDockerRunArgs, "prov-net-docker-run-args", "--sysctl net.ipv4.tcp_tw_reuse=1 --sysctl net.core.somaxconn=1024  --sysctl net.ipv4.tcp_fin_timeout=10", "Additional docker run arguments for netns container")
 		flags.BoolVar(&conf.ProvDockerDaemonPrivate, "prov-docker-daemon-private", true, "Use global or private registry per service")
 		flags.StringVar(&conf.ProvDBCompliance, "prov-db-compliance", "", "Path of compliance file for DB configuration")

--- a/share/dashboard_react/src/Pages/ClusterDB/components/ClusterDBTabContent/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterDB/components/ClusterDBTabContent/index.jsx
@@ -18,7 +18,7 @@ import Errors from '../Errors'
 import ServerAudit from '../ServerAudit'
 import PFSInstruments from '../PFSInstruments'
 
-function ClusterDBTabContent({ tab, dbId, clusterName, digestMode, toggleDigestMode, user, selectedDBServer, variableMode, toggleVariableMode, onNavigateToPFSInstruments, onNavigateToVariables, variablesSearchFilter }) {
+function ClusterDBTabContent({ tab, dbId, clusterName, digestMode, toggleDigestMode, user, selectedDBServer, variableMode, toggleVariableMode, onNavigateToPFSInstruments, onNavigateToVariables, variablesSearchFilter, orchestrator }) {
   const [currentTab, setCurrentTab] = useState('')
 
   const {
@@ -100,8 +100,8 @@ function ClusterDBTabContent({ tab, dbId, clusterName, digestMode, toggleDigestM
           user={user}
           selectedDBServer={selectedDBServer}
         />
-      ) : currentTab === 'opensvc' ? (
-        <ServiceOpenSvc clusterName={clusterName} type="db" id={dbId} />
+      ) : currentTab === 'serviceconfig' ? (
+        <ServiceOpenSvc clusterName={clusterName} type="db" id={dbId} orchestrator={orchestrator} />
       ) : currentTab === 'metadata' ? (
         <MetadataLocks clusterName={clusterName} dbId={dbId} selectedDBServer={selectedDBServer} />
       ) : currentTab === 'resptime' ? (

--- a/share/dashboard_react/src/Pages/ClusterDB/components/ServiceOpenSvc/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterDB/components/ServiceOpenSvc/index.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import { Box, Text, VStack } from '@chakra-ui/react'
 import { getAppService, getDatabaseService } from '../../../../redux/clusterSlice'
 
 import CopyObjectText from '../../../../components/CopyObjectText'
@@ -17,20 +18,48 @@ const useOpenSvcSelector = (type) => {
   });
 };
 
+// Kubernetes has no single "service config" object the way OpenSVC does, so
+// service/{orchestrator} (buildDatabaseServiceConfigResponse,
+// server/api_database.go) returns live Deployment/Service/PVC/Pod manifest
+// YAML sections as JSON instead of one raw text blob (#1497 gap 6).
+const K8S_MANIFEST_SECTIONS = [
+  { key: 'deployment', label: 'Deployment' },
+  { key: 'service', label: 'Service' },
+  { key: 'pvc', label: 'PersistentVolumeClaim' },
+  { key: 'pods', label: 'Pods' }
+]
 
-function ServiceOpenSvc({ clusterName, type, id, user }) {
+function ServiceOpenSvc({ clusterName, type, id, user, orchestrator }) {
   const dispatch = useDispatch()
-  const serviceOpensvc = useOpenSvcSelector(type)
-  const serviceName = 'service-opensvc'
+  const serviceConfig = useOpenSvcSelector(type)
+  // type="app" always uses the (unrelated, OpenSVC-only) app-level route --
+  // only the db route is orchestrator-dynamic.
+  const serviceName = type === 'db' && orchestrator ? `service/${orchestrator}` : 'service-opensvc'
 
   useEffect(() => {
     if (type === "db") {
-      dispatch(getDatabaseService({ clusterName, serviceName, dbId: id }))
+      if (orchestrator) {
+        dispatch(getDatabaseService({ clusterName, serviceName, dbId: id }))
+      }
     } else if (type === "app") {
       dispatch(getAppService({ clusterName, serviceName, appId: id }))
     }
-  }, [type])
-  return <CopyObjectText text={JSON.stringify(serviceOpensvc)} />
+  }, [type, orchestrator])
+
+  if (type === 'db' && orchestrator === 'kube' && serviceConfig && typeof serviceConfig === 'object') {
+    return (
+      <VStack align="stretch" spacing={6}>
+        {K8S_MANIFEST_SECTIONS.map(({ key, label }) => (
+          <Box key={key}>
+            <Text fontWeight="bold" mb={2}>{label}</Text>
+            <CopyObjectText text={serviceConfig[key] || ''} showPrettyJsonCheckbox={false} />
+          </Box>
+        ))}
+      </VStack>
+    )
+  }
+
+  return <CopyObjectText text={JSON.stringify(serviceConfig)} />
 }
 
 export default ServiceOpenSvc

--- a/share/dashboard_react/src/Pages/ClusterDB/index.jsx
+++ b/share/dashboard_react/src/Pages/ClusterDB/index.jsx
@@ -86,7 +86,12 @@ function ClusterDB(props) {
         if (apiUser.grants['db-show-variables']) {
           authorizedTabs.push('Variables')
         }
-        authorizedTabs.push('Service OpenSVC')
+        // Only orchestrators with an actual manifest/config view to show --
+        // service/{orchestrator} (buildDatabaseServiceConfigResponse,
+        // server/api_database.go) returns an empty body for everything else.
+        if (['opensvc', 'kube'].includes(clusterData?.config?.provOrchestrator)) {
+          authorizedTabs.push('Service Config')
+        }
         if (apiUser.grants['db-show-logs']) {
           authorizedTabs.push('Metadata Locks')
           authorizedTabs.push('Response Time')
@@ -148,9 +153,8 @@ function ClusterDB(props) {
     if (tabs.current[selectedTabRef.current] === 'Variables') {
       dispatch(getDatabaseService({ clusterName, serviceName: 'variables', dbId, queryParams: { diff: variableModeRef.current === 'diff' } }))
     }
-    if (tabs.current[selectedTabRef.current] === 'Service OpenSVC') {
-      // if (selectedTabRef.current === 8) {
-      dispatch(getDatabaseService({ clusterName, serviceName: 'service-opensvc', dbId }))
+    if (tabs.current[selectedTabRef.current] === 'Service Config' && clusterData?.config?.provOrchestrator) {
+      dispatch(getDatabaseService({ clusterName, serviceName: `service/${clusterData.config.provOrchestrator}`, dbId }))
     }
     if (tabs.current[selectedTabRef.current] === 'Metadata Locks') {
       // if (selectedTabRef.current === 9) {
@@ -305,13 +309,18 @@ function ClusterDB(props) {
                 ]
               : []),
 
-            <ClusterDBTabContent
-              tab='opensvc'
-              dbId={dbId}
-              clusterName={clusterName}
-              user={user}
-              selectedDBServer={selectedDBServer}
-            />,
+            ...(['opensvc', 'kube'].includes(clusterData?.config?.provOrchestrator)
+              ? [
+                  <ClusterDBTabContent
+                    tab='serviceconfig'
+                    dbId={dbId}
+                    clusterName={clusterName}
+                    user={user}
+                    selectedDBServer={selectedDBServer}
+                    orchestrator={clusterData?.config?.provOrchestrator}
+                  />
+                ]
+              : []),
 
             ...(user?.grants['db-show-logs']
               ? [

--- a/share/dashboard_react/src/Pages/Configs/components/OrchestratorDbVM.jsx
+++ b/share/dashboard_react/src/Pages/Configs/components/OrchestratorDbVM.jsx
@@ -6,6 +6,7 @@ import TableType2 from '../../../components/TableType2'
 import parentStyles from '../styles.module.scss'
 import { useDispatch, useSelector } from 'react-redux'
 import { setSetting, switchSetting } from '../../../redux/settingsSlice'
+import { getKubeStorageClasses } from '../../../redux/clusterSlice'
 import { convertObjectToArrayForDropdown } from '../../../utility/common'
 import RMSwitch from '../../../components/RMSwitch'
 
@@ -14,6 +15,7 @@ function OrchestratorDbVM({ selectedCluster, user }) {
   const {
     globalClusters: { monitor }
   } = useSelector((state) => state)
+  const kubeStorageClasses = useSelector((state) => state.cluster?.kubeStorageClasses || [])
   const [serviceVMs, setServiceVMs] = useState([])
 
   useEffect(() => {
@@ -21,6 +23,12 @@ function OrchestratorDbVM({ selectedCluster, user }) {
       setServiceVMs(convertObjectToArrayForDropdown(monitor.serviceVM))
     }
   }, [monitor?.serviceVM])
+
+  useEffect(() => {
+    if (selectedCluster?.name && selectedCluster?.config?.provOrchestrator === 'kube') {
+      dispatch(getKubeStorageClasses({ clusterName: selectedCluster.name }))
+    }
+  }, [selectedCluster?.name, selectedCluster?.config?.provOrchestrator])
 
   const dataObject = [
     {
@@ -74,6 +82,39 @@ function OrchestratorDbVM({ selectedCluster, user }) {
         />
       )
     },
+    selectedCluster?.config?.provOrchestrator === 'kube' && {
+      key: 'Kubernetes Storage Class',
+      value: (
+        <Dropdown
+          className={parentStyles.dropdown}
+          options={kubeStorageClasses}
+          selectedValue={selectedCluster?.config?.provKubeStorageClass}
+          confirmTitle={`Confirm change Kubernetes storage class to `}
+          onChange={(value) => {
+            dispatch(
+              setSetting({
+                clusterName: selectedCluster?.name,
+                setting: 'prov-kube-storage-class',
+                value: value
+              })
+            )
+          }}
+        />
+      )
+    },
+    selectedCluster?.config?.provOrchestrator === 'kube' && {
+      key: 'Kubernetes Force Image Pull',
+      value: (
+        <RMSwitch
+          isChecked={selectedCluster?.config?.provKubeImageForcePull}
+          isDisabled={user?.grants['cluster-settings'] == false}
+          confirmTitle={'Confirm switch settings for prov-kube-image-force-pull?'}
+          onChange={() =>
+            dispatch(switchSetting({ clusterName: selectedCluster?.name, setting: 'prov-kube-image-force-pull' }))
+          }
+        />
+      )
+    },
     {
       key: 'Provisioning Private Docker Daemon',
       value: (
@@ -100,7 +141,7 @@ function OrchestratorDbVM({ selectedCluster, user }) {
         />
       )
     }
-  ]
+  ].filter(Boolean)
   return (
     <VStack>
       <TableType2 dataArray={dataObject} className={parentStyles.table} />

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -81,6 +81,9 @@ const fulfilledHandlers = {
   'cluster/getOpenSVCPools': (state, action) => {
     state.opensvcPools = action.payload.data
   },
+  'cluster/getKubeStorageClasses': (state, action) => {
+    state.kubeStorageClasses = action.payload.data
+  },
   'cluster/getBackups': (state, action) => {
     state.backups.list = action.payload.data
   },
@@ -278,6 +281,19 @@ export const getOpenSVCPools = createGuardedAsyncThunk('cluster/getOpenSVCPools'
     return handleError(error, thunkAPI)
   }
 })
+
+export const getKubeStorageClasses = createGuardedAsyncThunk(
+  'cluster/getKubeStorageClasses',
+  async ({ clusterName }, thunkAPI) => {
+    try {
+      const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
+      const { data, status } = await clusterService.getKubeStorageClasses(clusterName, baseURL)
+      return { data, status }
+    } catch (error) {
+      return handleError(error, thunkAPI)
+    }
+  }
+)
 
 export const getBackups = createGuardedAsyncThunk('cluster/getBackups', async ({ clusterName }, thunkAPI) => {
   try {
@@ -2701,6 +2717,7 @@ const initialState = {
   topProcess: null,
   opensvcStats: null,
   opensvcPools: null,
+  kubeStorageClasses: null,
   jobs: null,
   shardSchema: null,
   queryRules: null,
@@ -2792,6 +2809,7 @@ export const clusterSlice = createSlice({
         getTopProcess.fulfilled,
         getOpenSVCStats.fulfilled,
         getOpenSVCPools.fulfilled,
+        getKubeStorageClasses.fulfilled,
         getShardSchema.fulfilled,
         getQueryRules.fulfilled,
         getBackups.fulfilled,

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -120,6 +120,15 @@ const fulfilledHandlers = {
 
 const handleDatabaseServiceFulfilled = (state, action) => {
   const { serviceName } = action.meta.arg
+  // service/{orchestrator} is dynamic (opensvc, kube, ...) -- matched by
+  // prefix rather than a case per orchestrator. Holds raw OpenSVC service
+  // config text, or a { deployment, service, pvc, pods } object of live
+  // Kubernetes manifest YAML for Kubernetes-orchestrated clusters (#1497
+  // gap 6, server/api_database.go's buildDatabaseServiceConfigResponse).
+  if (serviceName?.startsWith('service/')) {
+    state.database.serviceOpensvc = action.payload.data
+    return
+  }
   switch (serviceName) {
     case 'processlist':
       state.database.processList = action.payload.data
@@ -152,9 +161,6 @@ const handleDatabaseServiceFulfilled = (state, action) => {
       break
     case 'variables':
       state.database.variables = action.payload.status == 200 ? action.payload.data : []
-      break
-    case 'service-opensvc':
-      state.database.serviceOpensvc = action.payload.data
       break
     case 'meta-data-locks':
       state.database.metadataLocks = action.payload.data

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -13,6 +13,7 @@ export const clusterService = {
   getTopProcess,
   getOpenSVCStats,
   getOpenSVCPools,
+  getKubeStorageClasses,
   getBackups,
   getBackupStats,
   deleteBackup,
@@ -257,6 +258,10 @@ function getOpenSVCStats(clusterName, baseURL) {
 
 function getOpenSVCPools(clusterName, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/opensvc-pools`)
+}
+
+function getKubeStorageClasses(clusterName, baseURL) {
+  return getApi(baseURL).get(`clusters/${clusterName}/kube-storage-classes`)
 }
 
 function getBackups(clusterName, baseURL) {


### PR DESCRIPTION
Closes #1737

Hardens the native Kubernetes provisioning path and adds regression coverage — both fake-client unit tests and a real-cluster regtest — for the scheduler/PVC-binding lifecycle.

## ⚠️ Behavior changes for existing Kubernetes-orchestrated deployments

- **`K8SStopDatabaseService` now returns an explicit error instead of silently succeeding (`nil`).** There is no scale-to-zero/drain semantic implemented, so this was always a no-op — it just used to report success. `RestartDatabaseService`, `StopDatabaseServiceClean`, and the rolling-upgrade paths (master and slaves) all call `StopDatabaseService` with no Kubernetes-specific handling, so **restarts and rolling upgrades against Kubernetes-orchestrated clusters now hard-fail immediately, where they previously appeared to succeed** while doing nothing to the actual pod. This is the correct behavior — reporting success for an action that didn't happen was the actual bug — but it is a visible change for anyone relying on those code paths against a `prov-orchestrator=kube` cluster today.
- **`RestartDatabaseService` for Kubernetes is now a rollout request, not a synchronous readiness wait.** `/actions/restart` patches the Deployment (`restartedAt` + current `ImagePullPolicy`) and returns/clears its restart cookie once that patch succeeds; Kubernetes then replaces the pod asynchronously. This avoids stalling the monitor loop on rollout convergence, but it means success here means "restart requested" rather than "new pod is already Ready".
- Database Deployment pod placement changed from `Spec.NodeName` to `NodeSelector` on `kubernetes.io/hostname`. Functionally equivalent (same node pinning) for clusters using `Immediate`-binding StorageClasses, but **required** for `WaitForFirstConsumer` (the default for most dynamic provisioners, including `kind`'s local-path-provisioner and typical cloud CSI drivers) — previously the PVC would hang in `Pending` forever and the pod would never leave `Init:0/1`. One consequence: pod placement now goes through normal scheduler predicates (taints, etc.), which raw `NodeName` previously bypassed.
- Proxy Deployment name/selector changed from a single shared `<cluster>-deployment` (colliding across all proxies in a cluster) to unique-per-proxy `<cluster>-<proxy>-deployment`. A pre-existing shared deployment from before this change is not touched automatically (ownership can't be proven from a single-proxy-scoped call) — repman now logs a warning if one is detected; see the doc below for the manual migration step.
- `K8SUnprovisionProxyService` now actually deletes the Deployment it's asked to unprovision — previously a no-op that reported success while leaving it running.

All of the above are documented in detail in `doc/implementation/cluster/KUBERNETES_PROVISIONING.md`.

## Bug fixes
- Fixes nil-pointer panic in `K8SUnprovisionDatabaseService` when API connect fails.
- Fixes panic in `K8SGetNodes` when a node has no reported addresses.
- Fixes silent port-0 Services/containers by propagating `strconv.Atoi` errors.
- Fixes DB init-container command encoding (`["sh","-c","..."]`) so bootstrap actually runs.
- Fixes `api-credentials-secure-config=true` bootstrap fetches by sending an `Authorization: Basic` header from the Kubernetes init-container when config auth is enabled; the residual risk (credential is recoverable from the Deployment spec by anyone with RBAC read access) is documented in `doc/implementation/cluster/KUBERNETES_PROVISIONING.md`.
- Enforces single terminal send on `cluster.errorChan` and removes cross-talk from `K8SUnprovisionDatabaseService`.
- Implements `K8SUnprovisionProxyService` and gives proxies unique names/selectors (previously a shared name/selector across every proxy in a cluster).
- Adds typed `apierrors.IsAlreadyExists`/`IsNotFound` handling instead of logging empty-name objects as success.
- Namespace creation is now tolerant of a least-privilege RBAC setup that only grants namespaced-resource permissions, not `namespaces/create`.

Note: proxy image selection (`ProvProxProxysqlImg`) is still unconditional regardless of proxy type — that gap is *not* fixed here, only documented (see `doc/implementation/cluster/KUBERNETES_PROVISIONING.md`); native K8s proxy provisioning still only really supports ProxySQL.

## Refactoring
- Extracts `k8sDatabaseDeployment` as a pure builder (no API calls, no `ServerMonitor` methods invoked) so placement, selectors, and environment — in particular the `NodeSelector` fix above — can be asserted directly in a fast unit test, not only via the live-cluster regtest.

## Regression coverage
- `cluster/prov_k8s_test.go`: fake-client unit tests for nil-safety, port parsing, naming/idempotency, error classification, and — via `k8sDatabaseDeployment` — a direct assertion that the Deployment uses `NodeSelector` (not `NodeName`).
- `regtest/test_k8s_provision_scheduler_volume_binding.go`: reprovisions a server and verifies its PVC binds and its pod reaches `Running` against a real Kubernetes API — this specific check requires a live cluster (fake clientsets don't simulate the scheduler or volume-binding controller) and has no CI harness to run in yet (tracked as T13 debt); manually verified passing against a live 3-node `kind` cluster.

## Deferred
ConfigMap fate, PVC/namespace retention semantics, real K8s start/stop lifecycle, proxy Service exposure, and proxy-type-aware image selection remain design decisions outside this scope, as documented in `doc/implementation/cluster/KUBERNETES_PROVISIONING.md`.
