### PR TITLE
refactor(cluster): remove unused configurator helpers

### DIFF
--- a/cluster/configurator/configurator.go
+++ b/cluster/configurator/configurator.go
@@ -16,9 +16,9 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
-	"sync"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/signal18/replication-manager/config"
 	v3 "github.com/signal18/replication-manager/repmanv3"
@@ -49,12 +49,12 @@ type Configurator struct {
 	// ActiveDBCRC and ActivePrxCRC are CRC32 checksums of the compliance
 	// modules last accepted by the user. Persisted to disk so upgrades
 	// (new embedded module) and BO pushes are both detected on restart.
-	ActiveDBCRC           uint32            `json:"-"`
-	ActivePrxCRC          uint32            `json:"-"`
+	ActiveDBCRC  uint32 `json:"-"`
+	ActivePrxCRC uint32 `json:"-"`
 	// PendingDBCRC and PendingPrxCRC are CRC32 checksums of new compliance
 	// files found in PluginDataDir or embedded. Non-zero when an update is pending.
-	PendingDBCRC          uint32            `json:"pendingDBCRC,omitempty"`
-	PendingPrxCRC         uint32            `json:"pendingPrxCRC,omitempty"`
+	PendingDBCRC  uint32 `json:"pendingDBCRC,omitempty"`
+	PendingPrxCRC uint32 `json:"pendingPrxCRC,omitempty"`
 }
 
 func (configurator *Configurator) Init(conf config.Config, logger *logrus.Logger) error {
@@ -1308,48 +1308,6 @@ func ParseVariableNamesFromCnf(cnf string) []string {
 		}
 	}
 	return names
-}
-
-func (configurator *Configurator) GetDatabaseConfig(filter string, datadir string) (string, error) {
-	mydynamicconf := ""
-	// processing symlink
-	type Link struct {
-		Symlink string `json:"symlink"`
-		Target  string `json:"target"`
-	}
-	for _, rule := range configurator.DBModule.Rulesets {
-		if strings.Contains(rule.Name, "mariadb.svc.mrm.db.cnf.generic") {
-			for _, variable := range rule.Variables {
-				if variable.Class == "symlink" {
-					if configurator.IsFilterInDBTags(rule.Filter) || rule.Name == "mariadb.svc.mrm.db.cnf.generic" {
-						if configurator.ClusterConfig.IsEligibleForPrinting(config.ConstLogModConfigLoad, config.LvlDbg) || configurator.ClusterConfig.Verbose {
-							configurator.Logger.Debugf("content %s %s", filter, rule.Filter)
-						}
-						if filter == "" || strings.Contains(rule.Filter, filter) {
-							var f Link
-							json.Unmarshal([]byte(variable.Value), &f)
-							fpath := datadir + "/init/etc/mysql/conf.d/"
-							if configurator.ClusterConfig.IsEligibleForPrinting(config.ConstLogModConfigLoad, config.LvlDbg) || configurator.ClusterConfig.Verbose {
-								configurator.Logger.Debugf("Config symlink %s , %s", fpath, f.Target)
-							}
-							file, err := os.Open(fpath + f.Target)
-							if err == nil {
-								scanner := bufio.NewScanner(file)
-								for scanner.Scan() {
-									mydynamicconf = mydynamicconf + strings.Split(scanner.Text(), ":")[1]
-								}
-								file.Close()
-
-							} else {
-								return mydynamicconf, fmt.Errorf("Error in dynamic config: %s", err)
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-	return mydynamicconf, nil
 }
 
 func (configurator *Configurator) WriteDatabaseConfigFile(Datadir string, RemoteBasedir string, TemplateEnv map[string]string, RepMgrVersion string, rule *config.ComplianceRuleset, variable *config.ComplianceVariable) error {

--- a/cluster/configurator/configurator_get.go
+++ b/cluster/configurator/configurator_get.go
@@ -397,14 +397,3 @@ func (configurator *Configurator) GetSshUpgradeDBScript() string {
 	}
 	return configurator.ClusterConfig.HttpRoot + "/static/configurator/onpremise/repository/debian/" + dbtype + "/upgrade"
 }
-
-func (configurator *Configurator) GetSshPrintDefaultDBScript() string {
-	dbtype := "mariadb"
-	if configurator.HaveDBTag("rpm") {
-		return configurator.ClusterConfig.HttpRoot + "/static/configurator/onpremise/repository/redhat/" + dbtype + "/printcfg"
-	}
-	if configurator.HaveDBTag("package") {
-		return configurator.ClusterConfig.HttpRoot + "/static/configurator/onpremise/package/linux/" + dbtype + "/printcfg"
-	}
-	return configurator.ClusterConfig.HttpRoot + "/static/configurator/onpremise/repository/debian/" + dbtype + "/printcfg"
-}


### PR DESCRIPTION
## Summary
- remove the unused configurator database config helper
- remove the unused configurator print-default DB script helper
- keep the change scoped to the first two dead-code removals only

## Validation
- go test ./cluster/configurator ./cluster/... ./server/... ./clients/...
