### PR TITLE
fix(orchestrator): log missing OpenSVC p12 certificate only on state transition

### DIFF
--- a/cluster/cluster_bck_test.go
+++ b/cluster/cluster_bck_test.go
@@ -2585,7 +2585,7 @@ func TestResticInitRepoWithOptions_ProceedsWhenBucketPreCheckFails(t *testing.T)
 func TestPstates30_IncludesRejoinCatalogStates(t *testing.T) {
 	// WARN0190/0191: HasCatalogBackupForRejoin. WARN0161/0162:
 	// CheckClusterServiceAgents. WARN0169: CheckOnPremiseSSHKey. WARN0170:
-	// CheckConfiguratorPrerequisites (the 2026-09 mixr Slack alert storm).
+	// CheckConfiguratorPrerequisites (the 2026-09 client Slack alert storm).
 	// All run only at heartbeats%30==0.
 	for _, want := range []string{"WARN0190", "WARN0191", "WARN0161", "WARN0162", "WARN0169", "WARN0170"} {
 		found := false

--- a/cluster/prov_opensvc.go
+++ b/cluster/prov_opensvc.go
@@ -81,9 +81,18 @@ func (cluster *Cluster) OpenSVCConnect() opensvc.Collector {
 		svc.CertsDERSecret = cluster.Conf.GetDecryptedValue("opensvc-p12-secret")
 		err := svc.LoadCert(cluster.Conf.ProvOpensvcP12Certificate)
 		if err != nil {
+			// Log at Err only on the state transition: WARN0099 carries the
+			// persistent condition and alerts once; re-logging on every
+			// OpenSVCConnect() call floods the alert channels (a missing p12
+			// on a hot loop produced ~8K Slack messages/day, 2026-09).
+			firstFailure := !cluster.failLoadP12Cert
 			cluster.failLoadP12Cert = true
 			cluster.SetState("WARN0099", state.State{ErrType: "WARNING", ErrDesc: fmt.Sprintf(clusterError["WARN0099"], cluster.Conf.ProvOpensvcP12Certificate, err), ErrFrom: "OpenSVC"})
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot load OpenSVC cluster certificate %s ", err)
+			if firstFailure {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot load OpenSVC cluster certificate %s ", err)
+			} else {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlDbg, "Cannot load OpenSVC cluster certificate %s ", err)
+			}
 		} else {
 			cluster.failLoadP12Cert = false
 			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlDbg, "Load OpenSVC cluster certificate %s ", cluster.Conf.ProvOpensvcP12Certificate)


### PR DESCRIPTION
Fixes the concrete alert-channel flood instance behind #1746.

## Problem
When `prov-orchestrator = "opensvc"` is set with a missing/unreadable p12 certificate, `OpenSVCConnect()` logs the failure at LvlErr on every call, and every raw ERROR log line is forwarded verbatim to the alert channels (Slack/Teams). On a production instance this produced ~8K alert messages/day for a single configuration mistake.

The condition is already a tracked state: `WARN0099` opens via the state machine (which alerts once at the transition) and stays open while the file is missing. Re-logging the raw error adds nothing but noise — the fix logs Err only on the `failLoadP12Cert` edge, Dbg afterwards.

## Validation (dev3, reproduction cluster: opensvc + nonexistent p12 + dedicated test webhook)
- **Before** (develop): 17× "Cannot load OpenSVC cluster certificate" forwarded to the alert channel in 6 minutes.
- **After** (this branch): **1** occurrence, then silence; `WARN0099` verified open in `/topology/alerts` with the full description — the state carries the persistent condition.

Also scrubs a client name from a test comment (public-repo hygiene).

Part of #1746 — the generic design flaw (every raw ERROR/WARN log line forwarded to the alert channels) stays open; a separate rate-limiting proposal exists on branch fix/slack-log-flood for discussion.

https://claude.ai/code/session_01Kcii9hRkGBU7WaejuPfkdj
