### PR TITLE
Agree Compliance: drop agreed on reconcile + opt-in auto-agree (#1762)

### DIFF
--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1174,6 +1174,11 @@ func (server *ServerMonitor) Refresh() error {
 				// Clear the flag after processing
 				server.VariablesMap.ClearDeployedChanged()
 			}
+		} else {
+			// Config tracking off (prov-db-config): clear the drift pill so the GUI
+			// (hasConfigDiff) reflects the live off-state — surfaced as CINF0003 —
+			// instead of a value frozen from when tracking was last on.
+			server.HasConfigDiff = false
 		}
 
 		if server.IsNeedPathCheck {

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1148,12 +1148,12 @@ func (server *ServerMonitor) Refresh() error {
 				}
 
 				// Auto-agree value-differs deltas to the compliance value (opt-in,
-				// prov-auto-agree-compliance — the DB-side counterpart of
+				// prov-db-compliance-auto-agree — the DB-side counterpart of
 				// prov-auto-update-compliance). Runs before the delta is (re)written so
 				// agreed variables route to 03_agreed instead of 02_delta and the DB
 				// adopts them on its next restart. Value-changes only; deprecated /
 				// unknown drops are left for manual review (loose_ hides them, #1495).
-				if cluster.Conf.ProvAutoAgreeCompliance {
+				if cluster.Conf.ProvDBComplianceAutoAgree {
 					if agreed := server.VariablesMap.AutoAgreeValueDeltas(); len(agreed) > 0 {
 						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
 							"Auto-agreed %d value-differs delta(s) to compliance on %s: %s", len(agreed), server.URL, strings.Join(agreed, ", "))

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1103,69 +1103,77 @@ func (server *ServerMonitor) Refresh() error {
 
 		vars, _, err = dbhelper.GetVariablesCase(server.Conn, server.DBVersion, "LOWER")
 		server.SensitiveVariables = config.FromNormalStringMap(server.SensitiveVariables, vars)
-		runtimeChanged := server.VariablesMap.SetRuntimeValues(vars)
 		if err != nil {
 			return nil
 		}
 
-		// Once the DB actually runs the compliance value (Runtime == Config), a
-		// previously agreed variable (03_agreed.cnf) has served its purpose — it
-		// only existed to hold a value until the DB restarted with the compliance
-		// value. Drop it so it stops showing as a pending diff. Operator-forced
-		// preserves (PreservedSource != "") are never touched. Gated on a runtime
-		// change: reconciliation can only appear when a runtime value moved, so the
-		// steady state (runtime unchanged tick to tick) skips this walk entirely.
-		if runtimeChanged > 0 {
-			if dropped := server.VariablesMap.DropReconciledAgreed(); len(dropped) > 0 {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
-					"Dropped %d reconciled agreed variable(s) on %s: %s", len(dropped), server.URL, strings.Join(dropped, ", "))
-				if err := server.WritePreservedVariables(); err != nil {
-					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
-						"Failed to rewrite agreed variables after drop for %s: %s", server.URL, err)
-				}
-			}
-		}
+		// Configurator config-diff / compliance tracking. Gated by prov-db-config,
+		// the master switch for configurator config tracking: when the client turns
+		// it off, the monitor does no per-tick variable diff, reconcile-drop, or
+		// delta/agree work (T14 off-switch, F2 no monitor burden). SensitiveVariables
+		// above stays ungated — DATADIR/PID_FILE/LOG_ERROR feed jobs regardless.
+		if cluster.Conf.ProvDBConfig {
+			runtimeChanged := server.VariablesMap.SetRuntimeValues(vars)
 
-		// Update HasConfigDiff flag to indicate if there are differences between deployed and generated config
-		server.HasConfigDiff = server.VariablesMap.HasDifferences()
-
-		// Check if deployed config file was reloaded externally
-		// If so, re-read preserved variables to sync with any changes
-		if server.VariablesMap.HasDeployedChanged() {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
-				"Deployed config changed for %s, reloading preserved variables", server.URL)
-
-			if err := server.ReadPreservedVariables(); err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
-					"Failed to reload preserved variables for %s: %s", server.URL, err)
-			}
-
-			// Auto-agree value-differs deltas to the compliance value (opt-in,
-			// prov-auto-agree-compliance — the DB-side counterpart of
-			// prov-auto-update-compliance). Runs before the delta is (re)written so
-			// agreed variables route to 03_agreed instead of 02_delta and the DB
-			// adopts them on its next restart. Value-changes only; deprecated /
-			// unknown drops are left for manual review (loose_ hides them, #1495).
-			if cluster.Conf.ProvAutoAgreeCompliance {
-				if agreed := server.VariablesMap.AutoAgreeValueDeltas(); len(agreed) > 0 {
+			// Once the DB actually runs the compliance value (Runtime == Config), a
+			// previously agreed variable (03_agreed.cnf) has served its purpose — it
+			// only existed to hold a value until the DB restarted with the compliance
+			// value. Drop it so it stops showing as a pending diff. Operator-forced
+			// preserves (PreservedSource != "") are never touched. Gated on a runtime
+			// change: reconciliation can only appear when a runtime value moved, so the
+			// steady state (runtime unchanged tick to tick) skips this walk entirely.
+			if runtimeChanged > 0 {
+				if dropped := server.VariablesMap.DropReconciledAgreed(); len(dropped) > 0 {
 					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
-						"Auto-agreed %d value-differs delta(s) to compliance on %s: %s", len(agreed), server.URL, strings.Join(agreed, ", "))
+						"Dropped %d reconciled agreed variable(s) on %s: %s", len(dropped), server.URL, strings.Join(dropped, ", "))
 					if err := server.WritePreservedVariables(); err != nil {
 						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
-							"Failed to write agreed variables after auto-agree for %s: %s", server.URL, err)
+							"Failed to rewrite agreed variables after drop for %s: %s", server.URL, err)
 					}
 				}
 			}
 
-			// Refresh delta variables file whenever runtime values are updated
-			// This ensures 02_delta.cnf stays in sync with current deployed state
-			if err := server.WriteDeltaVariables(); err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
-					"Failed to refresh delta variables for %s: %s", server.URL, err)
-			}
+			// Update HasConfigDiff flag to indicate if there are differences between deployed and generated config
+			server.HasConfigDiff = server.VariablesMap.HasDifferences()
 
-			// Clear the flag after processing
-			server.VariablesMap.ClearDeployedChanged()
+			// Check if deployed config file was reloaded externally
+			// If so, re-read preserved variables to sync with any changes
+			if server.VariablesMap.HasDeployedChanged() {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+					"Deployed config changed for %s, reloading preserved variables", server.URL)
+
+				if err := server.ReadPreservedVariables(); err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+						"Failed to reload preserved variables for %s: %s", server.URL, err)
+				}
+
+				// Auto-agree value-differs deltas to the compliance value (opt-in,
+				// prov-auto-agree-compliance — the DB-side counterpart of
+				// prov-auto-update-compliance). Runs before the delta is (re)written so
+				// agreed variables route to 03_agreed instead of 02_delta and the DB
+				// adopts them on its next restart. Value-changes only; deprecated /
+				// unknown drops are left for manual review (loose_ hides them, #1495).
+				if cluster.Conf.ProvAutoAgreeCompliance {
+					if agreed := server.VariablesMap.AutoAgreeValueDeltas(); len(agreed) > 0 {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+							"Auto-agreed %d value-differs delta(s) to compliance on %s: %s", len(agreed), server.URL, strings.Join(agreed, ", "))
+						if err := server.WritePreservedVariables(); err != nil {
+							cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+								"Failed to write agreed variables after auto-agree for %s: %s", server.URL, err)
+						}
+					}
+				}
+
+				// Refresh delta variables file whenever runtime values are updated
+				// This ensures 02_delta.cnf stays in sync with current deployed state
+				if err := server.WriteDeltaVariables(); err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+						"Failed to refresh delta variables for %s: %s", server.URL, err)
+				}
+
+				// Clear the flag after processing
+				server.VariablesMap.ClearDeployedChanged()
+			}
 		}
 
 		if server.IsNeedPathCheck {

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1174,11 +1174,6 @@ func (server *ServerMonitor) Refresh() error {
 				// Clear the flag after processing
 				server.VariablesMap.ClearDeployedChanged()
 			}
-		} else {
-			// Config tracking off (prov-db-config): clear the drift pill so the GUI
-			// (hasConfigDiff) reflects the live off-state — surfaced as CINF0003 —
-			// instead of a value frozen from when tracking was last on.
-			server.HasConfigDiff = false
 		}
 
 		if server.IsNeedPathCheck {

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1108,6 +1108,20 @@ func (server *ServerMonitor) Refresh() error {
 			return nil
 		}
 
+		// Once the DB actually runs the compliance value (Runtime == Config), a
+		// previously agreed variable (03_agreed.cnf) has served its purpose — it
+		// only existed to hold a value until the DB restarted with the compliance
+		// value. Drop it so it stops showing as a pending diff. Operator-forced
+		// preserves (PreservedSource != "") are never touched.
+		if dropped := server.VariablesMap.DropReconciledAgreed(); len(dropped) > 0 {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+				"Dropped %d reconciled agreed variable(s) on %s: %s", len(dropped), server.URL, strings.Join(dropped, ", "))
+			if err := server.WritePreservedVariables(); err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+					"Failed to rewrite agreed variables after drop for %s: %s", server.URL, err)
+			}
+		}
+
 		// Update HasConfigDiff flag to indicate if there are differences between deployed and generated config
 		server.HasConfigDiff = server.VariablesMap.HasDifferences()
 

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1103,7 +1103,7 @@ func (server *ServerMonitor) Refresh() error {
 
 		vars, _, err = dbhelper.GetVariablesCase(server.Conn, server.DBVersion, "LOWER")
 		server.SensitiveVariables = config.FromNormalStringMap(server.SensitiveVariables, vars)
-		server.VariablesMap.SetRuntimeValues(vars)
+		runtimeChanged := server.VariablesMap.SetRuntimeValues(vars)
 		if err != nil {
 			return nil
 		}
@@ -1112,13 +1112,17 @@ func (server *ServerMonitor) Refresh() error {
 		// previously agreed variable (03_agreed.cnf) has served its purpose — it
 		// only existed to hold a value until the DB restarted with the compliance
 		// value. Drop it so it stops showing as a pending diff. Operator-forced
-		// preserves (PreservedSource != "") are never touched.
-		if dropped := server.VariablesMap.DropReconciledAgreed(); len(dropped) > 0 {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
-				"Dropped %d reconciled agreed variable(s) on %s: %s", len(dropped), server.URL, strings.Join(dropped, ", "))
-			if err := server.WritePreservedVariables(); err != nil {
-				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
-					"Failed to rewrite agreed variables after drop for %s: %s", server.URL, err)
+		// preserves (PreservedSource != "") are never touched. Gated on a runtime
+		// change: reconciliation can only appear when a runtime value moved, so the
+		// steady state (runtime unchanged tick to tick) skips this walk entirely.
+		if runtimeChanged > 0 {
+			if dropped := server.VariablesMap.DropReconciledAgreed(); len(dropped) > 0 {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+					"Dropped %d reconciled agreed variable(s) on %s: %s", len(dropped), server.URL, strings.Join(dropped, ", "))
+				if err := server.WritePreservedVariables(); err != nil {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+						"Failed to rewrite agreed variables after drop for %s: %s", server.URL, err)
+				}
 			}
 		}
 

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1136,6 +1136,23 @@ func (server *ServerMonitor) Refresh() error {
 					"Failed to reload preserved variables for %s: %s", server.URL, err)
 			}
 
