### PR TITLE
fix(prov): serialize errorChan provisioning ops with a per-cluster mutex (#1769 phase 1)

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -288,30 +288,43 @@ type Cluster struct {
 	// MaintenanceLogrus is a dedicated logrus.Logger that writes to maintenance.log.
 	// Receives ConstLogModMaintenance events: backup, SST, task execution, purge, etc.
 	// Set by the server on cluster init. Nil when no log-file is configured.
-	MaintenanceLogrus                   *log.Logger                 `json:"-"`
-	runOnceAfterTopology                bool                        `json:"-"`
-	logPtr                              *os.File                    `json:"-"`
-	termlength                          int                         `json:"-"`
-	runUUID                             string                      `json:"-"`
-	cfgGroupDisplay                     string                      `json:"-"`
-	RepMgrVersion                       string                      `json:"-"`
-	RepMgrFullVersion                   string                      `json:"-"`
-	RepMgrRestartTime                   int64                       `json:"-"`
-	RepMgrHostname                      string                      `json:"-"`
-	exitMsg                             string                      `json:"-"`
-	exit                                atomic.Bool                 `json:"-"`
-	stopOnce                            sync.Once                   `json:"-"`
-	canFlashBack                        bool                        `json:"-"`
-	canResticFetchRepo                  bool                        `json:"-"`
-	failoverCond                        *nbc.NonBlockingChan        `json:"-"`
-	switchoverCond                      *nbc.NonBlockingChan        `json:"-"`
-	rejoinCond                          *nbc.NonBlockingChan        `json:"-"`
-	bootstrapCond                       *nbc.NonBlockingChan        `json:"-"`
-	altertableCond                      *nbc.NonBlockingChan        `json:"-"`
-	addtableCond                        *nbc.NonBlockingChan        `json:"-"`
-	statecloseChan                      chan state.State            `json:"-"`
-	switchoverChan                      chan bool                   `json:"-"`
-	errorChan                           chan error                  `json:"-"`
+	MaintenanceLogrus    *log.Logger          `json:"-"`
+	runOnceAfterTopology bool                 `json:"-"`
+	logPtr               *os.File             `json:"-"`
+	termlength           int                  `json:"-"`
+	runUUID              string               `json:"-"`
+	cfgGroupDisplay      string               `json:"-"`
+	RepMgrVersion        string               `json:"-"`
+	RepMgrFullVersion    string               `json:"-"`
+	RepMgrRestartTime    int64                `json:"-"`
+	RepMgrHostname       string               `json:"-"`
+	exitMsg              string               `json:"-"`
+	exit                 atomic.Bool          `json:"-"`
+	stopOnce             sync.Once            `json:"-"`
+	canFlashBack         bool                 `json:"-"`
+	canResticFetchRepo   bool                 `json:"-"`
+	failoverCond         *nbc.NonBlockingChan `json:"-"`
+	switchoverCond       *nbc.NonBlockingChan `json:"-"`
+	rejoinCond           *nbc.NonBlockingChan `json:"-"`
+	bootstrapCond        *nbc.NonBlockingChan `json:"-"`
+	altertableCond       *nbc.NonBlockingChan `json:"-"`
+	addtableCond         *nbc.NonBlockingChan `json:"-"`
+	statecloseChan       chan state.State     `json:"-"`
+	switchoverChan       chan bool            `json:"-"`
+	errorChan            chan error           `json:"-"`
+	// provisioningMutex serialises every provision/unprovision operation that
+	// reports its result through the shared, unbuffered errorChan (the ~10
+	// receivers in prov.go + srv.go Uprovision). Without it, two overlapping
+	// operations cross-talk on that single channel: one receiver reads the
+	// other operation's result and the other blocks forever, deadlocking the
+	// orchestration and leaving a server stuck (e.g. in maintenance) with no
+	// log (issue #1769). This is the Phase-1 mitigation: it removes cross-op
+	// cross-talk while keeping the shared channel. The residual intra-op
+	// multi-send smell (config-building helpers such as OpenSVCGetDBEnvSection
+	// sending on errorChan mid-flight instead of returning the error) is left
+	// to the Phase-2 per-operation-channel refactor. See
+	// doc/implementation/cluster/ERRORCHAN_PROVISIONING.md.
+	provisioningMutex                   sync.Mutex                  `json:"-"`
 	testStopCluster                     bool                        `json:"-"`
 	testStartCluster                    bool                        `json:"-"`
 	lastmaster                          *ServerMonitor              `json:"-"`

--- a/cluster/prov.go
+++ b/cluster/prov.go
@@ -118,6 +118,13 @@ func (cluster *Cluster) Bootstrap() error {
 }
 
 func (cluster *Cluster) ProvisionServices() error {
+	// Serialise against every other provision/unprovision op on this cluster:
+	// they all report through the shared errorChan and would otherwise
+	// cross-talk (issue #1769). The fan-out below still launches its per-server
+	// goroutines in parallel under this single hold, so bulk provisioning
+	// (volume creation, etc.) keeps its concurrency.
+	cluster.provisioningMutex.Lock()
+	defer cluster.provisioningMutex.Unlock()
 	hasConfigPath := make(map[string]bool)
 	cluster.StateMachine.SetFailoverState()
 	// delete the cluster state here
@@ -207,6 +214,9 @@ func (cluster *Cluster) ProvisionServices() error {
 }
 
 func (cluster *Cluster) InitDatabaseService(server *ServerMonitor) error {
+	// Serialise errorChan use against other provision/unprovision ops (#1769).
+	cluster.provisioningMutex.Lock()
+	defer cluster.provisioningMutex.Unlock()
 	cluster.StateMachine.SetFailoverState()
 	server.WipeDeltaConfig()
 	switch cluster.GetOrchestrator() {
@@ -254,6 +264,9 @@ func (cluster *Cluster) proxyServiceOrchestrator(prx DatabaseProxy) string {
 }
 
 func (cluster *Cluster) InitProxyService(prx DatabaseProxy) error {
+	// Serialise errorChan use against other provision/unprovision ops (#1769).
+	cluster.provisioningMutex.Lock()
+	defer cluster.provisioningMutex.Unlock()
 	switch cluster.proxyServiceOrchestrator(prx) {
 	case config.ConstOrchestratorOpenSVC:
 		go cluster.OpenSVCProvisionProxyService(prx)
@@ -285,6 +298,9 @@ func (cluster *Cluster) InitProxyService(prx DatabaseProxy) error {
 }
 
 func (cluster *Cluster) InitAppService(app *App) error {
+	// Serialise errorChan use against other provision/unprovision ops (#1769).
+	cluster.provisioningMutex.Lock()
+	defer cluster.provisioningMutex.Unlock()
 	switch cluster.GetOrchestrator() {
 	case config.ConstOrchestratorOpenSVC:
 		go cluster.OpenSVCProvisionAppService(app)
@@ -319,6 +335,11 @@ func (cluster *Cluster) InitAppService(app *App) error {
 }
 
 func (cluster *Cluster) Unprovision() error {
+	// Serialise against every other provision/unprovision op on this cluster
+	// (#1769). The two fan-out loops below (proxies, then databases) still run
+	// their per-entity goroutines in parallel under this single hold.
+	cluster.provisioningMutex.Lock()
+	defer cluster.provisioningMutex.Unlock()
 
 	cluster.StateMachine.SetFailoverState()
 	// Unprovision proxies first, since they are dependent on databases
@@ -407,6 +428,9 @@ func (cluster *Cluster) Unprovision() error {
 }
 
 func (cluster *Cluster) UnprovisionProxyService(prx DatabaseProxy) error {
+	// Serialise errorChan use against other provision/unprovision ops (#1769).
+	cluster.provisioningMutex.Lock()
+	defer cluster.provisioningMutex.Unlock()
 	switch cluster.proxyServiceOrchestrator(prx) {
 	case config.ConstOrchestratorOpenSVC:
 		go cluster.OpenSVCUnprovisionProxyService(prx)
@@ -434,6 +458,11 @@ func (cluster *Cluster) UnprovisionProxyService(prx DatabaseProxy) error {
 }
 
 func (cluster *Cluster) UnprovisionDatabaseService(server *ServerMonitor) error {
+	// Serialise errorChan use against other provision/unprovision ops (#1769).
+	// This is the path that hung in the reported incident: a config-building
+	// send racing this unprovision's <-errorChan left the server in maintenance.
+	cluster.provisioningMutex.Lock()
+	defer cluster.provisioningMutex.Unlock()
 	cluster.ResetCrashes()
 	switch cluster.GetOrchestrator() {
 	case config.ConstOrchestratorOpenSVC:

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -1854,6 +1854,9 @@ func (server *ServerMonitor) FlushTables() (string, error) {
 
 func (server *ServerMonitor) Uprovision() {
 	cluster := server.ClusterGroup
+	// Serialise errorChan use against other provision/unprovision ops (#1769).
+	cluster.provisioningMutex.Lock()
+	defer cluster.provisioningMutex.Unlock()
 	go cluster.OpenSVCUnprovisionDatabaseService(server)
 	if err := <-cluster.errorChan; err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModOrchestrator, config.LvlErr, "Can not unprovision database service %s: %s", server.ServiceName, err)

--- a/doc/implementation/cluster/ERRORCHAN_PROVISIONING.md
+++ b/doc/implementation/cluster/ERRORCHAN_PROVISIONING.md
@@ -1,0 +1,120 @@
+# Provisioning IPC: the shared `errorChan`, its cross-talk bug, and the two-phase fix
+
+Issue: [#1769](https://github.com/signal18/replication-manager/issues/1769)
+
+## The mechanism
+
+Every provision / unprovision / config-build operation runs its orchestrator
+work in a **goroutine** and reports the outcome back to its caller through a
+single, **cluster-scoped, unbuffered** channel:
+
+```go
+// cluster/cluster.go
+errorChan chan error   // make(chan error)  -> UNBUFFERED
+```
+
+Callers use it as *launch a goroutine, then block on the result*:
+
+```go
+go cluster.OpenSVCUnprovisionDatabaseService(server) // goroutine ends with: cluster.errorChan <- err
+err := <-cluster.errorChan                           // caller blocks here
+```
+
+There are ~10 receivers (9 in `cluster/prov.go`, 1 in `cluster/srv.go`
+`Uprovision`) and ~90 send statements across every orchestrator backend
+(`prov_opensvc_*`, `prov_k8s_*`, `prov_localhost_*`, `prov_onpremise_*`,
+`prov_slapos_*`).
+
+## Why it breaks
+
+The channel carries **no correlation** between an operation and the result a
+receiver reads, and nothing serialises the operations. Two consequences:
+
+1. **Cross-op cross-talk.** If two operations on the same cluster overlap,
+   their sends and receives cross: one receiver reads the *other* operation's
+   result, and the other receiver blocks forever. That deadlock halts the
+   orchestration and leaves a server stuck — e.g. in maintenance, set before
+   the blocking call and cleared only after it returns — with **no log**,
+   because a goroutine blocked on `<-errorChan` prints nothing while it waits.
+   This is a release blocker (a hang that can halt monitoring — functional
+   law F2).
+
+2. **Intra-op multi-send.** Some config-*building* helpers report failures by
+   sending on `errorChan` directly instead of returning an error, because
+   their signature has no error return. Example:
+
+   ```go
+   // cluster/prov_opensvc_db.go
+   func (server *ServerMonitor) OpenSVCGetDBEnvSection() map[string]string { // no error return
+       agent, err := server.ClusterGroup.GetDatabaseAgent(server)
+       if err != nil {
+           server.ClusterGroup.errorChan <- err   // side-channel report, mid-flight
+           return svcenv
+       }
+       ...
+   }
+   ```
+
+   Called synchronously from the provision goroutine (via
+   `GenerateDBTemplateMap`), this sends **once mid-flight** and the goroutine
+   then sends **again** at the end — two sends for one operation. On an
+   unbuffered channel the mid-flight send also *blocks the provision goroutine*
+   until someone reads it, and the trailing send then has no matching reader.
+
+The root smell: `errorChan` is used as a **global "report an error from
+anywhere in the provisioning call tree" drop-box**, not as a per-operation
+result channel.
+
+Note: `OpenSVCUpdateDatabaseServiceConfig` (the real OpenSVC config *update*)
+does **not** touch `errorChan` — it returns its error directly. So every
+`errorChan` user is a provision/unprovision goroutine paired with one of the
+~10 receivers; there is no orphan cross-op sender.
+
+## Phase 1 — `provisioningMutex` (this change)
+
+Keep the shared channel, **protect it from concurrency**. A per-cluster
+`sync.Mutex` (`cluster.provisioningMutex`) is taken by each of the ~8 receiver
+wrappers (`ProvisionServices`, `InitDatabaseService`, `InitProxyService`,
+`InitAppService`, `Unprovision`, `UnprovisionProxyService`,
+`UnprovisionDatabaseService`, `ServerMonitor.Uprovision`) around their
+launch-and-receive span.
+
+Covered:
+- **All cross-op cross-talk** (consequence 1), including the reported incident
+  — no two operations can be reading/writing the channel at once. Since the
+  config *update* path does not use `errorChan`, wrapping the receivers covers
+  every channel user.
+
+Preserved (not a regression):
+- **Fan-out parallelism.** `ProvisionServices` / `Unprovision` launch their
+  per-server/per-proxy goroutines in parallel *under a single hold*, so bulk
+  volume creation etc. keeps its concurrency.
+- **Cross-cluster parallelism.** The mutex and the channel are per-cluster.
+- **Monitoring liveness (F2).** The monitor's config-drift path
+  (`UpdateDatabaseServiceConfig`) does not take this lock, so a long provision
+  never blocks the monitor.
+
+Not covered (residual, left to Phase 2):
+- **Intra-op multi-send** (consequence 2). A helper that sends mid-flight in
+  addition to the terminal send still leaves an extra/late value on the shared
+  channel that a subsequent locked operation can pick up. The mutex cannot
+  drain this reliably because the late send may arrive after the drain.
+
+## Phase 2 — per-operation channel (tracked epic)
+
+The complete root fix, to be done **in coordination with the active K8s work**
+(it touches `prov_k8s_db.go` / `prov_k8s_prx.go`; see #1737, which already
+hardened the K8s *sender* to single-send but did not remove the shared
+channel):
+
+1. Config-building helpers **return `(..., error)`** and propagate normally —
+   no helper sends on the result channel. Exactly **one terminal send per
+   goroutine**.
+2. Each operation (or fan-out group) allocates its **own buffered channel**
+   (`make(chan error, N)`), passes it to the goroutine(s), and reads only its
+   own results.
+
+With per-operation channels, a stray or late send lands in that operation's
+own (dead) channel and is harmless — cross-talk becomes impossible by
+construction, regardless of timing or send count, and the `provisioningMutex`
+can then be removed.


### PR DESCRIPTION
## What

Phase 1 mitigation for #1769: serialise the shared, unbuffered
`cluster.errorChan` provisioning IPC with a per-cluster mutex.

## Why

`cluster.errorChan` (`make(chan error)`, unbuffered, cluster-scoped) is used by
~10 provision/unprovision receivers (`cluster/prov.go` + `cluster/srv.go`
`Uprovision`) with **no op<->result correlation** and **no serialization**.
When two operations on the same cluster overlap, their sends/receives cross:
one receiver reads the other op's result and the other **blocks forever**,
deadlocking orchestration and leaving a server stuck in maintenance with **no
log** (a blocked `<-errorChan` prints nothing). Halts monitoring → release
blocker (F2).

Observed: a rolling reprovision's `UnprovisionDatabaseService` overlapped a
config-build send and hung, leaving the old master in maintenance.

## What this does

Add `cluster.provisioningMutex sync.Mutex`, taken around the launch-and-receive
span of each of the 8 receiver wrappers (`ProvisionServices`,
`InitDatabaseService`, `InitProxyService`, `InitAppService`, `Unprovision`,
`UnprovisionProxyService`, `UnprovisionDatabaseService`,
`ServerMonitor.Uprovision`).

- **Covers** all cross-op cross-talk. The config *update* path
  (`OpenSVCUpdateDatabaseServiceConfig`) does not use `errorChan`, so wrapping
  the receivers covers every channel user.
- **Preserves** fan-out parallelism (per-server goroutines still run in
  parallel under one hold), cross-cluster parallelism, and monitor liveness
  (the monitor's config path does not take this lock).
- **Residual** intra-op multi-send (config-building helpers such as
  `OpenSVCGetDBEnvSection` sending mid-flight) is left to **Phase 2** — the
  per-operation-channel refactor (see the epic on #1769; touches the K8s
  sender files, to be coordinated with the active K8s work).

Design writeup: `doc/implementation/cluster/ERRORCHAN_PROVISIONING.md`.

## Test

- `go build ./cluster/...` green; `go vet` clean (no copylocks — `Cluster` is
  always used by pointer).
- Live validation: rolling reprovision on a dev OpenSVC cluster (T13) — see PR
  thread.

Closes #1769 (Phase 1; Phase 2 tracked as the epic on the same issue).

https://claude.ai/code/session_01PseLp6M7Z5gzGhsN8whcdk
