### PR TITLE
serviceplan: refuse plan change when a plan-driven spec is pinned (#1760)

### DIFF
--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -247,6 +247,9 @@ var clusterACLRules = []ACLRule{
 	{"/settings/actions/reload-plan-info", nil, []string{config.GrantClusterSettings}},
 	{"/settings/actions/accept-compliance", nil, []string{config.GrantDBConfigAcceptCompliance, config.GrantProxyConfigAcceptCompliance}},
 	{"/configurator/compliance-diff", nil, []string{config.GrantDBConfigGet}},
+	// Read-only lock-state probes (immutable setting / preserved variable):
+	// /settings/{name}/lock and /configurator/variables/{name}/lock.
+	{"/lock", nil, []string{config.GrantDBConfigGet}},
 	{"/settings/actions/switch", nil, []string{config.GrantClusterSettings, config.GrantGlobalSettings}},
 	{"/settings/actions/set", nil, []string{config.GrantClusterSettings, config.GrantGlobalSettings}},
 	{"/settings/actions/clear", nil, []string{config.GrantClusterSettings, config.GrantGlobalSettings}},

--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -251,9 +251,11 @@ var clusterACLRules = []ACLRule{
 	// (config flag pinned in immutable.toml) and
 	// /configurator/variables/{name}/is-preserved (DB var frozen by the
 	// "agree"). Distinctive tokens, so each Contains rule is unambiguous even
-	// though {name} sits mid-path.
-	{"/is-immutable", nil, []string{config.GrantDBConfigGet}},
-	{"/is-preserved", nil, []string{config.GrantDBConfigGet}},
+	// though {name} sits mid-path. "Who can write can read": the read grants
+	// include the get grant AND the matching write grants — a setting spans
+	// cluster/server scope, a preserved var is database config.
+	{"/is-immutable", nil, []string{config.GrantDBConfigGet, config.GrantClusterSettings, config.GrantGlobalSettings}},
+	{"/is-preserved", nil, []string{config.GrantDBConfigGet, config.GrantDBConfigFlag}},
 	{"/settings/actions/switch", nil, []string{config.GrantClusterSettings, config.GrantGlobalSettings}},
 	{"/settings/actions/set", nil, []string{config.GrantClusterSettings, config.GrantGlobalSettings}},
 	{"/settings/actions/clear", nil, []string{config.GrantClusterSettings, config.GrantGlobalSettings}},

--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -247,9 +247,13 @@ var clusterACLRules = []ACLRule{
 	{"/settings/actions/reload-plan-info", nil, []string{config.GrantClusterSettings}},
 	{"/settings/actions/accept-compliance", nil, []string{config.GrantDBConfigAcceptCompliance, config.GrantProxyConfigAcceptCompliance}},
 	{"/configurator/compliance-diff", nil, []string{config.GrantDBConfigGet}},
-	// Read-only lock-state probes (immutable setting / preserved variable):
-	// /settings/{name}/lock and /configurator/variables/{name}/lock.
-	{"/lock", nil, []string{config.GrantDBConfigGet}},
+	// Read-only pin-state probes, one per concept: /settings/{name}/is-immutable
+	// (config flag pinned in immutable.toml) and
+	// /configurator/variables/{name}/is-preserved (DB var frozen by the
+	// "agree"). Distinctive tokens, so each Contains rule is unambiguous even
+	// though {name} sits mid-path.
+	{"/is-immutable", nil, []string{config.GrantDBConfigGet}},
+	{"/is-preserved", nil, []string{config.GrantDBConfigGet}},
 	{"/settings/actions/switch", nil, []string{config.GrantClusterSettings, config.GrantGlobalSettings}},
 	{"/settings/actions/set", nil, []string{config.GrantClusterSettings, config.GrantGlobalSettings}},
 	{"/settings/actions/clear", nil, []string{config.GrantClusterSettings, config.GrantGlobalSettings}},

--- a/cluster/cluster_cnf.go
+++ b/cluster/cluster_cnf.go
@@ -404,6 +404,21 @@ func (cluster *Cluster) AddPreservedVar(varName string, value string) error {
 	return nil
 }
 
+// IsVariablePreserved reports whether a DB variable is pinned to its running
+// value in the cluster's preserved set (01_preserved.cnf, the "agree"). Keys are
+// stored upper-cased. Returns false when the preserved set is not loaded yet.
+func (cluster *Cluster) IsVariablePreserved(varName string) bool {
+	cluster.preservedVarsMutex.RLock()
+	defer cluster.preservedVarsMutex.RUnlock()
+
+	if !cluster.preservedVarsLoaded {
+		return false
+	}
+
+	_, ok := cluster.preservedVars[strings.ToUpper(varName)]
+	return ok
+}
+
 // RemovePreservedVar removes a preserved variable
 func (cluster *Cluster) RemovePreservedVar(varName string) error {
 	cluster.preservedVarsMutex.Lock()

--- a/cluster/cluster_has.go
+++ b/cluster/cluster_has.go
@@ -646,6 +646,50 @@ func (cluster *Cluster) IsVariableServerLevel(v string) bool {
 	return ok
 }
 
+// planDrivenProvFlags are the provisioning specs a service plan (DBU) drives.
+var planDrivenProvFlags = []string{
+	"prov-db-cpu-cores",
+	"prov-db-memory",
+	"prov-db-disk-size",
+	"prov-db-disk-iops",
+	"prov-proxy-cpu-cores",
+	"prov-proxy-disk-size",
+}
+
+// planDrivenDBVars are the DB variables a service plan (DBU) drives through the
+// configurator. If the operator has preserved any of them (the "agree", pinning
+// it to its running value), a plan change can no longer move it, so it must be
+// refused just like an immutable prov flag.
+var planDrivenDBVars = []string{
+	"innodb_buffer_pool_size",    // prov-db-memory
+	"key_buffer_size",            // prov-db-memory (myisam)
+	"aria_pagecache_buffer_size", // prov-db-memory (aria)
+	"innodb_io_capacity",         // prov-db-disk-iops
+	"innodb_io_capacity_max",     // prov-db-disk-iops
+	"innodb_read_io_threads",     // prov-db-cpu-cores
+	"innodb_write_io_threads",    // prov-db-cpu-cores
+	"innodb_purge_threads",       // prov-db-cpu-cores
+}
+
+// CanChangePlan reports whether a service-plan (DBU) change may be applied. It
+// returns false when the operator has pinned any plan-driven spec so the plan
+// could no longer move it — either a provisioning flag made immutable
+// (immutable.toml) or a driven DB variable preserved (the "agree",
+// 01_preserved.cnf). The whole plan change is refused until the operator unpins.
+func (cluster *Cluster) CanChangePlan() bool {
+	for _, f := range planDrivenProvFlags {
+		if cluster.IsVariableImmutable(f) {
+			return false
+		}
+	}
+	for _, v := range planDrivenDBVars {
+		if cluster.IsVariablePreserved(v) {
+			return false
+		}
+	}
+	return true
+}
+
 func (cluster *Cluster) IsInBackup() bool {
 	return cluster.InPhysicalBackup || cluster.InLogicalBackup || cluster.InBinlogBackup || cluster.IsInResticBackup()
 }

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -1447,6 +1447,13 @@ func (cluster *Cluster) SetServicePlanInfos(theplan string) error {
 }
 
 func (cluster *Cluster) SetServicePlan(theplan string) error {
+	// A pinned (immutable) provisioning spec is a hard lock: since a plan would
+	// move prov-db-memory/cores/disk/iops, refuse the whole plan change while
+	// any of them is pinned. The operator must unpin before switching plans.
+	if !cluster.CanChangePlan() {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Service plan change refused for %s: a provisioning parameter is pinned (immutable); unpin it to change the plan", theplan)
+		return errors.New("plan change refused: a provisioning parameter is immutable (pinned)")
+	}
 	plans := cluster.GetServicePlans()
 
 	for _, plan := range plans {

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -1447,12 +1447,18 @@ func (cluster *Cluster) SetServicePlanInfos(theplan string) error {
 }
 
 func (cluster *Cluster) SetServicePlan(theplan string) error {
-	// A pinned (immutable) provisioning spec is a hard lock: since a plan would
-	// move prov-db-memory/cores/disk/iops, refuse the whole plan change while
-	// any of them is pinned. The operator must unpin before switching plans.
-	if !cluster.CanChangePlan() {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Service plan change refused for %s: a provisioning parameter is pinned (immutable); unpin it to change the plan", theplan)
-		return errors.New("plan change refused: a provisioning parameter is immutable (pinned)")
+	// Gate the plan change. A client-provided script wins (it receives every
+	// arg to reproduce the change and a non-zero exit refuses it); otherwise the
+	// built-in check refuses when a plan-driven spec is pinned — immutable
+	// (immutable.toml) or preserved (01_preserved.cnf) — since a plan could no
+	// longer move it. The operator must unpin/unpreserve before switching plans.
+	if cluster.Conf.ProvDbChangePlanScript != "" {
+		if err := cluster.ChangePlanScript(cluster.Conf.ProvServicePlan, theplan); err != nil {
+			return err
+		}
+	} else if !cluster.CanChangePlan() {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Service plan change refused for %s: a provisioning parameter is pinned (immutable/preserved); unpin it to change the plan", theplan)
+		return errors.New("plan change refused: a provisioning parameter is pinned (immutable/preserved)")
 	}
 	plans := cluster.GetServicePlans()
 

--- a/cluster/prov_scripts.go
+++ b/cluster/prov_scripts.go
@@ -8,7 +8,6 @@ package cluster
 
 import (
 	"errors"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -266,13 +265,15 @@ func (cluster *Cluster) ChangePlanScript(fromPlan string, toPlan string) error {
 		}
 	}
 
-	// Credentials go through the environment, never argv (argv is world-visible
-	// in the process list and would leak into logs). Plan + specs stay as args.
+	// The script talks to repman's own API, the same convention as the other
+	// sample scripts (see share/scripts/staging_refresh.sh). GetExecEnv already
+	// builds the standard REPLICATION_MANAGER_URL/USER/PASSWORD/CLUSTER_NAME
+	// (API admin creds + URL) through the environment — never argv, which is
+	// world-visible and would leak into logs. Plan + specs stay as args for
+	// convenience. The script reaches every DB variable through the API, so it
+	// never needs DB hosts or DB credentials.
 	scriptCmd := exec.Command(cluster.Conf.ProvDbChangePlanScript, cluster.Name, fromPlan, toPlan, mem, cores, disk, iops)
-	scriptCmd.Env = append(os.Environ(),
-		"REPLICATION_MANAGER_CLUSTER="+cluster.Name,
-		"REPLICATION_MANAGER_DB_USER="+cluster.GetDbUser(),
-		"REPLICATION_MANAGER_DB_PASSWORD="+cluster.GetDbPass(),
+	scriptCmd.Env = append(cluster.GetExecEnv(),
 		"REPLICATION_MANAGER_FROM_PLAN="+fromPlan,
 		"REPLICATION_MANAGER_TO_PLAN="+toPlan,
 	)

--- a/cluster/prov_scripts.go
+++ b/cluster/prov_scripts.go
@@ -7,7 +7,10 @@
 package cluster
 
 import (
+	"errors"
+	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -236,6 +239,52 @@ func (cluster *Cluster) StopProxyScript(server DatabaseProxy) error {
 	if err := scriptCmd.Wait(); err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, " %s", err)
 		return err
+	}
+	return nil
+}
+
+// ChangePlanScript is the client-overridable service-plan (DBU) change gate,
+// the bash-hook counterpart of the built-in CanChangePlan check. It is passed
+// every argument needed to reproduce the change — cluster, credentials, the
+// from/to plan and the target plan's specs — so a client script can validate,
+// log, or reproduce it. A non-zero exit refuses the plan change. Empty config
+// is a no-op (the built-in immutable/preserved gate applies instead).
+func (cluster *Cluster) ChangePlanScript(fromPlan string, toPlan string) error {
+	if cluster.Conf.ProvDbChangePlanScript == "" {
+		return nil
+	}
+
+	// Resolve the target plan's specs so the script has full context.
+	var mem, cores, disk, iops string
+	for _, plan := range cluster.GetServicePlans() {
+		if plan.Plan == toPlan {
+			mem = strconv.Itoa(plan.DbMemory)
+			cores = strconv.Itoa(plan.DbCores)
+			disk = strconv.Itoa(plan.DbDataSize)
+			iops = strconv.Itoa(plan.DbIops)
+			break
+		}
+	}
+
+	// Credentials go through the environment, never argv (argv is world-visible
+	// in the process list and would leak into logs). Plan + specs stay as args.
+	scriptCmd := exec.Command(cluster.Conf.ProvDbChangePlanScript, cluster.Name, fromPlan, toPlan, mem, cores, disk, iops)
+	scriptCmd.Env = append(os.Environ(),
+		"REPLICATION_MANAGER_CLUSTER="+cluster.Name,
+		"REPLICATION_MANAGER_DB_USER="+cluster.GetDbUser(),
+		"REPLICATION_MANAGER_DB_PASSWORD="+cluster.GetDbPass(),
+		"REPLICATION_MANAGER_FROM_PLAN="+fromPlan,
+		"REPLICATION_MANAGER_TO_PLAN="+toPlan,
+	)
+	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "%s", scriptCmd.String())
+
+	out, err := scriptCmd.CombinedOutput()
+	if len(out) > 0 {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "prov-db-change-plan-script output: %s", strings.TrimSpace(string(out)))
+	}
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Service plan change refused by %s: %s", cluster.Conf.ProvDbChangePlanScript, err)
+		return errors.New("plan change refused by prov-db-change-plan-script: " + err.Error())
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -700,6 +700,7 @@ type Config struct {
 	ProvProxyStartFetchConfig                 bool                         `mapstructure:"prov-proxy-start-fetch-config" toml:"prov-proxy-start-fetch-config" json:"provProxyStartFetchConfig"`
 	ProvDbStopScript                          string                       `mapstructure:"prov-db-stop-script" toml:"prov-db-stop-script" json:"provDbStopScript"`
 	ProvProxyStopScript                       string                       `mapstructure:"prov-proxy-stop-script" toml:"prov-proxy-stop-script" json:"provProxyStopScript"`
+	ProvDbChangePlanScript                    string                       `mapstructure:"prov-db-change-plan-script" toml:"prov-db-change-plan-script" json:"provDbChangePlanScript"`
 	ProvDBCompliance                          string                       `mapstructure:"prov-db-compliance" toml:"prov-db-compliance" json:"provDBCompliance"`
 	ProvProxyCompliance                       string                       `mapstructure:"prov-proxy-compliance" toml:"prov-proxy-compliance" json:"provProxyCompliance"`
 	ProvAutoUpdateCompliance                  bool                         `mapstructure:"prov-auto-update-compliance" toml:"prov-auto-update-compliance" json:"provAutoUpdateCompliance"`

--- a/doc/implementation/DEVELOPMENT_LAWS.md
+++ b/doc/implementation/DEVELOPMENT_LAWS.md
@@ -254,6 +254,21 @@ branch that depends on it cherry-picks that export commit; carrying an export
 inside a feature branch is the exception, and is what triggers the
 concurrent-branch check above.
 
+**T22. NEVER add an API route without both an ACL rule and a Swagger
+annotation.** Every new HTTP route MUST (1) resolve to an ACL rule and (2)
+carry `// @Summary … @Router …` annotations on its handler. The ACL is
+path-based: `IsValidClusterACL` passes `r.URL.Path` to `IsURLPassACL`, which
+routes to `matchACLRules`, and **an unmatched path is DENIED** (`matchACLRules`
+returns false on no match) — so a route with no rule is not "open", it is
+silently broken for every non-owner user. Add the rule to the right set
+(`clusterACLRules`, `databaseACLRules`, `globalSettingsACLRules`, …) with the
+least-privilege grant for the operation (read endpoints use a `*-get`/`*-show`
+grant, e.g. `GrantDBConfigGet`; writes use the mutating grant), keyed on a
+`strings.Contains` pattern specific enough not to widen access to sibling
+paths (longest-match wins). The Swagger block keeps `doc/api_latest.md`
+generatable and the route discoverable. A handler without both is incomplete —
+the route is unreachable in practice or invisible in the API surface.
+
 ---
 
 *Precedence: functional laws outrank technical laws; the perpetual-monitoring

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -118,7 +118,7 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterSettingLock)),
 	))
 
-	router.Handle("/api/clusters/{clusterName}/variables/{variableName}/lock", negroni.New(
+	router.Handle("/api/clusters/{clusterName}/configurator/variables/{variableName}/lock", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterVariableLock)),
 	))

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -113,6 +113,16 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterSettings)),
 	))
 
