### PR TITLE
fix(cluster): persist maintenance mode

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -858,6 +858,15 @@ func (cluster *Cluster) InitFromConf() {
 	if err != nil {
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlErr, "Could not set proxy list %s", err)
 	}
+	// Proxies were just rebuilt with no knowledge of maintenance restored onto
+	// Servers above (see newServerMonitor) -- replay the notification so
+	// HAProxy/ProxySQL/MaxScale converge immediately instead of waiting on
+	// their next refresh cycle.
+	for _, server := range cluster.Servers {
+		if server != nil && server.IsMaintenance {
+			cluster.SetProxyServerMaintenance(server.ServerID)
+		}
+	}
 	persistRebasedAppCreditCap := false
 	err = cluster.newAppList()
 	if err != nil {

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -808,16 +808,6 @@ func (cluster *Cluster) GetIgnoredHostList() string {
 	return strings.Join(prevIgnored, ",")
 }
 
-// GetMaintenanceHostList returns the durable maintenance-host membership list
-// (cluster.Conf.MaintenanceSrv) directly. Unlike GetIgnoredHostList, this does
-// NOT reconstruct the list from currently-instantiated cluster.Servers: a host
-// temporarily absent from cluster.Servers (topology churn, a config-driven
-// host-list change) would otherwise have its persisted maintenance entry
-// silently dropped the next time membership is mutated.
-func (cluster *Cluster) GetMaintenanceHostList() string {
-	return cluster.Conf.MaintenanceSrv
-}
-
 func (cluster *Cluster) GetIgnoredROList() string {
 	var prevIgnoredRO []string
 	for _, server := range cluster.Servers {

--- a/cluster/cluster_get.go
+++ b/cluster/cluster_get.go
@@ -808,6 +808,16 @@ func (cluster *Cluster) GetIgnoredHostList() string {
 	return strings.Join(prevIgnored, ",")
 }
 
+// GetMaintenanceHostList returns the durable maintenance-host membership list
+// (cluster.Conf.MaintenanceSrv) directly. Unlike GetIgnoredHostList, this does
+// NOT reconstruct the list from currently-instantiated cluster.Servers: a host
+// temporarily absent from cluster.Servers (topology churn, a config-driven
+// host-list change) would otherwise have its persisted maintenance entry
+// silently dropped the next time membership is mutated.
+func (cluster *Cluster) GetMaintenanceHostList() string {
+	return cluster.Conf.MaintenanceSrv
+}
+
 func (cluster *Cluster) GetIgnoredROList() string {
 	var prevIgnoredRO []string
 	for _, server := range cluster.Servers {

--- a/cluster/cluster_has.go
+++ b/cluster/cluster_has.go
@@ -287,6 +287,43 @@ func (cluster *Cluster) IsInIgnoredReadonly(server *ServerMonitor) bool {
 	return false
 }
 
+// maintenanceTokens splits a maintenance-host membership list into its
+// non-empty comma-separated tokens.
+func maintenanceTokens(hostList string) []string {
+	var toks []string
+	for _, tok := range strings.Split(hostList, ",") {
+		if tok != "" {
+			toks = append(toks, tok)
+		}
+	}
+	return toks
+}
+
+// maintenanceListHasHost reports whether hostList contains a token that
+// EXACTLY equals url or name -- never a substring/prefix match. This is the
+// single membership predicate shared by restoration (IsInMaintenanceHosts)
+// and mutation (SetMaintenanceSrv), so the two can never disagree about what
+// counts as a match.
+func maintenanceListHasHost(hostList, url, name string) bool {
+	for _, tok := range maintenanceTokens(hostList) {
+		if tok == url || tok == name {
+			return true
+		}
+	}
+	return false
+}
+
+// IsInMaintenanceHosts reports whether server belongs to the durable maintenance-host
+// membership, the persisted counterpart of the runtime IsMaintenance flag restored at
+// server-monitor construction (startup and config reload).
+func (cluster *Cluster) IsInMaintenanceHosts(server *ServerMonitor) bool {
+	// Child cluster servers never carry this cluster's maintenance membership
+	if server.SourceClusterName != cluster.Name {
+		return false
+	}
+	return maintenanceListHasHost(cluster.Conf.MaintenanceSrv, server.URL, server.Name)
+}
+
 func (cluster *Cluster) IsInPreferedHosts(server *ServerMonitor) bool {
 	// Ignore if child cluster
 	if server.SourceClusterName != cluster.Name {

--- a/cluster/cluster_maintenance_test.go
+++ b/cluster/cluster_maintenance_test.go
@@ -62,6 +62,82 @@ func TestIsInMaintenanceHostsChildClusterNeverMatches(t *testing.T) {
 	}
 }
 
+// TestMaintenanceDomainQualifiedServerNormalization exercises AddMaintenanceSrv's
+// entry := strings.ReplaceAll(node.URL, node.Domain+":3306", "") normalization
+// (copied from SetIgnoreSrv's existing idiom) against a domain-qualified
+// server (Domain != "", the GetDomain()/GetDomainHeadCluster() case), which
+// the other tests in this file don't cover since they all use an empty
+// Domain. Two sub-cases:
+//
+//  1. default port (3306): Domain+":3306" is a literal suffix of URL, so it
+//     gets stripped and the stored entry is the bare Name.
+//  2. non-default port: the ":3306" suffix isn't present in URL, so
+//     ReplaceAll is a no-op and the stored entry is the full domain-qualified
+//     URL.
+//
+// Both must still round-trip through IsInMaintenanceHosts for a freshly
+// rebuilt ServerMonitor (simulating restart/reload) with the same
+// deterministically-derived Name/Domain/Port/URL, since maintenanceListHasHost
+// checks both the URL and the Name form.
+func TestMaintenanceDomainQualifiedServerNormalization(t *testing.T) {
+	cl := newMaintenanceTestCluster(0)
+
+	// --- Sub-case 1: domain-qualified, default port -> stored as bare Name. ---
+	domSrv := &ServerMonitor{
+		Name:              "db1",
+		Domain:            ".svc.cluster.local",
+		Port:              "3306",
+		URL:               "db1.svc.cluster.local:3306",
+		SourceClusterName: cl.Name,
+	}
+	cl.Servers = []*ServerMonitor{domSrv}
+
+	cl.AddMaintenanceSrv(domSrv)
+	if got := cl.Conf.MaintenanceSrv; got != "db1" {
+		t.Fatalf("expected domain+port stripped to bare name %q, got %q", "db1", got)
+	}
+
+	rebuilt := &ServerMonitor{
+		Name:              "db1",
+		Domain:            ".svc.cluster.local",
+		Port:              "3306",
+		URL:               "db1.svc.cluster.local:3306",
+		SourceClusterName: cl.Name,
+	}
+	if !cl.IsInMaintenanceHosts(rebuilt) {
+		t.Fatalf("domain-qualified server on the default port did not restore from its stripped bare-name entry")
+	}
+
+	// --- Sub-case 2: domain-qualified, non-default port -> stored as the full URL. ---
+	if err := cl.RemoveMaintenanceSrv(domSrv); err != nil {
+		t.Fatalf("RemoveMaintenanceSrv: %v", err)
+	}
+	domSrvAltPort := &ServerMonitor{
+		Name:              "db2",
+		Domain:            ".svc.cluster.local",
+		Port:              "3307",
+		URL:               "db2.svc.cluster.local:3307",
+		SourceClusterName: cl.Name,
+	}
+	cl.Servers = []*ServerMonitor{domSrvAltPort}
+
+	cl.AddMaintenanceSrv(domSrvAltPort)
+	if got := cl.Conf.MaintenanceSrv; got != "db2.svc.cluster.local:3307" {
+		t.Fatalf("expected unstripped full URL %q for a non-default port, got %q", "db2.svc.cluster.local:3307", got)
+	}
+
+	rebuiltAltPort := &ServerMonitor{
+		Name:              "db2",
+		Domain:            ".svc.cluster.local",
+		Port:              "3307",
+		URL:               "db2.svc.cluster.local:3307",
+		SourceClusterName: cl.Name,
+	}
+	if !cl.IsInMaintenanceHosts(rebuiltAltPort) {
+		t.Fatalf("domain-qualified server on a non-default port did not restore from its unstripped URL entry")
+	}
+}
+
 // TestSetMaintenanceSrvExactMatchNoSubstring guards against a regression where
 // SetMaintenanceSrv matched membership with strings.Contains instead of an
 // exact token comparison: "1.2.3.4:3306" is a literal substring of

--- a/cluster/cluster_maintenance_test.go
+++ b/cluster/cluster_maintenance_test.go
@@ -1,0 +1,241 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// This source code is licensed under the GNU General Public License, version 3.
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/signal18/replication-manager/config"
+	"github.com/signal18/replication-manager/config/manager"
+)
+
+// newMaintenanceTestCluster builds a minimal Cluster with numServers servers
+// named db0..dbN-1, wired enough to exercise maintenance membership
+// (Conf, ConfigManager, Servers[i].URL/Name/SourceClusterName/ClusterGroup).
+// The ConfigManager is a bare zero-value: SaveConfig's non-wait path only
+// touches isStopping.Load() (safe zero-value) and cluster.Save() (no I/O), so
+// this avoids NewConfigManager's background git-push goroutine entirely.
+func newMaintenanceTestCluster(numServers int) *Cluster {
+	cl := &Cluster{
+		Name:          "cluster1",
+		Conf:          &config.Config{},
+		ConfigManager: &manager.ConfigManager{},
+		Servers:       make([]*ServerMonitor, numServers),
+	}
+	for i := 0; i < numServers; i++ {
+		name := "db" + string(rune('0'+i))
+		cl.Servers[i] = &ServerMonitor{
+			Name:              name,
+			URL:               name + ":3306",
+			SourceClusterName: cl.Name,
+			ClusterGroup:      cl,
+		}
+	}
+	return cl
+}
+
+func TestIsInMaintenanceHostsExactMatchNoSubstring(t *testing.T) {
+	cl := newMaintenanceTestCluster(2)
+	// "db1" must not match "db10" or a longer host sharing the same prefix.
+	cl.Conf.MaintenanceSrv = "db1:3306"
+
+	db10 := &ServerMonitor{Name: "db10", URL: "db10:3306", SourceClusterName: cl.Name}
+	if cl.IsInMaintenanceHosts(db10) {
+		t.Fatalf("IsInMaintenanceHosts matched db10:3306 against configured db1:3306 (substring collision)")
+	}
+
+	db1 := &ServerMonitor{Name: "db1", URL: "db1:3306", SourceClusterName: cl.Name}
+	if !cl.IsInMaintenanceHosts(db1) {
+		t.Fatalf("IsInMaintenanceHosts did not match the exact configured host db1:3306")
+	}
+}
+
+func TestIsInMaintenanceHostsChildClusterNeverMatches(t *testing.T) {
+	cl := newMaintenanceTestCluster(0)
+	cl.Conf.MaintenanceSrv = "db0:3306"
+
+	child := &ServerMonitor{Name: "db0", URL: "db0:3306", SourceClusterName: "other-cluster"}
+	if cl.IsInMaintenanceHosts(child) {
+		t.Fatalf("IsInMaintenanceHosts must not match a server sourced from a different (child) cluster")
+	}
+}
+
+// TestSetMaintenanceSrvExactMatchNoSubstring guards against a regression where
+// SetMaintenanceSrv matched membership with strings.Contains instead of an
+// exact token comparison: "1.2.3.4:3306" is a literal substring of
+// "11.2.3.4:3306" (starting at index 1), so a naive Contains(list, srv.URL)
+// check would have wrongly pulled the unrelated "1.2.3.4:3306" server into
+// maintenance when only "11.2.3.4:3306" was ever configured.
+func TestSetMaintenanceSrvExactMatchNoSubstring(t *testing.T) {
+	cl := newMaintenanceTestCluster(0)
+	cl.Servers = []*ServerMonitor{
+		{Name: "a", URL: "11.2.3.4:3306", SourceClusterName: cl.Name},
+		{Name: "b", URL: "1.2.3.4:3306", SourceClusterName: cl.Name},
+	}
+	for _, s := range cl.Servers {
+		s.ClusterGroup = cl
+	}
+
+	cl.SetMaintenanceSrv("11.2.3.4:3306")
+
+	if !cl.Servers[0].IsMaintenance {
+		t.Fatalf("SetMaintenanceSrv did not mark the exactly-configured host 11.2.3.4:3306 as in maintenance")
+	}
+	if cl.Servers[1].IsMaintenance {
+		t.Fatalf("SetMaintenanceSrv substring-matched 1.2.3.4:3306 against configured 11.2.3.4:3306")
+	}
+}
+
+// TestMaintenanceMutationPreservesAbsentServerEntries guards against a
+// regression where Add/RemoveMaintenanceSrv rebuilt the persisted list only
+// from currently-instantiated cluster.Servers: mutating maintenance for one
+// server used to silently drop a persisted entry belonging to a host that
+// isn't presently represented in cluster.Servers (e.g. topology churn, a
+// db-servers-hosts edit). The persisted token for that absent host must
+// survive an unrelated add or remove.
+func TestMaintenanceMutationPreservesAbsentServerEntries(t *testing.T) {
+	cl := newMaintenanceTestCluster(1)
+	present := cl.Servers[0]
+	cl.Conf.MaintenanceSrv = "db-absent"
+
+	cl.AddMaintenanceSrv(present)
+	if !maintenanceListHasHost(cl.Conf.MaintenanceSrv, "db-absent", "db-absent") {
+		t.Fatalf("AddMaintenanceSrv dropped the persisted entry for a server absent from cluster.Servers: got %q", cl.Conf.MaintenanceSrv)
+	}
+	if !cl.IsInMaintenanceHosts(present) {
+		t.Fatalf("AddMaintenanceSrv did not add the requested server")
+	}
+
+	if err := cl.RemoveMaintenanceSrv(present); err != nil {
+		t.Fatalf("RemoveMaintenanceSrv returned unexpected error: %v", err)
+	}
+	if !maintenanceListHasHost(cl.Conf.MaintenanceSrv, "db-absent", "db-absent") {
+		t.Fatalf("RemoveMaintenanceSrv dropped the persisted entry for a server absent from cluster.Servers: got %q", cl.Conf.MaintenanceSrv)
+	}
+	if cl.IsInMaintenanceHosts(present) {
+		t.Fatalf("RemoveMaintenanceSrv did not remove the requested server")
+	}
+}
+
+func TestAddRemoveMaintenanceSrvUpdatesMembershipAndRuntimeFlag(t *testing.T) {
+	cl := newMaintenanceTestCluster(2)
+	target := cl.Servers[0]
+	other := cl.Servers[1]
+
+	cl.AddMaintenanceSrv(target)
+
+	if !target.IsMaintenance {
+		t.Fatalf("AddMaintenanceSrv did not set the runtime IsMaintenance flag")
+	}
+	if other.IsMaintenance {
+		t.Fatalf("AddMaintenanceSrv incorrectly marked an unrelated server as in maintenance")
+	}
+	if !cl.IsInMaintenanceHosts(target) {
+		t.Fatalf("AddMaintenanceSrv did not persist target into cluster.Conf.MaintenanceSrv")
+	}
+	if !cl.IsNeedConfigSave {
+		t.Fatalf("AddMaintenanceSrv did not request config persistence (IsNeedConfigSave)")
+	}
+
+	// Adding an already-tracked server is a no-op (must not duplicate the entry).
+	// Note: SetMaintenanceSrv strips ":3306" when Domain is unset, mirroring
+	// SetIgnoreSrv's existing host-normalization behavior.
+	cl.AddMaintenanceSrv(target)
+	if got := cl.Conf.MaintenanceSrv; got != "db0" {
+		t.Fatalf("AddMaintenanceSrv duplicated membership on repeat call: got %q", got)
+	}
+
+	cl.IsNeedConfigSave = false
+	if err := cl.RemoveMaintenanceSrv(target); err != nil {
+		t.Fatalf("RemoveMaintenanceSrv returned unexpected error: %v", err)
+	}
+	if target.IsMaintenance {
+		t.Fatalf("RemoveMaintenanceSrv did not clear the runtime IsMaintenance flag")
+	}
+	if cl.IsInMaintenanceHosts(target) {
+		t.Fatalf("RemoveMaintenanceSrv did not clear target from cluster.Conf.MaintenanceSrv")
+	}
+	if !cl.IsNeedConfigSave {
+		t.Fatalf("RemoveMaintenanceSrv did not request config persistence (IsNeedConfigSave)")
+	}
+
+	// Removing a server that isn't tracked is an error and a no-op.
+	if err := cl.RemoveMaintenanceSrv(target); err == nil {
+		t.Fatalf("RemoveMaintenanceSrv should error when the server is not in the maintenance list")
+	}
+}
+
+func TestServerSetDelMaintenancePersistMembership(t *testing.T) {
+	cl := newMaintenanceTestCluster(1)
+	server := cl.Servers[0]
+
+	server.SetMaintenance()
+	if !server.IsMaintenance || !cl.IsInMaintenanceHosts(server) {
+		t.Fatalf("SetMaintenance did not set runtime flag and durable membership together")
+	}
+
+	server.DelMaintenance()
+	if server.IsMaintenance || cl.IsInMaintenanceHosts(server) {
+		t.Fatalf("DelMaintenance did not clear runtime flag and durable membership together")
+	}
+}
+
+func TestSwitchMaintenancePersistsBothDirections(t *testing.T) {
+	cl := newMaintenanceTestCluster(1)
+	server := cl.Servers[0]
+
+	if err := server.SwitchMaintenance(); err != nil {
+		t.Fatalf("SwitchMaintenance returned unexpected error: %v", err)
+	}
+	if !server.IsMaintenance || !cl.IsInMaintenanceHosts(server) {
+		t.Fatalf("SwitchMaintenance (off->on) did not persist membership")
+	}
+
+	if err := server.SwitchMaintenance(); err != nil {
+		t.Fatalf("SwitchMaintenance returned unexpected error: %v", err)
+	}
+	if server.IsMaintenance || cl.IsInMaintenanceHosts(server) {
+		t.Fatalf("SwitchMaintenance (on->off) did not clear persisted membership")
+	}
+}
+
+// TestMaintenanceRestoredOnServerMonitorRebuild simulates what newServerMonitor
+// does on process restart and config reload (cluster/srv.go): a brand new
+// ServerMonitor for a host that was previously in maintenance must come back
+// up with IsMaintenance derived from the durable membership, without any
+// call to SetMaintenance (which would replay the state-change script).
+func TestMaintenanceRestoredOnServerMonitorRebuild(t *testing.T) {
+	cl := newMaintenanceTestCluster(1)
+	server := cl.Servers[0]
+	server.SetMaintenance()
+
+	// Simulate a restart/reload: the old ServerMonitor is discarded and a
+	// fresh one is constructed for the same host.
+	rebuilt := &ServerMonitor{
+		Name:              server.Name,
+		URL:               server.URL,
+		SourceClusterName: cl.Name,
+		ClusterGroup:      cl,
+	}
+	// This is the exact restoration line added to newServerMonitor.
+	rebuilt.IsMaintenance = cl.IsInMaintenanceHosts(rebuilt)
+
+	if !rebuilt.IsMaintenance {
+		t.Fatalf("rebuilt ServerMonitor did not restore IsMaintenance from durable membership")
+	}
+
+	// And once cleared, a rebuild must NOT resurrect maintenance.
+	server.DelMaintenance()
+	rebuilt2 := &ServerMonitor{
+		Name:              server.Name,
+		URL:               server.URL,
+		SourceClusterName: cl.Name,
+		ClusterGroup:      cl,
+	}
+	rebuilt2.IsMaintenance = cl.IsInMaintenanceHosts(rebuilt2)
+	if rebuilt2.IsMaintenance {
+		t.Fatalf("rebuilt ServerMonitor resurrected maintenance after it was cleared")
+	}
+}

--- a/cluster/cluster_set.go
+++ b/cluster/cluster_set.go
@@ -416,6 +416,77 @@ func (cluster *Cluster) SetIgnoreSrv(IgnoredHostURL string) {
 	// fmt.Printf("Update config ignored server: " + cluster.Conf.IgnoreSrv + "\n")
 }
 
+// SetMaintenanceSrv replaces the durable maintenance-host membership list
+// with newList (a comma-separated set of host tokens, deduplicated; matched
+// EXACTLY -- see maintenanceListHasHost, never by substring), then syncs the
+// runtime IsMaintenance flag for every currently-instantiated server to match
+// it. It trusts newList as the complete intended membership -- it does not
+// filter tokens against cluster.Servers, so a host temporarily absent from
+// the live server list keeps its entry (see AddMaintenanceSrv/
+// RemoveMaintenanceSrv, which build newList by editing the existing token
+// list rather than reconstructing it from live servers). It does not run the
+// db-servers-state-change script or touch proxy backends -- callers
+// (SetMaintenance/DelMaintenance/SwitchMaintenance) own those side effects;
+// this only tracks membership so it survives restart and config reload (see
+// newServerMonitor).
+func (cluster *Cluster) SetMaintenanceSrv(newList string) {
+	seen := make(map[string]bool)
+	var deduped []string
+	for _, tok := range maintenanceTokens(newList) {
+		if seen[tok] {
+			continue
+		}
+		seen[tok] = true
+		deduped = append(deduped, tok)
+	}
+	cluster.Conf.MaintenanceSrv = strings.Join(deduped, ",")
+
+	for _, srv := range cluster.Servers {
+		if srv == nil || srv.GetSourceClusterName() != cluster.Name {
+			continue
+		}
+		srv.IsMaintenance = maintenanceListHasHost(cluster.Conf.MaintenanceSrv, srv.URL, srv.Name)
+	}
+}
+
+// AddMaintenanceSrv adds node to the durable maintenance-host membership and
+// persists it, preserving every other entry already tracked -- including
+// hosts not currently represented in cluster.Servers.
+func (cluster *Cluster) AddMaintenanceSrv(node *ServerMonitor) {
+	if maintenanceListHasHost(cluster.Conf.MaintenanceSrv, node.URL, node.Name) {
+		node.IsMaintenance = true
+		return
+	}
+	entry := strings.ReplaceAll(node.URL, node.Domain+":3306", "")
+	newList := append(maintenanceTokens(cluster.Conf.MaintenanceSrv), entry)
+	cluster.SetMaintenanceSrv(strings.Join(newList, ","))
+	cluster.ConfigManager.SaveConfig(cluster, false)
+}
+
+// RemoveMaintenanceSrv removes node from the durable maintenance-host
+// membership and persists it, preserving every other entry already tracked --
+// including hosts not currently represented in cluster.Servers.
+func (cluster *Cluster) RemoveMaintenanceSrv(node *ServerMonitor) error {
+	if node.SourceClusterName != cluster.Name {
+		return fmt.Errorf("Host is in child cluster. Cannot remove maintenance")
+	}
+
+	if !maintenanceListHasHost(cluster.Conf.MaintenanceSrv, node.URL, node.Name) {
+		return fmt.Errorf("Host not found in maintenance list")
+	}
+
+	var kept []string
+	for _, tok := range maintenanceTokens(cluster.Conf.MaintenanceSrv) {
+		if tok == node.URL || tok == node.Name {
+			continue
+		}
+		kept = append(kept, tok)
+	}
+	cluster.SetMaintenanceSrv(strings.Join(kept, ","))
+	cluster.ConfigManager.SaveConfig(cluster, false)
+	return nil
+}
+
 // Set Ignored for ReadOnly Check
 func (cluster *Cluster) SetIgnoreRO(IgnoredReadOnlyHostURL string) {
 	var ignoreROList []string

--- a/cluster/srv.go
+++ b/cluster/srv.go
@@ -450,6 +450,11 @@ func (cluster *Cluster) newServerMonitor(url string, user string, pass string, c
 		server.SetIgnoredReadonly(cluster.IsInIgnoredReadonly(server))
 		server.SetPreferedBackup(cluster.IsInPreferedBackupHosts(server))
 		server.SetPrefered(cluster.IsInPreferedHosts(server))
+		// Restore maintenance from durable membership (startup and config
+		// reload both rebuild ServerMonitor here). Set the field directly
+		// rather than calling SetMaintenance(): this is reconciliation, not a
+		// new state transition, so it must not replay the state-change script.
+		server.IsMaintenance = cluster.IsInMaintenanceHosts(server)
 	} else {
 		// Always ignore child cluster
 		server.SetIgnored(true)

--- a/cluster/srv_del.go
+++ b/cluster/srv_del.go
@@ -199,8 +199,14 @@ func (server *ServerMonitor) DelBackupTypeCookie(backtype string) error {
 func (server *ServerMonitor) DelMaintenance() {
 	server.IsMaintenance = false
 	// Clear the persisted membership too, otherwise a restart/reload would
-	// resurrect maintenance (see newServerMonitor).
-	server.ClusterGroup.RemoveMaintenanceSrv(server)
+	// resurrect maintenance (see newServerMonitor). Not expected to fail here
+	// (IsMaintenance was just true), but log rather than swallow: a silent
+	// failure would mean membership tracking drifted from the runtime flag
+	// without anyone noticing.
+	if err := server.ClusterGroup.RemoveMaintenanceSrv(server); err != nil {
+		server.ClusterGroup.LogModulePrintf(server.ClusterGroup.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"DelMaintenance: could not clear durable maintenance membership for %s: %s", server.URL, err)
+	}
 	server.ClusterGroup.SetProxyServerMaintenance(server.ServerID)
 }
 

--- a/cluster/srv_del.go
+++ b/cluster/srv_del.go
@@ -198,6 +198,9 @@ func (server *ServerMonitor) DelBackupTypeCookie(backtype string) error {
 
 func (server *ServerMonitor) DelMaintenance() {
 	server.IsMaintenance = false
+	// Clear the persisted membership too, otherwise a restart/reload would
+	// resurrect maintenance (see newServerMonitor).
+	server.ClusterGroup.RemoveMaintenanceSrv(server)
 	server.ClusterGroup.SetProxyServerMaintenance(server.ServerID)
 }
 

--- a/cluster/srv_set.go
+++ b/cluster/srv_set.go
@@ -258,6 +258,9 @@ func (server *ServerMonitor) SetReadWrite() error {
 
 func (server *ServerMonitor) SetMaintenance() {
 	server.IsMaintenance = true
+	// Persist membership so maintenance survives restart/config reload (see
+	// newServerMonitor); AddMaintenanceSrv is a no-op if already tracked.
+	server.ClusterGroup.AddMaintenanceSrv(server)
 	server.ClusterGroup.BashScriptDbServersChangeState(server, stateMaintenance, server.State)
 	server.ClusterGroup.SetProxyServerMaintenance(server.ServerID)
 }

--- a/cluster/srv_tgl.go
+++ b/cluster/srv_tgl.go
@@ -35,8 +35,12 @@ func (server *ServerMonitor) SwitchMaintenance() error {
 	if server.IsMaintenance {
 		server.ClusterGroup.AddMaintenanceSrv(server)
 		server.ClusterGroup.BashScriptDbServersChangeState(server, stateMaintenance, server.State)
-	} else {
-		server.ClusterGroup.RemoveMaintenanceSrv(server)
+	} else if err := server.ClusterGroup.RemoveMaintenanceSrv(server); err != nil {
+		// Not expected (IsMaintenance was just true), but log rather than
+		// swallow: a silent failure means membership tracking drifted from
+		// the runtime flag without anyone noticing.
+		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModGeneral, config.LvlWarn,
+			"SwitchMaintenance: could not clear durable maintenance membership for %s: %s", server.URL, err)
 	}
 	cluster.failoverProxies()
 	return nil

--- a/cluster/srv_tgl.go
+++ b/cluster/srv_tgl.go
@@ -33,7 +33,10 @@ func (server *ServerMonitor) SwitchMaintenance() error {
 
 	server.IsMaintenance = !server.IsMaintenance
 	if server.IsMaintenance {
+		server.ClusterGroup.AddMaintenanceSrv(server)
 		server.ClusterGroup.BashScriptDbServersChangeState(server, stateMaintenance, server.State)
+	} else {
+		server.ClusterGroup.RemoveMaintenanceSrv(server)
 	}
 	cluster.failoverProxies()
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -232,6 +232,7 @@ type Config struct {
 	BackupServers                             string                       `mapstructure:"db-servers-backup-hosts" toml:"db-servers-backup-hosts" json:"dbServersBackupHosts"`
 	IgnoreSrv                                 string                       `mapstructure:"db-servers-ignored-hosts" toml:"db-servers-ignored-hosts" json:"dbServersIgnoredHosts"`
 	IgnoreSrvRO                               string                       `mapstructure:"db-servers-ignored-readonly" toml:"db-servers-ignored-readonly" json:"dbServersIgnoredReadonly"`
+	MaintenanceSrv                            string                       `mapstructure:"db-servers-maintenance-hosts" toml:"db-servers-maintenance-hosts" json:"dbServersMaintenanceHosts"`
 	Timeout                                   int                          `mapstructure:"db-servers-connect-timeout" toml:"db-servers-connect-timeout" json:"dbServersConnectTimeout"`
 	ExecTimeout                               int                          `mapstructure:"db-servers-exec-timeout" toml:"db-servers-exec-timeout" json:"dbServersExecTimeout"`
 	ReadTimeout                               int                          `mapstructure:"db-servers-read-timeout" toml:"db-servers-read-timeout" json:"dbServersReadTimeout"`

--- a/doc/implementation/cluster/MAINTENANCE_PERSISTENCE.md
+++ b/doc/implementation/cluster/MAINTENANCE_PERSISTENCE.md
@@ -140,9 +140,28 @@ handlers, `clients/client_server.go`) already route through `SetMaintenance` /
 `DelMaintenance` / `SwitchMaintenance`, so they inherit persistence without
 code changes. Their Swagger `@Description` annotations were updated to state
 the persistence contract and the `monitoring-save-config=true` dependency
-(`server/api_database.go`), and the dashboard's maintenance confirmation
-dialog (`share/dashboard_react/.../DBServers/ServerMenu.jsx`) now shows the
-same note in its confirm-modal body so an operator sees it before confirming.
+(`server/api_database.go`).
+
+The dashboard's "Maintenance Mode" menu item
+(`share/dashboard_react/.../DBServers/ServerMenu.jsx`) dispatches
+`switchMaintenanceMode`, which hits the toggle endpoint
+(`actions/maintenance` → `SwitchMaintenance`), not a dedicated set action —
+the same click clears maintenance when the server is already in it. The
+action (`redux/clusterSlice.js`) and its API-call function
+(`services/clusterService.js`) were both renamed from `setMaintenanceMode`
+to `switchMaintenanceMode` (action type `cluster/switchMaintenanceMode`) to
+match what they actually do, mirroring this codebase's existing
+`switchOverCluster`/`switchClusterSetting` naming for toggle actions; the
+success/error banner text was reworded to be direction-neutral for the same
+reason. The dedicated `set-maintenance`/`del-maintenance` API endpoints
+(`SetMaintenance()`/`DelMaintenance()` server-side) are correctly named
+already but aren't wired into the dashboard at all — only the toggle is. The
+confirm-modal title and body are both gated on `row?.isMaintenance`
+accordingly: entering maintenance shows "Confirm maintenance for
+{server}?" plus the persistence/`monitoring-save-config=true` note; clearing
+it shows "Confirm clearing maintenance for {server}?" plus a note that the
+durable membership is cleared too and the server rejoins immediately and
+stays rejoined.
 
 ## Test coverage
 

--- a/doc/implementation/cluster/MAINTENANCE_PERSISTENCE.md
+++ b/doc/implementation/cluster/MAINTENANCE_PERSISTENCE.md
@@ -1,0 +1,239 @@
+# Maintenance Mode Persistence
+
+Tracking issue: [#1783](https://github.com/signal18/replication-manager/issues/1783).
+
+## Problem
+
+`ServerMonitor.IsMaintenance` was runtime-only. It was set/cleared by
+`SetMaintenance()` / `DelMaintenance()` / `SwitchMaintenance()`
+(`cluster/srv_set.go`, `cluster/srv_del.go`, `cluster/srv_tgl.go`) but never
+serialized. A process restart or a live config reload rebuilds every
+`ServerMonitor` from scratch (`newServerMonitor`, `cluster/srv.go`), which
+zero-values `IsMaintenance` back to `false` — a server an operator pulled out
+of rotation silently rejoined proxy routing and failover election on the next
+restart, including maintenance set automatically by failover logic
+(`cluster/cluster_fail.go`) when a slave can't safely rejoin.
+
+## Design
+
+Maintenance membership is durable now, following the exact pattern already
+used for `db-servers-ignored-hosts` (`IgnoreSrv`): a per-cluster comma-separated
+host-membership string in `config.Config`, with matching, add and remove
+helpers on `Cluster`.
+
+### Persisted field
+
+`config.Config.MaintenanceSrv` — `db-servers-maintenance-hosts`
+(`config/config.go`). Bound as a Cobra flag in `server/server.go`. Written to
+the cluster's dynamic TOML by the existing `ConfigManager.SaveConfig` /
+`Cluster.Save()` flow — **no new writer**.
+
+### Membership helpers (mirroring `cluster_has.go` / `cluster_set.go` /
+`cluster_get.go`'s `IgnoreSrv` triplet — with two deliberate departures from
+that precedent, below)
+
+- `maintenanceListHasHost(hostList, url, name)` / `maintenanceTokens(hostList)`
+  (`cluster/cluster_has.go`) — the single membership predicate, comparing
+  comma-separated tokens with **exact equality only**. `IgnoreSrv`'s
+  equivalent (`SetIgnoreSrv`) matches with `strings.Contains(list, srv.URL)`;
+  that is a real substring hazard (`"1.2.3.4:3306"` is a literal substring of
+  `"11.2.3.4:3306"`, so a Contains-based match would silently pull an
+  unrelated server into maintenance). Maintenance is safety-critical enough
+  that this file does not inherit that shortcut — every membership check
+  (restoration, mutation) goes through this one predicate so they can't
+  disagree.
+- `Cluster.IsInMaintenanceHosts(server)` (`cluster/cluster_has.go`) — exact
+  match against `Conf.MaintenanceSrv` via `maintenanceListHasHost`, false for
+  child-cluster servers. Used both as the membership check and as the
+  restart-restoration source (see below).
+  There is no `GetMaintenanceHostList` (unlike `IgnoreSrv`'s
+  `GetIgnoredHostList`, which reconstructs its list from live
+  `cluster.Servers` and is therefore lossy for a host temporarily absent from
+  `cluster.Servers`): `Add`/`RemoveMaintenanceSrv` below read
+  `Conf.MaintenanceSrv` directly instead of going through a getter, and no
+  caller outside this package currently needs the whole list, so a getter
+  with no caller was dropped rather than shipped speculatively. Add one (or an
+  API endpoint) when something needs to read the full durable list.
+- `Cluster.SetMaintenanceSrv(newList)` (`cluster/cluster_set.go`) — the
+  in-memory assignment/synchronization helper: dedupes and writes `newList`
+  into `Conf.MaintenanceSrv`, then syncs the runtime `IsMaintenance` flag for
+  every *currently-instantiated* server to match it (servers absent from
+  `cluster.Servers` have no runtime flag to sync — their token is left
+  untouched in `Conf.MaintenanceSrv` for the next restore). It does **not**
+  call `ConfigManager.SaveConfig` itself — it's the pure state-transform step,
+  reused below.
+- `AddMaintenanceSrv(node)` / `RemoveMaintenanceSrv(node)`
+  (`cluster/cluster_set.go`) — edit the existing token list from
+  `Conf.MaintenanceSrv` directly (append/filter a token), never rebuilding it
+  from `cluster.Servers`, so a token for a host not currently instantiated
+  survives an unrelated add or remove. Each calls `SetMaintenanceSrv` with the
+  updated list, then calls `ConfigManager.SaveConfig(cluster, false)` itself
+  after a real membership change (a no-op add/remove, e.g. adding an
+  already-tracked host, returns before either call). None of them run the
+  state-change script or touch proxies — that stays the job of
+  `SetMaintenance` / `DelMaintenance` / `SwitchMaintenance`, which call them as
+  one more side effect alongside the existing script/proxy calls.
+  `DelMaintenance` and `SwitchMaintenance`'s clear branch log a warning
+  (`ConstLogModGeneral`/`LvlWarn`) rather than discard `RemoveMaintenanceSrv`'s
+  error: not expected in practice (`IsMaintenance` was just true), but a
+  future membership-tracking bug should surface in logs, not degrade
+  silently. `SetMaintenance`/`AddMaintenanceSrv`'s add path has no error to
+  discard — it's a no-op when already tracked.
+
+### Restoration on startup and reload
+
+Both process startup and `Cluster.ReloadConfig()` route through
+`InitFromConf()` → `newServerList()` → `newServerMonitor()` (confirmed by
+reading the call graph — there is exactly one `newProxyList()` call site,
+inside `InitFromConf`, so one restoration point covers both paths). In
+`newServerMonitor` (`cluster/srv.go`), alongside the existing
+ignored/preferred restoration:
+
+```go
+server.IsMaintenance = cluster.IsInMaintenanceHosts(server)
+```
+
+This assigns the field directly rather than calling `SetMaintenance()`:
+restoration is reconciliation, not a new state transition, so it must not
+replay `db-servers-state-change-script` or send a duplicate proxy
+notification (that happens once, explicitly, right after).
+
+### Proxy reconciliation
+
+`newProxyList()` runs after `newServerList()` inside `InitFromConf`, so
+proxies are rebuilt with no knowledge of the maintenance state just restored
+onto `Servers`. Immediately after `newProxyList()`:
+
+```go
+for _, server := range cluster.Servers {
+    if server != nil && server.IsMaintenance {
+        cluster.SetProxyServerMaintenance(server.ServerID)
+    }
+}
+```
+
+replays the same notification `SetMaintenance()` sends, so
+HAProxy/ProxySQL/MaxScale converge immediately instead of waiting for their
+next refresh cycle.
+
+### Automatic (failover-triggered) maintenance
+
+Per product decision, maintenance set automatically by internal failover
+logic is persisted identically to operator/API-triggered maintenance — there
+is only one code path (`SetMaintenance`), so this required no special
+handling. A restart never silently returns a server to service, regardless of
+who put it into maintenance.
+
+## Prerequisite: `monitoring-save-config`
+
+Durability depends on the existing `monitoring-save-config` flag (default
+`true`). With it explicitly disabled, dynamic cluster configuration —
+including maintenance membership — is not written and does not survive
+restart. This is existing, documented behavior (see CLAUDE.md's
+"Environment Variable Conflicts" note); maintenance persistence introduces no
+new exception to it.
+
+## No new API/CLI surface; UI copy updated
+
+The existing maintenance endpoints (`server/api_database.go` toggle/set/clear
+handlers, `clients/client_server.go`) already route through `SetMaintenance` /
+`DelMaintenance` / `SwitchMaintenance`, so they inherit persistence without
+code changes. Their Swagger `@Description` annotations were updated to state
+the persistence contract and the `monitoring-save-config=true` dependency
+(`server/api_database.go`), and the dashboard's maintenance confirmation
+dialog (`share/dashboard_react/.../DBServers/ServerMenu.jsx`) now shows the
+same note in its confirm-modal body so an operator sees it before confirming.
+
+## Test coverage
+
+### Unit tests (`cluster/cluster_maintenance_test.go`)
+
+- exact URL/name membership matching, no substring collisions (`db1` vs
+  `db10`), and child-cluster exclusion;
+- a dedicated regression test for the `SetMaintenanceSrv` substring hazard
+  above (`"11.2.3.4:3306"` configured, `"1.2.3.4:3306"` must stay untouched);
+- a dedicated regression test that `Add`/`RemoveMaintenanceSrv` preserve a
+  persisted entry for a host absent from `cluster.Servers` while mutating a
+  different, present server;
+- a dedicated test for the `entry := strings.ReplaceAll(node.URL,
+  node.Domain+":3306", "")` normalization `AddMaintenanceSrv` copies from
+  `SetIgnoreSrv`, against a domain-qualified server (`Domain != ""`, the
+  `GetDomain()`/`GetDomainHeadCluster()` case the other tests don't cover):
+  both the default-port form (stripped to the bare name) and a non-default
+  port (left as the full domain-qualified URL) round-trip through
+  `IsInMaintenanceHosts` for a freshly rebuilt `ServerMonitor`;
+- `AddMaintenanceSrv` / `RemoveMaintenanceSrv` update both the durable
+  membership and every server's runtime flag, request persistence
+  (`IsNeedConfigSave`), and are idempotent / error on a no-op remove;
+- `SetMaintenance` / `DelMaintenance` / `SwitchMaintenance` persist membership
+  alongside the runtime flag;
+- a freshly constructed `ServerMonitor` (simulating what `newServerMonitor`
+  does on restart/reload) restores `IsMaintenance` from durable membership,
+  and does not resurrect it once cleared.
+
+### Live reload/rebuild regtest (partial T13): `regtest/test_maintenance_persist_reload.go`
+
+Registered as `testMaintenancePersistReload` (`regtest/regtest.go`,
+`server/regtest.go`), runnable standalone (`--test=testMaintenancePersistReload`)
+or as part of `ALL` against a live, already-provisioned cluster. There is no
+separate repman process for a regtest to kill and restart, so it drives
+`cl.ReloadConfig(*cl.Conf)` directly. This exercises the real server/proxy
+reconstruction sequence — `ReloadConfig` → `InitFromConf` → `newServerList` →
+`newServerMonitor` → `newProxyList`, the same sequence both process startup
+and the config-reload API endpoint (`ReplicationManager.ReloadClusterConfig` →
+`mycluster.ReloadConfig`) run, and there is only one `newProxyList()` call
+site in the codebase — but it is **not equivalent to a process restart**: it
+passes the already-mutated in-memory `*cl.Conf` straight into `ReloadConfig`,
+so it does not start a fresh process and does not prove that startup's config
+loading (Viper reading the TOML file back off disk) merges the persisted
+artifact correctly. That gap is exactly what `SaveConfigFile()` + reading the
+file back (step 2 below) is there to narrow, but a real Docker process
+restart remains the final T13 validation (see below).
+
+Flow: `SetMaintenance()` on a replica (the same entry point the API uses) →
+assert durable membership and, if a recognized proxy (HAProxy/ProxySQL) is
+attached, assert the read backend drains → `SaveConfigFile()` and assert the
+persisted TOML contains the entry → `ReloadConfig` (live rebuild, not a
+process restart) → re-fetch the server by URL (the old pointer is stale
+post-reload) and assert `IsMaintenance == true` (the same field the API's
+JSON response serializes) and the proxy backend stayed excluded →
+`DelMaintenance()` → `SaveConfigFile()` → `ReloadConfig` again → assert
+maintenance was **not** resurrected and the proxy backend returned.
+
+What this does verify, on a real cluster: the TOML artifact is actually
+written; the real reconstruction lifecycle (`newServerMonitor`/`newProxyList`)
+restores maintenance from configuration; rebuilt proxies converge correctly.
+What it does not verify: that a fresh process's own startup config-load path
+reads the same artifact back the same way.
+
+Not exercised in the session that authored this: an actual run against a live
+Docker DB/proxy matrix (it compiles and vets cleanly, and reuses the same
+live-cluster helpers `test_proxy_read_backend_reconciliation.go` already
+exercises in CI, but was not executed here — see PR for CI results).
+
+### Remaining gap: process-level restart (T13, pre-release)
+
+Before release, run the isolated Docker process-restart scenario this file
+above stops short of: set maintenance through the API, stop the
+`replication-manager` process, start a fresh one against the same
+datadir/config, and assert via the API that `isMaintenance=true` and the
+proxy backend is still excluded — then clear and repeat to confirm
+non-resurrection. Tracked on issue #1783.
+
+## User documentation
+
+`docs.signal18.io` content does not live in this repository (no submodule; the
+in-repo `doc/api_latest.md` and `docs/swagger.*` are the generated Swagger
+reference, not the prose user guide). The source-of-truth `@Description`
+annotations in `server/api_database.go` were updated with the persistence
+contract (see above); regenerating `docs/swagger.*` / `doc/api_latest.md` from
+them via `swag.sh` was tried and then deliberately left out of this change —
+that regeneration also pulled in several already-merged, previously
+ungenerated fields unrelated to maintenance (`maxscaleMode`,
+`provDbComplianceAutoAgree`, etc.), and `swag.sh` isn't a tracked/Makefile
+step this repo's contributor workflow otherwise runs per PR. Regenerate
+separately, or as part of the ordinary docs refresh cadence. The prose user
+guide entry for maintenance mode on `docs.signal18.io` — that it is now
+durable across restart/reload, and depends on `monitoring-save-config=true` —
+still needs to be written on that site; tracked as a follow-up on issue #1783
+since it's outside this repo's reach.

--- a/regtest/regtest.go
+++ b/regtest/regtest.go
@@ -107,6 +107,7 @@ var tests = []string{
 	"testDirectReseedSystemAllStrictPasswordValidationIdenticalAccountSkipped",
 	"testHaproxyRuntimeAPIDynamicServerLifecycle",
 	"testProxyReadBackendReconciliation",
+	"testMaintenancePersistReload",
 }
 
 const recoverTime = 8

--- a/regtest/test_maintenance_persist_reload.go
+++ b/regtest/test_maintenance_persist_reload.go
@@ -1,0 +1,197 @@
+// replication-manager - Replication Manager Monitoring and CLI for MariaDB and MySQL
+// Copyright 2017-2021 SIGNAL18 CLOUD SAS
+// Authors: Guillaume Lefranc <guillaume@signal18.io>
+//          Stephane Varoqui  <svaroqui@gmail.com>
+// This source code is licensed under the GNU General Public License, version 3.
+
+package regtest
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	"github.com/signal18/replication-manager/cluster"
+	"github.com/signal18/replication-manager/config"
+)
+
+// TestMaintenancePersistReload is the real-cluster regtest for maintenance-mode
+// durability (doc/implementation/cluster/MAINTENANCE_PERSISTENCE.md, issue
+// #1783): maintenance set through the same entry point the API uses
+// (ServerMonitor.SetMaintenance/DelMaintenance) must survive a config reload,
+// and an attached proxy's read backend must stay converged across it.
+//
+// A regtest has no separate repman process to kill and restart, so this
+// exercises cl.ReloadConfig directly. That is not a simulation of the restart
+// path -- it IS the restart path: ReloadConfig -> InitFromConf ->
+// newServerList -> newServerMonitor -> newProxyList is the exact sequence
+// server/server.go's config-reload endpoint runs (mycluster.ReloadConfig via
+// ReplicationManager.ReloadClusterConfig), and process startup's Init() calls
+// the very same InitFromConf. There is only one newProxyList() call site in
+// the whole codebase (inside InitFromConf), so this single reload path
+// exercises the identical restoration and proxy-reconciliation code a real
+// process restart runs.
+func (regtest *RegTest) TestMaintenancePersistReload(cl *cluster.Cluster, conf string, test *cluster.Test) bool {
+	logf := func(level, format string, args ...interface{}) {
+		cl.LogModulePrintf(cl.Conf.Verbose, config.ConstLogModGeneral, level, format, args...)
+	}
+
+	type target struct {
+		prx      cluster.DatabaseProxy
+		typeName string
+	}
+	// collectTargets is re-evaluated after every reload: newProxyList()
+	// rebuilds cl.Proxies with fresh objects, so a target list captured
+	// before a reload is stale afterward.
+	collectTargets := func() []target {
+		var targets []target
+		for _, prx := range cl.Proxies {
+			if prx == nil || prx.IsIgnored() {
+				continue
+			}
+			if _, ok := backendReadEligible(prx.GetType(), ""); ok {
+				targets = append(targets, target{prx: prx, typeName: prx.GetType()})
+			}
+		}
+		return targets
+	}
+	checkAll := func(targets []target, host, port string, want bool, timeout time.Duration) bool {
+		return proxyReadBackendWaitFor(timeout, func() bool {
+			for _, t := range targets {
+				backends, err := getProxyBackendsRead(t.prx)
+				if err != nil {
+					return false
+				}
+				bke, found := findReadBackend(backends, host, port)
+				if want {
+					if !found {
+						return false
+					}
+					if eligible, _ := backendReadEligible(t.typeName, bke.PrxStatus); !eligible {
+						return false
+					}
+				} else if found {
+					if eligible, _ := backendReadEligible(t.typeName, bke.PrxStatus); eligible {
+						return false
+					}
+				}
+			}
+			return true
+		})
+	}
+
+	slaves := cl.GetSlaves()
+	if len(slaves) == 0 {
+		logf(config.LvlErr, "TEST maintenance-persist-reload: FAIL cluster has no replica to test against")
+		return false
+	}
+	slave := slaves[0]
+	host, port := slave.Host, slave.Port
+
+	// Always leave the cluster clean, pass or fail.
+	defer func() {
+		if s := cl.GetServerFromURL(host + ":" + port); s != nil && s.IsMaintenance {
+			s.DelMaintenance()
+			cl.SaveConfigFile()
+		}
+	}()
+
+	targetsBefore := collectTargets()
+	if len(targetsBefore) == 0 {
+		logf(config.LvlWarn, "TEST maintenance-persist-reload: no recognized proxy attached (haproxy, proxysql) -- proxy-backend assertions are skipped, only membership persistence and restoration are checked")
+	}
+
+	// --- 1. Set maintenance through the same entry point the API uses. ---
+	slave.SetMaintenance()
+
+	if !cl.IsInMaintenanceHosts(slave) {
+		logf(config.LvlErr, "TEST maintenance-persist-reload: FAIL SetMaintenance did not write durable membership for %s", slave.URL)
+		return false
+	}
+
+	if len(targetsBefore) > 0 && !checkAll(targetsBefore, host, port, false, 10*time.Second) {
+		logf(config.LvlErr, "TEST maintenance-persist-reload: FAIL %s was not drained from the read backend within 10s of entering maintenance", slave.URL)
+		return false
+	}
+
+	// --- 2. Force and confirm the config artifact landed on disk. ---
+	savedFile := cl.Conf.WorkingDir + "/" + cl.Name + "/" + cl.Name + ".toml"
+	if changed, err := cl.SaveConfigFile(); err != nil {
+		logf(config.LvlErr, "TEST maintenance-persist-reload: FAIL SaveConfigFile error: %s", err)
+		return false
+	} else if !changed {
+		logf(config.LvlErr, "TEST maintenance-persist-reload: FAIL SaveConfigFile reported no change after SetMaintenance")
+		return false
+	}
+	data, err := os.ReadFile(savedFile)
+	if err != nil {
+		logf(config.LvlErr, "TEST maintenance-persist-reload: FAIL cannot read %s: %s", savedFile, err)
+		return false
+	}
+	if !strings.Contains(string(data), "db-servers-maintenance-hosts") || !strings.Contains(string(data), slave.Host) {
+		logf(config.LvlErr, "TEST maintenance-persist-reload: FAIL maintenance membership for %s was NOT persisted to %s", slave.URL, savedFile)
+		return false
+	}
+	logf("TEST", "maintenance-persist-reload: membership for %s persisted to %s -- OK", slave.URL, savedFile)
+
+	// --- 3. Reload: the exact InitFromConf sequence a process restart runs. ---
+	cl.ReloadConfig(*cl.Conf)
+
+	rebuilt := cl.GetServerFromURL(host + ":" + port)
+	if rebuilt == nil {
+		logf(config.LvlErr, "TEST maintenance-persist-reload: FAIL %s:%s not found after reload", host, port)
+		return false
+	}
+	// IsMaintenance is the same field the API's JSON response serializes as
+	// isMaintenance -- this is what GET /api/clusters/{c}/servers/{s} would
+	// report after a real restart.
+	if !rebuilt.IsMaintenance {
+		logf(config.LvlErr, "TEST maintenance-persist-reload: FAIL isMaintenance was NOT restored to true for %s after reload", rebuilt.URL)
+		return false
+	}
+	logf("TEST", "maintenance-persist-reload: %s restored isMaintenance=true after reload -- OK", rebuilt.URL)
+
+	targetsAfter := collectTargets()
+	if len(targetsAfter) > 0 && !checkAll(targetsAfter, host, port, false, 15*time.Second) {
+		logf(config.LvlErr, "TEST maintenance-persist-reload: FAIL %s did not stay excluded from the read backend across reload", rebuilt.URL)
+		return false
+	}
+	if len(targetsAfter) > 0 {
+		logf("TEST", "maintenance-persist-reload: %s stayed excluded from the read backend across reload -- OK", rebuilt.URL)
+	}
+
+	// --- 4. Clear and reload again: must NOT resurrect maintenance. ---
+	rebuilt.DelMaintenance()
+	if cl.IsInMaintenanceHosts(rebuilt) {
+		logf(config.LvlErr, "TEST maintenance-persist-reload: FAIL DelMaintenance did not clear durable membership for %s", rebuilt.URL)
+		return false
+	}
+	if _, err := cl.SaveConfigFile(); err != nil {
+		logf(config.LvlErr, "TEST maintenance-persist-reload: FAIL SaveConfigFile error clearing maintenance: %s", err)
+		return false
+	}
+
+	cl.ReloadConfig(*cl.Conf)
+
+	final := cl.GetServerFromURL(host + ":" + port)
+	if final == nil {
+		logf(config.LvlErr, "TEST maintenance-persist-reload: FAIL %s:%s not found after second reload", host, port)
+		return false
+	}
+	if final.IsMaintenance {
+		logf(config.LvlErr, "TEST maintenance-persist-reload: FAIL maintenance was resurrected for %s after clearing and reloading", final.URL)
+		return false
+	}
+	logf("TEST", "maintenance-persist-reload: %s did not resurrect maintenance after clearing and reloading -- OK", final.URL)
+
+	targetsFinal := collectTargets()
+	if len(targetsFinal) > 0 && !checkAll(targetsFinal, host, port, true, 30*time.Second) {
+		logf(config.LvlErr, "TEST maintenance-persist-reload: FAIL %s did not return to the read backend after clearing maintenance and reloading", final.URL)
+		return false
+	}
+	if len(targetsFinal) > 0 {
+		logf("TEST", "maintenance-persist-reload: %s returned to the read backend after clearing maintenance and reloading -- OK", final.URL)
+	}
+
+	return true
+}

--- a/server/api_database.go
+++ b/server/api_database.go
@@ -1590,6 +1590,11 @@ func (repman *ReplicationManager) handlerMuxServerBackupSlowQueryLog(w http.Resp
 // handlerMuxServerMaintenance handles the HTTP request to toggle maintenance mode on a specific server within a cluster.
 // @Summary Toggle maintenance mode on a server
 // @Description Toggles the maintenance mode on a specified server within a cluster.
+// @Description Maintenance mode is durable: it is written to the cluster's
+// @Description dynamic configuration and restored on process restart or config
+// @Description reload, so a server stays excluded from proxy routing and failover
+// @Description election until maintenance is explicitly cleared. Requires
+// @Description monitoring-save-config=true (the default) to survive a restart.
 // @Tags DatabaseMaintenance
 // @Produce json
 // @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
@@ -1624,6 +1629,12 @@ func (repman *ReplicationManager) handlerMuxServerMaintenance(w http.ResponseWri
 // handlerMuxServerSetMaintenance handles the HTTP request to set a server to maintenance mode.
 // @Summary Set a server to maintenance mode
 // @Description Sets a specified server within a cluster to maintenance mode.
+// @Description Maintenance mode is durable: it is written to the cluster's
+// @Description dynamic configuration and restored on process restart or config
+// @Description reload, so the server stays excluded from proxy routing and
+// @Description failover election until maintenance is explicitly cleared.
+// @Description Requires monitoring-save-config=true (the default) to survive a
+// @Description restart.
 // @Tags DatabaseMaintenance
 // @Produce json
 // @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
@@ -1658,6 +1669,9 @@ func (repman *ReplicationManager) handlerMuxServerSetMaintenance(w http.Response
 // handlerMuxServerDelMaintenance handles the HTTP request to delete maintenance mode on a specific server within a cluster.
 // @Summary Delete maintenance mode on a server
 // @Description Deletes the maintenance mode on a specified server within a cluster.
+// @Description Also clears the durable maintenance membership, so the server does
+// @Description not come back into maintenance on the next process restart or
+// @Description config reload.
 // @Tags DatabaseMaintenance
 // @Produce json
 // @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)

--- a/server/regtest.go
+++ b/server/regtest.go
@@ -305,6 +305,9 @@ func (repman *ReplicationManager) RunAllTests(cl *cluster.Cluster, testExp strin
 		if test.Name == "testProxyReadBackendReconciliation" {
 			res = regtest.TestProxyReadBackendReconciliation(cl, test.ConfigFile, &test)
 		}
+		if test.Name == "testMaintenancePersistReload" {
+			res = regtest.TestMaintenancePersistReload(cl, test.ConfigFile, &test)
+		}
 
 		test.Result = regtest.GetTestResultLabel(res)
 		if testExp == "SUITE" {

--- a/server/server.go
+++ b/server/server.go
@@ -546,6 +546,7 @@ func (repman *ReplicationManager) AddFlags(flags *pflag.FlagSet, conf *config.Co
 	flags.StringVar(&conf.PrefMaster, "db-servers-prefered-master", "", "Database preferred candidate in election,  host:[port] format")
 	flags.StringVar(&conf.IgnoreSrv, "db-servers-ignored-hosts", "", "Database list of hosts to ignore in election")
 	flags.StringVar(&conf.IgnoreSrvRO, "db-servers-ignored-readonly", "", "Database list of hosts not changing read only status")
+	flags.StringVar(&conf.MaintenanceSrv, "db-servers-maintenance-hosts", "", "Database list of hosts in maintenance mode, excluded from proxy routing and failover election, restored on restart/reload")
 	flags.StringVar(&conf.BackupServers, "db-servers-backup-hosts", "", "Database list of hosts to backup when set can backup a slave")
 	flags.StringVar(&conf.DbServersChangeStateScript, "db-servers-state-change-script", "", "Database state change script")
 	flags.StringVar(&conf.DbServersBindAddress, "db-servers-bind-address", "", "Database bind address to use for jobs like SST, backup")

--- a/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
@@ -104,6 +104,7 @@ function ServerMenu({
   // State for basic ConfirmModal (used for all non-reseed operations)
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false)
   const [confirmTitle, setConfirmTitle] = useState('')
+  const [confirmBody, setConfirmBody] = useState('')
   const [confirmHandler, setConfirmHandler] = useState(null)
 
   // State for AdvancedReseedModal (used for reseed operations)
@@ -136,6 +137,7 @@ function ServerMenu({
     setIsConfirmModalOpen(false)
     setConfirmHandler(null)
     setConfirmTitle('')
+    setConfirmBody('')
   }
 
   // Handlers for AdvancedReseedModal
@@ -204,6 +206,9 @@ function ServerMenu({
             onClick: () => {
               openConfirmModal()
               setConfirmTitle(`Confirm maintenance for ${serverName}?`)
+              setConfirmBody(
+                'Maintenance mode persists across a replication-manager restart or config reload -- the server stays out of proxy routing and failover election until maintenance is explicitly cleared. Requires monitoring-save-config=true (the default) to survive a restart.'
+              )
               setConfirmHandler(() => () => dispatch(setMaintenanceMode({ clusterName, serverId: row.id })))
             }
           },
@@ -593,6 +598,7 @@ function ServerMenu({
           isOpen={isConfirmModalOpen}
           closeModal={closeConfirmModal}
           title={confirmTitle}
+          body={confirmBody}
           onConfirmClick={() => {
             confirmHandler?.()
             closeConfirmModal()

--- a/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
+++ b/share/dashboard_react/src/Pages/Dashboard/components/DBServers/ServerMenu.jsx
@@ -25,7 +25,7 @@ import {
   setAsIgnored,
   setAsPreferred,
   setAsUnrated,
-  setMaintenanceMode,
+  switchMaintenanceMode,
   skipReplicationEvent,
   startDatabase,
   restartDatabase,
@@ -204,12 +204,22 @@ function ServerMenu({
             name: 'Maintenance Mode',
             isDisabled: !user?.grants['db-maintenance'],
             onClick: () => {
+              // This dispatches the toggle endpoint (actions/maintenance), so
+              // the confirm copy must reflect which direction this click
+              // actually flips, not always "entering maintenance".
               openConfirmModal()
-              setConfirmTitle(`Confirm maintenance for ${serverName}?`)
-              setConfirmBody(
-                'Maintenance mode persists across a replication-manager restart or config reload -- the server stays out of proxy routing and failover election until maintenance is explicitly cleared. Requires monitoring-save-config=true (the default) to survive a restart.'
-              )
-              setConfirmHandler(() => () => dispatch(setMaintenanceMode({ clusterName, serverId: row.id })))
+              if (row?.isMaintenance) {
+                setConfirmTitle(`Confirm clearing maintenance for ${serverName}?`)
+                setConfirmBody(
+                  'This clears the durable maintenance membership -- the server rejoins proxy routing and failover election immediately, and stays rejoined across a future restart or config reload.'
+                )
+              } else {
+                setConfirmTitle(`Confirm maintenance for ${serverName}?`)
+                setConfirmBody(
+                  'Maintenance mode persists across a replication-manager restart or config reload -- the server stays out of proxy routing and failover election until maintenance is explicitly cleared. Requires monitoring-save-config=true (the default) to survive a restart.'
+                )
+              }
+              setConfirmHandler(() => () => dispatch(switchMaintenanceMode({ clusterName, serverId: row.id })))
             }
           },
           {

--- a/share/dashboard_react/src/redux/clusterSlice.js
+++ b/share/dashboard_react/src/redux/clusterSlice.js
@@ -1065,16 +1065,19 @@ export const checksumRepairAllTables = createGuardedAsyncThunk(
 )
 
 
-export const setMaintenanceMode = createGuardedAsyncThunk(
-  'cluster/setMaintenanceMode',
+// Toggles maintenance (hits actions/maintenance -> server.SwitchMaintenance),
+// not a dedicated set action -- the banner text stays direction-neutral since
+// this thunk doesn't know which way it just flipped.
+export const switchMaintenanceMode = createGuardedAsyncThunk(
+  'cluster/switchMaintenanceMode',
   async ({ clusterName, serverId }, thunkAPI) => {
     try {
       const baseURL = thunkAPI.getState()?.auth?.baseURL || ''
-      const { data, status } = await clusterService.setMaintenanceMode(clusterName, serverId, baseURL)
-      showSuccessBanner('Maintenance mode is set!', status, thunkAPI)
+      const { data, status } = await clusterService.switchMaintenanceMode(clusterName, serverId, baseURL)
+      showSuccessBanner('Maintenance mode toggled!', status, thunkAPI)
       return { data, status }
     } catch (error) {
-      showErrorBanner('Setting Maintenance mode failed!', error, thunkAPI)
+      showErrorBanner('Toggling maintenance mode failed!', error, thunkAPI)
       return handleError(error, thunkAPI)
     }
   }
@@ -2894,7 +2897,7 @@ export const clusterSlice = createSlice({
         configReload.pending,
         configDiscoverDB.pending,
         configDynamic.pending,
-        setMaintenanceMode.pending,
+        switchMaintenanceMode.pending,
         promoteToLeader.pending,
         setAsUnrated.pending,
         setAsPreferred.pending,
@@ -2981,7 +2984,7 @@ export const clusterSlice = createSlice({
         configReload.fulfilled,
         configDiscoverDB.fulfilled,
         configDynamic.fulfilled,
-        setMaintenanceMode.fulfilled,
+        switchMaintenanceMode.fulfilled,
         promoteToLeader.fulfilled,
         setAsUnrated.fulfilled,
         setAsPreferred.fulfilled,
@@ -3069,7 +3072,7 @@ export const clusterSlice = createSlice({
         configReload.rejected,
         configDiscoverDB.rejected,
         configDynamic.rejected,
-        setMaintenanceMode.rejected,
+        switchMaintenanceMode.rejected,
         promoteToLeader.rejected,
         setAsUnrated.rejected,
         setAsPreferred.rejected,

--- a/share/dashboard_react/src/services/clusterService.js
+++ b/share/dashboard_react/src/services/clusterService.js
@@ -87,7 +87,7 @@ export const clusterService = {
   reseedStagingFromParent,
 
   // Server management APIs
-  setMaintenanceMode,
+  switchMaintenanceMode,
   jobsUpgrade,
   promoteToLeader,
   setAsUnrated,
@@ -489,7 +489,9 @@ function reseedStagingFromParent(clusterName, baseURL) {
 //#endregion Cluster management APIs
 
 //#region Server management APIs
-function setMaintenanceMode(clusterName, serverId, baseURL) {
+// Hits actions/maintenance, which toggles (server.SwitchMaintenance) -- not a
+// dedicated set action, hence the switch* name rather than set*.
+function switchMaintenanceMode(clusterName, serverId, baseURL) {
   return getApi(baseURL).get(`clusters/${clusterName}/servers/${serverId}/actions/maintenance`)
 }
 


### PR DESCRIPTION
## Summary

Fixes #1783 by persisting per-server maintenance mode across replication-manager configuration reloads and restarts.

Maintenance previously existed only on the in-memory `ServerMonitor.IsMaintenance` flag. Rebuilding server monitors during `InitFromConf()` reset that value, which could return a maintenance server to service after reload or restart.

## Changes

### Durable configuration
- Adds the per-cluster `db-servers-maintenance-hosts` setting and `--db-servers-maintenance-hosts` flag.
- Persists maintenance membership through the existing dynamic cluster TOML save flow.

### Exact, lossless membership management
- Adds centralized maintenance token helpers shared by mutation and restoration paths.
- Uses exact URL/name matching rather than substring matching, preventing collisions such as `1.2.3.4:3306` matching `11.2.3.4:3306`.
- Edits the persisted membership list directly so entries for servers temporarily absent from the live cluster remain intact.

### Lifecycle and proxy reconciliation
- Updates set, clear, and toggle maintenance actions to synchronize durable membership with `IsMaintenance`.
- Applies the same durable behavior to operator-initiated and automatic failover-triggered maintenance.
- Restores maintenance directly when `newServerMonitor()` rebuilds monitors, without replaying database state-change scripts.
- Reconciles restored maintenance to rebuilt HAProxy, ProxySQL, and MaxScale backends immediately after `newProxyList()`.

### API and dashboard
- Documents durable maintenance behavior in the set, clear, and toggle API descriptions.
- Updates the dashboard confirmation copy so operators know maintenance stays active until explicitly cleared.

## Tests

- Adds focused cluster coverage for exact matching, substring-collision prevention, idempotent add/remove operations, mutation entry points, absent-server membership preservation, and rebuild restoration.
- Adds and registers `testMaintenancePersistReload`, which validates a real cluster reload sequence, persisted TOML membership, proxy backend convergence, clearing maintenance, and no state resurrection after a second reload.

## Validation

- `go test ./cluster/...`
- `go test ./config/...`
- `go test ./server/...`
- `go test ./regtest/...`
- Server build-tag combinations
- `git diff --check origin/develop...HEAD`

## Release gate

The new regtest covers the live reload/rebuild lifecycle. Execute the isolated Docker process-restart scenario before release to validate a fresh repman process reads the persisted cluster TOML and keeps the corresponding proxy backend in maintenance.