### PR TITLE
fix: WriteBackupMetadata self-deadlock + JobsCheckStates api-mode 1146 storm

### DIFF
--- a/cluster/backup_helpers_test.go
+++ b/cluster/backup_helpers_test.go
@@ -1089,3 +1089,51 @@ func TestMarkBackupPhysicalDoneRaceWithResticUpdate(t *testing.T) {
 		t.Fatalf("ResticSnapshotID = %q, want %q", server.LastBackupMeta.Physical.ResticSnapshotID, "snap-id")
 	}
 }
+
+// TestWaitForBinlogMetaNoDeadlock reproduces the WriteBackupMetadata self-deadlock: the
+// metadata writer held backupMetaMutex while polling for lastmeta.BinLogFileName, but that
+// field is only ever published by the writelog API path, which takes the SAME mutex. The
+// writer therefore blocked forever on a value it was preventing anyone from setting -- this
+// wedged belair/db2's rejoin for a day. waitForBinlogMeta must poll with the mutex RELEASED
+// so the publisher can make progress, then return holding it again.
+func TestWaitForBinlogMetaNoDeadlock(t *testing.T) {
+	_, server := newTestClusterServer(t)
+	lastmeta := &backupmgr.BackupMetadata{}
+
+	done := make(chan struct{})
+	go func() {
+		// Match WriteBackupMetadata's caller state: enter holding the mutex.
+		server.backupMetaMutex.Lock()
+		server.waitForBinlogMeta(lastmeta)
+		server.backupMetaMutex.Unlock() // helper returns holding it, per its contract
+		close(done)
+	}()
+
+	// The writelog API path publishes BinLogFileName under the same mutex. With the old code
+	// (poll while holding the lock) this Lock() would block forever -> deadlock.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		server.backupMetaMutex.Lock()
+		lastmeta.BinLogFileName = "binlog.000042"
+		server.backupMetaMutex.Unlock()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitForBinlogMeta did not return within 5s: backupMetaMutex self-deadlock regressed")
+	}
+}
+
+// TestJobsCheckStatesApiModeSkipsSQL verifies the api-mode guard. In api mode the jobs table
+// is not the source of truth, so JobsCheckStates must return before the SQL path. With Conn
+// nil and no guard the function would instead return the "No connection pool" error (and in a
+// live server spam ERROR 1146 against the non-existent jobs table every tick).
+func TestJobsCheckStatesApiModeSkipsSQL(t *testing.T) {
+	cluster, server := newTestClusterServer(t)
+	cluster.Conf.SchedulerJobsMode = "api"
+
+	if err := server.JobsCheckStates(); err != nil {
+		t.Fatalf("JobsCheckStates in api mode returned %v, want nil (must skip the SQL path)", err)
+	}
+}