+	router.Handle("/api/clusters/{clusterName}/settings/{settingName}/lock", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterSettingLock)),
+	))
+
+	router.Handle("/api/clusters/{clusterName}/variables/{variableName}/lock", negroni.New(
+		negroni.HandlerFunc(repman.validateTokenMiddleware),
+		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterVariableLock)),
+	))
+
 	router.Handle("/api/clusters/{clusterName}/plugins", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterPlugins)),
@@ -2564,6 +2574,83 @@ func (repman *ReplicationManager) handlerMuxClusterTop(w http.ResponseWriter, r 
 // @Failure 500 {string} string "No cluster"
 // @Router /api/clusters/{clusterName}/settings/actions/switch/{settingName} [post]
 // @Router /api/clusters/{clusterName}/settings/actions/switch/{settingName}/{state} [post]
+// handlerMuxClusterSettingLock reports whether a single cluster setting is
+// locked (immutable, i.e. pinned in the config file). Name only, no value, so
+// no secret can leak. Lets the GUI show a pin state and a client check before a
+// change (e.g. the service-plan gate).
+func (repman *ReplicationManager) handlerMuxClusterSettingLock(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster == nil {
+		http.Error(w, "No cluster", http.StatusInternalServerError)
+		return
+	}
+	if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+		http.Error(w, "No valid ACL", http.StatusForbidden)
+		return
+	}
+	setting := vars["settingName"]
+	resp := struct {
+		Setting   string `json:"setting"`
+		Immutable bool   `json:"immutable"`
+	}{
+		Setting:   setting,
+		Immutable: mycluster.IsVariableImmutable(setting),
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handlerMuxClusterVariableLock reports whether a DB variable is pinned
+// (preserved, the "agree") across the cluster, looping every server so the
+// per-server exclusions are reflected. `preserved` is true when the variable is
+// preserved on at least one server. Names only, no values.
+func (repman *ReplicationManager) handlerMuxClusterVariableLock(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	vars := mux.Vars(r)
+	mycluster := repman.getClusterByName(vars["clusterName"])
+	if mycluster == nil {
+		http.Error(w, "No cluster", http.StatusInternalServerError)
+		return
+	}
+	if valid, _ := repman.IsValidClusterACL(r, mycluster); !valid {
+		http.Error(w, "No valid ACL", http.StatusForbidden)
+		return
+	}
+	variable := vars["variableName"]
+	clusterPreserved := mycluster.IsVariablePreserved(variable)
+
+	type serverLock struct {
+		Server    string `json:"server"`
+		Preserved bool   `json:"preserved"`
+	}
+	servers := []serverLock{}
+	anyPreserved := false
+	for _, node := range mycluster.GetServers() {
+		if node == nil {
+			continue
+		}
+		p := clusterPreserved && !mycluster.IsServerExcludedFromPreservedVar(variable, node.Id)
+		if p {
+			anyPreserved = true
+		}
+		servers = append(servers, serverLock{Server: node.Name, Preserved: p})
+	}
+
+	resp := struct {
+		Variable  string       `json:"variable"`
+		Preserved bool         `json:"preserved"`
+		Servers   []serverLock `json:"servers"`
+	}{
+		Variable:  variable,
+		Preserved: anyPreserved,
+		Servers:   servers,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
 func (repman *ReplicationManager) handlerMuxSwitchSettings(w http.ResponseWriter, r *http.Request) {
 	var value string
 	w.Header().Set("Access-Control-Allow-Origin", "*")

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2578,6 +2578,17 @@ func (repman *ReplicationManager) handlerMuxClusterTop(w http.ResponseWriter, r 
 // locked (immutable, i.e. pinned in the config file). Name only, no value, so
 // no secret can leak. Lets the GUI show a pin state and a client check before a
 // change (e.g. the service-plan gate).
+// @Summary Report the immutable lock state of a cluster setting
+// @Description Returns whether a config setting is immutable (pinned in the config file). Name only, no value.
+// @Tags ClusterSettings
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Param settingName path string true "Setting name (e.g. prov-db-memory)"
+// @Success 200 {object} object "{setting, immutable}"
+// @Failure 403 {string} string "No valid ACL"
+// @Failure 500 {string} string "No cluster"
+// @Router /api/clusters/{clusterName}/settings/{settingName}/lock [get]
 func (repman *ReplicationManager) handlerMuxClusterSettingLock(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	vars := mux.Vars(r)
@@ -2606,6 +2617,17 @@ func (repman *ReplicationManager) handlerMuxClusterSettingLock(w http.ResponseWr
 // (preserved, the "agree") across the cluster, looping every server so the
 // per-server exclusions are reflected. `preserved` is true when the variable is
 // preserved on at least one server. Names only, no values.
+// @Summary Report the preserved (pin) lock state of a DB variable across servers
+// @Description Returns whether a DB variable is preserved (the "agree") per server, accounting for per-server exclusions. Names only, no values.
+// @Tags ClusterConfigurator
+// @Produce json
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Param clusterName path string true "Cluster Name"
+// @Param variableName path string true "DB variable name (e.g. innodb_buffer_pool_size)"
+// @Success 200 {object} object "{variable, preserved, servers[]}"
+// @Failure 403 {string} string "No valid ACL"
+// @Failure 500 {string} string "No cluster"
+// @Router /api/clusters/{clusterName}/configurator/variables/{variableName}/lock [get]
 func (repman *ReplicationManager) handlerMuxClusterVariableLock(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	vars := mux.Vars(r)

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -3652,7 +3652,7 @@ func (repman *ReplicationManager) setClusterSetting(mycluster *cluster.Cluster, 
 		}
 		mycluster.Conf.DNSTimeout = val
 	case "prov-service-plan":
-		mycluster.SetServicePlan(value)
+		return mycluster.SetServicePlan(value)
 	case "prov-net-cni-cluster":
 		mycluster.SetProvNetCniCluster(value)
 	case "prov-orchestrator-cluster":

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -113,12 +113,12 @@ func (repman *ReplicationManager) apiClusterProtectedHandler(router *mux.Router)
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterSettings)),
 	))
 
-	router.Handle("/api/clusters/{clusterName}/settings/{settingName}/lock", negroni.New(
+	router.Handle("/api/clusters/{clusterName}/settings/{settingName}/is-immutable", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterSettingLock)),
 	))
 
-	router.Handle("/api/clusters/{clusterName}/configurator/variables/{variableName}/lock", negroni.New(
+	router.Handle("/api/clusters/{clusterName}/configurator/variables/{variableName}/is-preserved", negroni.New(
 		negroni.HandlerFunc(repman.validateTokenMiddleware),
 		negroni.Wrap(http.HandlerFunc(repman.handlerMuxClusterVariableLock)),
 	))
@@ -2588,7 +2588,7 @@ func (repman *ReplicationManager) handlerMuxClusterTop(w http.ResponseWriter, r 
 // @Success 200 {object} object "{setting, immutable}"
 // @Failure 403 {string} string "No valid ACL"
 // @Failure 500 {string} string "No cluster"
-// @Router /api/clusters/{clusterName}/settings/{settingName}/lock [get]
+// @Router /api/clusters/{clusterName}/settings/{settingName}/is-immutable [get]
 func (repman *ReplicationManager) handlerMuxClusterSettingLock(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	vars := mux.Vars(r)
@@ -2627,7 +2627,7 @@ func (repman *ReplicationManager) handlerMuxClusterSettingLock(w http.ResponseWr
 // @Success 200 {object} object "{variable, preserved, servers[]}"
 // @Failure 403 {string} string "No valid ACL"
 // @Failure 500 {string} string "No cluster"
-// @Router /api/clusters/{clusterName}/configurator/variables/{variableName}/lock [get]
+// @Router /api/clusters/{clusterName}/configurator/variables/{variableName}/is-preserved [get]
 func (repman *ReplicationManager) handlerMuxClusterVariableLock(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	vars := mux.Vars(r)

--- a/server/server.go
+++ b/server/server.go
@@ -1117,6 +1117,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.ProvProxyStartScript, "prov-proxy-start-script", "", "Proxy start script")
 	flags.StringVar(&conf.ProvDbStopScript, "prov-db-stop-script", "", "Database stop script")
 	flags.StringVar(&conf.ProvProxyStopScript, "prov-proxy-stop-script", "", "Proxy stop script")
+	flags.StringVar(&conf.ProvDbChangePlanScript, "prov-db-change-plan-script", "", "Service-plan (DBU) change gate script; exit non-zero refuses the plan change. Receives all args to reproduce the change.")
 	flags.BoolVar(&conf.ProvDbStartFetchConfig, "prov-db-start-fetch-config", true, "Fetch configuration from configurator on DB start")
 	flags.BoolVar(&conf.ProvProxyStartFetchConfig, "prov-proxy-start-fetch-config", true, "Fetch configuration from configurator on Proxy start")
 


### PR DESCRIPTION
First slice of #1760.

A service-plan (DBU) change drives `prov-db-{memory,cpu-cores,disk-size,disk-iops}` and `prov-proxy-{cpu-cores,disk-size}` plus the DB variables they map to. If the operator has pinned any of them, the plan can no longer move that spec — so the whole plan change is refused rather than silently partially applied.

- **`CanChangePlan()`** returns false when any plan-driven prov flag is **immutable** (immutable.toml) OR any driven DB variable is **preserved** (01_preserved.cnf, the "agree"). New `IsVariablePreserved()` membership helper.
- **`SetServicePlan`** refuses up front with a clear error; the `prov-service-plan` API now **returns** that error (it was discarded) so the refusal surfaces to the GUI.

Built-in default gate. The **client-overridable `prov-db-change-plan-script` hook** (bash, prov_scripts.go moule, exit≠0 = refuse) is the planned override, tracked in #1760 along with the rest of the DBU backend refactor.

Note: on a cluster with a pinned `prov-db-memory` (e.g. dev3 at 768M), plan changes are now correctly refused until it is unpinned.

https://claude.ai/code/session_01Kcii9hRkGBU7WaejuPfkdj