### PR TITLE
fix(k8s): make database upgrade actions apply deployment image updates

### DIFF
--- a/cluster/cluster_acl_rules.go
+++ b/cluster/cluster_acl_rules.go
@@ -89,6 +89,7 @@ var databaseACLRules = []ACLRule{
 	{"/actions/del-maintenance", nil, []string{config.GrantDBMaintenance}},
 	{"/actions/wait-innodb-purge", nil, []string{config.GrantDBMaintenance}},
 	{"/actions/jobs-upgrade", nil, []string{config.GrantDBMaintenance}},
+	{"/actions/upgrade", nil, []string{config.GrantDBMaintenance}},
 
 	// Job dispatch actions (dbjobs script API)
 	{"/needs/", nil, []string{config.GrantDBJobs}},

--- a/cluster/cluster_roll.go
+++ b/cluster/cluster_roll.go
@@ -311,11 +311,85 @@ func (cluster *Cluster) RollingOptimize() {
 	}
 }
 
+// rollingUpgradeStopUpdateStart stops a server, updates its database service
+// config (image + pull policy) for forcePull, and starts it back up -- one
+// stop/config/start step of RollingUpgrade. clean selects
+// StopDatabaseServiceClean (innodb_fast_shutdown=0) over a plain stop; phase
+// labels the step for logging ("pull" vs "clean").
+//
+// OpenSVC and Kubernetes need opposite ordering here. OpenSVC's service
+// config is inert until the container's next start, so updating before stop
+// is safe and the image is pulled during that stop→start cycle. Kubernetes
+// instead applies a Deployment patch that the controller can act on right
+// away: updating while the pod is still live would race that controller's
+// own rollout against this function's explicit stop, so for Kubernetes the
+// update must happen only once the Deployment is already scaled to 0 (see
+// K8SUpdateDatabaseServiceConfig, cluster/prov_k8s_db.go).
+//
+// On Kubernetes, whether a failed config update is fatal depends on the
+// phase. forcePull=true (the "pull" phase) is the actual image change: a
+// failed patch there is fatal, since the coming start step would otherwise
+// silently bring the server back up on the unchanged image while
+// RollingUpgrade reports success. forcePull=false (the "clean" phase) only
+// restores the steady-state pull policy on a server already upgraded by the
+// preceding pull phase -- failing that patch is cleanup drift, not an
+// upgrade failure, so it's logged as a warning and the server is started
+// anyway rather than left down (temporarily still forced to PullAlways).
+// OpenSVC keeps its pre-existing best-effort behavior in both phases (log
+// and continue) -- its push happens before the stop, so a failure there
+// just means "still running the old image" on a step that was always
+// best-effort.
+func (cluster *Cluster) rollingUpgradeStopUpdateStart(server *ServerMonitor, forcePull bool, clean bool, phase string) error {
+	stop := cluster.StopDatabaseService
+	if clean {
+		stop = cluster.StopDatabaseServiceClean
+	}
+	isKubernetes := cluster.GetOrchestrator() == config.ConstOrchestratorKubernetes
+	updateConfig := func() error {
+		cfgErr := cluster.UpdateDatabaseServiceConfig(server, forcePull)
+		if cfgErr == nil {
+			return nil
+		}
+		if isKubernetes && forcePull {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade (%s): failed to update service config for %s: %s", phase, server.URL, cfgErr)
+			return cfgErr
+		}
+		if isKubernetes {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn, "Rolling upgrade (%s): cleanup incomplete on %s, Deployment still forced to PullAlways: %s", phase, server.URL, cfgErr)
+			return nil
+		}
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade (%s): failed to update service config for %s: %s", phase, server.URL, cfgErr)
+		return nil
+	}
+
+	if !isKubernetes {
+		updateConfig()
+	}
+	if err := stop(server); err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade (%s): stop failed on %s: %s", phase, server.URL, err)
+		return err
+	}
+	if err := cluster.WaitDatabaseFailed(server); err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade (%s): %s does not transit failed: %s", phase, server.URL, err)
+		return err
+	}
+	if isKubernetes {
+		if err := updateConfig(); err != nil {
+			return err
+		}
+	}
+	if err := cluster.StartDatabaseWaitRejoin(server); err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade (%s): %s does not restart: %s", phase, server.URL, err)
+		return err
+	}
+	return nil
+}
+
 func (cluster *Cluster) RollingUpgrade() error {
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo, "Rolling upgrade")
 
 	// On-premise upgrades use a dedicated upgrade script (installs new packages +
-	// runs mariadb-upgrade) instead of the OpenSVC image-pull two-phase approach.
+	// runs mariadb-upgrade) instead of the OpenSVC/Kubernetes image-pull two-phase approach.
 	if cluster.GetOrchestrator() == config.ConstOrchestratorOnPremise {
 		return cluster.rollingUpgradeOnPremise()
 	}
@@ -326,11 +400,10 @@ func (cluster *Cluster) RollingUpgrade() error {
 	}
 	masterID := master.Id
 
-	// Loop 1 — pull: set image_pull_policy=always and restart every slave so
-	// OpenSVC re-pulls the new image. OpenSVC only reads this key at container
-	// start time, so the stop→start cycle is required to trigger the pull.
-	// Maintenance is toggled per node and cleared after sync, so nodes are only
-	// in maintenance during their own stop/start cycle.
+	// Loop 1 — pull: force PullAlways (K8s) / image_pull_policy=always (OpenSVC)
+	// and restart every slave so the orchestrator re-pulls the new image. Maintenance
+	// is toggled per node and cleared after sync, so nodes are only in maintenance
+	// during their own stop/start cycle.
 	for _, slave := range cluster.slaves {
 		if slave == nil || slave.IsIgnored() || slave.IsDown() {
 			continue
@@ -339,28 +412,7 @@ func (cluster *Cluster) RollingUpgrade() error {
 		if maintEnabled {
 			slave.SwitchMaintenance()
 		}
-		if cfgErr := cluster.UpdateDatabaseServiceConfig(slave, true); cfgErr != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade: failed to push service config for %s: %s", slave.URL, cfgErr)
-		}
-		err := cluster.StopDatabaseServiceClean(slave)
-		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade: clean stop failed on slave %s %s", slave.URL, err)
-			if maintEnabled {
-				slave.SwitchMaintenance()
-			}
-			return err
-		}
-		err = cluster.WaitDatabaseFailed(slave)
-		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade: slave does not transit failed %s %s", slave.URL, err)
-			if maintEnabled {
-				slave.SwitchMaintenance()
-			}
-			return err
-		}
-		err = cluster.StartDatabaseWaitRejoin(slave)
-		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade: slave does not restart %s %s", slave.URL, err)
+		if err := cluster.rollingUpgradeStopUpdateStart(slave, true, true, "pull"); err != nil {
 			if maintEnabled {
 				slave.SwitchMaintenance()
 			}
@@ -379,9 +431,9 @@ func (cluster *Cluster) RollingUpgrade() error {
 		}
 	}
 