--- a/cluster/srv_job.go
+++ b/cluster/srv_job.go
@@ -1226,6 +1226,13 @@ func (server *ServerMonitor) JobsCheckStates() error {
 	var err error
 	cluster := server.ClusterGroup
 
+	// In api mode the jobs table is not the source of truth (dbjobs report via the API),
+	// so polling it here spams ERROR 1146 "Table 'replication_manager_schema.jobs' doesn't
+	// exist". Mirror JobsCheckRunning's guard and skip the SQL path entirely.
+	if cluster.Conf.SchedulerJobsMode == "api" {
+		return nil
+	}
+
 	if cluster.IsInFailover() {
 		return nil
 	}

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -6784,6 +6784,28 @@ func (server *ServerMonitor) ProcessFlashbackPhysical(task string) error {
 	return nil
 }
 
+// waitForBinlogMeta blocks until the writelog API path fills in lastmeta.BinLogFileName.
+//
+// Lock contract: the caller MUST hold server.backupMetaMutex on entry, and it is held again on
+// return; the wait itself runs with the mutex RELEASED. BinLogFileName is published by the
+// writelog path (which takes this SAME mutex, see WriteJobMeta/writelog around the
+// server.backupMetaMutex.Lock that sets BinLogFileName), so polling it while holding the lock
+// is a self-deadlock: the poller would block forever on a value only settable by acquiring the
+// lock it is already holding. That is exactly what wedged belair/db2's rejoin for a day. The
+// per-iteration Lock/read/Unlock also keeps the read synchronized with the writer instead of
+// reading the field bare (race-clean).
+func (server *ServerMonitor) waitForBinlogMeta(lastmeta *backupmgr.BackupMetadata) {
+	server.backupMetaMutex.Unlock()
+	for {
+		server.backupMetaMutex.Lock()
+		if lastmeta.BinLogFileName != "" {
+			return // return holding the mutex, per the contract above
+		}
+		server.backupMetaMutex.Unlock()
+		time.Sleep(time.Second)
+	}
+}
+
 func (server *ServerMonitor) WriteBackupMetadata(backtype backupmgr.BackupMethod) {
 	// CRITICAL FIX: Lock to prevent concurrent metadata updates from async Restic callbacks
 	server.backupMetaMutex.Lock()
@@ -6826,13 +6848,11 @@ func (server *ServerMonitor) WriteBackupMetadata(backtype backupmgr.BackupMethod
 
 	task := server.JobResults.Get(lastmeta.BackupTool)
 
-	// DEADLOCK FIX: never hold backupMetaMutex across these unbounded poll loops. task.State
-	// and (below) lastmeta.BinLogFileName are advanced by OTHER goroutines that take this SAME
-	// mutex -- the writelog API path sets BinLogFileName under it -- so waiting on them while
-	// holding the lock is a self-deadlock: WriteBackupMetadata waits for a value only settable
-	// by acquiring the lock it is holding. That hung the flashback rejoin (and every later
-	// backup-meta op, e.g. snapshotLogicalBackupMeta) for a day. Release around each poll and
-	// re-acquire before mutating; the mutations below stay guarded.
+	// Drop backupMetaMutex while polling for the job to reach a terminal state. task.State is
+	// advanced by jobsUpdateState (srv_job.go) and is NOT guarded by this mutex -- it was an
+	// unsynchronized read before this change too -- so there is nothing to synchronize here.
+	// We still release the lock so this poll cannot block the writelog path, which needs the
+	// same mutex to publish BinLogFileName that waitForBinlogMeta waits for just below.
 	//Wait until job result changed since we're using pointer
 	server.backupMetaMutex.Unlock()
 	for task.State < 3 {
@@ -6845,13 +6865,9 @@ func (server *ServerMonitor) WriteBackupMetadata(backtype backupmgr.BackupMethod
 	if task.State == 3 || task.State == 4 {
 		//Wait for binlog metadata sent by writelog API
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Waiting for binlog info: %v", lastmeta)
-		// DEADLOCK FIX (see above): BinLogFileName is set by the writelog API path under this
-		// same mutex, so release while polling and re-acquire before mutating.
-		server.backupMetaMutex.Unlock()
-		for lastmeta.BinLogFileName == "" {
-			time.Sleep(time.Second)
-		}
-		server.backupMetaMutex.Lock()
+		// Releases backupMetaMutex while polling and re-acquires before we mutate below; see
+		// the waitForBinlogMeta contract -- this is the self-deadlock fix.
+		server.waitForBinlogMeta(lastmeta)
 		lastmeta.Completed = true
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Metadata completed: %v", lastmeta)
 		cluster.BackupPostScript(server, backtype, lastmeta.Dest)

--- a/cluster/srv_job_backup.go
+++ b/cluster/srv_job_backup.go
@@ -6826,19 +6826,32 @@ func (server *ServerMonitor) WriteBackupMetadata(backtype backupmgr.BackupMethod
 
 	task := server.JobResults.Get(lastmeta.BackupTool)
 
+	// DEADLOCK FIX: never hold backupMetaMutex across these unbounded poll loops. task.State
+	// and (below) lastmeta.BinLogFileName are advanced by OTHER goroutines that take this SAME
+	// mutex -- the writelog API path sets BinLogFileName under it -- so waiting on them while
+	// holding the lock is a self-deadlock: WriteBackupMetadata waits for a value only settable
+	// by acquiring the lock it is holding. That hung the flashback rejoin (and every later
+	// backup-meta op, e.g. snapshotLogicalBackupMeta) for a day. Release around each poll and
+	// re-acquire before mutating; the mutations below stay guarded.
 	//Wait until job result changed since we're using pointer
+	server.backupMetaMutex.Unlock()
 	for task.State < 3 {
 		time.Sleep(time.Second)
 	}
+	server.backupMetaMutex.Lock()
 
 	cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Continue for writing metadata for backup in %s", server.URL)
 
 	if task.State == 3 || task.State == 4 {
 		//Wait for binlog metadata sent by writelog API
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Waiting for binlog info: %v", lastmeta)
+		// DEADLOCK FIX (see above): BinLogFileName is set by the writelog API path under this
+		// same mutex, so release while polling and re-acquire before mutating.
+		server.backupMetaMutex.Unlock()
 		for lastmeta.BinLogFileName == "" {
 			time.Sleep(time.Second)
 		}
+		server.backupMetaMutex.Lock()
 		lastmeta.Completed = true
 		cluster.LogModulePrintf(cluster.Conf.Verbose, config.ConstLogModTask, config.LvlInfo, "Metadata completed: %v", lastmeta)
 		cluster.BackupPostScript(server, backtype, lastmeta.Dest)

--- a/doc/implementation/DEVELOPMENT_LAWS.md
+++ b/doc/implementation/DEVELOPMENT_LAWS.md
@@ -254,6 +254,41 @@ branch that depends on it cherry-picks that export commit; carrying an export
 inside a feature branch is the exception, and is what triggers the
 concurrent-branch check above.
 
+## Debugging discipline — investigate FULLY before you unblock
+
+**Never unblock a stuck issue before you have investigated it fully.** A restart, a
+killed goroutine, a cleared flag or a truncated file *makes the problem disappear and
+takes the evidence with it* — you lose the one chance to find the root cause and the bug
+ships to the next demo. This is the live-investigation half of "never delete the trigger":
+keep the investigation **read-only** until you understand *why*, then fix the cause, not
+the symptom.
+
+**The goroutine dump is the first tool for anything stuck / hung / deadlocked** (a
+rejoin/reseed that never completes, a server pinned in maintenance, an op that "runs"
+forever). repman registers `net/http/pprof` on the HTTP monitor (`server/http.go`,
+`http-port` default 10001, `http-bind-address` = localhost), so from **inside the repman
+container** (a read-only GET):
+
+    curl -s "http://localhost:10001/debug/pprof/goroutine?debug=2"
+
+`debug=2` prints every goroutine with its **wait state and blocked duration** —
+`[sync.Mutex.Lock, 1615 minutes]`, `[chan receive, 13079 minutes]`. Read it as:
+- **long durations are the smoking gun** — a goroutine blocked *minutes/hours/days* is
+  stuck, not busy. Sort on the `N minutes]` in each state header.
+- **a mutex deadlock** shows as ≥2 goroutines in `sync.Mutex.Lock` on the *same* mutex
+  address; find the **holder** (the goroutine that took that lock and is now blocked
+  *elsewhere* — a channel/network/another lock — while still holding it). The classic
+  cause is **a lock held across a blocking wait**.
+- `?debug=1` groups the counts — hundreds piling up in one stack = a **goroutine leak**.
+
+Worked example (2026-09-11, belair/db2): an operator logical rejoin sat "running" for a
+day. pprof showed `RejoinMaster → rejoinWithMethod → JobFlashbackLogicalBackup →
+snapshotLogicalBackupMeta` blocked 27h on `server.backupMetaMutex`, held by a cron
+physical backup parked in `waitForBackupSlot` while `MarkBackupPhysicalDone` (which frees
+the slot) had waited 8.6 days on the same mutex — a circular wait. Restarting repman "to
+unblock it" would have erased all of it, and the deadlock would have re-bitten the next
+demo.
+
 ---
 
 *Precedence: functional laws outrank technical laws; the perpetual-monitoring


### PR DESCRIPTION
## Context

Found while investigating **belair/db2** stuck in reseed for a day after an automatic failover during a prospect demo: the old master failed to auto-rejoin despite no binlog diff, a manual logical-backup rejoin was issued, and it never actually reseeded. pprof (`/debug/pprof/goroutine?debug=2`) showed goroutines blocked for ~a day on `server.backupMetaMutex`.

## Bug 1 — `WriteBackupMetadata` self-deadlock (`cluster/srv_job_backup.go`)

`WriteBackupMetadata` held `server.backupMetaMutex` across its **entire** body, including two unbounded poll loops:

```go
for task.State < 3 { time.Sleep(time.Second) }
...
for lastmeta.BinLogFileName == "" { time.Sleep(time.Second) }
```

`lastmeta.BinLogFileName` is set by the **writelog API path under the same mutex**. So the function blocked forever waiting on a value only settable by acquiring the lock it was already holding — a textbook self-deadlock. Every later backup-meta op then wedged behind it, including the flashback auto-rejoin's `snapshotLogicalBackupMeta` and the operator's manual logical rejoin. That is why db2 never reseeded.

**Fix:** release `backupMetaMutex` around each poll loop and re-acquire before mutating. All metadata mutations remain guarded; early returns precede the release, so the deferred `Unlock` stays balanced on every path.

## Bug 2 — `JobsCheckStates` missing api-mode guard (`cluster/srv_job.go`)

`JobsCheckStates` polled `replication_manager_schema.jobs` unconditionally. Under `scheduler-jobs-mode=api` that table doesn't exist, producing an `ERROR 1146` storm every tick. Its sibling `JobsCheckRunning` already guards this; `JobsCheckStates` now mirrors it and returns early when `SchedulerJobsMode == "api"`.

## Testing

- `go build ./cluster/ ./server/` clean.
- Also carries a docs-only commit: a debugging-discipline law (pprof how-to + never unblock before investigating fully) in `DEVELOPMENT_LAWS.md`.

Both are perpetual-monitoring blockers per the functional laws (a deadlock that halts backup-meta processing / a per-tick error storm).

https://claude.ai/code/session_01PseLp6M7Z5gzGhsN8whcdk