+			// Auto-agree value-differs deltas to the compliance value (opt-in,
+			// prov-auto-agree-compliance — the DB-side counterpart of
+			// prov-auto-update-compliance). Runs before the delta is (re)written so
+			// agreed variables route to 03_agreed instead of 02_delta and the DB
+			// adopts them on its next restart. Value-changes only; deprecated /
+			// unknown drops are left for manual review (loose_ hides them, #1495).
+			if cluster.Conf.ProvAutoAgreeCompliance {
+				if agreed := server.VariablesMap.AutoAgreeValueDeltas(); len(agreed) > 0 {
+					cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
+						"Auto-agreed %d value-differs delta(s) to compliance on %s: %s", len(agreed), server.URL, strings.Join(agreed, ", "))
+					if err := server.WritePreservedVariables(); err != nil {
+						cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+							"Failed to write agreed variables after auto-agree for %s: %s", server.URL, err)
+					}
+				}
+			}
+
 			// Refresh delta variables file whenever runtime values are updated
 			// This ensures 02_delta.cnf stays in sync with current deployed state
 			if err := server.WriteDeltaVariables(); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -703,7 +703,7 @@ type Config struct {
 	ProvDBCompliance                          string                       `mapstructure:"prov-db-compliance" toml:"prov-db-compliance" json:"provDBCompliance"`
 	ProvProxyCompliance                       string                       `mapstructure:"prov-proxy-compliance" toml:"prov-proxy-compliance" json:"provProxyCompliance"`
 	ProvAutoUpdateCompliance                  bool                         `mapstructure:"prov-auto-update-compliance" toml:"prov-auto-update-compliance" json:"provAutoUpdateCompliance"`
-	ProvAutoAgreeCompliance                   bool                         `mapstructure:"prov-auto-agree-compliance" toml:"prov-auto-agree-compliance" json:"provAutoAgreeCompliance"`
+	ProvDBComplianceAutoAgree                 bool                         `mapstructure:"prov-db-compliance-auto-agree" toml:"prov-db-compliance-auto-agree" json:"provDbComplianceAutoAgree"`
 	ProvDockerRegistryCredentials             string                       `mapstructure:"prov-docker-registry-credentials" toml:"prov-docker-registry-credentials" json:"provDockerRegistryCredentials"`
 	AppOn                                     bool                         `mapstructure:"app" toml:"app" json:"app"`
 	AppHosts                                  string                       `mapstructure:"app-hosts" toml:"app-hosts" json:"appHosts"`
@@ -873,106 +873,106 @@ type Config struct {
 	BackupResticMountRecoveryEnabled bool `mapstructure:"backup-restic-mount-recovery-enabled" toml:"backup-restic-mount-recovery-enabled" json:"backupResticMountRecoveryEnabled"`
 	// BackupResticMountDir defines the base directory for restic FUSE mounts.
 	// Default base is <working-dir>/<cluster>/mount. Relative paths resolve under that base.
-	BackupResticMountDir                   string                 `scope:"server" mapstructure:"backup-restic-mount-dir" toml:"backup-restic-mount-dir" json:"backupResticMountDir"`
-	BackupResticReseedCleanup              bool                   `mapstructure:"backup-restic-reseed-cleanup" toml:"backup-restic-reseed-cleanup" json:"backupResticReseedCleanup"`
-	BackupResticReseedTimeout              int                    `mapstructure:"backup-restic-reseed-timeout" toml:"backup-restic-reseed-timeout" json:"backupResticReseedTimeout"`
-	BackupResticAllowUnsafeMount           bool                   `mapstructure:"backup-restic-allow-unsafe-mount" toml:"backup-restic-allow-unsafe-mount" json:"backupResticAllowUnsafeMount"`
-	BackupResticAutoInit                   bool                   `mapstructure:"backup-restic-auto-init" toml:"backup-restic-auto-init" json:"backupResticAutoInit"`
-	BackupResticS3Mode                     string                 `mapstructure:"backup-restic-s3-mode" toml:"backup-restic-s3-mode" json:"backupResticS3Mode"`
-	BackupReconcileInterval                int                    `mapstructure:"backup-reconcile-interval" toml:"backup-reconcile-interval" json:"backupReconcileInterval"`
-	BackupReconcileAutoCleanup             bool                   `mapstructure:"backup-reconcile-auto-cleanup" toml:"backup-reconcile-auto-cleanup" json:"backupReconcileAutoCleanup"`
-	BackupStreaming                        bool                   `mapstructure:"backup-streaming" toml:"backup-streaming" json:"backupStreaming"`
-	BackupStreamingDebug                   bool                   `mapstructure:"backup-streaming-debug" toml:"backup-streaming-debug" json:"backupStreamingDebug"`
-	BackupStreamingAwsAccessKeyId          string                 `mapstructure:"backup-streaming-aws-access-key-id" toml:"backup-streaming-aws-access-key-id" json:"-"`
-	BackupStreamingAwsAccessSecret         string                 `mapstructure:"backup-streaming-aws-access-secret"  toml:"backup-streaming-aws-access-secret" json:"-"`
-	BackupStreamingEndpoint                string                 `mapstructure:"backup-streaming-endpoint" toml:"backup-streaming-endpoint" json:"backupStreamingEndpoint"`
-	BackupStreamingRegion                  string                 `mapstructure:"backup-streaming-region" toml:"backup-streaming-region" json:"backupStreamingRegion"`
-	BackupStreamingBucket                  string                 `mapstructure:"backup-streaming-bucket" toml:"backup-streaming-bucket" json:"backupStreamingBucket"`
-	BackupMysqldumpPath                    string                 `mapstructure:"backup-mysqldump-path" toml:"backup-mysqldump-path" json:"backupMysqldumpPath"`
-	BackupMysqldumpOptions                 string                 `mapstructure:"backup-mysqldump-options" toml:"backup-mysqldump-options" json:"backupMysqldumpOptions"`
-	BackupMyDumperPath                     string                 `mapstructure:"backup-mydumper-path" toml:"backup-mydumper-path" json:"backupMydumperPath"`
-	BackupMyLoaderPath                     string                 `mapstructure:"backup-myloader-path" toml:"backup-myloader-path" json:"backupMyloaderPath"`
-	BackupMyLoaderOptions                  string                 `mapstructure:"backup-myloader-options" toml:"backup-myloader-options" json:"backupMyLoaderOptions"`
-	BackupMyDumperOptions                  string                 `mapstructure:"backup-mydumper-options" toml:"backup-mydumper-options" json:"backupMyDumperOptions"`
-	BackupMyDumperRegex                    string                 `mapstructure:"backup-mydumper-regex" toml:"backup-mydumper-regex" json:"backupMyDumperRegex"`
-	BackupMyDumperStream                   bool                   `mapstructure:"backup-mydumper-stream" toml:"backup-mydumper-stream" json:"backupMyDumperStream"`
-	BackupMyDumperStreamFormat             string                 `mapstructure:"backup-mydumper-stream-format" toml:"backup-mydumper-stream-format" json:"backupMyDumperStreamFormat"`
-	BackupMyDumperStreamFile               string                 `mapstructure:"backup-mydumper-stream-file" toml:"backup-mydumper-stream-file" json:"backupMyDumperStreamFile"`
-	BackupMysqlbinlogPath                  string                 `mapstructure:"backup-mysqlbinlog-path" toml:"backup-mysqlbinlog-path" json:"backupMysqlbinlogPath"`
-	BackupMysqlclientPath                  string                 `mapstructure:"backup-mysqlclient-path" toml:"backup-mysqlclient-path" json:"backupMysqlclientPath"`
-	BackupMysqlclientOptions               string                 `mapstructure:"backup-mysqlclient-options" toml:"backup-mysqlclient-options" json:"backupMysqlclientOptions"`
-	BackupMysqldumpSplitDump               bool                   `mapstructure:"backup-mysqldump-splitdump" toml:"backup-mysqldump-splitdump" json:"backupMysqldumpSplitDump"`
-	BackupSplitdumpCreateDatabases         bool                   `mapstructure:"backup-splitdump-create-databases" toml:"backup-splitdump-create-databases" json:"backupSplitdumpCreateDatabases"`
-	BackupMytopPath                        string                 `mapstructure:"backup-mytop-path" toml:"backup-mytop-path" json:"backupMytopPath"`
-	BackupGottyClientPath                  string                 `mapstructure:"backup-gotty-client-path" toml:"backup-gotty-client-path" json:"backupGottyClientPath"`
-	TtyShareBinaryPath                     string                 `mapstructure:"tty-share-binary-path" toml:"tty-share-binary-path" json:"ttyShareBinaryPath"`
-	ReplicationManagerCliPath              string                 `mapstructure:"replication-manager-cli-path" toml:"replication-manager-cli-path" json:"replicationManagerCliPath"`
-	BackupBinlogs                          bool                   `mapstructure:"backup-binlogs" toml:"backup-binlogs" json:"backupBinlogs"`
-	BackupBinlogsKeep                      int                    `mapstructure:"backup-binlogs-keep" toml:"backup-binlogs-keep" json:"backupBinlogsKeep"`
-	BackupLockDDL                          bool                   `mapstructure:"backup-lockddl" toml:"backup-lockddl" json:"backupLockDDL"`
-	BackupRestoreVersionStrict             bool                   `mapstructure:"backup-restore-version-strict" toml:"backup-restore-version-strict" json:"backupRestoreVersionStrict"`
-	BackupRestoreDefinerStrict             bool                   `mapstructure:"backup-restore-definer-strict" toml:"backup-restore-definer-strict" json:"backupRestoreDefinerStrict"`
-	BinlogCopyMode                         string                 `mapstructure:"binlog-copy-mode" toml:"binlog-copy-mode" json:"binlogCopyMode"`
-	BinlogCopyScript                       string                 `mapstructure:"binlog-copy-script" toml:"binlog-copy-script" json:"binlogCopyScript"`
-	BinlogRotationScript                   string                 `mapstructure:"binlog-rotation-script" toml:"binlog-rotation-script" json:"binlogRotationScript"`
-	BinlogParseMode                        string                 `mapstructure:"binlog-parse-mode" toml:"binlog-parse-mode" json:"binlogParseMode"`
-	ClusterConfigPath                      string                 `mapstructure:"cluster-config-file" toml:"-" json:"-"`
-	VaultServerAddr                        string                 `mapstructure:"vault-server-addr" toml:"vault-server-addr" json:"vaultServerAddr"`
-	VaultRoleId                            string                 `mapstructure:"vault-role-id" toml:"vault-role-id" json:"vaultRoleId"`
-	VaultSecretId                          string                 `mapstructure:"vault-secret-id" toml:"vault-secret-id" json:"vaultSecretId"`
-	VaultMode                              string                 `mapstructure:"vault-mode" toml:"vault-mode" json:"vaultMode"`
-	VaultMount                             string                 `mapstructure:"vault-mount" toml:"vault-mount" json:"vaultMount"`
-	VaultAuth                              string                 `mapstructure:"vault-auth" toml:"vault-auth" json:"vaultAuth"`
-	VaultToken                             string                 `mapstructure:"vault-token" toml:"vault-token" json:"vaultToken"`
-	LogVault                               bool                   `mapstructure:"log-vault" toml:"log-vault" json:"logVault"`
-	LogVaultLevel                          int                    `mapstructure:"log-level-vault" toml:"log-level-vault" json:"logVaultLevel"`
-	GitUrl                                 string                 `scope:"server" mapstructure:"git-url" toml:"git-url" json:"gitUrl"`
-	GitUrlPull                             string                 `scope:"server" mapstructure:"git-url-pull" toml:"git-url-pull" json:"gitUrlPull"`
-	GitUsername                            string                 `scope:"server" mapstructure:"git-username" toml:"git-username" json:"gitUsername"`
-	GitAccesToken                          string                 `scope:"server" mapstructure:"git-acces-token" toml:"git-acces-token" json:"-"`
-	GitMonitoringTicker                    int                    `scope:"server" mapstructure:"git-monitoring-ticker" toml:"git-monitoring-ticker" json:"gitMonitoringTicker"`
-	GitConfigSyncStandby                   bool                   `mapstructure:"git-config-sync-standby" toml:"git-config-sync-standby" json:"gitConfigSyncStandby"`
-	Cloud18                                bool                   `scope:"server" mapstructure:"cloud18"  toml:"cloud18" json:"cloud18"`
-	Cloud18Domain                          string                 `scope:"server" mapstructure:"cloud18-domain" toml:"cloud18-domain" json:"cloud18Domain" groups:"apps"`
-	Cloud18SubDomain                       string                 `scope:"server" mapstructure:"cloud18-sub-domain" toml:"cloud18-sub-domain" json:"cloud18SubDomain" groups:"apps"`
-	Cloud18SubDomainZone                   string                 `scope:"server" mapstructure:"cloud18-sub-domain-zone" toml:"cloud18-sub-domain-zone" json:"cloud18SubDomainZone" groups:"apps"`
-	Cloud18GitUser                         string                 `scope:"server" mapstructure:"cloud18-gitlab-user" toml:"cloud18-gitlab-user" json:"cloud18GitUser"`
-	Cloud18GitPassword                     string                 `scope:"server" mapstructure:"cloud18-gitlab-password" toml:"cloud18-gitlab-password" json:"-"`
-	Cloud18GatewayDomainName               string                 `scope:"server" mapstructure:"cloud18-gateway-domain-name" toml:"cloud18-gateway-domain-name"  json:"cloud18GatewayDomainName"`
-	Cloud18GatewayService                  string                 `scope:"server" mapstructure:"cloud18-gateway-service" toml:"Cloud18-gateway-service" json:"cloud18GatewayService"`
-	Cloud18CrmApiUrl                       string                 `scope:"server" mapstructure:"cloud18-crm-api-url" toml:"cloud18-crm-api-url" json:"cloud18CrmApiUrl"`
-	Cloud18DomainAddScript                 string                 `scope:"server" mapstructure:"cloud18-domain-add-script" toml:"cloud18-domain-add-script" json:"cloud18DomainAddScript"`
-	Cloud18DomainDropScript                string                 `scope:"server" mapstructure:"cloud18-domain-drop-script" toml:"cloud18-domain-drop-script" json:"cloud18DomainDropScript"`
-	Cloud18DomainUser                      string                 `scope:"server" mapstructure:"cloud18-domain-user" toml:"cloud18-domain-user" json:"cloud18DomainUser"`
-	Cloud18DomainSecret                    string                 `scope:"server" mapstructure:"cloud18-domain-secret" toml:"cloud18-domain-secret" json:"cloud18DomainSecret"`
-	Cloud18Shared                          bool                   `mapstructure:"cloud18-shared"  toml:"cloud18-shared" json:"cloud18Shared"`
-	Cloud18PlatformDescription             string                 `mapstructure:"cloud18-platform-description"  toml:"cloud18-platform-description" json:"cloud18PlatformDescription"`
-	Cloud18MonthlyInfraCost                float64                `mapstructure:"cloud18-monthly-infra-cost"  toml:"cloud18-monthly-infra-cost" json:"cloud18MonthlyInfraCost"`
-	Cloud18MonthlyLicenseCost              float64                `mapstructure:"cloud18-monthly-license-cost"  toml:"cloud18-monthly-license-cost" json:"cloud18MonthlyLicenseCost"`
-	Cloud18MonthlySysopsCost               float64                `mapstructure:"cloud18-monthly-sysops-cost"  toml:"cloud18-monthly-sysops-cost" json:"cloud18MonthlySysopsCost"`
-	Cloud18MonthlyDbopsCost                float64                `mapstructure:"cloud18-monthly-dbops-cost"  toml:"cloud18-monthly-dbops-cost" json:"cloud18MonthlyDbopsCost"`
-	Cloud18MonthlyExternalSysopsCost       float64                `mapstructure:"cloud18-monthly-external-sysops-cost" toml:"cloud18-monthly-external-sysops-cost" json:"cloud18MonthlyExternalSysopsCost"`
-	Cloud18MonthlyExternalDbopsCost        float64                `mapstructure:"cloud18-monthly-external-dbops-cost" toml:"cloud18-monthly-external-dbops-cost" json:"cloud18MonthlyExternalDbopsCost"`
-	Cloud18PromotionPct                    float64                `mapstructure:"cloud18-promotion-pct"  toml:"cloud18-promotion-pct" json:"cloud18PromotionPct"`
-	Cloud18SlaResponseTime                 float64                `mapstructure:"cloud18-sla-response-time"  toml:"cloud18-sla-response-time" json:"cloud18SlaResponseTime"`
-	Cloud18SlaRepairTime                   float64                `mapstructure:"cloud18-sla-repair-time"  toml:"cloud18-sla-repair-time" json:"cloud18SlaRepairTime"`
-	Cloud18SlaProvisionTime                float64                `mapstructure:"cloud18-sla-provision-time"  toml:"cloud18-sla-provision-time" json:"cloud18SlaProvisionTime"`
-	Cloud18CostCurrency                    string                 `mapstructure:"cloud18-cost-currency"  toml:"cloud18-cost-currency" json:"cloud18CostCurrency"`
-	Cloud18InfraCPUModel                   string                 `mapstructure:"cloud18-infra-cpu-model"  toml:"cloud18-infra-cpu-model" json:"cloud18InfraCpuModel"`
-	Cloud18InfraCPUFreq                    string                 `mapstructure:"cloud18-infra-cpu-freq"  toml:"cloud18-infra-cpu-freq" json:"cloud18InfraCpuFreq"`
-	Cloud18InfraDescription                string                 `mapstructure:"cloud18-infra-description"  toml:"cloud18-infra-description" json:"cloud18InfraDescription"`
-	Cloud18InfraDataCenters                string                 `mapstructure:"cloud18-infra-data-centers"  toml:"cloud18-infra-data-centers" json:"cloud18InfraDataCenters"`
-	Cloud18InfraPublicBandwidth            float64                `mapstructure:"cloud18-infra-public-bandwidth"  toml:"cloud18-infra-public-bandwidth" json:"cloud18InfraPublicBandwidth"`
-	Cloud18InfraGeoLocalizations           string                 `mapstructure:"cloud18-infra-geo-localizations"  toml:"cloud18-infra-geo-localizations" json:"cloud18InfraGeoLocalizations"`
-	Cloud18DbOps                           string                 `mapstructure:"cloud18-dbops"  toml:"cloud18-dbops" json:"cloud18DbOps"`
-	Cloud18ExternalDbOps                   string                 `mapstructure:"cloud18-external-dbops"  toml:"cloud18-external-dbops" json:"cloud18ExternalDbOps"`
-	Cloud18ExternalDbOpsStatus             string                 `mapstructure:"cloud18-external-dbops-status"  toml:"cloud18-external-dbops-status" json:"cloud18ExternalDbOpsStatus"`
-	Cloud18ExternalSysOps                  string                 `mapstructure:"cloud18-external-sysops" toml:"cloud18-external-sysops" json:"cloud18ExternalSysOps"`
-	Cloud18ExternalSysOpsStatus            string                 `mapstructure:"cloud18-external-sysops-status" toml:"cloud18-external-sysops-status" json:"cloud18ExternalSysOpsStatus"`
-	Cloud18InfraCertifications             string                 `mapstructure:"cloud18-infra-certifications"  toml:"cloud18-infra-certifications" json:"cloud18InfraCertifications"`
-	Cloud18OpenDbops                       bool                   `mapstructure:"cloud18-open-dbops"  toml:"cloud18-open-dbops" json:"cloud18OpenDbops"`
-	Cloud18SubscribedDbops                 bool                   `mapstructure:"cloud18-subscribed-dbops"  toml:"cloud18-subscribed-dbops" json:"cloud18SubscribedDbops"`
-	Cloud18SubscriptionPlan                string                 `scope:"server" mapstructure:"cloud18-subscription-plan" toml:"cloud18-subscription-plan" json:"cloud18SubscriptionPlan"`
+	BackupResticMountDir             string  `scope:"server" mapstructure:"backup-restic-mount-dir" toml:"backup-restic-mount-dir" json:"backupResticMountDir"`
+	BackupResticReseedCleanup        bool    `mapstructure:"backup-restic-reseed-cleanup" toml:"backup-restic-reseed-cleanup" json:"backupResticReseedCleanup"`
+	BackupResticReseedTimeout        int     `mapstructure:"backup-restic-reseed-timeout" toml:"backup-restic-reseed-timeout" json:"backupResticReseedTimeout"`
+	BackupResticAllowUnsafeMount     bool    `mapstructure:"backup-restic-allow-unsafe-mount" toml:"backup-restic-allow-unsafe-mount" json:"backupResticAllowUnsafeMount"`
+	BackupResticAutoInit             bool    `mapstructure:"backup-restic-auto-init" toml:"backup-restic-auto-init" json:"backupResticAutoInit"`
+	BackupResticS3Mode               string  `mapstructure:"backup-restic-s3-mode" toml:"backup-restic-s3-mode" json:"backupResticS3Mode"`
+	BackupReconcileInterval          int     `mapstructure:"backup-reconcile-interval" toml:"backup-reconcile-interval" json:"backupReconcileInterval"`
+	BackupReconcileAutoCleanup       bool    `mapstructure:"backup-reconcile-auto-cleanup" toml:"backup-reconcile-auto-cleanup" json:"backupReconcileAutoCleanup"`
+	BackupStreaming                  bool    `mapstructure:"backup-streaming" toml:"backup-streaming" json:"backupStreaming"`
+	BackupStreamingDebug             bool    `mapstructure:"backup-streaming-debug" toml:"backup-streaming-debug" json:"backupStreamingDebug"`
+	BackupStreamingAwsAccessKeyId    string  `mapstructure:"backup-streaming-aws-access-key-id" toml:"backup-streaming-aws-access-key-id" json:"-"`
+	BackupStreamingAwsAccessSecret   string  `mapstructure:"backup-streaming-aws-access-secret"  toml:"backup-streaming-aws-access-secret" json:"-"`
+	BackupStreamingEndpoint          string  `mapstructure:"backup-streaming-endpoint" toml:"backup-streaming-endpoint" json:"backupStreamingEndpoint"`
+	BackupStreamingRegion            string  `mapstructure:"backup-streaming-region" toml:"backup-streaming-region" json:"backupStreamingRegion"`
+	BackupStreamingBucket            string  `mapstructure:"backup-streaming-bucket" toml:"backup-streaming-bucket" json:"backupStreamingBucket"`
+	BackupMysqldumpPath              string  `mapstructure:"backup-mysqldump-path" toml:"backup-mysqldump-path" json:"backupMysqldumpPath"`
+	BackupMysqldumpOptions           string  `mapstructure:"backup-mysqldump-options" toml:"backup-mysqldump-options" json:"backupMysqldumpOptions"`
+	BackupMyDumperPath               string  `mapstructure:"backup-mydumper-path" toml:"backup-mydumper-path" json:"backupMydumperPath"`
+	BackupMyLoaderPath               string  `mapstructure:"backup-myloader-path" toml:"backup-myloader-path" json:"backupMyloaderPath"`
+	BackupMyLoaderOptions            string  `mapstructure:"backup-myloader-options" toml:"backup-myloader-options" json:"backupMyLoaderOptions"`
+	BackupMyDumperOptions            string  `mapstructure:"backup-mydumper-options" toml:"backup-mydumper-options" json:"backupMyDumperOptions"`
+	BackupMyDumperRegex              string  `mapstructure:"backup-mydumper-regex" toml:"backup-mydumper-regex" json:"backupMyDumperRegex"`
+	BackupMyDumperStream             bool    `mapstructure:"backup-mydumper-stream" toml:"backup-mydumper-stream" json:"backupMyDumperStream"`
+	BackupMyDumperStreamFormat       string  `mapstructure:"backup-mydumper-stream-format" toml:"backup-mydumper-stream-format" json:"backupMyDumperStreamFormat"`
+	BackupMyDumperStreamFile         string  `mapstructure:"backup-mydumper-stream-file" toml:"backup-mydumper-stream-file" json:"backupMyDumperStreamFile"`
+	BackupMysqlbinlogPath            string  `mapstructure:"backup-mysqlbinlog-path" toml:"backup-mysqlbinlog-path" json:"backupMysqlbinlogPath"`
+	BackupMysqlclientPath            string  `mapstructure:"backup-mysqlclient-path" toml:"backup-mysqlclient-path" json:"backupMysqlclientPath"`
+	BackupMysqlclientOptions         string  `mapstructure:"backup-mysqlclient-options" toml:"backup-mysqlclient-options" json:"backupMysqlclientOptions"`
+	BackupMysqldumpSplitDump         bool    `mapstructure:"backup-mysqldump-splitdump" toml:"backup-mysqldump-splitdump" json:"backupMysqldumpSplitDump"`
+	BackupSplitdumpCreateDatabases   bool    `mapstructure:"backup-splitdump-create-databases" toml:"backup-splitdump-create-databases" json:"backupSplitdumpCreateDatabases"`
+	BackupMytopPath                  string  `mapstructure:"backup-mytop-path" toml:"backup-mytop-path" json:"backupMytopPath"`
+	BackupGottyClientPath            string  `mapstructure:"backup-gotty-client-path" toml:"backup-gotty-client-path" json:"backupGottyClientPath"`
+	TtyShareBinaryPath               string  `mapstructure:"tty-share-binary-path" toml:"tty-share-binary-path" json:"ttyShareBinaryPath"`
+	ReplicationManagerCliPath        string  `mapstructure:"replication-manager-cli-path" toml:"replication-manager-cli-path" json:"replicationManagerCliPath"`
+	BackupBinlogs                    bool    `mapstructure:"backup-binlogs" toml:"backup-binlogs" json:"backupBinlogs"`
+	BackupBinlogsKeep                int     `mapstructure:"backup-binlogs-keep" toml:"backup-binlogs-keep" json:"backupBinlogsKeep"`
+	BackupLockDDL                    bool    `mapstructure:"backup-lockddl" toml:"backup-lockddl" json:"backupLockDDL"`
+	BackupRestoreVersionStrict       bool    `mapstructure:"backup-restore-version-strict" toml:"backup-restore-version-strict" json:"backupRestoreVersionStrict"`
+	BackupRestoreDefinerStrict       bool    `mapstructure:"backup-restore-definer-strict" toml:"backup-restore-definer-strict" json:"backupRestoreDefinerStrict"`
+	BinlogCopyMode                   string  `mapstructure:"binlog-copy-mode" toml:"binlog-copy-mode" json:"binlogCopyMode"`
+	BinlogCopyScript                 string  `mapstructure:"binlog-copy-script" toml:"binlog-copy-script" json:"binlogCopyScript"`
+	BinlogRotationScript             string  `mapstructure:"binlog-rotation-script" toml:"binlog-rotation-script" json:"binlogRotationScript"`
+	BinlogParseMode                  string  `mapstructure:"binlog-parse-mode" toml:"binlog-parse-mode" json:"binlogParseMode"`
+	ClusterConfigPath                string  `mapstructure:"cluster-config-file" toml:"-" json:"-"`
+	VaultServerAddr                  string  `mapstructure:"vault-server-addr" toml:"vault-server-addr" json:"vaultServerAddr"`
+	VaultRoleId                      string  `mapstructure:"vault-role-id" toml:"vault-role-id" json:"vaultRoleId"`
+	VaultSecretId                    string  `mapstructure:"vault-secret-id" toml:"vault-secret-id" json:"vaultSecretId"`
+	VaultMode                        string  `mapstructure:"vault-mode" toml:"vault-mode" json:"vaultMode"`
+	VaultMount                       string  `mapstructure:"vault-mount" toml:"vault-mount" json:"vaultMount"`
+	VaultAuth                        string  `mapstructure:"vault-auth" toml:"vault-auth" json:"vaultAuth"`
+	VaultToken                       string  `mapstructure:"vault-token" toml:"vault-token" json:"vaultToken"`
+	LogVault                         bool    `mapstructure:"log-vault" toml:"log-vault" json:"logVault"`
+	LogVaultLevel                    int     `mapstructure:"log-level-vault" toml:"log-level-vault" json:"logVaultLevel"`
+	GitUrl                           string  `scope:"server" mapstructure:"git-url" toml:"git-url" json:"gitUrl"`
+	GitUrlPull                       string  `scope:"server" mapstructure:"git-url-pull" toml:"git-url-pull" json:"gitUrlPull"`
+	GitUsername                      string  `scope:"server" mapstructure:"git-username" toml:"git-username" json:"gitUsername"`
+	GitAccesToken                    string  `scope:"server" mapstructure:"git-acces-token" toml:"git-acces-token" json:"-"`
+	GitMonitoringTicker              int     `scope:"server" mapstructure:"git-monitoring-ticker" toml:"git-monitoring-ticker" json:"gitMonitoringTicker"`
+	GitConfigSyncStandby             bool    `mapstructure:"git-config-sync-standby" toml:"git-config-sync-standby" json:"gitConfigSyncStandby"`
+	Cloud18                          bool    `scope:"server" mapstructure:"cloud18"  toml:"cloud18" json:"cloud18"`
+	Cloud18Domain                    string  `scope:"server" mapstructure:"cloud18-domain" toml:"cloud18-domain" json:"cloud18Domain" groups:"apps"`
+	Cloud18SubDomain                 string  `scope:"server" mapstructure:"cloud18-sub-domain" toml:"cloud18-sub-domain" json:"cloud18SubDomain" groups:"apps"`
+	Cloud18SubDomainZone             string  `scope:"server" mapstructure:"cloud18-sub-domain-zone" toml:"cloud18-sub-domain-zone" json:"cloud18SubDomainZone" groups:"apps"`
+	Cloud18GitUser                   string  `scope:"server" mapstructure:"cloud18-gitlab-user" toml:"cloud18-gitlab-user" json:"cloud18GitUser"`
+	Cloud18GitPassword               string  `scope:"server" mapstructure:"cloud18-gitlab-password" toml:"cloud18-gitlab-password" json:"-"`
+	Cloud18GatewayDomainName         string  `scope:"server" mapstructure:"cloud18-gateway-domain-name" toml:"cloud18-gateway-domain-name"  json:"cloud18GatewayDomainName"`
+	Cloud18GatewayService            string  `scope:"server" mapstructure:"cloud18-gateway-service" toml:"Cloud18-gateway-service" json:"cloud18GatewayService"`
+	Cloud18CrmApiUrl                 string  `scope:"server" mapstructure:"cloud18-crm-api-url" toml:"cloud18-crm-api-url" json:"cloud18CrmApiUrl"`
+	Cloud18DomainAddScript           string  `scope:"server" mapstructure:"cloud18-domain-add-script" toml:"cloud18-domain-add-script" json:"cloud18DomainAddScript"`
+	Cloud18DomainDropScript          string  `scope:"server" mapstructure:"cloud18-domain-drop-script" toml:"cloud18-domain-drop-script" json:"cloud18DomainDropScript"`
+	Cloud18DomainUser                string  `scope:"server" mapstructure:"cloud18-domain-user" toml:"cloud18-domain-user" json:"cloud18DomainUser"`
+	Cloud18DomainSecret              string  `scope:"server" mapstructure:"cloud18-domain-secret" toml:"cloud18-domain-secret" json:"cloud18DomainSecret"`
+	Cloud18Shared                    bool    `mapstructure:"cloud18-shared"  toml:"cloud18-shared" json:"cloud18Shared"`
+	Cloud18PlatformDescription       string  `mapstructure:"cloud18-platform-description"  toml:"cloud18-platform-description" json:"cloud18PlatformDescription"`
+	Cloud18MonthlyInfraCost          float64 `mapstructure:"cloud18-monthly-infra-cost"  toml:"cloud18-monthly-infra-cost" json:"cloud18MonthlyInfraCost"`
+	Cloud18MonthlyLicenseCost        float64 `mapstructure:"cloud18-monthly-license-cost"  toml:"cloud18-monthly-license-cost" json:"cloud18MonthlyLicenseCost"`
+	Cloud18MonthlySysopsCost         float64 `mapstructure:"cloud18-monthly-sysops-cost"  toml:"cloud18-monthly-sysops-cost" json:"cloud18MonthlySysopsCost"`
+	Cloud18MonthlyDbopsCost          float64 `mapstructure:"cloud18-monthly-dbops-cost"  toml:"cloud18-monthly-dbops-cost" json:"cloud18MonthlyDbopsCost"`
+	Cloud18MonthlyExternalSysopsCost float64 `mapstructure:"cloud18-monthly-external-sysops-cost" toml:"cloud18-monthly-external-sysops-cost" json:"cloud18MonthlyExternalSysopsCost"`
+	Cloud18MonthlyExternalDbopsCost  float64 `mapstructure:"cloud18-monthly-external-dbops-cost" toml:"cloud18-monthly-external-dbops-cost" json:"cloud18MonthlyExternalDbopsCost"`
+	Cloud18PromotionPct              float64 `mapstructure:"cloud18-promotion-pct"  toml:"cloud18-promotion-pct" json:"cloud18PromotionPct"`
+	Cloud18SlaResponseTime           float64 `mapstructure:"cloud18-sla-response-time"  toml:"cloud18-sla-response-time" json:"cloud18SlaResponseTime"`
+	Cloud18SlaRepairTime             float64 `mapstructure:"cloud18-sla-repair-time"  toml:"cloud18-sla-repair-time" json:"cloud18SlaRepairTime"`
+	Cloud18SlaProvisionTime          float64 `mapstructure:"cloud18-sla-provision-time"  toml:"cloud18-sla-provision-time" json:"cloud18SlaProvisionTime"`
+	Cloud18CostCurrency              string  `mapstructure:"cloud18-cost-currency"  toml:"cloud18-cost-currency" json:"cloud18CostCurrency"`
+	Cloud18InfraCPUModel             string  `mapstructure:"cloud18-infra-cpu-model"  toml:"cloud18-infra-cpu-model" json:"cloud18InfraCpuModel"`
+	Cloud18InfraCPUFreq              string  `mapstructure:"cloud18-infra-cpu-freq"  toml:"cloud18-infra-cpu-freq" json:"cloud18InfraCpuFreq"`
+	Cloud18InfraDescription          string  `mapstructure:"cloud18-infra-description"  toml:"cloud18-infra-description" json:"cloud18InfraDescription"`
+	Cloud18InfraDataCenters          string  `mapstructure:"cloud18-infra-data-centers"  toml:"cloud18-infra-data-centers" json:"cloud18InfraDataCenters"`
+	Cloud18InfraPublicBandwidth      float64 `mapstructure:"cloud18-infra-public-bandwidth"  toml:"cloud18-infra-public-bandwidth" json:"cloud18InfraPublicBandwidth"`
+	Cloud18InfraGeoLocalizations     string  `mapstructure:"cloud18-infra-geo-localizations"  toml:"cloud18-infra-geo-localizations" json:"cloud18InfraGeoLocalizations"`
+	Cloud18DbOps                     string  `mapstructure:"cloud18-dbops"  toml:"cloud18-dbops" json:"cloud18DbOps"`
+	Cloud18ExternalDbOps             string  `mapstructure:"cloud18-external-dbops"  toml:"cloud18-external-dbops" json:"cloud18ExternalDbOps"`
+	Cloud18ExternalDbOpsStatus       string  `mapstructure:"cloud18-external-dbops-status"  toml:"cloud18-external-dbops-status" json:"cloud18ExternalDbOpsStatus"`
+	Cloud18ExternalSysOps            string  `mapstructure:"cloud18-external-sysops" toml:"cloud18-external-sysops" json:"cloud18ExternalSysOps"`
+	Cloud18ExternalSysOpsStatus      string  `mapstructure:"cloud18-external-sysops-status" toml:"cloud18-external-sysops-status" json:"cloud18ExternalSysOpsStatus"`
+	Cloud18InfraCertifications       string  `mapstructure:"cloud18-infra-certifications"  toml:"cloud18-infra-certifications" json:"cloud18InfraCertifications"`
+	Cloud18OpenDbops                 bool    `mapstructure:"cloud18-open-dbops"  toml:"cloud18-open-dbops" json:"cloud18OpenDbops"`
+	Cloud18SubscribedDbops           bool    `mapstructure:"cloud18-subscribed-dbops"  toml:"cloud18-subscribed-dbops" json:"cloud18SubscribedDbops"`
+	Cloud18SubscriptionPlan          string  `scope:"server" mapstructure:"cloud18-subscription-plan" toml:"cloud18-subscription-plan" json:"cloud18SubscriptionPlan"`
 	// Cloud18LicenseFile, when set, is the single switch for offline-license mode:
 	// the instance sources its plan from this signed file instead of the CRM (for
 	// air-gapped/PCI instances). Empty = normal online CRM path.

--- a/config/config.go
+++ b/config/config.go
@@ -703,6 +703,7 @@ type Config struct {
 	ProvDBCompliance                          string                       `mapstructure:"prov-db-compliance" toml:"prov-db-compliance" json:"provDBCompliance"`
 	ProvProxyCompliance                       string                       `mapstructure:"prov-proxy-compliance" toml:"prov-proxy-compliance" json:"provProxyCompliance"`
 	ProvAutoUpdateCompliance                  bool                         `mapstructure:"prov-auto-update-compliance" toml:"prov-auto-update-compliance" json:"provAutoUpdateCompliance"`
+	ProvAutoAgreeCompliance                   bool                         `mapstructure:"prov-auto-agree-compliance" toml:"prov-auto-agree-compliance" json:"provAutoAgreeCompliance"`
 	ProvDockerRegistryCredentials             string                       `mapstructure:"prov-docker-registry-credentials" toml:"prov-docker-registry-credentials" json:"provDockerRegistryCredentials"`
 	AppOn                                     bool                         `mapstructure:"app" toml:"app" json:"app"`
 	AppHosts                                  string                       `mapstructure:"app-hosts" toml:"app-hosts" json:"appHosts"`

--- a/config/maps.go
+++ b/config/maps.go
@@ -1147,10 +1147,38 @@ func (m *VariablesMap) SetRuntimeValue(varname string, value string) {
 	}
 }
 
-func (m *VariablesMap) SetRuntimeValues(strmap map[string]string) {
+// SetRuntimeValues applies the live DB variable values and returns how many
+// actually changed since the previous tick. Callers gate per-tick reconciliation
+// work (DropReconciledAgreed) on a non-zero return: a variable can only become
+// reconciled (Runtime == Config) when its runtime value moves, so in the steady
+// state — runtime identical tick to tick — the drop walk is skipped entirely.
+func (m *VariablesMap) SetRuntimeValues(strmap map[string]string) int {
+	changed := 0
 	for k, v := range strmap {
-		m.SetRuntimeValue(k, v)
+		lowervarname := strings.ToLower(k)
+		state, ok := m.Load(lowervarname)
+		if !ok {
+			ns := NewVariableState(lowervarname)
+			ns.SetRuntimeValue(v)
+			m.Store(lowervarname, ns)
+			changed++
+			continue
+		}
+		vs := state.(*VariableState)
+		before := ""
+		if vs.Runtime != nil {
+			before = vs.Runtime.String()
+		}
+		vs.SetRuntimeValue(v)
+		after := ""
+		if vs.Runtime != nil {
+			after = vs.Runtime.String()
+		}
+		if before != after {
+			changed++
+		}
 	}
+	return changed
 }
 
 func (m *VariablesMap) SetConfigValue(varname string, value string) {

--- a/config/maps.go
+++ b/config/maps.go
@@ -1056,6 +1056,38 @@ func (m *VariablesMap) EmptyPreservedValues() {
 	})
 }
 
+// DropReconciledAgreed drops the agreed (03_agreed.cnf) marking of every variable
+// the DB now actually runs at the compliance (Config) value: the agree has served
+// its purpose (it only exists to hold a value "until the DB is restarted with the
+// compliance value"), so once Runtime == Config it must be cleared to avoid a
+// phantom pending diff. It NEVER touches operator-forced values: only agreed ones
+// (Preserved set with an empty PreservedSource) are considered — server-specific
+// or cluster-level preserved values (PreservedSource != "") are left untouched.
+// Returns the names of the variables whose agree was dropped.
+func (m *VariablesMap) DropReconciledAgreed() []string {
+	var dropped []string
+	m.Range(func(key, value any) bool {
+		state, ok := value.(*VariableState)
+		if !ok {
+			return true
+		}
+		// Only agreed values: Preserved set, no explicit preserve source.
+		if state.Preserved == nil || state.PreservedSource != "" {
+			return true
+		}
+		// Need both the runtime value and the compliance value to compare.
+		if state.Runtime == nil || state.Config == nil {
+			return true
+		}
+		if state.Runtime.String() == state.Config.String() {
+			state.UnsetPreservedValue()
+			dropped = append(dropped, state.VariableName)
+		}
+		return true
+	})
+	return dropped
+}
+
 func (m *VariablesMap) SetDeployedValue(varname string, value string) {
 	lowerVarName := strings.ToLower(varname)
 	if state, ok := m.Load(lowerVarName); ok {

--- a/config/maps.go
+++ b/config/maps.go
@@ -1088,6 +1088,37 @@ func (m *VariablesMap) DropReconciledAgreed() []string {
 	return dropped
 }
 
+// AutoAgreeValueDeltas agrees every value-differs delta to the compliance
+// (Config) value: a known variable (Config != nil) whose deployed value differs
+// from Config and is neither preserved nor dropped. Agreeing sets Preserved =
+// Config, which routes it to 03_agreed.cnf so the DB adopts the compliance value
+// on its next restart (and DropReconciledAgreed clears it afterwards). Scoped to
+// value-differs only: no-config / dropped variables are left for manual review
+// (loose_ hides deprecation — see #1495). Returns the agreed variable names.
+func (m *VariablesMap) AutoAgreeValueDeltas() []string {
+	var agreed []string
+	m.Range(func(key, value any) bool {
+		state, ok := value.(*VariableState)
+		if !ok {
+			return true
+		}
+		// Skip anything already decided (preserved/agreed) or an accepted drop.
+		if state.Preserved != nil || state.Dropped {
+			return true
+		}
+		// Value-differs only: needs both a compliance value and a deployed value.
+		if state.Config == nil || state.Deployed == nil {
+			return true
+		}
+		if state.Deployed.String() != state.Config.String() {
+			state.SetPreservedValue(state.Config.String())
+			agreed = append(agreed, state.VariableName)
+		}
+		return true
+	})
+	return agreed
+}
+
 func (m *VariablesMap) SetDeployedValue(varname string, value string) {
 	lowerVarName := strings.ToLower(varname)
 	if state, ok := m.Load(lowerVarName); ok {

--- a/config/maps_test.go
+++ b/config/maps_test.go
@@ -54,3 +54,51 @@ func TestDropReconciledAgreed(t *testing.T) {
 	assertPreserved("forced", false)           // kept: server-specific forced
 	assertPreserved("forced_cluster", false)   // kept: cluster-level forced
 }
+
+func mkVarDeployed(name, cfg, deployed, preserved string, dropped bool) *VariableState {
+	v := NewVariableState(name)
+	if cfg != "" {
+		v.SetConfigValue(cfg)
+	}
+	if deployed != "" {
+		v.SetDeployedValue(deployed)
+	}
+	if preserved != "" {
+		v.SetPreservedValue(preserved)
+	}
+	v.Dropped = dropped
+	return v
+}
+
+func TestAutoAgreeValueDeltas(t *testing.T) {
+	m := NewVariablesMap()
+	// value-differs (config known, deployed != config, not preserved/dropped) -> agreed to config
+	m.Store("value_differs", mkVarDeployed("value_differs", "4096", "16384", "", false))
+	// no-config (Config nil) -> NOT agreed (deprecated/unknown, manual review)
+	m.Store("no_config", mkVarDeployed("no_config", "", "16384", "", false))
+	// already preserved -> untouched
+	m.Store("already", mkVarDeployed("already", "4096", "16384", "16384", false))
+	// dropped -> NOT agreed
+	m.Store("dropped", mkVarDeployed("dropped", "4096", "16384", "", true))
+	// deployed == config (no diff) -> NOT agreed
+	m.Store("equal", mkVarDeployed("equal", "4096", "4096", "", false))
+
+	agreed := m.AutoAgreeValueDeltas()
+
+	if len(agreed) != 1 || agreed[0] != "value_differs" {
+		t.Fatalf("expected only [value_differs] agreed, got %v", agreed)
+	}
+	// value_differs now has Preserved == Config (agreed)
+	v, _ := m.Load("value_differs")
+	vs := v.(*VariableState)
+	if vs.Preserved == nil || vs.Preserved.String() != "4096" {
+		t.Errorf("value_differs: expected Preserved=4096 (config), got %v", vs.Preserved)
+	}
+	// no_config, dropped, equal untouched (no Preserved set by us)
+	for _, k := range []string{"no_config", "dropped", "equal"} {
+		v, _ := m.Load(k)
+		if v.(*VariableState).Preserved != nil {
+			t.Errorf("%s: should not have been agreed", k)
+		}
+	}
+}

--- a/config/maps_test.go
+++ b/config/maps_test.go
@@ -102,3 +102,32 @@ func TestAutoAgreeValueDeltas(t *testing.T) {
 		}
 	}
 }
+
+// TestUnknownVariableSafety locks in that a variable not recognized by the DB
+// (PreservedSource == "unknown-variable", Preserved set by the unknown detector)
+// is never auto-agreed (would be deployed -> crash) and never auto-dropped
+// (must stay in 03_agreed for manual review).
+func TestUnknownVariableSafety(t *testing.T) {
+	// unknown: Config set, Preserved == Config, source "unknown-variable", no runtime (DB doesn't know it)
+	unknown := mkVarState("some_unknown_var", "1", "", "1", "unknown-variable")
+
+	m1 := NewVariablesMap()
+	m1.Store("some_unknown_var", unknown)
+	if agreed := m1.AutoAgreeValueDeltas(); len(agreed) != 0 {
+		t.Errorf("unknown must never be auto-agreed, got %v", agreed)
+	}
+	if v, _ := m1.Load("some_unknown_var"); v.(*VariableState).Preserved == nil {
+		t.Errorf("unknown Preserved must be kept (routed to agreed for review)")
+	}
+
+	// Even if runtime somehow equals config, DropReconciledAgreed must skip it (source != "")
+	unknown2 := mkVarState("some_unknown_var", "1", "1", "1", "unknown-variable")
+	m2 := NewVariablesMap()
+	m2.Store("some_unknown_var", unknown2)
+	if dropped := m2.DropReconciledAgreed(); len(dropped) != 0 {
+		t.Errorf("unknown must never be auto-dropped, got %v", dropped)
+	}
+	if v, _ := m2.Load("some_unknown_var"); v.(*VariableState).Preserved == nil {
+		t.Errorf("unknown Preserved must survive DropReconciledAgreed")
+	}
+}

--- a/config/maps_test.go
+++ b/config/maps_test.go
@@ -1,0 +1,56 @@
+package config
+
+import "testing"
+
+func mkVarState(name, cfg, runtime, preserved, source string) *VariableState {
+	v := NewVariableState(name)
+	if cfg != "" {
+		v.SetConfigValue(cfg)
+	}
+	if runtime != "" {
+		v.SetRuntimeValue(runtime)
+	}
+	if preserved != "" {
+		v.SetPreservedValue(preserved)
+	}
+	v.PreservedSource = source
+	return v
+}
+
+func TestDropReconciledAgreed(t *testing.T) {
+	m := NewVariablesMap()
+	// agreed (no source) + reconciled (runtime == config) -> dropped
+	m.Store("agreed_reconciled", mkVarState("agreed_reconciled", "4096", "4096", "4096", ""))
+	// agreed but not yet reconciled (runtime != config) -> kept
+	m.Store("agreed_pending", mkVarState("agreed_pending", "4096", "16384", "16384", ""))
+	// operator-forced preserve + reconciled -> MUST never be dropped
+	m.Store("forced", mkVarState("forced", "4096", "4096", "4096", "server-specific"))
+	// cluster-level forced preserve + reconciled -> MUST never be dropped
+	m.Store("forced_cluster", mkVarState("forced_cluster", "4096", "4096", "4096", "cluster-level"))
+	// nothing preserved -> untouched
+	m.Store("plain", mkVarState("plain", "4096", "4096", "", ""))
+
+	dropped := m.DropReconciledAgreed()
+
+	if len(dropped) != 1 || dropped[0] != "agreed_reconciled" {
+		t.Fatalf("expected only [agreed_reconciled] dropped, got %v", dropped)
+	}
+
+	assertPreserved := func(key string, wantNil bool) {
+		v, ok := m.Load(key)
+		if !ok {
+			t.Fatalf("%s: missing", key)
+		}
+		got := v.(*VariableState).Preserved
+		if wantNil && got != nil {
+			t.Errorf("%s: Preserved should be nil after drop", key)
+		}
+		if !wantNil && got == nil {
+			t.Errorf("%s: Preserved must be kept", key)
+		}
+	}
+	assertPreserved("agreed_reconciled", true) // dropped
+	assertPreserved("agreed_pending", false)   // kept: not reconciled
+	assertPreserved("forced", false)           // kept: server-specific forced
+	assertPreserved("forced_cluster", false)   // kept: cluster-level forced
+}

--- a/doc/implementation/config-diff/AUTO_AGREE_COMPLIANCE.md
+++ b/doc/implementation/config-diff/AUTO_AGREE_COMPLIANCE.md
@@ -70,7 +70,7 @@ names. **Forced preserves (`PreservedSource != ""`) are never touched.**
 ### 2. `AutoAgreeValueDeltas()` — opt-in auto-agree
 
 The DB-side counterpart of Auto-Update Compliance. When
-`prov-auto-agree-compliance` is enabled, a **value delta** (a variable whose
+`prov-db-compliance-auto-agree` is enabled, a **value delta** (a variable whose
 deployed value differs from the compliance value, not yet preserved/agreed) is
 automatically agreed to the compliance value: `SetPreservedValue(Config)`, which
 routes it to `03_agreed.cnf` and lets the DB adopt it on its next restart.
@@ -131,10 +131,10 @@ rare.
 
 ## Configuration & GUI
 
-- Flag: `prov-auto-agree-compliance` (`config.Config.ProvAutoAgreeCompliance`),
+- Flag: `prov-db-compliance-auto-agree` (`config.Config.ProvDBComplianceAutoAgree`),
   `server/server.go`, **default `false`** (opt-in; T14 off-switch).
-- JSON: `provAutoAgreeCompliance` (exposed in the cluster config object).
-- Switch handler: `server/api_cluster.go` `case "prov-auto-agree-compliance"`.
+- JSON: `provDbComplianceAutoAgree` (exposed in the cluster config object).
+- Switch handler: `server/api_cluster.go` `case "prov-db-compliance-auto-agree"`.
 - GUI: **Configurator tab → "Auto-Agree Compliance"** toggle
   (`share/dashboard_react/src/Pages/Configs/components/DBConfigs.jsx`), beside
   "Auto-Update Compliance", gated on the `cluster-settings` grant (T6, T22).
@@ -147,7 +147,7 @@ They are independent and complementary:
 
 | | Auto-**Update** Compliance | Auto-**Agree** Compliance |
 |---|---|---|
-| Flag | `prov-auto-update-compliance` (default **on**) | `prov-auto-agree-compliance` (default **off**) |
+| Flag | `prov-auto-update-compliance` (default **on**) | `prov-db-compliance-auto-agree` (default **off**) |
 | Side | repman / configurator | database |
 | Action | Accept a new moduleset / binary upgrade and **regenerate** the config | **Agree** value deltas to the compliance value and push to the DB |
 | Touches the running DB? | No | Yes (via `03_agreed` → restart) |

--- a/doc/implementation/config-diff/AUTO_AGREE_COMPLIANCE.md
+++ b/doc/implementation/config-diff/AUTO_AGREE_COMPLIANCE.md
@@ -1,0 +1,180 @@
+# Auto-Agree Compliance & Reconcile-Drop
+
+**Feature**: Automatic resolution of database config value deltas against the compliance value, and cleanup of agreed entries once the DB has adopted them
+**Issue**: [#1762](https://github.com/signal18/replication-manager/issues/1762) — *Missing Auto-Agree Compliance*
+**PR**: [#1763](https://github.com/signal18/replication-manager/pull/1763)
+**Status**: Implemented (opt-in), disabled by default
+**Version**: 3.1.42+
+
+---
+
+## Table of Contents
+
+1. [Background: the config layering](#background-the-config-layering)
+2. [The two mechanisms](#the-two-mechanisms)
+3. [Scoping and safety](#scoping-and-safety)
+4. [Performance: per-tick gating](#performance-per-tick-gating)
+5. [Configuration & GUI](#configuration--gui)
+6. [Relationship to Auto-Update Compliance](#relationship-to-auto-update-compliance)
+7. [Relationship to the variable-change script](#relationship-to-the-variable-change-script)
+8. [Code map](#code-map)
+
+---
+
+## Background: the config layering
+
+The database config is assembled from two directories, `custom.d` being loaded
+**after** `replication-manager.d` so it overrides it. Inside `custom.d`, three
+files carry the operator/compliance reconciliation state:
+
+| File | Meaning | Written by |
+|------|---------|-----------|
+| `01_preserved.cnf` | Operator **forced** values — must always survive a compliance regeneration | `WritePreservedVariables` (routes `IsPreserved()` here) |
+| `02_delta.cnf` | Variables that **differ but are not yet decided** (neither preserved nor agreed) | `WriteDeltaVariables` |
+| `03_agreed.cnf` | Accepted values **pushed to the DB** — the apply channel | `WritePreservedVariables` (routes non-forced here) |
+
+The distinction between *forced* and *agreed* lives in a single code field pair
+on `VariableState` (`config/maps.go`):
+
+- **agreed** = `Preserved != nil && PreservedSource == ""` (and `Preserved == Config`, so `!IsPreserved()`)
+- **forced** = `PreservedSource != ""` (`"server-specific"` / `"cluster-level"`), so `IsPreserved()` is true
+
+`WritePreservedVariables` routes `IsPreserved()` → `01_preserved` (`# preserved:<source>`),
+everything else → `03_agreed` (`# agreed:accepted`, `# agreed:unknown-variable`,
+`# agreed:dropped`).
+
+A `02_delta.cnf` entry **overrides the compliance value on the next DB restart**,
+so a variable stuck in the delta perpetuates the old value until it is either
+**agreed** (moves to `03_agreed`, delta skips it) or the config is **wiped**
+(`WipeDeltaConfig`, i.e. reprovision).
+
+---
+
+## The two mechanisms
+
+Both live in `config/maps.go` and are driven from the monitor cycle in
+`cluster/srv.go`.
+
+### 1. `DropReconciledAgreed()` — cleanup (always on)
+
+Once the DB **actually runs** the compliance value (`Runtime == Config`), an
+agreed entry in `03_agreed.cnf` has served its purpose — it only existed to hold
+a value until the DB restarted with the compliance value. Keeping it makes the
+variable show forever as a pending diff.
+
+For each variable where
+`Preserved != nil && PreservedSource == "" && Runtime != nil && Runtime == Config`,
+`DropReconciledAgreed()` calls `UnsetPreservedValue()` and returns the dropped
+names. **Forced preserves (`PreservedSource != ""`) are never touched.**
+
+### 2. `AutoAgreeValueDeltas()` — opt-in auto-agree
+
+The DB-side counterpart of Auto-Update Compliance. When
+`prov-auto-agree-compliance` is enabled, a **value delta** (a variable whose
+deployed value differs from the compliance value, not yet preserved/agreed) is
+automatically agreed to the compliance value: `SetPreservedValue(Config)`, which
+routes it to `03_agreed.cnf` and lets the DB adopt it on its next restart.
+
+Condition: `Preserved == nil && !Dropped && Config != nil && Deployed != nil && Deployed != Config`.
+
+It runs inside the `HasDeployedChanged()` block (after `ReadPreservedVariables`,
+before `WriteDeltaVariables`) so agreed variables route to `03_agreed` instead of
+`02_delta`.
+
+---
+
+## Scoping and safety
+
+Auto-agree is deliberately **scoped to value changes only** (`Config != nil`).
+Two classes are always left for **manual review** and are never auto-agreed:
+
+- **Dropped / deprecated** (`v.Dropped`) — removed in a newer DB version.
+- **UNKNOWN — not recognized by the DB** (`PreservedSource == "unknown-variable"`,
+  or a `# delta:no-config` where `Config == nil`).
+
+An unknown variable is detected by the dbjobs validation (a `# unknown:` marker),
+handled in `ReadPreservedVariables` (`cluster/srv_cnf.go`): it is removed from
+preserved (deploying it would **crash the DB on restart**) and routed to
+`03_agreed` as `# agreed:unknown-variable` for review, with `Preserved` set and
+`PreservedSource == "unknown-variable"`.
+
+Because that detection runs **before** auto-agree in the cycle, unknowns already
+have `Preserved != nil` when `AutoAgreeValueDeltas` runs → they are skipped. They
+are likewise skipped by `DropReconciledAgreed` (`PreservedSource != ""`) so they
+persist for review. This is locked in by `TestUnknownVariableSafety`
+(`config/maps_test.go`).
+
+> Why we cannot broaden auto-agree to dropped/unknown: our configs use the
+> `loose_` prefix, which makes the DB accept unknown/deprecated variables
+> silently instead of erroring — so their deprecation cannot be auto-detected.
+> Tracked by #1495.
+
+---
+
+## Performance: per-tick gating
+
+`DropReconciledAgreed()` walks the whole `VariablesMap` per server. Running it on
+every monitor tick would add a second full-map walk next to the existing
+`HasDifferences()` pass — an avoidable cost on the monitoring hot path (law F2:
+never burden the monitor).
+
+A variable can only *become* reconciled (`Runtime == Config`) when its **runtime
+value moves**. So `SetRuntimeValues()` now returns the number of variables that
+actually changed this tick (tallied during the set it already performs, ~zero
+added cost), and the drop walk is gated on `runtimeChanged > 0`. In the steady
+state — runtime identical tick to tick — no extra walk happens.
+
+`AutoAgreeValueDeltas()` is already gated behind `HasDeployedChanged()`, which is
+rare.
+
+---
+
+## Configuration & GUI
+
+- Flag: `prov-auto-agree-compliance` (`config.Config.ProvAutoAgreeCompliance`),
+  `server/server.go`, **default `false`** (opt-in; T14 off-switch).
+- JSON: `provAutoAgreeCompliance` (exposed in the cluster config object).
+- Switch handler: `server/api_cluster.go` `case "prov-auto-agree-compliance"`.
+- GUI: **Configurator tab → "Auto-Agree Compliance"** toggle
+  (`share/dashboard_react/src/Pages/Configs/components/DBConfigs.jsx`), beside
+  "Auto-Update Compliance", gated on the `cluster-settings` grant (T6, T22).
+
+---
+
+## Relationship to Auto-Update Compliance
+
+They are independent and complementary:
+
+| | Auto-**Update** Compliance | Auto-**Agree** Compliance |
+|---|---|---|
+| Flag | `prov-auto-update-compliance` (default **on**) | `prov-auto-agree-compliance` (default **off**) |
+| Side | repman / configurator | database |
+| Action | Accept a new moduleset / binary upgrade and **regenerate** the config | **Agree** value deltas to the compliance value and push to the DB |
+| Touches the running DB? | No | Yes (via `03_agreed` → restart) |
+
+---
+
+## Relationship to the variable-change script
+
+The existing client hook `monitoring-variable-change-script`
+(`MonitorVariableChangeScript`, wired via `Cluster.BashScriptVariableChange`,
+called from the runtime variable-diff detector in `cluster/cluster.go`) fires
+whenever the live DB variables change between ticks — diff piped to stdin, 30s
+timeout. When the DB adopts an auto-agreed value **after a restart**, that
+detector sees the runtime change and fires the script. So the F7 client override
+for "a variable moved on the DB" already covers auto-agree; no new hook is
+required.
+
+---
+
+## Code map
+
+| Concern | Location |
+|---|---|
+| `DropReconciledAgreed`, `AutoAgreeValueDeltas`, `SetRuntimeValues` (changed count) | `config/maps.go` |
+| Monitor-cycle wiring + per-tick gate | `cluster/srv.go` (~L1106–1155) |
+| Delta / agreed / preserved file writing | `cluster/srv_cnf.go` (`WriteDeltaVariables`, `WritePreservedVariables`, unknown detection in `ReadPreservedVariables`) |
+| Flag definition | `config/config.go`, `server/server.go` |
+| Switch handler | `server/api_cluster.go` |
+| GUI toggle | `share/dashboard_react/src/Pages/Configs/components/DBConfigs.jsx` |
+| Tests | `config/maps_test.go` (`TestDropReconciledAgreed`, `TestAutoAgreeValueDeltas`, `TestUnknownVariableSafety`) |

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2767,6 +2767,8 @@ func (repman *ReplicationManager) switchClusterSettings(mycluster *cluster.Clust
 		mycluster.SwitchDBApplyDynamicConfig()
 	case "prov-auto-update-compliance":
 		mycluster.Conf.ProvAutoUpdateCompliance = !mycluster.Conf.ProvAutoUpdateCompliance
+	case "prov-auto-agree-compliance":
+		mycluster.Conf.ProvAutoAgreeCompliance = !mycluster.Conf.ProvAutoAgreeCompliance
 	case "prov-docker-daemon-private":
 		mycluster.SwitchProvDockerDaemonPrivate()
 	case "prov-object-allow-overwrite":

--- a/server/api_cluster.go
+++ b/server/api_cluster.go
@@ -2767,8 +2767,8 @@ func (repman *ReplicationManager) switchClusterSettings(mycluster *cluster.Clust
 		mycluster.SwitchDBApplyDynamicConfig()
 	case "prov-auto-update-compliance":
 		mycluster.Conf.ProvAutoUpdateCompliance = !mycluster.Conf.ProvAutoUpdateCompliance
-	case "prov-auto-agree-compliance":
-		mycluster.Conf.ProvAutoAgreeCompliance = !mycluster.Conf.ProvAutoAgreeCompliance
+	case "prov-db-compliance-auto-agree":
+		mycluster.Conf.ProvDBComplianceAutoAgree = !mycluster.Conf.ProvDBComplianceAutoAgree
 	case "prov-docker-daemon-private":
 		mycluster.SwitchProvDockerDaemonPrivate()
 	case "prov-object-allow-overwrite":

--- a/server/server.go
+++ b/server/server.go
@@ -1272,6 +1272,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 		flags.StringVar(&conf.ProvDBCompliance, "prov-db-compliance", "", "Path of compliance file for DB configuration")
 		flags.StringVar(&conf.ProvProxyCompliance, "prov-proxy-compliance", "", "Path of compliance file for Proxy configuration")
 		flags.BoolVar(&conf.ProvAutoUpdateCompliance, "prov-auto-update-compliance", true, "Auto-update compliance best practices from back office or binary upgrades")
+		flags.BoolVar(&conf.ProvAutoAgreeCompliance, "prov-auto-agree-compliance", false, "Auto-agree value-differs config deltas to the compliance value on the DB (DB-side counterpart of prov-auto-update-compliance); off by default, value-changes only")
 		flags.BoolVar(&conf.MeasurementAutoClampLimit, "measurement-auto-clamp-limit", false, "Auto clamp to allowed value for measurement if exceed the min-max boundaries")
 		flags.BoolVar(&conf.ProvObjectAllowOverwrite, "prov-object-allow-overwrite", true, "Allow overwriting config/secret keys when objects already exist")
 

--- a/server/server.go
+++ b/server/server.go
@@ -1272,7 +1272,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 		flags.StringVar(&conf.ProvDBCompliance, "prov-db-compliance", "", "Path of compliance file for DB configuration")
 		flags.StringVar(&conf.ProvProxyCompliance, "prov-proxy-compliance", "", "Path of compliance file for Proxy configuration")
 		flags.BoolVar(&conf.ProvAutoUpdateCompliance, "prov-auto-update-compliance", true, "Auto-update compliance best practices from back office or binary upgrades")
-		flags.BoolVar(&conf.ProvAutoAgreeCompliance, "prov-auto-agree-compliance", false, "Auto-agree value-differs config deltas to the compliance value on the DB (DB-side counterpart of prov-auto-update-compliance); off by default, value-changes only")
+		flags.BoolVar(&conf.ProvDBComplianceAutoAgree, "prov-db-compliance-auto-agree", false, "Auto-agree value-differs config deltas to the compliance value on the DB (DB-side counterpart of prov-auto-update-compliance); off by default, value-changes only")
 		flags.BoolVar(&conf.MeasurementAutoClampLimit, "measurement-auto-clamp-limit", false, "Auto clamp to allowed value for measurement if exceed the min-max boundaries")
 		flags.BoolVar(&conf.ProvObjectAllowOverwrite, "prov-object-allow-overwrite", true, "Allow overwriting config/secret keys when objects already exist")
 

--- a/share/dashboard_react/src/Pages/Configs/components/DBConfigs.jsx
+++ b/share/dashboard_react/src/Pages/Configs/components/DBConfigs.jsx
@@ -248,6 +248,7 @@ function DBConfigs({ selectedCluster, user }) {
   const hDynamicConfig = `**Apply Dynamic Config**\n\nWhen enabled, replication-manager applies configuration changes dynamically using \`SET GLOBAL\` statements without requiring a database restart.\n\nOnly variables that support dynamic changes are applied this way. Variables requiring a restart are written to the config file for the next restart.\n\nConfig: \`prov-db-apply-dynamic-config\``
   const hRefreshConfig = `**Refresh Variables and DB Config**\n\nRegenerates the configuration files for all database servers in this cluster from the compliance module and the current tag selection.\n\nThis rebuilds the config tarball at \`{datadir}/config.tar.gz\` with all tag-specific cnf files merged with preserved variables and defaults.`
   const hAutoUpdateCompliance = `**Auto-Update Compliance**\n\nThe compliance module contains replication-manager's best practices for database and proxy configuration. It defines which variables are set for each configuration tag.\n\nWhen enabled (default), compliance updates from the back office or new replication-manager releases are **applied automatically**. Your preserved variables are never overwritten — they always take priority over compliance defaults.\n\nWhen disabled, a warning (WARN0168) is raised when new compliance is available. You can review the changes (added, removed, or modified tags) and accept when ready. This is recommended for production environments where you want to review best practice changes before they take effect.\n\nConfig: \`prov-auto-update-compliance\``
+  const hAutoAgreeCompliance = `**Auto-Agree Compliance**\n\nControls what happens to a config **delta** — a variable whose value on the database differs from the compliance value — that is neither preserved (operator-forced) nor already agreed.\n\nWhen **disabled (default)**, every value delta waits for a manual review and agree in the config editor before it is written to the database. Recommended for production.\n\nWhen **enabled**, a value delta is automatically agreed to the compliance value (written to \`03_agreed.cnf\` and pushed to the database). Scoped to **value changes only** — variables that are dropped, deprecated, or not recognized by the database are **never** auto-agreed and always stay for manual review (they would crash the database on restart).\n\nIndependent of Auto-Update Compliance: that one regenerates the config from a new module (repman side), this one applies value deltas to the running database (DB side).\n\nConfig: \`prov-auto-agree-compliance\``
 
   const dataObject = [
     {
@@ -288,6 +289,20 @@ function DBConfigs({ selectedCluster, user }) {
           confirmTitle={'Confirm switch settings for prov-auto-update-compliance?'}
           onChange={() =>
             dispatch(switchSetting({ clusterName: selectedCluster?.name, setting: 'prov-auto-update-compliance' }))
+          }
+        />
+      )
+    },
+    {
+      key: 'Auto-Agree Compliance',
+      help: h(hAutoAgreeCompliance, 'Auto-Agree Compliance'),
+      value: (
+        <RMSwitch
+          isChecked={selectedCluster?.config?.provAutoAgreeCompliance}
+          isDisabled={user?.grants['cluster-settings'] == false}
+          confirmTitle={'Confirm switch settings for prov-auto-agree-compliance?'}
+          onChange={() =>
+            dispatch(switchSetting({ clusterName: selectedCluster?.name, setting: 'prov-auto-agree-compliance' }))
           }
         />
       )

--- a/share/dashboard_react/src/Pages/Configs/components/DBConfigs.jsx
+++ b/share/dashboard_react/src/Pages/Configs/components/DBConfigs.jsx
@@ -248,7 +248,7 @@ function DBConfigs({ selectedCluster, user }) {
   const hDynamicConfig = `**Apply Dynamic Config**\n\nWhen enabled, replication-manager applies configuration changes dynamically using \`SET GLOBAL\` statements without requiring a database restart.\n\nOnly variables that support dynamic changes are applied this way. Variables requiring a restart are written to the config file for the next restart.\n\nConfig: \`prov-db-apply-dynamic-config\``
   const hRefreshConfig = `**Refresh Variables and DB Config**\n\nRegenerates the configuration files for all database servers in this cluster from the compliance module and the current tag selection.\n\nThis rebuilds the config tarball at \`{datadir}/config.tar.gz\` with all tag-specific cnf files merged with preserved variables and defaults.`
   const hAutoUpdateCompliance = `**Auto-Update Compliance**\n\nThe compliance module contains replication-manager's best practices for database and proxy configuration. It defines which variables are set for each configuration tag.\n\nWhen enabled (default), compliance updates from the back office or new replication-manager releases are **applied automatically**. Your preserved variables are never overwritten — they always take priority over compliance defaults.\n\nWhen disabled, a warning (WARN0168) is raised when new compliance is available. You can review the changes (added, removed, or modified tags) and accept when ready. This is recommended for production environments where you want to review best practice changes before they take effect.\n\nConfig: \`prov-auto-update-compliance\``
-  const hAutoAgreeCompliance = `**Auto-Agree Compliance**\n\nControls what happens to a config **delta** — a variable whose value on the database differs from the compliance value — that is neither preserved (operator-forced) nor already agreed.\n\nWhen **disabled (default)**, every value delta waits for a manual review and agree in the config editor before it is written to the database. Recommended for production.\n\nWhen **enabled**, a value delta is automatically agreed to the compliance value (written to \`03_agreed.cnf\` and pushed to the database). Scoped to **value changes only** — variables that are dropped, deprecated, or not recognized by the database are **never** auto-agreed and always stay for manual review (they would crash the database on restart).\n\nIndependent of Auto-Update Compliance: that one regenerates the config from a new module (repman side), this one applies value deltas to the running database (DB side).\n\nConfig: \`prov-auto-agree-compliance\``
+  const hAutoAgreeCompliance = `**Auto-Agree Compliance**\n\nControls what happens to a config **delta** — a variable whose value on the database differs from the compliance value — that is neither preserved (operator-forced) nor already agreed.\n\nWhen **disabled (default)**, every value delta waits for a manual review and agree in the config editor before it is written to the database. Recommended for production.\n\nWhen **enabled**, a value delta is automatically agreed to the compliance value (written to \`03_agreed.cnf\` and pushed to the database). Scoped to **value changes only** — variables that are dropped, deprecated, or not recognized by the database are **never** auto-agreed and always stay for manual review (they would crash the database on restart).\n\nIndependent of Auto-Update Compliance: that one regenerates the config from a new module (repman side), this one applies value deltas to the running database (DB side).\n\nConfig: \`prov-db-compliance-auto-agree\``
 
   const dataObject = [
     {
@@ -298,11 +298,11 @@ function DBConfigs({ selectedCluster, user }) {
       help: h(hAutoAgreeCompliance, 'Auto-Agree Compliance'),
       value: (
         <RMSwitch
-          isChecked={selectedCluster?.config?.provAutoAgreeCompliance}
+          isChecked={selectedCluster?.config?.provDbComplianceAutoAgree}
           isDisabled={user?.grants['cluster-settings'] == false}
-          confirmTitle={'Confirm switch settings for prov-auto-agree-compliance?'}
+          confirmTitle={'Confirm switch settings for prov-db-compliance-auto-agree?'}
           onChange={() =>
-            dispatch(switchSetting({ clusterName: selectedCluster?.name, setting: 'prov-auto-agree-compliance' }))
+            dispatch(switchSetting({ clusterName: selectedCluster?.name, setting: 'prov-db-compliance-auto-agree' }))
           }
         />
       )


### PR DESCRIPTION
Implements the two parts of #1762 (the DB-side counterpart of Auto-Update Compliance).

## Part 1 — drop agreed on reconcile (lifecycle fix)
An agreed variable (`03_agreed.cnf`) only exists to hold a value until the DB restarts with the compliance value. Once the DB actually runs it (`Runtime == Config`), nothing cleared the agree, so `HasConfigDiff` stayed true and the GUI showed a **phantom diff** on a node fully reconciled at the DB level.

- `VariablesMap.DropReconciledAgreed()`: drops the agreed marking of every variable running the compliance value; rewrites `03_agreed.cnf`. **Never** touches operator-forced preserves (`PreservedSource != ""`, i.e. `01_preserved.cnf` / cluster-level) — those are deliberate overrides that must survive.
- Called in the monitor cycle right after the runtime refresh, before `HasConfigDiff`.

## Part 2 — prov-auto-agree-compliance (opt-in auto-agree)
Update-Compliance is repman-side only (regenerates config); it never reaches the DB. This adds the DB-side auto-agree.

- New per-cluster flag `prov-auto-agree-compliance` (**off by default**, T14).
- `VariablesMap.AutoAgreeValueDeltas()`: for each **value-differs** delta (known variable, `Config != nil`, `Deployed != Config`, not preserved, not dropped) sets `Preserved = Config` → routes to `03_agreed.cnf` → the DB adopts the compliance value on its next restart; `DropReconciledAgreed` then clears it. **Scoped to value-changes only** — deprecated/unknown drops are left for manual review because `loose_` hides them (blocked on #1495).
- Wired in the monitor cycle on deployed-config change, guarded by the flag.

## Key design point
Agreed vs forced are distinguished: agreed = `Preserved != nil && PreservedSource == ""` (`Preserved == Config`); forced = `PreservedSource != ""` (`Preserved != Config`, `IsPreserved()`). The clean-on-reconcile only drops agreed, never forced.

Tests: `TestDropReconciledAgreed`, `TestAutoAgreeValueDeltas`.

Remaining (follow-up): GUI toggle for the flag (T6) + user/implementation docs (T8).

https://claude.ai/code/session_01Kcii9hRkGBU7WaejuPfkdj