### PR TITLE
fix(monitoring): preserve WARN0161/0162/0169/0170 in pstates30 — alert storm (#1744)

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -948,6 +948,9 @@ var pstates30 = []string{
 	"WARN0141", "WARN0142", "WARN0143", "WARN0150", "WARN0151", // Tresholds
 	"WARN0153",             // Job related
 	"WARN0158",             // Job secrets mismatch
+	"WARN0161", "WARN0162", // Service agents (CheckClusterServiceAgents runs %30)
+	"WARN0169",             // On-premise SSH key (CheckOnPremiseSSHKey runs %30)
+	"WARN0170",             // Configurator prerequisites (CheckConfiguratorPrerequisites runs %30)
 	"WARN0190", "WARN0191", // Rejoin catalog (HasCatalogBackupForRejoin runs %30)
 	"CREDIT01", // Credit related
 }

--- a/cluster/cluster_bck_test.go
+++ b/cluster/cluster_bck_test.go
@@ -2583,7 +2583,11 @@ func TestResticInitRepoWithOptions_ProceedsWhenBucketPreCheckFails(t *testing.T)
 // alerting. HasCatalogBackupForRejoin runs at heartbeats%30==0 and asserts
 // WARN0190/WARN0191, so both must be preserved by pstates30.
 func TestPstates30_IncludesRejoinCatalogStates(t *testing.T) {
-	for _, want := range []string{"WARN0190", "WARN0191"} {
+	// WARN0190/0191: HasCatalogBackupForRejoin. WARN0161/0162:
+	// CheckClusterServiceAgents. WARN0169: CheckOnPremiseSSHKey. WARN0170:
+	// CheckConfiguratorPrerequisites (the 2026-09 mixr Slack alert storm).
+	// All run only at heartbeats%30==0.
+	for _, want := range []string{"WARN0190", "WARN0191", "WARN0161", "WARN0162", "WARN0169", "WARN0170"} {
 		found := false
 		for _, k := range pstates30 {
 			if k == want {

--- a/doc/monitoring.md
+++ b/doc/monitoring.md
@@ -63,6 +63,14 @@ Alerts raised by checks use `SetState()`. For checks that run periodically
 (every N ticks), `PreserveState()` keeps their alerts visible on intermediate
 ticks.
 
+**Contract — every %N-tick check's states MUST be listed in the matching
+`pstatesN` preserve list** (`cluster/cluster.go`). A state raised only every N
+ticks but not preserved flaps open/resolve on every intermediate tick, and each
+cycle fires a notification: an alert storm (10K+/day). Known instances of this
+bug: WARN0190/0191 (rejoin catalog), and WARN0161/0162/0169/0170 (%30 checks,
+2026-09 Slack storm). When a state flaps, check `pstatesN` first. The guard
+test is `TestPstates30_IncludesRejoinCatalogStates`.
+
 ## Split Brain Detection
 
 Split brain detection operates at two levels:


### PR DESCRIPTION
Fixes #1744.

A client instance was storming Slack via alert forwarding: `WARN0170` (configurator prerequisites) flapping OPENED/RESOLV every 30-60s — one notification per cycle.

**Root cause** — the pstatesN preserve contract: `CheckConfiguratorPrerequisites` runs at `heartbeats%30==0` but WARN0170 was missing from `pstates30`, so the 29 intermediate ticks resolved the state and the %30 tick reopened it. Same defect as the WARN0190/0191 regression.

**Audit of the whole %30 block** found four states emitted only by %30 checks and absent from the list:
- WARN0170 — CheckConfiguratorPrerequisites (the live storm)
- WARN0169 — CheckOnPremiseSSHKey
- WARN0161 / WARN0162 — CheckClusterServiceAgents

**Changes**: the four states join `pstates30`; the guard test `TestPstates30_IncludesRejoinCatalogStates` now covers all six known cases; the pstatesN contract is spelled out in `doc/monitoring.md` (a %N-tick check's states MUST be in pstatesN — when a state flaps, check pstatesN first).

Tests: `go test ./cluster/ -run 'TestPstates30|TestRejoinCatalog'` green.

Note: this was first pushed directly to develop (9003d8fab) by mistake and reverted (process rule: every fix goes through a PR); this PR reintroduces it properly.