-	// Loop 2 — clean: strip image_pull_policy=always and restart every slave so
-	// the key is absent from the live config. Docker will not re-pull the
-	// already-local image, so this cycle costs only container restart time.
+	// Loop 2 — clean: restore the steady-state pull policy and restart every
+	// slave so the forced pull-always setting is no longer live. The image is
+	// already local, so this cycle costs only container restart time.
 	// Maintenance is re-evaluated per node; nodes were cleared at the end of
 	// loop 1 so they served traffic between the two loops.
 	for _, slave := range cluster.slaves {
@@ -392,28 +444,7 @@ func (cluster *Cluster) RollingUpgrade() error {
 		if maintEnabled {
 			slave.SwitchMaintenance()
 		}
-		if cfgErr := cluster.UpdateDatabaseServiceConfig(slave, false); cfgErr != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade: failed to reset service config for %s: %s", slave.URL, cfgErr)
-		}
-		err := cluster.StopDatabaseService(slave)
-		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade: stop failed on slave %s %s (clean config)", slave.URL, err)
-			if maintEnabled {
-				slave.SwitchMaintenance()
-			}
-			return err
-		}
-		err = cluster.WaitDatabaseFailed(slave)
-		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade: slave does not transit failed %s %s (clean config)", slave.URL, err)
-			if maintEnabled {
-				slave.SwitchMaintenance()
-			}
-			return err
-		}
-		err = cluster.StartDatabaseWaitRejoin(slave)
-		if err != nil {
-			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade: slave does not restart %s %s (clean config)", slave.URL, err)
+		if err := cluster.rollingUpgradeStopUpdateStart(slave, false, false, "clean"); err != nil {
 			if maintEnabled {
 				slave.SwitchMaintenance()
 			}
@@ -450,28 +481,7 @@ func (cluster *Cluster) RollingUpgrade() error {
 	}
 
 	// Phase 1: pull new image on the old master (now a replica after switchover).
-	if cfgErr := cluster.UpdateDatabaseServiceConfig(master, true); cfgErr != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade: failed to push service config for %s: %s", master.URL, cfgErr)
-	}
-	err := cluster.StopDatabaseServiceClean(master)
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade: old master clean stop failed %s %s", master.URL, err)
-		if maintenanceEnabled {
-			master.SwitchMaintenance()
-		}
-		return err
-	}
-	err = cluster.WaitDatabaseFailed(master)
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade: old master does not transit failed %s %s", master.URL, err)
-		if maintenanceEnabled {
-			master.SwitchMaintenance()
-		}
-		return err
-	}
-	err = cluster.StartDatabaseWaitRejoin(master)
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade: old master does not restart %s %s", master.URL, err)
+	if err := cluster.rollingUpgradeStopUpdateStart(master, true, true, "pull"); err != nil {
 		if maintenanceEnabled {
 			master.SwitchMaintenance()
 		}
@@ -479,29 +489,8 @@ func (cluster *Cluster) RollingUpgrade() error {
 	}
 	master.WaitSyncToMaster(cluster.master)
 
-	// Phase 2: strip image_pull_policy=always (see slave phase 2 comment above).
-	if cfgErr := cluster.UpdateDatabaseServiceConfig(master, false); cfgErr != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade: failed to reset service config for %s: %s", master.URL, cfgErr)
-	}
-	err = cluster.StopDatabaseService(master)
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade: old master stop failed %s %s (clean config)", master.URL, err)
-		if maintenanceEnabled {
-			master.SwitchMaintenance()
-		}
-		return err
-	}
-	err = cluster.WaitDatabaseFailed(master)
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade: old master does not transit failed %s %s (clean config)", master.URL, err)
-		if maintenanceEnabled {
-			master.SwitchMaintenance()
-		}
-		return err
-	}
-	err = cluster.StartDatabaseWaitRejoin(master)
-	if err != nil {
-		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Rolling upgrade: old master does not restart %s %s (clean config)", master.URL, err)
+	// Phase 2: restore the steady-state pull policy (see slave phase 2 comment above).
+	if err := cluster.rollingUpgradeStopUpdateStart(master, false, false, "clean"); err != nil {
 		if maintenanceEnabled {
 			master.SwitchMaintenance()
 		}

--- a/cluster/prov.go
+++ b/cluster/prov.go
@@ -463,6 +463,8 @@ func (cluster *Cluster) UpdateDatabaseServiceConfig(server *ServerMonitor, force
 	switch cluster.GetOrchestrator() {
 	case config.ConstOrchestratorOpenSVC:
 		return cluster.OpenSVCUpdateDatabaseServiceConfig(server, forcePull)
+	case config.ConstOrchestratorKubernetes:
+		return cluster.K8SUpdateDatabaseServiceConfig(server, forcePull)
 	default:
 		return nil
 	}

--- a/cluster/prov.go
+++ b/cluster/prov.go
@@ -477,10 +477,19 @@ func (cluster *Cluster) UpgradeDatabaseService(server *ServerMonitor) error {
 	case config.ConstOrchestratorOnPremise:
 		err = cluster.OnPremiseUpgradeDatabaseService(server)
 	default:
-		// For container orchestrators (OpenSVC, K8S), the image tag change handles
-		// the binary upgrade. The upgrade script is only needed for on-premise.
-		// Fall back to a regular start which pulls the new container image.
-		err = cluster.StartDatabaseService(server)
+		// Same two-phase pull/clean cycle RollingUpgrade (cluster_roll.go) runs
+		// per node, applied here to a single server via the shared
+		// rollingUpgradeStopUpdateStart helper: phase 1 pushes the currently
+		// configured image (forcePull, so a mutable/already-cached tag is
+		// still re-pulled) and restarts on it via a clean shutdown (safe for a
+		// major-version upgrade); phase 2 restores the steady-state pull
+		// policy. Previously this branch just called StartDatabaseService with
+		// no config update at all -- a restart on the unchanged image,
+		// silently upgrading nothing on OpenSVC/Kubernetes.
+		if err = cluster.rollingUpgradeStopUpdateStart(server, true, true, "pull"); err != nil {
+			return err
+		}
+		err = cluster.rollingUpgradeStopUpdateStart(server, false, false, "clean")
 	}
 	if err == nil {
 		server.SetConfigRefreshCookie()

--- a/cluster/prov_k8s_db.go
+++ b/cluster/prov_k8s_db.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -170,6 +171,20 @@ func k8sAPIAuthHeaderValue(cluster *Cluster) string {
 	return base64.StdEncoding.EncodeToString([]byte("admin:" + adminPass))
 }
 
+// k8sDatabasePVCName mirrors k8sProxyPVCName (prov_k8s_prx.go) for the
+// database side.
+func k8sDatabasePVCName(clusterName, serverName string) string {
+	return clusterName + "-" + serverName + "-claim"
+}
+
+// k8sDatabaseVolumeName mirrors k8sProxyVolumeName (prov_k8s_prx.go) for the
+// database side. Just the Pod-internal identifier linking this one Volume to
+// its VolumeMounts -- not a globally-unique object name like the PVC's own
+// (k8sDatabasePVCName), so it doesn't need the cluster name too.
+func k8sDatabaseVolumeName(serverName string) string {
+	return serverName + "-data"
+}
+
 // k8sDatabasePVC is a pure builder, directly testable. StorageClassName is
 // a *string specifically to distinguish "cluster default" (nil) from "no
 // StorageClass" (pointer to ""), so prov-kube-storage-class empty must stay
@@ -183,7 +198,7 @@ func (cluster *Cluster) k8sDatabasePVC(s *ServerMonitor) *apiv1.PersistentVolume
 	}
 	pvc := &apiv1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: cluster.Name + "-" + s.Name + "-claim",
+			Name: k8sDatabasePVCName(cluster.Name, s.Name),
 		},
 		Spec: apiv1.PersistentVolumeClaimSpec{
 			AccessModes: []apiv1.PersistentVolumeAccessMode{
@@ -426,19 +441,19 @@ func (cluster *Cluster) k8sDatabaseDeployment(s *ServerMonitor, port int, nodeHo
 							Env:     initEnv,
 							VolumeMounts: []apiv1.VolumeMount{
 								{
-									Name:      s.Name + "-persistent-storage",
+									Name:      k8sDatabaseVolumeName(s.Name),
 									MountPath: "/var/lib/mysql",
 								},
 								{
 									// SubPath, not emptyDir: matches OpenSVC's own
 									// {name}/etc/mysql (see applyConfig above).
-									Name:      s.Name + "-persistent-storage",
+									Name:      k8sDatabaseVolumeName(s.Name),
 									MountPath: "/etc/mysql/conf.d",
 									SubPath:   k8sConfPersistSubPath,
 								},
 								{
 									// SubPath, matches OpenSVC's {name}/init.
-									Name:      s.Name + "-persistent-storage",
+									Name:      k8sDatabaseVolumeName(s.Name),
 									MountPath: "/docker-entrypoint-initdb.d",
 									SubPath:   k8sInitPersistSubPath,
 								},
@@ -470,11 +485,11 @@ func (cluster *Cluster) k8sDatabaseDeployment(s *ServerMonitor, port int, nodeHo
 							}, k8sDBAllocatorEnv(cluster)...),
 							VolumeMounts: []apiv1.VolumeMount{
 								{
-									Name:      s.Name + "-persistent-storage",
+									Name:      k8sDatabaseVolumeName(s.Name),
 									MountPath: "/var/lib/mysql",
 								},
 								{
-									Name:      s.Name + "-persistent-storage",
+									Name:      k8sDatabaseVolumeName(s.Name),
 									MountPath: "/etc/mysql/conf.d",
 									SubPath:   k8sConfPersistSubPath,
 								},
@@ -517,11 +532,11 @@ func (cluster *Cluster) k8sDatabaseDeployment(s *ServerMonitor, port int, nodeHo
 							},
 							VolumeMounts: []apiv1.VolumeMount{
 								{
-									Name:      s.Name + "-persistent-storage",
+									Name:      k8sDatabaseVolumeName(s.Name),
 									MountPath: "/var/lib/mysql",
 								},
 								{
-									Name:      s.Name + "-persistent-storage",
+									Name:      k8sDatabaseVolumeName(s.Name),
 									MountPath: "/docker-entrypoint-initdb.d",
 									SubPath:   k8sInitPersistSubPath,
 								},
@@ -530,10 +545,10 @@ func (cluster *Cluster) k8sDatabaseDeployment(s *ServerMonitor, port int, nodeHo
 					},
 					Volumes: []apiv1.Volume{
 						{
-							Name: s.Name + "-persistent-storage",
+							Name: k8sDatabaseVolumeName(s.Name),
 							VolumeSource: apiv1.VolumeSource{
 								PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{
-									ClaimName: cluster.Name + "-" + s.Name + "-claim",
+									ClaimName: k8sDatabasePVCName(cluster.Name, s.Name),
 								},
 							},
 						},
@@ -804,6 +819,134 @@ func (cluster *Cluster) K8SForceRepullDatabaseService(s *ServerMonitor) error {
 		return err
 	}
 	return cluster.k8sForceRepullDatabaseServiceWithClient(client, s.Name)
+}
+
+// k8sUpdateDatabaseServiceConfigWithClient patches the Deployment's pod
+// template so the main DB container (named exactly like the Deployment) and,
+// if present, its dbjobs sidecar (named "<deployment>-dbjobs",
+// k8sDatabaseDeployment) both track cluster.Conf.ProvDbImg -- the Kubernetes
+// counterpart of OpenSVCUpdateDatabaseServiceConfig, used by
+// RollingUpgrade (cluster/cluster_roll.go) to actually change the running
+// image instead of only restarting the existing spec.
+//
+// forcePull=true patches PullAlways regardless of prov-kube-image-force-pull,
+// so the upgrade's pull phase re-fetches the tag even when it was already
+// cached locally under a different digest; forcePull=false restores the
+// steady-state k8sImagePullPolicy.
+//
+// The Deployment is fetched first and only container names already present
+// are included in the patch: a strategic merge patch treats "containers" as
+// a merge-by-name list, so patching a name that doesn't exist would create a
+// new, incomplete container (missing command, volume mounts, env) rather
+// than erroring. The main DB container is required; an older Deployment
+// without the dbjobs sidecar is patched on just the main container.
+//
+// Refuses to patch unless the Deployment is already scaled to 0 replicas
+// (enforced below, not just documented on the exported wrapper) -- patching
+// a live pod's image would race the Deployment controller's own rollout
+// against the caller's explicit stop/start.
+func (cluster *Cluster) k8sUpdateDatabaseServiceConfigWithClient(client kubernetes.Interface, name string, forcePull bool) error {
+	deploymentsClient := client.AppsV1().Deployments(cluster.Name)
+	dep, err := deploymentsClient.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot fetch Kubernetes deployment %s: %s ", name, err)
+		return err
+	}
+
+	// Enforced, not just documented: a nil Replicas is apps/v1's "default to
+	// 1" case, so both nil and any non-zero value mean pods may still be
+	// live. Patching the image while live would race the Deployment
+	// controller's own rollout against the caller's explicit stop/start
+	// (RollingUpgrade, cluster/cluster_roll.go) -- refusing here turns that
+	// precondition into a guarantee instead of relying on every future
+	// caller to remember it.
+	if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 0 {
+		replicas := "nil"
+		if dep.Spec.Replicas != nil {
+			replicas = strconv.Itoa(int(*dep.Spec.Replicas))
+		}
+		err := fmt.Errorf("deployment %s is not scaled to 0 replicas (replicas=%s): refusing to patch database image while pods may be live", name, replicas)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "%s", err)
+		return err
+	}
+
+	jobsName := name + "-dbjobs"
+	hasMain := false
+	hasJobs := false
+	for _, c := range dep.Spec.Template.Spec.Containers {
+		switch c.Name {
+		case name:
+			hasMain = true
+		case jobsName:
+			hasJobs = true
+		}
+	}
+	if !hasMain {
+		err := fmt.Errorf("deployment %s has no container named %s: cannot update database image", name, name)
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "%s", err)
+		return err
+	}
+
+	pullPolicy := k8sImagePullPolicy(cluster)
+	if forcePull {
+		pullPolicy = apiv1.PullAlways
+	}
+	image := cluster.Conf.ProvDbImg
+
+	container := func(cname string) map[string]interface{} {
+		return map[string]interface{}{
+			"name":            cname,
+			"image":           image,
+			"imagePullPolicy": pullPolicy,
+		}
+	}
+	containers := []map[string]interface{}{container(name)}
+	if hasJobs {
+		containers = append(containers, container(jobsName))
+	}
+
+	// Plain nested maps, not a named Go struct: StrategicMergePatchType's
+	// merge-by-name semantics on the "containers" list only need name/image/
+	// imagePullPolicy present -- a struct would either omit unrelated
+	// Container fields as their JSON zero values (fine for MergePatchType,
+	// but silently wrong for a *strategic* merge, which instead relies on
+	// the caller sending exactly the fields meant to change) or require
+	// pointer fields to make the omission explicit. Maps sidestep the
+	// question entirely.
+	patch, err := json.Marshal(map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": containers,
+				},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = deploymentsClient.Patch(context.TODO(), name, ktypes.StrategicMergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot update database image for %s: %s ", name, err)
+	}
+	return err
+}
+
+// K8SUpdateDatabaseServiceConfig is the Kubernetes implementation of
+// UpdateDatabaseServiceConfig (cluster/prov.go). Errors, including "not
+// scaled to 0", if called while the Deployment still has live pods (see the
+// Kubernetes ordering in RollingUpgrade, cluster/cluster_roll.go): patching
+// the pod template at that point would race the Deployment controller's own
+// rollout against the caller's explicit stop/start, unlike OpenSVC where a
+// service-config update is inert until the next container start.
+func (cluster *Cluster) K8SUpdateDatabaseServiceConfig(s *ServerMonitor, forcePull bool) error {
+	client, err := cluster.K8SConnectAPI()
+	if err != nil {
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Cannot init Kubernetes client API %s ", err)
+		return err
+	}
+	return cluster.k8sUpdateDatabaseServiceConfigWithClient(client, s.Name, forcePull)
 }
 
 // PVC and Namespace are intentionally retained — PVC deletion is

--- a/cluster/prov_k8s_test.go
+++ b/cluster/prov_k8s_test.go
@@ -882,6 +882,258 @@ func TestK8SForceRepullDatabaseService_MissingDeploymentIsError(t *testing.T) {
 	}
 }
 
+// --- Rolling upgrade: database image + pull policy update ---
+//
+// K8SUpdateDatabaseServiceConfig / k8sUpdateDatabaseServiceConfigWithClient
+// is what makes RollingUpgrade (cluster/cluster_roll.go) actually change the
+// running database image on Kubernetes, instead of only restarting pods on
+// the existing spec like K8SForceRepullDatabaseService above.
+
+func TestK8SUpdateDatabaseServiceConfig_PatchesMainContainerImage(t *testing.T) {
+	zero := int32(0)
+	client := fake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "db1", Namespace: "k8stest"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &zero,
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "db1", Image: "mariadb:10.6"},
+					},
+				},
+			},
+		},
+	})
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvDbImg = "mariadb:10.11"
+
+	if err := cluster.k8sUpdateDatabaseServiceConfigWithClient(client, "db1", false); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	dep, err := client.AppsV1().Deployments("k8stest").Get(context.TODO(), "db1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if got := dep.Spec.Template.Spec.Containers[0].Image; got != "mariadb:10.11" {
+		t.Fatalf("expected main container image to be patched to mariadb:10.11, got %q", got)
+	}
+}
+
+func TestK8SUpdateDatabaseServiceConfig_PatchesDbjobsSidecarImageWhenPresent(t *testing.T) {
+	zero := int32(0)
+	client := fake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "db1", Namespace: "k8stest"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &zero,
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "db1", Image: "mariadb:10.6"},
+						{Name: "db1-dbjobs", Image: "mariadb:10.6"},
+					},
+				},
+			},
+		},
+	})
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvDbImg = "mariadb:10.11"
+
+	if err := cluster.k8sUpdateDatabaseServiceConfigWithClient(client, "db1", false); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	dep, err := client.AppsV1().Deployments("k8stest").Get(context.TODO(), "db1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(dep.Spec.Template.Spec.Containers) != 2 {
+		t.Fatalf("expected exactly 2 containers (no bogus container created), got %d", len(dep.Spec.Template.Spec.Containers))
+	}
+	for _, c := range dep.Spec.Template.Spec.Containers {
+		if c.Image != "mariadb:10.11" {
+			t.Fatalf("expected container %s image to be patched to mariadb:10.11, got %q", c.Name, c.Image)
+		}
+	}
+}
+
+// A missing sidecar (an older Deployment provisioned before it existed) must
+// not produce a bogus, incomplete container entry -- strategic merge patches
+// treat "containers" as merge-by-name, so patching a name absent from the
+// live Deployment would otherwise create a container missing its command,
+// volume mounts, and env.
+func TestK8SUpdateDatabaseServiceConfig_MissingSidecarDoesNotCreateBogusContainer(t *testing.T) {
+	zero := int32(0)
+	client := fake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "db1", Namespace: "k8stest"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &zero,
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "db1", Image: "mariadb:10.6"},
+					},
+				},
+			},
+		},
+	})
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvDbImg = "mariadb:10.11"
+
+	if err := cluster.k8sUpdateDatabaseServiceConfigWithClient(client, "db1", false); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	dep, err := client.AppsV1().Deployments("k8stest").Get(context.TODO(), "db1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(dep.Spec.Template.Spec.Containers) != 1 {
+		t.Fatalf("expected exactly 1 container, got %d: %v", len(dep.Spec.Template.Spec.Containers), dep.Spec.Template.Spec.Containers)
+	}
+}
+
+func TestK8SUpdateDatabaseServiceConfig_ForcePullTruePatchesPullAlwaysEvenWhenConfigDisabled(t *testing.T) {
+	zero := int32(0)
+	client := fake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "db1", Namespace: "k8stest"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &zero,
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "db1", ImagePullPolicy: apiv1.PullIfNotPresent},
+					},
+				},
+			},
+		},
+	})
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvKubeImageForcePull = false
+
+	if err := cluster.k8sUpdateDatabaseServiceConfigWithClient(client, "db1", true); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	dep, err := client.AppsV1().Deployments("k8stest").Get(context.TODO(), "db1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if got := dep.Spec.Template.Spec.Containers[0].ImagePullPolicy; got != apiv1.PullAlways {
+		t.Fatalf("expected forcePull=true to patch PullAlways regardless of prov-kube-image-force-pull, got %q", got)
+	}
+}
+
+func TestK8SUpdateDatabaseServiceConfig_ForcePullFalseRestoresSteadyStatePolicy(t *testing.T) {
+	zero := int32(0)
+	client := fake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "db1", Namespace: "k8stest"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &zero,
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "db1", ImagePullPolicy: apiv1.PullAlways},
+					},
+				},
+			},
+		},
+	})
+	cluster := newTestCluster("k8stest")
+	cluster.Conf.ProvKubeImageForcePull = false
+
+	if err := cluster.k8sUpdateDatabaseServiceConfigWithClient(client, "db1", false); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	dep, err := client.AppsV1().Deployments("k8stest").Get(context.TODO(), "db1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if got := dep.Spec.Template.Spec.Containers[0].ImagePullPolicy; got != apiv1.PullIfNotPresent {
+		t.Fatalf("expected forcePull=false to restore the configured steady-state policy PullIfNotPresent, got %q", got)
+	}
+}
+
+func TestK8SUpdateDatabaseServiceConfig_MissingDeploymentIsError(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	cluster := newTestCluster("k8stest")
+
+	if err := cluster.k8sUpdateDatabaseServiceConfigWithClient(client, "db1", false); err == nil {
+		t.Fatal("expected an error when the deployment does not exist, got nil")
+	}
+}
+
+func TestK8SUpdateDatabaseServiceConfig_MissingMainContainerIsError(t *testing.T) {
+	zero := int32(0)
+	client := fake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "db1", Namespace: "k8stest"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &zero,
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "some-other-container", Image: "mariadb:10.6"},
+					},
+				},
+			},
+		},
+	})
+	cluster := newTestCluster("k8stest")
+
+	if err := cluster.k8sUpdateDatabaseServiceConfigWithClient(client, "db1", false); err == nil {
+		t.Fatal("expected an error when the main database container is missing, got nil")
+	}
+}
+
+// Patching while pods may still be live would race the Deployment
+// controller's own rollout against RollingUpgrade's explicit stop/start
+// (see the ordering comment on rollingUpgradeStopUpdateStart,
+// cluster/cluster_roll.go) -- refused unconditionally, not just documented.
+func TestK8SUpdateDatabaseServiceConfig_NotScaledToZeroIsError(t *testing.T) {
+	one := int32(1)
+	client := fake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "db1", Namespace: "k8stest"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &one,
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "db1", Image: "mariadb:10.6"},
+					},
+				},
+			},
+		},
+	})
+	cluster := newTestCluster("k8stest")
+
+	if err := cluster.k8sUpdateDatabaseServiceConfigWithClient(client, "db1", false); err == nil {
+		t.Fatal("expected an error when the deployment is not scaled to 0 replicas, got nil")
+	}
+}
+
+// A nil Replicas is apps/v1's own "default to 1" case -- must be treated the
+// same as an explicit non-zero value, not as "unset, assume safe".
+func TestK8SUpdateDatabaseServiceConfig_NilReplicasIsError(t *testing.T) {
+	client := fake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "db1", Namespace: "k8stest"},
+		Spec: appsv1.DeploymentSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{Name: "db1", Image: "mariadb:10.6"},
+					},
+				},
+			},
+		},
+	})
+	cluster := newTestCluster("k8stest")
+
+	if err := cluster.k8sUpdateDatabaseServiceConfigWithClient(client, "db1", false); err == nil {
+		t.Fatal("expected an error when Replicas is nil (apps/v1 defaults to 1), got nil")
+	}
+}
+
 // --- Database unprovisioning ---
 
 func TestK8SUnprovisionDatabase_DeletesDeploymentAndService(t *testing.T) {
@@ -1240,12 +1492,12 @@ func TestK8SDatabaseDeployment_InitContainerMountsDbjobsVolume(t *testing.T) {
 
 	found := false
 	for _, vm := range dep.Spec.Template.Spec.InitContainers[0].VolumeMounts {
-		if vm.Name == "db1-persistent-storage" && vm.MountPath == "/docker-entrypoint-initdb.d" && vm.SubPath == k8sInitPersistSubPath {
+		if vm.Name == "db1-data" && vm.MountPath == "/docker-entrypoint-initdb.d" && vm.SubPath == k8sInitPersistSubPath {
 			found = true
 		}
 	}
 	if !found {
-		t.Fatalf("expected the init container to mount db1-persistent-storage at /docker-entrypoint-initdb.d via subPath %q", k8sInitPersistSubPath)
+		t.Fatalf("expected the init container to mount db1-data at /docker-entrypoint-initdb.d via subPath %q", k8sInitPersistSubPath)
 	}
 }
 
@@ -1261,8 +1513,8 @@ func TestK8SDatabaseDeployment_ConfMountsAreSubPathsOfPersistentStorage(t *testi
 		t.Helper()
 		for _, vm := range mounts {
 			if vm.MountPath == "/etc/mysql/conf.d" {
-				if vm.Name != "db1-persistent-storage" || vm.SubPath != k8sConfPersistSubPath {
-					t.Fatalf("%s: expected /etc/mysql/conf.d mounted from db1-persistent-storage via subPath %q, got name=%q subPath=%q", where, k8sConfPersistSubPath, vm.Name, vm.SubPath)
+				if vm.Name != "db1-data" || vm.SubPath != k8sConfPersistSubPath {
+					t.Fatalf("%s: expected /etc/mysql/conf.d mounted from db1-data via subPath %q, got name=%q subPath=%q", where, k8sConfPersistSubPath, vm.Name, vm.SubPath)
 				}
 				return
 			}
@@ -1286,8 +1538,8 @@ func TestK8SDatabaseDeployment_OnlyPersistentStorageVolumeExists(t *testing.T) {
 		t.Fatalf("expected exactly one Volume (persistent-storage), got %d: %v", len(dep.Spec.Template.Spec.Volumes), dep.Spec.Template.Spec.Volumes)
 	}
 	v := dep.Spec.Template.Spec.Volumes[0]
-	if v.Name != "db1-persistent-storage" || v.VolumeSource.PersistentVolumeClaim == nil {
-		t.Fatalf("expected the sole volume to be the PVC-backed db1-persistent-storage, got: %+v", v)
+	if v.Name != "db1-data" || v.VolumeSource.PersistentVolumeClaim == nil {
+		t.Fatalf("expected the sole volume to be the PVC-backed db1-data, got: %+v", v)
 	}
 	if v.VolumeSource.ConfigMap != nil {
 		t.Fatal("expected no ConfigMap volume source at all")
@@ -1360,7 +1612,7 @@ func TestK8SDatabaseDeployment_DbjobsSidecarMountsDataAndInitVolumes(t *testing.
 	dep := cluster.k8sDatabaseDeployment(s, 3306, "node-a")
 	sidecar := dep.Spec.Template.Spec.Containers[1]
 
-	// Both mounts come from the same "db1-persistent-storage" Volume now
+	// Both mounts come from the same "db1-data" Volume now
 	// (init via subPath), so a plain name-keyed map can't distinguish them
 	// -- match on (MountPath, SubPath) pairs instead.
 	type wantMount struct {
@@ -1375,8 +1627,8 @@ func TestK8SDatabaseDeployment_DbjobsSidecarMountsDataAndInitVolumes(t *testing.
 		t.Fatalf("expected %d volume mounts, got %d: %v", len(want), len(sidecar.VolumeMounts), sidecar.VolumeMounts)
 	}
 	for _, vm := range sidecar.VolumeMounts {
-		if vm.Name != "db1-persistent-storage" {
-			t.Fatalf("expected every sidecar mount to come from db1-persistent-storage, got %q", vm.Name)
+		if vm.Name != "db1-data" {
+			t.Fatalf("expected every sidecar mount to come from db1-data, got %q", vm.Name)
 		}
 		found := false
 		for _, w := range want {

--- a/cluster/prov_onpremise_db.go
+++ b/cluster/prov_onpremise_db.go
@@ -104,8 +104,30 @@ func (cluster *Cluster) OnPremiseStopDatabaseService(server *ServerMonitor) erro
 	return nil
 }
 
+// OnPremiseUpgradeDatabaseService runs the ssh upgrade script, which handles
+// stop -> package upgrade -> start -> mariadb-upgrade internally but doesn't
+// itself set innodb_fast_shutdown=0 first -- unlike StopDatabaseServiceClean
+// (the container-orchestrator upgrade path's stop step, via
+// rollingUpgradeStopUpdateStart), so that SQL preamble is run here instead,
+// on the still-live connection before the script's own stop happens.
 func (cluster *Cluster) OnPremiseUpgradeDatabaseService(server *ServerMonitor) error {
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo, "OnPremise upgrade database via ssh script")
+
+	if server.Conn != nil {
+		if _, err := server.Conn.Exec("SET GLOBAL innodb_fast_shutdown = 0"); err != nil {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn,
+				"Failed to set innodb_fast_shutdown=0 on %s: %s", server.URL, err)
+		}
+		if server.IsMaster() && server.DBVersion.IsMariaDB() && server.DBVersion.Major >= 10 && server.DBVersion.Minor >= 4 {
+			cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlInfo,
+				"Master %s: issuing SHUTDOWN WAIT FOR ALL SLAVES before upgrade", server.URL)
+			if _, err := server.Conn.Exec("SHUTDOWN WAIT FOR ALL SLAVES"); err != nil {
+				cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlWarn,
+					"SHUTDOWN WAIT FOR ALL SLAVES failed on %s: %s", server.URL, err)
+			}
+		}
+	}
+
 	client, err := cluster.OnPremiseConnect(server)
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "OnPremise upgrade database via ssh failed: %s", err)

--- a/doc/implementation/cluster/KUBERNETES_PROVISIONING.md
+++ b/doc/implementation/cluster/KUBERNETES_PROVISIONING.md
@@ -613,12 +613,90 @@ rather than stopping/starting it, so it never hit the unsupported stop
 path) — and does still pick up the current image, since it goes through the
 full Deployment rebuild.
 
-`StopDatabaseServiceClean` and `RollingUpgrade` still dispatch through the
-generic stop lifecycle with no orchestrator-aware gating, so a Kubernetes
-version/image upgrade via `RollingUpgrade` still fails fast — not fixed
-here, since it's a materially different operation (clean shutdown ahead of
-an actual binary swap, not just a restart) that needs its own Kubernetes
-handling. A real scale-based start/stop pair remains deferred under #1497.
+`StopDatabaseServiceClean` dispatches through the generic stop lifecycle
+(`K8SStopDatabaseService`, same scale-to-0 path as a plain stop) with no
+extra Kubernetes-specific gating, since a clean shutdown ahead of a version
+swap doesn't need anything beyond what stop already does.
+
+`RollingUpgrade` (`cluster/cluster_roll.go`) now has a Kubernetes-specific
+`UpdateDatabaseServiceConfig` implementation — see "Rolling upgrade: image
+update" below — that actually changes the image Kubernetes pulls, instead of
+only restarting pods on the pre-existing spec.
+
+### Rolling upgrade: image update
+
+`UpdateDatabaseServiceConfig` (`cluster/prov.go`) now has a Kubernetes branch,
+`K8SUpdateDatabaseServiceConfig` (`k8sUpdateDatabaseServiceConfigWithClient`,
+`prov_k8s_db.go`), alongside the pre-existing OpenSVC one. It fetches the live
+Deployment and patches `cluster.Conf.ProvDbImg` onto the main DB container
+(named like the Deployment) and, if present, the `<name>-dbjobs` sidecar —
+both driven by `forcePull`: `true` patches `PullAlways` unconditionally (the
+pull phase of an upgrade), `false` restores the steady-state
+`k8sImagePullPolicy` (`prov-kube-image-force-pull`). Only container names
+already present on the live Deployment are included in the patch — a
+strategic merge patch treats `containers` as a merge-by-name list, so
+patching an absent name would otherwise create a new, incomplete container
+(missing command, volume mounts, env) rather than erroring. The main DB
+container is required and its absence is a hard error; an older Deployment
+provisioned before the dbjobs sidecar existed is patched on just the main
+container.
+
+OpenSVC and Kubernetes need opposite ordering around this call, because their
+service-config models behave differently once written: OpenSVC's is inert
+until the container's next start, so `RollingUpgrade` can call
+`UpdateDatabaseServiceConfig` before stopping a server and let the
+stop→start cycle pick up the change. Kubernetes' Deployment patch is instead
+something the controller can act on right away — patching it while the pod
+is still live would race the controller's own rollout against
+`RollingUpgrade`'s own explicit stop. `rollingUpgradeStopUpdateStart`
+(`cluster/cluster_roll.go`) branches on orchestrator to place the update
+call after `WaitDatabaseFailed` and before `StartDatabaseWaitRejoin` for
+Kubernetes, and before the stop for everything else — so on Kubernetes the
+Deployment is always patched while scaled to 0, and the subsequent
+`StartDatabaseWaitRejoin` scale-to-1 is what actually creates a pod running
+the new image.
+
+Deliberately *not* reusing `K8SForceRepullDatabaseService` for this: that
+function backs plain restarts (`RollingRestart`, `/actions/restart`) and must
+never change what image gets pulled, so it stays restart-only. Rolling
+upgrade's image-change behavior is isolated to `RollingUpgrade` via
+`UpdateDatabaseServiceConfig` instead.
+
+The scale-to-0 precondition is enforced inside
+`k8sUpdateDatabaseServiceConfigWithClient` itself, not just documented on the
+caller: it re-fetches `dep.Spec.Replicas` and refuses to patch (nil or
+non-zero both refused — nil is apps/v1's own "default to 1", not "unset,
+assume safe") rather than trusting every future call site to only invoke it
+post-stop. `rollingUpgradeStopUpdateStart` therefore surfaces this as a real
+error already, but the check protects any other caller that might reuse the
+helper later.
+
+A failed Kubernetes patch's fatality depends on which of the two phases
+`RollingUpgrade` is in, keyed off `forcePull` (not the `phase` string, which
+is log-only): in the **pull** phase (`forcePull=true`) the patch *is* the
+image change, so `rollingUpgradeStopUpdateStart` aborts and returns the
+error (unwinding `RollingUpgrade`, maintenance included) rather than
+proceeding to `StartDatabaseWaitRejoin` on the unchanged image — letting it
+slide there would silently defeat the whole point of this feature by
+starting the server back up on the same image while `RollingUpgrade` reports
+success. In the **clean** phase (`forcePull=false`) the server was already
+upgraded by the preceding pull phase, and this patch only restores the
+steady-state pull policy — a failure there is cleanup drift, not an upgrade
+failure, so it's logged as a warning ("cleanup incomplete … Deployment still
+forced to PullAlways") and the server is started anyway: leaving it down
+over a policy-cleanup failure would cost cluster capacity for no correctness
+benefit. OpenSVC keeps its pre-existing best-effort log-only behavior in
+both phases — its push runs before the stop, so a failure there just means
+"still on the old image", a state the stop/start cycle was going to produce
+anyway.
+
+Not yet covered: the single-server `/actions/upgrade` path
+(`server/api_database.go`) still falls through `UpgradeDatabaseService`
+(`cluster/prov.go`) to a plain `StartDatabaseService` for container
+orchestrators, which does not call `UpdateDatabaseServiceConfig` and so does
+not pick up a changed `prov-db-docker-img` outside of `RollingUpgrade`. Left
+as a follow-up rather than folded in here, since it shares the OpenSVC
+container-orchestrator upgrade path and deserves its own review.
 
 ## Idempotency and error propagation
 

--- a/doc/implementation/cluster/KUBERNETES_PROVISIONING.md
+++ b/doc/implementation/cluster/KUBERNETES_PROVISIONING.md
@@ -690,13 +690,25 @@ both phases — its push runs before the stop, so a failure there just means
 "still on the old image", a state the stop/start cycle was going to produce
 anyway.
 
-Not yet covered: the single-server `/actions/upgrade` path
-(`server/api_database.go`) still falls through `UpgradeDatabaseService`
+**Now covered**: the single-server `/actions/upgrade` path
+(`server/api_database.go`) previously fell through `UpgradeDatabaseService`
 (`cluster/prov.go`) to a plain `StartDatabaseService` for container
-orchestrators, which does not call `UpdateDatabaseServiceConfig` and so does
-not pick up a changed `prov-db-docker-img` outside of `RollingUpgrade`. Left
-as a follow-up rather than folded in here, since it shares the OpenSVC
-container-orchestrator upgrade path and deserves its own review.
+orchestrators — no `UpdateDatabaseServiceConfig` call at all, so it never
+picked up a changed `prov-db-docker-img` for OpenSVC or Kubernetes; it just
+stopped and restarted on whatever image was already running. Fixed by
+reusing `rollingUpgradeStopUpdateStart` directly: `UpgradeDatabaseService`'s
+non-OnPremise case now runs the same two-phase pull-then-clean cycle
+`RollingUpgrade` runs per node (`forcePull=true,clean=true` then
+`forcePull=false,clean=false`), so a single-server upgrade gets the identical
+Kubernetes-safe ordering and image-patch behavior described above. The
+handler's own manual `SET GLOBAL innodb_fast_shutdown = 0`/`SHUTDOWN WAIT FOR
+ALL SLAVES` preamble is now OnPremise-only (its ssh upgrade script doesn't
+run that SQL itself) — the container-orchestrator path already gets it for
+free from `StopDatabaseServiceClean` (`rollingUpgradeStopUpdateStart`'s
+`clean=true` stop), which previously duplicated the exact same two
+statements. No direct unit test exists yet for `UpgradeDatabaseService`'s
+orchestration (same live-`kind`-validation gap as `RollingUpgrade` itself,
+noted above).
 
 ## Idempotency and error propagation
 
@@ -790,21 +802,11 @@ Kubernetes-orchestrated scenarios.
   the orchestrator result, and the API stop/start handlers discard the
   returned error entirely. Same for every orchestrator, not
   Kubernetes-specific, and not fixed here.
-- `RollingUpgrade` (`handlerMuxRollingAction`, the scheduler, the
-  dashboard) no longer hits an unsupported stop lifecycle for Kubernetes —
-  `StopDatabaseServiceClean` now goes through the real
-  `K8SStopDatabaseService`/`K8SStartDatabaseService` scale cycle — but it's
-  still not a genuine upgrade there: `UpdateDatabaseServiceConfig` (the
-  step that would force a fresh image pull) is OpenSVC-only
-  (`cluster/prov.go`, defaults to a no-op for every other orchestrator),
-  and nothing in `RollingUpgrade` ever patches the Deployment's `image:`
-  field. Mechanically it would now stop and restart every server with the
-  same image, not actually upgrade it — not audited further here, since
-  fixing it needs its own Kubernetes-specific image-pull step (mirroring
-  what `K8SForceRepullDatabaseService` already does for `/actions/restart`)
-  and a survey of the rest of the function for other OpenSVC-only
-  assumptions. `RollingReprov` is different: it unprovisions and
-  reprovisions each server rather than stopping/starting it, so it always
-  picks up the current image regardless.
+- `RollingUpgrade` and the single-server `/actions/upgrade` path are now
+  genuine upgrades on Kubernetes too — see "Rolling upgrade: image update"
+  above for `K8SUpdateDatabaseServiceConfig`/`rollingUpgradeStopUpdateStart`.
+  `RollingReprov` is different: it unprovisions and reprovisions each server
+  rather than stopping/starting it, so it always picked up the current image
+  regardless, even before this fix.
 
 All of the above require a design decision and are tracked under issue #1497.

--- a/server/api_database.go
+++ b/server/api_database.go
@@ -2600,49 +2600,13 @@ func (repman *ReplicationManager) handlerMuxServerUpgrade(w http.ResponseWriter,
 		mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
 			"Upgrading database server %s", node.URL)
 
-		// Set innodb_fast_shutdown=0 while the DB is still running (needed for
-		// major version upgrades). The package manager stop won't set this.
-		if node.Conn != nil {
-			if _, err := node.Conn.Exec("SET GLOBAL innodb_fast_shutdown = 0"); err != nil {
-				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
-					"Failed to set innodb_fast_shutdown=0 on %s: %s", node.URL, err)
-			}
-			// For masters: wait for all slaves before the upgrade script stops the service
-			if node.IsMaster() && node.DBVersion.IsMariaDB() && node.DBVersion.Major >= 10 && node.DBVersion.Minor >= 4 {
-				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,
-					"Master %s: issuing SHUTDOWN WAIT FOR ALL SLAVES before upgrade", node.URL)
-				if _, err := node.Conn.Exec("SHUTDOWN WAIT FOR ALL SLAVES"); err != nil {
-					mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
-						"SHUTDOWN WAIT FOR ALL SLAVES failed on %s: %s", node.URL, err)
-				}
-			}
-		}
-
-		// Run the upgrade — on-premise scripts handle stop+upgrade+start internally.
-		// Container orchestrators need explicit stop first.
-		if mycluster.GetOrchestrator() == config.ConstOrchestratorOnPremise {
-			if err := mycluster.UpgradeDatabaseService(node); err != nil {
-				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
-					"Upgrade failed for %s: %s", node.URL, err)
-				return
-			}
-		} else {
-			// Container path: explicit stop then upgrade (start with new image)
-			if err := mycluster.StopDatabaseService(node); err != nil {
-				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
-					"Upgrade stop failed for %s: %s", node.URL, err)
-				return
-			}
-			if err := mycluster.WaitDatabaseFailed(node); err != nil {
-				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
-					"Upgrade wait-failed for %s: %s", node.URL, err)
-				return
-			}
-			if err := mycluster.UpgradeDatabaseService(node); err != nil {
-				mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
-					"Upgrade failed for %s: %s", node.URL, err)
-				return
-			}
+		// UpgradeDatabaseService (cluster/prov.go) owns every orchestrator-specific
+		// step itself, OnPremise's SQL preamble included -- nothing left to do here
+		// but trigger it and report the result.
+		if err := mycluster.UpgradeDatabaseService(node); err != nil {
+			mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr,
+				"Upgrade failed for %s: %s", node.URL, err)
+			return
 		}
 
 		mycluster.LogModulePrintf(mycluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlInfo,


### PR DESCRIPTION
## Why
Kubernetes database upgrade actions were not actually applying a changed database image. Rolling upgrade only restarted pods until the Deployment image was patched, and the single-node `/actions/upgrade` path was also missing the ACL rule needed to reach it through the API.

This PR closes that gap so database upgrade actions on Kubernetes perform a real two-phase image update instead of a restart on the existing spec.

## What changed
- add a Kubernetes implementation of `UpdateDatabaseServiceConfig`
- patch the database Deployment image and pull policy during rolling upgrades
- reuse the same pull/clean upgrade flow for single-node `/actions/upgrade`
- add the missing ACL rule for `/actions/upgrade`
- move the on-prem upgrade SQL preamble into `OnPremiseUpgradeDatabaseService`
- document the Kubernetes upgrade behavior and follow-up boundaries

## Validation
- `go test ./cluster -run 'Test.*ACL|TestK8S(UpdateDatabaseServiceConfig|ForceRepullDatabaseService|DatabaseDeployment_)'`\n- live `kind` validation on a MariaDB replica confirmed the expected stop -> patch -> restart -> clean sequence and clean replication recovery